### PR TITLE
fix!: Args separator on Skia, feat: Pass arguments to `LaunchActivatedEventArgs` on macOS

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia.Gtk/Properties/launchSettings.json
+++ b/src/SamplesApp/SamplesApp.Skia.Gtk/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SamplesApp.Skia.Gtk": {
       "commandName": "Project",
-      "commandLineArgs": "--_auto-screenshots=C:\\temp\\screenshots",
+      "commandLineArgs": "",
       "nativeDebugging": false
     }
   }

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -172,7 +172,7 @@ namespace Uno.UI.Runtime.Skia
 				app.Host = this;
 			}
 
-			WUX.Application.Start(CreateApp, _args);
+			WUX.Application.StartWithArguments(CreateApp);
 
 			UpdateWindowPropertiesFromPackage();
 

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -41,7 +41,6 @@ namespace Uno.UI.Runtime.Skia
 		[ThreadStatic]
 		private static bool _isDispatcherThread = false;
 
-		private readonly string[] _args;
 		private readonly Func<WUX.Application> _appBuilder;
 		private static Gtk.Window _window;
 		private static Gtk.EventBox _eventBox;
@@ -57,9 +56,17 @@ namespace Uno.UI.Runtime.Skia
 				? RenderSurfaceType.Software // OpenGL support on macOS is currently broken
 				: RenderSurfaceType.OpenGL;
 
+		/// <summary>
+		/// Creates a host for a Uno Skia GTK application.
+		/// </summary>
+		/// <param name="appBuilder">App builder.</param>
+		/// <param name="args">Deprecated, value ignored.</param>
+		/// <remarks>
+		/// Args are obsolete and will be removed in the future. Environment.CommandLine is used instead
+		/// to fill LaunchEventArgs.Arguments.
+		/// </remarks>
 		public GtkHost(Func<WUX.Application> appBuilder, string[] args)
 		{
-			_args = args;
 			_appBuilder = appBuilder;
 		}
 

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
@@ -13,15 +13,22 @@ namespace Uno.UI.Runtime.Skia
 		[ThreadStatic]
 		private static bool _isDispatcherThread = false;
 
-		private string[] _args;
 		private Func<Application> _appBuilder;
 		private readonly EventLoop _eventLoop;
 		private Renderer? _renderer;
 		private DisplayInformationExtension? _displayInformationExtension;
 
+		/// <summary>
+		/// Creates a host for a Uno Skia FrameBuffer application.
+		/// </summary>
+		/// <param name="appBuilder">App builder.</param>
+		/// <param name="args">Deprecated, value ignored.</param>		
+		/// <remarks>
+		/// Args are obsolete and will be removed in the future. Environment.CommandLine is used instead
+		/// to fill LaunchEventArgs.Arguments.
+		/// </remarks>
 		public FrameBufferHost(Func<WUX.Application> appBuilder, string[] args)
 		{
-			_args = args;
 			_appBuilder = appBuilder;
 
 			_eventLoop = new EventLoop();

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
@@ -55,7 +55,7 @@ namespace Uno.UI.Runtime.Skia
 			_renderer = new Renderer();
 			_displayInformationExtension!.Renderer = _renderer;
 
-			WUX.Application.Start(CreateApp, _args);
+			WUX.Application.StartWithArguments(CreateApp);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Tizen/TizenHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/TizenHost.cs
@@ -54,7 +54,7 @@ namespace Uno.UI.Runtime.Skia
 		/// <remarks>
 		/// If args are omitted, those from Environment.GetCommandLineArgs() will be used.
 		/// </remarks>
-		public TizenHost(Func<WinUI.Application> appBuilder, string[] args = null)
+		public TizenHost(Func<WinUI.Application> appBuilder, string[]? args = null)
 		{
 			Elementary.Initialize();
 			Elementary.ThemeOverlay();
@@ -63,12 +63,6 @@ namespace Uno.UI.Runtime.Skia
 
 			_appBuilder = appBuilder;
 			_args = args;
-
-
-			_args ??= Environment
-				.GetCommandLineArgs()
-				.Skip(1)
-				.ToArray();
 
 			Windows.UI.Core.CoreDispatcher.DispatchOverride = (d) => EcoreMainloop.PostAndWakeUp(d);
 			Windows.UI.Core.CoreDispatcher.HasThreadAccessOverride = () => EcoreMainloop.IsMainThread;
@@ -101,7 +95,7 @@ namespace Uno.UI.Runtime.Skia
 				new Windows.Foundation.Size(
 					_tizenApplication.Window.ScreenSize.Width,
 					_tizenApplication.Window.ScreenSize.Height));
-			WinUI.Application.Start(CreateApp, _args);
+			WinUI.Application.StartWithArguments(CreateApp);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Tizen/TizenHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/TizenHost.cs
@@ -44,16 +44,14 @@ namespace Uno.UI.Runtime.Skia
 		private readonly TizenApplication _tizenApplication;
 		private readonly Func<WinUI.Application> _appBuilder;
 		private readonly TizenWindow _window;
-		private readonly string[] _args;
 
 		public static TizenHost Current => _current;
 
 		/// <summary>
-		/// Creates a WpfHost element to host a Uno-Skia into a WPF application.
+		/// Creates a host for a Uno Skia Tizen application.
 		/// </summary>
-		/// <remarks>
-		/// If args are omitted, those from Environment.GetCommandLineArgs() will be used.
-		/// </remarks>
+		/// <param name="appBuilder">App builder.</param>
+		/// <param name="args">Arguments.</param>		
 		public TizenHost(Func<WinUI.Application> appBuilder, string[]? args = null)
 		{
 			Elementary.Initialize();
@@ -62,13 +60,12 @@ namespace Uno.UI.Runtime.Skia
 			_current = this;
 
 			_appBuilder = appBuilder;
-			_args = args;
 
 			Windows.UI.Core.CoreDispatcher.DispatchOverride = (d) => EcoreMainloop.PostAndWakeUp(d);
 			Windows.UI.Core.CoreDispatcher.HasThreadAccessOverride = () => EcoreMainloop.IsMainThread;
 
 			_tizenApplication = new TizenApplication(this);
-			_tizenApplication.Run(_args);
+			_tizenApplication.Run(args);
 		}
 
 		public void Run()

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -92,6 +92,8 @@ namespace Uno.UI.Skia.Platform
 		{
 			_current = this;
 
+			var commandLineArgs = Environment.CommandLine;
+						
 			args ??= Environment
 				.GetCommandLineArgs()
 				.Skip(1)
@@ -108,7 +110,7 @@ namespace Uno.UI.Skia.Platform
 			Windows.UI.Core.CoreDispatcher.DispatchOverride = d => dispatcher.BeginInvoke(d);
 			Windows.UI.Core.CoreDispatcher.HasThreadAccessOverride = dispatcher.CheckAccess;
 
-			WinUI.Application.Start(CreateApp, args);
+			WinUI.Application.StartWithArguments(CreateApp);
 
 			WinUI.Window.InvalidateRender += () =>
 			{

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -85,19 +85,15 @@ namespace Uno.UI.Skia.Platform
 		/// <summary>
 		/// Creates a WpfHost element to host a Uno-Skia into a WPF application.
 		/// </summary>
+		/// <param name="appBuilder">App builder.</param>
+		/// <param name="args">Deprecated, value ignored.</param>		
 		/// <remarks>
-		/// If args are omitted, those from Environment.GetCommandLineArgs() will be used.
+		/// Args are obsolete and will be removed in the future. Environment.CommandLine is used instead
+		/// to fill LaunchEventArgs.Arguments.
 		/// </remarks>
 		public WpfHost(global::System.Windows.Threading.Dispatcher dispatcher, Func<WinUI.Application> appBuilder, string[] args = null)
 		{
 			_current = this;
-
-			var commandLineArgs = Environment.CommandLine;
-						
-			args ??= Environment
-				.GetCommandLineArgs()
-				.Skip(1)
-				.ToArray();
 
 			designMode = DesignerProperties.GetIsInDesignMode(this);
 

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -445,5 +445,35 @@ namespace Windows.UI.Xaml
 				}
 			}
 		}
+
+		private static string GetCommandLineArgsWithoutExecutable()
+		{
+			var args = Environment.GetCommandLineArgs();
+			if (args.Length < 1)
+			{
+				return "";
+			}
+
+			// The first "argument" is actually application name, needs to be removed.
+			// May be wrapped in quotes.
+
+			var executable = args[0];
+			var rawCmd = Environment.CommandLine;
+
+			var index = rawCmd.IndexOf(executable);
+			if (index == 0)
+			{
+				rawCmd = rawCmd.Substring(executable.Length);
+			}
+			else if (index == 1)
+			{
+				// The executable is wrapped in quotes
+				rawCmd = rawCmd.Substring(executable.Length + 2);
+			}
+
+			// The whitespace on the start side of Arguments
+			// in UWP is trimmed whereas the ending is not.
+			return rawCmd.TrimStart();
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -449,7 +449,7 @@ namespace Windows.UI.Xaml
 		private static string GetCommandLineArgsWithoutExecutable()
 		{
 			var args = Environment.GetCommandLineArgs();
-			if (args.Length < 1)
+			if (args.Length <= 1)
 			{
 				return "";
 			}

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -87,13 +87,7 @@ namespace Windows.UI.Xaml
 			}
 			if (!handled)
 			{
-				var argumentsString = "";
-				
-				// First argument is just executable path
-				if (NSProcessInfo.ProcessInfo?.Arguments is { Length: > 1} processArguments)
-				{
-					argumentsString = GetCommandLineArgsWithoutExecutable();
-				}
+				var argumentsString = GetCommandLineArgsWithoutExecutable();
 
 				OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, argumentsString));
 			}

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -87,7 +87,17 @@ namespace Windows.UI.Xaml
 			}
 			if (!handled)
 			{
-				OnLaunched(new LaunchActivatedEventArgs());
+				var argumentsString = "";
+				if (NSProcessInfo.ProcessInfo?.Arguments is { } processArguments)
+				{
+					// First argument is just executable path
+					if (processArguments.Length > 1)
+					{
+						argumentsString = string.Join(" ", processArguments.Skip(1));
+					}
+				}
+
+				OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, argumentsString));
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -88,13 +88,11 @@ namespace Windows.UI.Xaml
 			if (!handled)
 			{
 				var argumentsString = "";
-				if (NSProcessInfo.ProcessInfo?.Arguments is { } processArguments)
+				
+				// First argument is just executable path
+				if (NSProcessInfo.ProcessInfo?.Arguments is { Length: > 1} processArguments)
 				{
-					// First argument is just executable path
-					if (processArguments.Length > 1)
-					{
-						argumentsString = string.Join(" ", processArguments.Skip(1));
-					}
+					argumentsString = GetCommandLineArgsWithoutExecutable();
 				}
 
 				OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, argumentsString));

--- a/src/Uno.UI/UI/Xaml/Application.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Application.skia.cs
@@ -82,7 +82,7 @@ namespace Windows.UI.Xaml
 
 				InitializationCompleted();
 
-				OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, string.Join(";", _args)));
+				OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, string.Join(" ", _args)));
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Application.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Application.skia.cs
@@ -15,13 +15,13 @@ using Uno.UI;
 using Uno.UI.Xaml;
 using Uno.Foundation.Extensibility;
 
-
 namespace Windows.UI.Xaml
 {
 	public partial class Application : IApplicationEvents
 	{
 		private static bool _startInvoked = false;
-		private static string[] _args;
+		private static string _arguments = "";
+
 		private readonly IApplicationExtension? _applicationExtension;
 
 		internal ISkiaHost? Host { get; set; }
@@ -41,9 +41,9 @@ namespace Windows.UI.Xaml
 			CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Normal, Initialize);
 		}
 
-		internal static void Start(global::Windows.UI.Xaml.ApplicationInitializationCallback callback, string[] args)
+		internal static void StartWithArguments(global::Windows.UI.Xaml.ApplicationInitializationCallback callback)
 		{
-			_args = args;
+			_arguments = GetCommandLineArgsWithoutExecutable();
 			Start(callback);
 		}
 
@@ -82,7 +82,7 @@ namespace Windows.UI.Xaml
 
 				InitializationCompleted();
 
-				OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, string.Join(" ", _args)));
+				OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, _arguments));
 			}
 		}
 

--- a/src/Uno.UWP/ApplicationModel/Activation/LaunchActivatedEventArgs.cs
+++ b/src/Uno.UWP/ApplicationModel/Activation/LaunchActivatedEventArgs.cs
@@ -21,38 +21,23 @@ namespace Windows.ApplicationModel.Activation
 #if !__ANDROID__ && !__IOS__
 		[NotImplemented]
 #endif
-		public ActivationKind Kind
-		{
-			get;
-		}
+		public ActivationKind Kind { get; } = ActivationKind.Launch;
 
 		/// <summary>
 		/// Defaults to NotRunning, may not be accurate in all cases for all platforms.
 		/// </summary>
-		public ApplicationExecutionState PreviousExecutionState { get; }
+		public ApplicationExecutionState PreviousExecutionState { get; } = ApplicationExecutionState.NotRunning;
 
 		[NotImplemented]
-		public SplashScreen SplashScreen
-		{
-			get;
-		}
+		public SplashScreen SplashScreen { get; } = new SplashScreen();
 
 		[NotImplemented]
-		public int CurrentlyShownApplicationViewId
-		{
-			get;
-		}
+		public int CurrentlyShownApplicationViewId { get; }
 
-		public string Arguments
-		{
-			get;
-		}
+		public string Arguments { get; } = "";
 
 		[NotImplemented]
-		public string TileId
-		{
-			get;
-		}
+		public string TileId { get; } = "App";
 
 		public bool PrelaunchActivated => false; // No platform other than UWP supports prelaunch yet.
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8449


## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

- Command-line arguments are not passed to macOS app's `LaunchActivatedEventArgs`
- Multiple arguments are separated by `;`

## What is the new behavior?

- Command-line arguments are passed to macOS app's `LaunchActivatedEventArgs`
- Multiple arguments are separated by to match UWP/WinUI this applies to Skia GTK/WPF too

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Breaking change

Instead of using semi-color args are now properly separated by space, which is technically a breaking change for those who are expecting semi-colon between multiple args.