### PR TITLE
fix: Ensure `DeferralManager.CompletedSynchronously` is set correctly before `Completed` event, feat: `Deferral.Dispose`

### DIFF
--- a/src/Uno.Foundation/Deferral.cs
+++ b/src/Uno.Foundation/Deferral.cs
@@ -26,6 +26,9 @@ namespace Windows.Foundation
 
 		public void Close() => Complete();
 
+		/// <summary>
+		/// Completes the deferral (calls <see cref="Complete" />).
+		/// </summary>
 		public void Dispose() => Complete();
 	}
 }

--- a/src/Uno.Foundation/Deferral.cs
+++ b/src/Uno.Foundation/Deferral.cs
@@ -24,6 +24,8 @@ namespace Windows.Foundation
 		/// </summary>
 		public void Complete() => _handler?.Invoke();
 
-		public void Close() { }
+		public void Close() => Complete();
+
+		public void Dispose() => Complete();
 	}
 }

--- a/src/Uno.Foundation/Generated/2.0.0.0/Windows.Foundation/Deferral.cs
+++ b/src/Uno.Foundation/Generated/2.0.0.0/Windows.Foundation/Deferral.cs
@@ -10,13 +10,7 @@ namespace Windows.Foundation
 		// Skipping already declared method Windows.Foundation.Deferral.Deferral(Windows.Foundation.DeferralCompletedHandler)
 		// Forced skipping of method Windows.Foundation.Deferral.Deferral(Windows.Foundation.DeferralCompletedHandler)
 		// Skipping already declared method Windows.Foundation.Deferral.Complete()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  void Dispose()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Foundation.Deferral", "void Deferral.Dispose()");
-		}
-		#endif
+		// Skipping already declared method Windows.Foundation.Deferral.Dispose()
 		// Processing: System.IDisposable
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_DeferralManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_DeferralManager.cs
@@ -1,0 +1,165 @@
+﻿#if HAS_UNO
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Uno.Helpers;
+using Windows.Foundation;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_DeferralManager
+{
+	[TestMethod]
+	public void When_Completed_Synchronously_After_Event_Raise()
+	{
+		var deferralManager = new DeferralManager<Deferral>(h => new Deferral(h));
+		Assert.IsTrue(deferralManager.EventRaiseCompleted());
+		Assert.IsTrue(deferralManager.CompletedSynchronously);
+	}
+
+	[TestMethod]
+	public void When_Completed_Synchronously_In_Event_Handler()
+	{
+		var deferralManager = new DeferralManager<Deferral>(h => new Deferral(h));
+		deferralManager.Completed += (s, e) =>
+		{
+			Assert.IsTrue(deferralManager.CompletedSynchronously);
+		};
+		deferralManager.EventRaiseCompleted();
+	}
+
+	[TestMethod]
+	public void When_Completed_Synchronously_With_Requests()
+	{
+		var deferralManager = new DeferralManager<Deferral>(h => new Deferral(h));
+		var deferral1 = deferralManager.GetDeferral();
+		var deferral2 = deferralManager.GetDeferral();
+		deferral2.Complete();
+		deferral1.Complete();
+		deferralManager.Completed += (s, e) =>
+		{
+			Assert.IsTrue(deferralManager.CompletedSynchronously);
+		};
+		Assert.IsTrue(deferralManager.EventRaiseCompleted());
+		Assert.IsTrue(deferralManager.CompletedSynchronously);
+	}
+
+	[TestMethod]
+	public async Task When_Completed_Asynchronously_With_Requests()
+	{
+		var deferralManager = new DeferralManager<Deferral>(h => new Deferral(h));
+		var deferral1 = deferralManager.GetDeferral();
+		var deferral2 = deferralManager.GetDeferral();
+
+		bool lastDeferralCompleting = false;
+		deferralManager.Completed += (s, e) =>
+		{
+			Assert.IsTrue(lastDeferralCompleting);
+			Assert.IsFalse(deferralManager.CompletedSynchronously);
+		};
+		var completedSynchronously = deferralManager.EventRaiseCompleted();
+		Assert.IsFalse(completedSynchronously);
+		Assert.IsFalse(deferralManager.CompletedSynchronously);
+
+		await Task.Yield();
+
+		deferral2.Complete();
+
+		Assert.IsFalse(deferralManager.CompletedSynchronously);
+
+		await Task.Yield();
+
+		Assert.IsFalse(deferralManager.CompletedSynchronously);
+
+		lastDeferralCompleting = true;
+		deferral1.Complete();
+
+		Assert.IsFalse(deferralManager.CompletedSynchronously);
+	}
+
+	[TestMethod]
+	public void When_Incomplete_Deferral()
+	{
+		var deferralManager = new DeferralManager<Deferral>(h => new Deferral(h));
+
+		var deferral = deferralManager.GetDeferral();
+
+		bool testFinished = false;
+		deferralManager.Completed += (s, e) =>
+		{
+			if (!testFinished)
+			{
+				Assert.Fail("Should not be called");
+			}
+		};
+
+		var completedSynchronously = deferralManager.EventRaiseCompleted();
+
+		// Set to avoid ghost assertion failure (deferral disposal will complete it).
+		testFinished = true;
+	}
+
+	[TestMethod]
+	public void When_Many_Deferrals()
+	{
+		var deferralManager = new DeferralManager<Deferral>(h => new Deferral(h));
+
+		var random = new Random(42);
+
+		var deferrals = new List<Deferral>();
+		for (int i = 0; i < 20; i++)
+		{
+			deferrals.Add(deferralManager.GetDeferral());
+		}
+
+		bool isCompleted = false;
+		deferralManager.Completed += (s,e) =>
+		{
+			isCompleted = true;
+		};
+
+		deferralManager.EventRaiseCompleted();
+
+		while (deferrals.Count > 0)
+		{
+			Assert.IsFalse(isCompleted);
+			var randomIndex = random.Next(deferrals.Count);
+			var randomDeferral = deferrals[randomIndex];
+			randomDeferral.Complete();
+			deferrals.RemoveAt(randomIndex);
+		}
+
+		Assert.IsTrue(isCompleted);
+	}
+
+	[TestMethod]
+	public void When_Deferrals_Disposed()
+	{
+		var deferralManager = new DeferralManager<Deferral>(h => new Deferral(h));
+
+		var deferral1 = deferralManager.GetDeferral();
+		var deferral2 = deferralManager.GetDeferral();
+				
+		bool isCompleted = false;
+		deferralManager.Completed += (s, e) =>
+		{
+			isCompleted = true;
+		};
+
+		deferralManager.EventRaiseCompleted();
+
+		Assert.IsFalse(isCompleted);
+
+		deferral1.Dispose();
+
+		Assert.IsFalse(isCompleted);
+
+		deferral2.Dispose();
+
+		Assert.IsTrue(isCompleted);
+	}
+}
+#endif

--- a/src/Uno.UWP/Helpers/DeferralManager.cs
+++ b/src/Uno.UWP/Helpers/DeferralManager.cs
@@ -48,7 +48,7 @@ internal class DeferralManager<T>
 			}
 
 			isCompleted = true;
-			DeferralCompleted();
+			DeferralCompleted(false);
 		}
 	}
 
@@ -61,22 +61,23 @@ internal class DeferralManager<T>
 	/// <returns>A value indicating whether the deferral completed synchronously.</returns>
 	internal bool EventRaiseCompleted()
 	{
-		CompletedSynchronously = DeferralCompleted();
+		DeferralCompleted(true);
 		return CompletedSynchronously;
 	}
 
 	internal Task WhenAllCompletedAsync() => _allDeferralsCompletedCompletionSource.Task;
 
-	private bool DeferralCompleted()
+	private void DeferralCompleted(bool eventRaiseCompletion)
 	{
 		_deferralsCount--;
 		if (_deferralsCount <= 0)
 		{
+			if (eventRaiseCompletion)
+			{
+				CompletedSynchronously = true;
+			}
 			Completed?.Invoke(this, EventArgs.Empty);
 			_allDeferralsCompletedCompletionSource.TrySetResult(null);
-			return true;
 		}
-
-		return false;
 	}
 }

--- a/src/Uno.UWP/Helpers/DeferralManager.cs
+++ b/src/Uno.UWP/Helpers/DeferralManager.cs
@@ -76,6 +76,7 @@ internal class DeferralManager<T>
 			{
 				CompletedSynchronously = true;
 			}
+
 			Completed?.Invoke(this, EventArgs.Empty);
 			_allDeferralsCompletedCompletionSource.TrySetResult(null);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8456 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- `CompletedSynchronously` is set after `Completed` execution, which gives listeners incorrect information about the event state.
- `Deferral.Dispose` does not close the deferral

## What is the new behavior?

- `CompletedSynchronously` set early.
- `Deferral.Dispose` completes the deferral
- Multiple tests to cover `DeferralManager` behavior

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.