### PR TITLE
fix: Set iOS Window background to Clear instead of White

### DIFF
--- a/src/Uno.UI/UI/Xaml/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.iOS.cs
@@ -40,7 +40,7 @@ namespace Windows.UI.Xaml
 			_window = new Uno.UI.Controls.Window();
 
 			_mainController = ViewControllerGenerator?.Invoke() ?? new RootViewController();
-			_mainController.View.BackgroundColor = UIColor.White;
+			_mainController.View.BackgroundColor = UIColor.Clear;
 			_mainController.NavigationBarHidden = true;
 			
 			ObserveOrientationAndSize();


### PR DESCRIPTION
Relates to #7554

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

White background appears while rotating:
![image](https://user-images.githubusercontent.com/4793020/157522669-8d84784b-78e8-4fa9-8cbd-a5b3ec510146.png)


## What is the new behavior?

![image](https://user-images.githubusercontent.com/4793020/157476901-09eab295-2032-4e3f-a1f2-c7f2603d4af8.gif)
