### PR TITLE
docs: Mention requirement for gtk under Windows in getting started

### DIFF
--- a/doc/articles/get-started-vscode.md
+++ b/doc/articles/get-started-vscode.md
@@ -13,7 +13,7 @@ See these sections for information about using Uno Platform with:
     * [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet-core/5.0) (**version 6.0 (SDK 6.0.100)** or later)
     > Use `dotnet --version` from the terminal to get the version installed.
 * The [Uno Platform Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=unoplatform.vscode) Extension
-* For windows also [GTK runtime](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases) (this is currently not checked by uno-check see [issue](https://github.com/unoplatform/uno.check/issues/12))
+* For Windows, install the [GTK+ 3 runtime](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases) (See [this uno-check issue](https://github.com/unoplatform/uno.check/issues/12))
 
 You can use [`uno-check`](https://github.com/unoplatform/uno.check) to make your installation compatible with Uno Platform.
 

--- a/doc/articles/get-started-vscode.md
+++ b/doc/articles/get-started-vscode.md
@@ -13,6 +13,7 @@ See these sections for information about using Uno Platform with:
     * [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet-core/5.0) (**version 6.0 (SDK 6.0.100)** or later)
     > Use `dotnet --version` from the terminal to get the version installed.
 * The [Uno Platform Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=unoplatform.vscode) Extension
+* For windows also [GTK runtime](https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases) (this is currently not checked by uno-check see [issue](https://github.com/unoplatform/uno.check/issues/12))
 
 You can use [`uno-check`](https://github.com/unoplatform/uno.check) to make your installation compatible with Uno Platform.
 


### PR DESCRIPTION
Added mention of GTK requirement for Windows

GitHub Issue (If applicable): closes #


## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Documentation content changes

-->

## What is the current behavior?

Getting started did not work correctly on Windows


## What is the new behavior?

Link to prerequirement of GTK


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] ~~Validated PR `Screenshots Compare Test Run` results.~~
- [ ] ~~Contains **NO** breaking changes~~
- [ ] ~~Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~~
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.  
       ~~Not yet, I think I can't change the github UI, I will check it out on my machine and make a chang it ther when there is a general OK for this request.~~ Updated commit message


## Other information

If the docs should not contain platform specific conditions, skia-gtk could be removed instead to make it cleaner. It may also reduce the barrier for people just want to try it out. Disclamer I personally did not installed GTK, since there is a high chance it will never leave the system again.

If platform specific conditions would be ok, Instead for windows `skia-wpf` could be enabled and `skia-gtk` disabled.

Internal Issue (If applicable):
not applicable.
