### PR TITLE
fix: TextWrapping="Wrap" does not seem to work for TextBox on Android

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -559,6 +559,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			// initial state
 			_app.WaitForElement(target);
+			target.SetDependencyPropertyValue("TextWrapping", "Wrap");
 			var multilineReadonlyTextRect = target.FirstResult().Rect.ToRectangle();
 
 			// remove readonly
@@ -657,6 +658,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			_app.FastTap("btnDouble");
 			_app.WaitForElement("Test");
+			_app.Marked("Test").SetDependencyPropertyValue("TextWrapping", "Wrap");
 			var height2 = _app.GetLogicalRect("Test").Height;
 
 			using var _ = new AssertionScope();

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Wrap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Wrap.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl
+    x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_Wrap"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+
+		<Grid.RowDefinitions>
+			<RowDefinition Height="50"></RowDefinition>
+			<RowDefinition Height="300"></RowDefinition>
+			<RowDefinition Height="*"></RowDefinition>
+		</Grid.RowDefinitions>
+		<Button x:Name="buttonWrap" Grid.Row="0" Content="Wrap"  Click="OnWrapButtonClick"></Button>
+		<TextBox Grid.Row="1"
+            x:Name="textWrap"
+                HorizontalAlignment="Center"
+                TextWrapping="Wrap"
+                Padding="8"
+               Text="Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?" />
+
+		<TextBox Grid.Row="2"
+            x:Name="textWrapBind"
+                HorizontalAlignment="Center"
+                TextWrapping="Wrap"
+				Text="{x:Bind LocalTextWrapping, Mode=TwoWay}" 
+                Padding="8" /> 
+		
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Wrap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Wrap.xaml.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+	[Sample("TextBox")]
+	public sealed partial class TextBox_Wrap : UserControl
+    {
+
+		public static readonly DependencyProperty LocalTextWrappingProperty = DependencyProperty.Register(
+		"LocalTextWrapping", typeof(TextWrapping), typeof(TextBox_Wrap), new PropertyMetadata(TextWrapping.Wrap));
+
+		public TextWrapping LocalTextWrapping
+		{
+			get { return (TextWrapping)GetValue(LocalTextWrappingProperty); }
+			set { SetValue(LocalTextWrappingProperty, value); }
+		}
+
+		public TextBox_Wrap()
+        {
+            this.InitializeComponent();
+
+			textWrapBind.Text = textWrap.Text;
+		}
+
+		private void OnWrapButtonClick(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+		{
+			if (buttonWrap.Content.ToString() == TextWrapping.Wrap.ToString())
+			{
+				textWrap.TextWrapping = TextWrapping.NoWrap;
+				textWrapBind.TextWrapping = TextWrapping.NoWrap;
+				buttonWrap.Content = textWrap.TextWrapping.ToString();
+				LocalTextWrapping = textWrap.TextWrapping;
+				textWrapBind.Text = textWrap.Text;
+			}
+			else
+			{
+				textWrap.TextWrapping = TextWrapping.Wrap;
+				buttonWrap.Content = textWrap.TextWrapping.ToString();
+				textWrapBind.TextWrapping = TextWrapping.Wrap;
+				LocalTextWrapping = textWrap.TextWrapping;
+				textWrapBind.Text = textWrap.Text;
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests.Helpers;
@@ -8,6 +9,7 @@ using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
 using Windows.UI.Xaml;
 using Windows.UI;
+using FluentAssertions;
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -293,6 +295,44 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsTrue(textbox.IsEnabled);
 			Assert.AreEqual(contentPresenter.Foreground, foregroundColor);
 		}
+
+#if __ANDROID__
+		[TestMethod]
+		public async Task When_Text_IsWrapping_Set()
+		{
+			var textbox = new TextBox();
+
+			textbox.Width = 100;
+			StackPanel panel = new() { Orientation = Orientation.Vertical };
+			panel.Children.Add(textbox);
+			WindowHelper.WindowContent = panel;
+			await WindowHelper.WaitForLoaded(textbox);
+			var originalActualHeigth = textbox.ActualHeight;
+			textbox.Text = "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremaaaaaaaaaaaaaaaaaa";
+			textbox.TextWrapping = TextWrapping.Wrap;
+			await WindowHelper.WaitForIdle();
+			textbox.ActualHeight.Should().BeGreaterThan(originalActualHeigth);
+		}
+
+
+		[TestMethod]
+		public async Task When_Text_IsNoWrap_Set()
+		{
+			var textbox = new TextBox();
+
+			textbox.Width = 100;
+			StackPanel panel = new() { Orientation = Orientation.Vertical };
+			panel.Children.Add(textbox);
+			WindowHelper.WindowContent = panel;
+			await WindowHelper.WaitForLoaded(textbox);
+			var originalActualHeigth = textbox.ActualHeight;
+			textbox.Text = "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremaaaaaaaaaaaaaaaaaa";
+			textbox.TextWrapping = TextWrapping.NoWrap;
+			await WindowHelper.WaitForIdle();
+			textbox.ActualHeight.Should().Be(originalActualHeigth);
+		}
+
+#endif
 
 		[TestMethod]
 		public async Task When_SelectedText_StartZero()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -380,7 +380,10 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextWrappingChangedPartial(DependencyPropertyChangedEventArgs e)
 		{
-			//TODO : see bug #8178
+			if (_textBoxView != null && e.NewValue is TextWrapping textWrapping)
+			{
+				_textBoxView.SetSingleLine(textWrapping == TextWrapping.NoWrap);
+			}
 		}
 
 		partial void UpdateFontPartial()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml.Controls
 			_ownerRef = WeakReferencePool.RentWeakReference(this, owner);
 			InitializeBinder();
 
-			base.SetSingleLine(true);
+			base.SetSingleLine(owner.TextWrapping == TextWrapping.NoWrap);
 
 			//This Background color is set to remove the native android underline on the EditText.
 			this.SetBackgroundColor(Colors.Transparent);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3648 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix


## What is the current behavior?

When the user sets TextWrapping="Wrap" the text is never wrapped on the Android Platform.


## What is the new behavior?

When the user sets TextWrapping="Wrap" the text is wrapped.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
