### PR TITLE
fix(ListView): Reduce the number of materialized items on large scrolls

### DIFF
--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -110,7 +110,7 @@ jobs:
     JobTimeoutInMinutes: 90
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
-    UITEST_TEST_TIMEOUT: '5400000'
+    UITEST_TEST_TIMEOUT: '7200000'
     UITEST_AUTOMATED_GROUP: 4
     UITEST_ALLOW_RERUN: 'false'
     xCodeRoot: ${{ parameters.xCodeRootTest }}

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -107,7 +107,7 @@ jobs:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Runtime_Tests'
     JobDisplayName: 'iOS Automated Runtime Tests'
-    JobTimeoutInMinutes: 90
+    JobTimeoutInMinutes: 120
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
     UITEST_TEST_TIMEOUT: '7200000'

--- a/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
+++ b/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
@@ -22713,7 +22713,7 @@
                     </ObjectAnimationUsingKeyFrames>
                     <!-- Uno specific (LinearGradientBrush borders): Adjust color for accent overlay -->
                     <not_win:ObjectAnimationUsingKeyFrames Storyboard.TargetName="BottomBorderElement" Storyboard.TargetProperty="BorderBrush">
-                      <DiscreteObjectKeyFrame KeyTime="0" Value="ControlStrokeColorOnAccentSecondaryBrush" />
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ControlStrokeColorOnAccentSecondaryBrush}" />
                     </not_win:ObjectAnimationUsingKeyFrames>
                     <contract7Present:ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BackgroundSizing">
                       <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonCheckedStateBackgroundSizing}" />

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -718,6 +718,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if HAS_UNO
 		[TestMethod]
 		[RunsOnUIThread]
+#if __IOS__ || __ANDROID__
+		[Ignore("Disabled because of animated scrolling, even when explicitly requested.")]
+#endif
 		public async Task When_SmallExtent_And_Large_List_Scroll_To_End_Full_Size()
 		{
 			var materialized = 0;
@@ -757,6 +760,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+#if __IOS__ || __ANDROID__
+		[Ignore("Disabled because of animated scrolling, even when explicitly requested")]
+#endif
 		public async Task When_SmallExtent_And_Large_List_Scroll_To_End_Half_Size()
 		{
 			var materialized = 0;
@@ -797,6 +803,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+#if __IOS__ || __ANDROID__
+		[Ignore("Disabled because of animated scrolling, even when explicitly requested")]
+#endif
 		public async Task When_SmallExtent_And_Large_List_Scroll_To_End_And_Back_Half_Size()
 		{
 			var materialized = 0;
@@ -854,6 +863,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+#if __IOS__ || __ANDROID__
+		[Ignore("Disabled because of animated scrolling, even when explicitly requested")]
+#endif
 		public async Task When_SmallExtent_And_Very_Large_List_Scroll_To_End_And_Back_Half_Size()
 		{
 			var materialized = 0;
@@ -906,6 +918,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+#if __IOS__ || __ANDROID__
+		[Ignore("Disabled because of animated scrolling, even when explicitly requested")]
+#endif
 		public async Task When_LargeExtent_And_Very_Large_List_Scroll_To_End_And_Back_Half_Size()
 		{
 			const int ElementHeight = 50;
@@ -944,35 +959,35 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var scroll = list.FindFirstChild<ScrollViewer>();
 			Assert.IsNotNull(scroll);
-			dataContextChanged.Should().BeLessThan(10, $"dataContextChanged {materialized}");
+			dataContextChanged.Should().BeLessThan(10, $"dataContextChanged {dataContextChanged}");
 
 			ScrollBy(list, ElementHeight);
 
 			await WindowHelper.WaitForIdle();
 
 			materialized.Should().BeLessThan(12, $"materialized {materialized}");
-			dataContextChanged.Should().BeLessThan(11, $"dataContextChanged {materialized}");
+			dataContextChanged.Should().BeLessThan(11, $"dataContextChanged {dataContextChanged}");
 
 			ScrollBy(list, ElementHeight * 3);
 
 			await WindowHelper.WaitForIdle();
 
 			materialized.Should().BeLessThan(14, $"materialized {materialized}");
-			dataContextChanged.Should().BeLessThan(13, $"dataContextChanged {materialized}");
+			dataContextChanged.Should().BeLessThan(13, $"dataContextChanged {dataContextChanged}");
 
 			ScrollBy(list, scroll.ExtentHeight / 2); // Scroll to middle
 
 			await WindowHelper.WaitForIdle();
 
 			materialized.Should().BeLessThan(14, $"materialized {materialized}");
-			dataContextChanged.Should().BeLessThan(25, $"dataContextChanged {materialized}");
+			dataContextChanged.Should().BeLessThan(25, $"dataContextChanged {dataContextChanged}");
 
 			ScrollBy(list, scroll.ExtentHeight / 4); // Scroll to Quarter
 
 			await WindowHelper.WaitForIdle();
 
 			materialized.Should().BeLessThan(14, $"materialized {materialized}");
-			dataContextChanged.Should().BeLessThan(35, $"dataContextChanged {materialized}");
+			dataContextChanged.Should().BeLessThan(35, $"dataContextChanged {dataContextChanged}");
 		}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelGenerator.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelGenerator.managed.cs
@@ -20,10 +20,24 @@ namespace Windows.UI.Xaml.Controls
 	/// </summary>
 	internal class VirtualizingPanelGenerator
 	{
-		private const int CacheLimit = 10;
+		/// <summary>
+		/// Maxmimum number of cached items per DataTemplate group.
+		/// </summary>
+		private const int MaxCacheLimit = 1024;
+
+		/// <summary>
+		/// Minimum number of cached items per DataTemplate group.
+		/// </summary>
+		private const int MinCacheLimit = 10;
+
 		private const int NoTemplateItemId = -1;
 		private const int IsOwnContainerItemId = -2;
 		private readonly _VirtualizingPanelLayout _owner;
+
+		/// <summary>
+		/// Current cache limit, to be adjusted based on the extent size
+		/// </summary>
+		private int _cacheLimit = 10;
 		/// <summary>
 		/// Recycled item containers that can be reused as needed. This is actually multiple caches indexed by template id.
 		/// </summary>
@@ -48,6 +62,31 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		/// <summary>
+		/// Sets the items cache limit per DataTemplate group
+		/// </summary>
+		internal int CacheLimit
+		{
+			get => _cacheLimit;
+			set
+			{
+				_cacheLimit = Math.Max(Math.Min(value, MaxCacheLimit), MinCacheLimit);
+
+				PurgeCache();
+			}
+		}
+
+		private void PurgeCache()
+		{
+			foreach (var cache in _itemContainerCache)
+			{
+				while (cache.Value.Count > _cacheLimit)
+				{
+					DiscardContainer(cache.Value.Pop());
+				}
+			}
+		}
+
+		/// <summary>
 		/// Returns a container view bound to the item at <paramref name="index"/>, recycling an available view if possible, or creating a new container if not.
 		/// </summary>
 		public FrameworkElement DequeueViewForItem(int index)
@@ -56,6 +95,10 @@ namespace Windows.UI.Xaml.Controls
 			var scrapped = TryGetScrappedContainer(index);
 			if (scrapped != null)
 			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"DequeueViewForItem: Using scrapped for index:{index}");
+				}
 				return scrapped;
 			}
 
@@ -68,7 +111,18 @@ namespace Windows.UI.Xaml.Controls
 			}
 			if (container == null)
 			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"DequeueViewForItem: Creating for index:{index}");
+				}
 				container = ItemsControl.GetContainerForIndex(index) as FrameworkElement;
+			}
+			else
+			{
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"DequeueViewForItem: Using cached for index:{index}");
+				}
 			}
 
 			ItemsControl.PrepareContainerForIndex(container, index);
@@ -162,8 +216,7 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		private static void DiscardContainer(FrameworkElement container)
 		{
-			var parent = (container.Parent) as Panel;
-			if (parent != null)
+			if (container.Parent is Panel parent)
 			{
 				parent.Children.Remove(container);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -19,6 +19,7 @@ using System.Collections.Specialized;
 using Uno.UI.Xaml.Controls;
 using DirectUI;
 using Uno.Foundation.Logging;
+using System.Diagnostics;
 #if __MACOS__
 using AppKit;
 #elif __IOS__
@@ -236,10 +237,37 @@ namespace Windows.UI.Xaml.Controls
 			{
 				this.Log().LogDebug($"Calling {GetMethodTag()} _lastScrollOffset={_lastScrollOffset} ScrollOffset={ScrollOffset}");
 			}
+
 			var delta = ScrollOffset - _lastScrollOffset;
 			var sign = Sign(delta);
 			var unappliedDelta = Abs(delta);
 			var fillDirection = sign > 0 ? Forward : Backward;
+			var isLargeScroll = Abs(delta) > ViewportExtent;
+
+			if (isLargeScroll)
+			{
+				// In this case, a majority of the materialized items are
+                // removed, let's clear everything and materialize from the
+				// new position.
+
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().LogDebug($"Large scroll Abs(delta):{Abs(delta)} AvailableBreadth:{AvailableBreadth}");
+				}
+
+				// Force the layout update below
+				unappliedDelta = 1;
+
+				// We know that the scroll is outside the available
+				// breath, so all lines can be recycled
+				ClearLines();
+
+				// Set the seed start to use the approximate position of
+				// the line based on the average line height.
+				var index = (int)(ScrollOffset / _averageLineHeight);
+				_dynamicSeedStart = ScrollOffset - _averageLineHeight;
+				_dynamicSeedIndex = Uno.UI.IndexPath.FromRowSection(index - sign, 0);
+			}
 
 			while (unappliedDelta > 0)
 			{
@@ -260,8 +288,16 @@ namespace Windows.UI.Xaml.Controls
 				unappliedDelta = Max(0, unappliedDelta);
 				UpdateLayout(extentAdjustment: sign * -unappliedDelta, isScroll: true);
 			}
+
 			ArrangeElements(_availableSize, ViewportSize);
 			UpdateCompleted();
+
+			if (isLargeScroll)
+			{
+				// Request the panel to remeasure children as we've
+				// reused all the lines.
+				OwnerPanel.InvalidateMeasure();
+			}
 
 			_lastScrollOffset = ScrollOffset;
 		}
@@ -337,6 +373,18 @@ namespace Windows.UI.Xaml.Controls
 			_availableSize = finalSize;
 			var adjustedVisibleWindow = ViewportSize;
 			ArrangeElements(finalSize, adjustedVisibleWindow);
+
+			if (_generator != null && _averageLineHeight > 0)
+			{
+				var cacheLimit = (int)(ViewportExtent / _averageLineHeight) * 2;
+
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().LogDebug($"Setting cache limit {cacheLimit}");
+				}
+
+				_generator.CacheLimit = cacheLimit;
+			}
 
 			return EstimatePanelSize(isMeasure: false);
 		}

--- a/src/Uno.UI/UI/Xaml/Style/mergedstyles.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/mergedstyles.xaml
@@ -117,13 +117,13 @@
       <StaticResource x:Key="NavigationViewButtonForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
       <StaticResource x:Key="NavigationViewButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
       <StaticResource x:Key="NumberBoxPopupIndicatorForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
-      <StaticResource x:Key="PagerControlSelectionIndicatorForeground" ResourceKey="SystemControlForegroundAccentBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundPressed" ResourceKey="SystemControlHighlightListMediumBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+      <StaticResource x:Key="PagerControlSelectionIndicatorForeground" ResourceKey="AccentFillColorDefaultBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundDisabled" ResourceKey="SubtleFillColorDisabledBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundPressed" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
       <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
       <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
       <Color x:Key="SystemControlErrorBackgroundColor">#33FFFFFF</Color>
@@ -893,13 +893,13 @@
       <StaticResource x:Key="NavigationViewButtonForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
       <StaticResource x:Key="NavigationViewButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
       <StaticResource x:Key="NumberBoxPopupIndicatorForeground" ResourceKey="SystemControlForegroundBaseMediumBrush" />
-      <StaticResource x:Key="PagerControlSelectionIndicatorForeground" ResourceKey="SystemControlForegroundAccentBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundPointerOver" ResourceKey="SystemControlHighlightListLowBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundPressed" ResourceKey="SystemControlHighlightListMediumBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundDisabled" ResourceKey="SystemControlDisabledTransparentBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundPointerOver" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundPressed" ResourceKey="SystemControlHighlightAltBaseHighBrush" />
-      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundDisabled" ResourceKey="SystemControlDisabledBaseMediumLowBrush" />
+      <StaticResource x:Key="PagerControlSelectionIndicatorForeground" ResourceKey="AccentFillColorDefaultBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonBackgroundDisabled" ResourceKey="SubtleFillColorDisabledBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundPressed" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="PagerControlPageNavigationButtonForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
       <CornerRadius x:Key="ControlCornerRadius">2,2,2,2</CornerRadius>
       <CornerRadius x:Key="OverlayCornerRadius">4,4,4,4</CornerRadius>
       <Color x:Key="SystemControlErrorBackgroundColor">#29C50500</Color>
@@ -5453,10 +5453,11 @@
     <Setter Property="HorizontalContentAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+    <contract7Present:Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="Button">
-          <Grid x:Name="RootGrid" Background="{TemplateBinding Background}">
+          <Grid x:Name="RootGrid" Background="{TemplateBinding Background}" contract7Present:CornerRadius="{TemplateBinding CornerRadius}" contract7NotPresent:CornerRadius="{StaticResource ControlCornerRadius}">
             <VisualStateManager.VisualStateGroups>
               <VisualStateGroup x:Name="CommonStates">
                 <VisualState x:Name="Normal" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/8312

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When scrolling for larger delta than the current ScrollViewer view port size, the list will materialize all items in the delta, instead of materializing the items at the end of the scroll.

## What is the new behavior?

The ListView (managed for Skia, Wasm and macOS) will now materialize only the items at the scroll's final position, improving the scrolling performance, as well as the interaction with the `ScrollViewer.ChangeView` method.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
