### PR TITLE
feat: [droid] BatteryReport and AggregateBattery

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8679,6 +8679,9 @@
 		</Assemblies>
 		<Methods>
 			<Member
+				fullName="System.Void Windows.Devices.Power.BatteryReport..ctor()"
+				reason="not public in UWP"/>
+			<Member
 				fullName="System.Boolean Windows.UI.Xaml.FrameworkElement.get_StretchAffectsMeasure()"
 				reason="False positive: added in an internal interface" />
 			<Member

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8770,6 +8770,9 @@
 	</IgnoreSet>
 	<IgnoreSet baseVersion="4.2.6">
 		<Methods>
+			<Member
+				fullName="System.Void Windows.Devices.Power.BatteryReport..ctor()"
+				reason="Does not exist in UWP" />
 			<!-- BEGIN Bluetooth API -->
 			<Member
 				fullName="System.Void Windows.Devices.Bluetooth.BluetoothLEDevice..ctor()"

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -385,6 +385,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_Devices\Power\Battery.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_Devices\RadioTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4851,6 +4855,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_ApplicationModel_Resources_ResourceLoader\ResourceLoader_Simple.xaml.cs">
       <DependentUpon>ResourceLoader_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\Power\Battery.xaml.cs">
+      <DependentUpon>Battery.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Devices\RadioTests.xaml.cs">
       <DependentUpon>RadioTests.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/Power/Battery.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/Power/Battery.xaml
@@ -1,0 +1,20 @@
+﻿<Page
+    x:Class="UITests.Windows_Devices.Power.Battery"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_Devices.Power"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Padding="20">
+		<Button Click="getBatteryInfo_Click">Get battery info</Button>
+		<TextBlock Text="" Foreground="Red" Name="uiErrorMsg"/>
+		<TextBlock Text="" Name="uiOkMsg"/>
+		<TextBlock Name="uiStatus"/>
+		<TextBlock Name="uiChargeRate" />
+		<TextBlock Name="uiFull" />
+		<TextBlock Name="uiRemaining" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/Power/Battery.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/Power/Battery.xaml
@@ -12,7 +12,7 @@
 		<Button Click="getBatteryInfo_Click">Get battery info</Button>
 		<TextBlock Text="" Foreground="Red" Name="uiErrorMsg"/>
 		<TextBlock Text="" Name="uiOkMsg"/>
-		<TextBlock Name="uiStatus"/>
+		<TextBlock Name="uiStatus" />
 		<TextBlock Name="uiChargeRate" />
 		<TextBlock Name="uiFull" />
 		<TextBlock Name="uiRemaining" />

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/Power/Battery.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/Power/Battery.xaml.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Data.Xml.Dom;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Notifications;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Windows.ApplicationModel.Appointments;
+
+
+namespace UITests.Windows_Devices.Power
+{
+
+	[SampleControlInfo("Windows_Devices.Power", "Battery")]
+	public sealed partial class Battery : Page
+    {
+        public Battery()
+        {
+            this.InitializeComponent();
+		}
+
+		private async void getBatteryInfo_Click(object sender, RoutedEventArgs e)
+		{
+			uiErrorMsg.Text = "";
+			uiOkMsg.Text = "";
+			uiStatus.Text = "";
+			uiChargeRate.Text = "";
+			uiFull.Text = "";
+			uiRemaining.Text = "";
+
+			Windows.Devices.Power.BatteryReport oBattRep;
+			try
+			{
+				oBattRep = Windows.Devices.Power.Battery.AggregateBattery.GetReport();
+			}
+			catch (Exception ex)
+			{
+				uiErrorMsg.Text = "Exception reading battery data, maybe not implemented? " + ex.Message;
+				return;
+			}
+
+
+
+			uiStatus.Text = oBattRep.Status.ToString();
+			uiChargeRate.Text = oBattRep.ChargeRateInMilliwatts + " mW";
+			uiFull.Text = oBattRep.FullChargeCapacityInMilliwattHours + " mWh";
+			uiRemaining.Text = oBattRep.RemainingCapacityInMilliwattHours + " mWh";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_Devices/Power/Battery.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/Power/Battery.xaml.cs
@@ -21,7 +21,7 @@ using Windows.ApplicationModel.Appointments;
 namespace UITests.Windows_Devices.Power
 {
 
-	[SampleControlInfo("Windows_Devices.Power", "Battery")]
+	[SampleControlInfo("Windows.Devices.Power", "Battery")]
 	public sealed partial class Battery : Page
     {
         public Battery()
@@ -51,10 +51,10 @@ namespace UITests.Windows_Devices.Power
 
 
 
-			uiStatus.Text = oBattRep.Status.ToString();
-			uiChargeRate.Text = oBattRep.ChargeRateInMilliwatts + " mW";
-			uiFull.Text = oBattRep.FullChargeCapacityInMilliwattHours + " mWh";
-			uiRemaining.Text = oBattRep.RemainingCapacityInMilliwattHours + " mWh";
+			uiStatus.Text = "Battery status: " + oBattRep.Status.ToString();
+			uiChargeRate.Text = "Charge Rate: " + oBattRep.ChargeRateInMilliwatts + " mW";
+			uiFull.Text = "Full Charge Capacity: " + oBattRep.FullChargeCapacityInMilliwattHours + " mWh";
+			uiRemaining.Text = "Remaining Capacity: " + oBattRep.RemainingCapacityInMilliwattHours + " mWh";
 		}
 	}
 }

--- a/src/Uno.UWP/Devices/Power/Battery.Android.cs
+++ b/src/Uno.UWP/Devices/Power/Battery.Android.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.Devices.Power
+{
+	public partial class Battery
+	{
+		public static Windows.Devices.Power.Battery AggregateBattery()
+		{
+			return new Battery();
+		}
+
+		public Windows.Devices.Power.BatteryReport GetReport()
+		{
+			return new BatteryReport();
+		}
+
+	}
+}

--- a/src/Uno.UWP/Devices/Power/Battery.Android.cs
+++ b/src/Uno.UWP/Devices/Power/Battery.Android.cs
@@ -1,14 +1,13 @@
 ﻿
+#nullable enable
+
 namespace Windows.Devices.Power
 {
 	public partial class Battery
 	{
 		public static Battery AggregateBattery => new Battery();
 
-		public BatteryReport GetReport()
-		{
-			return new BatteryReport();
-		}
+		public BatteryReport GetReport() => new BatteryReport();
 
 	}
 }

--- a/src/Uno.UWP/Devices/Power/Battery.Android.cs
+++ b/src/Uno.UWP/Devices/Power/Battery.Android.cs
@@ -6,12 +6,12 @@ namespace Windows.Devices.Power
 {
 	public partial class Battery
 	{
-		public static Windows.Devices.Power.Battery AggregateBattery()
+		public static Battery AggregateBattery()
 		{
 			return new Battery();
 		}
 
-		public Windows.Devices.Power.BatteryReport GetReport()
+		public BatteryReport GetReport()
 		{
 			return new BatteryReport();
 		}

--- a/src/Uno.UWP/Devices/Power/Battery.Android.cs
+++ b/src/Uno.UWP/Devices/Power/Battery.Android.cs
@@ -3,10 +3,7 @@ namespace Windows.Devices.Power
 {
 	public partial class Battery
 	{
-		public static Battery AggregateBattery()
-		{
-			return new Battery();
-		}
+		public static Battery AggregateBattery => new Battery();
 
 		public BatteryReport GetReport()
 		{

--- a/src/Uno.UWP/Devices/Power/Battery.Android.cs
+++ b/src/Uno.UWP/Devices/Power/Battery.Android.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿
 namespace Windows.Devices.Power
 {
 	public partial class Battery

--- a/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
+++ b/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿
+using AndroidBatteryStatus = Android.OS.BatteryStatus;
+using UwpBatteryStatus = Windows.System.Power.BatteryStatus;
+
 
 namespace Windows.Devices.Power
 {
@@ -10,7 +11,7 @@ namespace Windows.Devices.Power
 		public int? DesignCapacityInMilliwattHours { get; }
 		public int? FullChargeCapacityInMilliwattHours { get; }
 		public int? RemainingCapacityInMilliwattHours { get; }
-		public System.Power.BatteryStatus Status { get; }
+		public UwpBatteryStatus Status { get; }
 
 
 		internal BatteryReport()
@@ -23,11 +24,11 @@ namespace Windows.Devices.Power
 			// since API 5, so we don't have to check OS level
 			if (!batteryStatus.GetBooleanExtra(Android.OS.BatteryManager.ExtraPresent, false))
 			{
-				Status = System.Power.BatteryStatus.NotPresent;
+				Status = UwpBatteryStatus.NotPresent;
 				return;
 			}
 
-			Status = UWPstatusFromAndroStatus(batteryStatus.GetIntExtra(Android.OS.BatteryManager.ExtraStatus, -1));
+			Status = UwpStatusFromAndroidStatus(batteryStatus.GetIntExtra(Android.OS.BatteryManager.ExtraStatus, -1));
 
 
 			if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.Lollipop)
@@ -72,24 +73,24 @@ namespace Windows.Devices.Power
 			// UWP doc says: Some battery controllers might return the same value as FullChargeCapacityInMilliwattHours or return no value at all.
 			DesignCapacityInMilliwattHours = FullChargeCapacityInMilliwattHours;
 		}
-		private Windows.System.Power.BatteryStatus UWPstatusFromAndroStatus(int status)
+		private UwpBatteryStatus UwpStatusFromAndroidStatus(int status)
 		{
 			switch (status)
 			{
-				case 1: // BATTERY_STATUS_UNKNOWN
-					return System.Power.BatteryStatus.Idle;
-				case 2: // BATTERY_STATUS_CHARGING
-					return System.Power.BatteryStatus.Charging;
-				case 3: // BATTERY_STATUS_DISCHARGING
-					return System.Power.BatteryStatus.Discharging;
-				case 4: // BATTERY_STATUS_NOT_CHARGING
-					return System.Power.BatteryStatus.Idle;
-				case 5: // BATTERY_STATUS_FULL
-					return System.Power.BatteryStatus.Idle;
+				case (int)AndroidBatteryStatus.Unknown: 
+					return UwpBatteryStatus.NotPresent;
+				case (int)AndroidBatteryStatus.Charging: 
+					return UwpBatteryStatus.Charging;
+				case (int)AndroidBatteryStatus.Discharging: 
+					return UwpBatteryStatus.Discharging;
+				case (int)AndroidBatteryStatus.NotCharging: 
+					return UwpBatteryStatus.Idle;
+				case (int)AndroidBatteryStatus.Full: 
+					return UwpBatteryStatus.Idle;
 			}
 
-			// either OS is changed, or cannot get ExtraStatus (status == -1)
-			return System.Power.BatteryStatus.NotPresent;
+			// either OS is changed (new values, not known while writing this code), or cannot get ExtraStatus (status == -1)
+			return UwpBatteryStatus.NotPresent;
 		}
 	}
 }

--- a/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
+++ b/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.Devices.Power
+{
+	public partial class BatteryReport
+	{
+		public int? ChargeRateInMilliwatts;
+		public int? DesignCapacityInMilliwattHours;
+		public int? FullChargeCapacityInMilliwattHours;
+		public int? RemainingCapacityInMilliwattHours;
+		public Windows.System.Power.BatteryStatus Status;
+
+		private Windows.System.Power.BatteryStatus UWPstatusFromAndroStatus(int status)
+		{
+			switch (status)
+			{
+				case 1: // BATTERY_STATUS_UNKNOWN
+					return System.Power.BatteryStatus.Idle;
+				case 2: // BATTERY_STATUS_CHARGING
+					return System.Power.BatteryStatus.Charging;
+				case 3: // BATTERY_STATUS_DISCHARGING
+					return System.Power.BatteryStatus.Discharging;
+				case 4: // BATTERY_STATUS_NOT_CHARGING
+					return System.Power.BatteryStatus.Idle;
+				case 5: // BATTERY_STATUS_FULL
+					return System.Power.BatteryStatus.Idle;
+			}
+
+			// either OS is changed, or cannot get ExtraStatus (status == -1)
+			return System.Power.BatteryStatus.NotPresent;
+		}
+
+		public BatteryReport()
+		{
+			// values are current for object creation
+
+			var ifilter = new Android.Content.IntentFilter(Android.Content.Intent.ActionBatteryChanged);
+			var batteryStatus = Android.App.Application.Context.RegisterReceiver(null, ifilter);
+
+			// since API 5, so we don't have to check OS level
+			if (!batteryStatus.GetBooleanExtra(Android.OS.BatteryManager.ExtraPresent, false))
+			{
+				Status = System.Power.BatteryStatus.NotPresent;
+				return;
+			}
+
+			Status = UWPstatusFromAndroStatus(batteryStatus.GetIntExtra(Android.OS.BatteryManager.ExtraStatus, -1));
+
+
+			if (Android.OS.Build.VERSION.SdkInt < Android.OS.BuildVersionCodes.Lollipop)
+			{
+				// this probably doesn't happen, but anyway we can try set some values...
+
+				// since API 5
+				int level = batteryStatus.GetIntExtra(Android.OS.BatteryManager.ExtraLevel, 1);
+				int scale = batteryStatus.GetIntExtra(Android.OS.BatteryManager.ExtraScale, 100);
+
+				// 100*RemainingCapacityInMilliwattHours / FullChargeCapacityInMilliwattHours gives percentage of remaining battery
+				RemainingCapacityInMilliwattHours = level;
+				FullChargeCapacityInMilliwattHours = scale;
+
+				return;
+			}
+
+			// now, we have API 21+, so we have more values
+			int voltage = batteryStatus.GetIntExtra(Android.OS.BatteryManager.ExtraVoltage, 0);
+
+			var batteryManager = (Android.OS.BatteryManager)Android.App.Application.Context.GetSystemService(Android.Content.Context.BatteryService);
+			int currentMicroAmps = batteryManager.GetIntProperty((int)Android.OS.BatteryProperty.CurrentNow);   // Instantaneous battery current in microamperes, as an integer.
+			int chargeCounterMicroAmpHr = batteryManager.GetIntProperty((int)Android.OS.BatteryProperty.ChargeCounter); // Battery capacity in microampere-hours, as an integer.
+			long energyCounterNanoWattHr = batteryManager.GetLongProperty((int)Android.OS.BatteryProperty.EnergyCounter); // Battery remaining energy in nanowatt-hours, as a long integer.
+
+			// Android: Instantaneous battery current in microamperes, as an integer.
+			// UWP: mW
+			// both: > 0 charging, < 0 discharging
+			// conversion: milli = 1000 micro; and watt = volt * amper
+			ChargeRateInMilliwatts = voltage * currentMicroAmps / 1000;
+
+			// Android: Battery remaining energy in nanowatt-hours, as a long integer.
+			// UWP: mWh
+			// conversion: milli = 1000 micro; and micro = 1000 nano
+			RemainingCapacityInMilliwattHours = (int)(energyCounterNanoWattHr / (1000 * 1000));
+
+			// Android: Battery capacity in microampere-hours, as an integer.
+			// UWP: mWh
+			// conversion: milli = 1000 micro; and watt = volt * amper
+			FullChargeCapacityInMilliwattHours = voltage * chargeCounterMicroAmpHr / 1000;
+
+			// UWP doc says: Some battery controllers might return the same value as FullChargeCapacityInMilliwattHours or return no value at all.
+			DesignCapacityInMilliwattHours = FullChargeCapacityInMilliwattHours;
+		}
+	}
+}

--- a/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
+++ b/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
@@ -4,35 +4,16 @@ using System.Text;
 
 namespace Windows.Devices.Power
 {
-	public partial class BatteryReport
+	public sealed partial class BatteryReport
 	{
-		public int? ChargeRateInMilliwatts;
-		public int? DesignCapacityInMilliwattHours;
-		public int? FullChargeCapacityInMilliwattHours;
-		public int? RemainingCapacityInMilliwattHours;
-		public Windows.System.Power.BatteryStatus Status;
+		public int? ChargeRateInMilliwatts { get; }
+		public int? DesignCapacityInMilliwattHours { get; }
+		public int? FullChargeCapacityInMilliwattHours { get; }
+		public int? RemainingCapacityInMilliwattHours { get; }
+		public System.Power.BatteryStatus Status { get; }
 
-		private Windows.System.Power.BatteryStatus UWPstatusFromAndroStatus(int status)
-		{
-			switch (status)
-			{
-				case 1: // BATTERY_STATUS_UNKNOWN
-					return System.Power.BatteryStatus.Idle;
-				case 2: // BATTERY_STATUS_CHARGING
-					return System.Power.BatteryStatus.Charging;
-				case 3: // BATTERY_STATUS_DISCHARGING
-					return System.Power.BatteryStatus.Discharging;
-				case 4: // BATTERY_STATUS_NOT_CHARGING
-					return System.Power.BatteryStatus.Idle;
-				case 5: // BATTERY_STATUS_FULL
-					return System.Power.BatteryStatus.Idle;
-			}
 
-			// either OS is changed, or cannot get ExtraStatus (status == -1)
-			return System.Power.BatteryStatus.NotPresent;
-		}
-
-		public BatteryReport()
+		internal BatteryReport()
 		{
 			// values are current for object creation
 
@@ -90,6 +71,25 @@ namespace Windows.Devices.Power
 
 			// UWP doc says: Some battery controllers might return the same value as FullChargeCapacityInMilliwattHours or return no value at all.
 			DesignCapacityInMilliwattHours = FullChargeCapacityInMilliwattHours;
+		}
+		private Windows.System.Power.BatteryStatus UWPstatusFromAndroStatus(int status)
+		{
+			switch (status)
+			{
+				case 1: // BATTERY_STATUS_UNKNOWN
+					return System.Power.BatteryStatus.Idle;
+				case 2: // BATTERY_STATUS_CHARGING
+					return System.Power.BatteryStatus.Charging;
+				case 3: // BATTERY_STATUS_DISCHARGING
+					return System.Power.BatteryStatus.Discharging;
+				case 4: // BATTERY_STATUS_NOT_CHARGING
+					return System.Power.BatteryStatus.Idle;
+				case 5: // BATTERY_STATUS_FULL
+					return System.Power.BatteryStatus.Idle;
+			}
+
+			// either OS is changed, or cannot get ExtraStatus (status == -1)
+			return System.Power.BatteryStatus.NotPresent;
 		}
 	}
 }

--- a/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
+++ b/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
@@ -53,7 +53,9 @@ namespace Windows.Devices.Power
 			}
 
 			// now, we have API 21+, so we have more values
-			int voltage = batteryStatus.GetIntExtra(Android.OS.BatteryManager.ExtraVoltage, 0);
+
+			// voltage is int, but in mV; we want to have voltage in Volts
+			float voltage = batteryStatus.GetIntExtra(Android.OS.BatteryManager.ExtraVoltage, 0) / 1000;
 
 			using var batteryManager = (Android.OS.BatteryManager?)Android.App.Application.Context.GetSystemService(Android.Content.Context.BatteryService);
 			if (batteryManager is null)
@@ -63,13 +65,14 @@ namespace Windows.Devices.Power
 			}
 			int currentMicroAmps = batteryManager.GetIntProperty((int)Android.OS.BatteryProperty.CurrentNow);   // Instantaneous battery current in microamperes, as an integer.
 			int chargeCounterMicroAmpHr = batteryManager.GetIntProperty((int)Android.OS.BatteryProperty.ChargeCounter); // Battery capacity in microampere-hours, as an integer.
-			long energyCounterNanoWattHr = batteryManager.GetLongProperty((int)Android.OS.BatteryProperty.EnergyCounter); // Battery remaining energy in nanowatt-hours, as a long integer.
+			// long energyCounterNanoWattHr = batteryManager.GetLongProperty((int)Android.OS.BatteryProperty.EnergyCounter); // Battery remaining energy in nanowatt-hours, as a long integer.
+			int energyCounterNanoWattHr = batteryManager.GetIntProperty((int)Android.OS.BatteryProperty.EnergyCounter); // But in reality, seems like it is int not long (doc has error here)
 
 			// Android: Instantaneous battery current in microamperes, as an integer.
 			// UWP: mW
 			// both: > 0 charging, < 0 discharging
 			// conversion: milli = 1000 micro; and watt = volt * amper
-			ChargeRateInMilliwatts = voltage * currentMicroAmps / 1000;
+			ChargeRateInMilliwatts = (int) (voltage * currentMicroAmps / 1000);
 
 			// Android: Battery remaining energy in nanowatt-hours, as a long integer.
 			// UWP: mWh
@@ -79,7 +82,7 @@ namespace Windows.Devices.Power
 			// Android: Battery capacity in microampere-hours, as an integer.
 			// UWP: mWh
 			// conversion: milli = 1000 micro; and watt = volt * amper
-			FullChargeCapacityInMilliwattHours = voltage * chargeCounterMicroAmpHr / 1000;
+			FullChargeCapacityInMilliwattHours = (int) (voltage * chargeCounterMicroAmpHr / 1000);
 
 			// UWP doc says: Some battery controllers might return the same value as FullChargeCapacityInMilliwattHours or return no value at all.
 			DesignCapacityInMilliwattHours = FullChargeCapacityInMilliwattHours;

--- a/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
+++ b/src/Uno.UWP/Devices/Power/BatteryReport.Android.cs
@@ -17,8 +17,9 @@ namespace Windows.Devices.Power
 
 		internal BatteryReport()
 		{
-			// values are current for object creation
+			//  battery values are current for object creation
 
+			// using info from https://developer.android.com/training/monitoring-device-state/battery-monitoring
 			var ifilter = new Android.Content.IntentFilter(Android.Content.Intent.ActionBatteryChanged);
 			var batteryStatus = Android.App.Application.Context.RegisterReceiver(null, ifilter);
 			if(batteryStatus is null)

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Power/Battery.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Power/Battery.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Power
 {
-	#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Battery 
@@ -17,7 +17,7 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Devices.Power.Battery AggregateBattery
 		{
@@ -28,7 +28,7 @@ namespace Windows.Devices.Power
 		}
 		#endif
 		// Forced skipping of method Windows.Devices.Power.Battery.DeviceId.get
-		#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Devices.Power.BatteryReport GetReport()
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Power/Battery.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Power/Battery.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Power
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class Battery 
@@ -17,8 +17,8 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.Devices.Power.Battery AggregateBattery
 		{
 			get
@@ -28,8 +28,8 @@ namespace Windows.Devices.Power
 		}
 		#endif
 		// Forced skipping of method Windows.Devices.Power.Battery.DeviceId.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Devices.Power.BatteryReport GetReport()
 		{
 			throw new global::System.NotImplementedException("The member BatteryReport Battery.GetReport() is not implemented in Uno.");

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Power/BatteryReport.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Power/BatteryReport.cs
@@ -2,13 +2,13 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Power
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class BatteryReport 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented( "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int? ChargeRateInMilliwatts
 		{
 			get
@@ -17,8 +17,8 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if  __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int? DesignCapacityInMilliwattHours
 		{
 			get
@@ -27,8 +27,8 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if  __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented( "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int? FullChargeCapacityInMilliwattHours
 		{
 			get
@@ -37,8 +37,8 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if  __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented( "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int? RemainingCapacityInMilliwattHours
 		{
 			get
@@ -47,8 +47,8 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if  __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.System.Power.BatteryStatus Status
 		{
 			get

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Power/BatteryReport.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Devices.Power/BatteryReport.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Devices.Power
 {
-	#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class BatteryReport 
 	{
-		#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented( "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int? ChargeRateInMilliwatts
 		{
@@ -17,7 +17,7 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if  __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if  false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int? DesignCapacityInMilliwattHours
 		{
@@ -27,7 +27,7 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if  __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if  false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented( "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int? FullChargeCapacityInMilliwattHours
 		{
@@ -37,7 +37,7 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if  __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if  false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented( "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  int? RemainingCapacityInMilliwattHours
 		{
@@ -47,7 +47,7 @@ namespace Windows.Devices.Power
 			}
 		}
 		#endif
-		#if  __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if  false || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.System.Power.BatteryStatus Status
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type
- Feature

## What is the current behavior?
No class in Windows.Devices.Power is implemented.

## What is the new behavior?
Windows.Devices.Power.AggregateBattery and Windows.Devices.Power.BatteryReport is implemented.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
 Required for two of my apps: 
https://github.com/pkar70/AccuMon
and
https://github.com/pkar70/Waga/tree/master/WeedQbPlug

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
