### PR TITLE
fix: WebAuthenticationBroker returns canonical URL with the trailing

### DIFF
--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions/StringExtensions.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions/StringExtensions.cs
@@ -33,7 +33,6 @@ namespace Uno.Extensions
 #else
 		private static readonly Lazy<Regex> _newLineRegex = new Lazy<Regex>(() => new Regex(@"^", RegexOptions.Multiline));
 #endif
-
 		public static bool IsNullOrEmpty(this string instance)
 		{
 			return string.IsNullOrEmpty(instance);

--- a/src/Uno.Foundation/UriExtensions.cs
+++ b/src/Uno.Foundation/UriExtensions.cs
@@ -25,6 +25,7 @@ namespace Uno.Extensions
 				.ToDictionary(parts => parts[0], parts => String.Join("=", parts.Skip(1)));
 		}
 
+		internal static Uri TrimEndUriSlash(this Uri uri) => new (uri.OriginalString.TrimEnd("/"));
 
 		/// <summary>
 		/// Get extension of the traget file of the uri.

--- a/src/Uno.UI.RuntimeTests/Tests/Extensions/Given_Uri.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Extensions/Given_Uri.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Windows.Web.Http;
+
+namespace Uno.UI.RuntimeTests.Tests.Extensions
+{
+	[TestClass]
+	public class Given_Uri
+	{
+
+#if !WINDOWS_UWP
+		[TestMethod]
+		public void When_Do_TrimEndUriSlash()
+		{
+			var uri = new Uri("http://localhost/url/");
+
+			var initialLen = uri.ToString().Length;
+
+			uri = uri.TrimEndUriSlash();
+
+			var actualLen = uri.ToString().Length;	
+
+			Assert.AreNotEqual(initialLen, actualLen);
+		}
+
+		[TestMethod]
+		public void When_DoNot_Remove_TrimEndUriSlash()
+		{
+			var uri = new Uri("http://localhost/url");
+
+			var initialLen = uri.ToString().Length;
+
+			uri = uri.TrimEndUriSlash();
+
+			var actualLen = uri.ToString().Length;
+
+			Assert.AreEqual(initialLen, actualLen);
+		}
+
+#endif
+
+	}
+}

--- a/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.cs
+++ b/src/Uno.UWP/Security/Authentication/Web/WebAuthenticationBrokerProvider.cs
@@ -21,7 +21,14 @@ namespace Uno.AuthenticationBroker
 			{
 				// A default one is defined: we're using it instead of using
 				// a discovery mechanism.
+
+				//The Android Platform does not handle the last slash in Uri automatically
+#if __ANDROID__
+				return defaultUri.TrimEndUriSlash();
+#else
 				return defaultUri;
+#endif
+
 			}
 
 			var schemes = this.GetApplicationCustomSchemes().ToArray();
@@ -42,7 +49,11 @@ namespace Uno.AuthenticationBroker
 				this.Log().Warn(message);
 			}
 
-			return new Uri(schemes[0] + WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultCallbackPath);
+			var uri = new Uri(schemes[0] + WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultCallbackPath);
+#if __ANDROID__
+			uri = uri.TrimEndUriSlash();
+#endif
+			return uri;
 		}
 
 		public async Task<WebAuthenticationResult> AuthenticateAsync(


### PR DESCRIPTION
…slash which is not handled by Android

GitHub Issue (If applicable): closes #6485

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

WebAuthenticationBroker.GetCurrentApplicationCallbackUri() does return trailing slash for Android


## What is the new behavior?

WebAuthenticationBroker.GetCurrentApplicationCallbackUri() does not return trailing slash for Android


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ x] Validated PR `Screenshots Compare Test Run` results.
- [ x] Contains **NO** breaking changes
- [ x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
