### PR TITLE
perf: Reduce interop invocations during MeasureChildOverride

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
@@ -27,25 +27,9 @@ namespace Windows.UI.Xaml.Controls
 			var widthSpec = ViewHelper.SpecFromLogicalSize(slotSize.Width);
 			var heightSpec = ViewHelper.SpecFromLogicalSize(slotSize.Height);
 
-			if (double.IsPositiveInfinity(slotSize.Width) || double.IsPositiveInfinity(slotSize.Height))
-			{
-				// Bypass Android cache, to ensure the Child's Measure() is actually invoked.
-				view.ForceLayout();
+			var needsForceLayout = double.IsPositiveInfinity(slotSize.Width) || double.IsPositiveInfinity(slotSize.Height);
 
-				// This could occur when one of the dimension is _Infinite_: Android will cache the
-				// value, which is not something we want. Specially when the container is a <StackPanel>.
-
-				// Issue: https://github.com/unoplatform/uno/issues/2879
-			}
-
-			if (view.IsLayoutRequested && view.Parent is View parent && !parent.IsLayoutRequested)
-			{
-				// If a view has requested layout but its Parent hasn't, then the tree is in a broken state, because RequestLayout() calls
-				// cannot bubble up from below the view, and remeasures cannot bubble down from above the parent. This can arise, eg, when
-				// ForceLayout() is used. To fix this state, call RequestLayout() on the parent. Since MeasureChildOverride() is called
-				// from the top down, we should be able to assume that the tree above the parent is already in a good state.
-				parent.RequestLayout();
-			}
+			Uno.UI.Controls.BindableView.TryFastRequestLayout(view, needsForceLayout);
 
 			MeasureChild(view, widthSpec, heightSpec);
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Reduces android interop calls by moving some Measure-specific code to java.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
