### PR TITLE
[WASM] Use theme-aware splash screens by default

### DIFF
--- a/doc/articles/splash-screen.md
+++ b/doc/articles/splash-screen.md
@@ -170,7 +170,7 @@ This article covers how to add a splash screen to your application.
 
 1. In the `.WASM` project, navigate to `WasmScripts/AppManifest.js` 
 
-1. Add your splash screen image
+2. Add your splash screen image
 
     ```js
     var UnoAppManifest = {
@@ -182,6 +182,10 @@ This article covers how to add a splash screen to your application.
 
     > [!NOTE]
     > Currently, you need to set an explicit scale for the splash screen image.
+
+The `splashScreenColor` property allows you to set the background color for the splash screen. If you want to make the splash screen theme-aware, you can omit this property or set it to `"transparent"`.
+
+If you use the theme-aware splash screen background, you can also set the `darkThemeBackgroundColor` and `lightThemeBackgroundColor` properties to adjust the background color for each theme. Default values are `"#202020"` for dark theme and `"#F3F3F3"` for light theme.
 
 ## Table of scales
 

--- a/src/SamplesApp/SamplesApp.Wasm/WasmScripts/AppManifest.js
+++ b/src/SamplesApp/SamplesApp.Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.scale-200.png",
-    splashScreenColor: "#0078D7",
+    splashScreenColor: "transparent",
     displayName: "SamplesApp"
 
 }

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/WasmScripts/AppManifest.js
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.png",
-    splashScreenColor: "#0078D7",
+    splashScreenColor: "transparent",
     displayName: "BlankApp"
 
 }

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoXFQuickStart.Wasm/WasmScripts/AppManifest.js
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/xamarinforms-wasm/UnoXFQuickStart.Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.scale-200.png",
-    splashScreenColor: "#0078D7",
+    splashScreenColor: "transparent",
     displayName: "UnoXFQuickStart"
 
 }

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Wasm/WasmScripts/AppManifest.js
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.png",
-    splashScreenColor: "#fff",
+    splashScreenColor: "transparent",
     displayName: "$ext_safeprojectname$"
 
 }

--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmScripts/AppManifest.js
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/WasmScripts/AppManifest.js
@@ -1,7 +1,7 @@
 ﻿var UnoAppManifest = {
 
     splashScreenImage: "Assets/SplashScreen.png",
-    splashScreenColor: "#fff",
+    splashScreenColor: "transparent",
     displayName: "$ext_safeprojectname$"
 
 }


### PR DESCRIPTION
GitHub Issue (If applicable): related to #8096

## PR Type

What kind of change does this PR introduce?

- Feature
- Documentation content changes

## What is the current behavior?

Splash screens are white by default.

## What is the new behavior?

- Splash screens are dark or light based on system theme by default.
- Docs added for theme-aware splash screens.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.