### PR TITLE
fix: BorderThicknessProperty warning on skia/wasm

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -251,7 +251,7 @@ namespace Windows.UI.Xaml
 		internal void ArrangeVisual(Rect finalRect, Rect? clippedFrame = default)
 		{
 			LayoutSlotWithMarginsAndAlignments =
-				VisualTreeHelper.GetParent(this) is UIElement parent
+				VisualTreeHelper.GetParent(this) is UIElement parent && parent is not RootVisual
 					? finalRect.DeflateBy(parent.GetBorderThickness())
 					: finalRect;
 

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -13,6 +13,7 @@ using Uno.Foundation.Logging;
 using Uno.UI;
 using Uno.UI.Extensions;
 using Uno.UI.Xaml;
+using Uno.UI.Xaml.Core;
 using Windows.UI.Xaml.Controls;
 using Windows.System;
 
@@ -207,7 +208,7 @@ namespace Windows.UI.Xaml
 		protected internal void ArrangeVisual(Rect rect, Rect? clipRect)
 		{
 			LayoutSlotWithMarginsAndAlignments =
-				VisualTreeHelper.GetParent(this) is UIElement parent
+				VisualTreeHelper.GetParent(this) is UIElement parent && parent is not RootVisual
 					? rect.DeflateBy(parent.GetBorderThickness())
 					: rect;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8540

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On skia.gtk & wasm, when the app is launched, this warning message is shown in the console log:
warn: Windows.UI.Xaml.UIElement[0] The BorderThicknessProperty dependency property does not exist on Uno.UI.Xaml.Core.RootVisual

## What is the new behavior?

No longer happening.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->