### PR TITLE
docs(DocFX): Add Mermaid support to DocFX and update the documentation to run the doc locally with a local server

### DIFF
--- a/doc/articles/uno-development/docfx.md
+++ b/doc/articles/uno-development/docfx.md
@@ -88,6 +88,8 @@ The [`check_toc` script](https://github.com/unoplatform/uno/blob/master/doc/arti
 
 Sometimes you may want to run DocFX locally to validate that changes you've made look good in html. To do so you'll first need to generate the 'implemented views' documentation.
 
+### Run DocFX locally
+
 To run DocFX locally and check the resulting html:
 
 1. Open the `Uno.UI-Tools.slnf` solution filter in the `src` folder with Visual Studio. 
@@ -98,3 +100,21 @@ To run DocFX locally and check the resulting html:
 6. Open a Powershell window in the `tools` folder.
 7. Run the following command: `.\docfx "C:\src\Uno.UI\doc\docfx.json" -o C:\src\Uno.UI\docs-local-dist`, replacing `C:\src\Uno.UI` with your local path to the Uno.UI repository.
 8. When DocFX runs successfully, it will create the html output at `C:\src\Uno.UI\docs-local-dist\_site`, which you can now view or mount on a local server.
+
+### Use a local server
+
+You can use `dotnet-serve` as a simple command-line HTTP server for example.
+
+1. Install `dotnet-serve` using the following command: `dotnet tool install --global dotnet-serve`. For more info about its usage and options, 
+[please refer to the documentation](https://github.com/natemcmaster/dotnet-serve).
+2. Using the command prompt, navigate to `C:\src\Uno.UI\docs-local-dist\_site` (replacing `C:\src\Uno.UI` with your local path to the Uno.UI repository) and run the following command `dotnet serve -o -S`. This will start a simple server with HTTPS and open the browser directly.
+
+## Run the documentation generation performance test
+
+If needed, you can also run a script that will give you a performance summary for the documentation generation.
+
+To run the script on Windows:
+1. Make sure crosstargeting_override.props is not defininig UnoTargetFrameworkOverride
+2. Open a Developer Command Prompt for Visual Studio (2019 or 2022)
+3. Go the the uno\build folder (not the uno\src\build folder)
+4. Run the `run-doc-generation.cmd` script; make sure to follow the instructions

--- a/doc/templates/uno/partials/scripts.tmpl.partial
+++ b/doc/templates/uno/partials/scripts.tmpl.partial
@@ -1,0 +1,17 @@
+<!-- Mermaid -->
+<!-- Lets you create diagrams and visualizations using text and code. -->
+<script type="text/javascript" src="{{_rel}}styles/docfx.vendor.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/highlight.min.js"></script>
+<script src="https://unpkg.com/highlightjs-dotnetconfig@0.9.3/dist/dotnetconfig.min.js"></script>
+<script type="text/javascript" src="{{_rel}}styles/docfx.js"></script>
+<script type="text/javascript" src="{{_rel}}styles/main.js"></script>
+<!-- Mermaid version will need to be bumped here when this issue is fixed : https://github.com/mermaid-js/mermaid/issues/1984 -->
+<script type="text/javascript" src="https://unpkg.com/mermaid@8.14.0/dist/mermaid.min.js"
+integrity="sha384-atOyb0FxAgN9LyAc6PEf9BjgwLISyansgdH8/VXQH8p2o5vfrRgmGIJ2Sg22L0A0"
+crossorigin="anonymous"></script>
+<script>
+mermaid.initialize({
+startOnLoad: false
+});
+mermaid.init(undefined, ".lang-mermaid");
+</script>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8297

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

There is no support for Mermaid for DocFX

## What is the new behavior?

- Added Mermaid support to DocFX
- Updated the documentation to run locally the generated doc with a local server (dotnet-serve)
- Updated the documentation to run the generated doc performance test (`run-doc-generation.cmd` script)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Known issue

There is additional whitespace above and below the flowchart diagrams.
Mermaid version will need to be bumped here when this issue is fixed : https://github.com/mermaid-js/mermaid/issues/1984.
As of right now with this PR, it's using the version [**8.14.0**](https://github.com/mermaid-js/mermaid/releases/tag/8.14.0)
Related internal issue: https://github.com/unoplatform/uno/issues/8431