### PR TITLE
Clamp `Popup` and `Flyout` positioning to visible bounds

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/ScreenshotInfo.cs
+++ b/src/SamplesApp/SamplesApp.UITests/ScreenshotInfo.cs
@@ -23,6 +23,11 @@ namespace SamplesApp.UITests
 		public static implicit operator ScreenshotInfo(FileInfo fi) => new ScreenshotInfo(fi, fi.Name);
 
 		public Bitmap GetBitmap() => _bitmap ??= new Bitmap(File.FullName);
+
+		public int Width => GetBitmap().Width;
+		
+		public int Height => GetBitmap().Height;
+
 		public void Dispose()
 		{
 			_bitmap?.Dispose();

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -245,7 +245,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			_app.WaitForElement(windowButton);
 			_app.FastTap(windowButton);
 
-			var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			using var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
 			ImageAssert.HasColorAt(result, result.Width / 2, 150, Color.Red);
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -246,7 +246,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 			_app.FastTap(windowButton);
 
 			var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
-			ImageAssert.HasColorAt(result, result.Width / 2, 50, Color.Red);
+			ImageAssert.HasColorAt(result, result.Width / 2, 150, Color.Red);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -233,5 +233,20 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 
 			_app.FastTap(closeButton);
 		}
+
+		[Test]
+		[AutoRetry]
+		public void Flyout_ShowAt_Window_Content()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.FlyoutTests.Flyout_ShowAt_Window_Content");
+
+			var windowButton = _app.Marked("WindowButton");
+
+			_app.WaitForElement(windowButton);
+			_app.FastTap(windowButton);
+
+			var result = TakeScreenshot("Result", ignoreInSnapshotCompare: true);
+			ImageAssert.HasColorAt(result, result.Width / 2, 50, Color.Red);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1445,6 +1445,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_ShowAt_Window_Content.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_TemplatedParent.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5551,6 +5555,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Namescope.xaml.cs">
       <DependentUpon>Flyout_Namescope.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_ShowAt_Window_Content.xaml.cs">
+      <DependentUpon>Flyout_ShowAt_Window_Content.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_TemplatedParent.xaml.cs">
       <DependentUpon>Flyout_TemplatedParent.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.Flyout.Flyout_ShowAt_Window_Content"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.Flyout"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml
@@ -1,5 +1,5 @@
 ﻿<Page
-    x:Class="UITests.Windows_UI_Xaml_Controls.Flyout.Flyout_ShowAt_Window_Content"
+    x:Class="UITests.Windows_UI_Xaml_Controls.FlyoutTests.Flyout_ShowAt_Window_Content"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UITests.Windows_UI_Xaml_Controls.Flyout"
@@ -8,7 +8,8 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid>
-
-    </Grid>
+    <StackPanel>
+		<Button Click="ButtonButton_Click">Show at button</Button>
+		<Button Click="WindowButton_Click" x:Name="WindowButton">Show at window</Button>
+    </StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml.cs
@@ -1,10 +1,11 @@
 ﻿using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
-namespace UITests.Windows_UI_Xaml_Controls.Flyout
+namespace UITests.Windows_UI_Xaml_Controls.FlyoutTests
 {
 	/// <summary>
 	/// An empty page that can be used on its own or navigated to within a Frame.
@@ -15,34 +16,34 @@ namespace UITests.Windows_UI_Xaml_Controls.Flyout
 		public Flyout_ShowAt_Window_Content()
 		{
 			this.InitializeComponent();
-
-			Button button = new Button
-			{
-				Content = "Show at Window",
-				Tag = Window.Current.Content,
-			};
-			Button button2 = new Button
-			{
-				Content = "Show at this button",				
-			};
-			button2.Tag = button2;
-
-			var stackPanel = new StackPanel();
-			stackPanel.Margin = new Thickness(60);
-			stackPanel.Children.Add(button);
-			stackPanel.Children.Add(button2);
-			button.Click += Button_Click;
-			button2.Click += Button_Click;
-
-			Content = stackPanel;
 		}
 
-		private void Button_Click(object sender, RoutedEventArgs e)
+		private void ButtonButton_Click(object sender, RoutedEventArgs e)
 		{
 			Windows.UI.Xaml.Controls.Flyout flyout = new Windows.UI.Xaml.Controls.Flyout();
-			flyout.Content = new TextBlock { Text = "Hi there" };
+			flyout.Content =
+				new Border()
+				{
+					Width = 300,
+					Height = 300,
+					Background = new SolidColorBrush(Windows.UI.Colors.Red),
+				};
 
-			flyout.ShowAt(((Button)sender).Tag as FrameworkElement);
+			flyout.ShowAt((Button)sender);
+		}
+
+		private void WindowButton_Click(object sender, RoutedEventArgs e)
+		{
+			Windows.UI.Xaml.Controls.Flyout flyout = new Windows.UI.Xaml.Controls.Flyout();
+			flyout.Content =
+				new Border()
+				{
+					Width = 300,
+					Height = 300,
+					Background = new SolidColorBrush(Windows.UI.Colors.Red),
+				};
+
+			flyout.ShowAt(Window.Current.Content as FrameworkElement);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml.cs
@@ -1,0 +1,48 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.Flyout
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[Sample]
+	public sealed partial class Flyout_ShowAt_Window_Content : Page
+	{
+		public Flyout_ShowAt_Window_Content()
+		{
+			this.InitializeComponent();
+
+			Button button = new Button
+			{
+				Content = "Show at Window",
+				Tag = Window.Current.Content,
+			};
+			Button button2 = new Button
+			{
+				Content = "Show at this button",				
+			};
+			button2.Tag = button2;
+
+			var stackPanel = new StackPanel();
+			stackPanel.Margin = new Thickness(60);
+			stackPanel.Children.Add(button);
+			stackPanel.Children.Add(button2);
+			button.Click += Button_Click;
+			button2.Click += Button_Click;
+
+			Content = stackPanel;
+		}
+
+		private void Button_Click(object sender, RoutedEventArgs e)
+		{
+			Windows.UI.Xaml.Controls.Flyout flyout = new Windows.UI.Xaml.Controls.Flyout();
+			flyout.Content = new TextBlock { Text = "Hi there" };
+
+			flyout.ShowAt(((Button)sender).Tag as FrameworkElement);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml.cs
@@ -43,7 +43,7 @@ namespace UITests.Windows_UI_Xaml_Controls.FlyoutTests
 					Background = new SolidColorBrush(Windows.UI.Colors.Red),
 				};
 
-			flyout.ShowAt(Window.Current.Content as FrameworkElement);
+			flyout.ShowAt(global::Windows.UI.Xaml.Window.Current.Content as FrameworkElement);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -325,7 +325,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
 						throw new ArgumentException("Invalid flyout position");
 					}
 
-					// UNO TODO: clamp position within contentRect
+					var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
+					positionValue = new Point(
+						positionValue.X.Clamp(visibleBounds.Left, visibleBounds.Right),
+						positionValue.Y.Clamp(visibleBounds.Top, visibleBounds.Bottom));
 
 					SetTargetPosition(positionValue);
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
@@ -285,6 +285,66 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			{
 				this.Log().LogDebug($"Calculated placement, finalRect={finalRect}");
 			}
+
+			// Clamp the final rect to be within visible bounds. This can happen for example
+			// when the user is trying to show a flyout at Window.Current.Content - which will
+			// match Top position, which would be outside the visible bounds (negative Y).
+			// We nudge the position according to the FlowDirection (so in case the popup
+			// does not fit, the "start of sentences" are ideally visible.
+
+			if (finalRect.Bottom > visibleBounds.Bottom)
+			{
+				finalRect = new Rect(
+					finalRect.Left,
+					visibleBounds.Bottom - finalRect.Height,
+					finalRect.Width,
+					finalRect.Height);
+			}
+
+			if (finalRect.Top < visibleBounds.Top)
+			{
+				finalRect = new Rect(
+					finalRect.Left,
+					visibleBounds.Top,
+					finalRect.Width,
+					finalRect.Height);
+			}
+
+			void NudgeLeft()
+			{
+				if (finalRect.Left < visibleBounds.Left)
+				{
+					finalRect = new Rect(
+						visibleBounds.Left,
+						finalRect.Top,
+						finalRect.Width,
+						finalRect.Height);
+				}
+			}
+
+			void NudgeRight()
+			{
+				if (finalRect.Right > visibleBounds.Right)
+				{
+					finalRect = new Rect(
+						visibleBounds.Right - finalRect.Width,
+						finalRect.Top,
+						finalRect.Width,
+						finalRect.Height);
+				}
+			}
+
+			if (FlowDirection == FlowDirection.LeftToRight)
+			{
+				NudgeRight();
+				NudgeLeft();
+			}
+			else
+			{
+				NudgeLeft();
+				NudgeRight();
+			}
+
 			return finalRect;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PlacementPopupPanel.cs
@@ -286,22 +286,12 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				this.Log().LogDebug($"Calculated placement, finalRect={finalRect}");
 			}
 
-			// Clamp the final rect to be within visible bounds. This can happen for example
-			// when the user is trying to show a flyout at Window.Current.Content - which will
-			// match Top position, which would be outside the visible bounds (negative Y).
-			// We nudge the position according to the FlowDirection (so in case the popup
-			// does not fit, the "start of sentences" are ideally visible.
+			// Ensure the popup is not positioned fully beyond visible bounds.
+			// This can happen for example when the user is trying to show a flyout at
+			// Window.Current.Content - which will match Top position, which would be outside
+			// the visible bounds (negative Y).
 
-			if (finalRect.Bottom > visibleBounds.Bottom)
-			{
-				finalRect = new Rect(
-					finalRect.Left,
-					visibleBounds.Bottom - finalRect.Height,
-					finalRect.Width,
-					finalRect.Height);
-			}
-
-			if (finalRect.Top < visibleBounds.Top)
+			if (finalRect.Bottom < visibleBounds.Top)
 			{
 				finalRect = new Rect(
 					finalRect.Left,
@@ -310,39 +300,31 @@ namespace Windows.UI.Xaml.Controls.Primitives
 					finalRect.Height);
 			}
 
-			void NudgeLeft()
+			if (finalRect.Top > visibleBounds.Bottom)
 			{
-				if (finalRect.Left < visibleBounds.Left)
-				{
-					finalRect = new Rect(
-						visibleBounds.Left,
-						finalRect.Top,
-						finalRect.Width,
-						finalRect.Height);
-				}
+				finalRect = new Rect(
+					finalRect.Left,
+					visibleBounds.Bottom - finalRect.Height,
+					finalRect.Width,
+					finalRect.Height);
 			}
 
-			void NudgeRight()
+			if (finalRect.Right < visibleBounds.Left)
 			{
-				if (finalRect.Right > visibleBounds.Right)
-				{
-					finalRect = new Rect(
-						visibleBounds.Right - finalRect.Width,
-						finalRect.Top,
-						finalRect.Width,
-						finalRect.Height);
-				}
+				finalRect = new Rect(
+					visibleBounds.Left,
+					finalRect.Top,
+					finalRect.Width,
+					finalRect.Height);
 			}
 
-			if (FlowDirection == FlowDirection.LeftToRight)
+			if (finalRect.Left > visibleBounds.Right)
 			{
-				NudgeRight();
-				NudgeLeft();
-			}
-			else
-			{
-				NudgeLeft();
-				NudgeRight();
+				finalRect = new Rect(
+					visibleBounds.Right - finalRect.Width,
+					finalRect.Top,
+					finalRect.Width,
+					finalRect.Height);
 			}
 
 			return finalRect;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextVisual.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextVisual.skia.cs
@@ -139,7 +139,7 @@ namespace Windows.UI.Composition
 
 		internal override void Render(SKSurface surface)
 		{
-			if (!string.IsNullOrEmpty(_owner.Text))
+			if (!string.IsNullOrEmpty(_owner.Text) && Size != default)
 			{
 				UpdateForeground();
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5716

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`ShowAt` may position popups and flyouts outside of visible bounds


## What is the new behavior?

The popup or flyout position will be clamped within visible bounds.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.