### PR TITLE
fix(CommandBar): Remove 1px "shadow" from iOS native CommandBar

### DIFF
--- a/src/Uno.UI/Controls/CommandBar/CommandBarRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBar/CommandBarRenderer.iOS.cs
@@ -215,6 +215,13 @@ namespace Uno.UI.Controls
 				Native.BackIndicatorTransitionMaskImage = backButtonIcon;
 			}
 
+			// Remove 1px "shadow" line from the bottom of UINavigationBar
+			// The legacy customization (iOS12 and lower) to remove this shadow is done in the above switch for Background property
+			if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+			{
+				appearance.ShadowColor = UIColor.Clear;
+			}
+
 			Native.CompactAppearance = appearance;
 			Native.StandardAppearance = appearance;
 			Native.ScrollEdgeAppearance = appearance;


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/351

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

![image](https://user-images.githubusercontent.com/4793020/155012763-10943f01-ff67-4d92-aebb-087b64fdc406.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/4793020/155013557-22444319-3d21-4d30-9f6c-1470ae6c36e7.png)
