### PR TITLE
fix: Adjust `MonoAndroidAssetsPrefix` to use Assets from shared project

### DIFF
--- a/build/uno.winui.single-project.targets
+++ b/build/uno.winui.single-project.targets
@@ -48,7 +48,7 @@
 	<AndroidProjectFolder Condition=" '$(AndroidProjectFolder)' == '' ">Android\</AndroidProjectFolder>
 	<AndroidManifest>$(AndroidProjectFolder)AndroidManifest.xml</AndroidManifest>
 	<MonoAndroidResourcePrefix>$(AndroidProjectFolder)Resources</MonoAndroidResourcePrefix>
-	<MonoAndroidAssetsPrefix>$(AndroidProjectFolder)Assets</MonoAndroidAssetsPrefix>
+	<MonoAndroidAssetsPrefix>$(AndroidProjectFolder)Assets;Assets</MonoAndroidAssetsPrefix>
 
 	<!-- iOS -->
 	<EnableDefaultiOSItems>false</EnableDefaultiOSItems>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/8252

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Assets located in the shared project `Assets` folder are not included in the android package for net6 mobile projects.

## What is the new behavior?

`Assets` folder located at the root are now automatically included in net6.0-android target. Tests are included in the existig runtime tests, which are not yet enabled until net6 gets stabilized.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
