### PR TITLE
feat(macOS): Add SelectedRange on TextBox

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.macOS.cs
@@ -148,7 +148,17 @@ namespace Windows.UI.Xaml.Controls
 
 		public NSRange MarkedRange => throw new NotImplementedException();
 
-		public NSRange SelectedRange => throw new NotImplementedException();
+		public NSRange SelectedRange
+		{
+			get => CurrentEditor?.SelectedRange ?? new NSRange(start: 0, len: 0);
+			set
+			{
+				if (CurrentEditor != null)
+				{
+					CurrentEditor.SelectedRange = value;
+				}
+			}
+		}
 
 		public NSString[] ValidAttributesForMarkedText => null;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
`SelectedRange` on TextBox.macOS is not implemented.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
