### PR TITLE
Misc VS 2022 updates: Intellisense for non-WinAppSDK projects, exception when creating projects

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -443,7 +443,7 @@
 			<PackageNamePrefix Condition="'$(UNO_UWP_BUILD)'=='true'">Uno.UI</PackageNamePrefix>
 		</PropertyGroup>
 
-		<Exec Command="dotnet tool install --tool-path $(MSBuildThisFileDirectory)\tools Uno.PackageDiff --version 1.0.0-dev.36" IgnoreExitCode="true" />
+		<Exec Command="dotnet tool install --tool-path $(MSBuildThisFileDirectory)\tools Uno.PackageDiff --version 1.1.0-dev.11" IgnoreExitCode="true" />
 		<Exec Command="$(MSBuildThisFileDirectory)\tools\generatepkgdiff.exe --base=$(PackageNamePrefix) --other=$(PackageNamePrefix).$(GITVERSION_SemVer).nupkg --diffignore=PackageDiffIgnore.xml --outfile=$(OutputDir)\ApiDiff.$(GITVERSION_SemVer).md" />
 	</Target>
 	

--- a/build/uno.winui.cross-runtime.targets
+++ b/build/uno.winui.cross-runtime.targets
@@ -1,82 +1,82 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!--
+	<!--
   Cross-runtime libraries creation targets
   -->
-  <Target Name="PrepareUnoRuntimeProjectReferences" BeforeTargets="BeforeBuild">
+	<Target Name="PrepareUnoRuntimeProjectReferences" BeforeTargets="BeforeBuild">
 
-	<!--
+		<!--
 	Build the ProjectReference item group for UnoRuntimeProjectReference items.
 	The references are added as non-referencing ProjectReferences to enable the inclusion
 	of their output in the final nuget package.
 	-->
-	<ItemGroup>
-	  <ProjectReference Include="%(UnoRuntimeProjectReference.Identity)">
-		<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-		<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-		<UndefineProperties>TargetFramework</UndefineProperties>
-	  </ProjectReference>
-	</ItemGroup>
+		<ItemGroup>
+			<ProjectReference Include="%(UnoRuntimeProjectReference.Identity)">
+				<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+				<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+				<UndefineProperties>TargetFramework</UndefineProperties>
+			</ProjectReference>
+		</ItemGroup>
 
-  </Target>
+	</Target>
 
-  <Target Name="ResolvePrepareUnoRuntimeProjectReferences" AfterTargets="ResolveProjectReferences">
+	<Target Name="ResolvePrepareUnoRuntimeProjectReferences" AfterTargets="ResolveProjectReferences">
 
-	<!-- Execute UnoRuntimeGetTargetPath for all UnoRuntimeProjectReference to get their actual output -->
-	<MSBuild
-	  Projects="@(UnoRuntimeProjectReference)"
-	  Targets="UnoRuntimeGetTargetPath"
-	  BuildInParallel="$(BuildInParallel)"
-	  Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework)"
-	  ContinueOnError="!$(BuildingProject)">
+		<!-- Execute UnoRuntimeGetTargetPath for all UnoRuntimeProjectReference to get their actual output -->
+		<MSBuild
+		  Projects="@(UnoRuntimeProjectReference)"
+		  Targets="UnoRuntimeGetTargetPath"
+		  BuildInParallel="$(BuildInParallel)"
+		  Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework)"
+		  ContinueOnError="!$(BuildingProject)">
 
-	  <Output TaskParameter="TargetOutputs" ItemName="UnoRuntimeProjectReferenceOutput" />
-	</MSBuild>
+			<Output TaskParameter="TargetOutputs" ItemName="UnoRuntimeProjectReferenceOutput" />
+		</MSBuild>
 
-	<ItemGroup>
-	  <!-- Add the appropriate metadata to include those files -->
-	  <UnoRuntimeProjectReferenceOutput Update="@(UnoRuntimeProjectReferenceOutput)">
-		<Pack>true</Pack>
-		<PackagePath>uno-runtime/%(UnoRuntimeIdentifier)</PackagePath>
-	  </UnoRuntimeProjectReferenceOutput>
+		<ItemGroup>
+			<!-- Add the appropriate metadata to include those files -->
+			<UnoRuntimeProjectReferenceOutput Update="@(UnoRuntimeProjectReferenceOutput)">
+				<Pack>true</Pack>
+				<PackagePath>uno-runtime/%(UnoRuntimeIdentifier)</PackagePath>
+			</UnoRuntimeProjectReferenceOutput>
 
-	  <!-- Include symbols as well, if available -->
-	  <UnoRuntimeProjectReferenceOutput
-		  Include="@(UnoRuntimeProjectReferenceOutput->'%(rootdir)%(directory)%(filename).pdb')"
-		  Condition="exists('%(rootdir)%(directory)%(filename).pdb')">
-		<Pack>true</Pack>
-		<PackagePath>uno-runtime/%(UnoRuntimeIdentifier)</PackagePath>
-	  </UnoRuntimeProjectReferenceOutput>
+			<!-- Include symbols as well, if available -->
+			<UnoRuntimeProjectReferenceOutput
+				Include="@(UnoRuntimeProjectReferenceOutput->'%(rootdir)%(directory)%(filename).pdb')"
+				Condition="exists('%(rootdir)%(directory)%(filename).pdb')">
+				<Pack>true</Pack>
+				<PackagePath>uno-runtime/%(UnoRuntimeIdentifier)</PackagePath>
+			</UnoRuntimeProjectReferenceOutput>
 
-	</ItemGroup>
+		</ItemGroup>
 
-	<ItemGroup>
-	  <TfmSpecificPackageFile Include="@(UnoRuntimeProjectReferenceOutput)" />
-	</ItemGroup>
+		<ItemGroup>
+			<TfmSpecificPackageFile Include="@(UnoRuntimeProjectReferenceOutput)" />
+		</ItemGroup>
 
-	<RemoveDuplicates Inputs="@(TfmSpecificPackageFile)">
-	  <Output TaskParameter="Filtered" ItemName="FilteredUnoRuntimeProjectReferenceOutput" />
-	</RemoveDuplicates>
-	
-	<ItemGroup>
-	  <TfmSpecificPackageFile Remove="@(TfmSpecificPackageFile)" />
-	  <TfmSpecificPackageFile Include="@(FilteredUnoRuntimeProjectReferenceOutput)" />
-	</ItemGroup>
-  </Target>
+		<RemoveDuplicates Inputs="@(TfmSpecificPackageFile)">
+			<Output TaskParameter="Filtered" ItemName="FilteredUnoRuntimeProjectReferenceOutput" />
+		</RemoveDuplicates>
 
-  <!-- Target used to determine the outputs of a project alongs with its associated UnoRuntimeIdentifier -->
-  <Target
-	  Name="UnoRuntimeGetTargetPath"
-	  DependsOnTargets="GetTargetPath"
-	  Returns="@(UnoRuntimeTargetPathWithTargetPlatformMoniker)">
+		<ItemGroup>
+			<TfmSpecificPackageFile Remove="@(TfmSpecificPackageFile)" />
+			<TfmSpecificPackageFile Include="@(FilteredUnoRuntimeProjectReferenceOutput)" />
+		</ItemGroup>
+	</Target>
 
-	<ItemGroup>
-	  <UnoRuntimeTargetPathWithTargetPlatformMoniker
-		  Include="@(TargetPathWithTargetPlatformMoniker)"
-		  UnoRuntimeIdentifier="$(UnoRuntimeIdentifier.ToLower())" />
-	</ItemGroup>
+	<!-- Target used to determine the outputs of a project alongs with its associated UnoRuntimeIdentifier -->
+	<Target
+		Name="UnoRuntimeGetTargetPath"
+		DependsOnTargets="GetTargetPath"
+		Returns="@(UnoRuntimeTargetPathWithTargetPlatformMoniker)">
 
-  </Target>
+		<ItemGroup>
+			<UnoRuntimeTargetPathWithTargetPlatformMoniker
+				Include="@(TargetPathWithTargetPlatformMoniker)"
+				UnoRuntimeIdentifier="$(UnoRuntimeIdentifier.ToLower())" />
+		</ItemGroup>
+
+	</Target>
 
 </Project>

--- a/build/uno.winui.runtime-replace.targets
+++ b/build/uno.winui.runtime-replace.targets
@@ -1,53 +1,53 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Target used to override the runtime for netstandard2.0 based targets -->
-  <Target Name="ReplaceUnoRuntime"
-			  Condition="'$(UnoRuntimeIdentifier)'!=''"
-			  BeforeTargets="_ComputeResolvedCopyLocalPublishAssets;ResolveLockFileCopyLocalFiles;ComputeFilesToPublish;GeneratePublishDependencyFile">
-	<ItemGroup>
+	<!-- Target used to override the runtime for netstandard2.0 based targets -->
+	<Target Name="ReplaceUnoRuntime"
+				Condition="'$(UnoRuntimeIdentifier)'!=''"
+				BeforeTargets="_ComputeResolvedCopyLocalPublishAssets;ResolveLockFileCopyLocalFiles;ComputeFilesToPublish;GeneratePublishDependencyFile">
+		<ItemGroup>
 
-	  <!-- Create a list of all copy local items that are part of the UnoRuntimeEnabledPackage items -->
-	  <_RuntimeCopyLocalItemsToRemove Include="@(RuntimeCopyLocalItems)" EnabledIdentity="%(UnoRuntimeEnabledPackage.Identity)" />
-	  <_RuntimeCopyLocalItemsToRemove Remove="@(_RuntimeCopyLocalItemsToRemove)" Condition="'%(_RuntimeCopyLocalItemsToRemove.NuGetPackageId)' != '%(_RuntimeCopyLocalItemsToRemove.EnabledIdentity)'" />
+			<!-- Create a list of all copy local items that are part of the UnoRuntimeEnabledPackage items -->
+			<_RuntimeCopyLocalItemsToRemove Include="@(RuntimeCopyLocalItems)" EnabledIdentity="%(UnoRuntimeEnabledPackage.Identity)" />
+			<_RuntimeCopyLocalItemsToRemove Remove="@(_RuntimeCopyLocalItemsToRemove)" Condition="'%(_RuntimeCopyLocalItemsToRemove.NuGetPackageId)' != '%(_RuntimeCopyLocalItemsToRemove.EnabledIdentity)'" />
 
-	  <!-- Remove them from the files to be copied to the output -->
-	  <RuntimeCopyLocalItems Remove="@(_RuntimeCopyLocalItemsToRemove)" />
+			<!-- Remove them from the files to be copied to the output -->
+			<RuntimeCopyLocalItems Remove="@(_RuntimeCopyLocalItemsToRemove)" />
 
-	  <_UnoRuntimeEnabledPackage_EmptyPackageBasePath
-		  Include="@(UnoRuntimeEnabledPackage)"
-		  Condition="'%(UnoRuntimeEnabledPackage.PackageBasePath)'==''" />
+			<_UnoRuntimeEnabledPackage_EmptyPackageBasePath
+				Include="@(UnoRuntimeEnabledPackage)"
+				Condition="'%(UnoRuntimeEnabledPackage.PackageBasePath)'==''" />
 
-	  <!-- Add the files for the current selected runtime identifier -->
-	  <RuntimeCopyLocalItemsMerged
-		  Include="%(UnoRuntimeEnabledPackage.PackageBasePath)/../uno-runtime/$(UnoRuntimeIdentifier.ToLowerInvariant())/*.dll"
-		  NuGetPackageId="%(Identity)" />
+			<!-- Add the files for the current selected runtime identifier -->
+			<RuntimeCopyLocalItemsMerged
+				Include="%(UnoRuntimeEnabledPackage.PackageBasePath)/../uno-runtime/$(UnoRuntimeIdentifier.ToLowerInvariant())/*.dll"
+				NuGetPackageId="%(Identity)" />
 
-	  <!-- Add metadata so the .deps.json file is generated properly (.NET Core/5) -->
-	  <RuntimeCopyLocalItemsToUpdate
-		  Include="@(RuntimeCopyLocalItemsMerged)"
-		  AssetType="runtime"
-		  CopyLocal="true"
-		  DestinationSubPath="%(FileName)%(Extension)"
-		  CopyToPublishDirectory="true"
-		  PathInPackage="uno-runtime/$(UnoRuntimeIdentifier.ToLowerInvariant())/%(FileName)%(Extension)" />
+			<!-- Add metadata so the .deps.json file is generated properly (.NET Core/5) -->
+			<RuntimeCopyLocalItemsToUpdate
+				Include="@(RuntimeCopyLocalItemsMerged)"
+				AssetType="runtime"
+				CopyLocal="true"
+				DestinationSubPath="%(FileName)%(Extension)"
+				CopyToPublishDirectory="true"
+				PathInPackage="uno-runtime/$(UnoRuntimeIdentifier.ToLowerInvariant())/%(FileName)%(Extension)" />
 
-	  <RuntimeCopyLocalItems
-		  Include="@(RuntimeCopyLocalItemsToUpdate)"/>
+			<RuntimeCopyLocalItems
+				Include="@(RuntimeCopyLocalItemsToUpdate)"/>
 
-	  <!-- Publish pdb files -->
-	  <ReferenceCopyLocalPaths Include="%(UnoRuntimeEnabledPackage.PackageBasePath)/../uno-runtime/$(UnoRuntimeIdentifier.ToLowerInvariant())/*.pdb" />
+			<!-- Publish pdb files -->
+			<ReferenceCopyLocalPaths Include="%(UnoRuntimeEnabledPackage.PackageBasePath)/../uno-runtime/$(UnoRuntimeIdentifier.ToLowerInvariant())/*.pdb" />
+		</ItemGroup>
+
+		<Error
+			Text="The package(s) [@(_UnoRuntimeEnabledPackage_EmptyPackageBasePath)] do not define the UnoRuntimeEnabledPackage.PackageBasePath metadata. Make sure to add one to specify the current location of the targets file."
+			Condition="'@(_UnoRuntimeEnabledPackage_EmptyPackageBasePath)'!=''" />
+	</Target>
+
+	<!-- Force a rebuild on runtime files changes -->
+	<ItemGroup Condition="'$(UnoRuntimeIdentifier)'!=''">
+		<UpToDateCheckInput Include="$(MSBuildThisFileDirectory)/../../uno-runtime/*" />
 	</ItemGroup>
-
-	<Error
-		Text="The package(s) [@(_UnoRuntimeEnabledPackage_EmptyPackageBasePath)] do not define the UnoRuntimeEnabledPackage.PackageBasePath metadata. Make sure to add one to specify the current location of the targets file."
-		Condition="'@(_UnoRuntimeEnabledPackage_EmptyPackageBasePath)'!=''" />
-  </Target>
-
-  <!-- Force a rebuild on runtime files changes -->
-  <ItemGroup Condition="'$(UnoRuntimeIdentifier)'!=''">
-	<UpToDateCheckInput Include="$(MSBuildThisFileDirectory)/../../uno-runtime/*" />
-  </ItemGroup>
 
 
 </Project>

--- a/build/uno.winui.single-project.targets
+++ b/build/uno.winui.single-project.targets
@@ -98,4 +98,22 @@
   </ItemGroup>
 
 
+	<!-- Additional capabilities to enable XAML Intellisense for non UWP/WinUI native projects -->
+	<ItemGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
+		<AvailableItemName Include="PRIResource" />
+		<AvailableItemName Include="AppxManifest" />
+		<AvailableItemName Include="ApplicationDefinition" />
+		<AvailableItemName Include="Page" />
+		<AvailableItemName Include="DesignData" />
+		<AvailableItemName Include="DesignDataWithDesignTimeCreatableTypes" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectCapability Include="WindowsXaml"/>
+		<ProjectCapability Include="WindowsXamlPage"/>
+		<ProjectCapability Include="WindowsXamlCodeBehind"/>
+		<ProjectCapability Include="WindowsXamlResourceDictionary"/>
+		<ProjectCapability Include="WindowsXamlUserControl"/>
+		<ProjectCapability Include="WindowsUniversalMultiViews"/>
+	</ItemGroup>
 </Project>

--- a/build/uno.winui.single-project.targets
+++ b/build/uno.winui.single-project.targets
@@ -1,89 +1,89 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Props -->
-  <!-- Android -->
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'android' and '$(MonoAndroidResourcePrefix)' != '' ">
-	<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.xml" />
-	<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.axml" />
-	<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.png" />
-	<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.jpg" />
-	<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.gif" />
-	<AndroidResource Include="$(MonoAndroidResourcePrefix)/font/*.ttf" />
-	<AndroidResource Include="$(MonoAndroidResourcePrefix)/font/*.otf" />
-	<AndroidResource Include="$(MonoAndroidResourcePrefix)/font/*.ttc" />
-	<AndroidResource Include="$(MonoAndroidResourcePrefix)/raw/*" Exclude="$(MonoAndroidResourcePrefix)/raw/.*" />
-	<AndroidAsset Include="$(MonoAndroidAssetsPrefix)/**/*" Exclude="$(MonoAndroidAssetsPrefix)/**/.*/**" />
-  </ItemGroup>
-
-  <!-- iOS -->
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'ios' and '$(iOSProjectFolder)' != '' ">
-	<None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
-	<ImageAsset Include="$(iOSProjectFolder)**/*.xcassets/**/*.png;$(iOSProjectFolder)**/*.xcassets/*/*.jpg;$(iOSProjectFolder)**/*.xcassets/**/*.pdf;$(iOSProjectFolder)**/*.xcassets/**/*.json" Exclude="$(_SingleProjectiOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" Visible="false" IsDefaultItem="true" />
-	<SceneKitAsset Include="$(iOSProjectFolder)**/*.scnassets/*" Exclude="$(_SingleProjectiOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
-	<InterfaceDefinition Include="$(iOSProjectFolder)**/*.storyboard;$(iOSProjectFolder)**/*.xib" Exclude="$(_SingleProjectiOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
-  </ItemGroup>
-
-  <!-- MacCatalyst -->
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'maccatalyst' and '$(MacCatalystProjectFolder)' != '' ">
-	<None Include="$(MacCatalystProjectFolder)Info.plist" LogicalName="Info.plist" />
-	<ImageAsset Include="$(MacCatalystProjectFolder)**/*.xcassets/**/*.png;$(MacCatalystProjectFolder)**/*.xcassets/*/*.jpg;$(MacCatalystProjectFolder)**/*.xcassets/**/*.pdf;$(MacCatalystProjectFolder)**/*.xcassets/**/*.json" Exclude="$(_SingleProjectMacCatalystExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" Visible="false" IsDefaultItem="true" />
-	<SceneKitAsset Include="$(MacCatalystProjectFolder)**/*.scnassets/*" Exclude="$(_SingleProjectMacCatalystExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
-	<InterfaceDefinition Include="$(MacCatalystProjectFolder)**/*.storyboard;$(MacCatalystProjectFolder)**/*.xib" Exclude="$(_SingleProjectMacCatalystExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
-  </ItemGroup>
-
-  <!-- macOS -->
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'macos' and '$(MacOSProjectFolder)' != '' ">
-	<None Include="$(MacOSProjectFolder)Info.plist" LogicalName="Info.plist" />
-	<ImageAsset Include="$(MacOSProjectFolder)**/*.xcassets/**/*.png;$(MacOSProjectFolder)**/*.xcassets/*/*.jpg;$(MacOSProjectFolder)**/*.xcassets/**/*.pdf;$(MacOSProjectFolder)**/*.xcassets/**/*.json" Exclude="$(_SingleProjectMacOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" Visible="false" IsDefaultItem="true" />
-	<SceneKitAsset Include="$(MacOSProjectFolder)**/*.scnassets/*" Exclude="$(_SingleProjectMacOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
-	<InterfaceDefinition Include="$(MacOSProjectFolder)**/*.storyboard;$(MacOSProjectFolder)**/*.xib" Exclude="$(_SingleProjectMacOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
-  </ItemGroup>
-
-  <!-- Targets -->
-
-  <PropertyGroup Condition=" '$(SingleProject)' == 'true' ">
+	<!-- Props -->
 	<!-- Android -->
-	<EnableDefaultAndroidItems>false</EnableDefaultAndroidItems>
-	<AndroidProjectFolder Condition=" '$(AndroidProjectFolder)' == '' ">Android\</AndroidProjectFolder>
-	<AndroidManifest>$(AndroidProjectFolder)AndroidManifest.xml</AndroidManifest>
-	<MonoAndroidResourcePrefix>$(AndroidProjectFolder)Resources</MonoAndroidResourcePrefix>
-	<MonoAndroidAssetsPrefix>$(AndroidProjectFolder)Assets;Assets</MonoAndroidAssetsPrefix>
+	<ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'android' and '$(MonoAndroidResourcePrefix)' != '' ">
+		<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.xml" />
+		<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.axml" />
+		<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.png" />
+		<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.jpg" />
+		<AndroidResource Include="$(MonoAndroidResourcePrefix)/*/*.gif" />
+		<AndroidResource Include="$(MonoAndroidResourcePrefix)/font/*.ttf" />
+		<AndroidResource Include="$(MonoAndroidResourcePrefix)/font/*.otf" />
+		<AndroidResource Include="$(MonoAndroidResourcePrefix)/font/*.ttc" />
+		<AndroidResource Include="$(MonoAndroidResourcePrefix)/raw/*" Exclude="$(MonoAndroidResourcePrefix)/raw/.*" />
+		<AndroidAsset Include="$(MonoAndroidAssetsPrefix)/**/*" Exclude="$(MonoAndroidAssetsPrefix)/**/.*/**" />
+	</ItemGroup>
 
 	<!-- iOS -->
-	<EnableDefaultiOSItems>false</EnableDefaultiOSItems>
-	<iOSProjectFolder Condition=" '$(iOSProjectFolder)' == '' ">iOS\</iOSProjectFolder>
-	<IPhoneResourcePrefix Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' ">$(iOSProjectFolder)Resources</IPhoneResourcePrefix>
-	<_SingleProjectiOSExcludes>$(iOSProjectFolder)/**/.*/**</_SingleProjectiOSExcludes>
+	<ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'ios' and '$(iOSProjectFolder)' != '' ">
+		<None Include="$(iOSProjectFolder)Info.plist" LogicalName="Info.plist" />
+		<ImageAsset Include="$(iOSProjectFolder)**/*.xcassets/**/*.png;$(iOSProjectFolder)**/*.xcassets/*/*.jpg;$(iOSProjectFolder)**/*.xcassets/**/*.pdf;$(iOSProjectFolder)**/*.xcassets/**/*.json" Exclude="$(_SingleProjectiOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" Visible="false" IsDefaultItem="true" />
+		<SceneKitAsset Include="$(iOSProjectFolder)**/*.scnassets/*" Exclude="$(_SingleProjectiOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+		<InterfaceDefinition Include="$(iOSProjectFolder)**/*.storyboard;$(iOSProjectFolder)**/*.xib" Exclude="$(_SingleProjectiOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+	</ItemGroup>
 
 	<!-- MacCatalyst -->
-	<EnableDefaultMacCatalystItems>false</EnableDefaultMacCatalystItems>
-	<MacCatalystProjectFolder Condition=" '$(MacCatalystProjectFolder)' == '' ">MacCatalyst\</MacCatalystProjectFolder>
-	<IPhoneResourcePrefix Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'maccatalyst' ">$(MacCatalystProjectFolder)Resources</IPhoneResourcePrefix>
-	<_SingleProjectMacCatalystExcludes>$(MacCatalystProjectFolder)/**/.*/**</_SingleProjectMacCatalystExcludes>
+	<ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'maccatalyst' and '$(MacCatalystProjectFolder)' != '' ">
+		<None Include="$(MacCatalystProjectFolder)Info.plist" LogicalName="Info.plist" />
+		<ImageAsset Include="$(MacCatalystProjectFolder)**/*.xcassets/**/*.png;$(MacCatalystProjectFolder)**/*.xcassets/*/*.jpg;$(MacCatalystProjectFolder)**/*.xcassets/**/*.pdf;$(MacCatalystProjectFolder)**/*.xcassets/**/*.json" Exclude="$(_SingleProjectMacCatalystExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" Visible="false" IsDefaultItem="true" />
+		<SceneKitAsset Include="$(MacCatalystProjectFolder)**/*.scnassets/*" Exclude="$(_SingleProjectMacCatalystExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+		<InterfaceDefinition Include="$(MacCatalystProjectFolder)**/*.storyboard;$(MacCatalystProjectFolder)**/*.xib" Exclude="$(_SingleProjectMacCatalystExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+	</ItemGroup>
 
-	<!-- MacOS -->
-	<EnableDefaultMacOSItems>false</EnableDefaultMacOSItems>
-	<MacOSProjectFolder Condition=" '$(MacOSProjectFolder)' == '' ">MacOS\</MacOSProjectFolder>
-	<IPhoneResourcePrefix Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'macos' ">$(MacOSProjectFolder)Resources</IPhoneResourcePrefix>
-	<_SingleProjectMacOSExcludes>$(MacOSProjectFolder)/**/.*/**</_SingleProjectMacOSExcludes>
-  </PropertyGroup>
+	<!-- macOS -->
+	<ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' and '$(TargetPlatformIdentifier)' == 'macos' and '$(MacOSProjectFolder)' != '' ">
+		<None Include="$(MacOSProjectFolder)Info.plist" LogicalName="Info.plist" />
+		<ImageAsset Include="$(MacOSProjectFolder)**/*.xcassets/**/*.png;$(MacOSProjectFolder)**/*.xcassets/*/*.jpg;$(MacOSProjectFolder)**/*.xcassets/**/*.pdf;$(MacOSProjectFolder)**/*.xcassets/**/*.json" Exclude="$(_SingleProjectMacOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" Visible="false" IsDefaultItem="true" />
+		<SceneKitAsset Include="$(MacOSProjectFolder)**/*.scnassets/*" Exclude="$(_SingleProjectMacOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+		<InterfaceDefinition Include="$(MacOSProjectFolder)**/*.storyboard;$(MacOSProjectFolder)**/*.xib" Exclude="$(_SingleProjectMacOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+	</ItemGroup>
 
-  <!-- Removals -->
-  <ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' ">
-	<Compile Condition=" '$(TargetPlatformIdentifier)' != 'android' and '$(AndroidProjectFolder)' != '' " Remove="$(AndroidProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-	<Compile Condition=" '$(TargetPlatformIdentifier)' != 'ios' and '$(iOSProjectFolder)' != '' " Remove="$(iOSProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-	<Compile Condition=" '$(TargetPlatformIdentifier)' != 'maccatalyst' and '$(MacCatalystProjectFolder)' != '' " Remove="$(MacCatalystProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-	<Compile Condition=" '$(TargetPlatformIdentifier)' != 'macos' and '$(MacOSProjectFolder)' != '' " Remove="$(MacOSProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
-  </ItemGroup>
+	<!-- Targets -->
 
-  <!-- IDE capabilities -->
-  
-  <!-- Sync with https://github.com/dotnet/maui/blob/ffab30545ac146710a9ee61138be33e52ca4b326/src/Templates/src/templates/maui-mobile/Directory.Build.targets -->
-  <PropertyGroup>
-	<!-- Required - Enable Launch Profiles for .NET 6 iOS/Android -->
-	<_KeepLaunchProfiles>true</_KeepLaunchProfiles>
-  </PropertyGroup>
+	<PropertyGroup Condition=" '$(SingleProject)' == 'true' ">
+		<!-- Android -->
+		<EnableDefaultAndroidItems>false</EnableDefaultAndroidItems>
+		<AndroidProjectFolder Condition=" '$(AndroidProjectFolder)' == '' ">Android\</AndroidProjectFolder>
+		<AndroidManifest>$(AndroidProjectFolder)AndroidManifest.xml</AndroidManifest>
+		<MonoAndroidResourcePrefix>$(AndroidProjectFolder)Resources</MonoAndroidResourcePrefix>
+		<MonoAndroidAssetsPrefix>$(AndroidProjectFolder)Assets;Assets</MonoAndroidAssetsPrefix>
+
+		<!-- iOS -->
+		<EnableDefaultiOSItems>false</EnableDefaultiOSItems>
+		<iOSProjectFolder Condition=" '$(iOSProjectFolder)' == '' ">iOS\</iOSProjectFolder>
+		<IPhoneResourcePrefix Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'ios' ">$(iOSProjectFolder)Resources</IPhoneResourcePrefix>
+		<_SingleProjectiOSExcludes>$(iOSProjectFolder)/**/.*/**</_SingleProjectiOSExcludes>
+
+		<!-- MacCatalyst -->
+		<EnableDefaultMacCatalystItems>false</EnableDefaultMacCatalystItems>
+		<MacCatalystProjectFolder Condition=" '$(MacCatalystProjectFolder)' == '' ">MacCatalyst\</MacCatalystProjectFolder>
+		<IPhoneResourcePrefix Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'maccatalyst' ">$(MacCatalystProjectFolder)Resources</IPhoneResourcePrefix>
+		<_SingleProjectMacCatalystExcludes>$(MacCatalystProjectFolder)/**/.*/**</_SingleProjectMacCatalystExcludes>
+
+		<!-- MacOS -->
+		<EnableDefaultMacOSItems>false</EnableDefaultMacOSItems>
+		<MacOSProjectFolder Condition=" '$(MacOSProjectFolder)' == '' ">MacOS\</MacOSProjectFolder>
+		<IPhoneResourcePrefix Condition=" '$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))' == 'macos' ">$(MacOSProjectFolder)Resources</IPhoneResourcePrefix>
+		<_SingleProjectMacOSExcludes>$(MacOSProjectFolder)/**/.*/**</_SingleProjectMacOSExcludes>
+	</PropertyGroup>
+
+	<!-- Removals -->
+	<ItemGroup Condition=" '$(EnableDefaultItems)' == 'true' and '$(SingleProject)' == 'true' ">
+		<Compile Condition=" '$(TargetPlatformIdentifier)' != 'android' and '$(AndroidProjectFolder)' != '' " Remove="$(AndroidProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
+		<Compile Condition=" '$(TargetPlatformIdentifier)' != 'ios' and '$(iOSProjectFolder)' != '' " Remove="$(iOSProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
+		<Compile Condition=" '$(TargetPlatformIdentifier)' != 'maccatalyst' and '$(MacCatalystProjectFolder)' != '' " Remove="$(MacCatalystProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
+		<Compile Condition=" '$(TargetPlatformIdentifier)' != 'macos' and '$(MacOSProjectFolder)' != '' " Remove="$(MacOSProjectFolder)**/*$(DefaultLanguageSourceExtension)" />
+	</ItemGroup>
+
+	<!-- IDE capabilities -->
+
+	<!-- Sync with https://github.com/dotnet/maui/blob/ffab30545ac146710a9ee61138be33e52ca4b326/src/Templates/src/templates/maui-mobile/Directory.Build.targets -->
+	<PropertyGroup>
+		<!-- Required - Enable Launch Profiles for .NET 6 iOS/Android -->
+		<_KeepLaunchProfiles>true</_KeepLaunchProfiles>
+	</PropertyGroup>
 
   <ItemGroup Condition=" '$(SingleProject)' == 'true' ">
 	<ProjectCapability Include="Msix" />

--- a/build/uno.winui.targets
+++ b/build/uno.winui.targets
@@ -63,7 +63,7 @@
 		<UnoSourceGeneratorAdditionalProperty Include="UnoRemoteControlHost" />
 		<UnoSourceGeneratorAdditionalProperty Include="UnoRemoteControlProcessorsPath" />
 	</ItemGroup>
-  
+
 	<!-- List of packages that provide an uno-runtime folder -->
 	<ItemGroup>
 		<UnoRuntimeEnabledPackage Include="Uno.UI" PackageBasePath="$(MSBuildThisFileDirectory).." Condition="'$(MSBuildThisFile)'=='uno.ui.targets'" />
@@ -183,24 +183,24 @@
              ContinueOnError="true" />
 	</Target>
 
-  <Target Name="ValidateUnoUIAndroid" BeforeTargets="BeforeBuild" Condition="'$(AndroidApplication)'!='' and '$(TargetFrameworkVersion)'!=''">
+	<Target Name="ValidateUnoUIAndroid" BeforeTargets="BeforeBuild" Condition="'$(AndroidApplication)'!='' and '$(TargetFrameworkVersion)'!=''">
 
-	<PropertyGroup Condition="'$(NETCoreAppMaximumVersion)'!='' and '$(NETCoreAppMaximumVersion)'&gt;='6.0'">
-	  <UnoUIMinAndroidSDKVersion>30</UnoUIMinAndroidSDKVersion>
-	  <_CurrentTrimmedAndroidSDLVersion>$(_AndroidApiLevel)</_CurrentTrimmedAndroidSDLVersion>
-	</PropertyGroup>
+		<PropertyGroup Condition="'$(NETCoreAppMaximumVersion)'!='' and '$(NETCoreAppMaximumVersion)'&gt;='6.0'">
+			<UnoUIMinAndroidSDKVersion>30</UnoUIMinAndroidSDKVersion>
+			<_CurrentTrimmedAndroidSDLVersion>$(_AndroidApiLevel)</_CurrentTrimmedAndroidSDLVersion>
+		</PropertyGroup>
 
-	<PropertyGroup Condition="$(TargetFramework.ToLowerInvariant().StartsWith('monoandroid')) or '$(ProjectTypeGuids)'=='{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}'">
-	  <UnoUIMinAndroidSDKVersion>11.0</UnoUIMinAndroidSDKVersion>
-	  <_CurrentTrimmedAndroidSDLVersion>$(TargetFrameworkVersion.Substring(1))</_CurrentTrimmedAndroidSDLVersion>
-	</PropertyGroup>
+		<PropertyGroup Condition="$(TargetFramework.ToLowerInvariant().StartsWith('monoandroid')) or '$(ProjectTypeGuids)'=='{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}'">
+			<UnoUIMinAndroidSDKVersion>11.0</UnoUIMinAndroidSDKVersion>
+			<_CurrentTrimmedAndroidSDLVersion>$(TargetFrameworkVersion.Substring(1))</_CurrentTrimmedAndroidSDLVersion>
+		</PropertyGroup>
 
-	<Error Text="This version of the Android SDK ($(_CurrentTrimmedAndroidSDLVersion)) is not supported by Uno Platform. You must change the &quot;Compile using Android version:&quot; field in the android project property with at least version $(UnoUIMinAndroidSDKVersion)."
-				 Condition="'$(_CurrentTrimmedAndroidSDLVersion)' &lt; '$(UnoUIMinAndroidSDKVersion)'" />
-  </Target>
+		<Error Text="This version of the Android SDK ($(_CurrentTrimmedAndroidSDLVersion)) is not supported by Uno Platform. You must change the &quot;Compile using Android version:&quot; field in the android project property with at least version $(UnoUIMinAndroidSDKVersion)."
+					 Condition="'$(_CurrentTrimmedAndroidSDLVersion)' &lt; '$(UnoUIMinAndroidSDKVersion)'" />
+	</Target>
 
-  <Import Project="uno.winui.cross-runtime.targets" />
-  <Import Project="uno.winui.single-project.targets" />
-  <Import Project="uno.winui.runtime-replace.targets" />
+	<Import Project="uno.winui.cross-runtime.targets" />
+	<Import Project="uno.winui.single-project.targets" />
+	<Import Project="uno.winui.runtime-replace.targets" />
 
 </Project>

--- a/build/uno.winui.win.targets
+++ b/build/uno.winui.win.targets
@@ -2,24 +2,24 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 
-  <Target Name="_RemoveRoslynSourceGeneration" BeforeTargets="CoreCompile">
-	<!---
+	<Target Name="_RemoveRoslynSourceGeneration" BeforeTargets="CoreCompile">
+		<!---
 	If the users explicitly disables Roslyn source generation, remove the analyzer item which is automatically added by Nuget.
 	-->
-	<ItemGroup>
-	  <_AnalyzerToRemove Include="@(Analyzer)" Condition="'%(FileName)'=='Uno.UI.SourceGenerators'" />
-	  <Analyzer Remove="@(_AnalyzerToRemove)"/>
-	</ItemGroup>
-  </Target>
+		<ItemGroup>
+			<_AnalyzerToRemove Include="@(Analyzer)" Condition="'%(FileName)'=='Uno.UI.SourceGenerators'" />
+			<Analyzer Remove="@(_AnalyzerToRemove)"/>
+		</ItemGroup>
+	</Target>
 
-  <!--
+	<!--
   List of packages that provide an uno-runtime folder. Needed for WPF target.
   -->
-  <ItemGroup Condition="'$(UseWPF)'=='True'">
-	<UnoRuntimeEnabledPackage Include="Uno.UI" PackageBasePath="$(MSBuildThisFileDirectory).." Condition="'$(MSBuildThisFile)'=='uno.ui.targets'" />
-	<UnoRuntimeEnabledPackage Include="Uno.WinUI" PackageBasePath="$(MSBuildThisFileDirectory).." Condition="'$(MSBuildThisFile)'=='uno.winui.targets'" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(UseWPF)'=='True'">
+		<UnoRuntimeEnabledPackage Include="Uno.UI" PackageBasePath="$(MSBuildThisFileDirectory).." Condition="'$(MSBuildThisFile)'=='uno.ui.targets'" />
+		<UnoRuntimeEnabledPackage Include="Uno.WinUI" PackageBasePath="$(MSBuildThisFileDirectory).." Condition="'$(MSBuildThisFile)'=='uno.winui.targets'" />
+	</ItemGroup>
 
-  <Import Project="uno.winui.runtime-replace.targets" />
+	<Import Project="uno.winui.runtime-replace.targets" />
 
 </Project>

--- a/src/SolutionTemplate/UnoLibraryTemplate.net6/CrossTargetedLibrary.csproj
+++ b/src/SolutionTemplate/UnoLibraryTemplate.net6/CrossTargetedLibrary.csproj
@@ -4,8 +4,8 @@
 	Please see https://github.com/unoplatform/uno/issues/3909 for more details.
 	-->
 
-  <PropertyGroup>
-    <TargetFrameworks>uap10.0.18362;netstandard2.0;net6.0-ios;net6.0-macos;net6.0-maccatalyst;net6.0-android</TargetFrameworks>
+	<PropertyGroup>
+		<TargetFrameworks>uap10.0.18362;netstandard2.0;net6.0-ios;net6.0-macos;net6.0-maccatalyst;net6.0-android</TargetFrameworks>
 
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -14,9 +14,9 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.UI" Version="2.2.0" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
-	  <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+		<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 		<Compile Update="**\*.xaml.cs">
 			<DependentUpon>%(Filename)</DependentUpon>
 		</Compile>

--- a/src/SolutionTemplate/UnoLibraryTemplate/CrossTargetedLibrary.csproj
+++ b/src/SolutionTemplate/UnoLibraryTemplate/CrossTargetedLibrary.csproj
@@ -4,8 +4,8 @@
 	Please see https://github.com/unoplatform/uno/issues/3909 for more details.
 	-->
 
-  <PropertyGroup>
-    <TargetFrameworks>uap10.0.18362;netstandard2.0;xamarinios10;xamarinmac20;MonoAndroid11.0;MonoAndroid12.0</TargetFrameworks>
+	<PropertyGroup>
+		<TargetFrameworks>uap10.0.18362;netstandard2.0;xamarinios10;xamarinmac20;MonoAndroid11.0;MonoAndroid12.0</TargetFrameworks>
 
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -14,9 +14,9 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.UI" Version="2.2.0" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
-	  <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+		<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 		<Compile Update="**\*.xaml.cs">
 			<DependentUpon>%(Filename)</DependentUpon>
 		</Compile>

--- a/src/SolutionTemplate/UnoSolutionTemplate.Wizard/UnoSolutionWizard.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.Wizard/UnoSolutionWizard.cs
@@ -106,30 +106,31 @@ namespace UnoSolutionTemplate.Wizard
 
 		private void SetStartupProject()
 		{
-			if (_dte?.Solution.SolutionBuild is SolutionBuild2 val)
+			try
 			{
-				try
+				if (_dte?.Solution.SolutionBuild is SolutionBuild2 val)
 				{
-					var uwpProject = GetAllProjects().FirstOrDefault(s => s.Name.EndsWith(".UWP", StringComparison.OrdinalIgnoreCase));
+						var uwpProject = GetAllProjects().FirstOrDefault(s => s.Name.EndsWith(".UWP", StringComparison.OrdinalIgnoreCase));
 
-					if (uwpProject is { })
-					{
-						val.StartupProjects = uwpProject.UniqueName;
-					}
+						if (uwpProject is { })
+						{
+							val.StartupProjects = uwpProject.UniqueName;
+						}
 
-					var x86Config = val.SolutionConfigurations
-						.Cast<SolutionConfiguration2>()
-						.FirstOrDefault(c => c.Name == "Debug" && c.PlatformName == "x86");
+						var x86Config = val.SolutionConfigurations
+							.Cast<SolutionConfiguration2>()
+							.FirstOrDefault(c => c.Name == "Debug" && c.PlatformName == "x86");
 
-					x86Config?.Activate();
+						x86Config?.Activate();
 				}
-				catch (Exception)
+				else
 				{
+					// Unable to set the startup project when running from RunFinished since VS 2022 17.2 Preview 2
+					// throw new InvalidOperationException();
 				}
 			}
-			else
+			catch (Exception)
 			{
-				throw new InvalidOperationException();
 			}
 		}
 

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Wasm/UnoQuickStart.Wasm.csproj
@@ -11,7 +11,7 @@
 		<DefineConstants>$(DefineConstants);TRACE;DEBUG</DefineConstants>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
-		
+
 		<!--
 		IL Linking is disabled in Debug configuration.
 		When building in Release, see https://platform.uno/docs/articles/features/using-il-linker-webassembly.html


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/8455

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
- Adjust whitespace for some xaml files
- Adds support VS 2022 Intellisense for non-WinAppSDK files
- Fix exception when creating projects

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
