### PR TITLE
Dev/dr/and frame stack

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FrameTests/Given_Frame.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FrameTests/Given_Frame.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FrameTests;
+
+[TestFixture]
+internal class Given_Frame : SampleControlUITestBase
+{
+	[Test]
+	[AutoRetry]
+	public void When_PageIsTransparent_Then_DontSeeStackedPaged()
+	{
+		Run("UITests.Windows_UI_Xaml_Controls.FrameTests.Frame_PageStacking", skipInitialScreenshot: true);
+
+		var frame = _app.Query("MyFrame").Single().Rect;
+
+		_app.Marked("NavRed").FastTap();
+		_app.Marked("NavTransparent").FastTap();
+
+		var result = TakeScreenshot("post_nav", ignoreInSnapshotCompare: true);
+
+		ImageAssert.HasColorAt(result, frame.CenterX, frame.CenterY, Color.Purple);
+	}
+
+	[Test]
+	[AutoRetry]
+	public void When_PageHasNoContent_Then_PointerPassThrough()
+	{
+		Run("UITests.Windows_UI_Xaml_Controls.FrameTests.Frame_PageStacking", skipInitialScreenshot: true);
+
+		_app.Marked("NavRed").FastTap();
+		_app.Marked("NavTransparent").FastTap();
+
+		_app.FastTap("MyFrame");
+
+		QueryEx output = "TappedResult";
+		var result = output.GetDependencyPropertyValue<string>("Text");
+
+		// We expect a "tapped" as:
+		// 1. The red should be collapsed so it should not have receive the tapped event, so it has not flagged it as handled.
+		// 2. Even if the bg of the TransparentPage is not null (i.e. Transparent),
+		//	  the Page should not get any pointer event as its content is completely empty.
+		result.Should().Be("tapped"); 
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1437,6 +1437,18 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FrameTests\FrameTests_RedPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FrameTests\FrameTests_TransparentPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FrameTests\Frame_PageStacking.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_def_MinMaxValues.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5505,6 +5517,15 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Unloaded.xaml.cs">
       <DependentUpon>Flyout_Unloaded.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FrameTests\FrameTests_RedPage.xaml.cs">
+      <DependentUpon>FrameTests_RedPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FrameTests\FrameTests_TransparentPage.xaml.cs">
+      <DependentUpon>FrameTests_TransparentPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FrameTests\Frame_PageStacking.xaml.cs">
+      <DependentUpon>Frame_PageStacking.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_def_MinMaxValues.xaml.cs">
       <DependentUpon>Grid_def_MinMaxValues.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/FrameTests_RedPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/FrameTests_RedPage.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.FrameTests.FrameTests_RedPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.FrameTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="Red">
+
+	<Grid Background="Red">
+		<TextBlock Text="This is the red page" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/FrameTests_RedPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/FrameTests_RedPage.xaml.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace UITests.Windows_UI_Xaml_Controls.FrameTests;
+
+public sealed partial class FrameTests_RedPage : Page
+{
+	public FrameTests_RedPage()
+	{
+		this.InitializeComponent();
+	}
+
+	/// <inheritdoc />
+	protected override void OnTapped(TappedRoutedEventArgs e)
+		=> e.Handled = true;
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/FrameTests_TransparentPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/FrameTests_TransparentPage.xaml
@@ -1,0 +1,17 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.FrameTests.FrameTests_TransparentPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.FrameTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="Transparent">
+
+	<Grid BorderBrush="DarkGray" BorderThickness="5" x:Name="RootOfTransparentPage">
+		<!--
+			This page intentonnaly left completely blank without event a TextBlock,
+			so we can test if pointer are passing throug it (like they should, event if BG=Transparent !)
+		--> 
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/FrameTests_TransparentPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/FrameTests_TransparentPage.xaml.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace UITests.Windows_UI_Xaml_Controls.FrameTests;
+
+public sealed partial class FrameTests_TransparentPage : Page
+{
+	public FrameTests_TransparentPage()
+	{
+		this.InitializeComponent();
+	}
+
+	/// <inheritdoc />
+	protected override void OnTapped(TappedRoutedEventArgs e)
+		=> e.Handled = true;
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/Frame_PageStacking.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/Frame_PageStacking.xaml
@@ -1,0 +1,27 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.FrameTests.Frame_PageStacking"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.Frame"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Background="Purple">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+
+		<StackPanel Orientation="Horizontal" Tapped="HandleTappedOnNavBar">
+			<Button x:Name="NavBack" Content="Back" Click="NavigateBack" />
+			<Button x:Name="NavRed" Content="Nav to red page" Click="NavigateRed" />
+			<Button x:Name="NavTransparent" Content="Nav to transparent page" Click="NavigateTransparent" />
+
+			<TextBlock x:Name="TappedResult" Text="**not tapped**" />
+		</StackPanel>
+		
+		<Frame Grid.Row="1"  x:Name="MyFrame" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/Frame_PageStacking.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FrameTests/Frame_PageStacking.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media.Animation;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.FrameTests;
+
+[Sample("Frame", IgnoreInSnapshotTests = true)]
+public sealed partial class Frame_PageStacking : Page
+{
+	public Frame_PageStacking()
+	{
+		this.InitializeComponent();
+	}
+
+	private void NavigateBack(object sender, RoutedEventArgs e)
+		=> MyFrame.GoBack(new SuppressNavigationTransitionInfo());
+
+	private void NavigateRed(object sender, RoutedEventArgs e)
+		=> MyFrame.Navigate(typeof(FrameTests_RedPage), default, new SuppressNavigationTransitionInfo());
+
+	private void NavigateTransparent(object sender, RoutedEventArgs e)
+		=> MyFrame.Navigate(typeof(FrameTests_TransparentPage), default, new SuppressNavigationTransitionInfo());
+
+	/// <inheritdoc />
+	protected override void OnTapped(TappedRoutedEventArgs e)
+		=> TappedResult.Text = "tapped";
+
+	private void HandleTappedOnNavBar(object sender, TappedRoutedEventArgs e)
+		=> e.Handled = true;
+}

--- a/src/Uno.UI/NativeFramePresenter.Android.cs
+++ b/src/Uno.UI/NativeFramePresenter.Android.cs
@@ -129,15 +129,26 @@ namespace Uno.UI.Controls
 						await newPage.AnimateAsync(GetEnterAnimation());
 						newPage.ClearAnimation();
 					}
-					if (FeatureConfiguration.NativeFramePresenter.AndroidUnloadInactivePages && oldPage != null)
+					if (oldPage is not null)
 					{
-						_pageStack.Children.Remove(oldPage);
+						if (FeatureConfiguration.NativeFramePresenter.AndroidUnloadInactivePages)
+						{
+							_pageStack.Children.Remove(oldPage);
+						}
+						else
+						{
+							oldPage.Visibility = Visibility.Collapsed;
+						}
 					}
 					break;
 				case NavigationMode.Back:
 					if (FeatureConfiguration.NativeFramePresenter.AndroidUnloadInactivePages)
 					{
 						_pageStack.Children.Insert(0, newPage);
+					}
+					else
+					{
+						newPage.Visibility = Visibility.Visible;
 					}
 					if (GetIsAnimated(oldEntry))
 					{


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/8333

## Bugfix
Android's `Frame` stacking not hiding previous pages

## What is the current behavior?
Android's `Frame` can stack pages instead of unloading them (for perf consideration), but if a page is transparent, the previous page might be visible.

Also, as `Page` (and all `UserControl`) are not hit testable (even if `Background` is set), pointers are going to pass-through since https://github.com/unoplatform/uno/pull/7571 (like on UWP). So even if previous page is not visible due to page's background, it will remain "interact-able"

## What is the new behavior?
Previous page are now flagged as `Visibility = Collapsed` when stacked.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [ ] ~~Contains **NO** breaking changes~~ **cf. below**
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

```
                                   ******************************
                                   ********** BREAKING **********
                                   ******************************
```

On Android, when feature flag `FeatureConfiguration.NativeFramePresenter.AndroidUnloadInactivePages` has not been set to `true` (it's `false` by default), the `Visibility` of the `Page` might be altered by the `Frame` on navigation.

This will break any app's data-binding to this `Visibility` property.