### PR TITLE
fix: Avoid disabling Paint AntiAlias when drawing rounded corners

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SamplesApp.UITests._Utils;
 using SamplesApp.UITests.TestFramework;
 using SamplesApp.UITests.Windows_UI_Xaml_Controls.FrameworkElementTests;
 using Uno.UITest.Helpers;
@@ -219,6 +220,48 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests
 			using var screenshot = TakeScreenshot("Screenshot");
 
 			ImageAssert.HasColorAt(screenshot, textBoxRect.CenterX, textBoxRect.CenterY, Color.FromArgb(0, 255, 0));
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android)]
+		public void Border_AntiAlias()
+		{
+			const string firstRectBlueish = "#ffd8d8ff";
+			const string secondRectBlueish = "#ff9e9eff";
+
+			Run("UITests.Windows_UI_Xaml_Controls.BorderTests.BorderAntiAlias");
+
+			var firstBorderRect = _app.GetPhysicalRect("firstBorder");
+			var secondBorderRect = _app.GetPhysicalRect("secondBorder");
+			
+			using var screenshot = TakeScreenshot(nameof(Border_AntiAlias));
+
+			ImageAssert.HasColorInRectangle(
+					screenshot,
+					firstBorderRect.ToRectangle(),
+					ColorCodeParser.Parse(firstRectBlueish)
+				);
+
+			ImageAssert.HasPixels(
+					screenshot,
+					ExpectedPixels
+						.At($"top-left", secondBorderRect.X, secondBorderRect.Y)
+						.WithPixelTolerance(1, 1)
+						.Pixel(secondRectBlueish),
+					ExpectedPixels
+						.At($"top-right", secondBorderRect.Right, secondBorderRect.Y)
+						.WithPixelTolerance(1, 1)
+						.Pixel(secondRectBlueish),
+					ExpectedPixels
+						.At($"bottom-right", secondBorderRect.Right, secondBorderRect.Bottom)
+						.WithPixelTolerance(1, 1)
+						.Pixel(secondRectBlueish),
+					ExpectedPixels
+						.At($"bottom-left", secondBorderRect.X, secondBorderRect.Bottom)
+						.WithPixelTolerance(1, 1)
+						.Pixel(secondRectBlueish)
+				);
 		}
 
 		private void SetBorderProperty(string borderName, string propertyName, string value)

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1101,6 +1101,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\BorderAntiAlias.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\Border_BorderThickness.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5290,6 +5294,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\MeasuredBitmapIcon.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Sizing.xaml.cs">
       <DependentUpon>BitmapIcon_Sizing.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\BorderAntiAlias.xaml.cs">
+      <DependentUpon>BorderAntiAlias.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\Border_BorderThickness.xaml.cs">
       <DependentUpon>Border_BorderThickness.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/BorderAntiAlias.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/BorderAntiAlias.xaml
@@ -1,0 +1,20 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.BorderTests.BorderAntiAlias"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.BorderTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="White">
+
+<Grid>
+	<Grid.ColumnDefinitions>
+		<ColumnDefinition Width="*"/>
+		<ColumnDefinition Width="*"/>
+		<ColumnDefinition Width="Auto"/>
+	</Grid.ColumnDefinitions>
+	<Border x:Name="firstBorder" Background="Blue" CornerRadius="40" Height="300" Width="50" Margin="20" />
+	<Border x:Name="secondBorder" Background="Blue" CornerRadius="2" Height="50" Width="50" Margin="20" Grid.Column="1" />
+</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/BorderAntiAlias.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/BorderAntiAlias.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.BorderTests
+{
+	[Sample("Border", Name = "Border_AntiAlias")]
+	public sealed partial class BorderAntiAlias : Page
+    {
+        public BorderAntiAlias()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
@@ -202,7 +202,7 @@ namespace Windows.UI.Xaml.Controls
 					else
 					{
 						var fillPaint = background?.GetFillPaint(drawArea) ?? new Paint() { Color = Android.Graphics.Color.Transparent };
-						ExecuteWithNoRelayout(view, v => v.SetBackgroundDrawable(Brush.GetBackgroundDrawable(background, drawArea, fillPaint, backgroundPath)));
+						ExecuteWithNoRelayout(view, v => v.SetBackgroundDrawable(Brush.GetBackgroundDrawable(background, drawArea, fillPaint, backgroundPath, antiAlias: false)));
 					}
 					disposables.Add(() => ExecuteWithNoRelayout(view, v => v.SetBackgroundDrawable(null)));
 				}

--- a/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Android.cs
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml.Media
 
 				// Fall back to solid color
 				var fillPaint = GetFillPaint(Rect.Empty);
-				ExecuteWithNoRelayout(state.Owner, v => v.SetBackgroundDrawable(Brush.GetBackgroundDrawable(this, state.DrawArea, fillPaint, state.MaskingPath)));
+				ExecuteWithNoRelayout(state.Owner, v => v.SetBackgroundDrawable(Brush.GetBackgroundDrawable(this, state.DrawArea, fillPaint, state.MaskingPath, antiAlias: false)));
 
 				if (state.FallbackDisposable.Disposable == null)
 				{

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -163,7 +163,7 @@ namespace Windows.UI.Xaml.Media
 			return Disposable.Empty;
 		}
 
-		internal static Drawable GetBackgroundDrawable(Brush background, Windows.Foundation.Rect drawArea, Paint fillPaint, Path maskingPath = null)
+		internal static Drawable GetBackgroundDrawable(Brush background, Windows.Foundation.Rect drawArea, Paint fillPaint, Path maskingPath = null, bool antiAlias = true)
 		{
 			if (background is ImageBrush)
 			{
@@ -195,7 +195,7 @@ namespace Windows.UI.Xaml.Media
 			var paint = drawable.Paint;
 			paint.Color = fillPaint.Color;
 			paint.SetShader(fillPaint.Shader);
-			paint.AntiAlias = false;
+			paint.AntiAlias = antiAlias;
 			return drawable;
 		}
 	}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/8324

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

![image](https://user-images.githubusercontent.com/4793020/158612917-6cc5927c-81b6-4e9b-aaa8-30186292a6ce.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/4793020/158612948-aab818e6-5922-48e5-a91c-9f91033f44a9.png)