### PR TITLE
feat(gtk): Add OpenGL acceleration

### DIFF
--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -1,0 +1,26 @@
+# Using the Skia+GTK head
+
+Uno supports running applications using Gtk+3 shell, using a Skia backend rendering. Gtk3+ is used to create a shell for the application to be used on various operatings systems, such as Linux, Windows and macOS.
+
+Depending on the target platform, the UI rendering may be using OpenGL or software rendering.
+
+Note that for Linux, the [framebuffer rendering](using-linux-framebuffer.md) head is also available.
+
+## Get started with the Skia+GTK head
+Follow the getting started guide [for Linux](../get-started-with-linux.md) or [Windows](../get-started-vs-2022.md)
+
+Once done, you can create a new app using:
+```
+dotnet new unoapp -o MyApp
+```
+
+or by using the Visual Studio "project new" templates.
+
+## Changing the rendering target
+
+It may be required, depending on the environment, to use software rendering.
+
+To do so, immediately before the line `host.Run()` in you `main.cs` file, add the following:
+```
+host.RenderSurfaceType = RenderSurfaceType.Software;
+```

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -324,6 +324,10 @@
           items:
             - name: Overview
               href: features/uno-cupertino.md
+        - name: Working with the Skia+GTK head
+          href: features/using-skia-gtk.md
+        - name: Working with the Linux Framebuffer support
+          href: features/using-linux-framebuffer.md
         - name: Fluent icon font
           href: uno-fluent-assets.md
         - name: Lottie animations
@@ -334,8 +338,6 @@
           href: features/working-with-cookies.md
         - name: Using pointer cursors
           href: features/cursors.md
-        - name: Linux Framebuffer Support
-          href: features/using-linux-framebuffer.md
     - name: Core functionality
       items:
         - name: Logging

--- a/src/SamplesApp/SamplesApp.Skia.Gtk/Properties/launchSettings.json
+++ b/src/SamplesApp/SamplesApp.Skia.Gtk/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "SamplesApp.Skia.Gtk": {
       "commandName": "Project",
       "commandLineArgs": "--_auto-screenshots=C:\\temp\\screenshots",
-      "nativeDebugging": false
+      "nativeDebugging": true
     }
   }
 }

--- a/src/SamplesApp/SamplesApp.Skia.Gtk/Properties/launchSettings.json
+++ b/src/SamplesApp/SamplesApp.Skia.Gtk/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "SamplesApp.Skia.Gtk": {
       "commandName": "Project",
       "commandLineArgs": "--_auto-screenshots=C:\\temp\\screenshots",
-      "nativeDebugging": true
+      "nativeDebugging": false
     }
   }
 }

--- a/src/Uno.UI.Composition/Composition/CompositionShape.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionShape.skia.cs
@@ -8,7 +8,7 @@ namespace Windows.UI.Composition
 {
 	public  partial class CompositionShape
 	{
-		internal virtual void Render(SKSurface surface, SKImageInfo info)
+		internal virtual void Render(SKSurface surface)
 		{
 
 		}

--- a/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
@@ -9,7 +9,7 @@ namespace Windows.UI.Composition
 		private SKPaint? _strokePaint;
 		private SKPaint? _fillPaint;
 
-		internal override void Render(SKSurface surface, SKImageInfo info)
+		internal override void Render(SKSurface surface)
 		{
 			SkiaGeometrySource2D? geometrySource = Geometry?.BuildGeometry() as SkiaGeometrySource2D;
 

--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -41,7 +41,7 @@ namespace Windows.UI.Composition
 
 		internal float CurrentOpacity => _currentOpacity;
 
-		internal void Render(SKSurface surface, SKImageInfo info)
+		internal void Render(SKSurface surface)
 		{
 			_isDirty = false;
 
@@ -50,12 +50,12 @@ namespace Windows.UI.Composition
 				var children = RootVisual.GetChildrenInRenderOrder();
 				for (var i = 0; i < children.Count; i++)
 				{
-					RenderVisual(surface, info, children[i]);
+					RenderVisual(surface, children[i]);
 				}
 			}
 		}
 
-		private void RenderVisual(SKSurface surface, SKImageInfo info, Visual visual)
+		private void RenderVisual(SKSurface surface, Visual visual)
 		{
 			if (visual.Opacity != 0 && visual.IsVisible)
 			{
@@ -82,14 +82,14 @@ namespace Windows.UI.Composition
 
 				using var opacityDisposable = PushOpacity(visual.Opacity);
 
-				visual.Render(surface, info);
+				visual.Render(surface);
 
 				if (visual is ContainerVisual containerVisual)
 				{
 					var children = containerVisual.GetChildrenInRenderOrder();
 					for (var i = 0; i < children.Count; i++)
 					{
-						RenderVisual(surface, info, children[i]);
+						RenderVisual(surface, children[i]);
 					}
 				}
 

--- a/src/Uno.UI.Composition/Composition/ShapeVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ShapeVisual.skia.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Composition
 {
 	public partial class ShapeVisual
 	{
-		internal override void Render(SKSurface surface, SKImageInfo info)
+		internal override void Render(SKSurface surface)
 		{
 			foreach(var shape in Shapes)
 			{
@@ -34,7 +34,7 @@ namespace Windows.UI.Composition
 
 				surface.Canvas.SetMatrix(visualMatrix);
 
-				shape.Render(surface, info);
+				shape.Render(surface);
 
 				surface.Canvas.Restore();
 			}

--- a/src/Uno.UI.Composition/Composition/SpriteVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/SpriteVisual.skia.cs
@@ -22,9 +22,9 @@ namespace Windows.UI.Composition
 			Brush?.UpdatePaint(_paint, new SKRect(left: 0, top: 0, right: Size.X, bottom: Size.Y));
 		}
 
-		internal override void Render(SKSurface surface, SKImageInfo info)
+		internal override void Render(SKSurface surface)
 		{
-			base.Render(surface, info);
+			base.Render(surface);
 
 			surface.Canvas.Save();
 

--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -9,7 +9,7 @@ namespace Windows.UI.Composition
 {
 	public partial class Visual : global::Windows.UI.Composition.CompositionObject
 	{
-		internal virtual void Render(SKSurface surface, SKImageInfo info)
+		internal virtual void Render(SKSurface surface)
 		{
 
 		}

--- a/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurface.cs
@@ -68,10 +68,7 @@ namespace Uno.UI.Runtime.Skia
 
 		private void UnoGLDrawingArea_Render(object o, RenderArgs args)
 		{
-			var sw = Stopwatch.StartNew();
-
 			args.Context.MakeCurrent();
-
 
 			// create the contexts if not done already
 			if (_grContext == null)
@@ -110,8 +107,6 @@ namespace Uno.UI.Runtime.Skia
 				// create the surface
 				_surface?.Dispose();
 				_surface = SKSurface.Create(_grContext, _renderTarget, surfaceOrigin, colorType);
-
-				Console.WriteLine($"Recreated surfaces: {w}x{h} Samples:{samples} colorType:{colorType}");
 			}
 
 			using (new SKAutoCanvasRestore(_surface.Canvas, true))
@@ -127,8 +122,6 @@ namespace Uno.UI.Runtime.Skia
 			_surface.Canvas.Flush();
 
 			_gl.Flush();
-			sw.Stop();
-			Console.WriteLine($"Frame: {sw.Elapsed}");
 		}
 
 		private void OnDpiChanged(DisplayInformation sender, object args) =>
@@ -146,11 +139,14 @@ namespace Uno.UI.Runtime.Skia
 
 		public void TakeScreenshot(string filePath)
 		{
-			using Stream memStream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+			if (_surface != null)
+			{
+				using Stream memStream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
 
-			var image = _surface.Snapshot();
-			var pngData = image.Encode();
-			pngData.SaveTo(memStream);
+				var image = _surface.Snapshot();
+				var pngData = image.Encode();
+				pngData.SaveTo(memStream);
+			}
 		}
 
 		private void UpdateDpi() => _dpi = (float)_displayInformation.RawPixelsPerViewPixel;

--- a/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurface.cs
@@ -1,0 +1,180 @@
+﻿#nullable enable
+
+using System;
+using System.IO;
+using SkiaSharp;
+using Uno.Extensions;
+using Uno.UI.Xaml.Core;
+using Windows.UI.Xaml.Input;
+using WUX = Windows.UI.Xaml;
+using Uno.Foundation.Logging;
+using Windows.UI.Xaml.Controls;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Uno.UI.Runtime.Skia.Helpers.Windows;
+using Uno.UI.Runtime.Skia.Helpers.Dpi;
+using Windows.Graphics.Display;
+using Gdk;
+using System.Reflection;
+using Gtk;
+using Silk.NET.OpenGL;
+using Silk.NET.Core.Loader;
+
+namespace Uno.UI.Runtime.Skia
+{
+
+	internal class GLRenderSurface : GLArea, IRenderSurface
+	{
+		private const SKColorType colorType = SKColorType.Rgba8888;
+		private const GRSurfaceOrigin surfaceOrigin = GRSurfaceOrigin.BottomLeft;
+
+		private readonly DisplayInformation _displayInformation;
+		private FocusManager? _focusManager;
+
+		private float? _dpi = 1;
+		private GRContext? _grContext;
+		private GL _gl;
+		private GRBackendRenderTarget? _renderTarget;
+		private SKSurface? _surface;
+
+		public GLRenderSurface()
+		{
+			_displayInformation = DisplayInformation.GetForCurrentView();
+			_displayInformation.DpiChanged += OnDpiChanged;
+			WUX.Window.InvalidateRender
+				+= () =>
+				{
+					// TODO Uno: Make this invalidation less often if possible.
+					InvalidateOverlays();
+					QueueRender();
+				};
+
+			// Set some event handlers
+			Render += UnoGLDrawingArea_Render;
+			Realized += GLRenderSurface_Realized;
+
+			HasDepthBuffer = false;
+			HasStencilBuffer = false;
+			AutoRender = true;
+			SetRequiredVersion(3, 3);
+
+			_gl = new GL(new Silk.NET.Core.Contexts.DefaultNativeContext(new GLCoreLibraryNameContainer().GetLibraryName()));
+		}
+
+		private void GLRenderSurface_Realized(object? sender, EventArgs e)
+		{
+			Context.MakeCurrent();
+		}
+
+		private void UnoGLDrawingArea_Render(object o, RenderArgs args)
+		{
+			var sw = Stopwatch.StartNew();
+
+			args.Context.MakeCurrent();
+
+
+			// create the contexts if not done already
+			if (_grContext == null)
+			{
+				var glInterface = GRGlInterface.Create();
+				_grContext = GRContext.CreateGl(glInterface);
+			}
+
+			_gl.Clear(ClearBufferMask.ColorBufferBit);
+			_gl.ClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+
+			// manage the drawing surface
+			var res = (int)Math.Max(1.0, Screen.Resolution / 96.0);
+			var w = Math.Max(0, AllocatedWidth * res);
+			var h = Math.Max(0, AllocatedHeight * res);
+
+			if (_renderTarget == null || _surface == null || _renderTarget.Width != w || _renderTarget.Height != h)
+			{
+				// create or update the dimensions
+				_renderTarget?.Dispose();
+
+				_gl.GetInteger(GLEnum.FramebufferBinding, out var framebuffer);
+				_gl.GetInteger(GLEnum.Stencil, out var stencil);
+				_gl.GetInteger(GLEnum.Samples, out var samples);
+				var maxSamples = _grContext.GetMaxSurfaceSampleCount(colorType);
+
+				if (samples > maxSamples)
+				{
+					samples = maxSamples;
+				}
+
+				var glInfo = new GRGlFramebufferInfo((uint)framebuffer, colorType.ToGlSizedFormat());
+
+				_renderTarget = new GRBackendRenderTarget(w, h, samples, stencil, glInfo);
+
+				// create the surface
+				_surface?.Dispose();
+				_surface = SKSurface.Create(_grContext, _renderTarget, surfaceOrigin, colorType);
+
+				Console.WriteLine($"Recreated surfaces: {w}x{h} Samples:{samples} colorType:{colorType}");
+			}
+
+			using (new SKAutoCanvasRestore(_surface.Canvas, true))
+			{
+				_surface.Canvas.Clear(SKColors.White);
+
+				// _surface.Canvas.Scale((float)(1/_dpi));
+
+				WUX.Window.Current.Compositor.Render(_surface);
+			}
+
+			// update the control
+			_surface.Canvas.Flush();
+
+			_gl.Flush();
+			sw.Stop();
+			Console.WriteLine($"Frame: {sw.Elapsed}");
+		}
+
+		private void OnDpiChanged(DisplayInformation sender, object args) =>
+			UpdateDpi();
+
+		private void InvalidateOverlays()
+		{
+			_focusManager ??= VisualTree.GetFocusManagerForElement(Windows.UI.Xaml.Window.Current?.RootElement);
+			_focusManager?.FocusRectManager?.RedrawFocusVisual();
+			if (_focusManager?.FocusedElement is TextBox textBox)
+			{
+				textBox.TextBoxView?.Extension?.InvalidateLayout();
+			}
+		}
+
+		public void TakeScreenshot(string filePath)
+		{
+			using Stream memStream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+
+			var image = _surface.Snapshot();
+			var pngData = image.Encode();
+			pngData.SaveTo(memStream);
+		}
+
+		private void UpdateDpi() => _dpi = (float)_displayInformation.RawPixelsPerViewPixel;
+
+		// Extracted from https://github.com/dotnet/Silk.NET/blob/23f9bd4d67ad21c69fbd69cc38a62fb2c0ec3927/src/OpenGL/Silk.NET.OpenGL/GLCoreLibraryNameContainer.cs
+		internal class GLCoreLibraryNameContainer : SearchPathContainer
+		{
+			/// <inheritdoc />
+			public override string Linux => "libGL.so.1";
+
+			/// <inheritdoc />
+			public override string MacOS => "/System/Library/Frameworks/OpenGL.framework/OpenGL";
+
+			/// <inheritdoc />
+			public override string Android => "libGL.so.1";
+
+			/// <inheritdoc />
+			public override string IOS => "/System/Library/Frameworks/OpenGL.framework/OpenGL";
+
+			/// <inheritdoc />
+			public override string Windows64 => "opengl32.dll";
+
+			/// <inheritdoc />
+			public override string Windows86 => "opengl32.dll";
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/IRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/IRenderSurface.cs
@@ -1,0 +1,7 @@
+﻿namespace Uno.UI.Runtime.Skia
+{
+	internal interface IRenderSurface
+	{
+		void TakeScreenshot(string filePath);
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/RenderSurfaceType.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/RenderSurfaceType.cs
@@ -1,0 +1,8 @@
+﻿namespace Uno.UI.Runtime.Skia
+{
+	public enum RenderSurfaceType
+	{
+		Software,
+		OpenGL,
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/SoftwareRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/SoftwareRenderSurface.cs
@@ -15,7 +15,7 @@ using Windows.Graphics.Display;
 
 namespace Uno.UI.Runtime.Skia
 {
-	internal class UnoDrawingArea : Gtk.DrawingArea
+	internal class SoftwareRenderSurface : Gtk.DrawingArea, IRenderSurface
 	{
 		private readonly DisplayInformation _displayInformation;
 		private FocusManager _focusManager;
@@ -24,7 +24,7 @@ namespace Uno.UI.Runtime.Skia
 
 		private float? _dpi = 1;
 
-		public UnoDrawingArea()
+		public SoftwareRenderSurface()
 		{
 			_displayInformation = DisplayInformation.GetForCurrentView();
 			_displayInformation.DpiChanged += OnDpiChanged;
@@ -55,6 +55,8 @@ namespace Uno.UI.Runtime.Skia
 
 		protected override bool OnDrawn(Cairo.Context cr)
 		{
+			var sw = Stopwatch.StartNew();
+
 			int width, height;
 
 			if (this.Log().IsEnabled(LogLevel.Trace))
@@ -87,7 +89,7 @@ namespace Uno.UI.Runtime.Skia
 
 				surface.Canvas.Scale((float)_dpi);
 
-				WUX.Window.Current.Compositor.Render(surface, info);
+				WUX.Window.Current.Compositor.Render(surface);
 
 				using (var gtkSurface = new Cairo.ImageSurface(
 					bitmap.GetPixels(out _),
@@ -102,10 +104,13 @@ namespace Uno.UI.Runtime.Skia
 				}
 			}
 
+			sw.Stop();
+			Console.WriteLine($"Frame: {sw.Elapsed}");
+
 			return true;
 		}
 
-		internal void TakeScreenshot(string filePath)
+		public void TakeScreenshot(string filePath)
 		{
 			using Stream memStream = File.Open(filePath, FileMode.Create, FileAccess.Write, FileShare.None);
 			using SKManagedWStream wstream = new SKManagedWStream(memStream);

--- a/src/Uno.UI.Runtime.Skia.Gtk/Uno.UI.Runtime.Skia.Gtk.csproj
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Uno.UI.Runtime.Skia.Gtk.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<Import Project="../netcore-build.props" />
-	<Import Project="../targetframework-override.props" />
+	<!--<Import Project="../targetframework-override.props" />-->
 
 	<PropertyGroup>
 		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
@@ -21,6 +21,8 @@
 		<RootNamespace>Uno.UI.Runtime.Skia</RootNamespace>
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
+	
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -31,7 +33,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
-		<!--<PackageReference Include="SkiaSharp.Views" />-->
+		<PackageReference Include="Silk.NET.OpenGL" Version="2.13.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.Gtk/Uno.UI.Runtime.Skia.Gtk.csproj
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Uno.UI.Runtime.Skia.Gtk.csproj
@@ -5,7 +5,6 @@
 	</PropertyGroup>
 
 	<Import Project="../netcore-build.props" />
-	<!--<Import Project="../targetframework-override.props" />-->
 
 	<PropertyGroup>
 		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
@@ -67,7 +67,7 @@ namespace Uno.UI.Runtime.Skia
 
 				surface.Canvas.Scale((float)dpi);
 
-				WUX.Window.Current.Compositor.Render(surface, info);
+				WUX.Window.Current.Compositor.Render(surface);
 
 				_fbDev.VSync();
 				Libc.memcpy(_fbDev.BufferAddress, bitmap.GetPixels(out _), new IntPtr(_fbDev.RowBytes * height));

--- a/src/Uno.UI.Runtime.Skia.Tizen/UnoCanvas.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/UnoCanvas.cs
@@ -45,7 +45,7 @@ namespace Uno.UI.Runtime.Skia
 			var scale = (float)ScalingInfo.ScalingFactor;
 			e.Surface.Canvas.Scale(scale);
 
-			WUX.Window.Current.Compositor.Render(e.Surface, e.Info);
+			WUX.Window.Current.Compositor.Render(e.Surface);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -273,7 +273,7 @@ namespace Uno.UI.Skia.Platform
 			{
 				surface.Canvas.Clear(SKColors.White);
 				surface.Canvas.SetMatrix(SKMatrix.CreateScale((float)dpiScaleX, (float)dpiScaleY));
-				WinUI.Window.Current.Compositor.Render(surface, info);
+				WinUI.Window.Current.Compositor.Render(surface);
 			}
 
 			// draw the bitmap to the screen

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextVisual.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextVisual.skia.cs
@@ -137,7 +137,7 @@ namespace Windows.UI.Composition
 			}
 		}
 
-		internal override void Render(SKSurface surface, SKImageInfo info)
+		internal override void Render(SKSurface surface)
 		{
 			if (!string.IsNullOrEmpty(_owner.Text))
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #4309

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Adds support for hardware acceleration for Gtk heads on Linux and Windows. 

Note: macOS is not working properly yet for some unknown Gtk+3 issue where the drawn surface is incorrectly scaled on window resize.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
