### PR TITLE
fix: Decrease default `TreeViewItem` glyph size

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeViewItem.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeViewItem.Properties.cs
@@ -1,4 +1,4 @@
-﻿// MUX Reference TreeViewItem.properties.cpp, commit de78834
+﻿// MUX Reference TreeViewItem.properties.cpp, commit f56157d
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
@@ -119,7 +119,7 @@ namespace Microsoft.UI.Xaml.Controls
 		/// Identifies the GlyphSize dependency property.
 		/// </summary>
 		public static DependencyProperty GlyphSizeProperty { get; } =
-			DependencyProperty.Register(nameof(GlyphSize), typeof(double), typeof(TreeViewItem), new FrameworkPropertyMetadata(12.0));
+			DependencyProperty.Register(nameof(GlyphSize), typeof(double), typeof(TreeViewItem), new FrameworkPropertyMetadata(8.0));
 
 		/// <summary>
 		/// Identifies the HasUnrealizedChildren dependency property.


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7757

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`TreeView` item glyph size is larger than in WinUI and overflows.

## What is the new behavior?

Matches WinUI


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
