### PR TITLE
fix: Move focus properly within bounds of ScrollViewer on Android and iOS

### DIFF
--- a/src/Uno.UI/UI/Xaml/Input/Internal/FocusProperties.cs
+++ b/src/Uno.UI/UI/Xaml/Input/Internal/FocusProperties.cs
@@ -37,6 +37,15 @@ namespace Uno.UI.Xaml.Input
 				//focusChildren = GetFocusChildren<CDOCollection>(static_cast<CTextBlock*>(object));
 				return VisualTreeHelper.GetChildren(textBlock).ToArray();
 			}
+#if __ANDROID__ || __IOS__ // TODO Uno specific: NativeScrollContentPresenter does not return its children
+			else if (dependencyObject is NativeScrollContentPresenter scrollContentPresenter)
+			{
+				if (scrollContentPresenter.Content is DependencyObject child)
+				{
+					return new[] { child };
+				}
+			}
+#endif
 			else if (dependencyObject is UIElement uiElement)
 			{
 				return VisualTreeHelper.GetChildren(uiElement).ToArray();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7489

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Focus movement within `ScrollViewer` was broken due to the fact that on Android and iOS it uses a native presenter to handle the scrolling.

## What is the new behavior?

Focus movement now works.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.