### PR TITLE
feat!: Bump UWP version target to 18362

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -349,7 +349,7 @@
 
 		<!-- Adjust build targets file for Windows targets -->
 		<XmlPoke XmlInputPath=".\Uno.WinUI.nuspec" Query="/x:package/x:files/x:file[@target='buildTransitive\uap10.0.16299\uno.winui.targets']/@target" Value="buildTransitive\uap10.0.16299\$(PackageNamePrefix).targets" Namespaces="$(NugetNamespace)" Condition="'$(UNO_UWP_BUILD)'=='true'"/>
-		<XmlPoke XmlInputPath=".\Uno.WinUI.nuspec" Query="/x:package/x:files/x:file[@target='buildTransitive\uap10.0.17763\uno.winui.targets']/@target" Value="buildTransitive\uap10.0.17763\$(PackageNamePrefix).targets" Namespaces="$(NugetNamespace)" Condition="'$(UNO_UWP_BUILD)'=='true'"/>
+		<XmlPoke XmlInputPath=".\Uno.WinUI.nuspec" Query="/x:package/x:files/x:file[@target='buildTransitive\uap10.0.18362\uno.winui.targets']/@target" Value="buildTransitive\uap10.0.18362\$(PackageNamePrefix).targets" Namespaces="$(NugetNamespace)" Condition="'$(UNO_UWP_BUILD)'=='true'"/>
 		<XmlPoke XmlInputPath=".\Uno.WinUI.nuspec" Query="/x:package/x:files/x:file[@target='buildTransitive\net5.0-windows\uno.winui.targets']/@target" Value="buildTransitive\net5.0-windows\$(PackageNamePrefix).targets" Namespaces="$(NugetNamespace)" Condition="'$(UNO_UWP_BUILD)'=='true'"/>
 
 		<!-- Skia GTK targets/props-->
@@ -413,13 +413,13 @@
 		<PropertyGroup>
 			<NuSpecProperties>NoWarn=NU5100,NU5105,NU5131;branch=$(GITVERSION_BranchName);commitid=$(GITVERSION_VersionSourceSha)</NuSpecProperties>
 
-			<NuSpecProperties Condition="'$(UNO_UWP_BUILD)'=='true'">$(NuSpecProperties);winuisourcepath=uap10.0.17763;winuitargetpath=UAP</NuSpecProperties>
+			<NuSpecProperties Condition="'$(UNO_UWP_BUILD)'=='true'">$(NuSpecProperties);winuisourcepath=uap10.0.18362;winuitargetpath=UAP</NuSpecProperties>
 			<NuSpecProperties Condition="'$(UNO_UWP_BUILD)'!='true'">$(NuSpecProperties);winuisourcepath=net5.0-windows10.0.18362.0;winuitargetpath=net5.0-windows10.0.18362.0</NuSpecProperties>
 		</PropertyGroup>
 
 		<!-- Pre-validation of contents to be packed -->
 		<Error Text="The Uno.UI.Toolkit PRI file is not present in src\Uno.UI.Toolkit\bin\Release"
-					 Condition="'$(UNO_UWP_BUILD)'=='true' and !exists('..\src\Uno.UI.Toolkit\bin\Release\uap10.0.17763\Uno.UI.Toolkit.pri')" />
+					 Condition="'$(UNO_UWP_BUILD)'=='true' and !exists('..\src\Uno.UI.Toolkit\bin\Release\uap10.0.18362\Uno.UI.Toolkit.pri')" />
 		<Error Text="The Uno.UI.Toolkit PRI file is not present in src\Uno.UI.Toolkit\bin\Release"
 					 Condition="'$(UNO_UWP_BUILD)'!='true' and !exists('..\src\Uno.UI.Toolkit\bin\Release\net5.0-windows10.0.18362.0\Uno.UI.Toolkit.pri')" />
 

--- a/build/Uno.WinUI.MSAL.nuspec
+++ b/build/Uno.WinUI.MSAL.nuspec
@@ -32,7 +32,7 @@
 		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
 	  </group>
-	  <group targetFramework="UAP10.0.17763">
+	  <group targetFramework="UAP10.0.18362">
 		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
 	  </group>
 	  <group targetFramework="net6.0-android30.0">
@@ -66,7 +66,7 @@
 	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\MonoAndroid11.0\Uno.UI.MSAL.*" target="lib\MonoAndroid11.0" />
 	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\MonoAndroid12.0\Uno.UI.MSAL.*" target="lib\MonoAndroid12.0" />
 
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\uap10.0.17763\Uno.UI.MSAL.*" target="lib\uap10.0.17763" />
+	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\uap10.0.18362\Uno.UI.MSAL.*" target="lib\uap10.0.18362" />
 
 	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-android\Uno.UI.MSAL.*" target="lib\net6.0-android" />
 	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-ios\Uno.UI.MSAL.*" target="lib\net6.0-ios" />

--- a/build/Uno.WinUI.RemoteControl.nuspec
+++ b/build/Uno.WinUI.RemoteControl.nuspec
@@ -185,7 +185,7 @@
 
 	<!-- Force UAP/netx-win to ignore netstandard 2.0 -->
 	<file src="_._" target="build\uap10.0.16299" />
-	<file src="_._" target="build\uap10.0.17763" />
+	<file src="_._" target="build\uap10.0.18362" />
 	<file src="_._" target="build\net5.0-windows" />
   </files>
 </package>

--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -614,6 +614,9 @@
 	<file src="uno.winui.win.targets" target="buildTransitive\uap10.0.16299\uno.winui.targets" />
 	<file src="uno.winui.runtime-replace.targets" target="buildTransitive\uap10.0.16299" />
 
+	<file src="uno.winui.win.targets" target="buildTransitive\uap10.0.17763\uno.winui.targets" />
+	<file src="uno.winui.runtime-replace.targets" target="buildTransitive\uap10.0.17763" />
+
 	<file src="uno.winui.win.targets" target="buildTransitive\uap10.0.18362\uno.winui.targets" />
 	<file src="uno.winui.runtime-replace.targets" target="buildTransitive\uap10.0.18362" />
 

--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -239,7 +239,7 @@
 	  </group>
 
 	  <!-- Windows -->
-	  <group targetFramework="uap10.0.17763">
+	  <group targetFramework="uap10.0.18362">
 		<reference file="Uno.UI.Toolkit.dll" />
 	  </group>
 
@@ -614,8 +614,8 @@
 	<file src="uno.winui.win.targets" target="buildTransitive\uap10.0.16299\uno.winui.targets" />
 	<file src="uno.winui.runtime-replace.targets" target="buildTransitive\uap10.0.16299" />
 
-	<file src="uno.winui.win.targets" target="buildTransitive\uap10.0.17763\uno.winui.targets" />
-	<file src="uno.winui.runtime-replace.targets" target="buildTransitive\uap10.0.17763" />
+	<file src="uno.winui.win.targets" target="buildTransitive\uap10.0.18362\uno.winui.targets" />
+	<file src="uno.winui.runtime-replace.targets" target="buildTransitive\uap10.0.18362" />
 
 	<file src="uno.winui.win.targets" target="buildTransitive\net5.0-windows\uno.winui.targets" />
 	<file src="uno.winui.runtime-replace.targets" target="buildTransitive\net5.0-windows" />

--- a/build/ci/.azure-devops-package-generic.yml
+++ b/build/ci/.azure-devops-package-generic.yml
@@ -55,7 +55,7 @@ jobs:
 
   - template: templates/dotnet-install.yml
 
-  - powershell: .\build\Install-WindowsSdkISO.ps1 17763
+  - powershell: .\build\Install-WindowsSdkISO.ps1 18362
     displayName: Insider SDK
     
   # Required for the Wasm uitests project

--- a/build/ci/.azure-devops-uap.yml
+++ b/build/ci/.azure-devops-uap.yml
@@ -27,7 +27,7 @@ jobs:
 
   - template: templates/gitversion.yml
 
-  - powershell: .\build\Install-WindowsSdkISO.ps1 17763
+  - powershell: .\build\Install-WindowsSdkISO.ps1 18362
     displayName: Insider SDK
 
   - task: MSBuild@1

--- a/doc/ReleaseNotes/LegacyReleaseNotes.md
+++ b/doc/ReleaseNotes/LegacyReleaseNotes.md
@@ -215,7 +215,7 @@
 * [#1559] [#1167] Wasm: make the IsEnabled property inheritable.
 * Full support of pointer events cf. [routed events documentation](../articles/features/routed-events.md)
 * Add support of manipulation events cf. [routed events documentation](../articles/features/routed-events.md)
-* Update CheckBox style to 10.0.17763
+* Update CheckBox style to 10.0.18362
 * Adds the support for `AutomationProperties.AutomationId`
 * [#1328](https://github.com/unoplatform/uno/issues/1328) Basic ProgressRing implementation for WASM
 * Add support for `Windows.UI.Xaml.Controls.Primitives.LayoutInformation.GetAvailableSize`
@@ -574,7 +574,7 @@
  * [Wasm] Fix `ListView` recycling when the `XamlParent` is not available for `AutoSuggestBox`
  * 147405 Fix NRE on some MediaTransportControl controls
  * #139 Update Uno.SourceGenerationTasks to improve build performance
- * Update `Uno.UI.Toolkit` base UWP sdk to 17763
+ * Update `Uno.UI.Toolkit` base UWP sdk to 18362
  * [Wasm] Fixes items measured after being removed from their parent appear in the visual tree, on top of every other items.
  * [Wasm] Fixes lements may not be removed form the global active DOM elements tracking map
  * [Wasm] Disable the root element scrolling (bounce) on touch devices
@@ -590,7 +590,7 @@
 
 ### Features
 * [Wasm] Improve general performance and memory pressure by removing Javascript interop evaluations.
-* Add support for Windows 10 SDK 17763 (1809)
+* Add support for Windows 10 SDK 18362 (1809)
 * Improve the Uno.UI solution memory consumption for Android targets
 * Add support for GridLength conversion from double
 * Raise exceptions on missing styles in debug configuration

--- a/doc/ReleaseNotes/LegacyReleaseNotes.md
+++ b/doc/ReleaseNotes/LegacyReleaseNotes.md
@@ -215,7 +215,7 @@
 * [#1559] [#1167] Wasm: make the IsEnabled property inheritable.
 * Full support of pointer events cf. [routed events documentation](../articles/features/routed-events.md)
 * Add support of manipulation events cf. [routed events documentation](../articles/features/routed-events.md)
-* Update CheckBox style to 10.0.18362
+* Update CheckBox style to 10.0.17763
 * Adds the support for `AutomationProperties.AutomationId`
 * [#1328](https://github.com/unoplatform/uno/issues/1328) Basic ProgressRing implementation for WASM
 * Add support for `Windows.UI.Xaml.Controls.Primitives.LayoutInformation.GetAvailableSize`
@@ -590,7 +590,7 @@
 
 ### Features
 * [Wasm] Improve general performance and memory pressure by removing Javascript interop evaluations.
-* Add support for Windows 10 SDK 18362 (1809)
+* Add support for Windows 10 SDK 17763 (1809)
 * Improve the Uno.UI solution memory consumption for Android targets
 * Add support for GridLength conversion from double
 * Raise exceptions on missing styles in debug configuration

--- a/doc/articles/uno-community-toolkit.md
+++ b/doc/articles/uno-community-toolkit.md
@@ -163,15 +163,15 @@ To fix this, instead of adding the Uno version of the toolkit like the code belo
 Add a conditional reference:
 
 ```xml
-<ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.17763'">
+<ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.18362'">
   <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls" Version="7.0.0" />
 </ItemGroup>
-<ItemGroup Condition="'$(TargetFramework)' != 'uap10.0.17763'">
+<ItemGroup Condition="'$(TargetFramework)' != 'uap10.0.18362'">
   <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls" Version="7.0.0" />
 </ItemGroup>
 ```
 
-You may need to replace `uap10.0.17763` with the version defined in the `TargetFrameworks` node at the top of the csproj file.
+You may need to replace `uap10.0.18362` with the version defined in the `TargetFrameworks` node at the top of the csproj file.
 
 ## See a working example with data
 

--- a/doc/articles/uno-development/building-uno-ui.md
+++ b/doc/articles/uno-development/building-uno-ui.md
@@ -10,8 +10,8 @@ This article explains how to build Uno.UI locally, for instance if you wish to c
     - `MAUI Preview` (In VS 2022 17.1 Preview 1 or later, for .NET 6 Android/iOS support)
     - `ASP.NET and Web Development`
     - `.NET Core cross-platform development`
-    - `UWP Development`, install all recent UWP SDKs, starting from 10.0.17763 (or above or equal to `TargetPlatformVersion` line [in this file](https://github.com/unoplatform/uno/blob/master/src/Uno.CrossTargetting.props))
-      - Starting from VS 2022, the Windows SDK 10.0.17763 is not available from the installer. Use the [Microsoft Archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) instead.
+    - `UWP Development`, install all recent UWP SDKs, starting from 10.0.18362 (or above or equal to `TargetPlatformVersion` line [in this file](https://github.com/unoplatform/uno/blob/master/src/Uno.CrossTargetting.props))
+      - Starting from VS 2022, the Windows SDK 10.0.18362 is not available from the installer. Use the [Microsoft Archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) instead.
 - Install (**Tools** / **Android** / **Android SDK manager**) all Android SDKs starting from 7.1 (or the Android versions `TargetFrameworks` [list used here](https://github.com/unoplatform/uno/blob/master/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj))
 - Run [Uno.Check](https://github.com/unoplatform/uno.check) on your dev machine to setup .NET 6 Android/iOS workloads
 
@@ -87,7 +87,7 @@ Here are some tips when building the Uno solution and failures happen:
 - Try to close VS 2022, delete the `src/.vs` folder, then try rebuilding the solution
 - If the `.vs` deletion did not help, run `git clean -fdx` (after having closed visual studio) before building again
 - Make sure to have a valid `UnoTargetFrameworkOverride` which matches your solution filter
-- Make sure to have the Windows SDK `17763` installed
+- Make sure to have the Windows SDK `18362` installed
 
 ## Other build-related topics 
 

--- a/doc/articles/uno-development/building-uno-ui.md
+++ b/doc/articles/uno-development/building-uno-ui.md
@@ -11,7 +11,6 @@ This article explains how to build Uno.UI locally, for instance if you wish to c
     - `ASP.NET and Web Development`
     - `.NET Core cross-platform development`
     - `UWP Development`, install all recent UWP SDKs, starting from 10.0.18362 (or above or equal to `TargetPlatformVersion` line [in this file](https://github.com/unoplatform/uno/blob/master/src/Uno.CrossTargetting.props))
-      - Starting from VS 2022, the Windows SDK 10.0.18362 is not available from the installer. Use the [Microsoft Archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) instead.
 - Install (**Tools** / **Android** / **Android SDK manager**) all Android SDKs starting from 7.1 (or the Android versions `TargetFrameworks` [list used here](https://github.com/unoplatform/uno/blob/master/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj))
 - Run [Uno.Check](https://github.com/unoplatform/uno.check) on your dev machine to setup .NET 6 Android/iOS workloads
 

--- a/src/.vsconfig
+++ b/src/.vsconfig
@@ -57,7 +57,7 @@
     "Microsoft.VisualStudio.Component.VC.CoreIde",
     "Microsoft.VisualStudio.Component.ClassDesigner",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
+    "Microsoft.VisualStudio.Component.Windows10SDK.18362",
     "Microsoft.VisualStudio.Component.Graphics.Tools",
     "Microsoft.VisualStudio.Component.VC.ATL",
     "Microsoft.Component.NetFX.Native",

--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
 	<PropertyGroup>
-		<TargetFrameworks>xamarinmac20;MonoAndroid12.0;xamarinios10;net461;netstandard2.0;uap10.0.17763</TargetFrameworks>
-		<TargetFrameworksCI>xamarinmac20;MonoAndroid11.0;MonoAndroid12.0;xamarinios10;net461;netstandard2.0;uap10.0.17763</TargetFrameworksCI>
+		<TargetFrameworks>xamarinmac20;MonoAndroid12.0;xamarinios10;net461;netstandard2.0;uap10.0.18362</TargetFrameworks>
+		<TargetFrameworksCI>xamarinmac20;MonoAndroid11.0;MonoAndroid12.0;xamarinios10;net461;netstandard2.0;uap10.0.18362</TargetFrameworksCI>
 		<NoWarn>$(NoWarn);NU1701;NU5100;NU5118;NU5128</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Deterministic>true</Deterministic>
@@ -44,7 +44,7 @@
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.15.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' != 'uap10.0.17763'">
+	<ItemGroup Condition="'$(TargetFramework)' != 'uap10.0.18362'">
 		<ProjectReference Include="..\..\Uno.UI\Uno.UI.csproj" />
 	</ItemGroup>
 

--- a/src/SamplesApp/SamplesApp.UWP.Design/SamplesApp.UWP.Design.csproj
+++ b/src/SamplesApp/SamplesApp.UWP.Design/SamplesApp.UWP.Design.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>SamplesApp.UWP.Design</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/src/SamplesApp/SamplesApp.UWP/SamplesApp.UWP.csproj
+++ b/src/SamplesApp/SamplesApp.UWP/SamplesApp.UWP.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-net6/.vsconfig
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-net6/.vsconfig
@@ -70,7 +70,6 @@
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Component.Windows10SDK.18362",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
     "Microsoft.Component.NetFX.Native",
     "Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard",
     "Microsoft.VisualStudio.Component.Graphics",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/.vsconfig
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/.vsconfig
@@ -81,7 +81,6 @@
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Component.Windows10SDK.18362",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
     "Microsoft.Component.NetFX.Native",
     "Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard",
     "Microsoft.VisualStudio.Component.Graphics",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/.vsconfig
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/.vsconfig
@@ -70,7 +70,6 @@
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Component.Windows10SDK.18362",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
     "Microsoft.Component.NetFX.Native",
     "Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard",
     "Microsoft.VisualStudio.Component.Graphics",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows/Package.appxmanifest
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows/Package.appxmanifest
@@ -18,8 +18,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.18362.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.18362.0" MaxVersionTested="10.0.19041.0" />
   </Dependencies>
 
   <Resources>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows/UnoWinUIQuickStart.Windows.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows/UnoWinUIQuickStart.Windows.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
 		<RootNamespace>UnoWinUIQuickStart</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<Platforms>x86;x64;arm64</Platforms>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.vsconfig
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.vsconfig
@@ -81,7 +81,6 @@
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Component.Windows10SDK.18362",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
     "Microsoft.Component.NetFX.Native",
     "Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard",
     "Microsoft.VisualStudio.Component.Graphics",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/UnoWinUIQuickStart.Windows.Desktop/UnoWinUIQuickStart.Windows.Desktop.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/UnoWinUIQuickStart.Windows.Desktop/UnoWinUIQuickStart.Windows.Desktop.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
 		<RootNamespace>UnoWinUIQuickStart</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<Platforms>x86;x64;arm64</Platforms>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/UnoWinUIQuickStart.Windows.Package/Package.appxmanifest
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/UnoWinUIQuickStart.Windows.Package/Package.appxmanifest
@@ -18,8 +18,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.18362.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.18362.0" MaxVersionTested="10.0.19041.0" />
   </Dependencies>
 
   <Resources>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/UnoWinUIQuickStart.Windows.Package/UnoWinUIQuickStart.Windows.Package.wapproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/UnoWinUIQuickStart.Windows.Package/UnoWinUIQuickStart.Windows.Package.wapproj
@@ -39,7 +39,7 @@
   <PropertyGroup>
     <ProjectGuid>$guid6$</ProjectGuid>
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
     <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.vsconfig
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.vsconfig
@@ -81,7 +81,6 @@
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Component.Windows10SDK.18362",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
     "Microsoft.Component.NetFX.Native",
     "Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard",
     "Microsoft.VisualStudio.Component.Graphics",

--- a/src/SolutionTemplate/UnoSolutionTemplate.Wizard/.vsconfig.vs16
+++ b/src/SolutionTemplate/UnoSolutionTemplate.Wizard/.vsconfig.vs16
@@ -81,7 +81,6 @@
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Component.Windows10SDK.18362",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
     "Microsoft.Component.NetFX.Native",
     "Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard",
     "Microsoft.VisualStudio.Component.Graphics",

--- a/src/SolutionTemplate/UnoSolutionTemplate.Wizard/.vsconfig.vs17
+++ b/src/SolutionTemplate/UnoSolutionTemplate.Wizard/.vsconfig.vs17
@@ -70,7 +70,6 @@
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Component.Windows10SDK.18362",
-    "Microsoft.VisualStudio.Component.Windows10SDK.17763",
     "Microsoft.Component.NetFX.Native",
     "Microsoft.VisualStudio.ComponentGroup.UWP.NetCoreAndStandard",
     "Microsoft.VisualStudio.Component.Graphics",

--- a/src/Uno.CrossTargetting.props
+++ b/src/Uno.CrossTargetting.props
@@ -102,13 +102,13 @@
 	<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'uap10.0.17763' and '$(TargetFramework)'!='net5.0-windows10.0.18362.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'uap10.0.18362' and '$(TargetFramework)'!='net5.0-windows10.0.18362.0' ">
 	<DefineConstants>$(DefineConstants);HAS_UNO</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'uap10.0.17763' ">
-	<TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-	<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'uap10.0.18362' ">
+	<TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+	<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
 	<DefineConstants>$(DefineConstants);NETFX_CORE</DefineConstants>
 
 	<!-- Ensures the .xr.xml files are generated in a proper layout folder -->

--- a/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
@@ -69,7 +69,7 @@ namespace Uno.UI.RuntimeTests.Helpers
 		/// </summary>
 		public static IDisposable UseFluentStyles()
 		{
-#if NETFX_CORE // Disabled on UWP for now because 17763 doesn't support WinUI 2.x; Fluent resources are used by default in SamplesApp.UWP
+#if NETFX_CORE // Disabled on UWP for now because 18362 doesn't support WinUI 2.x; Fluent resources are used by default in SamplesApp.UWP
 			return null;
 #else
 			var resources = Application.Current.Resources;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ObjectAnimationUsingKeyFrames.cs
@@ -1,4 +1,4 @@
-﻿#if !NETFX_CORE // Disabled on UWP for now because 18362 doesn't support WinUI 2.x
+﻿#if !NETFX_CORE // Disabled on UWP as tests use Uno-specific APIs
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -322,12 +322,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
 		/// </summary>
 		private IDisposable UseDarkTheme() => ThemeHelper.UseDarkTheme();
 
-#if !NETFX_CORE // Disabled on UWP for now because 18362 doesn't support WinUI 2.x
 		/// <summary>
 		/// Ensure Fluent styles are available for the course of a single test.
 		/// </summary>
 		private IDisposable UseFluentStyles() => StyleHelper.UseFluentStyles();
-#endif
 
 		// Intentionally nested to test NativeCtorsGenerator handling of nested classes.
 		public partial class MyCheckBox : CheckBox

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ObjectAnimationUsingKeyFrames.cs
@@ -1,4 +1,4 @@
-﻿#if !NETFX_CORE // Disabled on UWP for now because 17763 doesn't support WinUI 2.x
+﻿#if !NETFX_CORE // Disabled on UWP for now because 18362 doesn't support WinUI 2.x
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -322,7 +322,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
 		/// </summary>
 		private IDisposable UseDarkTheme() => ThemeHelper.UseDarkTheme();
 
-#if !NETFX_CORE // Disabled on UWP for now because 17763 doesn't support WinUI 2.x
+#if !NETFX_CORE // Disabled on UWP for now because 18362 doesn't support WinUI 2.x
 		/// <summary>
 		/// Ensure Fluent styles are available for the course of a single test.
 		/// </summary>

--- a/src/Uno.UI.RuntimeTests/UnitTestsImport.props
+++ b/src/Uno.UI.RuntimeTests/UnitTestsImport.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
 
-  <ItemGroup Condition="'$(TargetFramework)'!='uap10.0.17763'">
+  <ItemGroup Condition="'$(TargetFramework)'!='uap10.0.18362'">
 	<Compile Include="$(MSBuildThisFileDirectory)..\Uno.UI.Tests\Windows_UI_Xaml\FrameworkElementTests\*.cs">
 	  <Link>UnitTests\Windows_UI_Xaml\FrameworkElementTests\%(RecursiveDir)%(FileName)%(Extension)</Link>
 	</Compile>

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Wasm.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Wasm.csproj
@@ -62,10 +62,10 @@
 		<Reference Include="System.json" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.17763'">
+	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 		<PackageReference Include="System.Numerics.Vectors" Version="4.3.0" />
 	</ItemGroup>
-	<PropertyGroup Condition="'$(TargetFramework)'=='uap10.0.17763'">
+	<PropertyGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 		<DefineConstants>$(DefineConstants);WINDOWS_UWP</DefineConstants>
 	</PropertyGroup>
 

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;xamarinios10;monoandroid12.0;xamarinmac20;uap10.0.17763</TargetFrameworks>
-		<TargetFrameworksCI>netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;xamarinmac20;uap10.0.17763</TargetFrameworksCI>
+		<TargetFrameworks>netstandard2.0;xamarinios10;monoandroid12.0;xamarinmac20;uap10.0.18362</TargetFrameworks>
+		<TargetFrameworksCI>netstandard2.0;xamarinios10;monoandroid11.0;monoandroid12.0;xamarinmac20;uap10.0.18362</TargetFrameworksCI>
 
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -62,7 +62,7 @@
 		<Reference Include="System.json" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.17763'">
+	<ItemGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 		<PackageReference Include="System.Numerics.Vectors" Version="4.3.0" />
 		<PackageReference Include="Microsoft.UI.Xaml" Version="2.7.0-prerelease.210816001" />
 		
@@ -75,7 +75,7 @@
 		<!-- We remove Unit tests imported from MUX on UAP as they are usualy heavily relying on internal classes.-->
 		<Compile Remove="$(MSBuildThisFileDirectory)MUX\Microsoft_UI_XAML_Controls\**\*.cs" />
 	</ItemGroup>
-	<PropertyGroup Condition="'$(TargetFramework)'=='uap10.0.17763'">
+	<PropertyGroup Condition="'$(TargetFramework)'=='uap10.0.18362'">
 		<!--SkipMicrosoftUIXamlCheckTargetPlatformVersion is required for Microsoft.UI.Xaml as we only validate compilation on UAP-->
 		<SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
 		<DefineConstants>$(DefineConstants);WINDOWS_UWP</DefineConstants>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -3,8 +3,8 @@
 		<TargetFrameworks>xamarinmac20;MonoAndroid12.0;xamarinios10;netstandard2.0</TargetFrameworks>
 		<TargetFrameworksCI>MonoAndroid11.0;MonoAndroid12.0;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworksCI>
 
-		<TargetFrameworks Condition="'$(UNO_UWP_BUILD)'=='true'">$(TargetFrameworks);uap10.0.17763</TargetFrameworks>
-		<TargetFrameworksCI Condition="'$(UNO_UWP_BUILD)'=='true'">$(TargetFrameworksCI);uap10.0.17763</TargetFrameworksCI>
+		<TargetFrameworks Condition="'$(UNO_UWP_BUILD)'=='true'">$(TargetFrameworks);uap10.0.18362</TargetFrameworks>
+		<TargetFrameworksCI Condition="'$(UNO_UWP_BUILD)'=='true'">$(TargetFrameworksCI);uap10.0.18362</TargetFrameworksCI>
 
 		<TargetFrameworks Condition="'$(UNO_UWP_BUILD)'!='true'">$(TargetFrameworks);net5.0-windows10.0.18362.0</TargetFrameworks>
 		<TargetFrameworksCI Condition="'$(UNO_UWP_BUILD)'!='true'">$(TargetFrameworksCI);net5.0-windows10.0.18362.0</TargetFrameworksCI>
@@ -89,7 +89,7 @@
 		</ProjectReference>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362.0' or '$(TargetFramework)'=='uap10.0.17763'">
+	<ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362.0' or '$(TargetFramework)'=='uap10.0.18362'">
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" Condition="'$(UNO_UWP_BUILD)'!='true'" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" Condition="'$(UNO_UWP_BUILD)'!='true'"/>
 
@@ -125,7 +125,7 @@
 
 		<PropertyGroup>
 			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
-			<_OverrideTargetFramework Condition="'$(_OverrideTargetFramework)' == 'uap10.0.17763'">UAP</_OverrideTargetFramework>
+			<_OverrideTargetFramework Condition="'$(_OverrideTargetFramework)' == 'uap10.0.18362'">UAP</_OverrideTargetFramework>
 			<_baseNugetPath Condition="'$(USERPROFILE)'!=''">$(USERPROFILE)</_baseNugetPath>
       <_baseNugetPath Condition="'$(HOME)'!=''">$(HOME)</_baseNugetPath>
 			<_TargetNugetFolder>$(_baseNugetPath)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\lib\$(_OverrideTargetFramework)</_TargetNugetFolder>
@@ -142,6 +142,6 @@
 	</Target>
 
 	<!-- https://github.com/microsoft/microsoft-ui-xaml/issues/4503 -->
-	<Target Name="_CalculateXbfSupport" Condition="'$(TargetFramework)'=='uap10.0.17763'"/>
+	<Target Name="_CalculateXbfSupport" Condition="'$(TargetFramework)'=='uap10.0.18362'"/>
 
 </Project>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.net6.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.net6.csproj
@@ -79,7 +79,7 @@
 
 		<PropertyGroup>
 			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
-			<_OverrideTargetFramework Condition="'$(_OverrideTargetFramework)' == 'uap10.0.17763'">UAP</_OverrideTargetFramework>
+			<_OverrideTargetFramework Condition="'$(_OverrideTargetFramework)' == 'uap10.0.18362'">UAP</_OverrideTargetFramework>
 			<_baseNugetPath Condition="'$(USERPROFILE)'!=''">$(USERPROFILE)</_baseNugetPath>
       <_baseNugetPath Condition="'$(HOME)'!=''">$(HOME)</_baseNugetPath>
 			<_TargetNugetFolder>$(_baseNugetPath)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\lib\$(_OverrideTargetFramework)</_TargetNugetFolder>

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/RatingControlAutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/RatingControlAutomationPeer.cs
@@ -2,18 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Automation.Peers
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class RatingControlAutomationPeer : global::Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer
 	{
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public RatingControlAutomationPeer( global::Windows.UI.Xaml.Controls.RatingControl owner) : base(owner)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.RatingControlAutomationPeer", "RatingControlAutomationPeer.RatingControlAutomationPeer(RatingControl owner)");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.RatingControlAutomationPeer.RatingControlAutomationPeer(Windows.UI.Xaml.Controls.RatingControl)
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.RatingControlAutomationPeer.RatingControlAutomationPeer(Windows.UI.Xaml.Controls.RatingControl)
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Provider/IWindowProvider.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Provider/IWindowProvider.cs
@@ -2,61 +2,25 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Automation.Provider
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IWindowProvider 
 	{
-#if false
-		global::Windows.UI.Xaml.Automation.WindowInteractionState InteractionState
-		{
-			get;
-		}
-#endif
-#if false
-		bool IsModal
-		{
-			get;
-		}
-#endif
-#if false
-		bool IsTopmost
-		{
-			get;
-		}
-#endif
-#if false
-		bool Maximizable
-		{
-			get;
-		}
-#endif
-#if false
-		bool Minimizable
-		{
-			get;
-		}
-#endif
-#if false
-		global::Windows.UI.Xaml.Automation.WindowVisualState VisualState
-		{
-			get;
-		}
-#endif
+		// Skipping already declared property InteractionState
+		// Skipping already declared property IsModal
+		// Skipping already declared property IsTopmost
+		// Skipping already declared property Maximizable
+		// Skipping already declared property Minimizable
+		// Skipping already declared property VisualState
 		// Forced skipping of method Windows.UI.Xaml.Automation.Provider.IWindowProvider.IsModal.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.Provider.IWindowProvider.IsTopmost.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.Provider.IWindowProvider.Maximizable.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.Provider.IWindowProvider.Minimizable.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.Provider.IWindowProvider.InteractionState.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.Provider.IWindowProvider.VisualState.get
-#if false
-		void Close();
-#endif
-#if false
-		void SetVisualState( global::Windows.UI.Xaml.Automation.WindowVisualState state);
-#endif
-#if false
-		bool WaitForInputIdle( int milliseconds);
-#endif
+		// Skipping already declared method Windows.UI.Xaml.Automation.Provider.IWindowProvider.Close()
+		// Skipping already declared method Windows.UI.Xaml.Automation.Provider.IWindowProvider.SetVisualState(Windows.UI.Xaml.Automation.WindowVisualState)
+		// Skipping already declared method Windows.UI.Xaml.Automation.Provider.IWindowProvider.WaitForInputIdle(int)
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
@@ -78,16 +78,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			}
 		}
 		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  bool IsOpen
-		{
-			get
-			{
-				return (bool)this.GetValue(IsOpenProperty);
-			}
-		}
-		#endif
+		// Skipping already declared property IsOpen
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.XamlRoot XamlRoot
@@ -170,14 +161,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty IsOpenProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(IsOpen), typeof(bool), 
-			typeof(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase), 
-			new FrameworkPropertyMetadata(default(bool)));
-		#endif
+		// Skipping already declared property IsOpenProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty ShowModeProperty { get; } = 

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBox.cs
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		// Skipping already declared property Description		
+		// Skipping already declared property Description
 		// Skipping already declared property AutoMaximizeSuggestionAreaProperty
 		// Skipping already declared property HeaderProperty
 		// Skipping already declared property IsSuggestionListOpenProperty
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared property TextProperty
 		// Skipping already declared property UpdateTextOnSelectProperty
 		// Skipping already declared property QueryIconProperty
-#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/BackgroundSizing.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/BackgroundSizing.cs
@@ -3,9 +3,6 @@
 namespace Windows.UI.Xaml.Controls
 {
 	#if false || false || false || false || false || false || false
-	#if false || false || false || false || false || false || false
-	[global::Uno.NotImplemented]
-	#endif
 	public   enum BackgroundSizing 
 	{
 		// Skipping already declared field Windows.UI.Xaml.Controls.BackgroundSizing.InnerBorderEdge

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ComboBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ComboBox.cs
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.ComboBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
-		// Skipping already declared property DescriptionProperty		
+		// Skipping already declared property DescriptionProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty IsEditableProperty { get; } = 

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -85,7 +85,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		// Skipping already declared property Description		
+		// Skipping already declared property Description
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool CanPasteClipboardContent

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingControl.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class RatingControl : global::Windows.UI.Xaml.Controls.Control
@@ -183,13 +183,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.RatingControl), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public RatingControl() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.RatingControl", "RatingControl.RatingControl()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.RatingControl.RatingControl()
 		// Forced skipping of method Windows.UI.Xaml.Controls.RatingControl.RatingControl()
 		// Forced skipping of method Windows.UI.Xaml.Controls.RatingControl.Caption.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.RatingControl.Caption.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SplitButton.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class SplitButton : global::Windows.UI.Xaml.Controls.ContentControl
@@ -73,13 +73,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.SplitButton), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public SplitButton() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.SplitButton", "SplitButton.SplitButton()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.SplitButton.SplitButton()
 		// Forced skipping of method Windows.UI.Xaml.Controls.SplitButton.SplitButton()
 		// Forced skipping of method Windows.UI.Xaml.Controls.SplitButton.Flyout.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.SplitButton.Flyout.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -190,20 +190,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  object Description
-		{
-			get
-			{
-				return (object)this.GetValue(DescriptionProperty);
-			}
-			set
-			{
-				this.SetValue(DescriptionProperty, value);
-			}
-		}
-		#endif
+		// Skipping already declared property Description
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool CanPasteClipboardContent
@@ -353,14 +340,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Primitives.FlyoutBase)));
 		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty DescriptionProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(Description), typeof(object), 
-			typeof(global::Windows.UI.Xaml.Controls.TextBox), 
-			new FrameworkPropertyMetadata(default(object)));
-		#endif
+		// Skipping already declared property DescriptionProperty
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty CanUndoProperty { get; } = 

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSplitButton.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSplitButton.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ToggleSplitButton : global::Windows.UI.Xaml.Controls.SplitButton
@@ -21,13 +21,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public ToggleSplitButton() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.ToggleSplitButton", "ToggleSplitButton.ToggleSplitButton()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.ToggleSplitButton.ToggleSplitButton()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSplitButton.ToggleSplitButton()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSplitButton.IsChecked.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSplitButton.IsChecked.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSplitButtonAutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ToggleSplitButtonAutomationPeer.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ToggleSplitButtonAutomationPeer : global::Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer,global::Windows.UI.Xaml.Automation.Provider.IExpandCollapseProvider,global::Windows.UI.Xaml.Automation.Provider.IToggleProvider
@@ -27,13 +27,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public ToggleSplitButtonAutomationPeer( global::Windows.UI.Xaml.Controls.ToggleSplitButton owner) : base(owner)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.ToggleSplitButtonAutomationPeer", "ToggleSplitButtonAutomationPeer.ToggleSplitButtonAutomationPeer(ToggleSplitButton owner)");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.ToggleSplitButtonAutomationPeer.ToggleSplitButtonAutomationPeer(Windows.UI.Xaml.Controls.ToggleSplitButton)
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSplitButtonAutomationPeer.ToggleSplitButtonAutomationPeer(Windows.UI.Xaml.Controls.ToggleSplitButton)
 		// Forced skipping of method Windows.UI.Xaml.Controls.ToggleSplitButtonAutomationPeer.ExpandCollapseState.get
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeView.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TreeView : global::Windows.UI.Xaml.Controls.Control
@@ -225,13 +225,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TreeView), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public TreeView() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TreeView", "TreeView.TreeView()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.TreeView.TreeView()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeView.TreeView()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeView.RootNodes.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeView.SelectionMode.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TwoPaneView.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TwoPaneView.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class TwoPaneView : global::Windows.UI.Xaml.Controls.Control
@@ -223,13 +223,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TwoPaneView), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.TwoPaneViewWideModeConfiguration)));
 		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public TwoPaneView() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TwoPaneView", "TwoPaneView.TwoPaneView()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.TwoPaneView.TwoPaneView()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TwoPaneView.TwoPaneView()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TwoPaneView.Pane1.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TwoPaneView.Pane1.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Application.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Application.cs
@@ -25,7 +25,7 @@ namespace Windows.UI.Xaml
 				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Application", "ApplicationHighContrastAdjustment Application.HighContrastAdjustment");
 			}
 		}
-#endif
+		#endif
 		// Skipping already declared property Current
 		// Skipping already declared method Windows.UI.Xaml.Application.Application()
 		// Forced skipping of method Windows.UI.Xaml.Application.Application()
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml
 		// Forced skipping of method Windows.UI.Xaml.Application.HighContrastAdjustment.set
 		// Skipping already declared method Windows.UI.Xaml.Application.OnActivated(Windows.ApplicationModel.Activation.IActivatedEventArgs)
 		// Skipping already declared method Windows.UI.Xaml.Application.OnLaunched(Windows.ApplicationModel.Activation.LaunchActivatedEventArgs)
-#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		protected virtual void OnFileActivated( global::Windows.ApplicationModel.Activation.FileActivatedEventArgs args)
 		{
@@ -105,6 +105,7 @@ namespace Windows.UI.Xaml
 		#endif
 		// Forced skipping of method Windows.UI.Xaml.Application.Current.get
 		// Skipping already declared method Windows.UI.Xaml.Application.Start(Windows.UI.Xaml.ApplicationInitializationCallback)
+		// Skipping already declared method Windows.UI.Xaml.Application.LoadComponent(object, System.Uri)
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static void LoadComponent( object component,  global::System.Uri resourceLocator,  global::Windows.UI.Xaml.Controls.Primitives.ComponentResourceLocation componentResourceLocation)

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/SetterBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/SetterBase.cs
@@ -1,7 +1,5 @@
 #pragma warning disable 108 // new keyword hiding
 #pragma warning disable 114 // new keyword hiding
-using System;
-
 namespace Windows.UI.Xaml
 {
 	#if false || false || false || false || false || false || false
@@ -9,5 +7,7 @@ namespace Windows.UI.Xaml
 	#endif
 	public  partial class SetterBase : global::Windows.UI.Xaml.DependencyObject
 	{
+		// Skipping already declared property IsSealed
+		// Forced skipping of method Windows.UI.Xaml.SetterBase.IsSealed.get
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/SetterBaseCollection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/SetterBaseCollection.cs
@@ -7,7 +7,8 @@ namespace Windows.UI.Xaml
 	#endif
 	public  partial class SetterBaseCollection : global::System.Collections.Generic.IList<global::Windows.UI.Xaml.SetterBase>,global::System.Collections.Generic.IEnumerable<global::Windows.UI.Xaml.SetterBase>
 	{
-
+		// Skipping already declared property Size
+		// Skipping already declared property IsSealed
 		// Skipping already declared method Windows.UI.Xaml.SetterBaseCollection.SetterBaseCollection()
 		// Forced skipping of method Windows.UI.Xaml.SetterBaseCollection.SetterBaseCollection()
 		// Forced skipping of method Windows.UI.Xaml.SetterBaseCollection.IsSealed.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Style.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/Style.cs
@@ -7,5 +7,20 @@ namespace Windows.UI.Xaml
 	#endif
 	public  partial class Style : global::Windows.UI.Xaml.DependencyObject
 	{
+		// Skipping already declared property TargetType
+		// Skipping already declared property BasedOn
+		// Skipping already declared property IsSealed
+		// Skipping already declared property Setters
+		// Skipping already declared method Windows.UI.Xaml.Style.Style(System.Type)
+		// Forced skipping of method Windows.UI.Xaml.Style.Style(System.Type)
+		// Skipping already declared method Windows.UI.Xaml.Style.Style()
+		// Forced skipping of method Windows.UI.Xaml.Style.Style()
+		// Forced skipping of method Windows.UI.Xaml.Style.IsSealed.get
+		// Forced skipping of method Windows.UI.Xaml.Style.Setters.get
+		// Forced skipping of method Windows.UI.Xaml.Style.TargetType.get
+		// Forced skipping of method Windows.UI.Xaml.Style.TargetType.set
+		// Forced skipping of method Windows.UI.Xaml.Style.BasedOn.get
+		// Forced skipping of method Windows.UI.Xaml.Style.BasedOn.set
+		// Skipping already declared method Windows.UI.Xaml.Style.Seal()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
@@ -929,7 +929,7 @@ namespace Windows.UI.Xaml
 		// Forced skipping of method Windows.UI.Xaml.UIElement.DragStarting.remove
 		// Forced skipping of method Windows.UI.Xaml.UIElement.DropCompleted.add
 		// Forced skipping of method Windows.UI.Xaml.UIElement.DropCompleted.remove
-		// Skipping already declared method Windows.UI.Xaml.UIElement.StartDragAsync(Windows.UI.Input.PointerPoint)
+		// Forced skipping of method Windows.UI.Xaml.UIElement.StartDragAsync(Windows.UI.Input.PointerPoint)
 		// Forced skipping of method Windows.UI.Xaml.UIElement.ContextFlyout.get
 		// Forced skipping of method Windows.UI.Xaml.UIElement.ContextFlyout.set
 		// Forced skipping of method Windows.UI.Xaml.UIElement.ExitDisplayModeOnAccessKeyInvoked.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/XamlRoot.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/XamlRoot.cs
@@ -18,6 +18,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
+		// Skipping already declared property RasterizationScale
 		// Skipping already declared property Size
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Foundation.Metadata/CreateFromStringAttribute.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Foundation.Metadata/CreateFromStringAttribute.cs
@@ -2,21 +2,13 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Foundation.Metadata
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class CreateFromStringAttribute : global::System.Attribute
 	{
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public CreateFromStringAttribute() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Foundation.Metadata.CreateFromStringAttribute", "CreateFromStringAttribute.CreateFromStringAttribute()");
-		}
-		#endif
+		// Skipping already declared method Windows.Foundation.Metadata.CreateFromStringAttribute.CreateFromStringAttribute()
 		// Forced skipping of method Windows.Foundation.Metadata.CreateFromStringAttribute.CreateFromStringAttribute()
-		#if false
-		public  string MethodName;
-		#endif
+		// Skipping already declared field Windows.Foundation.Metadata.CreateFromStringAttribute.MethodName
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Security.ExchangeActiveSyncProvisioning/EasClientDeviceInformation.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Security.ExchangeActiveSyncProvisioning/EasClientDeviceInformation.cs
@@ -7,93 +7,15 @@ namespace Windows.Security.ExchangeActiveSyncProvisioning
 	#endif
 	public  partial class EasClientDeviceInformation 
 	{
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string FriendlyName
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string EasClientDeviceInformation.FriendlyName is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::System.Guid Id
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member Guid EasClientDeviceInformation.Id is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string OperatingSystem
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string EasClientDeviceInformation.OperatingSystem is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string SystemManufacturer
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string EasClientDeviceInformation.SystemManufacturer is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string SystemProductName
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string EasClientDeviceInformation.SystemProductName is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string SystemSku
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string EasClientDeviceInformation.SystemSku is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string SystemFirmwareVersion
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string EasClientDeviceInformation.SystemFirmwareVersion is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string SystemHardwareVersion
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string EasClientDeviceInformation.SystemHardwareVersion is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public EasClientDeviceInformation() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation", "EasClientDeviceInformation.EasClientDeviceInformation()");
-		}
-		#endif
+		// Skipping already declared property FriendlyName
+		// Skipping already declared property Id
+		// Skipping already declared property OperatingSystem
+		// Skipping already declared property SystemManufacturer
+		// Skipping already declared property SystemProductName
+		// Skipping already declared property SystemSku
+		// Skipping already declared property SystemFirmwareVersion
+		// Skipping already declared property SystemHardwareVersion
+		// Skipping already declared method Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation.EasClientDeviceInformation()
 		// Forced skipping of method Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation.EasClientDeviceInformation()
 		// Forced skipping of method Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation.Id.get
 		// Forced skipping of method Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation.OperatingSystem.get

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsInfo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsInfo.cs
@@ -7,26 +7,8 @@ namespace Windows.System.Profile
 	#endif
 	public static partial class AnalyticsInfo 
 	{
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static string DeviceForm
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string AnalyticsInfo.DeviceForm is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.System.Profile.AnalyticsVersionInfo VersionInfo
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member AnalyticsVersionInfo AnalyticsInfo.VersionInfo is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property DeviceForm
+		// Skipping already declared property VersionInfo
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyDictionary<string, string>> GetSystemPropertiesAsync( global::System.Collections.Generic.IEnumerable<string> attributeNames)

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsVersionInfo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Profile/AnalyticsVersionInfo.cs
@@ -7,26 +7,8 @@ namespace Windows.System.Profile
 	#endif
 	public  partial class AnalyticsVersionInfo 
 	{
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string DeviceFamily
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string AnalyticsVersionInfo.DeviceFamily is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false || false || false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  string DeviceFamilyVersion
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string AnalyticsVersionInfo.DeviceFamilyVersion is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property DeviceFamily
+		// Skipping already declared property DeviceFamilyVersion
 		// Forced skipping of method Windows.System.Profile.AnalyticsVersionInfo.DeviceFamily.get
 		// Forced skipping of method Windows.System.Profile.AnalyticsVersionInfo.DeviceFamilyVersion.get
 	}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System/AppMemoryUsageLevel.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System/AppMemoryUsageLevel.cs
@@ -2,4 +2,13 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System
 {
+	#if false || false || false || false || false || false || false
+	public   enum AppMemoryUsageLevel 
+	{
+		// Skipping already declared field Windows.System.AppMemoryUsageLevel.Low
+		// Skipping already declared field Windows.System.AppMemoryUsageLevel.Medium
+		// Skipping already declared field Windows.System.AppMemoryUsageLevel.High
+		// Skipping already declared field Windows.System.AppMemoryUsageLevel.OverLimit
+	}
+	#endif
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System/MemoryManager.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System/MemoryManager.cs
@@ -2,13 +2,13 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System
 {
-	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public static partial class MemoryManager 
 	{
 		#if false || __IOS__ || NET461 || false || false || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static ulong AppMemoryUsage
 		{
 			get
@@ -17,8 +17,9 @@ namespace Windows.System
 			}
 		}
 		#endif
+		// Skipping already declared property AppMemoryUsageLevel
 		#if false || __IOS__ || NET461 || false || false || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static ulong AppMemoryUsageLimit
 		{
 			get

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/IdleDispatchedHandlerArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/IdleDispatchedHandlerArgs.cs
@@ -2,10 +2,10 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Core
 {
-#if false || false || false || false || false || false || false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
-#endif
-	public partial class IdleDispatchedHandlerArgs
+	#endif
+	public  partial class IdleDispatchedHandlerArgs 
 	{
 		// Skipping already declared property IsDispatcherIdle
 		// Forced skipping of method Windows.UI.Core.IdleDispatchedHandlerArgs.IsDispatcherIdle.get

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputMouseInfo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputMouseInfo.cs
@@ -2,88 +2,17 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class InjectedInputMouseInfo 
 	{
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  uint TimeOffsetInMilliseconds
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member uint InjectedInputMouseInfo.TimeOffsetInMilliseconds is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo", "uint InjectedInputMouseInfo.TimeOffsetInMilliseconds");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions MouseOptions
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member InjectedInputMouseOptions InjectedInputMouseInfo.MouseOptions is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo", "InjectedInputMouseOptions InjectedInputMouseInfo.MouseOptions");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  uint MouseData
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member uint InjectedInputMouseInfo.MouseData is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo", "uint InjectedInputMouseInfo.MouseData");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  int DeltaY
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int InjectedInputMouseInfo.DeltaY is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo", "int InjectedInputMouseInfo.DeltaY");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  int DeltaX
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int InjectedInputMouseInfo.DeltaX is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo", "int InjectedInputMouseInfo.DeltaX");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public InjectedInputMouseInfo() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo", "InjectedInputMouseInfo.InjectedInputMouseInfo()");
-		}
-		#endif
+		// Skipping already declared property TimeOffsetInMilliseconds
+		// Skipping already declared property MouseOptions
+		// Skipping already declared property MouseData
+		// Skipping already declared property DeltaY
+		// Skipping already declared property DeltaX
+		// Skipping already declared method Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo.InjectedInputMouseInfo()
 		// Forced skipping of method Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo.InjectedInputMouseInfo()
 		// Forced skipping of method Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo.MouseOptions.get
 		// Forced skipping of method Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo.MouseOptions.set

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputMouseOptions.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputMouseOptions.cs
@@ -2,55 +2,25 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::System.FlagsAttribute]
-	public enum InjectedInputMouseOptions : uint
+	public   enum InjectedInputMouseOptions : uint
 	{
-		#if false
-		None = 0,
-		#endif
-		#if false
-		Move = 1,
-		#endif
-		#if false
-		LeftDown = 2,
-		#endif
-		#if false
-		LeftUp = 4,
-		#endif
-		#if false
-		RightDown = 8,
-		#endif
-		#if false
-		RightUp = 16,
-		#endif
-		#if false
-		MiddleDown = 32,
-		#endif
-		#if false
-		MiddleUp = 64,
-		#endif
-		#if false
-		XDown = 128,
-		#endif
-		#if false
-		XUp = 256,
-		#endif
-		#if false
-		Wheel = 2048,
-		#endif
-		#if false
-		HWheel = 4096,
-		#endif
-		#if false
-		MoveNoCoalesce = 8192,
-		#endif
-		#if false
-		VirtualDesk = 16384,
-		#endif
-		#if false
-		Absolute = 32768,
-		#endif
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.None
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.Move
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.LeftDown
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.LeftUp
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.RightDown
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.RightUp
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.MiddleDown
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.MiddleUp
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.XDown
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.XUp
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.Wheel
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.HWheel
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.MoveNoCoalesce
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.VirtualDesk
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputMouseOptions.Absolute
 	}
 	#endif
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputPoint.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputPoint.cs
@@ -2,17 +2,13 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial struct InjectedInputPoint 
 	{
 		// Forced skipping of method Windows.UI.Input.Preview.Injection.InjectedInputPoint.InjectedInputPoint()
-		#if false
-		public  int PositionX;
-		#endif
-		#if false
-		public  int PositionY;
-		#endif
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPoint.PositionX
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPoint.PositionY
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputPointerInfo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputPointerInfo.cs
@@ -2,26 +2,16 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial struct InjectedInputPointerInfo 
 	{
 		// Forced skipping of method Windows.UI.Input.Preview.Injection.InjectedInputPointerInfo.InjectedInputPointerInfo()
-		#if false
-		public  uint PointerId;
-		#endif
-		#if false
-		public  global::Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions PointerOptions;
-		#endif
-		#if false
-		public  global::Windows.UI.Input.Preview.Injection.InjectedInputPoint PixelLocation;
-		#endif
-		#if false
-		public  uint TimeOffsetInMilliseconds;
-		#endif
-		#if false
-		public  ulong PerformanceCount;
-		#endif
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerInfo.PointerId
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerInfo.PointerOptions
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerInfo.PixelLocation
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerInfo.TimeOffsetInMilliseconds
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerInfo.PerformanceCount
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputPointerOptions.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputPointerOptions.cs
@@ -2,49 +2,23 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::System.FlagsAttribute]
 	public   enum InjectedInputPointerOptions : uint
 	{
-		#if false
-		None = 0,
-		#endif
-		#if false
-		New = 1,
-		#endif
-		#if false
-		InRange = 2,
-		#endif
-		#if false
-		InContact = 4,
-		#endif
-		#if false
-		FirstButton = 16,
-		#endif
-		#if false
-		SecondButton = 32,
-		#endif
-		#if false
-		Primary = 8192,
-		#endif
-		#if false
-		Confidence = 16384,
-		#endif
-		#if false
-		Canceled = 32768,
-		#endif
-		#if false
-		PointerDown = 65536,
-		#endif
-		#if false
-		Update = 131072,
-		#endif
-		#if false
-		PointerUp = 262144,
-		#endif
-		#if false
-		CaptureChanged = 2097152,
-		#endif
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.None
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.New
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.InRange
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.InContact
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.FirstButton
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.SecondButton
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.Primary
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.Confidence
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.Canceled
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.PointerDown
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.Update
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.PointerUp
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputPointerOptions.CaptureChanged
 	}
 	#endif
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputRectangle.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputRectangle.cs
@@ -2,23 +2,15 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial struct InjectedInputRectangle 
 	{
 		// Forced skipping of method Windows.UI.Input.Preview.Injection.InjectedInputRectangle.InjectedInputRectangle()
-		#if false
-		public  int Left;
-		#endif
-		#if false
-		public  int Top;
-		#endif
-		#if false
-		public  int Bottom;
-		#endif
-		#if false
-		public  int Right;
-		#endif
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputRectangle.Left
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputRectangle.Top
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputRectangle.Bottom
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputRectangle.Right
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputTouchInfo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputTouchInfo.cs
@@ -2,88 +2,17 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class InjectedInputTouchInfo 
 	{
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.UI.Input.Preview.Injection.InjectedInputTouchParameters TouchParameters
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member InjectedInputTouchParameters InjectedInputTouchInfo.TouchParameters is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo", "InjectedInputTouchParameters InjectedInputTouchInfo.TouchParameters");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  double Pressure
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member double InjectedInputTouchInfo.Pressure is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo", "double InjectedInputTouchInfo.Pressure");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.UI.Input.Preview.Injection.InjectedInputPointerInfo PointerInfo
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member InjectedInputPointerInfo InjectedInputTouchInfo.PointerInfo is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo", "InjectedInputPointerInfo InjectedInputTouchInfo.PointerInfo");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  int Orientation
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member int InjectedInputTouchInfo.Orientation is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo", "int InjectedInputTouchInfo.Orientation");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.UI.Input.Preview.Injection.InjectedInputRectangle Contact
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member InjectedInputRectangle InjectedInputTouchInfo.Contact is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo", "InjectedInputRectangle InjectedInputTouchInfo.Contact");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public InjectedInputTouchInfo() 
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo", "InjectedInputTouchInfo.InjectedInputTouchInfo()");
-		}
-		#endif
+		// Skipping already declared property TouchParameters
+		// Skipping already declared property Pressure
+		// Skipping already declared property PointerInfo
+		// Skipping already declared property Orientation
+		// Skipping already declared property Contact
+		// Skipping already declared method Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo.InjectedInputTouchInfo()
 		// Forced skipping of method Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo.InjectedInputTouchInfo()
 		// Forced skipping of method Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo.Contact.get
 		// Forced skipping of method Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo.Contact.set

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputTouchParameters.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputTouchParameters.cs
@@ -2,22 +2,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::System.FlagsAttribute]
 	public   enum InjectedInputTouchParameters : uint
 	{
-		#if false
-		None = 0,
-		#endif
-		#if false
-		Contact = 1,
-		#endif
-		#if false
-		Orientation = 2,
-		#endif
-		#if false
-		Pressure = 4,
-		#endif
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputTouchParameters.None
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputTouchParameters.Contact
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputTouchParameters.Orientation
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputTouchParameters.Pressure
 	}
 	#endif
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputVisualizationMode.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InjectedInputVisualizationMode.cs
@@ -2,18 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	public   enum InjectedInputVisualizationMode 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		None = 0,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		Default = 1,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		Indirect = 2,
-		#endif
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputVisualizationMode.None
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputVisualizationMode.Default
+		// Skipping already declared field Windows.UI.Input.Preview.Injection.InjectedInputVisualizationMode.Indirect
 	}
 	#endif
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InputInjector.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input.Preview.Injection/InputInjector.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Input.Preview.Injection
 {
-	#if false
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class InputInjector 
@@ -14,34 +14,10 @@ namespace Windows.UI.Input.Preview.Injection
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InputInjector", "void InputInjector.InjectKeyboardInput(IEnumerable<InjectedInputKeyboardInfo> input)");
 		}
 		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  void InjectMouseInput( global::System.Collections.Generic.IEnumerable<global::Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo> input)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InputInjector", "void InputInjector.InjectMouseInput(IEnumerable<InjectedInputMouseInfo> input)");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  void InitializeTouchInjection( global::Windows.UI.Input.Preview.Injection.InjectedInputVisualizationMode visualMode)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InputInjector", "void InputInjector.InitializeTouchInjection(InjectedInputVisualizationMode visualMode)");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  void InjectTouchInput( global::System.Collections.Generic.IEnumerable<global::Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo> input)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InputInjector", "void InputInjector.InjectTouchInput(IEnumerable<InjectedInputTouchInfo> input)");
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  void UninitializeTouchInjection()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Input.Preview.Injection.InputInjector", "void InputInjector.UninitializeTouchInjection()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Input.Preview.Injection.InputInjector.InjectMouseInput(System.Collections.Generic.IEnumerable<Windows.UI.Input.Preview.Injection.InjectedInputMouseInfo>)
+		// Skipping already declared method Windows.UI.Input.Preview.Injection.InputInjector.InitializeTouchInjection(Windows.UI.Input.Preview.Injection.InjectedInputVisualizationMode)
+		// Skipping already declared method Windows.UI.Input.Preview.Injection.InputInjector.InjectTouchInput(System.Collections.Generic.IEnumerable<Windows.UI.Input.Preview.Injection.InjectedInputTouchInfo>)
+		// Skipping already declared method Windows.UI.Input.Preview.Injection.InputInjector.UninitializeTouchInjection()
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  void InitializePenInjection( global::Windows.UI.Input.Preview.Injection.InjectedInputVisualizationMode visualMode)
@@ -98,12 +74,6 @@ namespace Windows.UI.Input.Preview.Injection
 			throw new global::System.NotImplementedException("The member InputInjector InputInjector.TryCreateForAppBroadcastOnly() is not implemented in Uno.");
 		}
 		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Input.Preview.Injection.InputInjector TryCreate()
-		{
-			throw new global::System.NotImplementedException("The member InputInjector InputInjector.TryCreate() is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Input.Preview.Injection.InputInjector.TryCreate()
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/PointerPointProperties.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Input/PointerPointProperties.cs
@@ -7,16 +7,7 @@ namespace Windows.UI.Input
 	#endif
 	public  partial class PointerPointProperties 
 	{
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.Foundation.Rect ContactRect
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member Rect PointerPointProperties.ContactRect is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property ContactRect
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.Rect ContactRectRaw
@@ -28,16 +19,7 @@ namespace Windows.UI.Input
 		}
 		#endif
 		// Skipping already declared property IsBarrelButtonPressed
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  bool IsCanceled
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool PointerPointProperties.IsCanceled is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property IsCanceled
 		// Skipping already declared property IsEraser
 		// Skipping already declared property IsHorizontalMouseWheel
 		// Skipping already declared property IsInRange
@@ -58,28 +40,10 @@ namespace Windows.UI.Input
 		// Skipping already declared property IsXButton1Pressed
 		// Skipping already declared property IsXButton2Pressed
 		// Skipping already declared property MouseWheelDelta
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  float Orientation
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member float PointerPointProperties.Orientation is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property Orientation
 		// Skipping already declared property PointerUpdateKind
 		// Skipping already declared property Pressure
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  bool TouchConfidence
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool PointerPointProperties.TouchConfidence is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property TouchConfidence
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  float Twist
@@ -90,26 +54,8 @@ namespace Windows.UI.Input
 			}
 		}
 		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public  float XTilt
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member float PointerPointProperties.XTilt is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if false
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public  float YTilt
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member float PointerPointProperties.YTilt is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property XTilt
+		// Skipping already declared property YTilt
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  float? ZDistance

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Text/FontWeights.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Text/FontWeights.cs
@@ -2,4 +2,32 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Text
 {
+	#if false || false || false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class FontWeights 
+	{
+		// Skipping already declared property Black
+		// Skipping already declared property Bold
+		// Skipping already declared property ExtraBlack
+		// Skipping already declared property ExtraBold
+		// Skipping already declared property ExtraLight
+		// Skipping already declared property Light
+		// Skipping already declared property Medium
+		// Skipping already declared property Normal
+		// Skipping already declared property SemiBold
+		// Skipping already declared property SemiLight
+		// Skipping already declared property Thin
+		// Forced skipping of method Windows.UI.Text.FontWeights.Black.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.Bold.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.ExtraBlack.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.ExtraBold.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.ExtraLight.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.Light.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.Medium.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.Normal.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.SemiBold.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.SemiLight.get
+		// Forced skipping of method Windows.UI.Text.FontWeights.Thin.get
+	}
 }

--- a/src/Uno.UWPSyncGenerator.Reference/Uno.UWPSyncGenerator.Reference.csproj
+++ b/src/Uno.UWPSyncGenerator.Reference/Uno.UWPSyncGenerator.Reference.csproj
@@ -18,7 +18,7 @@
 		<DefaultLanguage>en-US</DefaultLanguage>
 		<TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
 		<TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
-		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+		<TargetPlatformMinVersion>10.0.18362.0</TargetPlatformMinVersion>
 		<MinimumVisualStudioVersion>16</MinimumVisualStudioVersion>
 		<FileAlignment>512</FileAlignment>
 		<ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/src/Uno.UWPSyncGenerator/DocGenerator.cs
+++ b/src/Uno.UWPSyncGenerator/DocGenerator.cs
@@ -50,7 +50,7 @@ namespace Uno.UWPSyncGenerator
 
 			using (_sb.Section("List of views implemented in Uno"))
 			{
-				_sb.AppendParagraph("The Uno.UI assembly includes all types and members from the UWP API (as of the Windows 10 October 2018 Update (17763)). Only some of these are actually implemented. The remainder are marked with the `[NotImplemented]` attribute and will throw an exception at runtime if used.");
+				_sb.AppendParagraph("The Uno.UI assembly includes all types and members from the UWP API (as of the May 2019 Update (18362)). Only some of these are actually implemented. The remainder are marked with the `[NotImplemented]` attribute and will throw an exception at runtime if used.");
 
 				_sb.AppendParagraph("This page lists controls that are currently implemented in Uno. Navigate to individual control entries to see which properties, methods, and events are implemented for a given control.");
 

--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -18,7 +18,7 @@
         
         Available build targets and corresponding solution filters:
         
-          uap10.0.17763 (Windows) - Uno.UI-Windows-only.slnf
+          uap10.0.18362 (Windows) - Uno.UI-Windows-only.slnf
           xamarinios10 (iOS) - Uno.UI-iOS-only.slnf
           MonoAndroid12.0 (Android 12.0) - Uno.UI-Android-only.slnf
           netstandard2.0 (WebAssembly, Skia) - Uno.UI-Wasm-only.slnf, Uno.UI-Skia-only.slnf


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2840

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

All UWP project target 17763.

## What is the new behavior?

All UWP project target 18362.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Breaking change

This change removes support for targeting 17763 (October 2018 release of Windows 10) (but it still can be set as "min supported version"). This version is now only supported for Enterprise (as long term) https://en.wikipedia.org/wiki/Windows_10_version_history#Version_1903_(May_2019_Update) . WinUI 2.6 requires targeting 18362 or higher, so developers are essentially forced to target higher anyway.