### PR TITLE
fix: Improve `IsApiContractPresent` accuracy

### DIFF
--- a/src/Uno.Foundation/Metadata/ApiInformation.shared.cs
+++ b/src/Uno.Foundation/Metadata/ApiInformation.shared.cs
@@ -1,33 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Windows.Foundation.Metadata;
 
-namespace Windows.Foundation.Metadata
+public partial class ApiInformation
 {
-	public partial class ApiInformation
+	public static bool IsApiContractPresent(string contractName, ushort majorVersion)
+		=> IsApiContractPresent(contractName, majorVersion, 0);
+
+	public static bool IsApiContractPresent(string contractName, ushort majorVersion, ushort minorVersion)
 	{
-		public static bool IsApiContractPresent(string contractName, ushort majorVersion)
-			=> IsApiContractPresent(contractName, majorVersion, 0);
-
-		public static bool IsApiContractPresent(string contractName, ushort majorVersion, ushort minorVersion)
+		switch (contractName)
 		{
-			switch (contractName)
-			{
-				case "Windows.Foundation.UniversalApiContract":
-					// See C:\Program Files (x86)\Windows Kits\10\References\[version]\Windows.Foundation.UniversalApiContract
-					return majorVersion <= 10; // SDK 10.0.19041.1
+			case "Windows.Foundation.FoundationContract":
+				// See C:\Program Files (x86)\Windows Kits\10\References\[version]\Windows.Foundation.FoundationContract
+				return majorVersion <= 4; // SDK 10.0.22000.0
 
-				case "Uno.WinUI":
+			case "Windows.Foundation.UniversalApiContract":
+				// See C:\Program Files (x86)\Windows Kits\10\References\[version]\Windows.Foundation.UniversalApiContract
+				return majorVersion <= 14; // SDK 10.0.22000.0
+
+			case "Windows.Phone.PhoneContract":
+				// See C:\Program Files (x86)\Windows Kits\10\References\[version]\Windows.Phone.PhoneContract
+				return majorVersion <= 1; // SDK 10.0.22000.0					
+
+			case "Windows.Networking.Connectivity.WwanContract":
+				// See C:\Program Files (x86)\Windows Kits\10\References\[version]\Windows.Networking.Connectivity.WwanContract
+				return majorVersion <= 2; // SDK 10.0.22000.0
+
+			case "Windows.ApplicationModel.Calls.CallsPhoneContract":
+				// See C:\Program Files (x86)\Windows Kits\10\References\[version]\Windows.ApplicationModel.Calls.CallsPhoneContract
+				return majorVersion <= 6; // SDK 10.0.22000.0
+
+			case "Uno.WinUI":
 #if HAS_UNO_WINUI
-					return true;
+				return true;
 #else
-					return false;
+				return false;
 #endif
-				default:
-					return false;
-			}
+			default:
+				return false;
 		}
 	}
 }

--- a/src/Uno.Foundation/Metadata/ApiInformation.shared.cs
+++ b/src/Uno.Foundation/Metadata/ApiInformation.shared.cs
@@ -1,4 +1,6 @@
-﻿namespace Windows.Foundation.Metadata;
+﻿using System.Diagnostics;
+
+namespace Windows.Foundation.Metadata;
 
 public partial class ApiInformation
 {
@@ -36,6 +38,11 @@ public partial class ApiInformation
 				return false;
 #endif
 			default:
+				Debug.Fail(
+					"Contract " + contractName + " is not known." +
+					"If implemented, ensure it is added " +
+					"in ApiInformation.IsApiContractPresent.");
+
 				return false;
 		}
 	}

--- a/src/Uno.UWPSyncGenerator/Program.cs
+++ b/src/Uno.UWPSyncGenerator/Program.cs
@@ -33,6 +33,9 @@ namespace Uno.UWPSyncGenerator
 				new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.Networking.Connectivity.WwanContract");
 				new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.ApplicationModel.Calls.CallsPhoneContract");
 
+				// When adding support for a new WinRT contract here, ensure to add it to the list of origins in Generator.cs
+				// and to the list of supported contracts in ApiInformation.shared.cs
+
 #if HAS_UNO_WINUI
 				new SyncGenerator().Build(@"..\..\..\Uno.Foundation", "Uno.Foundation", "Microsoft.Foundation");
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8537 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Version information in `IsApiContractPresent` is not up to date
- Additional supported contracts are not reported correctly

## What is the new behavior?

- Updated to 22000
- Additional contracts are correctly reported


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.