### PR TITLE
fix(pointers): Make sure to set the UpdateKind on all platforms and use it handle focus

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/FocusManagerTests/UnoSamples_Tests.FocusManager.cs
@@ -530,7 +530,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FocusManagerTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)] // WASM temporarily disabled due to #7820
 		public void FocusManager_GetFocusedElement_ComboBoxItem_LostFocus_Validation()
 		{
 			Run("Uno.UI.Samples.Content.UITests.FocusTests.FocusManager_GetFocus_Automated");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ListViewTests/UnoSamples_Tests.ListView.cs
@@ -166,9 +166,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android)]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		// WASM: ClickCheckBoxAt() fails because AtIndex() isn't supported https://github.com/unoplatform/Uno.UITest/issues/47
-		// iOS: Visual states for selection fails https://github.com/unoplatform/uno/issues/8011
 		public void ListView_ExpandableItem_ExpandSingleItem()
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.ListView_Expandable_Item");
@@ -192,9 +191,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android)]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		// WASM: ClickCheckBoxAt() fails because AtIndex() isn't supported https://github.com/unoplatform/Uno.UITest/issues/47
-		// iOS: Visual states for selection fails https://github.com/unoplatform/uno/issues/8011
 		public void ListView_ExpandableItem_ExpandMultipleItems()
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.ListView_Expandable_Item");
@@ -332,9 +330,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android)]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		// WASM: ListView.Header not implemented https://github.com/unoplatform/uno/issues/1979
-		// iOS: Visual states for selection fails https://github.com/unoplatform/uno/issues/8011
 		public void ListView_ExpandableItemLarge_ExpandHeaderWithMultipleItems_Validation()
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.ListView_Expandable_Item_Large");
@@ -364,9 +361,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ListViewTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android)]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		// WASM: ListView.Header not implemented https://github.com/unoplatform/uno/issues/1979
-		// iOS: Visual states for selection fails https://github.com/unoplatform/uno/issues/8011
 		public void ListView_ExpandableItemLarge_ExpandHeaderWithSingleItem_Validation()
 		{
 			Run("SamplesApp.Windows_UI_Xaml_Controls.ListView.ListView_Expandable_Item_Large");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
@@ -125,13 +125,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		{
 			Run("UITests.Shared.Windows_UI_Input.VisualStatesTests.TextBox_VisualStates");
 
-			// Note: We don not validateFinalStateScreenShot as we are expecting to finish "focused" so may have the flashing cursor.
+			// Note: We do not validateFinalStateScreenShot as we are expecting to finish "focused" so may have the flashing cursor.
 			TestVisualTests("MyTextBox", ReleaseOut, validateFinalStateScreenShot: false, "CommonStates.PointerOver", "CommonStates.Focused");
 		}
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(/*Platform.Android, */Platform.iOS)] // For touch, focus should be set only when released outside of TextBox
+		[ActivePlatforms(/*Platform.Android, */Platform.iOS)] // For touch, focus should be set only when released over the TextBox
 		public void TestTextBoxReleaseOutUnfocused()
 		{
 			Run("UITests.Shared.Windows_UI_Input.VisualStatesTests.TextBox_VisualStates");

--- a/src/Uno.UI.Runtime.Skia.Tizen/TizenCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/TizenCoreWindowExtension.cs
@@ -34,6 +34,8 @@ namespace Uno.UI.Runtime.Skia
 		private readonly GestureLayer _gestureLayer;
 		private readonly UnoCanvas _canvas;
 
+		private PointerEventArgs _previous;
+
 		public CoreCursor PointerCursor
 		{
 			get => new CoreCursor(CoreCursorType.Arrow, 0);
@@ -83,12 +85,12 @@ namespace Uno.UI.Runtime.Skia
 		{
 			try
 			{
-				var properties = BuildProperties(true, false);
+				var properties = BuildProperties(true, false).SetUpdateKindFromPrevious(_previous?.CurrentPoint.Properties);
 				var modifiers = VirtualKeyModifiers.None;
 				var point = GetPoint(data.X2, data.Y2);
 
 				_ownerEvents.RaisePointerMoved(
-					new PointerEventArgs(
+					_previous = new PointerEventArgs(
 						new Windows.UI.Input.PointerPoint(
 							frameId: GetNextFrameId(),
 							timestamp: Math.Max(data.VerticalSwipeTimestamp, data.HorizontalSwipeTimestamp),
@@ -115,12 +117,12 @@ namespace Uno.UI.Runtime.Skia
 		{
 			try
 			{
-				var properties = BuildProperties(true, false);
+				var properties = BuildProperties(true, false).SetUpdateKindFromPrevious(_previous?.CurrentPoint.Properties);
 				var modifiers = VirtualKeyModifiers.None;
 				var point = GetPoint(data.X, data.Y);
 
 				_ownerEvents.RaisePointerPressed(
-					new PointerEventArgs(
+					_previous = new PointerEventArgs(
 						new Windows.UI.Input.PointerPoint(
 							frameId: GetNextFrameId(),
 							timestamp: (uint)data.Timestamp,
@@ -145,12 +147,12 @@ namespace Uno.UI.Runtime.Skia
 		{
 			try
 			{
-				var properties = BuildProperties(false, false);
+				var properties = BuildProperties(false, false).SetUpdateKindFromPrevious(_previous?.CurrentPoint.Properties);
 				var modifiers = VirtualKeyModifiers.None;
 				var point = GetPoint(data.X, data.Y);
 
 				_ownerEvents.RaisePointerReleased(
-					new PointerEventArgs(
+					_previous = new PointerEventArgs(
 						new Windows.UI.Input.PointerPoint(
 							frameId: GetNextFrameId(),
 							timestamp: (uint)data.Timestamp,

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -771,7 +771,9 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnPointerPressed(args);
 
-			if (ShouldFocusOnPointerPressed(args) && CapturePointer(args.Pointer))
+			if (ShouldFocusOnPointerPressed(args)
+				// UWP Captures pointer is not Touch
+				&& CapturePointer(args.Pointer))
 			{
 				Focus(FocusState.Pointer);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -771,7 +771,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnPointerPressed(args);
 
-			if (ShouldFocusOnPointerPressed(args))
+			if (ShouldFocusOnPointerPressed(args) && CapturePointer(args.Pointer))
 			{
 				Focus(FocusState.Pointer);
 			}
@@ -978,8 +978,10 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsEnabledChangedPartial(IsEnabledChangedEventArgs e);
 
-		private bool ShouldFocusOnPointerPressed(PointerRoutedEventArgs args) =>
-			// For mouse and pen, the TextBox should focus on pointer press, for other input types on release
-			args.Pointer.PointerDeviceType != PointerDeviceType.Touch;
+		private bool ShouldFocusOnPointerPressed(PointerRoutedEventArgs args)
+			// For mouse and pen, the TextBox should focus on pointer press
+			// (and then capture pointer to make sure to handle the whol down->move->up sequence).
+			// For touch we wait for the release to focus (avoid flickering in case of cancel due to scroll for instance).
+			=> args.Pointer.PointerDeviceType != PointerDeviceType.Touch;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
@@ -14,8 +14,8 @@ namespace Windows.UI.Xaml.Input
 	{
 		public ManipulationCompletedRoutedEventArgs() { }
 
-		internal ManipulationCompletedRoutedEventArgs(UIElement container, ManipulationCompletedEventArgs args)
-			: base(container)
+		internal ManipulationCompletedRoutedEventArgs(UIElement source, UIElement container, ManipulationCompletedEventArgs args)
+			: base(source)
 		{
 			Container = container;
 

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
@@ -16,8 +16,8 @@ namespace Windows.UI.Xaml.Input
 
 		public ManipulationDeltaRoutedEventArgs() { }
 
-		internal ManipulationDeltaRoutedEventArgs(UIElement container, GestureRecognizer recognizer, ManipulationUpdatedEventArgs args)
-			: base(container)
+		internal ManipulationDeltaRoutedEventArgs(UIElement source, UIElement container, GestureRecognizer recognizer, ManipulationUpdatedEventArgs args)
+			: base(source)
 		{
 			Container = container;
 

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationInertiaStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationInertiaStartingRoutedEventArgs.cs
@@ -13,8 +13,8 @@ namespace Windows.UI.Xaml.Input
 	{
 		public ManipulationInertiaStartingRoutedEventArgs() { }
 
-		internal ManipulationInertiaStartingRoutedEventArgs(UIElement container, ManipulationInertiaStartingEventArgs args)
-			: base(container)
+		internal ManipulationInertiaStartingRoutedEventArgs(UIElement source, UIElement container, ManipulationInertiaStartingEventArgs args)
+			: base(source)
 		{
 			Container = container;
 

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
@@ -16,8 +16,8 @@ namespace Windows.UI.Xaml.Input
 
 		public ManipulationStartedRoutedEventArgs() { }
 
-		internal ManipulationStartedRoutedEventArgs(UIElement container, GestureRecognizer recognizer, ManipulationStartedEventArgs args)
-			: base(container)
+		internal ManipulationStartedRoutedEventArgs(UIElement source, UIElement container, GestureRecognizer recognizer, ManipulationStartedEventArgs args)
+			: base(source)
 		{
 			Container = container;
 

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartingRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartingRoutedEventArgs.cs
@@ -17,8 +17,8 @@ namespace Windows.UI.Xaml.Input
 
 		public ManipulationStartingRoutedEventArgs() { }
 
-		internal ManipulationStartingRoutedEventArgs(UIElement container, ManipulationStartingEventArgs args)
-			: base(container)
+		internal ManipulationStartingRoutedEventArgs(UIElement source, UIElement container, ManipulationStartingEventArgs args)
+			: base(source)
 		{
 			Container = container;
 

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
@@ -60,7 +60,7 @@ namespace Windows.UI.Xaml.Input
 			var nativePointerButtons = nativeEvent.ButtonState;
 			var nativePointerType = nativeEvent.GetToolType(_pointerIndex);
 			var pointerType = nativePointerType.ToPointerDeviceType();
-			var isInContact = IsInContact(nativeEvent, (PointerDeviceType)pointerType,  nativePointerAction, nativePointerButtons);
+			var isInContact = IsInContact(nativeEvent, (PointerDeviceType)pointerType, nativePointerAction, nativePointerButtons);
 			var keys = nativeEvent.MetaState.ToVirtualKeyModifiers();
 
 			FrameId = (uint)_nativeEvent.EventTime;
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml.Input
 				IsInRange = Pointer.IsInRange
 			};
 
-			var isDown = action.HasFlag(MotionEventActions.Down) || action.HasFlag(MotionEventActions.PointerDown);
+			var isDown = action == /* 0 = */ MotionEventActions.Down || action.HasFlag(MotionEventActions.PointerDown);
 			var isUp = action.HasFlag(MotionEventActions.Up) || action.HasFlag(MotionEventActions.PointerUp);
 			var updates = _none;
 			switch (type)
@@ -188,22 +188,24 @@ namespace Windows.UI.Xaml.Input
 		}
 
 		#region Misc static helpers
-		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _none = new Dictionary<MotionEventButtonState, PointerUpdateKind>(0);
-		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _fingerDownUpdates = new Dictionary<MotionEventButtonState, PointerUpdateKind>
+		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _none = new(0);
+		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _fingerDownUpdates = new()
 		{
+			{ 0, PointerUpdateKind.LeftButtonPressed },
 			{ MotionEventButtonState.Primary, PointerUpdateKind.LeftButtonPressed }
 		};
-		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _fingerUpUpdates = new Dictionary<MotionEventButtonState, PointerUpdateKind>
+		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _fingerUpUpdates = new()
 		{
+			{ 0, PointerUpdateKind.LeftButtonReleased },
 			{ MotionEventButtonState.Primary, PointerUpdateKind.LeftButtonReleased }
 		};
-		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _mouseDownUpdates = new Dictionary<MotionEventButtonState, PointerUpdateKind>
+		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _mouseDownUpdates = new()
 		{
 			{ MotionEventButtonState.Primary, PointerUpdateKind.LeftButtonPressed },
 			{ MotionEventButtonState.Tertiary, PointerUpdateKind.MiddleButtonPressed },
 			{ MotionEventButtonState.Secondary, PointerUpdateKind.RightButtonPressed }
 		};
-		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _mouseUpUpdates = new Dictionary<MotionEventButtonState, PointerUpdateKind>
+		private static readonly Dictionary<MotionEventButtonState, PointerUpdateKind> _mouseUpUpdates = new()
 		{
 			{ MotionEventButtonState.Primary, PointerUpdateKind.LeftButtonReleased },
 			{ MotionEventButtonState.Tertiary, PointerUpdateKind.MiddleButtonReleased },
@@ -249,7 +251,7 @@ namespace Windows.UI.Xaml.Input
 						&& !action.HasFlag(MotionEventActions.PointerUp)
 						&& !action.HasFlag(MotionEventActions.Cancel);
 			}
-		}	
+		}
 		#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
@@ -135,6 +135,7 @@ namespace Windows.UI.Xaml.Input
 			switch (type)
 			{
 				case MotionEventToolType.Finger:
+				case MotionEventToolType.Unknown: // used by Xamarin.UITest
 					props.IsLeftButtonPressed = Pointer.IsInContact;
 					updates = isDown ? _fingerDownUpdates : isUp ? _fingerUpUpdates : _none;
 					// Pressure = .5f => Keeps default as UWP returns .5 for fingers.
@@ -171,15 +172,11 @@ namespace Windows.UI.Xaml.Input
 					props.Pressure = Math.Min(1f, _nativeEvent.GetPressure(_pointerIndex)); // Might exceed 1.0 on Android
 					break;
 
-				case MotionEventToolType.Unknown: // used by Xamarin.UITest
-					props.IsLeftButtonPressed = true;
-					break;
 				default:
 					break;
 			}
 
-			if (Android.OS.Build.VERSION.SdkInt >= BuildVersionCodes.M // ActionButton was introduced with API 23 (https://developer.android.com/reference/android/view/MotionEvent.html#getActionButton())
-				&& updates.TryGetValue(_nativeEvent.ActionButton, out var update))
+			if (updates.TryGetValue(_nativeEvent.ActionButton, out var update))
 			{
 				props.PointerUpdateKind = update;
 			}

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.iOS.cs
@@ -82,12 +82,18 @@ namespace Windows.UI.Xaml.Input
 			};
 
 		private PointerPointProperties GetProperties()
-			=> new PointerPointProperties()
+			=> new()
 			{
 				IsPrimary = true,
 				IsInRange = Pointer.IsInRange,
 				IsLeftButtonPressed = Pointer.IsInContact,
-				Pressure = (float)(_nativeTouch.Force / _nativeTouch.MaximumPossibleForce)
+				Pressure = (float)(_nativeTouch.Force / _nativeTouch.MaximumPossibleForce),
+				PointerUpdateKind = _nativeTouch.Phase switch
+				{
+					UITouchPhase.Began => PointerUpdateKind.LeftButtonPressed,
+					UITouchPhase.Ended => PointerUpdateKind.LeftButtonReleased,
+					_ => PointerUpdateKind.Other
+				}
 			};
 
 		#region Misc static helpers

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -7,6 +7,7 @@
 using Uno.UI.Extensions;
 using Windows.Foundation;
 using Windows.UI;
+using Windows.UI.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -51,9 +52,7 @@ namespace Uno.UI.Xaml.Core
 				handledEventsToo: false); 
 #endif
 
-			PointerPressed += RootVisual_PointerPressed;
 			PointerReleased += RootVisual_PointerReleased;
-			PointerCanceled += RootVisual_PointerCanceled;
 		}
 
 		/// <summary>
@@ -131,19 +130,10 @@ namespace Uno.UI.Xaml.Core
 		// Uno specific: To ensure focus is properly lost when clicking "outside" app's content,
 		// we set focus here. In case UWP, focus is set to the root ScrollViewer instead,
 		// but Uno does not have it on all targets yet.
-		private bool _isLeftButtonPressed = false;
-
-		private void RootVisual_PointerPressed(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
-		{
-			var point = e.GetCurrentPoint(this);
-			_isLeftButtonPressed = point.Properties.IsLeftButtonPressed;
-		}
-
 		private void RootVisual_PointerReleased(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
 		{
-			if (_isLeftButtonPressed)
+			if (e.GetCurrentPoint(null).Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonReleased)
 			{
-				_isLeftButtonPressed = false;
 				var element = FocusManager.GetFocusedElement();
 				if (element is UIElement uiElement)
 				{
@@ -151,12 +141,6 @@ namespace Uno.UI.Xaml.Core
 					e.Handled = true;
 				}
 			}
-		}
-
-
-		private void RootVisual_PointerCanceled(object sender, PointerRoutedEventArgs e)
-		{
-			_isLeftButtonPressed = false;
 		}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -7,7 +7,6 @@
 using Uno.UI.Extensions;
 using Windows.Foundation;
 using Windows.UI;
-using Windows.UI.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -18,6 +17,7 @@ using Windows.UI.Xaml.Input;
 using Microsoft.UI.Input;
 #else
 using Windows.Devices.Input;
+using Windows.UI.Input;
 #endif
 
 namespace Uno.UI.Xaml.Core

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -46,11 +46,7 @@ namespace Uno.UI.Xaml.Core
 			AddHandler(
 				PointerReleasedEvent,
 				new PointerEventHandler((snd, args) => ProcessPointerUp(args)),
-				// We don't want handled events, they are forwarded directly by the element that has handled it,
-				// but only ** AFTER ** the up has been fully processed.
-				// This is required to be sure that element process gestures and manipulations before we raise the exit
-				// (e.g. the 'tapped' event on a Button would be fired after the 'exit').
-				handledEventsToo: false); 
+				handledEventsToo: true); 
 #endif
 
 			PointerReleased += RootVisual_PointerReleased;
@@ -156,8 +152,15 @@ namespace Uno.UI.Xaml.Core
 		{
 #if __ANDROID__ // Not needed on WASM as we do have native support of the exit event
 			// On Android we use the RootVisual to raise the UWP only exit event (in managed only)
-			if (args.Pointer.PointerDeviceType is PointerDeviceType.Touch && args.OriginalSource is UIElement src)
+			if (!args.Handled
+				&& args.Pointer.PointerDeviceType is PointerDeviceType.Touch
+				&& args.OriginalSource is UIElement src)
 			{
+				// We don't want handled events, they are forwarded directly by the element that has handled it,
+				// but only ** AFTER ** the up has been fully processed.
+				// This is required to be sure that element process gestures and manipulations before we raise the exit
+				// (e.g. the 'tapped' event on a Button would be fired after the 'exit').
+
 				// It's acceptable to use only the OriginalSource on Android:
 				// since the platform has "implicit capture" and captures are propagated to the OS,
 				// the OriginalSource will be the element that has capture (if any).

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -42,7 +42,7 @@ namespace Uno.UI.Xaml.Core
 			SetAttribute("tabindex", "0");
 #endif
 
-#if __ANDROID__ || __WASM__
+#if __ANDROID__ || __WASM__ || __IOS__
 			AddHandler(
 				PointerReleasedEvent,
 				new PointerEventHandler((snd, args) => ProcessPointerUp(args)),
@@ -129,40 +129,35 @@ namespace Uno.UI.Xaml.Core
 		// but Uno does not have it on all targets yet.
 		private void RootVisual_PointerReleased(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
 		{
-			Console.Error.WriteLine($"Received released bubbling from {e.OriginalSource.GetDebugName()}");
-
 			if (e.GetCurrentPoint(null).Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonReleased
-				&& !PointerCapture.TryGet(e.Pointer, out _))
+				&& !PointerCapture.TryGet(e.Pointer, out _)
+				&& FocusManager.GetFocusedElement() is UIElement uiElement)
 			{
-				var element = FocusManager.GetFocusedElement();
-
-				Console.Error.WriteLine($"Removing focus from {element.GetDebugName()}");
-
-				if (element is UIElement uiElement)
-				{
-					uiElement.Unfocus();
-					e.Handled = true;
-				}
+				uiElement.Unfocus();
+				e.Handled = true;
 			}
 		}
 #endif
 
-#if __ANDROID__ || __WASM__
-		internal static void ProcessPointerUp(PointerRoutedEventArgs args)
+#if __ANDROID__ || __WASM__ || __IOS__
+		internal static void ProcessPointerUp(PointerRoutedEventArgs args, bool isAfterHandledUp = false)
 		{
-#if __ANDROID__ // Not needed on WASM as we do have native support of the exit event
-			// On Android we use the RootVisual to raise the UWP only exit event (in managed only)
-			if (!args.Handled
+#if __ANDROID__ || __IOS__ // Not needed on WASM as we do have native support of the exit event
+			// On Android and iOS we use the RootVisual to raise the UWP only exit event (in managed only)
+
+			// We don't want handled events raised on RootVisual,
+			// instead we wait for the element that handled it to directly forward it to us,
+			// but only ** AFTER ** the up has been fully processed (with isAfterHandledUp = true).
+			// This is required to be sure that element process gestures and manipulations before we raise the exit
+			// (e.g. the 'tapped' event on a Button would be fired after the 'exit').
+			var isUpFullyDispatched = isAfterHandledUp || !args.Handled;
+
+			if (isUpFullyDispatched
 				&& args.Pointer.PointerDeviceType is PointerDeviceType.Touch
 				&& args.OriginalSource is UIElement src)
 			{
-				// We don't want handled events, they are forwarded directly by the element that has handled it,
-				// but only ** AFTER ** the up has been fully processed.
-				// This is required to be sure that element process gestures and manipulations before we raise the exit
-				// (e.g. the 'tapped' event on a Button would be fired after the 'exit').
-
-				// It's acceptable to use only the OriginalSource on Android:
-				// since the platform has "implicit capture" and captures are propagated to the OS,
+				// It's acceptable to use only the OriginalSource on Android and iOS:
+				// since those platforms have "implicit capture" and captures are propagated to the OS,
 				// the OriginalSource will be the element that has capture (if any).
 
 				src.RedispatchPointerExited(args.Reset(canBubbleNatively: false));
@@ -183,5 +178,5 @@ namespace Uno.UI.Xaml.Core
 			}
 		}
 #endif
-		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Android.cs
@@ -142,7 +142,7 @@ namespace Windows.UI.Xaml
 					// but if the event has been handled, we need to raise it after the 'up' has been processed.
 					if (OnNativePointerUp(args))
 					{
-						Uno.UI.Xaml.Core.RootVisual.ProcessPointerUp(args);
+						Uno.UI.Xaml.Core.RootVisual.ProcessPointerUp(args, isAfterHandledUp: true);
 						return true;
 					}
 					else

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -283,7 +283,7 @@ namespace Windows.UI.Xaml
 			var that = (UIElement)sender.Owner;
 			var src = CoreWindow.GetForCurrentThread()?.LastPointerEvent?.OriginalSource as UIElement ?? that;
 
-			that.SafeRaiseEvent(ManipulationStartingEvent, new ManipulationStartingRoutedEventArgs(src, args));
+			that.SafeRaiseEvent(ManipulationStartingEvent, new ManipulationStartingRoutedEventArgs(src, that, args));
 		};
 
 		private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> OnRecognizerManipulationStarted = (sender,  args) =>
@@ -291,7 +291,7 @@ namespace Windows.UI.Xaml
 			var that = (UIElement)sender.Owner;
 			var src = CoreWindow.GetForCurrentThread()?.LastPointerEvent?.OriginalSource as UIElement ?? that;
 
-			that.SafeRaiseEvent(ManipulationStartedEvent, new ManipulationStartedRoutedEventArgs(src, sender, args));
+			that.SafeRaiseEvent(ManipulationStartedEvent, new ManipulationStartedRoutedEventArgs(src, that, sender, args));
 		};
 
 		private static readonly TypedEventHandler<GestureRecognizer, ManipulationUpdatedEventArgs> OnRecognizerManipulationUpdated = (sender, args) =>
@@ -299,7 +299,7 @@ namespace Windows.UI.Xaml
 			var that = (UIElement)sender.Owner;
 			var src = CoreWindow.GetForCurrentThread()?.LastPointerEvent?.OriginalSource as UIElement ?? that;
 
-			that.SafeRaiseEvent(ManipulationDeltaEvent, new ManipulationDeltaRoutedEventArgs(src, sender, args));
+			that.SafeRaiseEvent(ManipulationDeltaEvent, new ManipulationDeltaRoutedEventArgs(src, that, sender, args));
 		};
 
 		private static readonly TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> OnRecognizerManipulationInertiaStarting = (sender, args) =>
@@ -307,7 +307,7 @@ namespace Windows.UI.Xaml
 			var that = (UIElement)sender.Owner;
 			var src = CoreWindow.GetForCurrentThread()?.LastPointerEvent?.OriginalSource as UIElement ?? that;
 
-			that.SafeRaiseEvent(ManipulationInertiaStartingEvent, new ManipulationInertiaStartingRoutedEventArgs(src, args));
+			that.SafeRaiseEvent(ManipulationInertiaStartingEvent, new ManipulationInertiaStartingRoutedEventArgs(src, that, args));
 		};
 
 		private static readonly TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> OnRecognizerManipulationCompleted = (sender, args) =>
@@ -322,7 +322,7 @@ namespace Windows.UI.Xaml
 			}
 #endif
 
-			that.SafeRaiseEvent(ManipulationCompletedEvent, new ManipulationCompletedRoutedEventArgs(src, args));
+			that.SafeRaiseEvent(ManipulationCompletedEvent, new ManipulationCompletedRoutedEventArgs(src, that, args));
 		};
 
 		private static readonly TypedEventHandler<GestureRecognizer, TappedEventArgs> OnRecognizerTapped = (sender, args) =>
@@ -990,7 +990,7 @@ namespace Windows.UI.Xaml
 				}
 			}
 
-#if !UNO_HAS_MANAGED_POINTERS && !__ANDROID__ // Captures release are handled a root level (RootVisual for Android)
+#if !UNO_HAS_MANAGED_POINTERS && !__ANDROID__ && !__WASM__ // Captures release are handled a root level (RootVisual for Android and WASM)
 			// We release the captures on up but only after the released event and processed the gesture
 			// Note: For a "Tap" with a finger the sequence is Up / Exited / Lost, so we let the Exit raise the capture lost
 			// Note: If '!isOver', that means that 'IsCaptured == true' otherwise 'isOverOrCaptured' would have been false.
@@ -1017,7 +1017,7 @@ namespace Windows.UI.Xaml
 				global::Windows.UI.Xaml.Window.Current.DragDrop.ProcessMoved(args);
 			}
 
-#if !UNO_HAS_MANAGED_POINTERS && !__ANDROID__ // Captures release are handled a root level (RootVisual for Android)
+#if !UNO_HAS_MANAGED_POINTERS && !__ANDROID__ && !__WASM__ // Captures release are handled a root level (RootVisual for Android and WASM)
 			// We release the captures on exit when pointer if not pressed
 			// Note: for a "Tap" with a finger the sequence is Up / Exited / Lost, so the lost cannot be raised on Up
 			if (!IsPressed(args.Pointer))

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -16,6 +16,7 @@ using Uno.Foundation.Logging;
 using Uno.UI;
 using Uno.UI.Extensions;
 using Uno.UI.Xaml;
+using Uno.UI.Xaml.Core;
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;
@@ -178,8 +179,17 @@ public partial class UIElement : DependencyObject
 					break;
 
 				case NativePointerEvent.pointerup:
-					stopPropagation = element.OnNativePointerUp(ToPointerArgs(element, args, isInContact: false));
+				{
+					var routedArgs = ToPointerArgs(element, args, isInContact: false);
+					stopPropagation = element.OnNativePointerUp(routedArgs);
+
+					if (stopPropagation)
+					{
+						RootVisual.ProcessPointerUp(routedArgs, isAfterHandledUp: true);
+					}
+
 					break;
+				}
 
 				case NativePointerEvent.pointermove:
 					stopPropagation = element.OnNativePointerMove(ToPointerArgs(element, args));

--- a/src/Uno.UWP/UI/Input/PointerPointPropertiesExtensions.cs
+++ b/src/Uno.UWP/UI/Input/PointerPointPropertiesExtensions.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using System;
+using System.Linq;
+
+namespace Windows.UI.Input;
+
+internal static class PointerPointPropertiesExtensions
+{
+	public static PointerPointProperties SetUpdateKindFromPrevious(this PointerPointProperties current, PointerPointProperties? previous)
+	{
+		if (previous is null)
+		{
+			return current;
+		}
+
+		// The PointerUpdateKind is not a [Flags] enum, so we allow only one pointer change.
+		var result = PointerUpdateKind.Other;
+		if (HasChanged(previous.IsLeftButtonPressed, current.IsLeftButtonPressed, PointerUpdateKind.LeftButtonPressed, PointerUpdateKind.LeftButtonReleased, ref result)
+			|| HasChanged(previous.IsMiddleButtonPressed, current.IsMiddleButtonPressed, PointerUpdateKind.MiddleButtonPressed, PointerUpdateKind.MiddleButtonReleased, ref result)
+			|| HasChanged(previous.IsRightButtonPressed, current.IsRightButtonPressed, PointerUpdateKind.RightButtonPressed, PointerUpdateKind.RightButtonReleased, ref result)
+			|| HasChanged(previous.IsXButton1Pressed, current.IsXButton1Pressed, PointerUpdateKind.XButton1Pressed, PointerUpdateKind.XButton1Released, ref result)
+			|| HasChanged(previous.IsXButton2Pressed, current.IsXButton2Pressed, PointerUpdateKind.XButton2Pressed, PointerUpdateKind.XButton2Released, ref result))
+		{
+			current.PointerUpdateKind = result;
+		}
+
+		return current;
+
+		static bool HasChanged(bool was, bool @is, PointerUpdateKind pressed, PointerUpdateKind released, ref PointerUpdateKind update)
+		{
+			if (was == @is)
+			{
+				return false;
+			}
+			else if (was)
+			{
+				update = released;
+				return true;
+			}
+			else
+			{
+				update = pressed;
+				return true;
+			}
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Input/PointerPointPropertiesExtensions.cs
+++ b/src/Uno.UWP/UI/Input/PointerPointPropertiesExtensions.cs
@@ -3,7 +3,11 @@
 using System;
 using System.Linq;
 
+#if HAS_UNO_WINUI && IS_UNO_UI_PROJECT
+namespace Microsoft.UI.Input;
+#else
 namespace Windows.UI.Input;
+#endif
 
 internal static class PointerPointPropertiesExtensions
 {


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/7820
fixes https://github.com/unoplatform/uno/issues/8011

## Bugfix
We need to double click to remove focus on an element that modifies its visual tree on pointer release

## What is the current behavior?
When a `ComboxBoxItem` gets a `PointerRelease` it closes the drop down synchronously, which stop bubbling of the event. This drives the `RootVisual` to not receive it and believe that pointer is still pressed (internal state of the pointers handling of `UIElement` --which is still an issue-- **and** private local flag maintained of the `RootVisual` itself). We then need to double tap to reset that invalid state.

## What is the new behavior?
We no longer maintain a local private flag in the `RootVisual` but we are instead using the `PointerUpdateKind` to remove focus. Doing this we have only one state to clear so it self recovers on first click.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
