### PR TITLE
fix(pointers): Enter/Exit bubbling when crossing boundaries of OriginalSource

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
@@ -97,7 +97,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			await RunAsync(_sample);
 
 			var target = App.WaitForElement("_container").Single().Rect;
-			App.DragCoordinates(target.Left + 10, target.CenterY, target.CenterX, target.CenterY);
+			App.DragCoordinates(target.X + 10, target.CenterY, target.CenterX, target.CenterY);
 
 			var result = App.Marked("_result").GetDependencyPropertyValue<string>("Text");
 			var actual = Parse(result);
@@ -127,7 +127,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 			await RunAsync(_sample);
 
 			var target = App.WaitForElement("_container").Single().Rect;
-			App.DragCoordinates(target.Left + 10, target.CenterY, target.CenterX, target.CenterY);
+			App.DragCoordinates(target.X + 10, target.CenterY, target.CenterX, target.CenterY);
 
 			var result = App.Marked("_result").GetDependencyPropertyValue<string>("Text");
 			var actual = Parse(result);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
@@ -31,7 +31,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		[AutoRetry]
 		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		[InjectedPointer(PointerDeviceType.Touch)]
-		public async Task When_PressOnNestedReleaseOnContainer_Touch()
+		public async Task When_PressOnNestedAndReleaseOnContainer_Touch()
 		{
 			await RunAsync(_sample);
 
@@ -61,7 +61,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)]
 		[InjectedPointer(PointerDeviceType.Mouse)]
-		public async Task When_PressOnNestedReleaseOnContainer_Mouse()
+		public async Task When_PressOnNestedAndReleaseOnContainer_Mouse()
 		{
 			await RunAsync(_sample);
 
@@ -81,6 +81,65 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 				new("NESTED", "Exited", _inRange, _inContact),
 				new("INTERMEDIATE", "Exited", _inRange, _inContact),
 				new("CONTAINER", "Released", _inRange, _notInContact)
+			};
+
+			actual.Should().BeEquivalentTo(expected);
+		}
+
+		[Test]
+		[AutoRetry]
+#if !__SKIA__
+		[Ignore("Does not work due to the 'implicit capture'")]
+#endif
+		[InjectedPointer(PointerDeviceType.Touch)]
+		public async Task When_PressOnContainerAndReleaseOnNested_Touch()
+		{
+			await RunAsync(_sample);
+
+			var target = App.WaitForElement("_container").Single().Rect;
+			App.DragCoordinates(target.Left + 10, target.CenterY, target.CenterX, target.CenterY);
+
+			var result = App.Marked("_result").GetDependencyPropertyValue<string>("Text");
+			var actual = Parse(result);
+			var expected = new Expected[]
+			{
+				new("CONTAINER", "Entered", _inRange, _inContact),
+				new("CONTAINER", "Pressed", _inRange, _inContact),
+				new("NESTED", "Entered", _inRange, _inContact),
+				new("INTERMEDIATE", "Entered", _inRange, _inContact),
+				new("NESTED", "Released", _notInRange, _notInContact),
+				new("INTERMEDIATE", "Released", _notInRange, _notInContact),
+				new("CONTAINER", "Released", _notInRange, _notInContact),
+				new("NESTED", "Exited", _notInRange, _notInContact),
+				new("INTERMEDIATE", "Exited", _notInRange, _notInContact),
+				new("CONTAINER", "Exited", _notInRange, _notInContact),
+			};
+
+			actual.Should().BeEquivalentTo(expected);
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
+		[InjectedPointer(PointerDeviceType.Mouse)]
+		public async Task When_PressOnContainerAndReleaseOnNested_Mouse()
+		{
+			await RunAsync(_sample);
+
+			var target = App.WaitForElement("_container").Single().Rect;
+			App.DragCoordinates(target.Left + 10, target.CenterY, target.CenterX, target.CenterY);
+
+			var result = App.Marked("_result").GetDependencyPropertyValue<string>("Text");
+			var actual = Parse(result);
+			var expected = new Expected[]
+			{
+				new("CONTAINER", "Entered", _inRange, _notInContact),
+				new("CONTAINER", "Pressed", _inRange, _inContact),
+				new("NESTED", "Entered", _inRange, _inContact),
+				new("INTERMEDIATE", "Entered", _inRange, _inContact),
+				new("NESTED", "Released", _inRange, _notInContact),
+				new("INTERMEDIATE", "Released", _inRange, _notInContact),
+				new("CONTAINER", "Released", _inRange, _notInContact),
 			};
 
 			actual.Should().BeEquivalentTo(expected);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Windows.Devices.Input;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.Testing;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Input
+{
+	[TestFixture]
+	internal class Nested_Sequence_Tests : SampleControlUITestBase
+	{
+		private const string _sample = "UITests.Windows_UI_Input.PointersTests.Nested_Sequence";
+
+		private static readonly Regex _resultRegex = new Regex(@"\s*\[(?<element>\w+)\]\s+(?<evt>\w+)\s*(\((?<param>(?<key>\w+)\s*=\s*(?<value>\w+)|\s*\|\s*)+\))?");
+
+		private static KeyValuePair<string, string> _inRange = new("in_range", "true");
+		private static KeyValuePair<string, string> _inContact = new("in_contact", "true");
+		private static KeyValuePair<string, string> _notInRange = new("in_range", "false");
+		private static KeyValuePair<string, string> _notInContact = new("in_contact", "false");
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
+		[InjectedPointer(PointerDeviceType.Touch)]
+		public async Task When_PressOnNestedReleaseOnContainer_Touch()
+		{
+			await RunAsync(_sample);
+
+			var target = App.WaitForElement("_container").Single().Rect;
+			App.DragCoordinates(target.CenterX, target.CenterY, target.Right - 10, target.CenterY);
+
+			var result = App.Marked("_result").GetDependencyPropertyValue<string>("Text");
+			var actual = Parse(result);
+			var expected = new Expected[]
+			{
+				new("NESTED", "Entered", _inRange, _inContact),
+				new("INTERMEDIATE", "Entered", _inRange, _inContact),
+				new("CONTAINER", "Entered", _inRange, _inContact),
+				new("NESTED", "Pressed", _inRange, _inContact),
+				new("INTERMEDIATE", "Pressed", _inRange, _inContact),
+				new("CONTAINER", "Pressed", _inRange, _inContact),
+				new("NESTED", "Exited", _inRange, _inContact),
+				new("INTERMEDIATE", "Exited", _inRange, _inContact),
+				new("CONTAINER", "Released", _notInRange, _notInContact),
+				new("CONTAINER", "Exited", _notInRange, _notInContact),
+			};
+
+			actual.Should().BeEquivalentTo(expected);
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
+		[InjectedPointer(PointerDeviceType.Mouse)]
+		public async Task When_PressOnNestedReleaseOnContainer_Mouse()
+		{
+			await RunAsync(_sample);
+
+			var target = App.WaitForElement("_container").Single().Rect;
+			App.DragCoordinates(target.CenterX, target.CenterY, target.Right - 10, target.CenterY);
+
+			var result = App.Marked("_result").GetDependencyPropertyValue<string>("Text");
+			var actual = Parse(result);
+			var expected = new Expected[]
+			{
+				new("CONTAINER", "Entered", _inRange, _notInContact),
+				new("NESTED", "Entered", _inRange, _notInContact),
+				new("INTERMEDIATE", "Entered", _inRange, _notInContact),
+				new("NESTED", "Pressed", _inRange, _inContact),
+				new("INTERMEDIATE", "Pressed", _inRange, _inContact),
+				new("CONTAINER", "Pressed", _inRange, _inContact),
+				new("NESTED", "Exited", _inRange, _inContact),
+				new("INTERMEDIATE", "Exited", _inRange, _inContact),
+				new("CONTAINER", "Released", _inRange, _notInContact)
+			};
+
+			actual.Should().BeEquivalentTo(expected);
+		}
+
+		private IEnumerable<PointerEventInfo> Parse(string text)
+		{
+			foreach (Match match in _resultRegex.Matches(text))
+			{
+				var line = new PointerEventInfo(match.Groups["element"].Value, match.Groups["evt"].Value);
+
+				var keys = match.Groups["key"].Captures;
+				var values = match.Groups["value"].Captures;
+				Assert.AreEqual(keys.Count, values.Count);
+
+				for (var i = 0; i < keys.Count; i++)
+				{
+					line[keys[i].Value.ToLowerInvariant()] = values[i].Value.ToLowerInvariant();
+				}
+
+				yield return line;
+			}
+		}
+
+		private class PointerEventInfo : Dictionary<string, string>, IEquatable<Expected>
+		{
+			public PointerEventInfo(string element, string @event)
+			{
+				Element = element;
+				Event = @event;
+			}
+
+			public string Element { get; }
+
+			public string Event { get; }
+
+			/// <inheritdoc />
+			public bool Equals(Expected expected)
+			{
+				var success = true;
+				if (!Element.Equals(expected.Element))
+				{
+					AssertionScope.Current.AddPreFormattedFailure($"Not the same element (expected: {expected.Element} | actual: {Element})");
+					success = false;
+				}
+
+				if (!Event.Equals(expected.Event))
+				{
+					AssertionScope.Current.AddPreFormattedFailure($"Not the same event (expected: {expected.Event} | actual: {Event})");
+					success = false;
+				}
+
+				foreach (var parameter in expected)
+				{
+					if (!TryGetValue(parameter.Key, out var value))
+					{
+						AssertionScope.Current.AddPreFormattedFailure($"Key {parameter.Key} is not set");
+						success = false;
+					}
+					else if (!value.Equals(parameter.Value))
+					{
+						AssertionScope.Current.AddPreFormattedFailure($"Value of '{parameter.Key}' is not the same (expected: {parameter.Value} | actual: {value})");
+						success = false;
+					}
+				}
+
+				return success;
+			}
+
+			/// <inheritdoc />
+			public override bool Equals(object obj)
+				=> obj is Expected expected ? Equals(expected) : base.Equals(obj);
+		}
+
+		private class Expected : PointerEventInfo
+		{
+			public Expected(string element, string @event, params KeyValuePair<string, string>[] parameters) : base(element, @event)
+			{
+				foreach (var parameter in parameters)
+				{
+					Add(parameter.Key, parameter.Value);
+				}
+			}
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
@@ -59,7 +59,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Browser)]
+#if !__SKIA__
+		[Ignore("Inputs simulated by selenium are directly appreaing at the start location and wrongly inserting an exit.")]
+		//[ActivePlatforms(Platform.Browser)]
+#endif
 		[InjectedPointer(PointerDeviceType.Mouse)]
 		public async Task When_PressOnNestedAndReleaseOnContainer_Mouse()
 		{

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -697,9 +697,15 @@ namespace Uno.UI.Samples.Tests
 							{
 								await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 								{
+									if (instance is IInjectPointers pointersInjector)
+									{
+										pointersInjector.CleanupPointers();
+									}
+
 									if (testCase.Pointer is { } pt)
 									{
 										var ptSubscription = (instance as IInjectPointers ?? throw new InvalidOperationException("test class does not supports pointer selection.")).SetPointer(pt);
+
 										cleanupActions.Add(async _ => ptSubscription.Dispose());
 									}
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -653,6 +653,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Nested_Sequence.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\PointersOriginalSource.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5000,6 +5004,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\NestedHandling.xaml.cs">
       <DependentUpon>NestedHandling.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Nested_Sequence.xaml.cs">
+      <DependentUpon>Nested_Sequence.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\PointersOriginalSource.xaml.cs">
       <DependentUpon>PointersOriginalSource.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Sequence.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Sequence.xaml
@@ -1,0 +1,27 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Input.PointersTests.Nested_Sequence"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Input.PointersTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition />
+			<ColumnDefinition MinWidth="100" MaxWidth="300" />
+		</Grid.ColumnDefinitions>
+
+		<Border Width="300" Height="300" Background="DeepSkyBlue" x:Name="_container">
+			<Border Width="200" Height="200" x:Name="_intermediate">
+				<Border Background="DeepPink" x:Name="_nested" />
+			</Border>
+		</Border>
+
+		<ScrollViewer Grid.Column="1">
+			<TextBlock x:Name="_result" FontSize="8" />
+		</ScrollViewer>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Sequence.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Sequence.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Input.PointersTests
+{
+	[Sample(
+		"Pointers",
+		Description = "Automated test that validates the bubbling of pointer events, noticeably enter and exit.",
+		IgnoreInSnapshotTests = true)]
+	public sealed partial class Nested_Sequence : Page
+	{
+		public Nested_Sequence()
+		{
+			this.InitializeComponent();
+
+			HookEvents(_container);
+			HookEvents(_intermediate);
+			HookEvents(_nested);
+		}
+
+		private void HookEvents(UIElement elt)
+		{
+			elt.PointerEntered += LogEvent("Entered");
+			elt.PointerExited += LogEvent("Exited");
+			elt.PointerPressed += LogEvent("Pressed");
+			elt.PointerReleased += LogEvent("Released");
+			elt.PointerCanceled += LogEvent("Canceled");
+		}
+
+		private PointerEventHandler LogEvent(string eventName) => (snd, args)
+			=> Write($"[{((FrameworkElement)snd).Name.Trim('_').ToUpperInvariant()}] {eventName} (in_contact={args.Pointer.IsInContact} | in_range={args.Pointer.IsInRange})");
+
+		private void Write(string text)
+		{
+			Console.WriteLine(text);
+			_result.Text += text + "\r\n";
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Helpers/InjectedPointerAttribute.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/InjectedPointerAttribute.cs
@@ -30,5 +30,7 @@ public class InjectedPointerAttribute : Attribute
 
 public interface IInjectPointers
 {
+	public void CleanupPointers();
+
 	public IDisposable SetPointer(PointerDeviceType type);
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_VisibleBoundsPadding.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_VisibleBoundsPadding.cs
@@ -24,6 +24,8 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Toolkit
 		[RequiresFullWindow]
 #if __SKIA__ || __WASM__
 		[Ignore("VisibleBoundsPadding is not working correctly on these platforms - see https://github.com/unoplatform/uno/issues/7978")]
+#elif __ANDROID__
+		[Ignore("Flaky test on Android")]
 #endif
 		public async Task When_Mask_All()
 		{

--- a/src/Uno.UI.RuntimeTests/UITests/_Engine/SampleControlUITestBase.cs
+++ b/src/Uno.UI.RuntimeTests/UITests/_Engine/SampleControlUITestBase.cs
@@ -13,9 +13,7 @@ namespace SamplesApp.UITests;
 // Note: All tests that are inheriting from this base class will run on UI thread.
 public class SampleControlUITestBase : IInjectPointers
 {
-	private SkiaApp? _app;
-
-	protected SkiaApp App => _app ??= new();
+	protected SkiaApp App => SkiaApp.Current;
 
 	/// <summary>
 	/// Gets the default pointer type for the current platform
@@ -28,6 +26,9 @@ public class SampleControlUITestBase : IInjectPointers
 	{
 		await App.RunAsync(metadataName);
 	}
+
+	void IInjectPointers.CleanupPointers()
+		=> App.CleanupPointers();
 
 	/// <inheritdoc />
 	public IDisposable SetPointer(PointerDeviceType type)

--- a/src/Uno.UI.RuntimeTests/UITests/_Engine/SampleControlUITestBase.cs
+++ b/src/Uno.UI.RuntimeTests/UITests/_Engine/SampleControlUITestBase.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Uno.UI.RuntimeTests/UITests/_Engine/SkiaApp.MouseHelper.cs
+++ b/src/Uno.UI.RuntimeTests/UITests/_Engine/SkiaApp.MouseHelper.cs
@@ -1,0 +1,127 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Windows.Foundation;
+using Windows.UI.Core;
+using Windows.UI.Input.Preview.Injection;
+
+namespace Uno.UITest;
+
+public partial class SkiaApp
+{
+	private class MouseHelper
+	{
+		private readonly InputInjector _input;
+
+		public MouseHelper(InputInjector input)
+		{
+			_input = input;
+		}
+
+		public InjectedInputMouseInfo Press()
+			=> new()
+			{
+				TimeOffsetInMilliseconds = 1,
+				MouseOptions = InjectedInputMouseOptions.LeftDown,
+			};
+
+		public InjectedInputMouseInfo Release()
+			=> new()
+			{
+				TimeOffsetInMilliseconds = 1,
+				MouseOptions = InjectedInputMouseOptions.LeftUp,
+			};
+
+		public InjectedInputMouseInfo? ReleaseAny()
+		{
+			var options = default(InjectedInputMouseOptions);
+
+#if HAS_UNO
+			var current = _input.Mouse;
+			if (current.Properties.IsLeftButtonPressed)
+			{
+				options |= InjectedInputMouseOptions.LeftUp;
+			}
+
+			if (current.Properties.IsMiddleButtonPressed)
+			{
+				options |= InjectedInputMouseOptions.MiddleUp;
+			}
+
+			if (current.Properties.IsRightButtonPressed)
+			{
+				options |= InjectedInputMouseOptions.RightUp;
+			}
+
+			if (current.Properties.IsXButton1Pressed)
+			{
+				options |= InjectedInputMouseOptions.XUp;
+			}
+#else
+			options = InjectedInputMouseOptions.LeftUp
+				| InjectedInputMouseOptions.MiddleUp
+				| InjectedInputMouseOptions.RightUp
+				| InjectedInputMouseOptions.XUp;
+#endif
+
+			return options is default(InjectedInputMouseOptions)
+				? null
+				: new()
+				{
+					TimeOffsetInMilliseconds = 1,
+					MouseOptions = options
+				};
+		}
+
+		public InjectedInputMouseInfo MoveBy(int deltaX, int deltaY)
+			=> new()
+			{
+				DeltaX = deltaX,
+				DeltaY = deltaY,
+				TimeOffsetInMilliseconds = 1,
+				MouseOptions = InjectedInputMouseOptions.MoveNoCoalesce,
+			};
+
+		public IEnumerable<InjectedInputMouseInfo> MoveTo(double x, double y, int? steps = null)
+		{
+			Point Current()
+#if HAS_UNO
+				=> _input.Mouse.Position;
+#else
+				=> CoreWindow.GetForCurrentThread().PointerPosition;
+#endif
+
+			var deltaX = x - Current().X;
+			var deltaY = y - Current().Y;
+
+			steps ??= (int)Math.Min(Math.Max(Math.Abs(deltaX), Math.Abs(deltaY)), 512);
+			if (steps is 0)
+			{
+				yield break;
+			}
+
+			var stepX = deltaX / steps.Value;
+			var stepY = deltaY / steps.Value;
+
+			stepX = stepX is > 0 ? Math.Ceiling(stepX) : Math.Floor(stepX);
+			stepY = stepY is > 0 ? Math.Ceiling(stepY) : Math.Floor(stepY);
+
+			for (var step = 0; step <= steps && (stepX is not 0 || stepY is not 0); step++)
+			{
+				yield return MoveBy((int)stepX, (int)stepY);
+
+				if (Math.Abs(Current().X - x) < stepX)
+				{
+					stepX = 0;
+				}
+
+				if (Math.Abs(Current().Y - y) < stepY)
+				{
+					stepY = 0;
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/UITests/_Engine/SkiaApp.cs
+++ b/src/Uno.UI.RuntimeTests/UITests/_Engine/SkiaApp.cs
@@ -304,21 +304,24 @@ public class SkiaApp : IApp
 			yield break;
 		}
 
-		var stepX = (int)Math.Ceiling(deltaX / steps.Value);
-		var stepY = (int)Math.Ceiling(deltaY / steps.Value);
+		var stepX = deltaX / steps.Value;
+		var stepY = deltaY / steps.Value;
 
-		for (var step = 0; step <= steps; step++)
+		stepX = stepX is > 0 ? Math.Ceiling(stepX) : Math.Floor(stepX);
+		stepY = stepY is > 0 ? Math.Ceiling(stepY) : Math.Floor(stepY);
+
+		for (var step = 0; step <= steps && (stepX is not 0 || stepY is not 0); step++)
 		{
-			if (Math.Abs(_input.Mouse.Position.X - x) < 1)
+			yield return MoveMouseBy((int)stepX, (int)stepY);
+
+			if (Math.Abs(_input.Mouse.Position.X - x) < stepX)
 			{
 				stepX = 0;
 			}
-			if (Math.Abs(_input.Mouse.Position.Y - y) < 1)
+			if (Math.Abs(_input.Mouse.Position.Y - y) < stepY)
 			{
 				stepY = 0;
 			}
-
-			yield return MoveMouseBy(stepX, stepY);
 		}
 	}
 

--- a/src/Uno.UI.RuntimeTests/UITestsImport.props
+++ b/src/Uno.UI.RuntimeTests/UITestsImport.props
@@ -4,6 +4,7 @@
 		<!-- File path or directy with globbing relative to SamplesApp\SamplesApp.UITests directory -->
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\NestedHandling_Tests.cs" />
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\PointersOriginalSource_Tests.cs" />
+		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\Nested_Sequence_Tests.cs" />
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Controls\ListViewTests\Selection_Pointers.cs" />
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Controls\SwipeControlTests\SwipeControlTests.cs" />
 	</ItemGroup>

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Skia.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Skia.csproj
@@ -82,20 +82,4 @@
 	  <PRIResource Include="Resources\**\*.resw" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <SourceGeneratorInput Remove="UITests\_Engine\SkiaAppExtensions.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="UITests\_Engine\SamplesAppUITests\" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <SourceGeneratorInput Remove="UITests\_Engine\IAppRect.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <SourceGeneratorInput Remove="UITests\_Engine\UnoUITests\Helpers\QueryExtensions.async.cs" />
-	</ItemGroup>
-
 </Project>

--- a/src/Uno.UI.Tests/RoutedEventTests/Given_TappedRoutedEvent.cs
+++ b/src/Uno.UI.Tests/RoutedEventTests/Given_TappedRoutedEvent.cs
@@ -24,7 +24,7 @@ namespace Uno.UI.Tests.RoutedEventTests
 			root.Tapped += OnTapped;
 
 			var evt1 = new TappedRoutedEventArgs();
-			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeTrue();
+			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeFalse();
 
 			events.Should().HaveCount(1)
 				.And.ContainSingle(x => x.sender == root && x.args == evt1);
@@ -36,7 +36,7 @@ namespace Uno.UI.Tests.RoutedEventTests
 			var root = new Border();
 
 			var evt1 = new TappedRoutedEventArgs();
-			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeTrue();
+			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeFalse();
 		}
 
 		[TestMethod]
@@ -51,7 +51,7 @@ namespace Uno.UI.Tests.RoutedEventTests
 			root.AddHandler(UIElement.TappedEvent, (TappedEventHandler) OnTapped, false);
 
 			var evt1 = new TappedRoutedEventArgs();
-			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeTrue();
+			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeFalse();
 
 			events.Should().HaveCount(1)
 				.And.ContainSingle(x => x.sender == root && x.args == evt1);
@@ -69,7 +69,7 @@ namespace Uno.UI.Tests.RoutedEventTests
 			root.AddHandler(UIElement.TappedEvent, (TappedEventHandler)OnTapped, false);
 
 			var evt1 = new TappedRoutedEventArgs();
-			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeTrue();
+			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeFalse();
 
 			events.Should().HaveCount(1)
 				.And.ContainSingle(x => x.sender == root && x.args == evt1);
@@ -77,7 +77,7 @@ namespace Uno.UI.Tests.RoutedEventTests
 			root.RemoveHandler(UIElement.TappedEvent, (TappedEventHandler)OnTapped);
 
 			var evt2 = new TappedRoutedEventArgs();
-			root.RaiseEvent(UIElement.TappedEvent, evt2).Should().BeTrue();
+			root.RaiseEvent(UIElement.TappedEvent, evt2).Should().BeFalse();
 			events.Should().HaveCount(1);
 		}
 
@@ -98,7 +98,7 @@ namespace Uno.UI.Tests.RoutedEventTests
 
 			var evt1 = new TappedRoutedEventArgs();
 
-			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeTrue();
+			root.RaiseEvent(UIElement.TappedEvent, evt1).Should().BeFalse();
 			events.Should().HaveCount(1);
 		}
 

--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -136,7 +136,7 @@ namespace AppKit
 				{
 					var t = v as T;
 					return t != null && selector(t);
-				};
+				}; 
 			}
 
 			if (includeCurrent

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOS.cs
@@ -529,8 +529,11 @@ namespace Windows.UI.Xaml.Controls
 			// Like native dispatch on iOS, we do "implicit captures" the target.
 			if (this.GetParent() is UIElement parent)
 			{
+				// canBubbleNatively: true => We let native bubbling occur properly as it's never swallowed by system
+				//							  but blocking it would be breaking in lot of aspects.
+
 				_touchTarget = parent;
-				_touchTarget.TouchesBegan(touches, evt);
+				_touchTarget.TouchesBegan(touches, evt, canBubbleNatively: true); 
 			}
 		}
 
@@ -539,7 +542,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.TouchesMoved(touches, evt);
 
-			_touchTarget?.TouchesMoved(touches, evt);
+			// canBubbleNatively: false => system might silently swallow pointer after few moves so we prefer to bubble in managed.
+			_touchTarget?.TouchesMoved(touches, evt, canBubbleNatively: false);
 		}
 
 		/// <inheritdoc />
@@ -547,7 +551,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.TouchesEnded(touches, evt);
 
-			_touchTarget?.TouchesEnded(touches, evt);
+			// canBubbleNatively: false => system might silently swallow pointer after few moves so we prefer to bubble in managed.
+			_touchTarget?.TouchesEnded(touches, evt, canBubbleNatively: false);
 			_touchTarget = null;
 		}
 
@@ -556,7 +561,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.TouchesCancelled(touches, evt);
 
-			_touchTarget?.TouchesCancelled(touches, evt);
+			// canBubbleNatively: false => system might silently swallow pointer after few moves so we prefer to bubble in managed.
+			_touchTarget?.TouchesCancelled(touches, evt, canBubbleNatively: false);
 			_touchTarget = null;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOS.cs
@@ -530,7 +530,8 @@ namespace Windows.UI.Xaml.Controls
 			if (this.GetParent() is UIElement parent)
 			{
 				// canBubbleNatively: true => We let native bubbling occur properly as it's never swallowed by system
-				//							  but blocking it would be breaking in lot of aspects.
+				//							  but blocking it would be breaking in lot of aspects
+				//							  (e.g. it would prevent all sub-sequent events for the given pointer).
 
 				_touchTarget = parent;
 				_touchTarget.TouchesBegan(touches, evt, canBubbleNatively: true); 
@@ -542,7 +543,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.TouchesMoved(touches, evt);
 
-			// canBubbleNatively: false => system might silently swallow pointer after few moves so we prefer to bubble in managed.
+			// canBubbleNatively: false => The system might silently swallow pointers after a few moves so we prefer to bubble in managed.
 			_touchTarget?.TouchesMoved(touches, evt, canBubbleNatively: false);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.mux.cs
@@ -1862,6 +1862,7 @@ namespace Windows.UI.Xaml.Input
 			// TODO Uno specific: We need to do a full redraw, as render loop does not yet check for focus visuals rendering.
 			UpdateFocusRect(focusNavigationDirection, false);
 			FocusNative(_focusedElement as UIElement);
+			RootVisual.NotifyFocusChanged();
 
 			// At this point the focused pointer has been switched.  So success is true
 			// even in the case we run into trouble raising the event(s) to notify as such.

--- a/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/RootVisual.cs
@@ -46,7 +46,6 @@ namespace Uno.UI.Xaml.Core
 			SetAttribute("tabindex", "0");
 #endif
 
-#if HAS_UNO
 			AddHandler(
 				PointerPressedEvent,
 				new PointerEventHandler((snd, args) => ProcessPointerDown(args)),
@@ -55,7 +54,6 @@ namespace Uno.UI.Xaml.Core
 				PointerReleasedEvent,
 				new PointerEventHandler((snd, args) => ProcessPointerUp(args)),
 				handledEventsToo: true);
-#endif
 		}
 
 		/// <summary>
@@ -128,7 +126,6 @@ namespace Uno.UI.Xaml.Core
 			return finalSize;
 		}
 
-#if HAS_UNO
 		// As focus event are either async or cancellable,
 		// the FocusManager will explicitly notify us instead of listing to its events
 		internal static void NotifyFocusChanged()
@@ -157,7 +154,6 @@ namespace Uno.UI.Xaml.Core
 				return;
 			}
 
-#if __ANDROID__ || __WASM__ || __IOS__ || __SKIA__
 #if __ANDROID__ || __IOS__ // Not needed on WASM as we do have native support of the exit event
 			// On Android and iOS we use the RootVisual to raise the UWP only exit event (in managed only)
 
@@ -186,7 +182,6 @@ namespace Uno.UI.Xaml.Core
 			}
 
 			ReleaseCaptures(args.Reset(canBubbleNatively: false));
-#endif
 		}
 
 		private static void ReleaseCaptures(PointerRoutedEventArgs routedArgs)
@@ -199,6 +194,5 @@ namespace Uno.UI.Xaml.Core
 				}
 			}
 		}
-#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -881,7 +881,7 @@ namespace Windows.UI.Xaml
 			if (!isOverOrCaptured)
 			{
 				// We receive this event due to implicit capture, just ignore it locally and let is bubble
-				// note: If bubbling in managed then we are going to ignore element anyway as ctx is flagged as IsInternal.
+				// note: If bubbling in managed then we are going to ignore the element anyway as ctx is flagged as IsInternal.
 				// note 2: This case is actually impossible (no implicit capture on down)!
 				ctx = ctx.WithMode(ctx.Mode | BubblingMode.IgnoreElement);
 			}
@@ -1000,7 +1000,7 @@ namespace Windows.UI.Xaml
 			if (!isOverOrCaptured)
 			{
 				// We receive this event due to implicit capture, just ignore it locally and let is bubble
-				// note: If bubbling in managed then we are going to ignore element anyway as ctx is flagged as IsInternal.
+				// note: If bubbling in managed then we are going to ignore the element anyway as ctx is flagged as IsInternal.
 				ctx = ctx.WithMode(ctx.Mode | BubblingMode.IgnoreElement);
 			}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// #define TRACE_NATIVE_POINTER_EVENTS
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -83,7 +85,18 @@ namespace Windows.UI.Xaml
 
 		#region Native touch handling (i.e. source of the pointer / gesture events)
 		public override void TouchesBegan(NSSet touches, UIEvent evt)
+			=> TouchesBegan(touches, evt, canBubbleNatively: true);
+
+		/// <summary>
+		/// WARNING: canBubbleNatively=false on TouchesBegan has MAJOR impact regarding future events, use precautiously!
+		/// (cf. remarks in the method)
+		/// </summary>
+		internal void TouchesBegan(NSSet touches, UIEvent evt, bool canBubbleNatively)
 		{
+#if TRACE_NATIVE_POINTER_EVENTS
+			Console.WriteLine($"{this.GetDebugIdentifier()} [TOUCHES_BEGAN] enabled:{ArePointersEnabled}");
+#endif
+
 			if (!ArePointersEnabled)
 			{
 				return; // Will also prevent subsequents events
@@ -101,7 +114,7 @@ namespace Windows.UI.Xaml
 				foreach (UITouch touch in touches)
 				{
 					var pt = TransientNativePointer.Get(this, touch);
-					var args = new PointerRoutedEventArgs(pt.Id, touch, evt, this);
+					var args = new PointerRoutedEventArgs(pt.Id, touch, evt, this) { CanBubbleNatively = canBubbleNatively };
 
 					// We set the DownArgs only for the top most element (a.k.a. OriginalSource)
 					pt.DownArgs ??= args;
@@ -139,7 +152,10 @@ namespace Windows.UI.Xaml
 				 */
 
 				// Continue native bubbling up of the event
-				base.TouchesBegan(touches, evt);
+				if (canBubbleNatively)
+				{
+					base.TouchesBegan(touches, evt);
+				}
 			}
 			catch (Exception e)
 			{
@@ -148,14 +164,21 @@ namespace Windows.UI.Xaml
 		}
 
 		public override void TouchesMoved(NSSet touches, UIEvent evt)
+			=> TouchesMoved(touches, evt, canBubbleNatively: true);
+
+		internal void TouchesMoved(NSSet touches, UIEvent evt, bool canBubbleNatively)
 		{
+#if TRACE_NATIVE_POINTER_EVENTS
+			Console.WriteLine($"{this.GetDebugIdentifier()} [TOUCHES_MOVED]");
+#endif
+
 			try
 			{
 				var isHandledOrBubblingInManaged = default(bool);
 				foreach (UITouch touch in touches)
 				{
 					var pt = TransientNativePointer.Get(this, touch);
-					var args = new PointerRoutedEventArgs(pt.Id, touch, evt, this);
+					var args = new PointerRoutedEventArgs(pt.Id, touch, evt, this) { CanBubbleNatively = canBubbleNatively };
 					var isPointerOver = touch.IsTouchInView(this);
 
 					// This is acceptable to keep that flag in a kind-of static way, since iOS do "implicit captures",
@@ -167,7 +190,7 @@ namespace Windows.UI.Xaml
 					isHandledOrBubblingInManaged |= OnNativePointerMoveWithOverCheck(args, isPointerOver);
 				}
 
-				if (!isHandledOrBubblingInManaged)
+				if (canBubbleNatively && !isHandledOrBubblingInManaged)
 				{
 					// Continue native bubbling up of the event
 					base.TouchesMoved(touches, evt);
@@ -180,7 +203,14 @@ namespace Windows.UI.Xaml
 		}
 
 		public override void TouchesEnded(NSSet touches, UIEvent evt)
+			=> TouchesEnded(touches, evt, canBubbleNatively: true);
+
+		internal void TouchesEnded(NSSet touches, UIEvent evt, bool canBubbleNatively)
 		{
+#if TRACE_NATIVE_POINTER_EVENTS
+			Console.WriteLine($"{this.GetDebugIdentifier()} [TOUCHES_ENDED]");
+#endif
+
 			/* Note: Here we have a mismatching behavior with UWP, if the events bubble natively we're going to get
 					 (with Ctrl_02 is a child of Ctrl_01):
 							Ctrl_02: Released
@@ -204,7 +234,7 @@ namespace Windows.UI.Xaml
 				foreach (UITouch touch in touches)
 				{
 					var pt = TransientNativePointer.Get(this, touch);
-					var args = new PointerRoutedEventArgs(pt.Id, touch, evt, this);
+					var args = new PointerRoutedEventArgs(pt.Id, touch, evt, this) { CanBubbleNatively = canBubbleNatively };
 
 					if (!pt.HadMove)
 					{
@@ -218,7 +248,7 @@ namespace Windows.UI.Xaml
 						// Note: In case of multi-touch we might raise it unnecessarily, but it won't have any negative impact.
 						// Note: We do not consider the result of that move for the 'isHandledOrBubblingInManaged'
 						//		 as it's kind of un-related to the 'up' itself.
-						var mixedArgs = new PointerRoutedEventArgs(previous: pt.DownArgs, current: args);
+						var mixedArgs = new PointerRoutedEventArgs(previous: pt.DownArgs, current: args) { CanBubbleNatively = canBubbleNatively };
 						OnNativePointerMove(mixedArgs);
 					}
 
@@ -237,7 +267,7 @@ namespace Windows.UI.Xaml
 					pt.Release(this);
 				}
 
-				if (!isHandledOrBubblingInManaged)
+				if (canBubbleNatively && !isHandledOrBubblingInManaged)
 				{
 					// Continue native bubbling up of the event
 					base.TouchesEnded(touches, evt);
@@ -252,14 +282,21 @@ namespace Windows.UI.Xaml
 		}
 
 		public override void TouchesCancelled(NSSet touches, UIEvent evt)
+			=> TouchesCancelled(touches, evt, canBubbleNatively: true);
+
+		internal void TouchesCancelled(NSSet touches, UIEvent evt, bool canBubbleNatively)
 		{
+#if TRACE_NATIVE_POINTER_EVENTS
+			Console.WriteLine($"{this.GetDebugIdentifier()} [TOUCHES_CANCELLED]");
+#endif
+
 			try
 			{
 				var isHandledOrBubblingInManaged = default(bool);
 				foreach (UITouch touch in touches)
 				{
 					var pt = TransientNativePointer.Get(this, touch);
-					var args = new PointerRoutedEventArgs(pt.Id, touch, evt, this);
+					var args = new PointerRoutedEventArgs(pt.Id, touch, evt, this) { CanBubbleNatively = canBubbleNatively };
 
 					// Note: We should have raise either PointerCaptureLost or PointerCancelled here depending of the reason which
 					//		 drives the system to bubble a lost. However we don't have this kind of information on iOS, and it's
@@ -271,7 +308,7 @@ namespace Windows.UI.Xaml
 					pt.Release(this);
 				}
 
-				if (!isHandledOrBubblingInManaged)
+				if (canBubbleNatively && !isHandledOrBubblingInManaged)
 				{
 					// Continue native bubbling up of the event
 					base.TouchesCancelled(touches, evt);

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -701,7 +701,7 @@ namespace Windows.UI.Xaml
 			// [11] A parent is defined?
 			if (parent == null)
 			{
-				return true; // [12] processing finished
+				return isHandled; // [12] processing finished
 			}
 
 			// [13] Raise on parent
@@ -785,7 +785,7 @@ namespace Windows.UI.Xaml
 		{
 			public static readonly BubblingContext Bubble = default;
 
-			public static readonly BubblingContext NoBubbling = new BubblingContext { Mode = BubblingMode.NoBubbling };
+			public static readonly BubblingContext NoBubbling = new() { Mode = BubblingMode.NoBubbling };
 
 			/// <summary>
 			/// When bubbling in managed code, the <see cref="UIElement.RaiseEvent"/> will take care to raise the event on each parent,
@@ -793,10 +793,10 @@ namespace Windows.UI.Xaml
 			/// This value is used to flag events that are sent to element to maintain their internal state,
 			/// but which are not meant to initiate a new event bubbling (a.k.a. invoke the "RaiseEvent" again)
 			/// </summary>
-			public static readonly BubblingContext OnManagedBubbling = new BubblingContext { Mode = BubblingMode.NoBubbling, IsInternal = true };
+			public static readonly BubblingContext OnManagedBubbling = new() { Mode = BubblingMode.NoBubbling, IsInternal = true };
 
 			public static BubblingContext BubbleUpTo(UIElement root)
-				=> new BubblingContext { Root = root };
+				=> new() { Root = root };
 
 			/// <summary>
 			/// The mode to use for bubbling
@@ -819,7 +819,7 @@ namespace Windows.UI.Xaml
 			/// </remarks>
 			public bool IsInternal { get; set; }
 
-			public BubblingContext WithMode(BubblingMode mode) => new BubblingContext
+			public BubblingContext WithMode(BubblingMode mode) => new()
 			{
 				Mode = mode,
 				Root = Root,

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -9,7 +9,7 @@ body {
   overflow: hidden;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   /*
-    Disable **browsers** touche (and pen) manipulations support.
+    Disable **browsers** touch (and pen) manipulations support.
     Remarks: This has no relation with the UIElement.ManipulationMode which are handled in managed code.
              It only ensures that uno will always get ALL pointer events instead of being stolen by the browser for its internal gesture detection.
              This will also disable left and right swipe gesture to navigate through browser's history.

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputMouseInfo.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputMouseInfo.cs
@@ -83,12 +83,19 @@ public partial class InjectedInputMouseInfo
 			properties.MouseWheelDelta = DeltaX;
 			properties.IsHorizontalMouseWheel = true;
 		}
+		else if (MouseOptions.HasFlag(InjectedInputMouseOptions.Move) || MouseOptions.HasFlag(InjectedInputMouseOptions.MoveNoCoalesce))
+		{
+			properties.MouseWheelDelta = default;
+			properties.IsHorizontalMouseWheel = false;
+
+			// Should we use MouseData ??? But How to discriminate between X and Y moves?
+			position.X += DeltaX;
+			position.Y += DeltaY;
+		}
 		else
 		{
 			properties.MouseWheelDelta = default;
 			properties.IsHorizontalMouseWheel = false;
-			position.X += DeltaX;
-			position.Y += DeltaY;
 		}
 
 		properties.PointerUpdateKind = update;
@@ -97,10 +104,10 @@ public partial class InjectedInputMouseInfo
 			state.FrameId + TimeOffsetInMilliseconds,
 			state.Timestamp + TimeOffsetInMilliseconds,
 			PointerDevice.For(PointerDeviceType.Mouse),
-			1,
+			uint.MaxValue - 42, // Try to avoid conflict with the real mouse pointer
 			position,
 			position,
-			isInContact: true, // Always true for mouse
+			isInContact: properties.HasPressedButton,
 			properties);
 
 		return new PointerEventArgs(point, default);

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InputInjector.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InputInjector.cs
@@ -4,7 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Windows.Devices.Input;
+using Windows.Foundation;
 using Windows.UI.Core;
+using Uno.Extensions.Specialized;
 
 namespace Windows.UI.Input.Preview.Injection;
 
@@ -22,6 +24,11 @@ public partial class InputInjector
 
 	private readonly InjectedInputState _mouse = new(PointerDeviceType.Mouse);
 	private (InjectedInputState state, bool isAdded)? _touch;
+
+	/// <summary>
+	/// Gets the current state of the mouse pointer
+	/// </summary>
+	internal InjectedInputState Mouse => _mouse;
 
 	private InputInjector(CoreWindow window)
 	{


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/8289

## Bugfix
`PointerEntered` and `PointerExited` might not be raise nor bubble properly, especially when moving pointer while pressed from an element to another element.

## What is the current behavior?
1. When moving from an element to another element while pressed, on platform with "implicit capture" (iOS, Android, wasm-touch-chromium), when we try to "re-dispatch" up and exited, as the element is no longer considered pressed/hovered, we are filtering out the events instead of bubbling them as we should.
2. On iOS, the SCP (`UIScrollView`) might stop bubbling of native events for an unknown reason
3. When an event reach the top of the tree, the `RaiseEvent` method returns `true` which is interpreted has "handled" which alter the re-dispatching of exited event.

## What is the new behavior?
1. Either we make sure to flag "re-dispatched" events in a way that they are not filtering out, either we just disable the fitering when not needed at all.
2. [BREAKING] Pointer events are always bubble in managed by the SCP on iOS
3. The `RaiseEvent` now returns the `Handled` flag when reaching the top of the tree.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~ **cf. Below**
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
```

                                   ******************************
                                   ********** BREAKING **********
                                   ******************************
```

On iOS the `ScrollContentPresenter` is now bubbling all pointer events in managed only.
This means that a **native only** element that is hosting a managed `ScrollViewer` won't receive pointer event that occurs above that SV.

_Note: This is expected to not break any app since the native events was already not bubbling properly, so it would have already been broken._