### PR TITLE
chore: Remove outdated comment

### DIFF
--- a/src/Uno.UI/Media/PathMarkupParser.cs
+++ b/src/Uno.UI/Media/PathMarkupParser.cs
@@ -538,8 +538,6 @@ namespace Uno.Media
 			return span.Slice(i);
 		}
 
-		// Uno docs: Implementation (currently) different than Avalonia due to:
-		// https://github.com/unoplatform/uno/issues/2855
 		private bool ReadBool(ref ReadOnlySpan<char> span)
 		{
 			span = SkipWhitespace(span);


### PR DESCRIPTION
Uno has first fixed a bug here, diverging from Avalonia implementation. But later, Avalonia was fixed in the same way. So this comment no longer applies