### PR TITLE
feat: some Background structs for all platforms

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8787,6 +8787,9 @@
 				fullName="System.Void Windows.Devices.Bluetooth.GenericAttributeProfile.GattReadResult..ctor()"
 				reason="Does not exist in UWP" />
 			<!-- END Bluetooth API -->
+			<Member
+				fullName="System.Void Windows.ApplicationModel.Background.BackgroundTaskRegistration..ctor()"
+				reason="Not part of UWP API" />
 		</Methods>
 	</IgnoreSet>
 	<!--

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8694,6 +8694,9 @@
 				fullName="System.Void Windows.Devices.Geolocation.Geolocator.WaitForPermissionFromBackground()"
 				reason="Not part of UWP API" />
 			<Member
+				fullName="System.Void Windows.ApplicationModel.Background.BackgroundTaskRegistration..ctor()"
+				reason="Not part of UWP API" />
+			<Member
 				fullName="System.Void Windows.Graphics.Printing.Workflow.PrintWorkflowObjectModelSourceFileContent..ctor()"
 				reason="Does not exist in UWP" />
 			<Member

--- a/src/Uno.UWP/ApplicationModel/Background/BackgroundTaskRegistration.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/BackgroundTaskRegistration.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 
-namespace Windows.ApplicationModel.Background
-{
+namespace Windows.ApplicationModel.Background;
+
 
 	public partial class BackgroundTaskRegistration : IBackgroundTaskRegistration, IBackgroundTaskRegistration2, IBackgroundTaskRegistration3
 	{
@@ -16,4 +16,4 @@ namespace Windows.ApplicationModel.Background
 
 	}
 
-}
+

--- a/src/Uno.UWP/ApplicationModel/Background/BackgroundTaskRegistration.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/BackgroundTaskRegistration.cs
@@ -1,0 +1,11 @@
+﻿
+
+namespace Windows.ApplicationModel.Background
+{
+
+	public partial class BackgroundTaskRegistration : IBackgroundTaskRegistration, IBackgroundTaskRegistration2, IBackgroundTaskRegistration3
+	{
+		public string Name { get; internal set; }
+		public IBackgroundTrigger Trigger { get; internal set; }
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/Background/BackgroundTaskRegistration.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/BackgroundTaskRegistration.cs
@@ -1,4 +1,4 @@
-﻿
+﻿#nullable enable
 
 namespace Windows.ApplicationModel.Background
 {
@@ -7,5 +7,13 @@ namespace Windows.ApplicationModel.Background
 	{
 		public string Name { get; internal set; }
 		public IBackgroundTrigger Trigger { get; internal set; }
+
+		internal BackgroundTaskRegistration(string name, IBackgroundTrigger trigger)
+		{
+			Name = name;
+			Trigger = trigger;
+		}
+
 	}
+
 }

--- a/src/Uno.UWP/ApplicationModel/Background/IBackgroundTaskRegistration.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/IBackgroundTaskRegistration.cs
@@ -1,0 +1,9 @@
+﻿
+
+namespace Windows.ApplicationModel.Background
+{
+	public partial interface IBackgroundTaskRegistration
+	{
+		string Name { get; }
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/Background/IBackgroundTaskRegistration2.cs
+++ b/src/Uno.UWP/ApplicationModel/Background/IBackgroundTaskRegistration2.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.ApplicationModel.Background
+{
+	public partial interface IBackgroundTaskRegistration2 : IBackgroundTaskRegistration
+	{
+		IBackgroundTrigger Trigger { get; }
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/BackgroundTaskRegistration.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/BackgroundTaskRegistration.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel.Background
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false 
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class BackgroundTaskRegistration : global::Windows.ApplicationModel.Background.IBackgroundTaskRegistration,global::Windows.ApplicationModel.Background.IBackgroundTaskRegistration2,global::Windows.ApplicationModel.Background.IBackgroundTaskRegistration3
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false 
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  string Name
 		{
@@ -27,7 +27,7 @@ namespace Windows.ApplicationModel.Background
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false 
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.ApplicationModel.Background.IBackgroundTrigger Trigger
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/IBackgroundTaskRegistration.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/IBackgroundTaskRegistration.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel.Background
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IBackgroundTaskRegistration 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		string Name
 		{
 			get;

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/IBackgroundTaskRegistration2.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.Background/IBackgroundTaskRegistration2.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.ApplicationModel.Background
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	#if false
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial interface IBackgroundTaskRegistration2 : global::Windows.ApplicationModel.Background.IBackgroundTaskRegistration
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if false
 		global::Windows.ApplicationModel.Background.IBackgroundTrigger Trigger
 		{
 			get;


### PR DESCRIPTION
GitHub Issue (If applicable): #2406, #3045

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
No background processing at all.

## What is the new behavior?
Some structs are defined for all platforms.
No real code - code for Android is in #2655.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
 Part of #2655 - files that are valid for all platforms.
As #2655 is still waiting, maybe part of it can be merged much sooner. And I would get less Uno0001 messages when building my apps.

 Part of my apps
* https://github.com/pkar70/EnviroStatus
* https://github.com/pkar70/BackupSMS

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
