### PR TITLE
feat: `NetworkInformation` API support on Skia

### DIFF
--- a/src/Uno.UWP/Networking/Connectivity/ConnectionProfile.skia.cs
+++ b/src/Uno.UWP/Networking/Connectivity/ConnectionProfile.skia.cs
@@ -1,11 +1,13 @@
 ﻿#nullable enable
 
+using System.Net.NetworkInformation;
+using Uno;
 using Uno.Foundation.Extensibility;
 
 namespace Windows.Networking.Connectivity
 {
 	public partial class ConnectionProfile
-    {
+	{
 		private IConnectionProfileExtension _connectionProfileExtension;
 
 		internal static ConnectionProfile GetInternetConnectionProfile() =>
@@ -14,7 +16,27 @@ namespace Windows.Networking.Connectivity
 		private ConnectionProfile() =>
 			ApiExtensibility.CreateInstance(this, out _connectionProfileExtension);
 
-		private NetworkConnectivityLevel GetNetworkConnectivityLevelImpl() =>
-			_connectionProfileExtension?.GetNetworkConnectivityLevel() ?? NetworkConnectivityLevel.None;
+		private NetworkConnectivityLevel GetNetworkConnectivityLevelImpl()
+		{
+			if (_connectionProfileExtension is null)
+			{
+				try
+				{
+					using (var ping = new Ping())
+					{
+						var reply = ping.Send(WinRTFeatureConfiguration.NetworkInformation.ReachabilityHostname);
+						return reply?.Status == IPStatus.Success ? NetworkConnectivityLevel.InternetAccess : NetworkConnectivityLevel.None;
+					}
+				}
+				catch
+				{
+					// In case exception is thrown, assume
+					// connection was not possible
+					return NetworkConnectivityLevel.None;
+				}
+			}
+
+			return _connectionProfileExtension.GetNetworkConnectivityLevel();
+		}
 	}
 }

--- a/src/Uno.UWP/Networking/Connectivity/Internal/IConnectionProfileExtension.skia.cs
+++ b/src/Uno.UWP/Networking/Connectivity/Internal/IConnectionProfileExtension.skia.cs
@@ -1,7 +1,6 @@
-﻿namespace Windows.Networking.Connectivity
+﻿namespace Windows.Networking.Connectivity;
+
+internal interface IConnectionProfileExtension
 {
-	internal interface IConnectionProfileExtension
-	{
-		NetworkConnectivityLevel GetNetworkConnectivityLevel();
-	}
+	NetworkConnectivityLevel GetNetworkConnectivityLevel();
 }

--- a/src/Uno.UWP/Networking/Connectivity/Internal/INetworkInformationExtension.cs
+++ b/src/Uno.UWP/Networking/Connectivity/Internal/INetworkInformationExtension.cs
@@ -1,0 +1,8 @@
+﻿namespace Windows.Networking.Connectivity;
+
+internal interface INetworkInformationExtension
+{
+	void StartObservingNetworkStatus();
+
+	void StopObservingNetworkStatus();
+}

--- a/src/Uno.UWP/Networking/Connectivity/NetworkInformation.netstdref.cs
+++ b/src/Uno.UWP/Networking/Connectivity/NetworkInformation.netstdref.cs
@@ -1,22 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Uno;
+﻿namespace Windows.Networking.Connectivity;
 
-namespace Windows.Networking.Connectivity
+public partial class NetworkInformation
 {
-    public partial class NetworkInformation
-    {
-		private const string JsType = "Windows.Networking.Connectivity.NetworkInformation";
+	private static void StartNetworkStatusChanged()
+	{
+	}
 
-		private static void StartNetworkStatusChanged()
-		{
-		}
-
-		private static void StopNetworkStatusChanged()
-		{
-		}
+	private static void StopNetworkStatusChanged()
+	{
 	}
 }

--- a/src/Uno.UWP/Networking/Connectivity/NetworkInformation.skia.cs
+++ b/src/Uno.UWP/Networking/Connectivity/NetworkInformation.skia.cs
@@ -1,22 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Uno;
+﻿#nullable enable
 
-namespace Windows.Networking.Connectivity
+using System.Net.NetworkInformation;
+
+namespace Windows.Networking.Connectivity;
+
+public partial class NetworkInformation
 {
-    public partial class NetworkInformation
-    {
-		private const string JsType = "Windows.Networking.Connectivity.NetworkInformation";
-
-		private static void StartNetworkStatusChanged()
-		{
-		}
-
-		private static void StopNetworkStatusChanged()
-		{
-		}
+	private static void StartNetworkStatusChanged()
+	{
+		NetworkChange.NetworkAvailabilityChanged += OnNetworkAvailabilityChanged;
+		NetworkChange.NetworkAddressChanged += OnNetworkAddressChanged;
 	}
+
+	private static void StopNetworkStatusChanged()
+	{
+		NetworkChange.NetworkAvailabilityChanged -= OnNetworkAvailabilityChanged;
+		NetworkChange.NetworkAddressChanged -= OnNetworkAddressChanged;
+	}
+
+
+	private static void OnNetworkAddressChanged(object sender, global::System.EventArgs e) =>
+		OnNetworkStatusChanged();
+
+	private static void OnNetworkAvailabilityChanged(object sender, NetworkAvailabilityEventArgs e) =>
+		OnNetworkStatusChanged();
 }

--- a/src/Uno.UWP/WinRTFeatureConfiguration.NetworkInformation.cs
+++ b/src/Uno.UWP/WinRTFeatureConfiguration.NetworkInformation.cs
@@ -4,6 +4,10 @@
 	{
 		public static class NetworkInformation
 		{
+			/// <summary>
+			/// Gets or sets the hostname that is used to check for network connectivity.
+			/// Used to check internet availability on iOS, macOS and Skia targets.
+			/// </summary>
 			public static string ReachabilityHostname { get; set; } = "www.example.com";
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8609

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`NetworkInformation` always reports as not connected on Skia targets.

## What is the new behavior?

`NetworkInformation` reports proper connection status and status changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.