### PR TITLE
fix(xBind): Fix support for nullable struct binding

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
@@ -1398,6 +1398,68 @@ namespace Uno.UI.Tests.BinderTests
 		}
 
 		[TestMethod]
+		public void When_NullableStructRecordPropertyBinding()
+		{
+			var SUT = new Windows.UI.Xaml.Controls.Border();
+			var propertyOwner = new NullableStructRecordPropertyOwner()
+			{
+				MyProperty = null
+			};
+			SUT.Tag = propertyOwner;
+
+			var o2 = new Windows.UI.Xaml.Controls.Border();
+			o2.SetBinding(
+				Windows.UI.Xaml.Controls.Border.TagProperty,
+				new Binding()
+				{
+					Path = "Tag.MyProperty.Value.OtherProperty",
+					Mode = BindingMode.OneWay,
+					CompiledSource = SUT
+				}
+			);
+
+			o2.ApplyXBind();
+
+			Assert.IsNull(o2.Tag);
+
+			propertyOwner.MyProperty
+				= new NullableStructRecordPropertyOwner.MyRecord("42");
+
+			Assert.AreEqual("42", o2.Tag);
+		}
+
+		[TestMethod]
+		public void When_StructRecordWithValuePropertyBinding()
+		{
+			var SUT = new Windows.UI.Xaml.Controls.Border();
+			var propertyOwner = new StructRecordWithValuePropertyOwner()
+			{
+				MyProperty = new StructRecordWithValuePropertyOwner.MyRecord()
+			};
+			SUT.Tag = propertyOwner;
+
+			var o2 = new Windows.UI.Xaml.Controls.Border();
+			o2.SetBinding(
+				Windows.UI.Xaml.Controls.Border.TagProperty,
+				new Binding()
+				{
+					Path = "Tag.MyProperty.Value",
+					Mode = BindingMode.OneWay,
+					CompiledSource = SUT
+				}
+			);
+
+			o2.ApplyXBind();
+
+			Assert.IsNull(o2.Tag);
+
+			propertyOwner.MyProperty
+				= new StructRecordWithValuePropertyOwner.MyRecord("42");
+
+			Assert.AreEqual("42", o2.Tag);
+		}
+
+		[TestMethod]
 		public void When_DataContext_Changing()
 		{
 			var SUT = new NullablePropertyOwner();
@@ -1898,6 +1960,52 @@ namespace Uno.UI.Tests.BinderTests
 
 		#endregion
 
+	}
+
+	partial class NullableStructRecordPropertyOwner : FrameworkElement
+	{
+		public MyRecord? MyProperty
+		{
+			get => (MyRecord?)GetValue(MyPropertyProperty);
+			set => SetValue(MyPropertyProperty, value);
+		}
+
+		public static readonly DependencyProperty MyPropertyProperty =
+			DependencyProperty.Register(
+				nameof(MyProperty),
+				typeof(MyRecord?),
+				typeof(NullableStructRecordPropertyOwner),
+				new PropertyMetadata(null, DataReady));
+
+		private static void DataReady(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+
+		}
+
+		public readonly record struct MyRecord(string OtherProperty);
+	}
+
+	partial class StructRecordWithValuePropertyOwner : FrameworkElement
+	{
+		public MyRecord MyProperty
+		{
+			get => (MyRecord)GetValue(MyPropertyProperty);
+			set => SetValue(MyPropertyProperty, value);
+		}
+
+		public static readonly DependencyProperty MyPropertyProperty =
+			DependencyProperty.Register(
+				nameof(MyProperty),
+				typeof(MyRecord),
+				typeof(StructRecordWithValuePropertyOwner),
+				new PropertyMetadata(null, DataReady));
+
+		private static void DataReady(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+
+		}
+
+		public readonly record struct MyRecord(string Value);
 	}
 
 	partial class MyDependencyObjectWithDefaultValueOverride : FrameworkElement

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_NullableRecordStruct.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_NullableRecordStruct.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.xBind_NullableRecordStruct"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<TextBlock x:Name="tb1"
+				   x:FieldModifier="public"
+				   Text="{x:Bind MyProperty.Value.OtherProperty, Mode=OneWay}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_NullableRecordStruct.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_NullableRecordStruct.xaml.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	#pragma warning disable UXAML0002
+	public sealed partial class xBind_NullableRecordStruct : UserControl
+#pragma warning restore UXAML0002
+	{
+		public xBind_NullableRecordStruct()
+		{
+			this.InitializeComponent();
+		}
+
+		public MyRecord? MyProperty
+		{
+			get => (MyRecord?)GetValue(MyPropertyProperty);
+			set => SetValue(MyPropertyProperty, value);
+		}
+
+		public static readonly DependencyProperty MyPropertyProperty =
+			DependencyProperty.Register(
+				nameof(MyProperty),
+				typeof(MyRecord?),
+				typeof(xBind_NullableRecordStruct),
+				new PropertyMetadata(null, DataReady));
+
+		private static void DataReady(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+
+		}
+
+		public readonly record struct MyRecord(string OtherProperty);
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -1183,7 +1183,6 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			}
 		}
 
-
 		[TestMethod]
 		public async Task When_Binding_xNull()
 		{
@@ -1199,6 +1198,20 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 
 			Assert.IsNotNull(SUT.tb03);
 			Assert.AreEqual("MMM d <null>", SUT.tb03.Text);
+		}
+
+		[TestMethod]
+		public async Task When_NullableRecordStruct()
+		{
+			var SUT = new xBind_NullableRecordStruct();
+
+			SUT.ForceLoaded();
+
+			Assert.AreEqual("", SUT.tb1.Text);
+
+			SUT.MyProperty = new xBind_NullableRecordStruct.MyRecord("42");
+
+			Assert.AreEqual("42", SUT.tb1.Text);
 		}
 
 		private async Task AssertIsNullAsync<T>(Func<T> getter, TimeSpan? timeout = null) where T:class

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -333,7 +333,7 @@ namespace Uno.UI.DataBinding
 						return attachedPropertyGetter.ReturnType;
 					}
 
-					if (type.IsPrimitive && property == "Value")
+					if (type.IsValueType && property == "Value")
 					{
 						// This case is trying assuming that Value for a primitive is used for the case
 						// of a Nullable primitive.
@@ -724,7 +724,7 @@ namespace Uno.UI.DataBinding
 				}
 
 				if (
-					type.IsPrimitive
+					type.IsValueType
 					&& property == "Value"
 				)
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/7486

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

x:Bind and Binding to a nullable struct is now supported.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
