### PR TITLE
feat: `ContentDialog`-based `MessageDialog`

### DIFF
--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -25,3 +25,7 @@ Use `Uno.UI.FeatureConfiguration.Font.IgnoreTextScaleFactor` to control this.
 ## Popups
 
 In older versions of Uno Platforms, the `Popup.IsLightDismissEnabled` dependency property defaulted to `true`. In UWP/WinUI and Uno 4.1 and newer, it correctly defaults to `false`. If your code depended on the old behavior, you can set the `Uno.UI.FeatureConfiguration.Popup.EnableLightDismissByDefault` property to `true` to override this.
+
+## MessageDialog
+
+By default, `MessageDialog` in Uno Platform targets displays using `ContentDialog`, to ensure consistent functionality and appearance across platforms. If you prefer to display it using native dialogs on iOS, Android, macOS, and WASM, you can set the `WinRTFeatureConfiguration.MessageDialog.UseNativeDialog` flag to `true`. Beware that some features may be missing for the native implementations.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Popups/Given_MessageDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Popups/Given_MessageDialog.cs
@@ -11,7 +11,9 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
 using System.Linq;
+#if HAS_UNO
 using Uno.UI.WinRT.Extensions.UI.Popups;
+#endif
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Popups
 {

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -14,6 +14,10 @@ using Uno.Extensions;
 using System.Collections.Generic;
 using Uno.Foundation.Logging;
 using Windows.UI.Xaml.Data;
+using Uno.Foundation.Extensibility;
+using Windows.UI.Popups.Internal;
+using Windows.UI.Popups;
+using Uno.UI.WinRT.Extensions.UI.Popups;
 
 #if HAS_UNO_WINUI
 using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
@@ -38,10 +42,6 @@ using AppKit;
 #else
 using View = Windows.UI.Xaml.UIElement;
 using ViewGroup = Windows.UI.Xaml.UIElement;
-using Uno.Foundation.Extensibility;
-using Windows.UI.Popups.Internal;
-using Windows.UI.Popups;
-using Uno.UI.WinRT.Extensions.UI.Popups;
 #endif
 
 namespace Windows.UI.Xaml

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -38,6 +38,10 @@ using AppKit;
 #else
 using View = Windows.UI.Xaml.UIElement;
 using ViewGroup = Windows.UI.Xaml.UIElement;
+using Uno.Foundation.Extensibility;
+using Windows.UI.Popups.Internal;
+using Windows.UI.Popups;
+using Uno.UI.WinRT.Extensions.UI.Popups;
 #endif
 
 namespace Windows.UI.Xaml
@@ -59,7 +63,14 @@ namespace Windows.UI.Xaml
 			Uno.Helpers.DispatcherTimerProxy.SetDispatcherTimerGetter(() => new DispatcherTimer());
 			Uno.Helpers.VisualTreeHelperProxy.SetCloseAllFlyoutsAction(() => Media.VisualTreeHelper.CloseAllFlyouts());
 
+			RegisterExtensions();
+
 			InitializePartialStatic();
+		}
+
+		private static void RegisterExtensions()
+		{
+			ApiExtensibility.Register<MessageDialog>(typeof(IMessageDialogExtension), dialog => new MessageDialogExtension(dialog));
 		}
 
 		static partial void InitializePartialStatic();

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -125,7 +125,7 @@ namespace Windows.UI.Xaml.Controls
 			Hide(ContentDialogResult.None);
 		}
 
-		private bool Hide(ContentDialogResult result)
+		internal bool Hide(ContentDialogResult result)
 		{
 			void Complete(ContentDialogClosingEventArgs args)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -227,7 +227,14 @@ namespace Windows.UI.Xaml.Controls
 
 				_tcs = new TaskCompletionSource<ContentDialogResult>();
 
-				return await _tcs.Task;
+				using (ct.Register(() =>
+				{
+					_tcs.TrySetCanceled();
+					Hide();
+				}))
+				{
+					return await _tcs.Task;
+				}
 			});
 
 		public event TypedEventHandler<ContentDialog, ContentDialogClosedEventArgs> Closed;

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -231,7 +231,11 @@ namespace Windows.UI.Xaml.Controls
 				{
 					_tcs.TrySetCanceled();
 					Hide();
-				}))
+				}
+#if !__WASM__ // WASM lacks threading support
+					, useSynchronizationContext: true
+#endif
+					))
 				{
 					return await _tcs.Task;
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -84,7 +84,7 @@ namespace Windows.UI.Xaml.Controls
 			DefaultStyleKey = typeof(ContentDialog);
 		}
 
-		private void OnPopupKeyDown(object sender, KeyRoutedEventArgs e)
+		private protected virtual void OnPopupKeyDown(object sender, KeyRoutedEventArgs e)
 		{
 			switch (e.Key)
 			{

--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
@@ -144,6 +144,7 @@ namespace Windows.UI.Xaml.Media
 			return _openPopups
 				.Select(WeakReferenceExtensions.GetTarget)
 				.OfType<Popup>()
+				.Distinct()
 				.ToList()
 				.AsReadOnly();
 		}
@@ -153,6 +154,7 @@ namespace Windows.UI.Xaml.Media
 			return _openPopups
 				.Select(WeakReferenceExtensions.GetTarget)
 				.OfType<Popup>()
+				.Distinct()
 				.Where(p => p.IsForFlyout)
 				.ToList().AsReadOnly();
 		}

--- a/src/Uno.UI/Uno.UI.Skia.csproj
+++ b/src/Uno.UI/Uno.UI.Skia.csproj
@@ -111,4 +111,8 @@
 			<UndefineProperties>TargetFramework</UndefineProperties>
 		</ProjectReference>
 	</ItemGroup>
+
+	<ItemGroup>
+	  <UpToDateCheckInput Remove="WinRT\Extensions\UI\Popups\MessageDialogContentDialog.cs" />
+	</ItemGroup>
 </Project>

--- a/src/Uno.UI/Uno.UI.Skia.csproj
+++ b/src/Uno.UI/Uno.UI.Skia.csproj
@@ -111,8 +111,4 @@
 			<UndefineProperties>TargetFramework</UndefineProperties>
 		</ProjectReference>
 	</ItemGroup>
-
-	<ItemGroup>
-	  <UpToDateCheckInput Remove="WinRT\Extensions\UI\Popups\MessageDialogContentDialog.cs" />
-	</ItemGroup>
 </Project>

--- a/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
+++ b/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Uno.UI.Helpers.WinUI;
+using Windows.System;
+using Windows.UI.Popups;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace Uno.UI.WinRT.Extensions.UI.Popups;
+
+internal class MessageDialogContentDialog : ContentDialog
+{
+	private readonly MessageDialog _messageDialog;
+
+	public MessageDialogContentDialog(MessageDialog messageDialog)
+	{
+		DefaultStyleKey = typeof(ContentDialog);
+		_messageDialog = messageDialog ?? throw new ArgumentNullException(nameof(messageDialog));
+	}
+
+	public new async Task<IUICommand> ShowAsync()
+	{
+		if (Application.Current.Resources.ContainsKey("DefaultContentDialogStyle"))
+		{
+			Style = (Style)Application.Current.Resources["DefaultContentDialogStyle"];
+		}
+
+		var commands = _messageDialog.Commands.ToList();
+
+		Content = _messageDialog.Content;
+		Title = _messageDialog.Title;
+
+		if (commands.Count == 0)
+		{
+			// Only show a close button
+			var closeText = ResourceAccessor.GetLocalizedStringResource("NavigationCloseButtonName");
+			commands.Add(new UICommand(closeText));
+		}
+
+		PrimaryButtonText = commands[0].Label;
+		SecondaryButtonText = commands.Count > 1 ? commands[1].Label : null;
+		CloseButtonText = commands.Count > 2 ? commands[2].Label : null;
+
+		DefaultButton = (ContentDialogButton)(_messageDialog.DefaultCommandIndex + 1); // ContentDialogButton indexed from 1
+
+		var result = await base.ShowAsync();
+		if (result == ContentDialogResult.Primary)
+		{
+			commands[0].Invoked?.Invoke(commands[0]);
+			return commands[0];
+		}
+		else if (result == ContentDialogResult.Secondary)
+		{
+			commands[1].Invoked?.Invoke(commands[1]);
+			return commands[1];
+		}
+		else
+		{
+			commands[2].Invoked?.Invoke(commands[2]);
+			return commands[2];
+		}
+	}
+
+	private protected override void OnPopupKeyDown(object sender, KeyRoutedEventArgs e)
+	{
+		// Escape should not apply on MessageDialog.
+		if (e.Key != VirtualKey.Escape)
+		{
+			base.OnPopupKeyDown(sender, e);
+		}
+	}
+}

--- a/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
+++ b/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
@@ -12,7 +12,7 @@ using Windows.UI.Xaml.Input;
 
 namespace Uno.UI.WinRT.Extensions.UI.Popups;
 
-internal class MessageDialogContentDialog : ContentDialog
+internal partial class MessageDialogContentDialog : ContentDialog
 {
 	private readonly MessageDialog _messageDialog;
 	private readonly List<IUICommand> _commands;
@@ -23,9 +23,10 @@ internal class MessageDialogContentDialog : ContentDialog
 		DefaultStyleKey = typeof(ContentDialog);
 		_messageDialog = messageDialog ?? throw new ArgumentNullException(nameof(messageDialog));
 
-		if (Application.Current.Resources.ContainsKey("DefaultContentDialogStyle"))
+		// WinUI provides a modern style for ContentDialog, which is not applied automatically - force it
+		if (Application.Current.Resources.TryGetValue("DefaultContentDialogStyle", out var resource) && resource is Style winUIStyle)
 		{
-			Style = (Style)Application.Current.Resources["DefaultContentDialogStyle"];
+			Style = winUIStyle;
 		}
 
 		_commands = _messageDialog.Commands.ToList();

--- a/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
+++ b/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Uno.UI.Helpers.WinUI;
@@ -13,53 +14,57 @@ namespace Uno.UI.WinRT.Extensions.UI.Popups;
 internal class MessageDialogContentDialog : ContentDialog
 {
 	private readonly MessageDialog _messageDialog;
+	private readonly List<IUICommand> _commands;
+	private readonly uint _cancelCommandIndex;
 
 	public MessageDialogContentDialog(MessageDialog messageDialog)
 	{
 		DefaultStyleKey = typeof(ContentDialog);
 		_messageDialog = messageDialog ?? throw new ArgumentNullException(nameof(messageDialog));
-	}
 
-	public new async Task<IUICommand> ShowAsync()
-	{
 		if (Application.Current.Resources.ContainsKey("DefaultContentDialogStyle"))
 		{
 			Style = (Style)Application.Current.Resources["DefaultContentDialogStyle"];
 		}
 
-		var commands = _messageDialog.Commands.ToList();
+		_commands = _messageDialog.Commands.ToList();
+		_cancelCommandIndex = _messageDialog.CancelCommandIndex;
 
 		Content = _messageDialog.Content;
 		Title = _messageDialog.Title;
 
-		if (commands.Count == 0)
+		if (_commands.Count == 0)
 		{
 			// Only show a close button
 			var closeText = ResourceAccessor.GetLocalizedStringResource("NavigationCloseButtonName");
-			commands.Add(new UICommand(closeText));
+			_commands.Add(new UICommand(closeText));
 		}
 
-		PrimaryButtonText = commands[0].Label;
-		SecondaryButtonText = commands.Count > 1 ? commands[1].Label : null;
-		CloseButtonText = commands.Count > 2 ? commands[2].Label : null;
+		PrimaryButtonText = _commands[0].Label;
+		SecondaryButtonText = _commands.Count > 1 ? _commands[1].Label : null;
+		CloseButtonText = _commands.Count > 2 ? _commands[2].Label : null;
 
 		DefaultButton = (ContentDialogButton)(_messageDialog.DefaultCommandIndex + 1); // ContentDialogButton indexed from 1
+	}
 
+	public new async Task<IUICommand> ShowAsync()
+	{
+		
 		var result = await base.ShowAsync();
 		if (result == ContentDialogResult.Primary)
 		{
-			commands[0].Invoked?.Invoke(commands[0]);
-			return commands[0];
+			_commands[0].Invoked?.Invoke(_commands[0]);
+			return _commands[0];
 		}
 		else if (result == ContentDialogResult.Secondary)
 		{
-			commands[1].Invoked?.Invoke(commands[1]);
-			return commands[1];
+			_commands[1].Invoked?.Invoke(_commands[1]);
+			return _commands[1];
 		}
 		else
 		{
-			commands[2].Invoked?.Invoke(commands[2]);
-			return commands[2];
+			_commands[2].Invoked?.Invoke(_commands[2]);
+			return _commands[2];
 		}
 	}
 
@@ -69,6 +74,18 @@ internal class MessageDialogContentDialog : ContentDialog
 		if (e.Key != VirtualKey.Escape)
 		{
 			base.OnPopupKeyDown(sender, e);
+		}
+		else
+		{
+			if (_messageDialog.CancelCommandIndex < _commands.Count)
+			{
+				var contentDialogResult = ContentDialogResult.None;
+				if (_messageDialog.CancelCommandIndex != 2) // Index 2 matches the close button - result of None.
+				{
+					contentDialogResult = (ContentDialogResult)(_messageDialog.CancelCommandIndex + 1);
+				}
+				Hide(contentDialogResult);
+			}
 		}
 	}
 }

--- a/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
+++ b/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
@@ -65,8 +65,7 @@ internal partial class MessageDialogContentDialog : ContentDialog
 		}
 		else
 		{
-			// In case of task cancellation, the "third" button
-			// might not really exist - use last instead.
+			// Always use the "last" command as fallback
 			var lastCommand = _commands.Last();
 			lastCommand.Invoked?.Invoke(lastCommand);
 			return lastCommand;

--- a/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogExtension.cs
+++ b/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.UI.Popups;
 using Windows.UI.Popups.Internal;
@@ -18,9 +19,9 @@ internal class MessageDialogExtension : IMessageDialogExtension
 		_messageDialog = messageDialog ?? throw new ArgumentNullException(nameof(messageDialog));
 	}
 
-	public async Task<IUICommand> ShowAsync()
+	public async Task<IUICommand> ShowAsync(CancellationToken ct)
 	{
 		var contentDialog = new MessageDialogContentDialog(_messageDialog);
-		return await contentDialog.ShowAsync();
+		return await contentDialog.ShowAsync(ct);
 	}
 }

--- a/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogExtension.cs
+++ b/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogExtension.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI.Popups;
+using Windows.UI.Popups.Internal;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.WinRT.Extensions.UI.Popups;
+
+/// <summary>
+/// Provides a ContentDialog-based implementation of MessageDialog.
+/// </summary>
+internal class MessageDialogExtension : IMessageDialogExtension
+{
+	private readonly MessageDialog _messageDialog;
+
+	public MessageDialogExtension(MessageDialog messageDialog)
+	{
+		_messageDialog = messageDialog ?? throw new ArgumentNullException(nameof(messageDialog));
+	}
+
+	public async Task<IUICommand> ShowAsync()
+	{
+		var contentDialog = new MessageDialogContentDialog(_messageDialog);
+		return await contentDialog.ShowAsync();
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Popups/MessageDialog.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Popups/MessageDialog.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Popups
 		// Forced skipping of method Windows.UI.Popups.MessageDialog.CancelCommandIndex.set
 		// Forced skipping of method Windows.UI.Popups.MessageDialog.Content.get
 		// Forced skipping of method Windows.UI.Popups.MessageDialog.Content.set
-		#if false || false || NET461 || false || __SKIA__ || __NETSTD_REFERENCE__ || false
+		#if false || false || false || false || false || false || false
 		[global::Uno.NotImplemented("NET461", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public  global::Windows.Foundation.IAsyncOperation<global::Windows.UI.Popups.IUICommand> ShowAsync()
 		{

--- a/src/Uno.UWP/UI/Popups/IUICommand.cs
+++ b/src/Uno.UWP/UI/Popups/IUICommand.cs
@@ -1,24 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Windows.UI.Popups;
 
-namespace Windows.UI.Popups
+/// <summary>
+/// Represents a command in a context menu or message dialog box.
+/// </summary>
+public partial interface IUICommand
 {
-	public partial interface IUICommand
-	{
-		/// <summary>
-		/// Gets or sets the identifier of the command.
-		/// </summary>
-		object Id { get; set; }
-		
-		/// <summary>
-		/// Gets or sets the handler for the event that is fired when the user invokes the command. 
-		/// </summary>
-		UICommandInvokedHandler Invoked { get; set; }
+	/// <summary>
+	/// Gets or sets the identifier of the command.
+	/// </summary>
+	object Id { get; set; }
 
-		/// <summary>
-		/// Gets or sets the label for the command.
-		/// </summary>
-		string Label {get; set;}
-    }
+	/// <summary>
+	/// Gets or sets the handler for the event that is fired when the user invokes the command. 
+	/// </summary>
+	UICommandInvokedHandler Invoked { get; set; }
+
+	/// <summary>
+	/// Gets or sets the label for the command.
+	/// </summary>
+	string Label { get; set; }
 }

--- a/src/Uno.UWP/UI/Popups/Internal/IMessageDialogExtension.cs
+++ b/src/Uno.UWP/UI/Popups/Internal/IMessageDialogExtension.cs
@@ -1,0 +1,8 @@
+﻿using System.Threading.Tasks;
+
+namespace Windows.UI.Popups.Internal;
+
+internal interface IMessageDialogExtension
+{
+	Task<IUICommand> ShowAsync();
+}

--- a/src/Uno.UWP/UI/Popups/Internal/IMessageDialogExtension.cs
+++ b/src/Uno.UWP/UI/Popups/Internal/IMessageDialogExtension.cs
@@ -1,8 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace Windows.UI.Popups.Internal;
 
 internal interface IMessageDialogExtension
 {
-	Task<IUICommand> ShowAsync();
+	Task<IUICommand> ShowAsync(CancellationToken ct);
 }

--- a/src/Uno.UWP/UI/Popups/MessageDialog.Android.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.Android.cs
@@ -20,7 +20,7 @@ public partial class MessageDialog
 {
 	const int MaximumCommands = 3;
 
-	private async Task<IUICommand> ShowInner(CancellationToken ct)
+	private async Task<IUICommand> ShowNativeAsync(CancellationToken ct)
 	{
 		// Android recommends placing buttons in this order:
 		//  1) positive (default accept)
@@ -76,11 +76,6 @@ public partial class MessageDialog
 
 	partial void ValidateCommandsNative()
 	{
-		if (!WinRTFeatureConfiguration.MessageDialog.UseNativeDialog)
-		{
-			return;
-		}
-
 		// On Android, providing more than 3 commands will skip all but the first two and the last.
 		// We intercept this bad situation right away.
 		if (this.Commands.Count > MaximumCommands)

--- a/src/Uno.UWP/UI/Popups/MessageDialog.Android.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.Android.cs
@@ -1,5 +1,4 @@
-﻿#if XAMARIN_ANDROID
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;
@@ -15,103 +14,106 @@ using Windows.UI.Core;
 using Windows.Foundation;
 using System.Threading;
 
-namespace Windows.UI.Popups
+namespace Windows.UI.Popups;
+
+public partial class MessageDialog
 {
-	public partial class MessageDialog
+	const int MaximumCommands = 3;
+
+	private async Task<IUICommand> ShowInner(CancellationToken ct)
 	{
-		const int MaximumCommands = 3;
+		// Android recommends placing buttons in this order:
+		//  1) positive (default accept)
+		//  2) negative (default cancel)
+		//  3) neutral
+		// For the moment, we respect instead the order they were added in Commands,
+		// just like under Windows.
 
-		private async Task<IUICommand> ShowInner(CancellationToken ct)
+		var result = new TaskCompletionSource<IUICommand>();
+		var dialog = Commands
+			.Where(command => !(command is UICommandSeparator)) // Not supported on Android
+			.DefaultIfEmpty(new UICommand("Close")) // TODO: Localize (PBI 28711)
+			.Reverse()
+			.Select((command, index) =>
+				new
+				{
+					Command = command,
+					ButtonType = GetDialogButtonType(index)
+				})
+			.Aggregate(
+				new global::AndroidX.AppCompat.App.AlertDialog.Builder(ContextHelper.Current)
+					.SetTitle(Title ?? "")
+					.SetMessage(Content ?? "")
+					.SetOnCancelListener(new DialogListener(this, result))
+					.SetCancelable(false)
+					.Create(),
+				(alertDialog, commandInfo) =>
+				{
+					alertDialog.SetButton(
+						commandInfo.ButtonType,
+						commandInfo.Command.Label,
+						(_, __) =>
+						{
+							commandInfo.Command.Invoked?.Invoke(commandInfo.Command);
+							result.TrySetResult(commandInfo.Command);
+						}
+					);
+					return alertDialog;
+				}
+			);
+
+		await using (ct.Register(() =>
 		{
-			// Android recommends placing buttons in this order:
-			//  1) positive (default accept)
-			//  2) negative (default cancel)
-			//  3) neutral
-			// For the moment, we respect instead the order they were added in Commands,
-			// just like under Windows.
+			// If the cancellation token itself gets cancelled, we cancel as well.
+			result.TrySetCanceled();
+			dialog.Dismiss();
+		}))
+		{
+			dialog.Show();
+			return await result.Task;
+		}
+	}
 
-			var result = new TaskCompletionSource<IUICommand>();
-			var dialog = Commands
-				.Where(command => !(command is UICommandSeparator)) // Not supported on Android
-				.DefaultIfEmpty(new UICommand("Close")) // TODO: Localize (PBI 28711)
-				.Reverse()
-				.Select((command, index) =>
-					new
-					{
-						Command = command,
-						ButtonType = GetDialogButtonType(index)
-					})
-				.Aggregate(
-					new global::AndroidX.AppCompat.App.AlertDialog.Builder(ContextHelper.Current)
-						.SetTitle(Title ?? "")
-						.SetMessage(Content ?? "")
-						.SetOnCancelListener(new DialogListener(this, result))
-						.SetCancelable(false)
-						.Create(),
-					(alertDialog, commandInfo) =>
-					{
-						alertDialog.SetButton(
-							commandInfo.ButtonType,
-							commandInfo.Command.Label,
-							(_, __) =>
-							{
-								commandInfo.Command.Invoked?.Invoke(commandInfo.Command);
-								result.TrySetResult(commandInfo.Command);
-							}
-						);
-						return alertDialog;
-					}
-				);
-
-			await using (ct.Register(() =>
-			{
-				// If the cancellation token itself gets cancelled, we cancel as well.
-				result.TrySetCanceled();
-				dialog.Dismiss();
-			}))
-			{
-				dialog.Show();
-				return await result.Task;
-			}
+	partial void ValidateCommandsNative()
+	{
+		if (!WinRTFeatureConfiguration.MessageDialog.UseNativeDialog)
+		{
+			return;
 		}
 
-		partial void ValidateCommands()
+		// On Android, providing more than 3 commands will skip all but the first two and the last.
+		// We intercept this bad situation right away.
+		if (this.Commands.Count > MaximumCommands)
 		{
-			// On Android, providing more than 3 commands will skip all but the first two and the last.
-			// We intercept this bad situation right away.
-			if (this.Commands.Count > MaximumCommands)
-			{
-				throw new ArgumentOutOfRangeException("Commands", $"This platform does not support more than {MaximumCommands} commands.");
-			}
+			throw new ArgumentOutOfRangeException("Commands", $"This platform does not support more than {MaximumCommands} commands.");
+		}
+	}
+
+	private int GetDialogButtonType(int commandIndex)
+	{
+		return (int)DialogButtonType.Positive - commandIndex;
+	}
+
+	private class DialogListener : Java.Lang.Object, IDialogInterfaceOnCancelListener, IDialogInterfaceOnDismissListener
+	{
+		private readonly MessageDialog _dialog;
+		private readonly TaskCompletionSource<IUICommand> _source;
+
+		public DialogListener(MessageDialog dialog, TaskCompletionSource<IUICommand> source)
+		{
+			_dialog = dialog;
+			_source = source;
 		}
 
-		private int GetDialogButtonType(int commandIndex)
+		public void OnCancel(IDialogInterface dialog)
 		{
-			return (int)DialogButtonType.Positive - commandIndex;
+			// Cancelling from user action should never throw, but instead return either the "cancel" command, or null.
+			_source.TrySetResult(_dialog.Commands.ElementAtOrDefault((int)_dialog.CancelCommandIndex));
 		}
 
-		private class DialogListener : Java.Lang.Object, IDialogInterfaceOnCancelListener, IDialogInterfaceOnDismissListener
+		public void OnDismiss(IDialogInterface dialog)
 		{
-			private readonly MessageDialog _dialog;
-			private readonly TaskCompletionSource<IUICommand> _source;
-
-			public DialogListener(MessageDialog dialog, TaskCompletionSource<IUICommand> source)
-			{
-				_dialog = dialog;
-				_source = source;
-			}
-
-			public void OnCancel(IDialogInterface dialog)
-			{
-				// Cancelling from user action should never throw, but instead return either the "cancel" command, or null.
-				_source.TrySetResult(_dialog.Commands.ElementAtOrDefault((int)_dialog.CancelCommandIndex));
-			}
-
-			public void OnDismiss(IDialogInterface dialog)
-			{
-				// Nothing special here
-			}
+			// Nothing special here
 		}
 	}
 }
-#endif

--- a/src/Uno.UWP/UI/Popups/MessageDialog.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Uno;
@@ -117,23 +115,24 @@ public sealed partial class MessageDialog
 			throw new InvalidOperationException("MessageDialog extension is not registered");
 		}
 
-		return await extension.ShowAsync();
+		return await extension.ShowAsync(ct);
 	}
 
 	private void ValidateCommands()
 	{
+#if __IOS__ || __MACOS__ || __ANDROID__
 		if (WinRTFeatureConfiguration.MessageDialog.UseNativeDialog)
 		{
 			ValidateCommandsNative();
+			return;
 		}
-		else
+#endif
+
+		if (Commands.Count > 3)
 		{
-			if (Commands.Count > 3)
-			{
-				this.Log().LogError(
-					"Maximum of 3 commands is allowed. Further commands will not be displayed. " +
-					"On WinUI/UWP adding more commands will cause an exception.");
-			}
+			this.Log().LogError(
+				"Maximum of 3 commands is allowed. Further commands will not be displayed. " +
+				"On WinUI/UWP adding more commands will cause an exception.");
 		}
 	}
 

--- a/src/Uno.UWP/UI/Popups/MessageDialog.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.cs
@@ -5,69 +5,137 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Uno;
+using Uno.Foundation.Extensibility;
+using Uno.Foundation.Logging;
 using Uno.Helpers;
 using Windows.Foundation;
 using Windows.UI.Core;
+using Windows.UI.Popups.Internal;
 
-namespace Windows.UI.Popups
+namespace Windows.UI.Popups;
+
+/// <summary>
+/// Represents a dialog for showing messages to the user.
+/// </summary>
+public sealed partial class MessageDialog
 {
-	public sealed partial class MessageDialog
+	/// <summary>
+	/// Creates a new instance of the MessageDialog class, using the specified message content and no title.
+	/// </summary>
+	/// <param name="content">The message displayed to the user.</param>
+	public MessageDialog(string content)
+		: this(content, "")
 	{
-		/// <summary>
-		/// Creates a new instance of the MessageDialog class, using the specified message content and no title.
-		/// </summary>
-		/// <param name="content"></param>
-		public MessageDialog(string content)
-			: this(content, "")
+	}
+
+	/// <summary>
+	/// Creates a new instance of the MessageDialog class, using the specified message content and title.
+	/// </summary>
+	/// <param name="content">The message displayed to the user.</param>
+	/// <param name="title">The title you want displayed on the dialog.</param>
+	public MessageDialog(string content, string title)
+	{
+		// They can both be empty.
+		Content = content ?? throw new ArgumentNullException(nameof(content));
+		Title = title ?? throw new ArgumentNullException(nameof(title));
+
+		var commands = new ObservableCollection<IUICommand>();
+		commands.CollectionChanged += (s, e) => ValidateCommands();
+
+		Commands = commands;
+	}
+
+	public IAsyncOperation<IUICommand> ShowAsync()
+	{
+		VisualTreeHelperProxy.CloseAllFlyouts();
+
+		return AsyncOperation.FromTask<IUICommand>(async ct =>
 		{
-		}
-
-		/// <summary>
-		/// Creates a new instance of the MessageDialog class, using the specified message content and title.
-		/// </summary>
-		/// <param name="content"></param>
-		/// <param name="title"></param>
-		public MessageDialog(string content, string title)
-		{
-			// They can both be empty.
-			Content = content ?? throw new ArgumentNullException(nameof(content));
-			Title = title ?? throw new ArgumentNullException(nameof(title));
-
-			var collection = new ObservableCollection<IUICommand>();
-			collection.CollectionChanged += (s, e) => this.ValidateCommands();
-
-			Commands = collection;
-		}
-
-#if __ANDROID__ || __IOS__
-		public IAsyncOperation<IUICommand> ShowAsync()
-		{
-			VisualTreeHelperProxy.CloseAllFlyouts();
-
-			return AsyncOperation.FromTask<IUICommand>(async ct =>
+			if (CoreDispatcher.Main.HasThreadAccess)
 			{
-				if (CoreDispatcher.Main.HasThreadAccess)
-				{
-					return await ShowInner(ct);
-				}
-				else
-				{
-					var show = default(Task<IUICommand>);
-					await CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Normal, () => show = ShowInner(ct));
+				return await ShowInnerAsync(ct);
+			}
+			else
+			{
+				var show = default(Task<IUICommand>);
+				await CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Normal, () => show = ShowInnerAsync(ct));
 
-					return await show;
-				}
-			});
+				return await show;
+			}
+		});
+	}
+
+	/// <summary>
+	/// Gets or sets the index of the command you want to use as the cancel command.
+	/// This is the command that fires when users press the ESC key.	
+	/// Add the commands before you set the index.
+	/// </summary>
+	public uint CancelCommandIndex { get; set; } = uint.MaxValue;
+
+	/// <summary>
+	/// Gets an array of commands that appear in the command bar of the message dialog. These commands makes the dialog actionable.
+	/// </summary>
+	/// <remarks>
+	/// Maximum of 3 commands is allowed.
+	/// </remarks>
+	public IList<IUICommand> Commands { get; }
+
+	/// <summary>
+	/// Gets or sets the message to be displayed to the user.
+	/// </summary>
+	public string Content { get; set; }
+
+	/// <summary>
+	/// Gets or sets the index of the command you want to use as the default.
+	/// This is the command that fires by default when users press the ENTER key.
+	/// Add the commands before you set the index.
+	/// </summary>
+	public uint DefaultCommandIndex { get; set; } = 0;
+
+	/// <summary>
+	/// Gets or sets the options for a MessageDialog.
+	/// </summary>
+	public MessageDialogOptions Options { get; set; }
+
+	/// <summary>
+	/// Gets or sets the title to display on the dialog, if any.
+	/// </summary>
+	public string Title { get; set; }
+
+	private async Task<IUICommand> ShowInnerAsync(CancellationToken ct)
+	{
+#if __IOS__ || __MACOS__ || __ANDROID__
+		if (WinRTFeatureConfiguration.MessageDialog.UseNativeDialog)
+		{
+			return await ShowNativeAsync(ct);
 		}
 #endif
 
-		public uint CancelCommandIndex { get; set; } = uint.MaxValue;
-		public IList<IUICommand> Commands { get; }
-		public string Content { get; set; }
-		public uint DefaultCommandIndex { get; set; } = 0;
-		public MessageDialogOptions Options { get; set; }
-		public string Title { get; set; }
+		if (!ApiExtensibility.CreateInstance<IMessageDialogExtension>(this, out var extension))
+		{
+			throw new InvalidOperationException("MessageDialog extension is not registered");
+		}
 
-		partial void ValidateCommands();
+		return await extension.ShowAsync();
 	}
+
+	private void ValidateCommands()
+	{
+		if (WinRTFeatureConfiguration.MessageDialog.UseNativeDialog)
+		{
+			ValidateCommandsNative();
+		}
+		else
+		{
+			if (Commands.Count > 3)
+			{
+				this.Log().LogError(
+					"Maximum of 3 commands is allowed. Further commands will not be displayed. " +
+					"On WinUI/UWP adding more commands will cause an exception.");
+			}
+		}
+	}
+
+	partial void ValidateCommandsNative();
 }

--- a/src/Uno.UWP/UI/Popups/MessageDialog.iOS.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.iOS.cs
@@ -9,71 +9,70 @@ using Uno.Extensions;
 using Windows.Foundation;
 using Windows.UI.Core;
 
-namespace Windows.UI.Popups
+namespace Windows.UI.Popups;
+
+public partial class MessageDialog
 {
-	public partial class MessageDialog
+	private static readonly SemaphoreSlim _viewControllerAccess = new SemaphoreSlim(1, 1);
+
+	private async Task<IUICommand> ShowInner(CancellationToken ct)
 	{
-		private static readonly SemaphoreSlim _viewControllerAccess = new SemaphoreSlim(1, 1);
-
-		private async Task<IUICommand> ShowInner(CancellationToken ct)
-		{
-			var result = new TaskCompletionSource<IUICommand>();
-			var alertActions = Commands
-				.Where(command => !(command is UICommandSeparator)) // Not supported on iOS
-				.DefaultIfEmpty(new UICommand("OK")) // TODO: Localize (PBI 28711)
-				.Select((command, index) => UIAlertAction
-					.Create(
-						title: command.Label ?? "",
-						style: (command as UICommand)?.IsDestructive ?? false
-							? UIAlertActionStyle.Destructive
-							: UIAlertActionStyle.Default,
-						handler: _ =>
-						{
-							command.Invoked?.Invoke(command);
-							result.TrySetResult(command);
-						}
-					)
+		var result = new TaskCompletionSource<IUICommand>();
+		var alertActions = Commands
+			.Where(command => !(command is UICommandSeparator)) // Not supported on iOS
+			.DefaultIfEmpty(new UICommand("OK")) // TODO: Localize (PBI 28711)
+			.Select((command, index) => UIAlertAction
+				.Create(
+					title: command.Label ?? "",
+					style: (command as UICommand)?.IsDestructive ?? false
+						? UIAlertActionStyle.Destructive
+						: UIAlertActionStyle.Default,
+					handler: _ =>
+					{
+						command.Invoked?.Invoke(command);
+						result.TrySetResult(command);
+					}
 				)
-				.ToArray();
+			)
+			.ToArray();
 
-			var alertController = UIAlertController.Create(
-				Title ?? "",
-				Content ?? "",
-				UIAlertControllerStyle.Alert
-			);
+		var alertController = UIAlertController.Create(
+			Title ?? "",
+			Content ?? "",
+			UIAlertControllerStyle.Alert
+		);
 
-			alertActions.ForEach(alertController.AddAction);
+		alertActions.ForEach(alertController.AddAction);
 
-			if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
+		if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion(9, 0))
+		{
+			alertController.PreferredAction = alertActions.ElementAtOrDefault((int)DefaultCommandIndex);
+		}
+
+		using (ct.Register(() =>
 			{
-				alertController.PreferredAction = alertActions.ElementAtOrDefault((int)DefaultCommandIndex);
-			}
-			
-			using (ct.Register(() =>
-				{
 					// If the cancellation token itself gets cancelled, we cancel as well.
 					result.TrySetCanceled();
-					UIApplication.SharedApplication.KeyWindow?.RootViewController?.DismissViewController(false, () => { });
-				}, useSynchronizationContext: true))
-			{
-				await _viewControllerAccess.WaitAsync(ct);
-
-				try
-				{
-					await UIApplication.SharedApplication.KeyWindow?.RootViewController?.PresentViewControllerAsync(alertController, animated: true);
-				}
-				finally
-				{
-					_viewControllerAccess.Release();
-				}
-
-				return await result.Task;
-			}
-		}
-
-		partial void ValidateCommands()
+				UIApplication.SharedApplication.KeyWindow?.RootViewController?.DismissViewController(false, () => { });
+			}, useSynchronizationContext: true))
 		{
-			// On iOS, there is no limit. The items will be in a scrollable list.
+			await _viewControllerAccess.WaitAsync(ct);
+
+			try
+			{
+				await UIApplication.SharedApplication.KeyWindow?.RootViewController?.PresentViewControllerAsync(alertController, animated: true);
+			}
+			finally
+			{
+				_viewControllerAccess.Release();
+			}
+
+			return await result.Task;
 		}
+	}
+
+	partial void ValidateCommandsNative()
+	{		
+		// On iOS, there is no limit. The items will be in a scrollable list.
 	}
 }

--- a/src/Uno.UWP/UI/Popups/MessageDialog.iOS.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.iOS.cs
@@ -15,7 +15,7 @@ public partial class MessageDialog
 {
 	private static readonly SemaphoreSlim _viewControllerAccess = new SemaphoreSlim(1, 1);
 
-	private async Task<IUICommand> ShowInner(CancellationToken ct)
+	private async Task<IUICommand> ShowNativeAsync(CancellationToken ct)
 	{
 		var result = new TaskCompletionSource<IUICommand>();
 		var alertActions = Commands

--- a/src/Uno.UWP/UI/Popups/MessageDialog.macOS.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.macOS.cs
@@ -1,70 +1,67 @@
-﻿#if __MACOS__
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using AppKit;
 using Windows.Foundation;
 
-namespace Windows.UI.Popups
+namespace Windows.UI.Popups;
+
+public partial class MessageDialog
 {
-	public partial class MessageDialog
+	private const int FirstButtonResultIndex = 1000;  // Result is a number starting at 1000
+
+	public IAsyncOperation<IUICommand> ShowAsync()
 	{
-		private const int FirstButtonResultIndex = 1000;  // Result is a number starting at 1000
-
-		public IAsyncOperation<IUICommand> ShowAsync()
+		var alert = new NSAlert()
 		{
-			var alert = new NSAlert()
-			{
-				MessageText = Title ?? "",
-				InformativeText = Content ?? "",
-				AlertStyle = NSAlertStyle.Informational
-			};
+			MessageText = Title ?? "",
+			InformativeText = Content ?? "",
+			AlertStyle = NSAlertStyle.Informational
+		};
 
-			var actualCommandOrder = new List<UICommand>();
+		var actualCommandOrder = new List<UICommand>();
 
-			UICommand defaultCommand = null;
-			if (DefaultCommandIndex >= 0 &&
-				DefaultCommandIndex < Commands.Count)
+		UICommand defaultCommand = null;
+		if (DefaultCommandIndex >= 0 &&
+			DefaultCommandIndex < Commands.Count)
+		{
+			defaultCommand = Commands[(int)DefaultCommandIndex] as UICommand;
+		}
+
+		// Default command must be added first (to be default on macOS).
+		if (defaultCommand != null)
+		{
+			alert.AddButton(defaultCommand.Label);
+			actualCommandOrder.Add(defaultCommand);
+		}
+
+		// Add remaining alert buttons in reverse because NSAlert.AddButtons adds them
+		// from the right to the left.
+		foreach (var command in Commands.OfType<UICommand>())
+		{
+			if (command == defaultCommand)
 			{
-				defaultCommand = Commands[(int)DefaultCommandIndex] as UICommand;				
+				// Skip, already added.
+				continue;
 			}
 
-			// Default command must be added first (to be default on macOS).
-			if ( defaultCommand != null)
-			{
-				alert.AddButton(defaultCommand.Label);
-				actualCommandOrder.Add(defaultCommand);
-			}
-			
-			// Add remaining alert buttons in reverse because NSAlert.AddButtons adds them
-			// from the right to the left.
-			foreach (var command in Commands.OfType<UICommand>())
-			{
-				if (command == defaultCommand)
-				{
-					// Skip, already added.
-					continue;
-				}
+			alert.AddButton(command.Label);
+			actualCommandOrder.Add(command);
+		}
 
-				alert.AddButton(command.Label);
-				actualCommandOrder.Add(command);
-			}
+		return AsyncOperation.FromTask<IUICommand>(async ct =>
+		{
+			var response = await alert.BeginSheetAsync(NSApplication.SharedApplication.KeyWindow);
 
-			return AsyncOperation.FromTask<IUICommand>(async ct =>
+			if (actualCommandOrder.Count == 0)
 			{
-				var response = await alert.BeginSheetAsync(NSApplication.SharedApplication.KeyWindow);
-
-				if (actualCommandOrder.Count == 0)
-				{
 					// There is no button specified, return dummy OK result.
 					return new UICommand("OK");
-				}
+			}
 
-				var commandIndex = (int)response - FirstButtonResultIndex;
-				var commandResponse = actualCommandOrder[commandIndex];
-				commandResponse?.Invoked?.Invoke(commandResponse);
-				return commandResponse;
-			});
-		}
+			var commandIndex = (int)response - FirstButtonResultIndex;
+			var commandResponse = actualCommandOrder[commandIndex];
+			commandResponse?.Invoked?.Invoke(commandResponse);
+			return commandResponse;
+		});
 	}
 }
-#endif

--- a/src/Uno.UWP/UI/Popups/MessageDialog.macOS.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.macOS.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using AppKit;
 using Windows.Foundation;
 
@@ -9,7 +11,7 @@ public partial class MessageDialog
 {
 	private const int FirstButtonResultIndex = 1000;  // Result is a number starting at 1000
 
-	public IAsyncOperation<IUICommand> ShowAsync()
+	private IAsyncOperation<IUICommand> ShowNativeAsync(CancellationToken ct)
 	{
 		var alert = new NSAlert()
 		{

--- a/src/Uno.UWP/UI/Popups/MessageDialog.wasm.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.wasm.cs
@@ -9,26 +9,25 @@ using Uno.Helpers;
 using Windows.Foundation;
 using Windows.UI.Core;
 
-namespace Windows.UI.Popups
+namespace Windows.UI.Popups;
+
+public partial class MessageDialog
 {
-	public partial class MessageDialog
+	private static readonly SemaphoreSlim _viewControllerAccess = new SemaphoreSlim(1, 1);
+
+	public IAsyncOperation<IUICommand> ShowAsync()
 	{
-		private static readonly SemaphoreSlim _viewControllerAccess = new SemaphoreSlim(1, 1);
+		VisualTreeHelperProxy.CloseAllFlyouts();
 
-		public IAsyncOperation<IUICommand> ShowAsync()
-		{
-			VisualTreeHelperProxy.CloseAllFlyouts();
+		var command = $"Uno.UI.WindowManager.current.alert(\"{Uno.Foundation.WebAssemblyRuntime.EscapeJs(Content)}\");";
+		Uno.Foundation.WebAssemblyRuntime.InvokeJS(command);
 
-			var command = $"Uno.UI.WindowManager.current.alert(\"{Uno.Foundation.WebAssemblyRuntime.EscapeJs(Content)}\");";
-			Uno.Foundation.WebAssemblyRuntime.InvokeJS(command);
+		return AsyncOperation.FromTask<IUICommand>(
+			async ct => new UICommand("OK") // TODO: Localize (PBI 28711)
+		);
+	}
 
-			return AsyncOperation.FromTask<IUICommand>(
-				async ct => new UICommand("OK") // TODO: Localize (PBI 28711)
-			);
-		}
-
-		partial void ValidateCommands()
-		{
-		}
+	partial void ValidateCommandsNative()
+	{
 	}
 }

--- a/src/Uno.UWP/UI/Popups/MessageDialog.wasm.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.wasm.cs
@@ -15,7 +15,7 @@ public partial class MessageDialog
 {
 	private static readonly SemaphoreSlim _viewControllerAccess = new SemaphoreSlim(1, 1);
 
-	public IAsyncOperation<IUICommand> ShowAsync()
+	private IAsyncOperation<IUICommand> ShowNativeAsync(CancellationToken ct)
 	{
 		VisualTreeHelperProxy.CloseAllFlyouts();
 

--- a/src/Uno.UWP/UI/Popups/MessageDialogOptions.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialogOptions.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 
-namespace Windows.UI.Popups
-{
-	/// <summary>
-	/// Specifies less frequently used options for a MessageDialog.
-	/// </summary>
-	[Flags]
-	public enum MessageDialogOptions : uint
-	{
-		/// <summary> 
-		/// No options are specified and default behavior is used.
-		/// </summary>
-		None = 0U,
+namespace Windows.UI.Popups;
 
-		/// <summary>
-		/// Ignore user input for a short period. This enables browsers to defend against clickjacking.
-		/// </summary>
-		AcceptUserInputAfterDelay = 1U
-	}
+/// <summary>
+/// Specifies less frequently used options for a MessageDialog.
+/// </summary>
+[Flags]
+public enum MessageDialogOptions : uint
+{
+	/// <summary> 
+	/// No options are specified and default behavior is used.
+	/// </summary>
+	None = 0U,
+
+	/// <summary>
+	/// Ignore user input for a short period. This enables browsers to defend against clickjacking.
+	/// </summary>
+	AcceptUserInputAfterDelay = 1U
 }

--- a/src/Uno.UWP/UI/Popups/UICommand.cs
+++ b/src/Uno.UWP/UI/Popups/UICommand.cs
@@ -9,6 +9,8 @@ namespace Windows.UI.Popups;
 /// </summary>
 public sealed partial class UICommand : IUICommand
 {
+	private string _label = "";
+
 	/// <summary>
 	/// Creates a new instance of the UICommand class.
 	/// </summary>
@@ -64,5 +66,9 @@ public sealed partial class UICommand : IUICommand
 	/// <summary>
 	/// Gets or sets the label for the command.
 	/// </summary>
-	public string Label { get; set; }
+	public string Label
+	{
+		get => _label;
+		set => _label = value ?? throw new ArgumentNullException(nameof(value));
+	}
 }

--- a/src/Uno.UWP/UI/Popups/UICommand.cs
+++ b/src/Uno.UWP/UI/Popups/UICommand.cs
@@ -1,70 +1,68 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿#nullable enable
 
-namespace Windows.UI.Popups
+using System;
+
+namespace Windows.UI.Popups;
+
+/// <summary>
+/// Represents a command in a context menu.
+/// </summary>
+public sealed partial class UICommand : IUICommand
 {
-	public sealed partial class UICommand : IUICommand
+	/// <summary>
+	/// Creates a new instance of the UICommand class.
+	/// </summary>
+	public UICommand()
+		: this("", null, null)
 	{
-		/// <summary>
-		/// Creates a new instance of the UICommand class.
-		/// </summary>
-		public UICommand()
-			: this("", null, null)
-		{
-		}
-
-		/// <summary>
-		/// Creates a new instance of the UICommand class using the specified label.
-		/// </summary>
-		/// <param name="label"></param>
-		public UICommand(string label)
-			: this(label, null, null)
-		{
-		}
-
-		/// <summary>
-		///  Creates a new instance of the UICommand class using the specified label and optional event handler.
-		/// </summary>
-		/// <param name="label"></param>
-		/// <param name="action"></param>
-		public UICommand(string label, UICommandInvokedHandler action)
-			: this(label, action, null)
-		{
-		}
-
-		/// <summary>
-		/// Creates a new instance of the UICommand class using the specified label, and optional event handler and command identifier.
-		/// </summary>
-		/// <param name="label"></param>
-		/// <param name="action"></param>
-		/// <param name="commandId"></param>
-		public UICommand(string label, UICommandInvokedHandler action, object commandId)
-		{
-			if (label == null)
-			{
-				throw new ArgumentNullException(nameof(label));
-			}
-
-			Label = label;
-			// These can be null
-			Invoked = action;
-			Id = commandId;
-		}
-
-		/// <summary>
-		/// Gets or sets the identifier of the command.
-		/// </summary>
-		public object Id { get; set; }
-
-		/// <summary>
-		/// Gets or sets the handler for the event that is fired when the user invokes the command. 
-		/// </summary>
-		public UICommandInvokedHandler Invoked { get; set; }
-
-		/// <summary>
-		/// Gets or sets the label for the command.
-		/// </summary>
-		public string Label { get; set; }
 	}
+
+	/// <summary>
+	/// Creates a new instance of the UICommand class using the specified label.
+	/// </summary>
+	/// <param name="label">The label for the UICommand.</param>
+	public UICommand(string label)
+		: this(label, null, null)
+	{
+	}
+
+	/// <summary>
+	///  Creates a new instance of the UICommand class using the specified label and optional event handler.
+	/// </summary>
+	/// <param name="label">The label for the UICommand.</param>
+	/// <param name="action">The event handler for the new command.</param>
+	public UICommand(string label, UICommandInvokedHandler? action)
+		: this(label, action, null)
+	{
+	}
+
+	/// <summary>
+	/// Creates a new instance of the UICommand class using the specified label, and optional event handler and command identifier.
+	/// </summary>
+	/// <param name="label">The label for the UICommand.</param>
+	/// <param name="action">The event handler for the new command.</param>
+	/// <param name="commandId">The command identifier for the new command.</param>
+	public UICommand(string label, UICommandInvokedHandler? action, object? commandId)
+	{
+		Label = label ?? throw new ArgumentNullException(nameof(label));
+
+		// These can be null
+		Invoked = action;
+		Id = commandId;
+	}
+
+	/// <summary>
+	/// Gets or sets the identifier of the command.
+	/// </summary>
+	public object? Id { get; set; }
+
+	/// <summary>
+	/// Gets or sets the handler for the event that is fired when the user invokes the command. 
+	/// </summary>
+	public UICommandInvokedHandler? Invoked { get; set; }
+
+	/// <summary>
+	/// Gets or sets the label for the command.
+	/// </summary>
+	public string Label { get; set; }
 }

--- a/src/Uno.UWP/UI/Popups/UICommandSeparator.cs
+++ b/src/Uno.UWP/UI/Popups/UICommandSeparator.cs
@@ -1,31 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Windows.UI.Popups;
 
-namespace Windows.UI.Popups
+public sealed partial class UICommandSeparator : IUICommand
 {
-	public sealed partial class UICommandSeparator : IUICommand
+	/// <summary>
+	/// Creates a new instance of the UICommand class.
+	/// </summary>
+	public UICommandSeparator()
 	{
-		/// <summary>
-		/// Creates a new instance of the UICommand class.
-		/// </summary>
-		public UICommandSeparator()
-		{
-		}
-
-		/// <summary>
-		/// Gets or sets the identifier of the command.
-		/// </summary>
-		public object Id { get; set; }
-
-		/// <summary>
-		/// Gets or sets the handler for the event that is fired when the user invokes the command. 
-		/// </summary>
-		public UICommandInvokedHandler Invoked { get; set; }
-
-		/// <summary>
-		/// Gets or sets the label for the command.
-		/// </summary>
-		public string Label { get; set; }
 	}
+
+	/// <summary>
+	/// Gets or sets the identifier of the command.
+	/// </summary>
+	public object Id { get; set; }
+
+	/// <summary>
+	/// Gets or sets the handler for the event that is fired when the user invokes the command. 
+	/// </summary>
+	public UICommandInvokedHandler Invoked { get; set; }
+
+	/// <summary>
+	/// Gets or sets the label for the command.
+	/// </summary>
+	public string Label { get; set; }
 }

--- a/src/Uno.UWP/WinRTFeatureConfiguration.MessageDialog.cs
+++ b/src/Uno.UWP/WinRTFeatureConfiguration.MessageDialog.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel;
+
+namespace Uno;
+
+partial class WinRTFeatureConfiguration
+{
+	public static class MessageDialog
+	{
+		/// <summary>
+		/// Set this flag to true to use native OS dialogs when displaying MessageDialog.
+		/// Note the native dialogs may not support all the features and they are also not
+		/// supported on Skia targets.
+		/// </summary>
+		public static bool UseNativeDialog { get; set; } = false;
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4810

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

- `MessageDialog` looks different on each platform
- `MessageDialog` is not supported on Skia targets

## What is the new behavior?

- `MessageDialog` by default displays using `ContentDialog` provided by Uno.UI.
- Feature flag `WinRTFeatureConfiguration.MessageDialog.UseNativeDialog` was added to make it possible to show the native OS dialog instead

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.