### PR TITLE
[iOS] Fixed a regression caused by Measure Dirty Path

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -41,12 +41,6 @@ namespace Windows.UI.Xaml
 
 		public override void LayoutSubviews()
 		{
-			if (Visibility == Visibility.Collapsed)
-			{
-				// //Don't layout collapsed views
-				return;
-			}
-
 			try
 			{
 				try
@@ -56,10 +50,11 @@ namespace Windows.UI.Xaml
 					if (IsMeasureDirty)
 					{
 						// Add back the Margin (which is normally 'outside' the view's bounds) - the layouter will subtract it again
-						XamlMeasure(Bounds.Size.Add(Margin));
+						var availableSizeWithMargins = Bounds.Size.Add(Margin);
+						XamlMeasure(availableSizeWithMargins);
 					}
 
-					if (IsArrangeDirty)
+					//if (IsArrangeDirty) // commented until the MEASURE_DIRTY_PATH is properly implemented for iOS
 					{
 						ClearLayoutFlags(LayoutFlag.ArrangeDirty);
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -402,7 +402,7 @@ namespace <#= mixin.NamespaceName #>
 						// If this FrameworkElement has a native parent, then it probably wasn't measured prior to having its Frame changed.
 						// Set RequiresMeasure flag so that this branch of the visual tree will be measured before being arranged, this is
 						// required for some views (eg Image) to display correctly.
-						ClearLayoutFlags(LayoutFlag.MeasureDirty);
+						SetLayoutFlags(LayoutFlag.MeasureDirty);
 					}
 #endif
 				}

--- a/src/Uno.UI/UI/Xaml/ILayouterElement.cs
+++ b/src/Uno.UI/UI/Xaml/ILayouterElement.cs
@@ -41,7 +41,6 @@ internal static class LayouterElementExtensions
 		var frameworkElement = element as FrameworkElement;
 		if (frameworkElement is null) // native unmanaged element?
 		{
-			measuredSizeLogical = availableSize;
 			isDirty = true;
 		}
 		else if (!isDirty)

--- a/src/Uno.UI/UI/Xaml/ILayouterElement.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/ILayouterElement.iOSmacOS.cs
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Windows.Foundation;
 using CoreGraphics;
 using Uno.UI;
 
@@ -8,9 +10,10 @@ namespace Windows.UI.Xaml;
 
 internal partial interface ILayouterElement
 {
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	internal bool XamlMeasureInternal(
-		CGSize availableSize,
-		CGSize? lastAvailableSize,
+		Size availableSize,
+		Size? lastAvailableSize,
 		out CGSize measuredSize)
 	{
 		if (IsMeasureDirty || availableSize != lastAvailableSize)

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.netstd.cs
@@ -237,7 +237,6 @@ namespace Windows.UI.Xaml
 
 				if (isDirty)
 				{
-					Console.WriteLine($"{this}: Looping for measure, {remainingTries} tries remaining...");
 					continue;
 				}
 


### PR DESCRIPTION
Fixes https://github.com/unoplatform/nventive-private/issues/367
Fixes https://github.com/unoplatform/nventive-private/issues/368

# Regression fix

Fixed a regression on iOS caused by a refactoring done while implementing the Measure Dirty Path feature on Android.

Was unable to reproduce the problem using an automated test, but this contains the fix.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
