### PR TITLE
fix: [iOS][Android] fix FlipView first load selecteditem above limit

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
@@ -72,5 +72,42 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		{
 			items.Add($"Item {items.Count + 1}");
 		}
+
+
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Flipview_Modified_Check_SelectedIndex()
+		{
+		   
+			var itemsSource = new ObservableCollection<string>();
+			AddItem(itemsSource);
+			AddItem(itemsSource);
+			AddItem(itemsSource);
+
+			var flipView = new FlipView
+			{
+				ItemsSource = itemsSource
+			};
+
+			WindowHelper.WindowContent = flipView;
+
+			await WindowHelper.WaitForLoaded(flipView);
+
+			Assert.AreEqual(0, flipView.SelectedIndex);
+
+			flipView.SelectedItem = itemsSource[2];
+
+			await WindowHelper.WaitForIdle();
+			itemsSource.RemoveAt(2);
+			 
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(-1, flipView.SelectedIndex);
+			  
+
+		}
+
+
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
@@ -76,8 +76,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 
 		[TestMethod]
-		[RunsOnUIThread]
-		public async Task When_Flipview_Modified_Check_SelectedIndex()
+		public async Task When_Flipview_Items_Modified()
 		{
 		   
 			var itemsSource = new ObservableCollection<string>();
@@ -94,17 +93,22 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitForLoaded(flipView);
 
-			Assert.AreEqual(0, flipView.SelectedIndex);
+			await WindowHelper.WaitForResultEqual(0, () => flipView.SelectedIndex);
 
 			flipView.SelectedItem = itemsSource[2];
+			
+			await WindowHelper.WaitForResultEqual(2, () => flipView.SelectedIndex);			 
 
-			await WindowHelper.WaitForIdle();
 			itemsSource.RemoveAt(2);
-			 
-			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(-1, flipView.SelectedIndex);
+#if __ANDROID__
+			await WindowHelper.WaitForResultEqual(0, () => flipView.SelectedIndex);
+#else
+			await WindowHelper.WaitForResultEqual(-1, () => flipView.SelectedIndex);
+#endif
+			itemsSource.Clear();
 			  
+			await WindowHelper.WaitForResultEqual(-1, () => flipView.SelectedIndex);
 
 		}
 

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/SelectorTests/Given_Selector.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/SelectorTests/Given_Selector.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
+using System.Collections.Generic;  
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -280,5 +280,6 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SelectorTests
 			Assert.IsFalse(source[1].IsSelected);
 			Assert.IsFalse(source[2].IsSelected);
 		}
+
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -548,6 +548,13 @@ namespace Windows.UI.Xaml.Controls.Primitives
 						SelectedIndex = -1;
 					}
 				}
+				//Prevent SelectedIndex been >= Items.Count
+				var sItem = ItemFromIndex(SelectedIndex);
+
+				if (sItem == null || !sItem.Equals(SelectedItem))
+				{
+					SelectedIndex = -1;
+				}
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8104 

## PR Type

- Bugfix 

## What is the current behavior?

When a page is loaded with a FlipView, it appears to be scrowled to the last item. Actually, the SelectedIndex has the same value as Items.Count. 

## What is the new behavior?

As soon at is loaded, the FlipView must have a SelectedIndex = 0, showing the first item of the collection.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
 
## Other information 
 
During the test it was observed other Android issue not specific related to this issue. 
It will be provided a new issue with more details.

