### PR TITLE
fix(listview): Fix flickering when reordering items on Android

### DIFF
--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -326,6 +326,15 @@ namespace Uno.UI
 			/// from crashing when pressured: Tmp detached view should be removed from RecyclerView before it can be recycled
 			/// </summary>
 			public static bool RemoveItemAnimator = true;
+
+			/// <summary>
+			/// Indicates if a full recycling pass should be achieved on drop (re-order) on a ListView instead of a simple layout pass.
+			/// </summary>
+			/// <remarks>
+			/// This flag should be kept to 'false' if you turned <see cref="RemoveItemAnimator"/> to 'false'.
+			/// Forcing a recycling pass with ItemAnimator is known to cause a flicker of the whole list.
+			/// </remarks>
+			public static bool ForceRecycleOnDrop = false;
 		}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -2240,9 +2240,18 @@ namespace Windows.UI.Xaml.Controls
 			_pendingReorder = null;
 
 			ViewCache.RemoveReorderingItem();
-			// We need a full refresh to properly re-arrange all items at their right location,
-			// ignoring the temp location of the dragged / reordered item.
-			RecycleLayout();
+
+			if (FeatureConfiguration.NativeListViewBase.ForceRecycleOnDrop)
+			{
+				// We need a full refresh to properly re-arrange all items at their right location,
+				// ignoring the temp location of the dragged / reordered item.
+				// Since https://github.com/unoplatform/uno/pull/8227 a full recycle pass seems to be no longer required.
+				RecycleLayout();
+			}
+			else
+			{
+				RequestLayout();
+			}
 		}
 
 		protected bool ShouldInsertReorderingView(GeneratorDirection direction, double physicalExtentOffset)


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/328

## Bugfix
`ListView` flicker when we re-order items in few projects.

## What is the current behavior?
When we re-order item, we request a `RecycleLayout` in order to fully redraw the `ListView`, but if the feature flag `NativeListViewBase.RemoveItemAnimator` has been turn to `false` (default is `true`) then the native animator will animate exit and re-entrance of items in the view, driving to a flicker of the whole `ListView`.

## What is the new behavior?
Since https://github.com/unoplatform/uno/pull/8227 it seems that we can only `RequestLayout` (instead of **recycle**) which properly re-draw the whole list.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
If this causes an issue, a feature flag `NativeListViewBase.ForceRecycleOnDrop` (default to `false`) has been added on Android to restore the previous behavior on drop (i.e. `RecycleLayout`).