### PR TITLE
fix(pointers): Fix gesture recognizer not completing drag manipulations internally.

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -1536,6 +1536,27 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		}
 
 		[TestMethod]
+		public void Drag_CompleteGesture()
+		{
+			var sut = new GestureRecognizer { GestureSettings = GestureSettings.Drag };
+			var drags = new List<DraggingEventArgs>();
+			sut.Dragging += (snd, e) => drags.Add(e);
+
+			using var _ = Touch();
+
+			sut.ProcessDownEvent(25, 25, ts: 0);
+			sut.ProcessMoveEvent(26, 26, ts: GestureRecognizer.DragWithTouchMinDelayTicks + 1);
+			var start = sut.ProcessMoveEvent(50, 50, ts: GestureRecognizer.DragWithTouchMinDelayTicks + 2);
+			var move = sut.ProcessMoveEvent(51, 51, ts: GestureRecognizer.DragWithTouchMinDelayTicks + 1);
+			var end = sut.ProcessUpEvent(52, 52, ts: GestureRecognizer.DragWithTouchMinDelayTicks + 2);
+
+			drags.Should().BeEquivalentTo(
+				Drag(start, DraggingState.Started),
+				Drag(move, DraggingState.Continuing),
+				Drag(end, DraggingState.Completed));
+		}
+
+		[TestMethod]
 		public void Drag_And_Holding_Touch()
 		{
 			var delay = (ulong)Math.Max(GestureRecognizer.DragWithTouchMinDelayTicks, GestureRecognizer.HoldMinDelayTicks);

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Manipulation.cs
@@ -366,12 +366,6 @@ namespace Windows.UI.Input
 							new ManipulationUpdatedEventArgs(_currents.Identifiers, position, cumulative, cumulative, ManipulationVelocities.Empty, isInertial: false, _contacts.onStart, _contacts.current));
 						break;
 
-					case ManipulationState.Started when IsDragManipulation:
-						_recognizer.Dragging?.Invoke(
-							_recognizer,
-							new DraggingEventArgs(_currents.Pointer1, DraggingState.Continuing, _contacts.onStart));
-						break;
-
 					case ManipulationState.Started when pointerRemoved && ShouldStartInertia(velocities):
 						_state = ManipulationState.Inertia;
 						_inertia = new InertiaProcessor(this, position, cumulative, velocities);
@@ -391,6 +385,12 @@ namespace Windows.UI.Input
 					// It's however the right behavior in case of drag conflicting with manipulation (which is not supported by Uno).
 					case ManipulationState.Inertia when !_inertia!.IsRunning:
 						Complete();
+						break;
+
+					case ManipulationState.Started when IsDragManipulation:
+						_recognizer.Dragging?.Invoke(
+							_recognizer,
+							new DraggingEventArgs(_currents.Pointer1, DraggingState.Continuing, _contacts.onStart));
 						break;
 
 					case ManipulationState.Started when pointerAdded:


### PR DESCRIPTION
fixes https://github.com/unoplatform/nventive-private/issues/353

## Bugfix
Fix gesture recognizer not completing drag manipulations internally.

## What is the current behavior?
When the pointer is release the Drag & Drop is completed, but the internal state of the `GestureRecognizer` is not cleaned. This prevent the dragged element to be drag a second time / forces user to tap element before being able to re-drag it.

## What is the new behavior?
We make sure to properly clean the internal state of the `GestureRecognizer` on pointer up.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
