### PR TITLE
docs: IsTabStop on Page to disable initial focus

### DIFF
--- a/doc/articles/features/focus-management.md
+++ b/doc/articles/features/focus-management.md
@@ -1,4 +1,4 @@
-# Focus Management
+ # Focus Management
 
 ## Programmatic focus
 
@@ -15,3 +15,17 @@ WinRTFeatureConfiguration.Focus.EnableExperimentalKeyboardFocus = true;
 ```
 
 The feature requires additional testing to verify all edge cases on Android and iOS. In a future release, we will switch the experimental support to be enabled by default.
+
+## Disabling initial focus on Page
+
+The focus management logic in UWP/WinUI sets initial focus on `Page` that is being loaded (for example during navigation) if no element in the app is currently focused. This may cause an input element like `TextBox` to get focused automatically. This may not be a desirable behavior though, as it will cause the virtual keyboard on mobile platforms to open up. To avoid this initial focus, please set `IsTabStop` of the `Page` to `false`:
+
+```xaml
+<Page
+   ...
+   IsTabStop="False">
+   ...
+</Page>
+```
+
+Alternatively you can set focus explicitly to some other UI element by calling `element.Focus(FocusState.Programmatic)` in the code-behind - ideally in the `Loaded` event handler or in `OnNavigatedTo` override.


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7185

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

No docs

## What is the new behavior?

Docs!


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.