### PR TITLE
[WASM] fix: Sync system focus visual with the focused element on scroll

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Controls/Given_SystemFocusVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Controls/Given_SystemFocusVisual.cs
@@ -1,0 +1,76 @@
+﻿#if __WASM__
+using System.Linq;
+using System.Threading.Tasks;
+using Private.Infrastructure;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Controls;
+
+[TestClass]
+[RunsOnUIThread]
+[RequiresFullWindow]
+public class Given_SystemFocusVisual
+{
+	[TestMethod]
+	public async Task When_Focused_Element_Scrolled()
+	{
+		var scrollViewer = new ScrollViewer()
+		{
+			Height = 200,
+			Margin = ThicknessHelper.FromUniformLength(30)
+		};
+		var button = new Button()
+		{
+			Content = "Test",
+			FocusVisualPrimaryThickness = ThicknessHelper.FromUniformLength(10),
+			FocusVisualSecondaryThickness = ThicknessHelper.FromUniformLength(10),
+		};
+		var topBorder = new Border() { Height = 150, Width = 300, Background = SolidColorBrushHelper.Blue };
+		var bottomBorder = new Border() { Height = 300, Width = 300, Background = SolidColorBrushHelper.Red };
+		var stackPanel = new StackPanel()
+		{
+			Children =
+			{
+				topBorder,
+				button,
+				bottomBorder,
+			}
+		};
+
+		scrollViewer.Content = stackPanel;
+
+		TestServices.WindowHelper.WindowContent = scrollViewer;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		button.Focus(FocusState.Keyboard);
+		await TestServices.WindowHelper.WaitForIdle();
+		var visualTree = Uno.UI.Xaml.Core.CoreServices.Instance.ContentRootCoordinator.CoreWindowContentRoot?.VisualTree;
+		var focusVisualLayer = visualTree?.FocusVisualRoot;
+
+		Assert.IsNotNull(focusVisualLayer);
+		Assert.AreEqual(1, focusVisualLayer.Children.Count);
+
+		var focusVisual = focusVisualLayer.Children.First();
+
+		var transform = focusVisual.TransformToVisual(scrollViewer);
+		var initialPoint = transform.TransformPoint(default);
+
+		scrollViewer.ChangeView(null, 100, null, true);
+
+		await TestServices.WindowHelper.WaitFor(() =>
+		{
+			transform = focusVisual.TransformToVisual(scrollViewer);
+			var currentPoint = transform.TransformPoint(default);
+
+			return currentPoint.Y < initialPoint.Y;
+		});
+		
+		await TestServices.WindowHelper.WaitForIdle();
+
+		transform = focusVisual.TransformToVisual(scrollViewer);
+		var scrolledPoint = transform.TransformPoint(default);
+		Assert.AreEqual(initialPoint.Y - 100, scrolledPoint.Y, 0.5);
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Controls/Given_SystemFocusVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Controls/Given_SystemFocusVisual.cs
@@ -53,14 +53,14 @@ public class Given_SystemFocusVisual
 
 		var focusVisual = focusVisualLayer.Children.First();
 
-		var transform = focusVisual.TransformToVisual(scrollViewer);
+		var transform = focusVisual.TransformToVisual(Windows.UI.Xaml.Window.Current.RootElement);
 		var initialPoint = transform.TransformPoint(default);
 
 		scrollViewer.ChangeView(null, 100, null, true);
 
 		await TestServices.WindowHelper.WaitFor(() =>
 		{
-			transform = focusVisual.TransformToVisual(scrollViewer);
+			transform = focusVisual.TransformToVisual(Windows.UI.Xaml.Window.Current.RootElement);
 			var currentPoint = transform.TransformPoint(default);
 
 			return currentPoint.Y < initialPoint.Y;
@@ -68,7 +68,7 @@ public class Given_SystemFocusVisual
 		
 		await TestServices.WindowHelper.WaitForIdle();
 
-		transform = focusVisual.TransformToVisual(scrollViewer);
+		transform = focusVisual.TransformToVisual(Windows.UI.Xaml.Window.Current.RootElement);
 		var scrolledPoint = transform.TransformPoint(default);
 		Assert.AreEqual(initialPoint.Y - 100, scrolledPoint.Y, 0.5);
 	}

--- a/src/Uno.UI/LinkerDefinition.Wasm.xml
+++ b/src/Uno.UI/LinkerDefinition.Wasm.xml
@@ -24,6 +24,10 @@
       <method name="DispatchSystemThemeChange" />
       <method name="DispatchVisibilityChange" />
 	</type>
+
+	<type fullname="Uno.UI.Xaml.Controls.SystemFocusVisual">
+		<method name="DispatchNativePositionChange" />
+	</type>
   </assembly>
 
   <assembly fullname="Uno">

--- a/src/Uno.UI/UI/Xaml/Controls/FocusVisual/SystemFocusVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/FocusVisual/SystemFocusVisual.cs
@@ -12,95 +12,107 @@ using WindowSizeChangedEventArgs = Microsoft.UI.Xaml.WindowSizeChangedEventArgs;
 using WindowSizeChangedEventArgs = Windows.UI.Core.WindowSizeChangedEventArgs;
 #endif
 
-namespace Uno.UI.Xaml.Controls
+namespace Uno.UI.Xaml.Controls;
+
+internal partial class SystemFocusVisual : Control
 {
-	internal partial class SystemFocusVisual : Control
+	private SerialDisposable _focusedElementSubscriptions = new SerialDisposable();
+	private Rect _lastRect = Rect.Empty;
+
+	public SystemFocusVisual()
 	{
-		private SerialDisposable _focusedElementSubscriptions = new SerialDisposable();
-		private Rect _lastRect = Rect.Empty;
+		DefaultStyleKey = typeof(SystemFocusVisual);
+		Windows.UI.Xaml.Window.Current.SizeChanged += WindowSizeChanged;
+	}
 
-		public SystemFocusVisual()
+	public UIElement? FocusedElement
+	{
+		get => (FrameworkElement?)GetValue(FocusedElementProperty);
+		set => SetValue(FocusedElementProperty, value);
+	}
+
+	public static readonly DependencyProperty FocusedElementProperty =
+		DependencyProperty.Register(
+			nameof(FocusedElement),
+			typeof(UIElement),
+			typeof(SystemFocusVisual),
+			new FrameworkPropertyMetadata(default, OnFocusedElementChanged));
+
+	internal void Redraw() => SetLayoutProperties();
+
+	private static void OnFocusedElementChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+	{
+		var focusVisual = (SystemFocusVisual)dependencyObject;
+
+		focusVisual._focusedElementSubscriptions.Disposable = null;
+
+		if (args.NewValue is FrameworkElement element)
 		{
-			DefaultStyleKey = typeof(SystemFocusVisual);
-			Windows.UI.Xaml.Window.Current.SizeChanged += WindowSizeChanged;
-		}
+			element.EnsureFocusVisualBrushDefaults();
+			element.SizeChanged += focusVisual.FocusedElementSizeChanged;
+			element.LayoutUpdated += focusVisual.FocusedElementLayoutUpdated;
+			element.Unloaded += focusVisual.FocusedElementUnloaded;
 
-		public UIElement? FocusedElement
-		{
-			get => (FrameworkElement?)GetValue(FocusedElementProperty);
-			set => SetValue(FocusedElementProperty, value);
-		}
+			var visibilityToken = element.RegisterPropertyChangedCallback(VisibilityProperty, focusVisual.FocusedElementVisibilityChanged);
 
-		public static readonly DependencyProperty FocusedElementProperty =
-			DependencyProperty.Register(
-				nameof(FocusedElement),
-				typeof(UIElement),
-				typeof(SystemFocusVisual),
-				new FrameworkPropertyMetadata(default, OnFocusedElementChanged));
+			focusVisual.AttachVisualPartial();
 
-		internal void Redraw() => SetLayoutProperties();
+			focusVisual.SetLayoutProperties();
 
-		private static void OnFocusedElementChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
-		{
-			var focusVisual = (SystemFocusVisual)dependencyObject;
-
-			focusVisual._focusedElementSubscriptions.Disposable = null;
-
-			if (args.NewValue is FrameworkElement element)
+			focusVisual._focusedElementSubscriptions.Disposable = Disposable.Create(() =>
 			{
-				element.EnsureFocusVisualBrushDefaults();
-				element.SizeChanged += focusVisual.FocusedElementSizeChanged;
-				element.LayoutUpdated += focusVisual.FocusedElementLayoutUpdated;
-				element.Unloaded += focusVisual.FocusedElementUnloaded;
+				element.SizeChanged -= focusVisual.FocusedElementSizeChanged;
+				element.LayoutUpdated -= focusVisual.FocusedElementLayoutUpdated;
+				element.UnregisterPropertyChangedCallback(VisibilityProperty, visibilityToken);
 
-				var visibilityToken = element.RegisterPropertyChangedCallback(VisibilityProperty, focusVisual.FocusedElementVisibilityChanged);
-
-				focusVisual.SetLayoutProperties();
-
-				focusVisual._focusedElementSubscriptions.Disposable = Disposable.Create(() =>
-				{
-					element.SizeChanged -= focusVisual.FocusedElementSizeChanged;
-					element.LayoutUpdated -= focusVisual.FocusedElementLayoutUpdated;
-					element.UnregisterPropertyChangedCallback(VisibilityProperty, visibilityToken);
-				});
-			}
+				focusVisual.DetachVisualPartial();
+			});
 		}
+	}
 
-		private void WindowSizeChanged(object sender, WindowSizeChangedEventArgs e) => SetLayoutProperties();
+	partial void AttachVisualPartial();
 
-		private void FocusedElementUnloaded(object sender, RoutedEventArgs e) => FocusedElement = null;
+	partial void DetachVisualPartial();
 
-		private void FocusedElementVisibilityChanged(DependencyObject sender, DependencyProperty dp) => SetLayoutProperties();
+	partial void SetLayoutPropertiesPartial();
 
-		private void FocusedElementLayoutUpdated(object? sender, object e) => SetLayoutProperties();
+	private void WindowSizeChanged(object sender, WindowSizeChangedEventArgs e) => SetLayoutProperties();
 
-		private void FocusedElementSizeChanged(object sender, SizeChangedEventArgs args) => SetLayoutProperties();
+	private void FocusedElementUnloaded(object sender, RoutedEventArgs e) => FocusedElement = null;
 
-		private void SetLayoutProperties()
+	private void FocusedElementVisibilityChanged(DependencyObject sender, DependencyProperty dp) => SetLayoutProperties();
+
+	private void FocusedElementLayoutUpdated(object? sender, object e) => SetLayoutProperties();
+
+	private void FocusedElementSizeChanged(object sender, SizeChangedEventArgs args) => SetLayoutProperties();
+
+	private void SetLayoutProperties()
+	{
+		if (FocusedElement == null ||
+			FocusedElement.Visibility == Visibility.Collapsed ||
+			(FocusedElement is Control control && !control.IsEnabled && !control.AllowFocusWhenDisabled))
 		{
-			if (FocusedElement == null ||
-				FocusedElement.Visibility == Visibility.Collapsed ||
-				(FocusedElement is Control control && !control.IsEnabled && !control.AllowFocusWhenDisabled))
-			{
-				Visibility = Visibility.Collapsed;
-				return;
-			}
-
-			Visibility = Visibility.Visible;
-			var transformToRoot = FocusedElement.TransformToVisual(Windows.UI.Xaml.Window.Current.Content);
-			var point = transformToRoot.TransformPoint(new Windows.Foundation.Point(0, 0));
-			var newRect = new Rect(point.X, point.Y, FocusedElement.ActualSize.X, FocusedElement.ActualSize.Y);
-
-			if (newRect != _lastRect)
-			{
-				Width = FocusedElement.ActualSize.X;
-				Height = FocusedElement.ActualSize.Y;
-
-				Canvas.SetLeft(this, point.X);
-				Canvas.SetTop(this, point.Y);
-
-				_lastRect = newRect;
-			}
+			Visibility = Visibility.Collapsed;
+			return;
 		}
+
+		Visibility = Visibility.Visible;
+
+		var transformToRoot = FocusedElement.TransformToVisual(Windows.UI.Xaml.Window.Current.Content);
+		var point = transformToRoot.TransformPoint(new Windows.Foundation.Point(0, 0));
+		var newRect = new Rect(point.X, point.Y, FocusedElement.ActualSize.X, FocusedElement.ActualSize.Y);
+
+		if (newRect != _lastRect)
+		{
+			Width = FocusedElement.ActualSize.X;
+			Height = FocusedElement.ActualSize.Y;
+
+			Canvas.SetLeft(this, point.X);
+			Canvas.SetTop(this, point.Y);
+
+			_lastRect = newRect;
+		}
+
+		SetLayoutPropertiesPartial();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/FocusVisual/SystemFocusVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/FocusVisual/SystemFocusVisual.cs
@@ -57,6 +57,7 @@ internal partial class SystemFocusVisual : Control
 
 			focusVisual.AttachVisualPartial();
 
+			focusVisual._lastRect = Rect.Empty;
 			focusVisual.SetLayoutProperties();
 
 			focusVisual._focusedElementSubscriptions.Disposable = Disposable.Create(() =>
@@ -98,7 +99,7 @@ internal partial class SystemFocusVisual : Control
 
 		Visibility = Visibility.Visible;
 
-		var transformToRoot = FocusedElement.TransformToVisual(Windows.UI.Xaml.Window.Current.Content);
+		var transformToRoot = FocusedElement.TransformToVisual(Windows.UI.Xaml.Window.Current.RootElement);
 		var point = transformToRoot.TransformPoint(new Windows.Foundation.Point(0, 0));
 		var newRect = new Rect(point.X, point.Y, FocusedElement.ActualSize.X, FocusedElement.ActualSize.Y);
 

--- a/src/Uno.UI/UI/Xaml/Controls/FocusVisual/SystemFocusVisual.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/FocusVisual/SystemFocusVisual.wasm.cs
@@ -1,0 +1,39 @@
+﻿#nullable enable
+
+using Uno.Foundation;
+using Uno.UI.Xaml.Core;
+using Uno.UI.Xaml.Input;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace Uno.UI.Xaml.Controls;
+
+internal partial class SystemFocusVisual : Control
+{
+	private const string JsType = "Windows.UI.Xaml.Input.FocusVisual";
+
+	partial void AttachVisualPartial()
+	{
+		if (FocusedElement == null)
+		{
+			return;
+		}
+
+		WebAssemblyRuntime.InvokeJS($"{JsType}.attachVisual({HtmlId}, {FocusedElement.HtmlId})");
+	}
+
+	partial void DetachVisualPartial()
+    {
+		WebAssemblyRuntime.InvokeJS($"{JsType}.detachVisual()");
+	}
+
+	[Preserve]
+	public static int DispatchNativePositionChange(int focusVisualId)
+	{
+		var element = UIElement.GetElementFromHandle(focusVisualId) as SystemFocusVisual;
+		element?.SetLayoutProperties();
+
+		return 0;
+	}
+}

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -1249,6 +1249,19 @@ declare namespace Windows.UI.Xaml.Media.Animation {
         private _isEnabled;
     }
 }
+declare namespace Windows.UI.Xaml.Input {
+    class FocusVisual {
+        private static focusVisualId;
+        private static focusVisual;
+        private static focusedElement;
+        private static currentDispatchTimeout?;
+        private static dispatchPositionChange;
+        static attachVisual(focusVisualId: number, focusedElementId: number): void;
+        static detachVisual(): void;
+        private static onDocumentScroll;
+        static updatePosition(): void;
+    }
+}
 declare class WindowManagerAddViewParams {
     HtmlId: number;
     ChildView: number;

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -4636,6 +4636,51 @@ var Windows;
         })(Xaml = UI.Xaml || (UI.Xaml = {}));
     })(UI = Windows.UI || (Windows.UI = {}));
 })(Windows || (Windows = {}));
+var Windows;
+(function (Windows) {
+    var UI;
+    (function (UI) {
+        var Xaml;
+        (function (Xaml) {
+            var Input;
+            (function (Input) {
+                class FocusVisual {
+                    static attachVisual(focusVisualId, focusedElementId) {
+                        FocusVisual.focusVisualId = focusVisualId;
+                        FocusVisual.focusVisual = Uno.UI.WindowManager.current.getView(focusVisualId);
+                        FocusVisual.focusedElement = Uno.UI.WindowManager.current.getView(focusedElementId);
+                        document.addEventListener("scroll", FocusVisual.onDocumentScroll, true);
+                    }
+                    static detachVisual() {
+                        document.removeEventListener("scroll", FocusVisual.onDocumentScroll, true);
+                        FocusVisual.focusVisualId = null;
+                    }
+                    static onDocumentScroll() {
+                        if (!FocusVisual.dispatchPositionChange) {
+                            FocusVisual.dispatchPositionChange = Module.mono_bind_static_method("[Uno.UI] Uno.UI.Xaml.Controls.SystemFocusVisual:DispatchNativePositionChange");
+                        }
+                        FocusVisual.updatePosition();
+                        // Throttle managed notification while actively scrolling
+                        if (FocusVisual.currentDispatchTimeout) {
+                            clearTimeout(FocusVisual.currentDispatchTimeout);
+                        }
+                        FocusVisual.currentDispatchTimeout = setTimeout(() => FocusVisual.dispatchPositionChange(FocusVisual.focusVisualId), 100);
+                    }
+                    static updatePosition() {
+                        const focusVisual = FocusVisual.focusVisual;
+                        const focusedElement = FocusVisual.focusedElement;
+                        const boundingRect = focusedElement.getBoundingClientRect();
+                        const centerX = boundingRect.x + boundingRect.width / 2;
+                        const centerY = boundingRect.y + boundingRect.height / 2;
+                        focusVisual.style.setProperty("left", boundingRect.x + "px");
+                        focusVisual.style.setProperty("top", boundingRect.y + "px");
+                    }
+                }
+                Input.FocusVisual = FocusVisual;
+            })(Input = Xaml.Input || (Xaml.Input = {}));
+        })(Xaml = UI.Xaml || (UI.Xaml = {}));
+    })(UI = Windows.UI || (Windows.UI = {}));
+})(Windows || (Windows = {}));
 /* TSBindingsGenerator Generated code -- this code is regenerated on each build */
 class WindowManagerAddViewParams {
     static unmarshal(pData) {

--- a/src/Uno.UI/ts/Windows/UI/Xaml/Input/FocusVisual.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/Input/FocusVisual.ts
@@ -1,0 +1,53 @@
+﻿namespace Windows.UI.Xaml.Input {
+
+	export class FocusVisual {
+
+		private static focusVisualId: number;
+		private static focusVisual: HTMLElement | SVGElement;
+		private static focusedElement: HTMLElement | SVGElement;
+		private static currentDispatchTimeout?: number;
+
+		private static dispatchPositionChange: (id: number) => number;
+
+		public static attachVisual(focusVisualId: number, focusedElementId: number): void {
+			FocusVisual.focusVisualId = focusVisualId;
+			FocusVisual.focusVisual = Uno.UI.WindowManager.current.getView(focusVisualId);
+			FocusVisual.focusedElement = Uno.UI.WindowManager.current.getView(focusedElementId);
+
+			document.addEventListener("scroll", FocusVisual.onDocumentScroll, true);
+		}
+
+		public static detachVisual(): void {
+			document.removeEventListener("scroll", FocusVisual.onDocumentScroll, true);
+
+			FocusVisual.focusVisualId = null;
+		}
+
+		private static onDocumentScroll() {
+			if (!FocusVisual.dispatchPositionChange) {
+				FocusVisual.dispatchPositionChange = (<any>Module).mono_bind_static_method(
+					"[Uno.UI] Uno.UI.Xaml.Controls.SystemFocusVisual:DispatchNativePositionChange");
+			}
+
+			FocusVisual.updatePosition();
+
+			// Throttle managed notification while actively scrolling
+			if (FocusVisual.currentDispatchTimeout) {
+				clearTimeout(FocusVisual.currentDispatchTimeout);
+			}
+			FocusVisual.currentDispatchTimeout = setTimeout(() => FocusVisual.dispatchPositionChange(FocusVisual.focusVisualId), 100);
+		}
+
+		public static updatePosition(): void {
+			const focusVisual = FocusVisual.focusVisual;
+			const focusedElement = FocusVisual.focusedElement;
+
+			const boundingRect = focusedElement.getBoundingClientRect();
+			const centerX = boundingRect.x + boundingRect.width / 2;
+			const centerY = boundingRect.y + boundingRect.height / 2;
+
+			focusVisual.style.setProperty("left", boundingRect.x + "px");
+			focusVisual.style.setProperty("top", boundingRect.y + "px");
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6404

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- System focus visual position does not change when focused element is scrolled on WASM
- `SystemFocusVisual` position is calculated relative to Window content

## What is the new behavior?

- When scrolling, focus visual position changes accordingly
- `SystemFocusVisual` position is calculated relative to Window root element - handles the case when Window content is centered within the window and does not fully stretch

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.