### PR TITLE
fix(Wasm): Changing TextBox.Text in code should reset the caret to the beginning

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -38,7 +38,11 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			_contentElement = textBox.ContentElement;
 
 			EnsureWidgetForAcceptsReturn();
-			textInputLayer.Children.Add(_currentInputWidget!);
+
+			if (textInputLayer.Children.Count == 0)
+			{
+				textInputLayer.Children.Add(_currentInputWidget!);
+			}
 
 			UpdateNativeView();
 			SetTextNative(textBox.Text);
@@ -160,7 +164,17 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			// No support for now.
 		}
 
-		public void Select(int start, int length) => _currentInputWidget?.Select(start, length);
+		public void Select(int start, int length)
+		{
+			_currentInputWidget?.Select(start, length);
+
+			if (_currentInputWidget == null)
+			{
+				this.StartEntry();
+
+				_currentInputWidget!.Select(start, length);
+			}
+		}
 
 		public int GetSelectionStart() => _currentInputWidget?.SelectionStart ?? 0;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -134,12 +134,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
-#if __WASM__ // Wasm is behaving differently than UWP and other platforms. https://github.com/unoplatform/uno/issues/7016
-			Assert.AreEqual(10, textBox.SelectionStart);
-#else
-			Assert.AreEqual(0, textBox.SelectionStart);
-#endif
-
+			textBox.Focus(FocusState.Programmatic);
+			Assert.AreEqual(textBox.Text.Length, textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(1, 7);
 			Assert.AreEqual(1, textBox.SelectionStart);
@@ -156,12 +152,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
-
-#if __WASM__ // Wasm is behaving differently than UWP and other platforms. https://github.com/unoplatform/uno/issues/7016
-			Assert.AreEqual(10, textBox.SelectionStart);
-#else
-			Assert.AreEqual(0, textBox.SelectionStart);
-#endif
+			textBox.Focus(FocusState.Programmatic);
+			Assert.AreEqual(textBox.Text.Length, textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(1, 20);
 			Assert.AreEqual(1, textBox.SelectionStart);
@@ -178,12 +170,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
-
-#if __WASM__ // Wasm is behaving differently than UWP and other platforms. https://github.com/unoplatform/uno/issues/7016
-			Assert.AreEqual(10, textBox.SelectionStart);
-#else
-			Assert.AreEqual(0, textBox.SelectionStart);
-#endif
+			textBox.Focus(FocusState.Programmatic);
+			Assert.AreEqual(textBox.Text.Length, textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(20, 5);
 			Assert.AreEqual(10, textBox.SelectionStart);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -169,6 +169,15 @@ namespace Windows.UI.Xaml.Controls
 					using (focusState == FocusState.Programmatic ? PreventKeyboardDisplayIfSet() : null)
 					{
 						_textBoxView.RequestFocus();
+
+						var selectionStart = this.SelectionStart;
+
+						if (selectionStart == 0)
+						{
+							int cursorPosition = selectionStart + _textBoxView?.Text?.Length ?? 0;
+
+							this.Select(cursorPosition, 0);
+						}
 					}
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -264,9 +264,11 @@ namespace Windows.UI.Xaml.Controls
 					_isTextChangedPending = false;
 				}
 			}
-
+			
 			_textBoxView?.SetTextNative(Text);
+		
 		}
+
 
 		private void UpdatePlaceholderVisibility()
 		{
@@ -303,9 +305,9 @@ namespace Windows.UI.Xaml.Controls
 			return baseString;
 		}
 
-		#endregion
+#endregion
 
-		#region Description DependencyProperty
+#region Description DependencyProperty
 
 		public
 #if __IOS__ || __MACOS__
@@ -342,7 +344,7 @@ namespace Windows.UI.Xaml.Controls
 				descriptionPresenter.Visibility = Description != null ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
-		#endregion
+#endregion
 
 		protected override void OnFontSizeChanged(double oldValue, double newValue)
 		{
@@ -374,7 +376,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnForegroundColorChangedPartial(Brush newValue);
 
-		#region PlaceholderText DependencyProperty
+#region PlaceholderText DependencyProperty
 
 		public string PlaceholderText
 		{
@@ -390,9 +392,9 @@ namespace Windows.UI.Xaml.Controls
 				new FrameworkPropertyMetadata(defaultValue: string.Empty)
 			);
 
-		#endregion
+#endregion
 
-		#region InputScope DependencyProperty
+#region InputScope DependencyProperty
 
 		public InputScope InputScope
 		{
@@ -423,9 +425,9 @@ namespace Windows.UI.Xaml.Controls
 		protected void OnInputScopeChanged(DependencyPropertyChangedEventArgs e) => OnInputScopeChangedPartial(e);
 		partial void OnInputScopeChangedPartial(DependencyPropertyChangedEventArgs e);
 
-		#endregion
+#endregion
 
-		#region MaxLength DependencyProperty
+#region MaxLength DependencyProperty
 
 		public int MaxLength
 		{
@@ -448,9 +450,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnMaxLengthChangedPartial(DependencyPropertyChangedEventArgs e);
 
-		#endregion
+#endregion
 
-		#region AcceptsReturn DependencyProperty
+#region AcceptsReturn DependencyProperty
 
 		public bool AcceptsReturn
 		{
@@ -487,9 +489,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnAcceptsReturnChangedPartial(DependencyPropertyChangedEventArgs e);
 
-		#endregion
+#endregion
 
-		#region TextWrapping DependencyProperty
+#region TextWrapping DependencyProperty
 		public TextWrapping TextWrapping
 		{
 			get => (TextWrapping)this.GetValue(TextWrappingProperty);
@@ -514,7 +516,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextWrappingChangedPartial(DependencyPropertyChangedEventArgs e);
 
-		#endregion
+#endregion
 
 #if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
@@ -545,7 +547,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextCharacterCasingChangedPartial(DependencyPropertyChangedEventArgs e);
 
-		#region IsReadOnly DependencyProperty
+#region IsReadOnly DependencyProperty
 
 		public bool IsReadOnly
 		{
@@ -572,9 +574,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsReadonlyChangedPartial(DependencyPropertyChangedEventArgs e);
 
-		#endregion
+#endregion
 
-		#region Header DependencyProperties
+#region Header DependencyProperties
 
 		public object Header
 		{
@@ -618,9 +620,9 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		#endregion
+#endregion
 
-		#region IsSpellCheckEnabled DependencyProperty
+#region IsSpellCheckEnabled DependencyProperty
 
 		public bool IsSpellCheckEnabled
 		{
@@ -643,9 +645,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsSpellCheckEnabledChangedPartial(DependencyPropertyChangedEventArgs e);
 
-		#endregion
+#endregion
 
-		#region IsTextPredictionEnabled DependencyProperty
+#region IsTextPredictionEnabled DependencyProperty
 
 		[Uno.NotImplemented]
 		public bool IsTextPredictionEnabled
@@ -670,9 +672,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsTextPredictionEnabledChangedPartial(DependencyPropertyChangedEventArgs e);
 
-		#endregion
+#endregion
 
-		#region TextAlignment DependencyProperty
+#region TextAlignment DependencyProperty
 
 #if XAMARIN_ANDROID
 		public new TextAlignment TextAlignment
@@ -704,7 +706,7 @@ namespace Windows.UI.Xaml.Controls
 					throw new ArgumentNullException();
 				}
 
-				var actual = (string)this.GetValue(TextProperty); 
+				var actual = (string)this.GetValue(TextProperty);
 				actual = actual.Remove(SelectionStart, SelectionLength);
 				actual = actual.Insert(SelectionStart, value);
 
@@ -908,7 +910,11 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnDeleteButtonClickPartial();
 
-		internal void OnSelectionChanged() => SelectionChanged?.Invoke(this, new RoutedEventArgs(this));
+		internal void OnSelectionChanged()
+		{
+			SelectionChanged?.Invoke(this, new RoutedEventArgs(this));
+		}
+
 
 		public void OnTemplateRecycled()
 		{
@@ -989,7 +995,7 @@ namespace Windows.UI.Xaml.Controls
 			UpdateKeyboardThemePartial();
 		}
 
-		partial void UpdateKeyboardThemePartial();
+		partial void UpdateKeyboardThemePartial();		
 
 		private protected override void OnIsEnabledChanged(IsEnabledChangedEventArgs e)
 		{
@@ -1000,10 +1006,10 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsEnabledChangedPartial(IsEnabledChangedEventArgs e);
 
-		private bool ShouldFocusOnPointerPressed(PointerRoutedEventArgs args)
+		private bool ShouldFocusOnPointerPressed(PointerRoutedEventArgs args) =>
 			// For mouse and pen, the TextBox should focus on pointer press
 			// (and then capture pointer to make sure to handle the whol down->move->up sequence).
 			// For touch we wait for the release to focus (avoid flickering in case of cancel due to scroll for instance).
-			=> args.Pointer.PointerDeviceType != PointerDeviceType.Touch;
+			args.Pointer.PointerDeviceType != PointerDeviceType.Touch;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -43,7 +43,7 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 		}
-
+		
 		partial void InitializePropertiesPartial()
 		{
 			if (_header != null)
@@ -57,6 +57,21 @@ namespace Windows.UI.Xaml.Controls
 		partial void OnTappedPartial()
 		{
 			FocusTextView();
+		}
+
+
+		private void ResetCaret()
+		{
+
+			this.SelectionStart = 0;
+			this.SelectionLength = 0;
+
+			if (_textBoxView != null)
+			{
+				_textBoxView.SelectionStart = 0;
+				_textBoxView.SelectionEnd = 0;
+
+			}
 		}
 
 		private void OnHeaderClick(object sender, object args)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -87,11 +87,20 @@ namespace Windows.UI.Xaml.Controls
 			{
 				DisplayBlock.Opacity = 0;
 				_textBoxExtension?.StartEntry();
+				
+				var selectionStart = this.GetSelectionStart();
+
+				if (selectionStart == 0)
+				{
+					int cursorPosition = selectionStart + TextBox?.Text?.Length ?? 0;
+
+					_textBoxExtension?.Select(cursorPosition, 0);
+				}				
 			}
 			else
 			{
 				_textBoxExtension?.EndEntry();
-				DisplayBlock.Opacity = 1;
+				DisplayBlock.Opacity = 1;								
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7016

## PR Type

What kind of change does this PR introduce?


- Bugfix


## What is the current behavior?

[Issue](https://github.com/unoplatform/uno/pull/6995#issuecomment-916392149)


## What is the new behavior?

When the developer set an invalid range in SelectionStart and SelectionLength the caret reset to the beginning


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ x] Validated PR `Screenshots Compare Test Run` results.
- [ x] Contains **NO** breaking changes
- [ x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
