### PR TITLE
ci: reduce runtime tests timeout

### DIFF
--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -107,10 +107,10 @@ jobs:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Runtime_Tests'
     JobDisplayName: 'iOS Automated Runtime Tests'
-    JobTimeoutInMinutes: 120
+    JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
-    UITEST_TEST_TIMEOUT: '7200000'
+    UITEST_TEST_TIMEOUT: '3600000'
     UITEST_AUTOMATED_GROUP: 4
     UITEST_ALLOW_RERUN: 'false'
     xCodeRoot: ${{ parameters.xCodeRootTest }}

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -177,17 +177,17 @@ log show --style syslog $TMP_LOG_FILEPATH > $LOG_FILEPATH_FULL
 if grep -xFe "mini-generic-sharing.c:899" $LOG_FILEPATH_FULL
 then
 	# The application may crash without known cause, add a marker so the job can be restarted in that case.
-    echo "##[error]mini-generic-sharing.c:899 assertion reached (https://github.com/unoplatform/uno/issues/8167)"
+    echo "##[error]UNOBLD001: mini-generic-sharing.c:899 assertion reached (https://github.com/unoplatform/uno/issues/8167)"
 fi
 
-if grep -xFe "System.Exception: Watchdog failed" $LOG_FILEPATH_FULL
+if grep -xFe "Unhandled managed exception: Watchdog failed" $LOG_FILEPATH_FULL
 then
 	# The application UI thread stalled
-    echo "##[error]Unknown failure, UI Thread Watchdog failed"
+    echo "##[error]UNOBLD002: Unknown failure, UI Thread Watchdog failed"
 fi
 
 if [ ! -f "$UNO_ORIGINAL_TEST_RESULTS" ]; then
-	echo "##[error]ERROR: The test results file $UNO_ORIGINAL_TEST_RESULTS does not exist (did nunit crash ?)"
+	echo "##[error]UNOBLD003: ERROR: The test results file $UNO_ORIGINAL_TEST_RESULTS does not exist (did nunit crash ?)"
 	return 1
 fi
 

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -180,6 +180,12 @@ then
     echo "##[error]mini-generic-sharing.c:899 assertion reached (https://github.com/unoplatform/uno/issues/8167)"
 fi
 
+if grep -xFe "System.Exception: Watchdog failed" $LOG_FILEPATH_FULL
+then
+	# The application UI thread stalled
+    echo "##[error]Unknown failure, UI Thread Watchdog failed"
+fi
+
 if [ ! -f "$UNO_ORIGINAL_TEST_RESULTS" ]; then
 	echo "##[error]ERROR: The test results file $UNO_ORIGINAL_TEST_RESULTS does not exist (did nunit crash ?)"
 	return 1


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Scale down runtime tests timeout after stabilization. Current runtime is between 30 to 40 minutes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
