### PR TITLE
fix(storage): [wasm] Fix invalid IBFS initialization

### DIFF
--- a/src/Uno.UI/ts/Windows/Storage/StorageFolder.ts
+++ b/src/Uno.UI/ts/Windows/Storage/StorageFolder.ts
@@ -65,9 +65,9 @@ namespace Windows.Storage {
 			// Ensure to sync pseudo file system on unload (and periodically for safety)
 			if (!this._isInitialized) {
 				// Request an initial sync to populate the file system
-				StorageFolder.synchronizeFileSystem(() => StorageFolder.onStorageInitialized());
+				StorageFolder.synchronizeFileSystem(true, () => StorageFolder.onStorageInitialized());
 
-				window.addEventListener("beforeunload", () => this.synchronizeFileSystem());
+				window.addEventListener("beforeunload", () => this.synchronizeFileSystem(false));
 				setInterval(this.synchronizeFileSystem, 10000);
 
 				this._isInitialized = true;
@@ -84,14 +84,16 @@ namespace Windows.Storage {
 		}
 
 		/**
-		 * Synchronize the IDBFS memory cache back to IndexDB
+		 * Synchronize the IDBFS memory cache back to IndexedDB
+		 * populate: requests the filesystem to be popuplated from the IndexedDB
+		 * onSynchronized: function invoked when the synchronization finished
 		 * */
-		private static synchronizeFileSystem(onSynchronized: Function = null): void {
+		private static synchronizeFileSystem(populate: boolean, onSynchronized: Function = null): void {
 
 			if (!StorageFolder._isSynchronizing) {
 				StorageFolder._isSynchronizing = true;
 
-				FS.syncfs(err => {
+				FS.syncfs(populate, err => {
 					StorageFolder._isSynchronizing = false;
 
 					if (onSynchronized) {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8157

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Initialization of the IDBFS provider is populating from the persisted `IndexedDB`. Caused by https://github.com/unoplatform/uno/pull/7876.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
