### PR TITLE
fix: FileSavePicker does not return the picked file in Android

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml.cs
@@ -21,7 +21,7 @@ using Windows.UI.Xaml.Media.Imaging;
 namespace UITests.Shared.Windows_Storage.Pickers
 {
 	[Sample("Windows.Storage", ViewModelType = typeof(FileSavePickerTestsViewModel), IsManualTest = true,
-		Description = "Allows testing all features of FileSavePicker. Currently not supported on Android, iOS, macOS and GTK. Not selecting a file should not cause an exception")]
+		Description = "Allows testing all features of FileSavePicker. Not selecting a file should not cause an exception.")]
 	public sealed partial class FileSavePickerTests : Page
 	{
 		public FileSavePickerTests()


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/8419

## PR Type

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

await picker.PickSaveFileAsync(); does not return and continues to wait indefinitely.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

await picker.PickSaveFileAsync(); Returns the file selected by the user.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ x] Validated PR `Screenshots Compare Test Run` results.
- [ x] Contains **NO** breaking changes
- [ x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
