### PR TITLE
fix(DependencyObject): Fix possible infinite loop on ancestor lookup

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyObject.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyObject.cs
@@ -122,6 +122,21 @@ namespace Uno.UI.Tests
 			Assert.AreEqual(1, typeof(MyObject).GetCustomAttributes(typeof(BindableAttribute), true).Length);
 		}
 
+		[TestMethod]
+		public void When_LayoutLoop()
+		{
+			var SUT = new ContentControl();
+			var inner1 = new Grid();
+			var inner2 = new Grid();
+
+			SUT.Content = inner1;
+			inner1.Children.Add(inner2);
+			inner2.Children.Add(SUT);
+
+			// No exception should be raised for this test, until
+			// Children.Add validates for cycles.
+		}
+
 		public partial class MyObject : DependencyObject
 		{
 			public MyObject(int value)
@@ -145,7 +160,6 @@ namespace Uno.UI.Tests
 
 			public override int GetHashCode() => Value.GetHashCode();
 		}
-
 	}
 
 	public partial class MyProvider : DependencyObject


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8165

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Break layout cycles for inherited `DependencyProperty` propagation with a maximum depth
- Exit ancestor search loop when the ancestor is found

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
