### PR TITLE
fix(NVI): stuck PointerOver state

### DIFF
--- a/src/SamplesApp/UITests.Shared/Helpers/VisualTreeHelperEx.cs
+++ b/src/SamplesApp/UITests.Shared/Helpers/VisualTreeHelperEx.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+
+namespace UITests.Helpers
+{
+	/// <summary>
+	/// Contains various methods to debug the visual tree
+	/// </summary>
+	internal static class VisualTreeHelperEx
+	{
+		/// <summary>
+		/// Prints the visual tree starting from the <paramref name="reference"/> node.
+		/// </summary>
+		/// <param name="reference"></param>
+		/// <returns></returns>
+		public static string TreeGraph(this DependencyObject reference) => TreeGraph(reference, DebugVTNode);
+
+		/// <summary>
+		/// Prints the visual tree starting from the <paramref name="reference"/> node with custom way to <paramref name="describe"/> each node.
+		/// </summary>
+		/// <param name="reference"></param>
+		/// <param name="describe"></param>
+		/// <returns></returns>
+		public static string TreeGraph(this DependencyObject reference, Func<DependencyObject, string> describe)
+		{
+			var buffer = new StringBuilder();
+			Walk(reference);
+			return buffer.ToString();
+
+			void Walk(DependencyObject o, int depth = 0)
+			{
+				Print(o, depth);
+				foreach (var child in GetChildren(o))
+				{
+					Walk(child, depth + 1);
+				}
+			}
+			void Print(DependencyObject o, int depth)
+			{
+				buffer
+					.Append(new string(' ', depth * 4))
+					.Append(describe(o))
+					.AppendLine();
+			}
+		}
+
+		private static string DebugVTNode(DependencyObject x)
+		{
+			var xname = (x as FrameworkElement)?.Name;
+
+			return new StringBuilder()
+				.Append(x.GetType().Name)
+				.Append(xname != null ? $"#{xname}" : string.Empty)
+				.ToString();
+		}
+
+		public static T GetFirstAncestor<T>(this DependencyObject reference) => GetAncestors(reference)
+			.OfType<T>()
+			.FirstOrDefault();
+
+		public static T GetFirstAncestor<T>(this DependencyObject reference, Func<T, bool> predicate) => GetAncestors(reference)
+			.OfType<T>()
+			.FirstOrDefault(predicate);
+
+		public static T GetFirstDescendant<T>(DependencyObject reference) => GetDescendants(reference)
+			.OfType<T>()
+			.FirstOrDefault();
+
+		public static T GetFirstDescendant<T>(DependencyObject reference, Func<T, bool> predicate) => GetDescendants(reference)
+			.OfType<T>()
+			.FirstOrDefault(predicate);
+
+		public static IEnumerable<DependencyObject> GetAncestors(this DependencyObject o)
+		{
+			if (o is null) yield break;
+			while (VisualTreeHelper.GetParent(o) is DependencyObject parent)
+			{
+				yield return o = parent;
+			}
+		}
+
+		public static IEnumerable<DependencyObject> GetDescendants(DependencyObject reference)
+		{
+			foreach (var child in GetChildren(reference))
+			{
+				yield return child;
+				foreach (var grandchild in GetDescendants(child))
+				{
+					yield return grandchild;
+				}
+			}
+		}
+
+		public static IEnumerable<DependencyObject> GetChildren(DependencyObject reference)
+		{
+			return Enumerable
+				.Range(0, VisualTreeHelper.GetChildrenCount(reference))
+				.Select(x => VisualTreeHelper.GetChild(reference, x));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/NavViewItemVisualState.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/NavViewItemVisualState.xaml
@@ -1,0 +1,20 @@
+﻿<Page x:Class="UITests.Microsoft_UI_Xaml_Controls.NavigationViewTests.NavViewItemVisualState"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.NavigationViewTests"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<TextBlock Grid.Row="0" x:Name="DebugText" />
+		<muxc:NavigationView Grid.Row="1" x:Name="NavigationViewControl" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/NavViewItemVisualState.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/NavViewItemVisualState.xaml.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using UITests.Helpers;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using MUXC = Microsoft.UI.Xaml.Controls;
+using MUXCP = Microsoft.UI.Xaml.Controls.Primitives;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.NavigationViewTests
+{
+	[SampleControlInfo("NavigationView", nameof(NavViewItemVisualState), Description = Description, IsManualTest = true, IgnoreInSnapshotTests = true)]
+	public sealed partial class NavViewItemVisualState : Page
+	{
+		private const string Description =
+			"[iOS]ManualTest: open the nav-view, and then expand 'asd'. Press and hold 'asd_4'." +
+			"While still holding, slowly drag vertically. When the scrollviewer moved, " +
+			"the visual-state should reset to 'Normal', instead of being stuck in 'PointerOver'.";
+
+		private bool _initialized = false;
+
+		public NavViewItemVisualState()
+		{
+			this.InitializeComponent();
+			InitializeNVItems();
+		}
+
+		private void InitializeNVItems()
+		{
+			// add a few items and some sub-items for each
+			foreach (var header in "qwe,asd,zxc".Split(','))
+			{
+				var item = new MUXC.NavigationViewItem { Content = new TextBlock { Text = header } };
+				InstallDebugHook(item);
+
+				for (int i = 0; i < 20; i++)
+				{
+					var subitem = new MUXC.NavigationViewItem { Content = new TextBlock { Text = $"{header}_{i}" } };
+					InstallDebugHook(subitem);
+
+					item.MenuItems.Add(subitem);
+				}
+				NavigationViewControl.MenuItems.Add(item);
+			}
+
+			void InstallDebugHook(MUXC.NavigationViewItem item)
+			{
+				var tb = item.Content as TextBlock;
+				tb.Tag = tb.Text;
+
+				tb.Loaded += (s, e) =>
+				{
+					// for tier-1 nvi, the textbox is loaded immediately
+					// for tier-2 nvi, the textbox is loaded twice and the 2nd time is when it is ready
+					var nvip = VisualTreeHelperEx.GetFirstDescendant<MUXCP.NavigationViewItemPresenter>(item, x => x.Name == "NavigationViewItemPresenter");
+					var root = nvip == null ? default : VisualTreeHelperEx.GetFirstDescendant<Grid>(nvip, x => x.Name == "LayoutRoot");
+
+					// check if the template is ready
+					if (root != null)
+					{
+						var group = VisualStateManager.GetVisualStateGroups(root).FirstOrDefault(x => x.Name == "PointerStates");
+						group.CurrentStateChanged += (s2, e2) =>
+							tb.Text = $"{tb.Tag}: {e2.NewState?.Name}";
+						tb.Text = $"{tb.Tag}: {group.CurrentState?.Name}";
+					}
+				};
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -153,6 +153,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\NavViewItemVisualState.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\Regression\NavigationViewRS3Page.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4454,6 +4458,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BindableBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\UWPViewHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ViewModelBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\VisualTreeHelperEx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lottie\LottieEmbeddedJson.xaml.cs">
       <DependentUpon>LottieEmbeddedJson.xaml</DependentUpon>
     </Compile>
@@ -4558,6 +4563,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\NavigationViewCaseBundle.xaml.cs">
       <DependentUpon>NavigationViewCaseBundle.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\NavViewItemVisualState.xaml.cs">
+      <DependentUpon>NavViewItemVisualState.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\NavigationViewTests\Regression\NavigationViewRS3Page.xaml.cs">
       <DependentUpon>NavigationViewRS3Page.xaml</DependentUpon>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
@@ -1108,7 +1108,12 @@ namespace Microsoft.UI.Xaml.Controls
 			// What this flag tracks is complicated because of the NavigationView sub items and the m_capturedPointers that are being tracked..
 			// We do this check because PointerCaptureLost can sometimes take the place of PointerReleased events.
 			// In these cases we need to test if the pointer is over the item to maintain the proper state.
-			if (IsOutOfControlBounds(args.GetCurrentPoint(this).Position))
+			if (IsOutOfControlBounds(args.GetCurrentPoint(this).Position)
+#if HAS_UNO
+				// UNO#7150 workaround: pointer can be still within when the events are raised
+				|| (args.Pointer.PointerDeviceType == PointerDeviceType.Touch && !args.Pointer.IsInContact)
+#endif
+				)
 			{
 				m_isPointerOver = false;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7150

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Tapping on a NavigationViewItem with some dragging can result in the NVI to be stuck in the PointerOver visual-state, until next pointer interaction.

## What is the new behavior?

Make sure NVI's pointer-over flag is always cleared properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This bug seems to only manifest on a custom style (MaterialMUXNavigationViewItemPresenterStyleWhenOnLeftPane) in Uno.Themes.