### PR TITLE
`TreeView` expand chevron should not invoke item

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewBasics.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewBasics.xaml
@@ -12,7 +12,7 @@
     <Grid>
         <muxc:TreeView>
             <muxc:TreeView.RootNodes>
-                <muxc:TreeViewNode Content="Flavors" IsExpanded="True">
+                <muxc:TreeViewNode x:Name="RootNode" Content="Flavors" IsExpanded="True">
                     <muxc:TreeViewNode.Children>
                         <muxc:TreeViewNode Content="Vanilla" />
                         <muxc:TreeViewNode Content="Strawberry" />

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewBasics.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewBasics.xaml.cs
@@ -3,12 +3,12 @@ using Windows.UI.Xaml.Controls;
 
 namespace UITests.Microsoft_UI_Xaml_Controls.TreeView
 {
-	[SampleControlInfo("TreeView", "TreeViewBasics")]
+	[Sample("TreeView")]
 	public sealed partial class TreeViewBasics : Page
     {
         public TreeViewBasics()
         {
-            this.InitializeComponent();
+            this.InitializeComponent();			
         }
     }
 }

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeView_ItemInvoked.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeView_ItemInvoked.xaml
@@ -1,0 +1,36 @@
+﻿<Page
+    x:Class="UITests.Microsoft_UI_Xaml_Controls.TreeViewTests.TreeView_ItemInvoked"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.TreeView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid RowSpacing="8" Margin="8">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<TextBlock x:Name="StatusTextBlock" Text="No invocation" />
+		<muxc:TreeView Grid.Row="1" x:Name="Tree">
+			<muxc:TreeView.RootNodes>
+				<muxc:TreeViewNode x:Name="RootNode" Content="Flavors" IsExpanded="True">
+					<muxc:TreeViewNode.Children>
+						<muxc:TreeViewNode Content="Vanilla" />
+						<muxc:TreeViewNode Content="Strawberry" />
+						<muxc:TreeViewNode Content="Chocolate">
+							<muxc:TreeViewNode.Children>
+								<muxc:TreeViewNode Content="Dark" />
+								<muxc:TreeViewNode Content="White" />
+							</muxc:TreeViewNode.Children>
+						</muxc:TreeViewNode>
+						<muxc:TreeViewNode Content="Caramel" />
+					</muxc:TreeViewNode.Children>
+				</muxc:TreeViewNode>
+			</muxc:TreeView.RootNodes>
+		</muxc:TreeView>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeView_ItemInvoked.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeView_ItemInvoked.xaml.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Controls;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.TreeViewTests
+{
+	[Sample("TreeView")]
+    public sealed partial class TreeView_ItemInvoked : Page
+    {
+        public TreeView_ItemInvoked()
+        {
+            this.InitializeComponent();
+			Tree.ItemInvoked += OnItemInvoked;			
+        }
+
+		private void OnItemInvoked(Microsoft.UI.Xaml.Controls.TreeView sender, Microsoft.UI.Xaml.Controls.TreeViewItemInvokedEventArgs args)
+		{
+			StatusTextBlock.Text = $"{DateTime.UtcNow.ToLongTimeString()}: {(args.InvokedItem as Microsoft.UI.Xaml.Controls.TreeViewNode)?.Content}";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -301,6 +301,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\TreeView\TreeView_ItemInvoked.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\TwoPaneViewTests\TwoPaneViewPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4724,6 +4728,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\TreeView\TreeViewUnrealizedChildrenTestPage.xaml.cs">
       <DependentUpon>TreeViewUnrealizedChildrenTestPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\TreeView\TreeView_ItemInvoked.xaml.cs">
+      <DependentUpon>TreeView_ItemInvoked.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\TreeView\VirtualizingDataSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\TwoPaneViewTests\TwoPaneViewPage.xaml.cs">

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -306,7 +306,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		protected override void OnPointerReleased(PointerRoutedEventArgs args)
 		{
 			ManipulationUpdateKind update;
-			if (IsCaptured(args.Pointer, PointerCaptureKind.Implicit))
+			if (IsCaptured(args.Pointer, PointerCaptureKind.Implicit) &&
+				_isPressed)
 			{
 				_isPressed = false;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -289,8 +289,12 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			if (ShouldHandlePressed
 				&& IsItemClickEnabled
 				&& args.GetCurrentPoint(this).Properties.IsLeftButtonPressed
-				&& CapturePointer(args.Pointer, PointerCaptureKind.Implicit))
+				&& CapturePointer(args.Pointer, PointerCaptureKind.Implicit) is not PointerCaptureResult.Failed)
 			{
+				// Note: We do allow PointerCaptureResult.AlreadyCaptured as if element has been flagged as CanDrag
+				//		 (common in ListView that do allow re-ordering ;) ),
+				//		 the pointer might have already been captured for this SelectorItem.
+
 				_isPressed = true;
 			}
 
@@ -306,8 +310,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		protected override void OnPointerReleased(PointerRoutedEventArgs args)
 		{
 			ManipulationUpdateKind update;
-			if (IsCaptured(args.Pointer, PointerCaptureKind.Implicit) &&
-				_isPressed)
+			if (_isPressed)
 			{
 				_isPressed = false;
 

--- a/src/Uno.UI/UI/Xaml/UIElement.PointerCapture.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.PointerCapture.cs
@@ -33,6 +33,25 @@ namespace Windows.UI.Xaml
 			Any = Explicit | Implicit,
 		}
 
+		internal enum PointerCaptureResult
+		{
+			/// <summary>
+			/// The capture has been added for the given element.
+			/// </summary>
+			Added,
+
+			/// <summary>
+			/// The pointer has already been captured with the same kind by the given element.
+			/// </summary>
+			AlreadyCaptured,
+
+			/// <summary>
+			/// The pointer has already been captured by another element,
+			/// or it cannot be captured at this time (pointer not pressed).
+			/// </summary>
+			Failed,
+		}
+
 		private protected class PointerCapture
 		{
 			private static readonly IDictionary<PointerIdentifier, PointerCapture> _actives = new Dictionary<PointerIdentifier, PointerCapture>(EqualityComparer<PointerIdentifier>.Default);
@@ -101,7 +120,7 @@ namespace Windows.UI.Xaml
 					.Values
 					.Where(target => (target.Kind & kinds) != PointerCaptureKind.None);
 
-			public bool TryAddTarget(UIElement element, PointerCaptureKind kind, PointerRoutedEventArgs relatedArgs = null)
+			public PointerCaptureResult TryAddTarget(UIElement element, PointerCaptureKind kind, PointerRoutedEventArgs relatedArgs = null)
 			{
 				global::System.Diagnostics.Debug.Assert(
 					kind == PointerCaptureKind.Explicit || kind == PointerCaptureKind.Implicit,
@@ -117,7 +136,7 @@ namespace Windows.UI.Xaml
 					// Validate if the requested kind is not already handled
 					if (target.Kind.HasFlag(kind))
 					{
-						return false;
+						return PointerCaptureResult.AlreadyCaptured;
 					}
 					else
 					{
@@ -156,7 +175,7 @@ namespace Windows.UI.Xaml
 				// Make sure that this capture is effective
 				EnsureEffectiveCaptureState();
 
-				return true;
+				return PointerCaptureResult.Added;
 			}
 
 			/// <summary>

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1281,10 +1281,10 @@ namespace Windows.UI.Xaml
 		{
 			var pointer = value ?? throw new ArgumentNullException(nameof(value));
 
-			return Capture(pointer, PointerCaptureKind.Explicit, _pendingRaisedEvent.args);
+			return Capture(pointer, PointerCaptureKind.Explicit, _pendingRaisedEvent.args) is PointerCaptureResult.Added;
 		}
 
-		private protected bool CapturePointer(Pointer value, PointerCaptureKind kind)
+		private protected PointerCaptureResult CapturePointer(Pointer value, PointerCaptureKind kind)
 		{
 			var pointer = value ?? throw new ArgumentNullException(nameof(value));
 
@@ -1379,7 +1379,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private bool Capture(Pointer pointer, PointerCaptureKind kind, PointerRoutedEventArgs relatedArgs)
+		private PointerCaptureResult Capture(Pointer pointer, PointerCaptureKind kind, PointerRoutedEventArgs relatedArgs)
 		{
 			if (_localExplicitCaptures == null)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8030


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Clicking expand chevron on `TreeView` item invokes item

## What is the new behavior?

- ✅ Clicking chevron no longer invokes item
- ⛔ Items cannot be invoked at all 👀

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
