### PR TITLE
test: Don't wrap setup and teardown on UI tests auto retry

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/AutoRetry.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/AutoRetry.cs
@@ -14,7 +14,7 @@ namespace SamplesApp.UITests.TestFramework
 	/// maximum number of times.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-	public partial class AutoRetryAttribute : NUnitAttribute, IRepeatTest, IWrapSetUpTearDown
+	public partial class AutoRetryAttribute : NUnitAttribute, IRepeatTest
 	{
 		private readonly int _tryCount;
 


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?
- Test

## What is the new behavior?

This changes removes `IWrapSetUpTearDown` from `AutoRetryAttribute` in order to remove the useless retries added (6 total) because of the wrapping of setup and teardown methods. The test method itself already can retry on setup/teardown failures.