### PR TITLE
fix: `UnitTestsControl` crashes on UWP

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestEngineConfig.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestEngineConfig.cs
@@ -1,23 +1,16 @@
-﻿using System;
-using System.Linq;
+﻿namespace Uno.UI.Samples.Tests;
 
-namespace Uno.UI.Samples.Tests
+public class UnitTestEngineConfig
 {
-	public class UnitTestEngineConfig
-	{
-		public const int DefaultRepeatCount = 3;
-		public const bool DefaultIsScrollerEnabled = true;
+	public const int DefaultRepeatCount = 3;
 
-		public static UnitTestEngineConfig Default { get; } = new UnitTestEngineConfig();
+	public static UnitTestEngineConfig Default { get; } = new UnitTestEngineConfig();
 
-		public string[] Filters { get; set; }
+	public string[] Filters { get; set; }
 
-		public int Attempts { get; set; } = DefaultRepeatCount;
+	public int Attempts { get; set; } = DefaultRepeatCount;
 
-		public bool IsConsoleOutputEnabled { get; set; }
+	public bool IsConsoleOutputEnabled { get; set; }
 
-		public bool IsRunningIgnored { get; set; }
-
-		public bool IsScrollerEnabled { get; set; } = DefaultIsScrollerEnabled;
-	}
+	public bool IsRunningIgnored { get; set; }
 }

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -84,6 +84,8 @@ namespace Uno.UI.Samples.Tests
 			EnableConfigPersistence();
 			OverrideDebugProviderAsserts();
 
+			UpdateContentScroller();
+
 			_applicationView = ApplicationView.GetForCurrentView();
 		}
 
@@ -915,8 +917,15 @@ namespace Uno.UI.Samples.Tests
 			Clipboard.SetContent(data);
 		}
 
-		private void UpdateContentScroller(object sender, RoutedEventArgs e)
+		private void ContentScrollerToggleChanged(object sender, RoutedEventArgs e) => UpdateContentScroller();
+
+		private void UpdateContentScroller()
 		{
+			if (unitTestContentScroller == null || unitTestContentRoot == null)
+			{
+				return;
+			}
+
 			if (contentScroller.IsChecked ?? UnitTestEngineConfig.DefaultIsScrollerEnabled)
 			{
 				unitTestContentScroller.HorizontalScrollMode = ScrollMode.Auto;

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices.WindowsRuntime;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -16,7 +15,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SampleControl.Presentation;
 using Uno.Disposables;
 using Uno.Extensions;
-using Uno.UI.RuntimeTests;
 using Uno.Testing;
 using Uno.UI.Samples.Helper;
 using Windows.UI;
@@ -73,7 +71,6 @@ namespace Uno.UI.Samples.Tests
 				getContent: () => unitTestContentRoot.Content as UIElement,
 				setContent: elt =>
 				{
-					unitTestContentScroller.ChangeView(0, 0, 1, disableAnimation: true);
 					unitTestContentRoot.Content = elt;
 				}
 			);
@@ -83,8 +80,6 @@ namespace Uno.UI.Samples.Tests
 			SampleChooserViewModel.Instance.SampleChanging += OnSampleChanging;
 			EnableConfigPersistence();
 			OverrideDebugProviderAsserts();
-
-			UpdateContentScroller();
 
 			_applicationView = ApplicationView.GetForCurrentView();
 		}
@@ -416,7 +411,6 @@ namespace Uno.UI.Samples.Tests
 
 					consoleOutput.IsChecked = config.IsConsoleOutputEnabled;
 					runIgnored.IsChecked = config.IsRunningIgnored;
-					contentScroller.IsChecked = config.IsScrollerEnabled;
 					retry.IsChecked = config.Attempts > 1;
 					testFilter.Text = string.Join(";", config.Filters);
 				}
@@ -437,8 +431,6 @@ namespace Uno.UI.Samples.Tests
 			runIgnored.Unchecked += (snd, e) => StoreConfig();
 			retry.Checked += (snd, e) => StoreConfig();
 			retry.Unchecked += (snd, e) => StoreConfig();
-			contentScroller.Checked += (snd, e) => StoreConfig();
-			contentScroller.Unchecked += (snd, e) => StoreConfig();
 			testFilter.TextChanged += (snd, e) => StoreConfig();
 
 			void StoreConfig()
@@ -452,7 +444,6 @@ namespace Uno.UI.Samples.Tests
 		{
 			var isConsoleOutput = consoleOutput.IsChecked ?? false;
 			var isRunningIgnored = runIgnored.IsChecked ?? false;
-			var isScrollerEnable = contentScroller.IsChecked ?? UnitTestEngineConfig.DefaultIsScrollerEnabled;
 			var attempts = (retry.IsChecked ?? true) ? UnitTestEngineConfig.DefaultRepeatCount : 1;
 			var filter = testFilter.Text.Trim();
 			if (string.IsNullOrEmpty(filter))
@@ -465,7 +456,6 @@ namespace Uno.UI.Samples.Tests
 				Filters = filter?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>(),
 				IsConsoleOutputEnabled = isConsoleOutput,
 				IsRunningIgnored = isRunningIgnored,
-				IsScrollerEnabled = isScrollerEnable,
 				Attempts = attempts,
 			};
 		}
@@ -867,7 +857,7 @@ namespace Uno.UI.Samples.Tests
 				   where type.GetTypeInfo().GetCustomAttribute(typeof(TestClassAttribute)) != null
 				   orderby type.Name
 				   let info = BuildType(type)
-				   where info.Type is {}
+				   where info.Type is { }
 				   select info;
 		}
 
@@ -915,41 +905,6 @@ namespace Uno.UI.Samples.Tests
 			data.SetText(NUnitTestResultsDocument);
 
 			Clipboard.SetContent(data);
-		}
-
-		private void ContentScrollerToggleChanged(object sender, RoutedEventArgs e) => UpdateContentScroller();
-
-		private void UpdateContentScroller()
-		{
-			if (unitTestContentScroller == null || unitTestContentRoot == null)
-			{
-				return;
-			}
-
-			if (contentScroller.IsChecked ?? UnitTestEngineConfig.DefaultIsScrollerEnabled)
-			{
-				unitTestContentScroller.HorizontalScrollMode = ScrollMode.Auto;
-				unitTestContentScroller.VerticalScrollMode = ScrollMode.Auto;
-				unitTestContentScroller.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
-				unitTestContentScroller.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
-
-				unitTestContentRoot.MinWidth = 1600;
-				unitTestContentRoot.MinHeight = 1600;
-				unitTestContentRoot.HorizontalContentAlignment = HorizontalAlignment.Center;
-				unitTestContentRoot.VerticalAlignment = VerticalAlignment.Center;
-			}
-			else
-			{
-				unitTestContentScroller.HorizontalScrollMode = ScrollMode.Disabled;
-				unitTestContentScroller.VerticalScrollMode = ScrollMode.Disabled;
-				unitTestContentScroller.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
-				unitTestContentScroller.VerticalScrollBarVisibility = ScrollBarVisibility.Disabled;
-
-				unitTestContentRoot.MinWidth = double.NaN;
-				unitTestContentRoot.MinHeight = double.NaN;
-				unitTestContentRoot.HorizontalContentAlignment = HorizontalAlignment.Left;
-				unitTestContentRoot.VerticalAlignment = VerticalAlignment.Top;
-			}
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
@@ -75,8 +75,8 @@
 									IsChecked="True"
 									not_skia:Content="⇲ Content scroll"
 									skia:Content="Content scroll"
-									Checked="UpdateContentScroller"
-									Unchecked="UpdateContentScroller"/>
+									Checked="ContentScrollerToggleChanged"
+									Unchecked="ContentScrollerToggleChanged"/>
 							</StackPanel>
 						</Flyout>
 					</Button.Flyout>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.xaml
@@ -13,7 +13,8 @@
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
-			<RowDefinition Height="0" x:Name="failedTestDetailsRow" /><!--Will be set to height = 100 if any exception-->
+			<RowDefinition Height="0" x:Name="failedTestDetailsRow" />
+			<!--Will be set to height = 100 if any exception-->
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
@@ -70,13 +71,6 @@
 									IsChecked="True"
 									not_skia:Content="➰ Auto retry"
 									skia:Content="Auto retry" />
-								<ToggleButton
-									x:Name="contentScroller"
-									IsChecked="True"
-									not_skia:Content="⇲ Content scroll"
-									skia:Content="Content scroll"
-									Checked="ContentScrollerToggleChanged"
-									Unchecked="ContentScrollerToggleChanged"/>
 							</StackPanel>
 						</Flyout>
 					</Button.Flyout>
@@ -186,16 +180,11 @@
 			ManipulationMode="TranslateX"
 			ManipulationDelta="UpdateOuputSize"/>
 
-		<ScrollViewer
+		<ContentControl
+			x:Name="unitTestContentRoot"
 			Grid.Column="2"
 			Grid.RowSpan="4"
-			x:Name="unitTestContentScroller">
-			<ContentControl
-				x:Name="unitTestContentRoot"
-					HorizontalContentAlignment="Center"
-				VerticalAlignment="Center"
-				MinWidth="1600"
-				MinHeight="1600" />
-		</ScrollViewer>
+			HorizontalContentAlignment="Left"
+			VerticalAlignment="Top" />
 	</Grid>
 </UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NativeFrame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NativeFrame.cs
@@ -21,6 +21,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 	{
 		[TestMethod]
 		[RunsOnUIThread]
+		[RequiresFullWindow]
 		public async Task When_NavigateForward()
 		{
 			var style = Windows.UI.Xaml.Application.Current.Resources["NativeDefaultFrame"] as Style;
@@ -51,6 +52,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[RequiresFullWindow]
 		public async Task When_NavigateBackSkipingPages()
 		{
 			var style = Windows.UI.Xaml.Application.Current.Resources["NativeDefaultFrame"] as Style;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -128,6 +128,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[RequiresFullWindow]
 		public async Task When_ScrollViewer_Resized()
 		{
 			var content = new Border
@@ -142,8 +143,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var container = new Border {Child = sut};
 
 			WindowHelper.WindowContent = container;
-
-			await WindowHelper.WaitForLoaded(content);
 
 			using var _ = new AssertionScope();
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8182

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`UnitTestsControl` crashes on UWP

## What is the new behavior?

`UnitTestsControl` does not crash on UWP

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.