### PR TITLE
Misc pointer fixes for wasm

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Manipulation_Tests.cs
@@ -91,7 +91,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 			_app.PinchToZoomInCoordinates(target.Rect.CenterX, target.Rect.CenterY, TimeSpan.FromSeconds(.1));
 
-			var resultStr = _app.Marked("Output").GetDependencyPropertyValue<string>("Text");
+			var resultStr = new QueryEx(q => q.All().Marked("Output")).GetDependencyPropertyValue<string>("Text");
 			var result = Parse(resultStr);
 
 			Assert.AreEqual(2.0, result.cumulative.Scale);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/VisualState_Tests.cs
@@ -103,7 +103,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android, Platform.iOS)] // Failing on WASM: https://github.com/unoplatform/uno/issues/2905
 		public void TestListViewReleasedOut()
 		{
 			Run("UITests.Shared.Windows_UI_Input.VisualStatesTests.ListViewItem");

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Basics.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Basics.xaml
@@ -12,6 +12,7 @@
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="100" />
 			<ColumnDefinition />
+			<ColumnDefinition MaxWidth="250" />
 		</Grid.ColumnDefinitions>
 
 		<StackPanel>
@@ -57,19 +58,29 @@
 			ManipulationInertiaStarting="OnManipInertiaStarting"
 			ManipulationCompleted="OnManipCompleted"/>
 
-		<TextBlock
-			x:Name="Output"
-			Grid.Column="1"
-			FontSize="10"
-			TextWrapping="Wrap"
-			IsHitTestVisible="False" />
+		<ScrollViewer
+			Grid.Column="2"
+			VerticalScrollMode="Auto"
+			VerticalScrollBarVisibility="Auto"
+			HorizontalScrollMode="Auto"
+			HorizontalScrollBarVisibility="Auto">
+			<StackPanel>
+				<TextBlock
+					x:Name="Output"
+					FontSize="10"
+					IsHitTestVisible="False" />
 
-		<TextBlock
-			x:Name="Previous"
-			Grid.Column="1"
-			Margin="0,20,0,0"
-			FontSize="8"
-			TextWrapping="Wrap"
-			IsHitTestVisible="False" />
+				<TextBlock
+					x:Name="MoveOutput"
+					FontSize="8"
+					IsHitTestVisible="False" />
+
+				<TextBlock
+					x:Name="Previous"
+					Margin="0,5,0,0"
+					FontSize="8"
+					IsHitTestVisible="False" />
+			</StackPanel>
+		</ScrollViewer>
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Basics.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Basics.xaml.cs
@@ -78,7 +78,7 @@ namespace UITests.Shared.Windows_UI_Input.GestureRecognizerTests
 			var position = pt.Position;
 			var raw = pt.RawPosition;
 
-			Output.Text += $"{args.Pointer.PointerId}@[{position.X:000.00},{position.Y:000.00}][{raw.X:000.00},{raw.Y:000.00}] ";
+			MoveOutput.Text += $"{args.Pointer.PointerId}@[{position.X:000.00},{position.Y:000.00}][{raw.X:000.00},{raw.Y:000.00}] ";
 		}
 
 		private void OnManipStarting(object sender, ManipulationStartingRoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -387,6 +387,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		private protected override void ChangeVisualState(bool useTransitions)
 		{
+			// !!!!!! WARNING: This method is actually not used (at least on skia and wasm) !!!!!!
+			// cf. UpdateCommonStates instead ...
+
 			base.ChangeVisualState(useTransitions);
 
 			if (IsListViewBaseItem)

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/VisualStatesHelper.h.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/VisualStatesHelper.h.mux.cs
@@ -23,5 +23,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		public int dragItemsCount;
 
 		public FocusState focusState;
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> $"isEnabled: {isEnabled} | isSelected: {isSelected} | isPressed: {isPressed} | isPointerOver: {isPointerOver} | isMultiSelect: {isMultiSelect} | isDragging: {isDragging} | isItemDragPrimary: {isItemDragPrimary} | isInsideListView: {isInsideListView} | isDragVisualCaptured: {isDragVisualCaptured} | isHolding: {isHolding} | canDrag: {canDrag} | canReorder: {canReorder} | isDraggedOver: {isDraggedOver} | dragItemsCount: {dragItemsCount} | focusState: {focusState}"
+		;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.wasm.cs
@@ -29,6 +29,7 @@ namespace Windows.UI.Xaml.Input
 			PointerDeviceType pointerType,
 			Point absolutePosition,
 			bool isInContact,
+			bool isInRange,
 			WindowManagerInterop.HtmlPointerButtonsState buttons,
 			WindowManagerInterop.HtmlPointerButtonUpdate buttonUpdate,
 			VirtualKeyModifiers keys,
@@ -45,7 +46,7 @@ namespace Windows.UI.Xaml.Input
 			_wheel = wheel;
 
 			FrameId = ToFrameId(timestamp);
-			Pointer = new Pointer(pointerId, pointerType, isInContact, isInRange: true);
+			Pointer = new Pointer(pointerId, pointerType, isInContact, isInRange);
 			KeyModifiers = keys;
 			OriginalSource = source;
 		}

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Linq;
 using Uno.UI.Extensions;
 using Windows.Foundation;
 using Windows.UI;
@@ -170,7 +171,7 @@ namespace Uno.UI.Xaml.Core
 		{
 			if (PointerCapture.TryGet(routedArgs.Pointer, out var capture))
 			{
-				foreach (var target in capture.Targets)
+				foreach (var target in capture.Targets.ToList())
 				{
 					target.Element.ReleasePointerCapture(capture.Pointer.UniqueId, kinds: PointerCaptureKind.Any);
 				}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -820,7 +820,9 @@ namespace Windows.UI.Xaml
 					// with an exception for touch which has no notion of "over": if not "in contact" (i.e. no longer touching the screen),
 					// no matter the location, we consider the pointer has out.
 
-					var isOver = (ptArgs.Pointer.PointerDeviceType, ptArgs.Pointer.IsInContact) switch
+					// TODO: Once IsInRange has been implemented on all platform, we can simplify this condition to something like
+					//		 ptArgs.Pointer.IsInRange && ptArgs.IsPointCoordinatesOver(this) (and probably share it on all platforms).
+					var isOver = ptArgs.Pointer.IsInRange && (ptArgs.Pointer.PointerDeviceType, ptArgs.Pointer.IsInContact) switch
 					{
 						(PointerDeviceType.Touch, false) => false,
 						_ => ptArgs.IsPointCoordinatesOver(this),

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -254,15 +254,21 @@ public partial class UIElement : DependencyObject
 		var src = GetElementFromHandle(args.srcHandle) ?? (UIElement)snd;
 		var position = new Point(args.x, args.y);
 		var isInContact = args.buttons != 0;
-		var isInRange = args.Event is cancel ? false
-			: (args.Event & exitOrUp) != 0 ? pointerType switch
-				{
-					PointerDeviceType.Mouse => true, // Mouse is always in range (unless for 'cancel' eg. if it was unplugged from computer)
-					PointerDeviceType.Touch => false, // If we get a pointer out for touch, it means that pointer left the screen (pt up - a.k.a. Implicit capture)
-					PointerDeviceType.Pen => args.hasRelatedTarget, // If the relatedTarget is null it means pointer left the detection range ... but only for out event!
-					_ => !isInContact // Safety!
-				}
-			: true;
+		var isInRange = true;
+		if (args.Event is cancel)
+		{
+			isInRange = false;
+		}
+		else if ((args.Event & exitOrUp) != 0)
+		{
+			isInRange = pointerType switch
+			{
+				PointerDeviceType.Mouse => true, // Mouse is always in range (unless for 'cancel' eg. if it was unplugged from computer)
+				PointerDeviceType.Touch => false, // If we get a pointer out for touch, it means that pointer left the screen (pt up - a.k.a. Implicit capture)
+				PointerDeviceType.Pen => args.hasRelatedTarget, // If the relatedTarget is null it means pointer left the detection range ... but only for out event!
+				_ => !isInContact // Safety!
+			};
+		}
 		var keyModifiers = VirtualKeyModifiers.None;
 		if (args.ctrl) keyModifiers |= VirtualKeyModifiers.Control;
 		if (args.shift) keyModifiers |= VirtualKeyModifiers.Shift;

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -283,6 +283,21 @@ public partial class UIElement : DependencyObject
 	}
 	#endregion
 
+	#region
+
+	partial void OnManipulationModeChanged(ManipulationModes _, ManipulationModes newMode)
+	{
+		if (newMode is ManipulationModes.None or ManipulationModes.System)
+		{
+			ResetStyle("touch-action");
+		}
+		else
+		{
+			// 'none' here means that the browser is not allowed to steal pointer for it's own manipulations
+			SetStyle("touch-action", "none");
+		}
+	}
+
 	#region Capture
 	partial void CapturePointerNative(Pointer pointer)
 	{

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -70,10 +70,6 @@ public partial class UIElement : DependencyObject
 		// Add optional events
 		switch (routedEvent.Flag)
 		{
-			case RoutedEventFlag.PointerMoved when !_subscribedNativeEvents.HasFlag(NativePointerEvent.pointermove):
-				events |= NativePointerEvent.pointermove;
-				break;
-
 			case RoutedEventFlag.PointerWheelChanged when !_subscribedNativeEvents.HasFlag(NativePointerEvent.wheel):
 				events |= NativePointerEvent.wheel;
 				break;
@@ -170,17 +166,17 @@ public partial class UIElement : DependencyObject
 					break;
 				}
 
-				case NativePointerEvent.pointerout: // No needs to check IsOver, it's already done in native code
+				case NativePointerEvent.pointerout: // No needs to check IsOver (leaving vs. bubbling), it's already done in native code
 					stopPropagation = element.OnNativePointerExited(ToPointerArgs(element, args));
 					break;
 
 				case NativePointerEvent.pointerdown:
-					stopPropagation = element.OnNativePointerDown(ToPointerArgs(element, args, isInContact: true));
+					stopPropagation = element.OnNativePointerDown(ToPointerArgs(element, args));
 					break;
 
 				case NativePointerEvent.pointerup:
 				{
-					var routedArgs = ToPointerArgs(element, args, isInContact: false);
+					var routedArgs = ToPointerArgs(element, args);
 					stopPropagation = element.OnNativePointerUp(routedArgs);
 
 					if (stopPropagation)
@@ -192,22 +188,37 @@ public partial class UIElement : DependencyObject
 				}
 
 				case NativePointerEvent.pointermove:
-					stopPropagation = element.OnNativePointerMove(ToPointerArgs(element, args));
+				{
+					var ptArgs = ToPointerArgs(element, args);
+
+					// We do have "implicit capture" for touch and pen on chromium browsers, they won't raise 'pointerout' once in contact,
+					// this means that we need to validate the isOver to raise enter and exit like on UWP.
+					var needsToCheckIsOver = ptArgs.Pointer.PointerDeviceType switch
+					{
+						PointerDeviceType.Touch => ptArgs.Pointer.IsInRange, // If pointer no longer in range, isOver is always false
+						PointerDeviceType.Pen => ptArgs.Pointer.IsInContact, // We can ignore check when only hovering elements, browser does its job in that case
+						PointerDeviceType.Mouse => PointerCapture.TryGet(ptArgs.Pointer, out _), // Browser won't raise pointerenter/out as soon has we have an active capture
+						_ => true // For safety
+					};
+					stopPropagation = needsToCheckIsOver
+						? element.OnNativePointerMoveWithOverCheck(ptArgs, isOver: ptArgs.IsPointCoordinatesOver(element))
+						: element.OnNativePointerMove(ptArgs);
 					break;
+				}
 
 				case NativePointerEvent.pointercancel:
-					stopPropagation = element.OnNativePointerCancel(ToPointerArgs(element, args, isInContact: false), isSwallowedBySystem: true);
+					stopPropagation = element.OnNativePointerCancel(ToPointerArgs(element, args), isSwallowedBySystem: true);
 					break;
 
 				case NativePointerEvent.wheel:
 					if (args.wheelDeltaX is not 0)
 					{
-						stopPropagation |= element.OnNativePointerWheel(ToPointerArgs(element, args, wheel: (true, args.wheelDeltaX), isInContact: null /* maybe */));
+						stopPropagation |= element.OnNativePointerWheel(ToPointerArgs(element, args, wheel: (true, args.wheelDeltaX)));
 					}
 					if (args.wheelDeltaY is not 0)
 					{
 						// Note: Web browser vertical scrolling is the opposite compared to WinUI!
-						stopPropagation |= element.OnNativePointerWheel(ToPointerArgs(element, args, wheel: (false, -args.wheelDeltaY), isInContact: null /* maybe */));
+						stopPropagation |= element.OnNativePointerWheel(ToPointerArgs(element, args, wheel: (false, -args.wheelDeltaY)));
 					}
 					break;
 			}
@@ -233,13 +244,25 @@ public partial class UIElement : DependencyObject
 	private static PointerRoutedEventArgs ToPointerArgs(
 		UIElement snd,
 		NativePointerEventArgs args,
-		bool? isInContact = null,
 		(bool isHorizontalWheel, double delta) wheel = default)
 	{
+		const int cancel = (int)NativePointerEvent.pointercancel;
+		const int exitOrUp = (int)(NativePointerEvent.pointerout | NativePointerEvent.pointerup);
+
 		var pointerId = (uint)args.pointerId;
+		var pointerType = (PointerDeviceType)args.deviceType;
 		var src = GetElementFromHandle(args.srcHandle) ?? (UIElement)snd;
 		var position = new Point(args.x, args.y);
-		var pointerType = ConvertPointerTypeString(args.typeStr);
+		var isInContact = args.buttons != 0;
+		var isInRange = args.Event is cancel ? false
+			: (args.Event & exitOrUp) != 0 ? pointerType switch
+				{
+					PointerDeviceType.Mouse => true, // Mouse is always in range (unless for 'cancel' eg. if it was unplugged from computer)
+					PointerDeviceType.Touch => false, // If we get a pointer out for touch, it means that pointer left the screen (pt up - a.k.a. Implicit capture)
+					PointerDeviceType.Pen => args.hasRelatedTarget, // If the relatedTarget is null it means pointer left the detection range ... but only for out event!
+					_ => !isInContact // Safety!
+				}
+			: true;
 		var keyModifiers = VirtualKeyModifiers.None;
 		if (args.ctrl) keyModifiers |= VirtualKeyModifiers.Control;
 		if (args.shift) keyModifiers |= VirtualKeyModifiers.Shift;
@@ -249,7 +272,8 @@ public partial class UIElement : DependencyObject
 			pointerId,
 			pointerType,
 			position,
-			isInContact ?? ((UIElement)snd).IsPressed(pointerId),
+			isInContact,
+			isInRange,
 			(WindowManagerInterop.HtmlPointerButtonsState)args.buttons,
 			(WindowManagerInterop.HtmlPointerButtonUpdate)args.buttonUpdate,
 			keyModifiers,
@@ -257,54 +281,19 @@ public partial class UIElement : DependencyObject
 			wheel,
 			src);
 	}
-
-	private static PointerDeviceType ConvertPointerTypeString(string typeStr)
-	{
-		PointerDeviceType type;
-		switch (typeStr.ToUpper())
-		{
-			case "MOUSE":
-			default:
-				type = PointerDeviceType.Mouse;
-				break;
-			// Note: As of 2019-11-28, once pen pressed events pressed/move/released are reported as TOUCH on Firefox
-			//		 https://bugzilla.mozilla.org/show_bug.cgi?id=1449660
-			case "PEN":
-				type = PointerDeviceType.Pen;
-				break;
-			case "TOUCH":
-				type = PointerDeviceType.Touch;
-				break;
-		}
-
-		return type;
-	}
 	#endregion
 
 	#region Capture
-	partial void OnManipulationModeChanged(ManipulationModes _, ManipulationModes newMode)
-		=> SetStyle("touch-action", newMode == ManipulationModes.None ? "none" : "auto");
-
 	partial void CapturePointerNative(Pointer pointer)
 	{
 		var command = "Uno.UI.WindowManager.current.setPointerCapture(" + HtmlId + ", " + pointer.PointerId + ");";
 		WebAssemblyRuntime.InvokeJS(command);
-
-		if (pointer.PointerDeviceType != PointerDeviceType.Mouse)
-		{
-			SetStyle("touch-action", "none");
-		}
 	}
 
 	partial void ReleasePointerNative(Pointer pointer)
 	{
 		var command = "Uno.UI.WindowManager.current.releasePointerCapture(" + HtmlId + ", " + pointer.PointerId + ");";
 		WebAssemblyRuntime.InvokeJS(command);
-
-		if (pointer.PointerDeviceType != PointerDeviceType.Mouse && ManipulationMode != ManipulationModes.None)
-		{
-			SetStyle("touch-action", "auto");
-		}
 	}
 	#endregion
 
@@ -368,20 +357,14 @@ public partial class UIElement : DependencyObject
 
 	private void ApplyHitTestVisibility(HitTestability value)
 	{
-		if (value == HitTestability.Visible)
-		{
-			// By default, elements have 'pointer-event' set to 'auto' (see Uno.UI.css .uno-uielement class).
-			// This means that they can be the target of hit-testing and will raise pointer events when interacted with.
-			// This is aligned with HitTestVisibilityProperty's default value of Visible.
-			WindowManagerInterop.SetPointerEvents(HtmlId, true);
-		}
-		else
-		{
-			// If HitTestVisibilityProperty is calculated to Invisible or Collapsed,
-			// we don't want to be the target of hit-testing and raise any pointer events.
-			// This is done by setting 'pointer-events' to 'none'.
-			WindowManagerInterop.SetPointerEvents(HtmlId, false);
-		}
+		// By default, elements have 'pointer-event' set to 'none' (see Uno.UI.css .uno-uielement class)
+		// which is aligned with HitTestVisibilityProperty's default value of Visible.
+		// If HitTestVisibilityProperty is calculated to Invisible or Collapsed,
+		// we don't want to be the target of hit-testing and raise any pointer events.
+		// This is done by setting 'pointer-events' to 'none'.
+		// However setting it to 'none' will allow pointer event to pass through the element (a.k.a. Invisible)
+
+		WindowManagerInterop.SetPointerEvents(HtmlId, value is HitTestability.Visible);
 
 		if (FeatureConfiguration.UIElement.AssignDOMXamlProperties)
 		{
@@ -428,16 +411,17 @@ public partial class UIElement : DependencyObject
 		public bool shift;
 		public int buttons;
 		public int buttonUpdate;
-		public string typeStr;
+		public int deviceType;
 		public int srcHandle;
 		public double timestamp;
 		public double pressure;
 		public double wheelDeltaX;
 		public double wheelDeltaY;
+		public bool hasRelatedTarget;
 
 		/// <inheritdoc />
 		public override string ToString()
-			=> $"elt={HtmlId}|evt={(NativePointerEvent)Event}|id={pointerId}|x={x}|y={x}|ctrl={ctrl}|shift={shift}|bts={buttons}|btUpdate={buttonUpdate}|tyep={typeStr}|srcId={srcHandle}|ts={timestamp}|pres={pressure}|wheelX={wheelDeltaX}|wheelY={wheelDeltaY}";
+			=> $"elt={HtmlId}|evt={(NativePointerEvent)Event}|id={pointerId}|x={x}|y={x}|ctrl={ctrl}|shift={shift}|bts={buttons}|btUpdate={buttonUpdate}|type={(PointerDeviceType)deviceType}|srcId={srcHandle}|ts={timestamp}|pres={pressure}|wheelX={wheelDeltaX}|wheelY={wheelDeltaY}|relTarget={hasRelatedTarget}";
 	}
 
 	[TSInteropMessage(Marshaller = CodeGeneration.Disabled, UnMarshaller = CodeGeneration.Enabled)]
@@ -458,11 +442,11 @@ public partial class UIElement : DependencyObject
 		pointerdown = 1 << 2,
 		pointerup = 1 << 3,
 		pointercancel = 1 << 4,
+		pointermove = 1 << 5, // Required since when pt is captured, isOver will be maintained by the moveWithOverCheck
 
 		// Optional pointer events
-		pointermove = 1 << 5,
 		wheel = 1 << 6,
 
-		Defaults = pointerover | pointerout | pointerdown | pointerup | pointercancel,
+		Defaults = pointerover | pointerout | pointerdown | pointerup | pointercancel | pointermove,
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.wasm.cs
@@ -283,8 +283,6 @@ public partial class UIElement : DependencyObject
 	}
 	#endregion
 
-	#region
-
 	partial void OnManipulationModeChanged(ManipulationModes _, ManipulationModes newMode)
 	{
 		if (newMode is ManipulationModes.None or ManipulationModes.System)

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -8,11 +8,10 @@ body {
   width: 100%;
   overflow: hidden;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
-
   /*
     Disable **browsers** touche (and pen) manipulations support.
-    Remarks: This has no relation with the UIElement.ManipualtionMode which are handled in managed code.
-             It only ensure that uno will always get ALL pointers events instead of being stollen by the browser for its internal gesture detection.
+    Remarks: This has no relation with the UIElement.ManipulationMode which are handled in managed code.
+             It only ensures that uno will always get ALL pointer events instead of being stolen by the browser for its internal gesture detection.
              This will also disable left and right swipe gesture to navigate through browser's history.
     Remarks 2: If applied only on the root of the app, this won't break the scrolling (unlike if applied on all UIElement).
   */

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -8,6 +8,15 @@ body {
   width: 100%;
   overflow: hidden;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
+
+  /*
+    Disable **browsers** touche (and pen) manipulations support.
+    Remarks: This has no relation with the UIElement.ManipualtionMode which are handled in managed code.
+             It only ensure that uno will always get ALL pointers events instead of being stollen by the browser for its internal gesture detection.
+             This will also disable left and right swipe gesture to navigate through browser's history.
+    Remarks 2: If applied only on the root of the app, this won't break the scrolling (unlike if applied on all UIElement).
+  */
+  touch-action: none;
 }
 
 .uno-root-element {
@@ -22,8 +31,7 @@ body {
   display: inline;
   outline: none;
   /*
-      Disable pointer events by default to match HitTestVisibilityProperty
-      default value
+    Disable pointer events by default to match HitTestVisibilityProperty default value.
   */
   pointer-events: none;
   /*
@@ -178,7 +186,7 @@ embed.uno-frameworkelement.uno-unarranged {
 
   .uno-scrollcontentpresenter.scroll-x-hidden {
     overflow-x: auto; /* We must not use "hidden" to allow native scrolling interaction like mouse wheel */
-    scrollbar-width: none; /* scrollbar-height has no effect on FF, using scrollbar-width works on all browsers (non standard proeprty) */
+    scrollbar-width: none; /* scrollbar-height has no effect on FF, using scrollbar-width works on all browsers (non standard property) */
   }
 
   .uno-scrollcontentpresenter.scroll-x-hidden::-webkit-scrollbar {

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -1014,7 +1014,7 @@ declare namespace Uno.Storage {
 }
 declare namespace Windows.Storage {
     class StorageFolder {
-        private static _isInit;
+        private static _isInitialized;
         private static _isSynchronizing;
         private static dispatchStorageInitialized;
         /**
@@ -1031,7 +1031,9 @@ declare namespace Windows.Storage {
         static setupStorage(path: string): void;
         private static onStorageInitialized;
         /**
-         * Synchronize the IDBFS memory cache back to IndexDB
+         * Synchronize the IDBFS memory cache back to IndexedDB
+         * populate: requests the filesystem to be popuplated from the IndexedDB
+         * onSynchronized: function invoked when the synchronization finished
          * */
         private static synchronizeFileSystem;
     }
@@ -1187,6 +1189,13 @@ declare namespace Windows.UI.Xaml {
         Dark = "Dark"
     }
 }
+declare namespace Windows.Devices.Input {
+    enum PointerDeviceType {
+        Touch = 0,
+        Pen = 1,
+        Mouse = 2
+    }
+}
 declare namespace Windows.UI.Xaml {
     enum NativePointerEvent {
         pointerover = 1,
@@ -1212,6 +1221,7 @@ declare namespace Windows.UI.Xaml {
         private static get wheelLineSize();
         private static toNativePointerEventArgs;
         private static toNativeEvent;
+        private static toPointerDeviceType;
     }
 }
 declare namespace Windows.UI.Xaml {
@@ -1598,12 +1608,13 @@ declare namespace Windows.UI.Xaml {
         shift: boolean;
         buttons: number;
         buttonUpdate: number;
-        typeStr: string;
+        deviceType: number;
         srcHandle: number;
         timestamp: number;
         pressure: number;
         wheelDeltaX: number;
         wheelDeltaY: number;
+        hasRelatedTarget: boolean;
         marshal(pData: number): void;
     }
 }

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -742,6 +742,13 @@ declare namespace Windows.Devices.Geolocation {
         private static getAccurateCurrentPosition;
     }
 }
+declare module Windows.Devices.Input {
+    enum PointerDeviceType {
+        Touch = 0,
+        Pen = 1,
+        Mouse = 2
+    }
+}
 declare namespace Windows.Devices.Midi {
     class MidiInPort {
         private static dispatchMessage;
@@ -1187,13 +1194,6 @@ declare namespace Windows.UI.Xaml {
     enum ApplicationTheme {
         Light = "Light",
         Dark = "Dark"
-    }
-}
-declare namespace Windows.Devices.Input {
-    enum PointerDeviceType {
-        Touch = 0,
-        Pen = 1,
-        Mouse = 2
     }
 }
 declare namespace Windows.UI.Xaml {

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -2418,6 +2418,21 @@ var Windows;
 (function (Windows) {
     var Devices;
     (function (Devices) {
+        var Input;
+        (function (Input) {
+            let PointerDeviceType;
+            (function (PointerDeviceType) {
+                PointerDeviceType[PointerDeviceType["Touch"] = 0] = "Touch";
+                PointerDeviceType[PointerDeviceType["Pen"] = 1] = "Pen";
+                PointerDeviceType[PointerDeviceType["Mouse"] = 2] = "Mouse";
+            })(PointerDeviceType = Input.PointerDeviceType || (Input.PointerDeviceType = {}));
+        })(Input = Devices.Input || (Devices.Input = {}));
+    })(Devices = Windows.Devices || (Windows.Devices = {}));
+})(Windows || (Windows = {}));
+var Windows;
+(function (Windows) {
+    var Devices;
+    (function (Devices) {
         var Midi;
         (function (Midi) {
             class MidiInPort {
@@ -4267,20 +4282,6 @@ var Windows;
     })(UI = Windows.UI || (Windows.UI = {}));
 })(Windows || (Windows = {}));
 var Windows;
-(function (Windows) {
-    var Devices;
-    (function (Devices) {
-        var Input;
-        (function (Input) {
-            let PointerDeviceType;
-            (function (PointerDeviceType) {
-                PointerDeviceType[PointerDeviceType["Touch"] = 0] = "Touch";
-                PointerDeviceType[PointerDeviceType["Pen"] = 1] = "Pen";
-                PointerDeviceType[PointerDeviceType["Mouse"] = 2] = "Mouse";
-            })(PointerDeviceType = Input.PointerDeviceType || (Input.PointerDeviceType = {}));
-        })(Input = Devices.Input || (Devices.Input = {}));
-    })(Devices = Windows.Devices || (Windows.Devices = {}));
-})(Windows || (Windows = {}));
 (function (Windows) {
     var UI;
     (function (UI) {

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -3499,12 +3499,12 @@ var Windows;
                 FS.mkdir(path);
                 FS.mount(IDBFS, {}, path);
                 // Ensure to sync pseudo file system on unload (and periodically for safety)
-                if (!this._isInit) {
+                if (!this._isInitialized) {
                     // Request an initial sync to populate the file system
-                    StorageFolder.synchronizeFileSystem();
-                    window.addEventListener("beforeunload", this.synchronizeFileSystem);
+                    StorageFolder.synchronizeFileSystem(true, () => StorageFolder.onStorageInitialized());
+                    window.addEventListener("beforeunload", () => this.synchronizeFileSystem(false));
                     setInterval(this.synchronizeFileSystem, 10000);
-                    this._isInit = true;
+                    this._isInitialized = true;
                 }
             }
             static onStorageInitialized() {
@@ -3515,13 +3515,18 @@ var Windows;
                 StorageFolder.dispatchStorageInitialized();
             }
             /**
-             * Synchronize the IDBFS memory cache back to IndexDB
+             * Synchronize the IDBFS memory cache back to IndexedDB
+             * populate: requests the filesystem to be popuplated from the IndexedDB
+             * onSynchronized: function invoked when the synchronization finished
              * */
-            static synchronizeFileSystem() {
+            static synchronizeFileSystem(populate, onSynchronized = null) {
                 if (!StorageFolder._isSynchronizing) {
                     StorageFolder._isSynchronizing = true;
-                    FS.syncfs(err => {
+                    FS.syncfs(populate, err => {
                         StorageFolder._isSynchronizing = false;
+                        if (onSynchronized) {
+                            onSynchronized();
+                        }
                         if (err) {
                             console.error(`Error synchronizing filesystem from IndexDB: ${err} (errno: ${err.errno})`);
                         }
@@ -3529,7 +3534,7 @@ var Windows;
                 }
             }
         }
-        StorageFolder._isInit = false;
+        StorageFolder._isInitialized = false;
         StorageFolder._isSynchronizing = false;
         Storage.StorageFolder = StorageFolder;
     })(Storage = Windows.Storage || (Windows.Storage = {}));
@@ -4263,12 +4268,27 @@ var Windows;
 })(Windows || (Windows = {}));
 var Windows;
 (function (Windows) {
+    var Devices;
+    (function (Devices) {
+        var Input;
+        (function (Input) {
+            let PointerDeviceType;
+            (function (PointerDeviceType) {
+                PointerDeviceType[PointerDeviceType["Touch"] = 0] = "Touch";
+                PointerDeviceType[PointerDeviceType["Pen"] = 1] = "Pen";
+                PointerDeviceType[PointerDeviceType["Mouse"] = 2] = "Mouse";
+            })(PointerDeviceType = Input.PointerDeviceType || (Input.PointerDeviceType = {}));
+        })(Input = Devices.Input || (Devices.Input = {}));
+    })(Devices = Windows.Devices || (Windows.Devices = {}));
+})(Windows || (Windows = {}));
+(function (Windows) {
     var UI;
     (function (UI) {
         var Xaml;
         (function (Xaml) {
             var WindowManager = Uno.UI.WindowManager;
             var HtmlEventDispatchResult = Uno.UI.HtmlEventDispatchResult;
+            var PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
             let NativePointerEvent;
             (function (NativePointerEvent) {
                 NativePointerEvent[NativePointerEvent["pointerover"] = 1] = "pointerover";
@@ -4351,12 +4371,15 @@ var Windows;
                 }
                 static onPointerOutReceived(evt) {
                     const element = evt.currentTarget;
-                    if (evt.isDirectlyOver(element)) {
+                    if (evt.relatedTarget && evt.isDirectlyOver(element)) {
                         // The 'pointerout' event is bubbling so we get the event when the pointer is going out of a nested element,
                         // but pointer is still over the current element.
                         // So here we check if the event is effectively because the pointer is leaving the bounds of the current element.
                         // If not, we stopPropagation so parent won't have to check it again and again.
                         // Note: We don't have to do that for the "enter" as we anyway maintain the IsOver state in managed.
+                        // Note: If relatedTarget is null it means that pointer is no longer on the app at all
+                        //		 (alt + tab for mouse, finger removed from screen, pen out of detection range)
+                        //		 If so, we have to forward the exit in all cases.
                         evt.stopPropagation();
                         return;
                     }
@@ -4428,7 +4451,7 @@ var Windows;
                     let wheelDeltaX, wheelDeltaY;
                     if (evt instanceof WheelEvent) {
                         pointerId = evt.mozInputSource ? 0 : 1; // Try to match the mouse pointer ID 0 for FF, 1 for others
-                        pointerType = "mouse";
+                        pointerType = PointerDeviceType.Mouse;
                         pressure = 0.5; // like WinUI
                         wheelDeltaX = evt.deltaX;
                         wheelDeltaY = evt.deltaY;
@@ -4446,7 +4469,7 @@ var Windows;
                     }
                     else {
                         pointerId = evt.pointerId;
-                        pointerType = evt.pointerType;
+                        pointerType = Xaml.UIElement.toPointerDeviceType(evt.pointerType);
                         pressure = evt.pressure;
                         wheelDeltaX = 0;
                         wheelDeltaY = 0;
@@ -4458,9 +4481,10 @@ var Windows;
                     args.y = evt.clientY;
                     args.ctrl = evt.ctrlKey;
                     args.shift = evt.shiftKey;
+                    args.hasRelatedTarget = evt.relatedTarget !== null;
                     args.buttons = evt.buttons;
                     args.buttonUpdate = evt.button;
-                    args.typeStr = pointerType;
+                    args.deviceType = pointerType;
                     args.srcHandle = Number(srcHandle);
                     args.timestamp = evt.timeStamp;
                     args.pressure = pressure;
@@ -4486,6 +4510,19 @@ var Windows;
                             return NativePointerEvent.wheel;
                         default:
                             return undefined;
+                    }
+                }
+                static toPointerDeviceType(type) {
+                    switch (type) {
+                        case "touch":
+                            return PointerDeviceType.Touch;
+                        case "pen":
+                            // Note: As of 2019-11-28, once pen pressed events pressed/move/released are reported as TOUCH on Firefox
+                            //		 https://bugzilla.mozilla.org/show_bug.cgi?id=1449660
+                            return PointerDeviceType.Pen;
+                        case "mouse":
+                        default:
+                            return PointerDeviceType.Mouse;
                     }
                 }
             }
@@ -5876,17 +5913,13 @@ var Windows;
                     Module.setValue(pData + 36, this.shift, "i32");
                     Module.setValue(pData + 40, this.buttons, "i32");
                     Module.setValue(pData + 44, this.buttonUpdate, "i32");
-                    {
-                        const stringLength = lengthBytesUTF8(this.typeStr);
-                        const pString = Module._malloc(stringLength + 1);
-                        stringToUTF8(this.typeStr, pString, stringLength + 1);
-                        Module.setValue(pData + 48, pString, "*");
-                    }
+                    Module.setValue(pData + 48, this.deviceType, "i32");
                     Module.setValue(pData + 52, this.srcHandle, "i32");
                     Module.setValue(pData + 56, this.timestamp, "double");
                     Module.setValue(pData + 64, this.pressure, "double");
                     Module.setValue(pData + 72, this.wheelDeltaX, "double");
                     Module.setValue(pData + 80, this.wheelDeltaY, "double");
+                    Module.setValue(pData + 88, this.hasRelatedTarget, "i32");
                 }
             }
             Xaml.NativePointerEventArgs = NativePointerEventArgs;

--- a/src/Uno.UI/ts/Windows/Devices/Input/PointerDeviceType.ts
+++ b/src/Uno.UI/ts/Windows/Devices/Input/PointerDeviceType.ts
@@ -1,0 +1,7 @@
+﻿module Windows.Devices.Input {
+	export enum PointerDeviceType {
+		Touch = 0,
+		Pen = 1,
+		Mouse = 2,
+	}
+}

--- a/src/Uno.UI/ts/Windows/UI/Xaml/UIElement.Pointers.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/UIElement.Pointers.ts
@@ -1,12 +1,4 @@
-﻿namespace Windows.Devices.Input {
-	export enum PointerDeviceType {
-		Touch = 0,
-		Pen = 1,
-		Mouse = 2,
-	}
-}
-
-namespace Windows.UI.Xaml {
+﻿namespace Windows.UI.Xaml {
 	import WindowManager = Uno.UI.WindowManager;
 	import HtmlEventDispatchResult = Uno.UI.HtmlEventDispatchResult;
 	import PointerDeviceType = Windows.Devices.Input.PointerDeviceType;

--- a/src/Uno.UI/ts/Windows/UI/Xaml/UIElement.Pointers.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/UIElement.Pointers.ts
@@ -9,7 +9,7 @@
 namespace Windows.UI.Xaml {
 	import WindowManager = Uno.UI.WindowManager;
 	import HtmlEventDispatchResult = Uno.UI.HtmlEventDispatchResult;
-	import PointerDeviceType = Devices.Input.PointerDeviceType;
+	import PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 
 	export enum NativePointerEvent {
 		pointerover = 1,

--- a/src/Uno.UI/ts/Windows/UI/Xaml/UIElement.Pointers.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/UIElement.Pointers.ts
@@ -1,6 +1,15 @@
-﻿namespace Windows.UI.Xaml {
+﻿namespace Windows.Devices.Input {
+	export enum PointerDeviceType {
+		Touch = 0,
+		Pen = 1,
+		Mouse = 2,
+	}
+}
+
+namespace Windows.UI.Xaml {
 	import WindowManager = Uno.UI.WindowManager;
 	import HtmlEventDispatchResult = Uno.UI.HtmlEventDispatchResult;
+	import PointerDeviceType = Devices.Input.PointerDeviceType;
 
 	export enum NativePointerEvent {
 		pointerover = 1,
@@ -99,12 +108,15 @@
 		private static onPointerOutReceived(evt: PointerEvent): void {
 			const element = evt.currentTarget as HTMLElement | SVGElement;
 
-			if (evt.isDirectlyOver(element)) {
+			if (evt.relatedTarget && evt.isDirectlyOver(element)) {
 				// The 'pointerout' event is bubbling so we get the event when the pointer is going out of a nested element,
 				// but pointer is still over the current element.
 				// So here we check if the event is effectively because the pointer is leaving the bounds of the current element.
 				// If not, we stopPropagation so parent won't have to check it again and again.
 				// Note: We don't have to do that for the "enter" as we anyway maintain the IsOver state in managed.
+				// Note: If relatedTarget is null it means that pointer is no longer on the app at all
+				//		 (alt + tab for mouse, finger removed from screen, pen out of detection range)
+				//		 If so, we have to forward the exit in all cases.
 				evt.stopPropagation();
 				return;
 			}
@@ -186,11 +198,11 @@
 				src = src.parentElement;
 			}
 
-			let pointerId: number, pointerType: string, pressure: number;
+			let pointerId: number, pointerType: PointerDeviceType, pressure: number;
 			let wheelDeltaX: number, wheelDeltaY: number;
 			if (evt instanceof WheelEvent) {
 				pointerId = (evt as any).mozInputSource ? 0 : 1; // Try to match the mouse pointer ID 0 for FF, 1 for others
-				pointerType = "mouse";
+				pointerType = PointerDeviceType.Mouse;
 				pressure = 0.5; // like WinUI
 				wheelDeltaX = evt.deltaX;
 				wheelDeltaY = evt.deltaY;
@@ -208,7 +220,7 @@
 				}
 			} else {
 				pointerId = evt.pointerId;
-				pointerType = evt.pointerType;
+				pointerType = UIElement.toPointerDeviceType(evt.pointerType);
 				pressure = evt.pressure;
 				wheelDeltaX = 0;
 				wheelDeltaY = 0;
@@ -221,9 +233,10 @@
 			args.y = evt.clientY;
 			args.ctrl = evt.ctrlKey;
 			args.shift = evt.shiftKey;
+			args.hasRelatedTarget = evt.relatedTarget !== null;
 			args.buttons = evt.buttons;
 			args.buttonUpdate = evt.button;
-			args.typeStr = pointerType;
+			args.deviceType = pointerType;
 			args.srcHandle = Number(srcHandle);
 			args.timestamp = evt.timeStamp;
 			args.pressure = pressure;
@@ -251,6 +264,20 @@
 					return NativePointerEvent.wheel;
 				default:
 					return undefined;
+			}
+		}
+
+		private static toPointerDeviceType(type: string): PointerDeviceType {
+			switch (type) {
+				case "touch":
+					return PointerDeviceType.Touch;
+				case "pen":
+					// Note: As of 2019-11-28, once pen pressed events pressed/move/released are reported as TOUCH on Firefox
+					//		 https://bugzilla.mozilla.org/show_bug.cgi?id=1449660
+					return PointerDeviceType.Pen;
+				case "mouse":
+				default:
+					return PointerDeviceType.Mouse;
 			}
 		}
 		//#endregion

--- a/src/Uno.UI/tsBindings/Windows_UI_Xaml_NativePointerEventArgs.ts
+++ b/src/Uno.UI/tsBindings/Windows_UI_Xaml_NativePointerEventArgs.ts
@@ -13,12 +13,13 @@ namespace Windows.UI.Xaml
 		public shift : boolean;
 		public buttons : number;
 		public buttonUpdate : number;
-		public typeStr : string;
+		public deviceType : number;
 		public srcHandle : number;
 		public timestamp : number;
 		public pressure : number;
 		public wheelDeltaX : number;
 		public wheelDeltaY : number;
+		public hasRelatedTarget : boolean;
 		public marshal(pData:number)
 		{
 			Module.setValue(pData + 0, this.HtmlId, "*");
@@ -30,18 +31,13 @@ namespace Windows.UI.Xaml
 			Module.setValue(pData + 36, this.shift, "i32");
 			Module.setValue(pData + 40, this.buttons, "i32");
 			Module.setValue(pData + 44, this.buttonUpdate, "i32");
-			
-			{
-				const stringLength = lengthBytesUTF8(this.typeStr);
-				const pString = Module._malloc(stringLength + 1);
-				stringToUTF8(this.typeStr, pString, stringLength + 1);
-				Module.setValue(pData + 48, pString, "*");
-			}
+			Module.setValue(pData + 48, this.deviceType, "i32");
 			Module.setValue(pData + 52, this.srcHandle, "i32");
 			Module.setValue(pData + 56, this.timestamp, "double");
 			Module.setValue(pData + 64, this.pressure, "double");
 			Module.setValue(pData + 72, this.wheelDeltaX, "double");
 			Module.setValue(pData + 80, this.wheelDeltaY, "double");
+			Module.setValue(pData + 88, this.hasRelatedTarget, "i32");
 		}
 	}
 }

--- a/src/Uno.UWP/Devices/Input/PointerDeviceType.cs
+++ b/src/Uno.UWP/Devices/Input/PointerDeviceType.cs
@@ -6,6 +6,8 @@ namespace Windows.Devices.Input
 {
 	public enum PointerDeviceType
 	{
+		// WARNING: This enum has a corresponding version in TypeScript!
+
 		/// <summary>
 		/// A touch-enabled device
 		/// </summary>

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -157,9 +157,9 @@ namespace Windows.UI.Input
 				var recognized = TryRecognizeRightTap() // We check right tap first as for touch a right tap is a press and hold of the finger :)
 					|| TryRecognizeTap();
 
-				if (!recognized && _recognizer._log.IsEnabled(LogLevel.Information))
+				if (!recognized && _recognizer._log.IsEnabled(LogLevel.Debug))
 				{
-					_recognizer._log.Info("No gesture recognized");
+					_recognizer._log.Debug("No gesture recognized");
 				}
 			}
 

--- a/src/Uno.UWP/UI/Input/PointerPointProperties.cs
+++ b/src/Uno.UWP/UI/Input/PointerPointProperties.cs
@@ -71,6 +71,9 @@ namespace Windows.UI.Input
 		}
 #endif
 
+		/// <summary>
+		/// This is actually equivalent to pointer.IsInContact
+		/// </summary>
 		internal bool HasPressedButton => IsLeftButtonPressed || IsMiddleButtonPressed || IsRightButtonPressed || IsXButton1Pressed || IsXButton2Pressed || IsBarrelButtonPressed;
 
 		public bool IsPrimary { get; internal set; }


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/2905
closes https://github.com/unoplatform/uno/issues/8073
closes https://github.com/unoplatform/nventive-private/issues/350

## Bugfix
Multiple fixed regarding pointerExit
* Make sure to always raise and bubble exit if pointer is leaving the detection range (touch and pen)
* Manually track element bounds crossing while pointer is captured (mouse) or even just pressed (touch and pen) and raise enter/exit accordingly
* Prevent browser from stealing touch and pen after few moves for its internal gesture recognition

General fix regarding pointer captures:
* Fix possible enumeration of a modified collection

## What is the current behavior?
`pointerout` is not raised as expected by the browser or filtered out on some invalid criteria, resulting in the `Pointer<Entered|Exited>` not being fired properly (driving some invalid visual states).

## What is the new behavior?
🙃

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
