### PR TITLE
feat!: Bump to net6 preview 13.2, VS 2022 17.2 Preview 1

### DIFF
--- a/build/ci/templates/dotnet6-install-mac.yml
+++ b/build/ci/templates/dotnet6-install-mac.yml
@@ -1,7 +1,7 @@
 parameters:
-  DotNetVersion: '6.0.200-preview.22055.15'
+  DotNetVersion: '6.0.200'
   UnoCheck_Version: '1.1.0-dev.22'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/4b89f56d8fa3f2cdd980425dcc8cbc4db1249d99/manifests/uno.ui-preview.manifest.json'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/90603a57991621c9998fa66534a14e5bf470acc4/manifests/uno.ui-preview.manifest.json'
   Dotnet_Root: '/usr/local/share/dotnet/'
   Dotnet_Tools: '~/.dotnet/tools'
 
@@ -20,14 +20,23 @@ steps:
       version: 3.1.x
       installationPath: ${{ parameters.Dotnet_Root }}
 
-  - bash: |
-      export PATH="${{ parameters.Dotnet_Root }}:${{ parameters.Dotnet_Tools }}:$PATH"
-      curl -L https://raw.githubusercontent.com/dotnet/install-scripts/7a9d5dcab92cf131fc2d8977052f8c2c2d540e22/src/dotnet-install.sh > dotnet-install.sh
-      sh dotnet-install.sh --version ${{ parameters.DotNetVersion }} --install-dir $DOTNET_ROOT --verbose
-      dotnet --list-sdks
-      echo "##vso[task.setvariable variable=PATH]$PATH"
-    displayName: install .NET ${{ parameters.DotNetVersion }}
+  ## Required until .NET 6 installs properly using UseDotnet
+  ## using preview builds
+  # - bash: |
+  #     export PATH="${{ parameters.Dotnet_Root }}:${{ parameters.Dotnet_Tools }}:$PATH"
+  #     curl -L https://raw.githubusercontent.com/dotnet/install-scripts/11b4eebe23d871c074364940d301c3eb53e7c7ec/src/dotnet-install.sh > dotnet-install.sh
+  #     sh dotnet-install.sh --version ${{ parameters.DotNetVersion }} --install-dir $DOTNET_ROOT --verbose
+  #     dotnet --list-sdks
+  #     echo "##vso[task.setvariable variable=PATH]$PATH"
+  #   displayName: install .NET ${{ parameters.DotNetVersion }}
+  #   retryCountOnTaskFailure: 3
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK ${{ parameters.DotNetVersion }}'
     retryCountOnTaskFailure: 3
+    inputs:
+      packageType: sdk
+      version: ${{ parameters.DotNetVersion }}
 
   - template: jdk-setup.yml
 

--- a/build/ci/templates/dotnet6-install-windows.yml
+++ b/build/ci/templates/dotnet6-install-windows.yml
@@ -1,19 +1,26 @@
 parameters:
-  DotNetVersion: '6.0.200-preview.22055.15'
+  DotNetVersion: '6.0.200'
   UnoCheck_Version: '1.1.0-dev.22'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/4b89f56d8fa3f2cdd980425dcc8cbc4db1249d99/manifests/uno.ui-preview.manifest.json'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/90603a57991621c9998fa66534a14e5bf470acc4/manifests/uno.ui-preview.manifest.json'
 
 steps:
 
   ## Required until .NET 6 installs properly on Windows using UseDotnet
-  - powershell: |
-      $ProgressPreference = 'SilentlyContinue'
-      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
-      & .\dotnet-install.ps1 -Version ${{ parameters.DotNetVersion }} -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
-      & dotnet --list-sdks
-    displayName: Install .NET ${{ parameters.DotNetVersion }}
-    errorActionPreference: stop
+  ## using preview builds
+  #- powershell: |
+  #    $ProgressPreference = 'SilentlyContinue'
+  #    Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+  #    & .\dotnet-install.ps1 -Version ${{ parameters.DotNetVersion }} -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
+  #    & dotnet --list-sdks
+  #  displayName: Install .NET ${{ parameters.DotNetVersion }}
+  #  errorActionPreference: stop
+  #  retryCountOnTaskFailure: 3
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK ${{ parameters.DotNetVersion }}'
     retryCountOnTaskFailure: 3
+    inputs:
+      packageType: sdk
+      version: ${{ parameters.DotNetVersion }}
 
   - template: jdk-setup.yml
     

--- a/doc/articles/get-started-dotnet-new.md
+++ b/doc/articles/get-started-dotnet-new.md
@@ -112,6 +112,8 @@ To use it:
 
 ## Uno Platform Blank Application (.NET 6 - Preview)
 
+> .NET 6 Mobile support is currently in Preview, following Microsoft's support status. As of Uno 4.1, .NET 6 Mobile Preview 13 and above is supported with [Visual Studio 2022 17.2 Preview 1](https://visualstudio.microsoft.com/vs/preview). Previous releases of Visual Studio are not supported.
+
 This template can be used to create a blank multi-platform application for iOS, Android, WebAssembly, macOS, mac Catalyst, Skia/GTK (Windows, Linux, macOS) and Skia/Wpf (Windows 7 and 10).
 
 This template uses a single project head for iOS, Android, macOS and mac Catalyst and requires Visual Studio 2022.

--- a/doc/articles/get-started-vs-2022.md
+++ b/doc/articles/get-started-vs-2022.md
@@ -11,12 +11,12 @@
 	* **Mobile development with .NET (Xamarin)** workload installed.
 
     ![visual-studio-installer-xamarin](Assets/quick-start/vs-install-xamarin.png)
-    * Starting from VS 2022 17.1 Preview 1, select the **.NET Maui (Preview)** optional component (Installs the .NET 6 Android and iOS workloads)
+    * Starting from **[Visual Studio 2022 17.2 Preview 1](https://visualstudio.microsoft.com/vs/preview)**, select the **.NET Maui (Preview)** optional component (Installs the .NET 6 Android and iOS workloads)
         * The iOS Remote Simulator installed (for iOS development)
 	    * A working Mac with Visual Studio for Mac, Xcode 13.5 Beta or later installed (for iOS development)
 	    * Google's Android x86 emulators or a physical Android device (for Android development)
 
-    * **ASP**.**NET and web** workload installed, along with .NET 6.0 (for WASM development)
+    * **ASP**.**NET and web** workload installed, along with .NET 6.0 (for WebAssembly development)
 
     ![visual-studio-installer-web](Assets/quick-start/vs-install-web.png)
 
@@ -59,7 +59,7 @@ To easily create a multi-platform application:
 
 ## Create an application from the .NET 6 Mobile Preview solution template
 
-> .NET 6 Mobile support is currently in Preview, following Microsoft's support status. As of Uno 4.1, .NET 6 Mobile Preview 12 and above is supported.
+> .NET 6 Mobile support is currently in Preview, following Microsoft's support status. As of Uno 4.1, .NET 6 Mobile Preview 13 and above is supported with [Visual Studio 2022 17.2 Preview 1](https://visualstudio.microsoft.com/vs/preview). Previous releases of Visual Studio are not supported.
 
 To create a multi-platform application:
 * Create a new C# solution using the **Multi-Platform App (Uno Platform|net6)** template, from Visual Studio's **Start Page**

--- a/src/AddIns/Uno.UI.MSAL/AcquireTokenInteractiveParameterBuilderExtensions.cs
+++ b/src/AddIns/Uno.UI.MSAL/AcquireTokenInteractiveParameterBuilderExtensions.cs
@@ -15,7 +15,12 @@ namespace Uno.UI.MSAL
 #if __WASM__
 			builder.WithCustomWebUi(WasmWebUi.Instance);
 #elif __MACOS__
+#if NET6_0_OR_GREATER
+			// WithUnoHelpers is not yet supported for macOS on .NET 6
+			// builder.WithParentActivityOrWindow(Windows.UI.Xaml.Window.Current.Content.Window);
+#else
 			builder.WithParentActivityOrWindow(Windows.UI.Xaml.Window.Current.Content.Window);
+#endif
 #endif
 			return builder;
 		}

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Mobile/iOS/Info.plist
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Mobile/iOS/Info.plist
@@ -12,8 +12,6 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MinimumOSVersion</key>
-	<string>10.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 	  <integer>1</integer>

--- a/src/Uno.UI/Extensions/Matrix3x2Extensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/Matrix3x2Extensions.iOSmacOS.cs
@@ -11,6 +11,7 @@ namespace Uno.UI.Extensions
 		public static CATransform3D ToTransform3D(this Matrix3x2 matrix)
 			=> new CATransform3D
 			{
+#if !NET6_0_OR_GREATER
 				// Note: The transformation X and Y (M31 and M32) are on the fourth row of 4x4 transform matrix.
 				// Note2: As we cannot assume that there is no marshaling on each value we set, we set only the
 				//		  needed values for an affine transform (3x2).
@@ -19,6 +20,16 @@ namespace Uno.UI.Extensions
 				m21 = matrix.M21, m22 = matrix.M22, // m23 = 0, m24 = 0,
 				/*m31 = 0, m32 = 0,*/ m33 = 1, // m34 = 0,
 				m41 = matrix.M31, m42 = matrix.M32, /*m43 = 0,*/ m44 = 1
+#else
+				// Note: The transformation X and Y (M31 and M32) are on the fourth row of 4x4 transform matrix.
+				// Note2: As we cannot assume that there is no marshaling on each value we set, we set only the
+				//		  needed values for an affine transform (3x2).
+
+				M11 = matrix.M11, M12 = matrix.M12, // m13 = 0, m14 = 0,
+				M21 = matrix.M21, M22 = matrix.M22, // m23 = 0, m24 = 0,
+				/*m31 = 0, m32 = 0,*/ M33 = 1, // m34 = 0,
+				M41 = matrix.M31, M42 = matrix.M32, /*m43 = 0,*/ M44 = 1
+#endif
 			};
 	}
 }

--- a/src/Uno.UI/Services/ResourceService.iOSmacOS.cs
+++ b/src/Uno.UI/Services/ResourceService.iOSmacOS.cs
@@ -32,9 +32,13 @@ namespace Uno.UI.Services
 			// If key is nil and value is non-nil, returns value.
 			// If key is not found and value is nil or an empty string, returns key.
 			// If key is not found and value is non-nil and not empty, return value.
+#if NET6_0_OR_GREATER
+			var localizedString = bundle.GetLocalizedString(id, KeyNotFoundValue, null);
+#else
 #pragma warning disable CS0618 // Type or member is obsolete
 			var localizedString = bundle.LocalizedString(id, KeyNotFoundValue, null);
 #pragma warning restore CS0618 // Type or member is obsolete
+#endif
 
 			if (localizedString == KeyNotFoundValue)
 			{

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -153,7 +153,13 @@ namespace Windows.UI.Xaml
 
 		partial void ObserveSystemThemeChanges()
 		{
-			NSDistributedNotificationCenter.GetDefaultCenter().AddObserver(
+			NSDistributedNotificationCenter
+#if NET6_0_OR_GREATER
+				.DefaultCenter
+#else
+				.GetDefaultCenter()
+#endif
+				.AddObserver(
 				this,
 				_modeSelector,
 				_themeChangedNotification,

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS.cs
@@ -20,7 +20,12 @@ namespace Windows.UI.Xaml.Controls
 		private static DependencyProperty CancelTextIosOverrideProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.MenuFlyoutExtensions", "CancelTextIosOverride");
 
 #pragma warning disable CS0618 // Type or member is obsolete
-		private string LocalizedCancelString => NSBundle.FromIdentifier("com.apple.UIKit").LocalizedString("Cancel", null);
+		private string LocalizedCancelString => NSBundle.FromIdentifier("com.apple.UIKit")
+#if NET6_0_OR_GREATER
+			.GetLocalizedString("Cancel", null);
+#else
+			.LocalizedString("Cancel", null);
+#endif
 #pragma warning restore CS0618 // Type or member is obsolete
 
 		internal protected override void Open()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
@@ -321,7 +321,14 @@ namespace Windows.UI.Xaml.Controls
 				}
 
 				_textContainer.Size = size;
-				return _layoutManager.GetUsedRectForTextContainer(_textContainer).Size;
+
+#if NET6_0_OR_GREATER
+				return _layoutManager.GetUsedRect
+#else
+				return _layoutManager.GetUsedRectForTextContainer
+#endif
+
+				(_textContainer).Size;
 			}
 			else
 			{
@@ -344,9 +351,17 @@ namespace Windows.UI.Xaml.Controls
 			// Find the tapped character's index
 			var partialFraction = (nfloat)0;
 			var pointInTextContainer = new CGPoint(point.X - _drawRect.X, point.Y - _drawRect.Y);
+
+#if NET6_0_OR_GREATER
+			var characterIndex = (int)_layoutManager.GetCharacterIndex
+			(pointInTextContainer, _layoutManager.TextContainers.FirstOrDefault(), out partialFraction);
+#else
 #pragma warning disable CS0618 // Type or member is obsolete (For VS2017 compatibility)
-			var characterIndex = (int)_layoutManager.CharacterIndexForPoint(pointInTextContainer, _layoutManager.TextContainers.FirstOrDefault(), ref partialFraction);
+			var characterIndex = (int)_layoutManager.CharacterIndexForPoint
+			(pointInTextContainer, _layoutManager.TextContainers.FirstOrDefault(), ref partialFraction);
 #pragma warning restore CS0618 // Type or member is obsolete
+#endif
+
 
 			return characterIndex;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.macOS.cs
@@ -66,7 +66,12 @@ namespace Windows.UI.Xaml.Controls
 				// While DrawBackgroundForGlyphRange will draw the background mark for specified Glyphs DrawGlyphsForGlyphRange will draw the actual Glyphs.
 
 				// Note: This part of the code is called only under very specific situations. For most of the scenarios DrawString is used to draw the text.
-				_layoutManager?.DrawGlyphsForGlyphRange(new NSRange(0, (nint)_layoutManager.NumberOfGlyphs), _drawRect.Location);
+#if NET6_0_OR_GREATER
+				_layoutManager?.DrawGlyphs
+#else
+				_layoutManager?.DrawGlyphsForGlyphRange
+#endif
+					(new NSRange(0, (nint)_layoutManager.NumberOfGlyphs), _drawRect.Location);
 			}
 			else
 			{
@@ -366,7 +371,13 @@ namespace Windows.UI.Xaml.Controls
 				_textContainer.Size = size;
 				// Required for GetUsedRectForTextContainer to return a value.
 				_layoutManager.GetGlyphRange(_textContainer);
-				return _layoutManager.GetUsedRectForTextContainer(_textContainer).Size;
+				return _layoutManager
+#if NET6_0_OR_GREATER
+					.GetUsedRect
+#else
+					.GetUsedRectForTextContainer
+#endif
+						(_textContainer).Size;
 			}
 			else
 			{
@@ -390,9 +401,15 @@ namespace Windows.UI.Xaml.Controls
 			var partialFraction = (nfloat)0;
 			var pointInTextContainer = new CGPoint(point.X - _drawRect.X, point.Y - _drawRect.Y);
 
+#if NET6_0_OR_GREATER
+			var characterIndex = (int)_layoutManager.GetCharacterIndex
+				(pointInTextContainer, _layoutManager.TextContainers.FirstOrDefault(), out partialFraction);
+#else
 #pragma warning disable CS0618 // Type or member is obsolete (For VS2017 compatibility)
-			var characterIndex = (int)_layoutManager.CharacterIndexForPoint(pointInTextContainer, _layoutManager.TextContainers.FirstOrDefault(), ref partialFraction);
+			var characterIndex = (int)_layoutManager.CharacterIndexForPoint
+				(pointInTextContainer, _layoutManager.TextContainers.FirstOrDefault(), ref partialFraction);
 #pragma warning restore CS0618 // Type or member is obsolete
+#endif
 
 			return characterIndex;
 		}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/GPUFloatValueAnimator.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/GPUFloatValueAnimator.iOSmacOS.cs
@@ -401,8 +401,16 @@ namespace Windows.UI.Xaml.Media.Animation
 		private NSValue ToCASkewTransform(float angleX, float angleY)
 		{
 			var matrix = CGAffineTransform.MakeIdentity();
-			matrix.yx = (float)Math.Tan(MathEx.ToRadians(angleY));
-			matrix.xy = (float)Math.Tan(MathEx.ToRadians(angleX));
+			var b = (float)Math.Tan(MathEx.ToRadians(angleY));
+			var c = (float)Math.Tan(MathEx.ToRadians(angleX));
+
+#if NET6_0_OR_GREATER
+			matrix.B = b;
+			matrix.C = c;
+#else
+			matrix.yx = b;
+			matrix.xy = c;
+#endif
 
 			return NSValue.FromCATransform3D(CATransform3D.MakeFromAffine(matrix));
 		}

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.macOS.cs
@@ -250,7 +250,7 @@ namespace Windows.UI.Xaml.Media
 
 #pragma warning disable CS0618
 				// fallback on the platform's loader
-				using (var data = NSData.FromUrl(url, NSDataReadingOptions.Coordinated, out error))
+				using (var data = NSData.FromUrl(url, NSDataReadingOptions.Mapped, out error))
 #pragma warning restore CS0618
 				{
 					if (error != null)

--- a/src/Uno.UWP/ApplicationModel/Contacts/ContactPicker.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/Contacts/ContactPicker.iOS.cs
@@ -19,7 +19,7 @@ namespace Windows.ApplicationModel.Contacts
 		private async Task<Contact[]> PickContactsAsync(bool multiple, CancellationToken token)
 		{
 			var window = UIApplication.SharedApplication.KeyWindow;
-			var controller = window.RootViewController;
+			var controller = window?.RootViewController;
 			if (controller == null)
 			{
 				throw new InvalidOperationException(

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOSmacOS.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.iOSmacOS.cs
@@ -171,9 +171,9 @@ namespace Uno.AuthenticationBroker
 		private class PresentationContextProviderToSharedKeyWindow : NSObject, IASWebAuthenticationPresentationContextProviding
 		{
 #if __IOS__
-			public UIWindow GetPresentationAnchor(ASWebAuthenticationSession session) => UIApplication.SharedApplication.KeyWindow;
+			public UIWindow GetPresentationAnchor(ASWebAuthenticationSession session) => UIApplication.SharedApplication.KeyWindow!;
 #else
-			public NSWindow GetPresentationAnchor(ASWebAuthenticationSession session) => NSApplication.SharedApplication.KeyWindow;
+			public NSWindow GetPresentationAnchor(ASWebAuthenticationSession session) => NSApplication.SharedApplication.KeyWindow!;
 #endif
 		}
 


### PR DESCRIPTION
**BREAKING CHANGE:** This update contains binary breaking changes to follow .NET 6 Mobile iOS/macOS/Catalyst API changes. It requires Visual Studio 2022 17.2 Preview 1 or later and cannot work on previous VS 2022 releases.

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
