### PR TITLE
refactor: Improve default App.xaml template

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Shared/App.xaml
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Shared/App.xaml
@@ -4,8 +4,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:$ext_safeprojectname$">
 	
-	<Application.Resources>
-		<XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-	</Application.Resources>
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <!-- Add resource dictionaries here -->                
+            </ResourceDictionary.MergedDictionaries>
+            <!-- Add resources here -->
+        </ResourceDictionary>
+    </Application.Resources>
 
 </Application>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml
@@ -8,7 +8,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <!-- Add resource dictionaries here -->                
+                <!-- Add resource dictionaries here -->
             </ResourceDictionary.MergedDictionaries>
             <!-- Add resources here -->
         </ResourceDictionary>

--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml
@@ -8,8 +8,9 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <!-- Place resources here -->
+                <!-- Add resource dictionaries here -->                
             </ResourceDictionary.MergedDictionaries>
+            <!-- Add resources here -->
         </ResourceDictionary>
     </Application.Resources>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/pull/8223

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Default `App.xaml` template is misleading for new developers.

## What is the new behavior?

Improved documentation, wrapping `XamlControlsResources` in `MergedDictionaries`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.