### PR TITLE
fix(XamlReader): collection parsing issues

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -18,6 +18,7 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI;
 using Windows.UI;
+using System.Text.RegularExpressions;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 {
@@ -1094,6 +1095,91 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 
 			SUT.IsChecked = true;
 			Assert.AreEqual(true, r.MyVM.MyBool);
+		}
+
+		[TestMethod]
+		public void When_Collection_Implicit_Add_Item()
+		{
+			var SUT = LoadXaml<SwipeItems>(@"
+				<SwipeItems>
+					<SwipeItem Text='asd' />
+				</SwipeItems>
+			");
+
+			Assert.AreEqual(1, SUT.Count);
+			Assert.AreEqual("asd", SUT[0].Text);
+		}
+
+		[TestMethod]
+		public void When_Collection_Property_Nest_Collection()
+		{
+			var SUT = LoadXaml<SwipeControl>(@"
+				<SwipeControl>
+					<SwipeControl.LeftItems>
+						<SwipeItems Mode='Execute'>
+							<SwipeItem Text='asd' />
+						</SwipeItems>
+					</SwipeControl.LeftItems>
+				</SwipeControl>
+			");
+
+			Assert.IsNotNull(SUT.LeftItems);
+			Assert.AreEqual(SwipeMode.Execute, SUT.LeftItems.Mode); // check we are using the very same collection in the xaml, and not a new instance
+			Assert.AreEqual(1, SUT.LeftItems.Count);
+			Assert.AreEqual("asd", SUT.LeftItems[0].Text);
+		}
+
+		[TestMethod]
+		public void When_Collection_Property_Nest_Multiple_Collections()
+		{
+			var SUT = LoadXaml<SwipeControl>(@"
+				<SwipeControl>
+					<SwipeControl.LeftItems>
+						<!-- This is actually allowed, however only the last will be kept -->
+						<SwipeItems>
+							<SwipeItem Text='asd' />
+						</SwipeItems>
+						<SwipeItems Mode='Execute'>
+							<SwipeItem Text='qwe' />
+						</SwipeItems>
+					</SwipeControl.LeftItems>
+				</SwipeControl>
+			");
+
+			Assert.IsNotNull(SUT.LeftItems);
+			Assert.AreEqual(SwipeMode.Execute, SUT.LeftItems.Mode); // check we are using the very same collection in the xaml, and not a new instance
+			Assert.AreEqual(1, SUT.LeftItems.Count);
+			Assert.AreEqual("qwe", SUT.LeftItems[0].Text);
+		}
+		
+		/// <summary>
+		/// XamlReader.Load the xaml and type-check result.
+		/// </summary>
+		/// <param name="sanitizedXaml">Xaml with single or double quots</param>
+		/// <param name="defaultXmlns">The default xmlns to inject; use null to not inject one.</param>
+		private T LoadXaml<T>(string sanitizedXaml, string defaultXmlns = "http://schemas.microsoft.com/winfx/2006/xaml/presentation") where T : class =>
+			LoadXaml<T>(sanitizedXaml, new Dictionary<string, string>{ [string.Empty] = defaultXmlns });
+
+		/// <summary>
+		/// XamlReader.Load the xaml and type-check result.
+		/// </summary>
+		/// <param name="sanitizedXaml">Xaml with single or double quots</param>
+		/// <param name="xmlnses">Xmlns to inject; use string.Empty for the default xmlns' key</param>
+		private T LoadXaml<T>(string xaml, Dictionary<string, string> xmlnses) where T : class
+		{
+			var injection = " " + string.Join(" ", xmlnses
+				.Where(x => x.Value != null)
+				.Select(x => $"xmlns{(string.IsNullOrEmpty(x.Key) ? "" : $":{x.Key}")}='{x.Value}'")
+			);
+
+			xaml = new Regex(@"(?=\\?>)").Replace(xaml, injection, 1);
+			xaml = xaml.Replace('\'', '"');
+
+			var result = Windows.UI.Xaml.Markup.XamlReader.Load(xaml);
+			Assert.IsNotNull(result, "XamlReader.Load returned null");
+			Assert.IsInstanceOfType(result, typeof(T), "XamlReader.Load did not return the expected type");
+
+			return (T)result;
 		}
 
 		private string GetContent(string testName)

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -271,6 +271,12 @@ namespace Windows.UI.Xaml.Markup.Reader
 				{
 					ProcessSpan(control, span, member, rootInstance);
 				}
+				else if (member.Member.Name == "_UnknownContent"
+					&& TypeResolver.FindContentProperty(TypeResolver.FindType(control.Type)) == null
+					&& TypeResolver.IsCollectionOrListType(TypeResolver.FindType(control.Type)))
+				{
+					AddCollectionItems(instance, member.Objects, rootInstance);
+				}
 				else if (GetMemberProperty(control, member) is PropertyInfo propertyInfo)
 				{
 					if (member.Objects.None())
@@ -541,10 +547,21 @@ namespace Windows.UI.Xaml.Markup.Reader
 						addMethod.Invoke(propertyInstance, new[] { resourceKey ?? resourceTargetType, item });
 					}
 				}
-				else if (TypeResolver.IsNewableProperty(propertyInfo, out var collectionType))
+				else if (propertyInfo.SetMethod?.IsPublic == true &&
+					member.Objects.Select(x => x.Type).Distinct().All(x => TypeResolver.FindType(x).Is(propertyInfo.PropertyType)))
 				{
-					var collection = Activator.CreateInstance(collectionType!);
+					// It is actually valid to have multiple nested collection containers under a property, however only the last will be kept.
+					foreach (var child in member.Objects)
+					{
+						var collection = LoadObject(child, rootInstance: rootInstance);
 
+						GetPropertySetter(propertyInfo).Invoke(instance, new[] { collection });
+					}
+				}
+				else if (propertyInfo.SetMethod?.IsPublic == true
+					&& TypeResolver.IsNewableType(propertyInfo.PropertyType))
+				{
+					var collection = Activator.CreateInstance(propertyInfo.PropertyType);
 					AddCollectionItems(collection!, member.Objects, rootInstance);
 
 					GetPropertySetter(propertyInfo).Invoke(instance, new[] { collection });
@@ -896,7 +913,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 						.Where(m => m.Name == "set_Item")
 						.FirstOrDefault(m => m.GetParameters() is { Length: 1 } p
 							&& (item?.GetType() ?? typeof(object)).Is(p[0].ParameterType))
-						?? throw new InvalidOperationException($"The type does {collectionInstance.GetType()} contains an Add({item?.GetType()}) method");
+						?? throw new InvalidOperationException($"The type {collectionInstance.GetType()} does not contains an Add({item?.GetType()}) method");
 				}
 
 				addMethodInfo.Invoke(collectionInstance, new[] { item });
@@ -919,11 +936,22 @@ namespace Windows.UI.Xaml.Markup.Reader
 						.Where(m => m.Name == "Add")
 						.FirstOrDefault(m => m.GetParameters() is { Length: 1 } p
 							&& (item?.GetType() ?? typeof(object)).Is(p[0].ParameterType))
-						?? throw new InvalidOperationException($"The type does {collectionInstance.GetType()} contains an Add({item?.GetType()}) method");
+						?? throw new InvalidOperationException($"The type {collectionInstance.GetType()} does not contains an Add({item?.GetType()}) method");
 				}
 
 				addMethodInfo.Invoke(collectionInstance, new[] { item });
 			}
+		}
+
+		private MethodInfo? FindAddMethod(object collectionInstance, Type? itemType)
+		{
+			return collectionInstance.GetType()
+				.GetMethods(BindingFlags.Instance | BindingFlags.FlattenHierarchy | BindingFlags.Public)
+				.Where(m => m.Name == "Add")
+				.FirstOrDefault(m =>
+					m.GetParameters() is { Length: 1 } p &&
+					(itemType ?? typeof(object)).Is(p[0].ParameterType)
+				);
 		}
 
 		private object? GetResourceKey(XamlObjectDefinition child) =>

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -162,20 +162,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 			}
 		}
 
-		/// <summary>
-		/// Returns true if the property has an accessible public setter and has a parameterless constructor
-		/// </summary>
-		public bool IsNewableProperty(PropertyInfo property, out Type? newableType)
-		{
-			var namedType = property.PropertyType as Type;
-
-			var isNewable = (property.SetMethod?.IsPublic ?? false) &&
-				namedType.SelectOrDefault(nts => nts.GetConstructors().Any(ms => ms.GetParameters().Length == 0), false);
-
-			newableType = isNewable ? namedType : null;
-
-			return isNewable;
-		}
+		public bool IsNewableType(Type type) => type.GetConstructors().Any(x => x.GetParameters().Length == 0);
 
 		public DependencyProperty? FindDependencyProperty(XamlMemberDefinition member)
 		{
@@ -242,8 +229,13 @@ namespace Windows.UI.Xaml.Markup.Reader
 		private bool IsInitializableProperty(PropertyInfo property)
 			=> !(property.SetMethod?.IsPublic ?? false);
 
-		public bool IsCollectionOrListType(Type type)
+		public bool IsCollectionOrListType(Type? type)
 		{
+			if (type == null)
+			{
+				return false;
+			}
+
 			return IsImplementingInterface(type, typeof(global::System.Collections.ICollection)) ||
 				IsImplementingInterface(type, typeof(ICollection<>)) ||
 				IsImplementingInterface(type, typeof(global::System.Collections.IList)) ||


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8510

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`XamlReader.Load` would throw when:
1. Adding an item to a collection type with an appropriate `Add(item)` method, but without `[ContentPropertyAttribute]`
2. Adding a collection to a collection property

## What is the new behavior?

^ will both work now.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): closes: unoplatform/Uno.Figma#515