### PR TITLE
fix(flyout): full placement not taking entire screen

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -32,7 +32,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			//_app.WaitForElement(_app.Marked("BottomFlyout"));
 			//var flyoutRect = _app.Marked("BottomFlyout").FirstResult().Rect;
 
-			//// Assert initial state 
+			//// Assert initial state
 			//Assert.AreEqual("0", flyoutRect.X.ToString());
 		}
 
@@ -55,7 +55,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 
 			_app.FastTap(dataBoundButton);
 			Assert.AreEqual("Button was clicked", dataBoundText.GetText());
-			
+
 			_app.TapCoordinates(10, 100);
 		}
 
@@ -151,6 +151,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 				"BottomFlyoutButton",
 				"TopFlyoutButton",
 				//"FullFlyoutButton", // unclosable without native back button/gesture
+				//"FullFlyoutButtonNoConstraint", // unclosable without native back button/gesture
 				"CenteredFullFlyoutButton",
 				//"FullOverlayFlyoutButton", // unclosable without native back button/gesture
 				"WithOffsetFlyoutButton",

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
@@ -40,6 +40,12 @@
 				</Setter.Value>
 			</Setter>
 		</Style>
+		<Style x:Key="FullFlyoutPresenterStyle"
+			   TargetType="FlyoutPresenter"
+			   BasedOn="{StaticResource SampleFlyoutPresenterStyle}">
+			<Setter Property="MaxWidth" Value="NaN" />
+			<Setter Property="MaxHeight" Value="NaN" />
+		</Style>
 		<Style x:Key="SimpleFlyoutButtonStyle" TargetType="Button">
 			<Setter Property="Width" Value="200" />
 			<Setter Property="Height" Value="50" />
@@ -100,6 +106,15 @@
 							Style="{StaticResource SimpleFlyoutButtonStyle}">
 						<Button.Flyout>
 							<Flyout Placement="Full" FlyoutPresenterStyle="{StaticResource SampleFlyoutPresenterStyle}">
+								<Border Style="{StaticResource SmallSkyBlueBorderStyle}" />
+							</Flyout>
+						</Button.Flyout>
+					</Button>
+					<Button x:Name="FullFlyoutButtonNoConstraint"
+							Content="Show Flyout Full (No MaxWidth/Height)*"
+							Style="{StaticResource SimpleFlyoutButtonStyle}">
+						<Button.Flyout>
+							<Flyout Placement="Full" FlyoutPresenterStyle="{StaticResource FullFlyoutPresenterStyle}">
 								<Border Style="{StaticResource SmallSkyBlueBorderStyle}" />
 							</Flyout>
 						</Button.Flyout>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml.cs
@@ -9,7 +9,7 @@ namespace Uno.UI.Samples.Content.UITests.Flyout
 		public Flyout_Simple()
 		{
 			this.InitializeComponent();
-			this.SampleRoot.SampleDescription = "note: buttons with * are not closable without native back button/gesture";
+			this.SampleRoot.SampleDescription = "note: On smaller devices, buttons with * are not closable without native back button/gesture. They can also be closed by going to home screen or switching app.";
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.extensions#196

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Flyout with full placement are constrained within the visible bounds.

## What is the new behavior?

Flyout with full placement can take up the space below the visible bounds (eg: curved edge bottom on iPhone Max Pro 13), as needed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->