### PR TITLE
fix(NameScope): Ensure NameScope is not overriden for XAML backed controls

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -889,8 +889,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 										using (writer.BlockInvariant("if (__rootInstance is DependencyObject d)", kvp.Value.ReturnType))
 										{
-											writer.AppendLineInvariant("global::Windows.UI.Xaml.NameScope.SetNameScope(d, nameScope);");
-											writer.AppendLineInvariant("nameScope.Owner = d;");
+											using (writer.BlockInvariant("if (global::Windows.UI.Xaml.NameScope.GetNameScope(d) == null)", kvp.Value.ReturnType))
+											{
+												writer.AppendLineInvariant("global::Windows.UI.Xaml.NameScope.SetNameScope(d, nameScope);");
+												writer.AppendLineInvariant("nameScope.Owner = d;");
+											}
+
 											writer.AppendLineInvariant("global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);");
 										}
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl
+	x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_NameScope"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	x:Name="OuterElementTopLevel"
+	x:FieldModifier="public"
+    mc:Ignorable="d">
+	<Grid>
+		<local:When_NameScope_Inner x:Name="OuterElementName"
+									   x:FieldModifier="public" />
+		<Grid x:Name="OuterBorder"
+			  x:FieldModifier="public" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_NameScope : UserControl
+	{
+		public When_NameScope()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope_DataTemplate.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope_DataTemplate.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+	x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_NameScope_DataTemplate"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	x:Name="OuterElementTopLevel"
+	x:FieldModifier="public"
+    mc:Ignorable="d">
+	<Grid>
+		<ContentControl x:Name="content01" Content="42">
+			<ContentControl.ContentTemplate>
+				<DataTemplate>
+					<local:When_NameScope_Inner x:Name="OuterElementName"
+												   x:FieldModifier="public" />
+				</DataTemplate>
+			</ContentControl.ContentTemplate>
+		</ContentControl>
+		<Grid x:Name="OuterBorder"
+			  x:FieldModifier="public" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope_DataTemplate.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope_DataTemplate.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_NameScope_DataTemplate : UserControl
+	{
+		public When_NameScope_DataTemplate()
+		{
+			this.InitializeComponent();
+			Loaded += delegate {
+				OuterElementName = (content01.ContentTemplateRoot as FrameworkElement).FindName("OuterElementName") as When_NameScope_Inner;
+			};
+		}
+
+		public When_NameScope_Inner OuterElementName { get; set; }
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope_Inner.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope_Inner.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl
+	x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.When_NameScope_Inner"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	x:Name="InnerElementTopLevel"
+	x:FieldModifier="public"
+    mc:Ignorable="d">
+	<Grid>
+		<Border x:Name="InnerBorder"
+				x:FieldModifier="public" />
+	</Grid>
+		
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope_Inner.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/When_NameScope_Inner.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_NameScope_Inner : UserControl
+	{
+		public When_NameScope_Inner()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_Namescope.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_Namescope.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.Windows_UI_Xaml.Controls;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_NameScope
+	{
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+		}
+
+		[TestMethod]
+		public void When_NameScope()
+		{
+			var SUT = new When_NameScope();
+			SUT.ForceLoaded();
+
+			var OuterElementName = NameScope.FindInNamescopes(
+				SUT,
+				nameof(SUT.OuterElementName)) as FrameworkElement;
+			var OuterBorder = NameScope.FindInNamescopes(
+				SUT,
+				nameof(SUT.OuterBorder)) as FrameworkElement;
+
+			Assert.IsNotNull(OuterElementName);
+			Assert.IsNotNull(OuterBorder);
+
+			var OuterElementTopLevelFromOuterBorder = NameScope.FindInNamescopes(
+				OuterBorder,
+				nameof(SUT.OuterElementTopLevel)) as FrameworkElement;
+			Assert.IsNotNull(OuterElementTopLevelFromOuterBorder);
+
+			// search through visual tree walking
+			var OuterElementTopLevelFromOuterElementName = NameScope.FindInNamescopes(
+				OuterElementName,
+				nameof(SUT.OuterElementTopLevel)) as FrameworkElement;
+			var OuterBorderFromOuterElementName = NameScope.FindInNamescopes(
+				OuterElementName,
+				nameof(SUT.OuterBorder)) as FrameworkElement;
+
+			Assert.IsNotNull(OuterElementTopLevelFromOuterElementName);
+			Assert.IsNotNull(OuterBorderFromOuterElementName);
+
+			// search via namescope
+			var InnerBorderFromOuterElementName = NameScope.FindInNamescopes(
+				SUT.OuterElementName as FrameworkElement,
+				nameof(When_NameScope_Inner.InnerBorder)) as FrameworkElement;
+			Assert.IsNotNull(InnerBorderFromOuterElementName);
+
+			var InnerBorderFromOuterElementNameContent = NameScope.FindInNamescopes(
+				SUT.OuterElementName.Content as FrameworkElement,
+				nameof(When_NameScope_Inner.InnerBorder)) as FrameworkElement;
+			Assert.IsNotNull(InnerBorderFromOuterElementNameContent);
+
+			// Search through namescope from the inner element to the inner top level name
+			var InnerElementTopLevelFromInnerBorder = NameScope.FindInNamescopes(
+				InnerBorderFromOuterElementNameContent,
+				nameof(When_NameScope_Inner.InnerElementTopLevel)) as FrameworkElement;
+			Assert.IsNotNull(InnerBorderFromOuterElementNameContent);
+			Assert.AreEqual(InnerElementTopLevelFromInnerBorder.Name, "OuterElementName");
+		}
+
+		[TestMethod]
+		public void When_NameScope_DataTemplate()
+		{
+			var SUT = new When_NameScope_DataTemplate();
+			SUT.ForceLoaded();
+
+			var OuterBorder = NameScope.FindInNamescopes(
+				SUT,
+				nameof(SUT.OuterBorder)) as FrameworkElement;
+
+			Assert.IsNotNull(SUT.OuterElementName);
+			Assert.IsNotNull(OuterBorder);
+
+			var OuterElementTopLevelFromOuterBorder = NameScope.FindInNamescopes(
+				OuterBorder,
+				nameof(SUT.OuterElementTopLevel)) as FrameworkElement;
+			Assert.IsNotNull(OuterElementTopLevelFromOuterBorder);
+
+			// search through visual tree walking
+			var OuterElementTopLevelFromOuterElementName = NameScope.FindInNamescopes(
+				SUT.OuterElementName,
+				nameof(SUT.OuterElementTopLevel)) as FrameworkElement;
+			var OuterBorderFromOuterElementName = NameScope.FindInNamescopes(
+				SUT.OuterElementName,
+				nameof(SUT.OuterBorder)) as FrameworkElement;
+
+			Assert.IsNotNull(OuterElementTopLevelFromOuterElementName);
+			Assert.IsNotNull(OuterBorderFromOuterElementName);
+
+			// search via namescope
+			var InnerBorderFromOuterElementName = NameScope.FindInNamescopes(
+				SUT.OuterElementName as FrameworkElement,
+				nameof(When_NameScope_Inner.InnerBorder)) as FrameworkElement;
+			Assert.IsNotNull(InnerBorderFromOuterElementName);
+
+			var InnerBorderFromOuterElementNameContent = NameScope.FindInNamescopes(
+				SUT.OuterElementName.Content as FrameworkElement,
+				nameof(When_NameScope_Inner.InnerBorder)) as FrameworkElement;
+			Assert.IsNotNull(InnerBorderFromOuterElementNameContent);
+
+			// Search through namescope from the inner element to the inner top level name
+			var InnerElementTopLevelFromInnerBorder = NameScope.FindInNamescopes(
+				InnerBorderFromOuterElementNameContent,
+				nameof(When_NameScope_Inner.InnerElementTopLevel)) as FrameworkElement;
+			Assert.IsNotNull(InnerBorderFromOuterElementNameContent);
+
+			Assert.AreEqual(InnerElementTopLevelFromInnerBorder.Name, "OuterElementName");
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_Nested.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_Nested.xaml
@@ -1,0 +1,31 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls.Binding_ElementName_In_Template_ItemsControl_Nested"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  x:Name="ThisPage"
+	  Tag="42"
+	  mc:Ignorable="d">
+
+	<ItemsControl x:Name="SecondaryActionsList" x:FieldModifier="public">
+		<ItemsControl.Template>
+			<ControlTemplate TargetType="ItemsControl">
+				<ItemsPresenter/>
+			</ControlTemplate>
+		</ItemsControl.Template>
+		<ItemsControl.ItemsPanel>
+			<ItemsPanelTemplate>
+				<StackPanel/>
+			</ItemsPanelTemplate>
+		</ItemsControl.ItemsPanel>
+		<ItemsControl.ItemTemplate>
+			<DataTemplate>
+				<StackPanel>
+					<Button x:Name="button"
+							Tag="{Binding Tag, ElementName=ThisPage}" />
+				</StackPanel>
+			</DataTemplate>
+		</ItemsControl.ItemTemplate>
+	</ItemsControl>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_Nested.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_Nested.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_ElementName_In_Template_ItemsControl_Nested : Page
+	{
+		public Binding_ElementName_In_Template_ItemsControl_Nested()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_Nested_Outer.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_Nested_Outer.xaml
@@ -1,0 +1,28 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls.Binding_ElementName_In_Template_ItemsControl_Nested_Outer"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  x:Name="OuterPage"
+	  Tag="42"
+	  mc:Ignorable="d">
+
+	<ItemsControl x:Name="PrimaryActionsList" x:FieldModifier="public">
+		<ItemsControl.Template>
+			<ControlTemplate TargetType="ItemsControl">
+				<ItemsPresenter/>
+			</ControlTemplate>
+		</ItemsControl.Template>
+		<ItemsControl.ItemsPanel>
+			<ItemsPanelTemplate>
+				<StackPanel/>
+			</ItemsPanelTemplate>
+		</ItemsControl.ItemsPanel>
+		<ItemsControl.ItemTemplate>
+			<DataTemplate>
+				<local:Binding_ElementName_In_Template_ItemsControl_Nested Tag="{Binding Tag, ElementName=OuterPage}" />
+			</DataTemplate>
+		</ItemsControl.ItemTemplate>
+	</ItemsControl>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_Nested_Outer.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Controls/Binding_ElementName_In_Template_ItemsControl_Nested_Outer.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Binding_ElementName_In_Template_ItemsControl_Nested_Outer : Page
+	{
+		public Binding_ElementName_In_Template_ItemsControl_Nested_Outer()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls;
+using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests
 {
@@ -59,6 +60,27 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests
 			var button = SUT.FindName("button") as Windows.UI.Xaml.Controls.Button;
 
 			Assert.AreEqual(SUT.PrimaryActionsList.Tag, button.Tag);
+		}
+
+		[TestMethod]
+		public void Binding_ElementName_In_Template_ItemsControl_Nested_Outer()
+		{
+			var SUT = new Binding_ElementName_In_Template_ItemsControl_Nested_Outer();
+
+			SUT.ForceLoaded();
+
+			SUT.PrimaryActionsList.ApplyTemplate();
+
+			SUT.PrimaryActionsList.ItemsSource = new[] { "test" };
+
+			//var control = SUT.PrimaryActionsList.FindName("control") as Binding_ElementName_In_Template_ItemsControl_Nested;
+			//Assert.AreEqual(SUT.Tag, control.Tag);
+
+			var SecondaryActionsList = SUT.FindName("SecondaryActionsList") as ItemsControl;
+			SecondaryActionsList.ItemsSource = new[] { "test" };
+
+			var button = SUT.FindName("button") as Button;
+			Assert.AreEqual(SUT.Tag, button.Tag);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/BindingTests/Given_Binding.cs
@@ -73,9 +73,6 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests
 
 			SUT.PrimaryActionsList.ItemsSource = new[] { "test" };
 
-			//var control = SUT.PrimaryActionsList.FindName("control") as Binding_ElementName_In_Template_ItemsControl_Nested;
-			//Assert.AreEqual(SUT.Tag, control.Tag);
-
 			var SecondaryActionsList = SUT.FindName("SecondaryActionsList") as ItemsControl;
 			SecondaryActionsList.ItemsSource = new[] { "test" };
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/8077

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Namespace should not be overriden for template root elements if one already exists.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
