### PR TITLE
fix(net6): remove unsupported lottie support for apple targets

### DIFF
--- a/build/Uno.WinUI.Lottie.nuspec
+++ b/build/Uno.WinUI.Lottie.nuspec
@@ -28,17 +28,17 @@
 	  </group>
 	  <group targetFramework="net6.0-ios">
 		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Com.Airbnb.iOS.Lottie" version="2.5.11" />
+		<!--<dependency id="Com.Airbnb.iOS.Lottie" version="2.5.11" /> Disabled until net6 apple targets can support lottie properly -->
 		<dependency id="System.Json" version="4.7.1" />
 	  </group>
 	  <group targetFramework="net6.0-maccatalyst">
 		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Com.Airbnb.iOS.Lottie" version="2.5.11" />
+		<!--<dependency id="Com.Airbnb.iOS.Lottie" version="2.5.11" /> Disabled until net6 apple targets can support lottie properly -->
 		<dependency id="System.Json" version="4.7.1" />
 	  </group>
 	  <group targetFramework="net6.0-macos">
 		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Com.Airbnb.iOS.Lottie" version="2.5.11" />
+		<!--<dependency id="Com.Airbnb.iOS.Lottie" version="2.5.11" /> Disabled until net6 apple targets can support lottie properly -->
 		<dependency id="System.Json" version="4.7.1" />
 	  </group>
 	  <group targetFramework="xamarinios10">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Lottie for apple targets is not yet supported, this change remove the nuget dependency from the nuspec file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
