### PR TITLE
fix: Adjust AndroidSupportedAbis and add proper validation for the target list

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -21,9 +21,8 @@
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\SamplesApp.Shared\Strings</ResourcesDirectory>
     <AndroidUseAapt2>true</AndroidUseAapt2>
-		
-		<!-- Workaround for https://github.com/xamarin/xamarin-android/issues/6480 -->
-		<AndroidUseAssemblyStore>false</AndroidUseAssemblyStore>
+    <!-- Workaround for https://github.com/xamarin/xamarin-android/issues/6480 -->
+    <AndroidUseAssemblyStore>false</AndroidUseAssemblyStore>
   </PropertyGroup>
   <PropertyGroup>
     <IsUiAutomationMappingEnabled>true</IsUiAutomationMappingEnabled>
@@ -43,10 +42,13 @@
     <EnableLLVM>false</EnableLLVM>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <MandroidI18n />
-    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidUseAapt2>true</AndroidUseAapt2>
+    <!-- Workaround for https://github.com/xamarin/xamarin-android/issues/6480 -->
+    <AndroidUseAssemblyStore>false</AndroidUseAssemblyStore>
     <AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -63,7 +65,7 @@
     <EnableLLVM>false</EnableLLVM>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>false</BundleAssemblies>
-    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
   </PropertyGroup>
@@ -244,6 +246,9 @@
       <_MyMdpiAsset>%(_myFilteredGroup.LogicalName)</_MyMdpiAsset>
     </PropertyGroup>
     <Error Condition="!$(_MyMdpiAsset.Contains('-nodpi'))" Text="The file nodpi-validationresource.jpeg does not exist under drawable-nodpi directory" />
+  </Target>
+  <Target Name="_ValidateAndroidSupportedAbis" BeforeTargets="BeforeBuild">
+    <Error Condition="'$(AndroidSupportedAbis)' != 'armeabi-v7a;x86;x86_64;arm64-v8a'" Text="The target list isn't correct, it must be 'armeabi-v7a;x86;x86_64;arm64-v8a'" />
   </Target>
   <Target Name="_FilterInvalidMacOSmsorlibReference" BeforeTargets="BeforeBuild">
     <!--Condition="$([MSBuild]::IsOsPlatform('OSX'))"-->

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Droid/BlankApp.Droid.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-prism/BlankApp.Droid/BlankApp.Droid.csproj
@@ -21,6 +21,8 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\BlankApp.Shared\Strings</ResourcesDirectory>
+    <!-- Workaround for https://github.com/xamarin/xamarin-android/issues/6480 -->
+    <AndroidUseAssemblyStore>false</AndroidUseAssemblyStore>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,6 +34,11 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
+    <!-- Workaround for https://github.com/xamarin/xamarin-android/issues/6480 -->
+    <AndroidUseAssemblyStore>false</AndroidUseAssemblyStore>
+    <AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -49,6 +56,8 @@
     <AotAssemblies>true</AotAssemblies>
     <EnableLLVM>true</EnableLLVM>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/src/SolutionTemplate/UnoSolutionTemplate/Droid/UnoQuickStart.Droid.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Droid/UnoQuickStart.Droid.csproj
@@ -21,6 +21,8 @@
 		<AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
 		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
 		<ResourcesDirectory>..\$ext_safeprojectname$.Shared\Strings</ResourcesDirectory>
+		<!-- Workaround for https://github.com/xamarin/xamarin-android/issues/6480 -->
+		<AndroidUseAssemblyStore>false</AndroidUseAssemblyStore>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<DebugSymbols>true</DebugSymbols>
@@ -32,6 +34,11 @@
 		<WarningLevel>4</WarningLevel>
 		<AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
 		<AndroidLinkMode>None</AndroidLinkMode>
+		<AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
+		<!-- Workaround for https://github.com/xamarin/xamarin-android/issues/6480 -->
+		<AndroidUseAssemblyStore>false</AndroidUseAssemblyStore>
+		<AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>
+		<BundleAssemblies>false</BundleAssemblies>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
 		<DebugType>portable</DebugType>
@@ -49,6 +56,8 @@
 		<AotAssemblies>true</AotAssemblies>
 		<EnableLLVM>true</EnableLLVM>
 		<AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
+		<AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
+		<BundleAssemblies>false</BundleAssemblies>
 	</PropertyGroup>
 	<ItemGroup>
 		<Reference Include="Mono.Android" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Easy to forget to correctly check the proper architecture depending on the Android simulator


## What is the new behavior?

Making sure all the Android Supported ABIs are checked and validate the target list


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


