### PR TITLE
feat: Support Enter, Space, Escape and Up/Down on `ComboBox`

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -492,7 +492,15 @@ namespace Windows.UI.Xaml.Controls
 			if (args.Key == VirtualKey.Enter ||
 				args.Key == VirtualKey.Space)
 			{
-				if (!IsDropDownOpen)
+				if (IsDropDownOpen)
+				{
+					if (SelectedIndex > -1)
+					{
+						IsDropDownOpen = false;
+						return true;
+					}
+				}
+				else
 				{
 					IsDropDownOpen = true;
 					return true;
@@ -504,6 +512,20 @@ namespace Windows.UI.Xaml.Controls
 				{
 					IsDropDownOpen = false;
 					return true;
+				}
+			}
+			else if (args.Key == VirtualKey.Down)
+			{
+				if (SelectedIndex < (NumberOfItems - 1))
+				{
+					SelectedIndex++;
+				}
+			}
+			else if (args.Key == VirtualKey.Up)
+			{
+				if (SelectedIndex > 0)
+				{
+					SelectedIndex -= 1;
 				}
 			}
 			return false;

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -1,29 +1,18 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Windows.Input;
-using Uno.Client;
-using System.Collections;
-using Uno.UI.Controls;
-using Uno.Extensions;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Input;
 using Uno.Foundation.Logging;
 using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.Foundation;
 using Uno.UI;
-using System.Linq;
-using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Data;
 
 
 using Uno.UI.DataBinding;
 using Uno.UI.Xaml.Controls;
-using Windows.UI.Core;
 #if __ANDROID__
 using Android.Views;
 using _View = Android.Views.View;
@@ -35,6 +24,7 @@ using AppKit;
 using _View = AppKit.NSView;
 #else
 using _View = Windows.UI.Xaml.FrameworkElement;
+using Windows.System;
 #endif
 
 #if HAS_UNO_WINUI
@@ -488,6 +478,35 @@ namespace Windows.UI.Xaml.Controls
 
 			// On UWP ComboBox does handle the released event.
 			args.Handled = true;
+		}
+
+		protected override void OnKeyDown(KeyRoutedEventArgs args)
+		{
+			args.Handled = TryHandleKeyDown(args);
+
+			base.OnKeyDown(args);
+		}
+
+		internal bool TryHandleKeyDown(KeyRoutedEventArgs args)
+		{
+			if (args.Key == VirtualKey.Enter ||
+				args.Key == VirtualKey.Space)
+			{
+				if (!IsDropDownOpen)
+				{
+					IsDropDownOpen = true;
+					return true;
+				}
+			}
+			else if (args.Key == VirtualKey.Escape)
+			{
+				if (IsDropDownOpen)
+				{
+					IsDropDownOpen = false;
+					return true;
+				}
+			}
+			return false;
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
@@ -29,7 +29,7 @@ namespace Windows.UI.Xaml.Controls
 				if (!args.Handled)
 				{
 					// Fallback to combobox keydown handling
-					args.Handled = comboBox.TryHandleKeyDown(args);
+					args.Handled = comboBox.TryHandleKeyDown(args, this);
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Windows.System;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -10,6 +9,31 @@ namespace Windows.UI.Xaml.Controls
 		public ComboBoxItem()
 		{
 			DefaultStyleKey = typeof(ComboBoxItem);
+		}
+
+		protected override void OnKeyDown(KeyRoutedEventArgs args)
+		{
+			if (ItemsControl.ItemsControlFromItemContainer(this) is ComboBox comboBox)
+			{
+				if (args.Key == VirtualKey.Enter && comboBox.IsDropDownOpen)
+				{
+					var item = comboBox.ItemFromContainer(this);
+					if (item != null)
+					{
+						comboBox.SelectedItem = item;
+						comboBox.IsDropDownOpen = false;
+						args.Handled = true;
+					}
+				}
+
+				if (!args.Handled)
+				{
+					// Fallback to combobox keydown handling
+					args.Handled = comboBox.TryHandleKeyDown(args);
+				}
+			}
+
+			base.OnKeyDown(args);
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7759

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`ComboBox` does not support key events

## What is the new behavior?

Basic support for key navigation on `ComboBox` - Enter, Space and Escape

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.