### PR TITLE
Enable `IndexPath` and `SelectionModel` runtime tests

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/IndexPathTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/IndexPathTests.cs
@@ -1,6 +1,4 @@
-﻿#if false
-
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Windows.UI.Xaml.Controls;
@@ -61,4 +59,3 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 		}
 	}
 }
-#endif

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/IndexPathTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/IndexPathTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference IndexPathTests.cs, commit e7e0823
 
 using Windows.UI.Xaml.Controls;
 using MUXControlsTestApp.Utilities;

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/SelectionModelTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/SelectionModelTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference SelectionModelTests.cs, commit 6ab6d30
 
 using MUXControlsTestApp.Utilities;
 using System.Collections;

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/SelectionModelTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/SelectionModelTests.cs
@@ -1,6 +1,4 @@
-﻿#if false
-
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using MUXControlsTestApp.Utilities;
@@ -1536,4 +1534,3 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 		private int _intProperty;
 	}
 }
-#endif

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/CustomProperty.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/CustomProperty.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX Reference CustomProperty.cpp, commit d883cf3
+
+#nullable enable
+
+using System;
+using Windows.UI.Xaml.Data;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+internal class CustomProperty : ICustomProperty
+{
+	private Func<object, object>? _getter;
+	private Action<object, object>? _setter;
+
+	public CustomProperty(string name, Type type, Func<object, object> getter, Action<object, object> setter)
+	{
+		Name = name;
+		Type = type;
+		_getter = getter;
+		_setter = setter;
+	}
+
+	public bool CanRead => _getter != null;
+
+	public bool CanWrite => _setter != null;
+
+	public string Name { get; }
+
+	public Type Type { get; }
+
+	public object GetValue(object target)
+	{
+		if (!CanRead)
+		{
+			throw new InvalidOperationException($"Property {Name} is not readable.");
+		}
+		return _getter!(target);
+	}
+
+	public void SetValue(object target, object value)
+	{
+		if (!CanWrite)
+		{
+			throw new InvalidOperationException($"Property {Name} is not writable.");
+		}
+		_setter!(target, value);
+	}
+
+	public object GetIndexedValue(object target, object index) => throw new NotImplementedException();
+
+	public void SetIndexedValue(object target, object value, object index) => throw new NotImplementedException();
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/CustomProperty.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/CustomProperty.cs
@@ -11,8 +11,8 @@ namespace Microsoft.UI.Xaml.Controls;
 
 internal class CustomProperty : ICustomProperty
 {
-	private Func<object, object>? _getter;
-	private Action<object, object>? _setter;
+	private readonly Func<object, object>? _getter;
+	private readonly Action<object, object>? _setter;
 
 	public CustomProperty(string name, Type type, Func<object, object> getter, Action<object, object> setter)
 	{
@@ -20,11 +20,13 @@ internal class CustomProperty : ICustomProperty
 		Type = type;
 		_getter = getter;
 		_setter = setter;
+		CanRead = _getter != null;
+		CanWrite = _setter != null;
 	}
 
-	public bool CanRead => _getter != null;
+	public bool CanRead { get; }
 
-	public bool CanWrite => _setter != null;
+	public bool CanWrite { get; }
 
 	public string Name { get; }
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/SelectedItems.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/SelectedItems.cs
@@ -49,7 +49,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private class SelectedItemsEnumerator : IEnumerator<T>
 		{
 			private readonly IReadOnlyList<T> m_selectedItems = null;
-			private int m_currentIndex = 0;
+			private int m_currentIndex = -1;
 
 			public SelectedItemsEnumerator(IReadOnlyList<T> selectedItems)
 			{
@@ -91,7 +91,7 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 			}
 
-			public void Reset() => m_currentIndex = 0;
+			public void Reset() => m_currentIndex = -1;
 		}
 
 		#endregion

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/SelectionModel.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/SelectionModel.cs
@@ -40,7 +40,7 @@ namespace Microsoft.UI.Xaml.Controls
 				ClearSelection(true /* resetAnchor */, false /* raiseSelectionChanged */);
 				m_rootNode.Source = value;
 				OnSelectionChanged();
-				RaisePropertyChanged("Source");
+				RaisePropertyChanged(nameof(Source));
 			}
 		}
 
@@ -66,7 +66,7 @@ namespace Microsoft.UI.Xaml.Controls
 						SelectWithPathImpl(firstSelectionIndexPath, true /* select */, true /* raiseSelectionChanged */);
 					}
 
-					RaisePropertyChanged("SingleSelect");
+					RaisePropertyChanged(nameof(SingleSelect));
 				}
 			}
 		}
@@ -445,19 +445,18 @@ namespace Microsoft.UI.Xaml.Controls
 
 		ICustomProperty ICustomPropertyProvider.GetCustomProperty(string name)
 		{
-			//TODO: MZ: Not implemented, maybe not used currently
-			//// Exposing SelectedItem through ICustomPropertyProvider so that Binding can work 
-			//// for SelectedItem. This is requried since SelectedItem is not a dependency proeprty and
-			//// is evaluated when requested.
-			//if (name == "SelectedItem")
-			//{
-			//	var selectedItemCustomProperty = new CustomProperty(
-			//		"SelectedItem" /* name */,
-			//		typeof(object) /* typeName */,
-			//		(target) => ((SelectionModel)target).SelectedItem /* getter */,
-			//		null /* setter */);
-			//	return selectedItemCustomProperty;
-			//}
+			// Exposing SelectedItem through ICustomPropertyProvider so that Binding can work 
+			// for SelectedItem. This is requried since SelectedItem is not a dependency proeprty and
+			// is evaluated when requested.
+			if (name == "SelectedItem")
+			{
+				var selectedItemCustomProperty = new CustomProperty(
+					nameof(SelectedItem) /* name */,
+					typeof(object) /* typeName */,
+					(target) => ((SelectionModel)target).SelectedItem /* getter */,
+					null /* setter */);
+				return selectedItemCustomProperty;
+			}
 
 			return null;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): part of #8261

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Tests

## What is the current behavior?

`IndexPath` and `SelectionModel` tests are disabled.


## What is the new behavior?

- Tests are enabled
- Fixes for invalid `SelectedItems` enumeration

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.