### PR TITLE
fix: Point users to MUX version of ColorPicker

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ColorPicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ColorPicker.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class ColorPicker : global::Windows.UI.Xaml.Controls.Control
@@ -425,13 +425,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.ColorPicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color?)));
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public ColorPicker() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.ColorPicker", "ColorPicker.ColorPicker()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.ColorPicker.ColorPicker()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ColorPicker.ColorPicker()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ColorPicker.Color.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.ColorPicker.Color.set

--- a/src/Uno.UI/UI/Xaml/Controls/Unsupported/ColorPicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Unsupported/ColorPicker.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Windows.UI.Xaml.Controls;
+
+[Obsolete(
+		"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+		"Please use Microsoft.UI.Xaml.Controls.ColorPicker instead.")]
+public partial class ColorPicker
+{
+	public ColorPicker()
+	{
+		throw new NotImplementedException(
+			"The Windows.UI.Xaml.Controls version of this control is not supported. " +
+			"Please use Microsoft.UI.Xaml.Controls.ColorPicker instead.");
+	}
+}

--- a/src/Uno.WinUIRevert/Program.cs
+++ b/src/Uno.WinUIRevert/Program.cs
@@ -84,6 +84,7 @@ namespace UnoWinUIRevert
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\ToggleSplitButtonAutomationPeer.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\TreeView.cs"),
 				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\TwoPaneView.cs"),
+				Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Controls\Unsupported\ColorPicker.cs"),
 			};
 			DeleteFiles(duplicatedImplementations);
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8305

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

WUX `ColorPicker` is normally usable

## What is the new behavior?

WUX `ColorPicker` throws and notifies user to use MUX `ColorPicker`.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.