### PR TITLE
fix(templatepool): template not being applied on recycled item

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -40,7 +40,7 @@ using ViewGroup = Windows.UI.Xaml.UIElement;
 namespace Windows.UI.Xaml.Controls
 {
 	[ContentProperty(Name = "Content")]
-	public partial class ContentPresenter : FrameworkElement, ICustomClippingElement
+	public partial class ContentPresenter : FrameworkElement, ICustomClippingElement, IFrameworkTemplatePoolAware
 	{
 		private bool _firstLoadResetDone;
 		private View _contentTemplateRoot;
@@ -814,6 +814,13 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			return false;
+		}
+
+		void IFrameworkTemplatePoolAware.OnTemplateRecycled()
+		{
+			// This needs to be cleared on recycle, to prevent
+			// SetUpdateTemplate from being skipped in OnLoaded.
+			_firstLoadResetDone = false;
 		}
 
 		protected override void OnVisibilityChanged(Visibility oldValue, Visibility newValue)


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/nventive-private#352

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Recycled items would sometimes not have its template applied, and use the placeholder ImplicitTextBlock as template.

## What is the new behavior?

Template should be correctly applied to recycled items.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.