### PR TITLE
refactor: Write `ReferenceImplComparer` error messages to Error output

### DIFF
--- a/src/Uno.ReferenceImplComparer/Program.cs
+++ b/src/Uno.ReferenceImplComparer/Program.cs
@@ -61,7 +61,7 @@ namespace Uno.ReferenceImplComparer
 						// and that the hierarchy will be adjusted for wasm to match skia.
 						&& referenceType.BaseType?.FullName != "Windows.UI.Xaml.Shapes.ArbitraryShapeBase")
 					{
-						Console.WriteLine($"{referenceType.FullName} base type is different {referenceType.BaseType?.FullName} in reference, {runtimeType.BaseType?.FullName} in {identifier}");
+						Console.Error.WriteLine($"Error: {referenceType.FullName} base type is different {referenceType.BaseType?.FullName} in reference, {runtimeType.BaseType?.FullName} in {identifier}");
 						hasError = true;
 					}
 
@@ -72,8 +72,8 @@ namespace Uno.ReferenceImplComparer
 				}
 				else
 				{
+					Console.Error.WriteLine($"Error: The type {referenceType} is missing from ");
 					hasError = true;
-					Console.WriteLine($"The type {referenceType} is missing from ");
 				}
 			}
 
@@ -89,7 +89,7 @@ namespace Uno.ReferenceImplComparer
 			{
 				if (!runtimeMembersLookup.ContainsKey(referenceMember.ToString()))
 				{
-					Console.WriteLine($"The member {referenceMember} cannot be found in {identifier}");
+					Console.Error.WriteLine($"Error: The member {referenceMember} cannot be found in {identifier}");
 					hasError = true;
 				}
 			}

--- a/src/Uno.UI-Tools.slnf
+++ b/src/Uno.UI-Tools.slnf
@@ -6,6 +6,7 @@
       "ResourceConverter\\ResourceConverter.csproj",
       "T4Generator\\T4Generator.csproj",
       "UWPUsageStatsGenerator\\UWPUsageStatsGenerator.csproj",
+      "Uno.ReferenceImplComparer\\Uno.ReferenceImplComparer.csproj",
       "Uno.UI.AssemblyComparer\\Uno.UI.AssemblyComparer.csproj",
       "Uno.UI.TestComparer\\Uno.UI.TestComparer.csproj",
       "Uno.UWPSyncGenerator.Reference\\Uno.UWPSyncGenerator.Reference.csproj",


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8219

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

Error output is not written in DevOps

## What is the new behavior?

Output is written in DevOps (I hope!)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.