### PR TITLE
Use native `MessageDialog` UI on Android, iOS and macOS; allow overriding style

### DIFF
--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -28,4 +28,26 @@ In older versions of Uno Platforms, the `Popup.IsLightDismissEnabled` dependency
 
 ## MessageDialog
 
-By default, `MessageDialog` in Uno Platform targets displays using `ContentDialog`, to ensure consistent functionality and appearance across platforms. If you prefer to display it using native dialogs on iOS, Android, macOS, and WASM, you can set the `WinRTFeatureConfiguration.MessageDialog.UseNativeDialog` flag to `true`. Beware that some features may be missing for the native implementations.
+By default, `MessageDialog` in Uno Platform targets displays using `ContentDialog` on WebAssembly and Skia, whereas it uses native dialog UI on Android, iOS and macOS. The native dialogs are familiar to the users of the target platform, whereas the `ContentDialog` version offers the same UI on all targets. The  `WinRTFeatureConfiguration.MessageDialog.UseNativeDialog` flag allows you to either disable or enable the use of native dialog UI. The default value of the flag depends on the target platform and changing the value of the flag on Skia has no effect (only `ContentDialog` version is available there):
+
+| Feature        | Android | iOS | macOS | WASM | Skia |
+|----------------|---------|-----|-------|------| --- |
+| Default value of `UseNativeDialog`     | `true` | `true` |  `true`   | `false` | `false` |
+| Native version available     | ✅ | ✅ |  ✅   | ✅(*) | ❌ |
+| `ContentDialog` version available     | ✅ | ✅ |  ✅   | ✅ | ✅ |
+
+(*) Native WebAssembly implementation uses `alert()` and is very limited.
+
+When `ContentDialog` version is used, it uses the default `ContentDialog` style. If you want to customize the UI, you can declare your own `Style` on the application resource level and then set the `StyleOverride` flag to the resource key:
+
+```xaml
+<Application.Resources>
+    <Style x:Key="CustomMessageDialogStyle" TargetType="ContentDialog">
+    ...
+    </Style>
+</Application.Resources>
+```
+
+```c#
+WinRTFeatureConfiguration.MessageDialog.StyleOverride = "CustomMessageDialogStyle";
+```

--- a/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
+++ b/src/Uno.UI/WinRT/Extensions/UI/Popups/MessageDialogContentDialog.cs
@@ -23,10 +23,12 @@ internal partial class MessageDialogContentDialog : ContentDialog
 		DefaultStyleKey = typeof(ContentDialog);
 		_messageDialog = messageDialog ?? throw new ArgumentNullException(nameof(messageDialog));
 
-		// WinUI provides a modern style for ContentDialog, which is not applied automatically - force it
-		if (Application.Current.Resources.TryGetValue("DefaultContentDialogStyle", out var resource) && resource is Style winUIStyle)
-		{
-			Style = winUIStyle;
+		var styleOverriden = TryApplyStyle(WinRTFeatureConfiguration.MessageDialog.StyleOverride);
+		if (!styleOverriden)
+        {
+			// WinUI provides a modern style for ContentDialog, which is not applied automatically.
+			// Force apply it if available.
+			TryApplyStyle("DefaultContentDialogStyle");
 		}
 
 		_commands = _messageDialog.Commands.ToList();
@@ -47,6 +49,19 @@ internal partial class MessageDialogContentDialog : ContentDialog
 		CloseButtonText = _commands.Count > 2 ? _commands[2].Label : null;
 
 		DefaultButton = (ContentDialogButton)(_messageDialog.DefaultCommandIndex + 1); // ContentDialogButton indexed from 1
+	}
+
+	private bool TryApplyStyle(string resourceKey)
+	{
+		if (!string.IsNullOrEmpty(resourceKey) &&
+			Application.Current.Resources.TryGetValue(resourceKey, out var resource) &&
+			resource is Style style)
+		{
+			Style = style;
+			return true;
+		}
+
+		return false;
 	}
 
 	public async Task<IUICommand> ShowAsync(CancellationToken ct)

--- a/src/Uno.UWP/UI/Popups/MessageDialog.cs
+++ b/src/Uno.UWP/UI/Popups/MessageDialog.cs
@@ -103,7 +103,7 @@ public sealed partial class MessageDialog
 
 	private async Task<IUICommand> ShowInnerAsync(CancellationToken ct)
 	{
-#if __IOS__ || __MACOS__ || __ANDROID__
+#if __IOS__ || __MACOS__ || __ANDROID__ || __WASM__
 		if (WinRTFeatureConfiguration.MessageDialog.UseNativeDialog)
 		{
 			return await ShowNativeAsync(ct);

--- a/src/Uno.UWP/WinRTFeatureConfiguration.MessageDialog.cs
+++ b/src/Uno.UWP/WinRTFeatureConfiguration.MessageDialog.cs
@@ -17,5 +17,12 @@ partial class WinRTFeatureConfiguration
 			#else
 				false;
 			#endif
+
+		/// <summary>
+		/// Allows overriding the style used by the ContentDialog
+		/// which displays the MessageDialog. Should be set to a name (Key)
+		/// of a Application-level ContentDialog style resource.
+		/// </summary>
+		public static string StyleOverride { get; set; }
 	}
 }

--- a/src/Uno.UWP/WinRTFeatureConfiguration.MessageDialog.cs
+++ b/src/Uno.UWP/WinRTFeatureConfiguration.MessageDialog.cs
@@ -11,6 +11,11 @@ partial class WinRTFeatureConfiguration
 		/// Note the native dialogs may not support all the features and they are also not
 		/// supported on Skia targets.
 		/// </summary>
-		public static bool UseNativeDialog { get; set; } = false;
+		public static bool UseNativeDialog { get; set; } =
+			#if __ANDROID__ || __IOS__ || __MACOS__
+				true;
+			#else
+				false;
+			#endif
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8415

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

- `MessageDialog` UI defaults to `ContentDialog` everywhere
- - `MessageDialog` style cannot be customized

## What is the new behavior?

- `MessageDialog` UI defaults to native dialog on Android, iOS and macOS
- `MessageDialog` style can be customized


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.