### PR TITLE
fix(macOS): UpdateHitTest in some events.

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.macOS.cs
@@ -23,6 +23,8 @@ namespace Windows.UI.Xaml
 		{
 			Initialize();
 			InitializePointers();
+
+			UpdateHitTest();
 		}
 
 		/// <summary>
@@ -52,8 +54,15 @@ namespace Windows.UI.Xaml
 			}
 		}
 
+		partial void OnIsHitTestVisibleChangedPartial(bool oldValue, bool newValue)
+		{
+			UpdateHitTest();
+		}
+
 		partial void OnVisibilityChangedPartial(Visibility oldValue, Visibility newValue)
 		{
+			UpdateHitTest();
+
 			var newVisibility = (Visibility)newValue;
 
 			if (base.Hidden != newVisibility.IsHidden())


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7312

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
Since #6645, macOS started [respecting](https://github.com/unoplatform/uno/blob/f56230cea1e55d5c4f723b845e835f69d8535997/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs#L220-L222) the `HitTestVisibility` property. However, unlike the other two platforms with managed pointers that are respecting this property (Skia and Wasm), macOS does not make the required calls to `UpdateHitTest` in relevant events.

This obstructs the propagation of `HitTestVisibilityProperty`, causing issues such as #7312.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->



## What is the new behavior?

macOS now calls `UpdateHitTest` three places: Constructor, `OnIsHitTestVisibleChangedPartial`, and `OnVisibilityChangedPartial`, similar to Skia and Wasm.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
