### PR TITLE
color animation theming fix

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ColorAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ColorAnimationUsingKeyFrames.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_ColorAnimationUsingKeyFrames
+	{
+		[TestMethod]
+		public async Task When_ThemeChanged_WithColorBinding()
+		{
+			var page = new TestPages.ColorAnimationPage();
+			WindowHelper.WindowContent = page;
+			await WindowHelper.WaitForLoaded(page);
+			await WindowHelper.WaitForIdle();
+
+			// minor delay added, so the "State1" visual-state applied on Page.Loaded have time to complete
+			await Task.Delay(1000);
+
+			Assert.AreEqual(Colors.Green, (page.Rect3.Fill as SolidColorBrush).Color);
+
+			using (ThemeHelper.UseDarkTheme())
+			{
+				await WindowHelper.WaitForIdle();
+				
+				Assert.AreEqual(Colors.Blue, (page.Rect3.Fill as SolidColorBrush).Color);
+			}
+		}
+
+		[TestMethod]
+		public async Task When_ThemeChanged_WithBrushBinding_AndColorPath()
+		{
+			var page = new TestPages.ColorAnimationPage();
+			WindowHelper.WindowContent = page;
+			await WindowHelper.WaitForLoaded(page);
+			await WindowHelper.WaitForIdle();
+
+			// minor delay added, so the "State1" visual-state applied on Page.Loaded have time to complete
+			await Task.Delay(1000);
+
+			Assert.AreEqual(Colors.Green, (page.Rect4.Fill as SolidColorBrush).Color);
+
+			using (ThemeHelper.UseDarkTheme())
+			{
+				await WindowHelper.WaitForIdle();
+				
+				Assert.AreEqual(Colors.Blue, (page.Rect4.Fill as SolidColorBrush).Color);
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/TestPages/ColorAnimationPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/TestPages/ColorAnimationPage.xaml
@@ -1,0 +1,61 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation.TestPages.ColorAnimationPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.ThemeDictionaries>
+				<ResourceDictionary x:Key="Light">
+					<Color x:Key="GreenBlueThemeColor">Green</Color>
+				</ResourceDictionary>
+				<ResourceDictionary x:Key="Dark">
+					<Color x:Key="GreenBlueThemeColor">Blue</Color>
+				</ResourceDictionary>
+			</ResourceDictionary.ThemeDictionaries>
+			<SolidColorBrush x:Key="GreenBlueThemeColor_Brush" Color="{ThemeResource GreenBlueThemeColor}" />
+
+			<Style x:Key="SmallRedRectangleStyle" TargetType="Rectangle">
+				<Setter Property="Width" Value="25" />
+				<Setter Property="Height" Value="25" />
+				<Setter Property="Fill" Value="Red" />
+			</Style>
+		</ResourceDictionary>
+	</Page.Resources>
+
+	<Grid>
+		<StackPanel Spacing="2" HorizontalAlignment="Left">
+
+			<Rectangle x:Name="Rect3"
+					   x:FieldModifier="Public"
+					   Style="{StaticResource SmallRedRectangleStyle}" />
+			<Rectangle x:Name="Rect4"
+					   x:FieldModifier="Public"
+					   Style="{StaticResource SmallRedRectangleStyle}" />
+
+			<StackPanel Orientation="Horizontal">
+				<Button Content="State1" Click="SetPageState" />
+				<Button Content="State2" Click="SetPageState" />
+			</StackPanel>
+
+		</StackPanel>
+
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup x:Name="TestStates">
+				<VisualState x:Name="State1">
+					<Storyboard>
+						<ColorAnimationUsingKeyFrames Storyboard.TargetName="Rect3" Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)">
+							<LinearColorKeyFrame KeyTime="0" Value="{ThemeResource GreenBlueThemeColor}" />
+						</ColorAnimationUsingKeyFrames>
+						<ColorAnimationUsingKeyFrames Storyboard.TargetName="Rect4" Storyboard.TargetProperty="(Shape.Fill).(SolidColorBrush.Color)">
+							<LinearColorKeyFrame KeyTime="0" Value="{Binding Color, Source={StaticResource GreenBlueThemeColor_Brush}}" />
+						</ColorAnimationUsingKeyFrames>
+					</Storyboard>
+				</VisualState>
+				<VisualState x:Name="State2" />
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/TestPages/ColorAnimationPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/TestPages/ColorAnimationPage.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation.TestPages
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class ColorAnimationPage : Page
+	{
+		public ColorAnimationPage()
+		{
+			this.InitializeComponent();
+			this.Loaded += (s, e) => VisualStateManager.GoToState(this, "State1", true);
+		}
+
+		private void SetPageState(object sender, RoutedEventArgs e)
+		{
+			VisualStateManager.GoToState(this, (sender as Button).Content.ToString(), true);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimationUsingKeyFrames.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimationUsingKeyFrames.Android.cs
@@ -22,8 +22,16 @@ namespace Windows.UI.Xaml.Media.Animation
 				SetValue(newValue);
 				return;
 			}
-
-			// TODO
+			// TODO: https://github.com/unoplatform/uno/issues/2947
+			else
+			{
+				// since there is no gpu-bound implementation,
+				// make sure at least a value is set when the animation is ended/paused.
+				if (!currentAnimator.IsRunning)
+				{
+					SetValue(_finalValue);
+				}
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ColorKeyFrameCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ColorKeyFrameCollection.cs
@@ -9,10 +9,6 @@ namespace Windows.UI.Xaml.Media.Animation
 		{
 		}
 
-		internal ColorKeyFrameCollection(DependencyObject owner, bool isAutoPropertyInheritanceEnabled) : base(owner,  isAutoPropertyInheritanceEnabled)
-		{
-		}
-
 		// Following members are for binary backward compatibility. They can be safely remove in an eventual "breaking" new version.
 		public new uint Size => base.Size;
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
@@ -1,4 +1,4 @@
-﻿using Uno.Extensions;
+using Uno.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -15,7 +15,7 @@ using System.Diagnostics;
 namespace Windows.UI.Xaml.Media.Animation
 {
 	[ContentProperty(Name = "Children")]
-	public sealed partial class Storyboard : Timeline, ITimeline, IAdditionalChildrenProvider, IThemeChangeAware, ITimelineListener
+	public sealed partial class Storyboard : Timeline, ITimeline, IAdditionalChildrenProvider, ITimelineListener
 	{
 		private static readonly IEventProvider _trace = Tracing.Get(TraceProvider.Id);
 		private EventActivity _traceActivity;
@@ -364,7 +364,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		IEnumerable<DependencyObject> IAdditionalChildrenProvider.GetAdditionalChildObjects() => Children;
 
-		void IThemeChangeAware.OnThemeChanged()
+		private protected override void OnThemeChanged()
 		{
 			if (State == TimelineState.Filling)
 			{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -11,7 +11,7 @@ using System.Diagnostics;
 
 namespace Windows.UI.Xaml.Media.Animation
 {
-	public partial class Timeline : DependencyObject, ITimeline
+	public partial class Timeline : DependencyObject, ITimeline, IThemeChangeAware
 	{
 		private WeakReference<DependencyObject> _targetElement;
 		private BindingPath _propertyInfo;
@@ -413,6 +413,10 @@ namespace Windows.UI.Xaml.Media.Animation
 			Dispose(true);
 			GC.SuppressFinalize(this);
 		}
+
+		void IThemeChangeAware.OnThemeChanged() => OnThemeChanged();
+
+		private protected virtual void OnThemeChanged() { }
 
 		~Timeline()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7096, closes #8214

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

ColorAnimationUsingKeyFrame now properly supports theme changing.
Fixed an issue where gpu-bound color animation doesn't set value on droid.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

<!-- Please provide any additional information if necessary -->