### PR TITLE
Fix item wrongly appears selected when reordering selected item in LV

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.ExpectedPixels.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.ExpectedPixels.cs
@@ -122,6 +122,22 @@ namespace SamplesApp.UITests.TestFramework
 			=> Or(Pixel(alternativeColor) with { Alternatives = Array.Empty<ExpectedPixels>() });
 		#endregion
 
+		private ExpectedPixels(
+			string name,
+			Point location,
+			Point? sourceLocation,
+			Color[,] pixels,
+			PixelTolerance tolerance,
+			ExpectedPixels[] alternatives)
+		{
+			Name = name;
+			Location = location;
+			SourceLocation = sourceLocation;
+			Values = pixels ?? new Color[0, 0];
+			Tolerance = tolerance;
+			Alternatives = alternatives ?? Array.Empty<ExpectedPixels>();
+		}
+
 		public string Name { get; init; }
 
 		/// <summary>
@@ -144,9 +160,12 @@ namespace SamplesApp.UITests.TestFramework
 		public IEnumerable<ExpectedPixels> GetAllPossibilities()
 		{
 			yield return this;
-			foreach (var alternative in Alternatives)
+			if (Alternatives is not null)
 			{
-				yield return alternative;
+				foreach (var alternative in Alternatives)
+				{
+					yield return alternative;
+				}
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.ExpectedPixels.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.ExpectedPixels.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
@@ -57,7 +59,7 @@ namespace SamplesApp.UITests.TestFramework
 			=> this with { Values = new[,] { { color } } };
 
 		public ExpectedPixels Pixel(string color)
-			=> Pixel(GetColorFromString(color));
+			=> this with { Values = new[,] { { GetColorFromString(color) } } };
 
 		public ExpectedPixels Pixels(string[,] pixels)
 		{
@@ -113,13 +115,18 @@ namespace SamplesApp.UITests.TestFramework
 			=> this with { Tolerance = Tolerance.WithOffset(x, y) };
 
 		public ExpectedPixels Or(ExpectedPixels alternative)
-			=> this with { Alternatives = Alternatives.Concat(alternative.GetAllPossibilities()).ToArray() };
-
-		public ExpectedPixels OrPixel(string alternativeColor)
-			=> Or(Pixel(alternativeColor) with { Alternatives = Array.Empty<ExpectedPixels>() });
+			=> this with
+			{
+				Alternatives = Alternatives is null
+					? alternative.GetAllPossibilities().ToArray()
+					: Alternatives.Concat(alternative.GetAllPossibilities()).ToArray()
+			};
 
 		public ExpectedPixels OrPixel(Color alternativeColor)
-			=> Or(Pixel(alternativeColor) with { Alternatives = Array.Empty<ExpectedPixels>() });
+			=> Or(this with { Values = new[,] { { alternativeColor } }, Alternatives = null });
+
+		public ExpectedPixels OrPixel(string alternativeColor)
+			=> Or(this with { Values = new[,] { { GetColorFromString(alternativeColor) } }, Alternatives = null });
 		#endregion
 
 		private ExpectedPixels(
@@ -155,7 +162,7 @@ namespace SamplesApp.UITests.TestFramework
 
 		public PixelTolerance Tolerance { get; init; } = PixelTolerance.None;
 
-		public ExpectedPixels[] Alternatives { get; init; } = Array.Empty<ExpectedPixels>();
+		public ExpectedPixels[]? Alternatives { get; init; } = Array.Empty<ExpectedPixels>();
 
 		public IEnumerable<ExpectedPixels> GetAllPossibilities()
 		{

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/ImageAssert.cs
@@ -349,6 +349,12 @@ namespace SamplesApp.UITests.TestFramework
 			{
 				report.AppendLine($"{pixels.Name}:");
 
+				if (pixels.Values is null)
+				{
+					report.AppendLine("INVALID EXPECTATION: No pixels defined.");
+					continue;
+				}
+
 				bool isSuccess;
 				switch (pixels.Tolerance.OffsetKind)
 				{

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/IsExternalInit.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/IsExternalInit.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Linq;
+
+namespace System.Runtime.CompilerServices;
+
+#if !NET5_0 && !NET6_0
+#pragma warning disable CS0436
+public class IsExternalInit
+{
+}
+#endif

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListView_Selection_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListView_Selection_Automated.cs
@@ -33,14 +33,14 @@ public partial class DragDrop_ListView_Selection_Automated : SampleControlUITest
 		mode.SetDependencyPropertyValue("SelectedValue", "Single");
 
 		var sutBounds = _app.Query(sut).Single().Rect;
-		var x = sutBounds.X + 100;
+		var x = sutBounds.X + 50;
 		float Item(int index) => this.Item(sutBounds, index, itemHeight);
 
-		// Select "Item #5"
+		// Select "Item #6"
 		App.TapCoordinates(x, Item(5));
 		var afterSelect = TakeScreenshot("Item_5_Selected");
 
-		// Reorder "Item #5" to position 2
+		// Reorder "Item #6" to position 3
 		App.DragCoordinates(x, Item(5), x, Item(2));
 		var afterReorder = TakeScreenshot("Item_5_selected_at_position_2");
 
@@ -70,14 +70,14 @@ public partial class DragDrop_ListView_Selection_Automated : SampleControlUITest
 		mode.SetDependencyPropertyValue("SelectedValue", "Single");
 
 		var sutBounds = _app.Query(sut).Single().Rect;
-		var x = sutBounds.X + 100;
+		var x = sutBounds.X + 50;
 		float Item(int index) => this.Item(sutBounds, index, itemHeight);
 
-		// Select "Item #2"
+		// Select "Item #3"
 		App.TapCoordinates(x, Item(2));
 		var afterSelect = TakeScreenshot("Item_2_Selected");
 
-		// Reorder "Item #2" to position 5
+		// Reorder "Item #3" to position 6
 		App.DragCoordinates(x, Item(2), x, Item(5));
 		var afterReorder = TakeScreenshot("Item_2_selected_at_position_5");
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListView_Selection_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListView_Selection_Automated.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests;
+
+public partial class DragDrop_ListView_Selection_Automated : SampleControlUITestBase
+{
+	private float Item(IAppRect sut, int index, int itemLogicalHeight)
+		=> sut.Y + (index + .5f) * LogicalToPhysical(itemLogicalHeight);
+
+	[Test]
+	[AutoRetry]
+	[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+	public void When_Reorder_SelectedItem_Up()
+	{
+		const int itemHeight = 75;
+
+		Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView_Selection", skipInitialScreenshot: true);
+
+		var mode = App.Marked("SelectionModeConfig");
+		var sut = App.Marked("SUT");
+
+		mode.SetDependencyPropertyValue("SelectedValue", "Single");
+
+		var sutBounds = _app.Query(sut).Single().Rect;
+		var x = sutBounds.X + 100;
+		float Item(int index) => this.Item(sutBounds, index, itemHeight);
+
+		// Select "Item #5"
+		App.TapCoordinates(x, Item(5));
+		var afterSelect = TakeScreenshot("Item_5_Selected");
+
+		// Reorder "Item #5" to position 2
+		App.DragCoordinates(x, Item(5), x, Item(2));
+		var afterReorder = TakeScreenshot("Item_5_selected_at_position_2");
+
+		ImageAssert.HasColorAt(afterSelect, x, Item(2), Color.White);
+		ImageAssert.HasColorAt(afterSelect, x, Item(4), Color.White);
+		ImageAssert.HasColorAt(afterSelect, x, Item(5), Color.Red);
+		ImageAssert.HasColorAt(afterSelect, x, Item(6), Color.White);
+
+		ImageAssert.HasColorAt(afterReorder, x, Item(1), Color.White);
+		ImageAssert.HasColorAt(afterReorder, x, Item(2), Color.Red);
+		ImageAssert.HasColorAt(afterReorder, x, Item(3), Color.White);
+		ImageAssert.HasColorAt(afterReorder, x, Item(5), Color.White);
+	}
+
+	[Test]
+	[AutoRetry]
+	[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+	public void When_Reorder_SelectedItem_Down()
+	{
+		const int itemHeight = 75;
+
+		Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView_Selection", skipInitialScreenshot: true);
+
+		var mode = App.Marked("SelectionModeConfig");
+		var sut = App.Marked("SUT");
+
+		mode.SetDependencyPropertyValue("SelectedValue", "Single");
+
+		var sutBounds = _app.Query(sut).Single().Rect;
+		var x = sutBounds.X + 100;
+		float Item(int index) => this.Item(sutBounds, index, itemHeight);
+
+		// Select "Item #2"
+		App.TapCoordinates(x, Item(2));
+		var afterSelect = TakeScreenshot("Item_2_Selected");
+
+		// Reorder "Item #2" to position 5
+		App.DragCoordinates(x, Item(2), x, Item(5));
+		var afterReorder = TakeScreenshot("Item_2_selected_at_position_5");
+
+		ImageAssert.HasColorAt(afterSelect, x, Item(1), Color.White);
+		ImageAssert.HasColorAt(afterSelect, x, Item(2), Color.Red);
+		ImageAssert.HasColorAt(afterSelect, x, Item(3), Color.White);
+		ImageAssert.HasColorAt(afterSelect, x, Item(5), Color.White);
+
+		ImageAssert.HasColorAt(afterReorder, x, Item(2), Color.White);
+		ImageAssert.HasColorAt(afterReorder, x, Item(4), Color.White);
+		ImageAssert.HasColorAt(afterReorder, x, Item(5), Color.Red);
+		ImageAssert.HasColorAt(afterReorder, x, Item(6), Color.White);
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListView_Selection_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListView_Selection_Automated.cs
@@ -82,13 +82,13 @@ public partial class DragDrop_ListView_Selection_Automated : SampleControlUITest
 		var afterReorder = TakeScreenshot("Item_2_selected_at_position_5");
 
 		ImageAssert.HasColorAt(afterSelect, x, Item(1), Color.White);
-		ImageAssert.HasColorAt(afterSelect, x, Item(2), Color.Red);
+		ImageAssert.HasPixels(afterSelect, ExpectedPixels.At(x, Item(2)).Pixel(Color.Red).OrPixel("#FFFF00").OrPixel("#FFA000C0")); // Any selected state
 		ImageAssert.HasColorAt(afterSelect, x, Item(3), Color.White);
 		ImageAssert.HasColorAt(afterSelect, x, Item(5), Color.White);
 
 		ImageAssert.HasColorAt(afterReorder, x, Item(2), Color.White);
 		ImageAssert.HasColorAt(afterReorder, x, Item(4), Color.White);
-		ImageAssert.HasColorAt(afterReorder, x, Item(5), Color.Red);
+		ImageAssert.HasPixels(afterReorder, ExpectedPixels.At(x, Item(5)).Pixel(Color.Red).OrPixel("#FFFF00").OrPixel("#FFA000C0")); // Any selected state
 		ImageAssert.HasColorAt(afterReorder, x, Item(6), Color.White);
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListView_Selection_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListView_Selection_Automated.cs
@@ -46,11 +46,11 @@ public partial class DragDrop_ListView_Selection_Automated : SampleControlUITest
 
 		ImageAssert.HasColorAt(afterSelect, x, Item(2), Color.White);
 		ImageAssert.HasColorAt(afterSelect, x, Item(4), Color.White);
-		ImageAssert.HasColorAt(afterSelect, x, Item(5), Color.Red);
+		ImageAssert.HasPixels(afterSelect, ExpectedPixels.At(x, Item(5)).Pixel(Color.Red).OrPixel("#FFFF00").OrPixel("#FFA000C0")); // Any selected stateColor.Red);
 		ImageAssert.HasColorAt(afterSelect, x, Item(6), Color.White);
 
 		ImageAssert.HasColorAt(afterReorder, x, Item(1), Color.White);
-		ImageAssert.HasColorAt(afterReorder, x, Item(2), Color.Red);
+		ImageAssert.HasPixels(afterReorder, ExpectedPixels.At(x, Item(2)).Pixel(Color.Red).OrPixel("#FFFF00").OrPixel("#FFA000C0")); // Any selected state
 		ImageAssert.HasColorAt(afterReorder, x, Item(3), Color.White);
 		ImageAssert.HasColorAt(afterReorder, x, Item(5), Color.White);
 	}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -805,6 +805,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView_Selection.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView_WithPadding.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5091,6 +5095,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView_Custom_States.xaml.cs">
       <DependentUpon>DragDrop_ListView_Custom_States.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView_Selection.xaml.cs">
+      <DependentUpon>DragDrop_ListView_Selection.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView_WithPadding.xaml.cs">
       <DependentUpon>DragDrop_ListView_WithPadding.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_Selection.xaml
@@ -1,0 +1,122 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView_Selection"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml.DragAndDrop"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<Style x:Key="LVIStyle" TargetType="ListViewItem">
+			<Setter Property="HorizontalAlignment" Value="Left" />
+			<Setter Property="HorizontalContentAlignment" Value="Left" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ListViewItem">
+						<Grid 
+							x:Name="ContentBorder"
+							Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							BorderThickness="{TemplateBinding BorderThickness}">
+
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+
+									<VisualState x:Name="Selected">
+										<VisualState.Setters>
+											<Setter Target="SelectionIndicator.Color" Value="#FF0000" />
+										</VisualState.Setters>
+									</VisualState>
+
+									<VisualState x:Name="PointerOver">
+										<VisualState.Setters>
+											<Setter Target="SelectionIndicator.Color" Value="#FF8000" />
+										</VisualState.Setters>
+									</VisualState>
+
+									<VisualState x:Name="PointerOverSelected">
+										<VisualState.Setters>
+											<Setter Target="SelectionIndicator.Color" Value="#FFFF00" />
+										</VisualState.Setters>
+									</VisualState>
+
+									<VisualState x:Name="PointerOverPressed">
+										<VisualState.Setters>
+											<Setter Target="SelectionIndicator.Color" Value="#008000" />
+										</VisualState.Setters>
+									</VisualState>
+
+									<VisualState x:Name="Pressed">
+										<VisualState.Setters>
+											<Setter Target="SelectionIndicator.Color" Value="#0000FF" />
+										</VisualState.Setters>
+									</VisualState>
+
+									<VisualState x:Name="PressedSelected">
+										<VisualState.Setters>
+											<Setter Target="SelectionIndicator.Color" Value="#A000C0" />
+										</VisualState.Setters>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition />
+							</Grid.ColumnDefinitions>
+
+							<Rectangle Grid.Column="0" Width="75" Height="75">
+								<Rectangle.Fill>
+									<SolidColorBrush x:Name="SelectionIndicator" Color="White" />
+								</Rectangle.Fill>
+							</Rectangle>
+
+							<ContentPresenter 
+								x:Name="ContentPresenter"
+								Grid.Column="1"
+								Content="{TemplateBinding Content}"
+								ContentTransitions="{TemplateBinding ContentTransitions}"
+								ContentTemplate="{TemplateBinding ContentTemplate}"
+								ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+								Margin="4,0,0,0" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</Page.Resources>
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<ComboBox x:Name="SelectionModeConfig">
+			<x:String>Single</x:String>
+			<x:String>Multiple</x:String>
+			<x:String>Extended</x:String>
+		</ComboBox>
+
+		<ListView 
+			CanDragItems="True"
+			CanReorderItems="True"
+			AllowDrop="True"
+			SelectionMode="{Binding ElementName=SelectionModeConfig, Path=SelectedValue}"
+			MinHeight="300"
+			x:Name="SUT"
+			Grid.Row="1"
+			ItemContainerStyle="{StaticResource LVIStyle}"
+			ItemsSource="{x:Bind Items}"
+			SelectionChanged="SUT_OnSelectionChanged">
+		</ListView>
+
+		<TextBlock x:Name="SelectedOuput" Text="--none--" Grid.Row="2" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView_Selection.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml.DragAndDrop;
+
+[Sample("DragAndDrop", "ListView",
+	Description = "This automated tests validate that reordering selected items in ListView keeps valid selection.",
+	IgnoreInSnapshotTests = true)]
+public sealed partial class DragDrop_ListView_Selection : Page
+{
+	public DragDrop_ListView_Selection()
+	{
+		this.InitializeComponent();
+	}
+
+	public ObservableCollection<string> Items { get; } = new(Enumerable.Range(1, 32).Select(i => $"Item #{i}"));
+
+	private void SUT_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+	{
+		SelectedOuput.Text = e.AddedItems?.FirstOrDefault()?.ToString() ?? "--none--";
+	}
+}

--- a/src/Uno.Foundation/Collections/VectorChangedEventArgs.cs
+++ b/src/Uno.Foundation/Collections/VectorChangedEventArgs.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text;
-using Android.Media;
 
 namespace Windows.Foundation.Collections;
 

--- a/src/Uno.Foundation/Collections/VectorChangedEventArgs.cs
+++ b/src/Uno.Foundation/Collections/VectorChangedEventArgs.cs
@@ -1,19 +1,31 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Text;
+using Android.Media;
 
-namespace Windows.Foundation.Collections
+namespace Windows.Foundation.Collections;
+
+internal class VectorChangedEventArgs : IVectorChangedEventArgs
 {
-	internal class VectorChangedEventArgs : IVectorChangedEventArgs
+	public VectorChangedEventArgs(CollectionChange change, uint index)
 	{
-		public VectorChangedEventArgs(CollectionChange change, uint index)
-		{
-			CollectionChange = change;
-			Index = index;
-		}
-
-		public CollectionChange CollectionChange { get; }
-
-		public uint Index { get; }
+		CollectionChange = change;
+		Index = index;
 	}
+
+	public VectorChangedEventArgs(NotifyCollectionChangedEventArgs ncArgs, CollectionChange change, uint index)
+	{
+		NotifyCollectionChanged = ncArgs;
+		CollectionChange = change;
+		Index = index;
+	}
+
+	public NotifyCollectionChangedEventArgs? NotifyCollectionChanged { get; }
+
+	public CollectionChange CollectionChange { get; }
+
+	public uint Index { get; }
 }

--- a/src/Uno.Foundation/Extensions/NotifyCollectionChangedEventArgsExtensions.cs
+++ b/src/Uno.Foundation/Extensions/NotifyCollectionChangedEventArgsExtensions.cs
@@ -4,88 +4,92 @@ using System.Collections.Specialized;
 using System.Text;
 using Windows.Foundation.Collections;
 
-namespace Uno.Extensions
+namespace Uno.Extensions;
+
+public static class NotifyCollectionChangedEventArgsExtensions
 {
-	public static class NotifyCollectionChangedEventArgsExtensions
+	public static IVectorChangedEventArgs ToVectorChangedEventArgs(this NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 	{
-		public static IVectorChangedEventArgs ToVectorChangedEventArgs(this NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
+		var change = notifyCollectionChangedEventArgs.Action.ToCollectionChange();
+
+		int index;
+		switch (notifyCollectionChangedEventArgs.Action)
 		{
-			var change = notifyCollectionChangedEventArgs.Action.ToCollectionChange();
-
-			int index;
-			switch (notifyCollectionChangedEventArgs.Action)
-			{
-				case NotifyCollectionChangedAction.Add:
-				case NotifyCollectionChangedAction.Replace:
-					index = notifyCollectionChangedEventArgs.NewStartingIndex;
-					break;
-				case NotifyCollectionChangedAction.Remove:
-					index = notifyCollectionChangedEventArgs.OldStartingIndex;
-					break;
-				case NotifyCollectionChangedAction.Move:
-				case NotifyCollectionChangedAction.Reset:
-					index = 0;
-					break;
-				default:
-					throw new ArgumentOutOfRangeException();
-			}
-
-			return new VectorChangedEventArgs(change, (uint)index);
+			case NotifyCollectionChangedAction.Add:
+			case NotifyCollectionChangedAction.Replace:
+				index = notifyCollectionChangedEventArgs.NewStartingIndex;
+				break;
+			case NotifyCollectionChangedAction.Remove:
+				index = notifyCollectionChangedEventArgs.OldStartingIndex;
+				break;
+			case NotifyCollectionChangedAction.Move:
+			case NotifyCollectionChangedAction.Reset:
+				index = 0;
+				break;
+			default:
+				throw new ArgumentOutOfRangeException();
 		}
 
-		public static CollectionChange ToCollectionChange(this NotifyCollectionChangedAction action)
-		{
-			switch (action)
-			{
-				case NotifyCollectionChangedAction.Add:
-					return CollectionChange.ItemInserted;
-				case NotifyCollectionChangedAction.Move:
-					return CollectionChange.Reset;
-				case NotifyCollectionChangedAction.Remove:
-					return CollectionChange.ItemRemoved;
-				case NotifyCollectionChangedAction.Replace:
-					return CollectionChange.ItemChanged;
-				case NotifyCollectionChangedAction.Reset:
-					return CollectionChange.Reset;
-			}
+		return new VectorChangedEventArgs(notifyCollectionChangedEventArgs, change, (uint)index);
+	}
 
-			throw new ArgumentOutOfRangeException();
+	public static CollectionChange ToCollectionChange(this NotifyCollectionChangedAction action)
+	{
+		switch (action)
+		{
+			case NotifyCollectionChangedAction.Add:
+				return CollectionChange.ItemInserted;
+			case NotifyCollectionChangedAction.Move:
+				return CollectionChange.Reset;
+			case NotifyCollectionChangedAction.Remove:
+				return CollectionChange.ItemRemoved;
+			case NotifyCollectionChangedAction.Replace:
+				return CollectionChange.ItemChanged;
+			case NotifyCollectionChangedAction.Reset:
+				return CollectionChange.Reset;
 		}
 
-		public static NotifyCollectionChangedEventArgs ToNotifyCollectionChangedEventArgs(this IVectorChangedEventArgs vectorChangedEventArgs)
+		throw new ArgumentOutOfRangeException();
+	}
+
+	public static NotifyCollectionChangedEventArgs ToNotifyCollectionChangedEventArgs(this IVectorChangedEventArgs vectorChangedEventArgs)
+	{
+		if (vectorChangedEventArgs is VectorChangedEventArgs { NotifyCollectionChanged: not null } args)
 		{
-			var action = vectorChangedEventArgs.CollectionChange.ToNotifyCollectionChangedAction();
-
-			// Note: we don't populate NewItems/OldItems, but Uno only checks their lengths
-			switch (action)
-			{
-				case NotifyCollectionChangedAction.Add:
-				case NotifyCollectionChangedAction.Remove:
-					return new NotifyCollectionChangedEventArgs(action, changedItem: null, index: (int)vectorChangedEventArgs.Index);
-				case NotifyCollectionChangedAction.Replace:
-					return new NotifyCollectionChangedEventArgs(action, newItem: null, oldItem: null, index: (int)vectorChangedEventArgs.Index);
-				case NotifyCollectionChangedAction.Reset:
-					return new NotifyCollectionChangedEventArgs(action);
-			}
-
-			throw new ArgumentOutOfRangeException();
+			return args.NotifyCollectionChanged;
 		}
 
-		public static NotifyCollectionChangedAction ToNotifyCollectionChangedAction(this CollectionChange change)
-		{
-			switch (change)
-			{
-				case CollectionChange.ItemChanged:
-					return NotifyCollectionChangedAction.Replace;
-				case CollectionChange.ItemInserted:
-					return NotifyCollectionChangedAction.Add;
-				case CollectionChange.ItemRemoved:
-					return NotifyCollectionChangedAction.Remove;
-				case CollectionChange.Reset:
-					return NotifyCollectionChangedAction.Reset;
-			}
+		var action = vectorChangedEventArgs.CollectionChange.ToNotifyCollectionChangedAction();
 
-			throw new ArgumentOutOfRangeException();
+		// Note: we don't populate NewItems/OldItems, but Uno only checks their lengths
+		switch (action)
+		{
+			case NotifyCollectionChangedAction.Add:
+			case NotifyCollectionChangedAction.Remove:
+				return new NotifyCollectionChangedEventArgs(action, changedItem: null, index: (int)vectorChangedEventArgs.Index);
+			case NotifyCollectionChangedAction.Replace:
+				return new NotifyCollectionChangedEventArgs(action, newItem: null, oldItem: null, index: (int)vectorChangedEventArgs.Index);
+			case NotifyCollectionChangedAction.Reset:
+				return new NotifyCollectionChangedEventArgs(action);
 		}
+
+		throw new ArgumentOutOfRangeException();
+	}
+
+	public static NotifyCollectionChangedAction ToNotifyCollectionChangedAction(this CollectionChange change)
+	{
+		switch (change)
+		{
+			case CollectionChange.ItemChanged:
+				return NotifyCollectionChangedAction.Replace;
+			case CollectionChange.ItemInserted:
+				return NotifyCollectionChangedAction.Add;
+			case CollectionChange.ItemRemoved:
+				return NotifyCollectionChangedAction.Remove;
+			case CollectionChange.Reset:
+				return NotifyCollectionChangedAction.Reset;
+		}
+
+		throw new ArgumentOutOfRangeException();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Android.cs
@@ -163,6 +163,14 @@ namespace Windows.UI.Xaml.Controls
 
 		internal override int IndexFromContainerInner(DependencyObject container)
 		{
+			if (_isProcessingReorder)
+			{
+				// When we process a re-ordering, the "attached" indexes (IndexForItemContainerProperty) are known to be valid,
+				// but the native (NativePanel) is not (moved item is still at it's original location / index).
+
+				return base.IndexFromContainerInner(container);
+			}
+
 			if (NativePanel != null)
 			{
 				var selectorItem = container as SelectorItem;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -465,7 +465,7 @@ namespace Windows.UI.Xaml.Controls
 
 					// Because new items are added, the containers for existing items with higher indices
 					// will be moved, and we must make sure to increase their indices
-					SaveContainersForIndexRepair(args.NewStartingIndex, args.NewItems.Count);
+					SaveContainersBeforeAddForIndexRepair(args.NewItems, args.NewStartingIndex, args.NewItems.Count);
 					AddItems(args.NewStartingIndex, args.NewItems.Count, section);
 					RepairIndices();
 
@@ -483,7 +483,7 @@ namespace Windows.UI.Xaml.Controls
 						this.Log().Debug($"Deleting {args.OldItems.Count} items starting at {args.OldStartingIndex}");
 					}
 
-					SaveContainersForIndexRepair(args.OldStartingIndex, -args.OldItems.Count);
+					SaveContainersBeforeRemoveForIndexRepair(args.OldStartingIndex, args.OldItems.Count);
 					RemoveItems(args.OldStartingIndex, args.OldItems.Count, section);
 					RepairIndices();
 
@@ -524,16 +524,55 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		/// <param name="startingIndex">The minimum index of containers we care about.</param>
 		/// <param name="indexChange">How does the index change.</param>
-		private void SaveContainersForIndexRepair(int startingIndex, int indexChange)
+		private void SaveContainersBeforeAddForIndexRepair(IList addedItems, int startingIndex, int indexChange)
 		{
 			_containersForIndexRepair.Clear();
 			foreach (var container in MaterializedContainers)
 			{
 				var currentIndex = (int)container.GetValue(ItemsControl.IndexForItemContainerProperty);
-				if (currentIndex >= startingIndex)
+				if (currentIndex is -1 && container is ContentControl ctrl)
+				{
+					var offset = addedItems.IndexOf(ctrl.Content);
+					if (offset >= 0)
+					{
+						_containersForIndexRepair.Add(container, startingIndex + offset);
+					}
+				}
+				else if (currentIndex >= startingIndex)
 				{
 					// we store the index, that should be set after the collection change
 					_containersForIndexRepair.Add(container, currentIndex + indexChange);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Stores materialized containers starting a given index, so that their
+		/// ItemsControl.IndexForContainerProperty can be updated after the collection changes.		
+		/// </summary>
+		/// <param name="startingIndex">The minimum index of containers we care about.</param>
+		/// <param name="indexChange">How does the index change.</param>
+		private void SaveContainersBeforeRemoveForIndexRepair(int startingIndex, int indexChange)
+		{
+			_containersForIndexRepair.Clear();
+
+			var firstRemainingIndex = startingIndex + indexChange;
+			foreach (var container in MaterializedContainers)
+			{
+				var currentIndex = (int)container.GetValue(ItemsControl.IndexForItemContainerProperty);
+				if (currentIndex < startingIndex)
+				{
+					continue;
+				}
+
+				if (currentIndex < firstRemainingIndex)
+				{
+					_containersForIndexRepair.Add(container, -1);
+				}
+				else
+				{
+					// we store the index, that should be set after the collection change
+					_containersForIndexRepair.Add(container, currentIndex - indexChange);
 				}
 			}
 		}


### PR DESCRIPTION
fixes https://github.com/unoplatform/nventive-private/issues/362
fixes https://github.com/unoplatform/uno/issues/4741

## Bugfix
When we re-order a selected item in a LV, the item above or below drop location might appears as selected.

## What is the current behavior?
When the moved item is being drop, we are doing remove+add which drives the LV to wrongly updates internal indices, which drives the selected state to be applied on the wrong item.

## What is the new behavior?
* On collection add/remove we are computing indices properly
* On Android, while reordering an item we no longer rely on the non-yet-updated native collection of items.

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
