### PR TITLE
fix: `TextBox_No_Text_Entered` test failing on iOS 15

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -324,7 +324,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 		[Test]
 		[AutoRetry]
 		[Timeout(400000)] // Increased iOS timeout for Xamarin.UITest 3.2
-		[Ignore("Failed to find [Pointer] on [FocusState] in last DefocusTextBox invocation: https://github.com/unoplatform/uno/issues/8015")]
 		public void TextBox_No_Text_Entered()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxControl.TextBox_Binding_Null");
@@ -354,11 +353,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			_app.FastTap(TextBox);
 
-			_app.EnterText("fleep");
+			_app.EnterText("fleet");
 
 			DefocusTextBox();
 
-			Assert.AreEqual("fleep", GetMappedText());
+			Assert.AreEqual("fleet", GetMappedText());
 
 			_app.FastTap("ResetButton");
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Binding_Null.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Binding_Null.xaml
@@ -1,23 +1,24 @@
-﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxControl.TextBox_Binding_Null"
-			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBox"
-			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-			 mc:Ignorable="d"
-			 d:DesignHeight="300"
-			 d:DesignWidth="400">
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxControl.TextBox_Binding_Null"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBox"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="300"
+    d:DesignWidth="400"
+    mc:Ignorable="d">
 
-	<StackPanel Spacing="15">
-		<Button x:Name="DummyButton"
-				Content="Dummy" />
-		<TextBox x:Name="TargetTextBox"
-				 Text="{Binding MyString, Mode=TwoWay}"
-				 PlaceholderText="enter..." />
-		<TextBlock x:Name="MappedText"
-				   Text="initial" />
-		<Button x:Name="ResetButton"
-				Content="Reset text"
-				Click="OnClick" />
-	</StackPanel>
+    <StackPanel Spacing="16">
+        <TextBox
+            x:Name="TargetTextBox"
+            PlaceholderText="enter..."
+            Text="{Binding MyString, Mode=TwoWay}" />
+        <TextBlock x:Name="MappedText" Text="initial" />
+        <Button
+            x:Name="ResetButton"
+            Click="OnClick"
+            Content="Reset text" />
+        <Button x:Name="DummyButton" Content="Dummy" />
+    </StackPanel>
 </UserControl>


### PR DESCRIPTION

GitHub Issue (If applicable): closes #8015

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The TextBox_No_Text_Entered test is failing on iOS due to the fact that the text input in the text field by the test was not a real word which made the system show a autocorrect popup above the text field, which appeared right on top of the button the test was trying to tap :-)


## What is the new behavior?

Not failing anymore.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.