### PR TITLE
fix: [iOS][macOS] fixed BitmapImage needs encoding when loading from url

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -139,5 +139,21 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual("ms-appx:///Assets/StoreLogo.png", targetNullValueSource.UriSource.ToString());
 #endif
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Image_Is_Loaded_From_URL()
+		{
+			string decoded_url = "https://nv-assets.azurewebsites.net/tests/images/image with spaces.jpg";
+			var img = new Image();
+			var SUT = new BitmapImage(new Uri(decoded_url));
+			img.Source = SUT;
+
+			TestServices.WindowHelper.WindowContent = img;
+			await TestServices.WindowHelper.WaitForIdle();
+			await TestServices.WindowHelper.WaitFor(() => img.ActualHeight > 0, 3000);
+
+			Assert.IsTrue(img.ActualHeight > 0);			
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ImageSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ImageSource.cs
@@ -64,7 +64,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			ImageSource imageSource = "mysceheme:///Assets/File.png";
 			var actual = ((BitmapImage)imageSource).UriSource.ToString();
 			Assert.AreEqual("mysceheme:///Assets/File.png", actual);
-		}
+		} 
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
@@ -260,9 +260,9 @@ namespace Windows.UI.Xaml.Media
 			if (ct.IsCancellationRequested)
 			{
 				return;
-			}
+			} 
 
-			using (var url = new NSUrl(WebUri.OriginalString))
+			using (var url = new NSUrl(WebUri.AbsoluteUri))
 			{
 				using (var request = NSUrlRequest.FromUrl(url))
 				{

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.macOS.cs
@@ -239,7 +239,7 @@ namespace Windows.UI.Xaml.Media
 
 		private void DownloadUsingPlatformDownloader()
 		{
-			using (var url = new NSUrl(WebUri.OriginalString))
+			using (var url = new NSUrl(WebUri.AbsoluteUri))
 			{
 				NSError error;
 


### PR DESCRIPTION
GitHub Issue: closes #8133 
 
## PR Type

What kind of change does this PR introduce? 

- Bugfix  

## What is the current behavior?

BitmapImage needs an escaped string when loading from URL, on macOS and iOS. 


## What is the new behavior?

BitmapImage (ImageSource) class now works with any string that is passed to the constructor. Like other platforms do. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
 
## Other information

 