### PR TITLE
fix: [iOS] [Android] Fix set bitmap stream after delay not update Image - set bitmap URI not update ImageBrush

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -436,6 +436,40 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			ImageAssert.AreEqual(beforeLoad, afterClear, physicalRect, tolerance: PixelTolerance.Exclusive(1));
 		}
 
+		[Test]
+		[AutoRetry] 
+		public void BitmapImage_is_SetSource_After_Delay()
+		{ 
+			Run("Uno.UI.Samples.UITests.Image.ImageSourceDelay");
+
+			var SUT = _app.Marked("imgControl");
+			var txt = _app.Marked("txtStatus");
+			var btn1 = _app.Marked("btnLoadBmp1");
+			var btn2 = _app.Marked("btnLoadBmp2");
+
+			_app.WaitForElement(SUT, null, TimeSpan.FromSeconds(10),null, null);
+			_app.WaitForElement(txt);
+
+			_app.WaitForElement(btn1);
+			_app.WaitForElement(btn2);
+
+			_app.FastTap(btn1);
+
+			_app.WaitForText(txt, "Bmp1");
+
+			var screenRect = _app.GetPhysicalRect(SUT);
+
+			using var before = TakeScreenshot("Before");
+
+			_app.FastTap(btn2);
+
+			_app.WaitForText(txt, "Bmp2");
+
+			using var after = TakeScreenshot("After");
+
+			ImageAssert.AreNotEqual(before, after, screenRect);
+		}
+
 		private void WaitForBitmapOrSvgLoaded()
 		{
 			var isLoaded = _app.Marked("isLoaded");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Tests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Media.ImageBrushTests
+{
+	[TestFixture]
+	public partial class ImageBrush_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
+		public void When_ImageBrush_Source_URI_Changes()
+		{
+			Run("Uno.UI.Samples.UITests.ImageBrushTestControl.ImageBrushChangingURI");
+
+			var border = _app.Marked("brCont");
+			var txt = _app.Marked("txtStatus");
+
+			_app.WaitForElement(border);
+			_app.WaitForElement(txt);
+
+			var screenRect = _app.GetPhysicalRect(border);
+
+			using var before = TakeScreenshot("Before", ignoreInSnapshotCompare: true);
+
+			_app.FastTap("btnImage1"); 
+			
+			_app.WaitForText("txtStatus", "Changed");
+
+			using var after = TakeScreenshot("After");
+
+			ImageAssert.AreNotEqual(before, after, screenRect);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1557,6 +1557,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\ImageSourceDelay.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PasswordBoxTests\PasswordBox_AutoFill.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4161,6 +4165,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrushChangingURI.xaml">
+	    <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrushShapeStretchesAlignments.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6164,6 +6172,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\ImageAlignment2541.xaml.cs">
       <DependentUpon>ImageAlignment2541.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\ImageSourceDelay.xaml.cs">
+      <DependentUpon>ImageSourceDelay.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\ImageSourceUrlMsAppDataScheme.xaml.cs">
       <DependentUpon>ImageSourceUrlMsAppDataScheme.xaml</DependentUpon>
     </Compile>
@@ -7438,6 +7449,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\GradientBrushTests\LinearGradientBrush_Opacity.xaml.cs">
       <DependentUpon>LinearGradientBrush_Opacity.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrushChangingURI.xaml.cs">
+      <DependentUpon>ImageBrushChangingURI.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\ImageBrushShapeStretchesAlignments.xaml.cs">
       <DependentUpon>ImageBrushShapeStretchesAlignments.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceDelay.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceDelay.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+    x:Class="Uno.UI.Samples.UITests.Image.ImageSourceDelay"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Samples.UITests.Image"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+
+		<Button x:Name="btnLoadBmp1" Click="btnLoadBmp1_Click">Load Image 1</Button>
+		<Button x:Name="btnLoadBmp2" Click="btnLoadBmp2_Click">Load Image 2</Button>
+		<TextBlock x:Name="txtStatus"></TextBlock>
+		
+		<Image x:Name="imgControl" Height="50" />
+		 
+
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceDelay.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/ImageSourceDelay.xaml.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Storage;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Samples.UITests.Image
+{
+	[SampleControlInfo("Image", "ImageSourceDelay")]
+	public sealed partial class ImageSourceDelay : UserControl
+    {
+        public ImageSourceDelay()
+        {
+            this.InitializeComponent(); 
+        }
+
+		private void btnLoadBmp1_Click(object sender, RoutedEventArgs e)
+		{
+			imgControl.Source = GetBitmap("ms-appx:///Assets/search.png");
+			txtStatus.Text = "Bmp1";
+		}
+		
+		private void btnLoadBmp2_Click(object sender, RoutedEventArgs e)
+		{
+			imgControl.Source = GetBitmap("ms-appx:///Assets/cart.png");
+			txtStatus.Text = "Bmp2";
+		}
+
+		private BitmapImage GetBitmap(string fname)
+		{
+			var bmp = new BitmapImage();
+			LoadImage();
+			return bmp;
+
+			async void LoadImage()
+			{ 
+				var file = await StorageFile.GetFileFromApplicationUriAsync(new Uri(fname));
+				using (var fs = await file.OpenStreamForReadAsync())
+				{
+					await Task.Delay(100);
+					await bmp.SetSourceAsync(fs.AsRandomAccessStream()); 
+				}
+
+			}
+		}  
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrushChangingURI.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrushChangingURI.xaml
@@ -1,0 +1,31 @@
+<UserControl 
+	x:Class="Uno.UI.Samples.UITests.ImageBrushTestControl.ImageBrushChangingURI"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="Uno.UI.Samples.UITests.ImageBrushTestControl"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls" 
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<Button x:Name="btnImage1" HorizontalAlignment="Center" Margin="8" Click="OnButton1">Image 1</Button>
+		<Button x:Name="btnImage2" HorizontalAlignment="Center" Margin="8" Click="OnButton2">Image 2</Button>
+		<TextBlock x:Name="txtStatus"></TextBlock>
+		<Border Width="48" Height="48" CornerRadius="8" x:Name="brCont">
+			<Border.Background>
+				<ImageBrush Stretch="None" x:Name="brush">
+					<ImageBrush.ImageSource>
+						<BitmapImage UriSource="{x:Bind TileContent, Mode=OneWay}" DecodePixelType="Logical" />
+					</ImageBrush.ImageSource>
+				</ImageBrush>
+			</Border.Background>
+		</Border> 
+	</StackPanel> 
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrushChangingURI.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrushChangingURI.xaml.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.UITests.ImageTests.Models;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Samples.UITests.ImageBrushTestControl
+{
+	[SampleControlInfo("ImageBrushTestControl", "ImageBrushChangingURI")]
+	public sealed partial class ImageBrushChangingURI : UserControl
+	{
+		public static readonly DependencyProperty TileContentProperty = DependencyProperty.Register(nameof(TileContent), typeof(Uri), typeof(ImageBrushChangingURI), new PropertyMetadata(new Uri("https://cdn.pixabay.com/photo/2020/03/09/17/51/narcis-4916584_960_720.jpg")));
+
+		public Uri TileContent
+		{
+			get { return (Uri)GetValue(TileContentProperty); }
+			set { SetValue(TileContentProperty, value); }
+		}
+
+		public ImageBrushChangingURI()
+		{
+			this.InitializeComponent();
+
+			TileContent = new Uri("ms-appx:///Assets/rect.png");
+		}
+
+		private void OnButton1(object sender, RoutedEventArgs e)
+		{
+			TileContent = new Uri("ms-appx:///Assets/cart.png");
+			txtStatus.Text = "Changed";
+		}
+		private void OnButton2(object sender, RoutedEventArgs e)
+		{
+			TileContent = new Uri("ms-appx:///Assets/rect.png");
+			txtStatus.Text = "Changed";
+		}
+
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
@@ -60,8 +60,7 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			var imageHasChanged = newState.BackgroundImageSource != previousLayoutState?.BackgroundImageSource;
-			var shouldDisposeEagerly = imageHasChanged || newState.BackgroundImageSource == null;
+			var shouldDisposeEagerly = newState.BackgroundImageSource == null;
 			if (shouldDisposeEagerly)
 			{
 				// Clear previous value anyway in order to make sure the previous values are unset before the new ones.
@@ -494,6 +493,8 @@ namespace Windows.UI.Xaml.Controls
 			public readonly Thickness Padding;
 			public readonly Color? BackgroundFallbackColor;
 
+			public readonly long? StateVersion;
+
 			public LayoutState(Windows.Foundation.Rect area, Brush background, Thickness borderThickness, Brush borderBrush, CornerRadius cornerRadius, Thickness padding)
 			{
 				Area = area;
@@ -506,6 +507,8 @@ namespace Windows.UI.Xaml.Controls
 				var imageBrushBackground = Background as ImageBrush;
 				BackgroundImageSource = imageBrushBackground?.ImageSource;
 
+				StateVersion = BackgroundImageSource?.StateVersion;
+
 				BackgroundColor = (Background as SolidColorBrush)?.Color;
 				BorderBrushColor = (BorderBrush as SolidColorBrush)?.Color;
 
@@ -515,6 +518,7 @@ namespace Windows.UI.Xaml.Controls
 			public bool Equals(LayoutState other)
 			{
 				return other != null
+					&& other.StateVersion == StateVersion
 					&& other.Area == Area
 					&& other.Background == Background
 					&& other.BackgroundImageSource == BackgroundImageSource

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
@@ -87,10 +87,10 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else if (newValue is WriteableBitmap wb)
 			{
-				wb.Invalidated += OnInvalidated;
-				_sourceDisposable.Disposable = Disposable.Create(() => wb.Invalidated -= OnInvalidated);
+				newValue.InvalidateSource += OnInvalidateSource;
+				_sourceDisposable.Disposable = Disposable.Create(() => newValue.InvalidateSource -= OnInvalidateSource);
 
-				void OnInvalidated(object sdn, EventArgs args)
+				void OnInvalidateSource(object sdn, EventArgs args)
 				{
 					_openedSource = null;
 					TryOpenImage();
@@ -138,7 +138,6 @@ namespace Windows.UI.Xaml.Controls
 				
 				_sourceDisposable.Disposable = compositeDisposable;
 			}
-
 			TryOpenImage(forceReload);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -90,33 +90,18 @@ namespace Windows.UI.Xaml.Media
 			}
 			else if (b is ImageBrush imageBrush && imageBrushCallback != null)
 			{
-				var disposables = new CompositeDisposable(5);
+				var disposables = new CompositeDisposable(6);
 				imageBrushCallback();
+				 
+				void ImageChanged()
+				{
+					imageBrushCallback();
+				}
 
-				imageBrush.RegisterDisposablePropertyChangedCallback(
-					ImageBrush.ImageSourceProperty,
-					(_, __) => imageBrushCallback()
-				).DisposeWith(disposables);
+				imageBrush.ImageChanged += ImageChanged;
+				Disposable.Create(() => imageBrush.ImageChanged -= ImageChanged)
+					.DisposeWith(disposables); 
 
-				imageBrush.RegisterDisposablePropertyChangedCallback(
-					ImageBrush.StretchProperty,
-					(_, __) => imageBrushCallback()
-				).DisposeWith(disposables);
-
-				imageBrush.RegisterDisposablePropertyChangedCallback(
-					ImageBrush.AlignmentXProperty,
-					(_, __) => imageBrushCallback()
-				).DisposeWith(disposables);
-
-				imageBrush.RegisterDisposablePropertyChangedCallback(
-					ImageBrush.AlignmentYProperty,
-					(_, __) => imageBrushCallback()
-				).DisposeWith(disposables);
-
-				imageBrush.RegisterDisposablePropertyChangedCallback(
-					ImageBrush.RelativeTransformProperty,
-					(_, __) => imageBrushCallback()
-				).DisposeWith(disposables);
 
 				return disposables;
 			}

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.netstd.cs
@@ -77,7 +77,7 @@ namespace Windows.UI.Xaml.Media
 			return false;
 		}
 
-		private protected void InvalidateSource()
+		private protected void OnInvalidateSource()
 		{
 			_imageData = default;
 			if (_subscriptions.Count > 0 || this is SvgImageSource)

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.cs
@@ -32,9 +32,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 				UnloadImageData();
 			}
 			InitFromUri(e.NewValue as Uri);
-#if UNO_REFERENCE_API
-			InvalidateSource();
-#endif
+			OnInvalidateSource();
 		}
 
 		#endregion

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapSource.cs
@@ -120,7 +120,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 			using var r = ct.Register(() => tcs.TrySetCanceled());
 			using var s = Subscribe(OnChanged);
 
-			InvalidateSource();
+			OnInvalidateSource();
 
 			await tcs.Task;
 

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.cs
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 						?? Window.Current.Content;
 					(_bufferSize, PixelWidth, PixelHeight) = RenderAsBgra8_Premul(elementToRender, ref _buffer, new Size(scaledWidth, scaledHeight));
 #if __WASM__ || __SKIA__
-					InvalidateSource();
+					OnInvalidateSource();
 #endif
 				}
 				catch (Exception error)
@@ -115,7 +115,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 					(_bufferSize, PixelWidth, PixelHeight) = RenderAsBgra8_Premul(elementToRender, ref _buffer);
 #if __WASM__ || __SKIA__
-					InvalidateSource();
+					OnInvalidateSource();
 #endif
 				}
 				catch (Exception error)

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.cs
@@ -59,7 +59,7 @@ public partial class SvgImageSource : ImageSource
 		}
 		InitFromUri(e.NewValue as Uri);
 #if __NETSTD__
-		InvalidateSource();
+		OnInvalidateSource();
 #endif
 	}
 
@@ -98,7 +98,7 @@ public partial class SvgImageSource : ImageSource
 			using var x = Subscribe(OnChanged);
 
 
-			InvalidateSource();
+			OnInvalidateSource();
 
 			return await tcs.Task;
 

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.cs
@@ -26,10 +26,8 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 		public void Invalidate()
 		{
-#if __WASM__ || __SKIA__
-			InvalidateSource();
-#endif
+			OnInvalidateSource(); 
 			Invalidated?.Invoke(this, EventArgs.Empty);
-		}
+		} 
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5453 
closes #7288 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Changing the stream of a BitmapImage wasn't firing Image Control`s OnSourceChanged event. 
It was expected the same behavior like changing UriSource property of BitmapImage.

The same occurs whith ImageBrush when changing the URI of the bitmap.

## What is the new behavior?

Now, changing the Stream of a BitmapImage will trigger the OnInvalidated event that make possible to Image Control to update itself, loading the bitmap as it should be. 

The OnInvalidated event is also used to make possible Border / ImageBrush track the changes of its ImageSource.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


## Other information