### PR TITLE
Revert "test: Android Emulator wait boot timeout"

### DIFF
--- a/build/ci/.azure-devops-android-tests.yml
+++ b/build/ci/.azure-devops-android-tests.yml
@@ -179,7 +179,7 @@ jobs:
       #   TARGETPLATFORM_NAME: net6
       #   ALLOW_RERUN: false
       #   UITEST_TEST_TIMEOUT: '2600000'
-      #   FAILBUILD_ON_FAILURE: false # false until https://github.com/unoplatform/uno/issues/5873 and https://github.com/dotnet/runtime/pull/55681 are released
+      #   FAILBUILD_ON_FAILURE: false # false until https://github.com/unoplatform/uno/issues/5873 and https://github.com/dotnet/runtime/pull/55681 are released 
 
       # Android 10 testing is disabled because of https://github.com/microsoft/appcenter/issues/1451
       # Android_10.0:
@@ -219,13 +219,6 @@ jobs:
       XamarinSDKVersion: ${{ parameters.XamarinSDKVersion }}
 
   - task: PowerShell@2
-    displayName: 'Install coreutils'
-    inputs:
-      targetType: inline
-      script: |
-        brew install coreutils
-
-  - task: PowerShell@2
     displayName: 'Fill Rerun Variable'
     inputs:
       ## Expression evaluation for task parameters is not supported
@@ -255,7 +248,7 @@ jobs:
       UITEST_TEST_TIMEOUT: "$(UITEST_TEST_TIMEOUT)"
       SAMPLEAPP_ARTIFACT_NAME: "$(SAMPLEAPP_ARTIFACT_NAME)"
       TARGETPLATFORM_NAME: "$(TARGETPLATFORM_NAME)"
-
+ 
   - task: PublishTestResults@2
     condition: always()
     inputs:
@@ -282,7 +275,7 @@ jobs:
       UITEST_TEST_TIMEOUT: "$(UITEST_TEST_TIMEOUT)"
       SAMPLEAPP_ARTIFACT_NAME: "$(SAMPLEAPP_ARTIFACT_NAME)"
       TARGETPLATFORM_NAME: "$(TARGETPLATFORM_NAME)"
-
+ 
   - task: PublishTestResults@2
     condition: eq(variables.ALLOW_RERUN, 'true')
     inputs:

--- a/build/test-scripts/android-uitest-run.sh
+++ b/build/test-scripts/android-uitest-run.sh
@@ -103,14 +103,14 @@ then
 	nohup $ANDROID_HOME/emulator/emulator -avd "$AVD_NAME" -skin 1280x800 -memory 2048 -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim > /dev/null 2>&1 &
 
 	# Wait for the emulator to finish booting
-	source $BUILD_SOURCESDIRECTORY/build/test-scripts/android-uitest-wait-systemui.sh 500
+	source $BUILD_SOURCESDIRECTORY/build/test-scripts/android-uitest-wait-systemui.sh
 
 else
 	# Restart the emulator to avoid running first-time tasks
 	$ANDROID_HOME/platform-tools/adb reboot
 
 	# Wait for the emulator to finish booting
-	source $BUILD_SOURCESDIRECTORY/build/test-scripts/android-uitest-wait-systemui.sh 500
+	source $BUILD_SOURCESDIRECTORY/build/test-scripts/android-uitest-wait-systemui.sh
 fi
 
 # list active devices

--- a/build/test-scripts/android-uitest-wait-systemui.sh
+++ b/build/test-scripts/android-uitest-wait-systemui.sh
@@ -1,21 +1,9 @@
 #!/usr/bin/env bash
-BOOT_TIMEOUT=$1
+
 retry() {
-    local -r -i max_attempts="$1";shift 1
+    local -r -i max_attempts="$1"; shift
     local -i attempt_num=1
-    local -a COMMANDS=( timeout $BOOT_TIMEOUT )
-
-    while (( "$#" )); do
-        local arg="$1";
-        if [[ "$arg" = *" "* ]]; then
-            COMMANDS+=( $( printf "\''%s'\'" "$arg" ) )
-        else
-            COMMANDS+=( "$arg" )
-        fi
-        shift
-    done
-
-    until "${COMMANDS[@]}"
+    until "$@"
     do
         if ((attempt_num==max_attempts))
         then
@@ -29,13 +17,13 @@ retry() {
 }
 
 echo ""
-echo "[Waiting for device to boot] timeout $BOOT_TIMEOUT sec"
+echo "[Waiting for device to boot]"
 
 if [ $ANDROID_SIMULATOR_APILEVEL -gt 25 ];
-then
-retry 3 "$ANDROID_HOME/platform-tools/adb" wait-for-device shell 'echo "emulator is attached, wait for boot completion"; while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]] && [[ "$SECONDS" -lt 300 ]]; do sleep 1; done; input keyevent 82; echo "boot is complete."'
+then 
+retry 3 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; [[ "$SECONDS" -lt 300 ]]; do sleep 1; done; input keyevent 82'
 else
-retry 3 "$ANDROID_HOME/platform-tools/adb" wait-for-device shell 'echo "emulator is attached, wait for boot completion"; while [[ -z $(getprop sys.boot_completed) ]] && [[ "$SECONDS" -lt 300 ]]; do sleep 1; done; input keyevent 82; echo "boot is complete."'
+retry 3 $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; [[ "$SECONDS" -lt 300 ]]; do sleep 1; done; input keyevent 82'
 fi
 
 # Wait for com.android.systemui to become available,
@@ -51,7 +39,7 @@ START_TIME=$SECONDS
 while [[ -z ${LAUNCHER_READY} ]]; do
 
     if [ $ANDROID_SIMULATOR_APILEVEL -ge 29 ];
-    then
+    then 
     UI_FOCUS=`$ANDROID_HOME/platform-tools/adb shell dumpsys window 2>/dev/null | grep -E 'mCurrentFocus|mFocusedApp'`
     else
     UI_FOCUS=`$ANDROID_HOME/platform-tools/adb shell dumpsys window windows 2>/dev/null | grep -i mCurrentFocus`
@@ -84,9 +72,9 @@ while [[ -z ${LAUNCHER_READY} ]]; do
         echo "Waiting for launcher..."
         sleep 3
 
-        # For some reason the messaging app can be brought up in front
-        # (DEBUG) Current focus:   mCurrentFocus=Window{1170051 u0 com.google.android.apps.messaging/com.google.android.apps.messaging.ui.ConversationListActivity}
-        # Try bringing back the home screen to check on the launcher.
+		# For some reason the messaging app can be brought up in front
+		# (DEBUG) Current focus:   mCurrentFocus=Window{1170051 u0 com.google.android.apps.messaging/com.google.android.apps.messaging.ui.ConversationListActivity}
+		# Try bringing back the home screen to check on the launcher.
         $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_HOME
     ;;
     esac


### PR DESCRIPTION
Reverts unoplatform/uno#8168

```
[Waiting for device to boot] timeout 500 sec
/Users/runner/work/1/s/build/test-scripts/android-uitest-wait-systemui.sh: line 18: timeout: command not found
Attempt 1 failed! Waiting 1 seconds...
/Users/runner/work/1/s/build/test-scripts/android-uitest-wait-systemui.sh: line 18: timeout: command not found
Attempt 2 failed! Waiting 2 seconds...
/Users/runner/work/1/s/build/test-scripts/android-uitest-wait-systemui.sh: line 18: timeout: command not found
Last attempt 3 failed, exiting.
```