### PR TITLE
ItemsControls: Fixed internal assignment of indexes to generated containers

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -995,6 +995,18 @@ namespace Windows.UI.Xaml.Controls
 				if (container is DependencyObject doContainer)
 				{
 					CleanUpContainer(doContainer);
+					doContainer.ClearValue(IndexForItemContainerProperty);
+				}
+			}
+
+			void ReassignIndexes(int startingIndex)
+			{
+				var children = ItemsPanelRoot.Children;
+				var count = children.Count;
+				for (var i = startingIndex; i<count; i++)
+				{
+					var container = children[i];
+					container.SetValue(IndexForItemContainerProperty, i);
 				}
 			}
 
@@ -1014,28 +1026,33 @@ namespace Windows.UI.Xaml.Controls
 				else if (args.Action == NotifyCollectionChangedAction.Remove
 					&& args.OldItems.Count == 1)
 				{
-					var container = ItemsPanelRoot.Children[args.OldStartingIndex];
+					var index = args.OldStartingIndex;
+					var container = ItemsPanelRoot.Children[index];
 
-					ItemsPanelRoot.Children.RemoveAt(args.OldStartingIndex);
+					ItemsPanelRoot.Children.RemoveAt(index);
 
 					LocalCleanupContainer(container);
+					ReassignIndexes(index);
 					RequestLayoutPartial();
 					return;
 				}
 				else if (args.Action == NotifyCollectionChangedAction.Add
 					&& args.NewItems.Count == 1)
 				{
-					ItemsPanelRoot.Children.Insert(args.NewStartingIndex, (UIElement)LocalCreateContainer(args.NewStartingIndex));
+					var index = args.NewStartingIndex;
+					ItemsPanelRoot.Children.Insert(index, (UIElement)LocalCreateContainer(index));
+					ReassignIndexes(index+1);
 					RequestLayoutPartial();
 					return;
 				}
 				else if (args.Action == NotifyCollectionChangedAction.Replace
 					&& args.NewItems.Count == 1)
 				{
-					var container = ItemsPanelRoot.Children[args.NewStartingIndex];
+					var index = args.NewStartingIndex;
+					var container = ItemsPanelRoot.Children[index];
 					LocalCleanupContainer(container);
 
-					ItemsPanelRoot.Children[args.NewStartingIndex] = (UIElement)LocalCreateContainer(args.NewStartingIndex);
+					ItemsPanelRoot.Children[index] = (UIElement)LocalCreateContainer(index);
 					RequestLayoutPartial();
 					return;
 				}


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/8203
# Bugfix
Internal indexes were not properly reassigned after an operation (Add/Delete) on the ItemsSource.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
