### PR TITLE
fix(net6): [iOS] Ensure current culture is set at Application startup

### DIFF
--- a/src/Uno.UI/UI/Xaml/Application.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.iOS.cs
@@ -11,6 +11,8 @@ using Uno.UI.Services;
 using Uno.Extensions;
 using Windows.UI.Core;
 using Uno.Foundation.Logging;
+using System.Globalization;
+using System.Threading;
 
 #if HAS_UNO_WINUI
 using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
@@ -31,6 +33,7 @@ namespace Windows.UI.Xaml
 		public Application()
 		{
 			Current = this;
+			SetCurrentLanguage();
 			ResourceHelper.ResourcesService = new ResourcesService(new[] { NSBundle.MainBundle });
 
 			SubscribeBackgroundNotifications();
@@ -241,6 +244,28 @@ namespace Windows.UI.Xaml
 		private void OnDeactivated(NSNotification notification)
 		{
 			Windows.UI.Xaml.Window.Current?.OnActivated(CoreWindowActivationState.Deactivated);
+		}
+
+		private void SetCurrentLanguage()
+		{
+#if NET6_0_OR_GREATER
+			// net6.0-iOS does not automatically set the thread and culture info
+			// https://github.com/xamarin/xamarin-macios/issues/14740
+			var language = NSLocale.PreferredLanguages.ElementAtOrDefault(0);
+
+			try
+			{
+				var cultureInfo = CultureInfo.CreateSpecificCulture(language);
+				CultureInfo.CurrentUICulture = cultureInfo;
+				CultureInfo.CurrentCulture = cultureInfo;
+				Thread.CurrentThread.CurrentCulture = cultureInfo;
+				Thread.CurrentThread.CurrentUICulture = cultureInfo;
+			}
+			catch (Exception ex)
+			{
+				this.Log().Error($"Failed to set current culture for language: {language}", ex);
+			}
+#endif
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`CultureInfo.CurrentCulture` and `CultureInfo.CurrentUICulture` are now properly set based on the OS's settings for the main thread.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Related to https://github.com/xamarin/xamarin-macios/issues/14740