### PR TITLE
fix: [macOS] follow system colors changes

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI/Given_Color.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI/Given_Color.cs
@@ -63,7 +63,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Core
 			yield return new object[] { ColorHelper.FromArgb(0xFF, 0xFF, 0x7F, 0xFF), ColorHelper.FromArgb(0xFF, 0xFF, 0x7F, 0xFF), true };
 			yield return new object[] { ColorHelper.FromArgb(0xFF, 0xFF, 0xFF, 0x7F), ColorHelper.FromArgb(0xFF, 0xFF, 0xFF, 0x7F), true };
 		}
-#if __MACOS__
+#if __MACOS__ && NET6_0_OR_GREATER
 		[TestMethod]
 		public async Task When_User_Change_macOS_System_Colors()
 		{
@@ -72,7 +72,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Core
 		  	Color SUT_1 = _uiSettings.GetColorValue(Windows.UI.ViewManagement.UIColorType.Accent);
 			Color SUT_2 = _uiSettings.GetColorValue(Windows.UI.ViewManagement.UIColorType.Background);
 
-			var accent = new Windows.UI.Xaml.Media.SolidColorBrush(AppKit.NSColor.ControlAccentColor).Color;
+			var accent = new Windows.UI.Xaml.Media.SolidColorBrush(AppKit.NSColor.ControlAccent).Color;
 			var background = new Windows.UI.Xaml.Media.SolidColorBrush(AppKit.NSColor.ControlBackground).Color;
 
 			Assert.AreEqual(SUT_1, accent);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI/Given_Color.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI/Given_Color.cs
@@ -63,5 +63,25 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Core
 			yield return new object[] { ColorHelper.FromArgb(0xFF, 0xFF, 0x7F, 0xFF), ColorHelper.FromArgb(0xFF, 0xFF, 0x7F, 0xFF), true };
 			yield return new object[] { ColorHelper.FromArgb(0xFF, 0xFF, 0xFF, 0x7F), ColorHelper.FromArgb(0xFF, 0xFF, 0xFF, 0x7F), true };
 		}
+#if __MACOS__
+		[TestMethod]
+		public async Task When_User_Change_macOS_System_Colors()
+		{
+			var _uiSettings = new Windows.UI.ViewManagement.UISettings();
+
+		  	Color SUT_1 = _uiSettings.GetColorValue(Windows.UI.ViewManagement.UIColorType.Accent);
+			Color SUT_2 = _uiSettings.GetColorValue(Windows.UI.ViewManagement.UIColorType.Background);
+
+			var accent = new Windows.UI.Xaml.Media.SolidColorBrush(AppKit.NSColor.ControlAccentColor).Color;
+			var background = new Windows.UI.Xaml.Media.SolidColorBrush(AppKit.NSColor.ControlBackground).Color;
+
+			Assert.AreEqual(SUT_1, accent);
+			Assert.AreEqual(SUT_2, background);
+		}
+
+#endif
+
+
+
 	}
 }

--- a/src/Uno.UWP/UI/ViewManagement/UISettings.cs
+++ b/src/Uno.UWP/UI/ViewManagement/UISettings.cs
@@ -28,7 +28,7 @@ namespace Windows.UI.ViewManagement
 			_instances.TryAdd(_weakReference, null);
 
 
-#if  __MACOS__
+#if __MACOS__ && NET6_0_OR_GREATER
 			NSColor.Notifications.ObserveSystemColorsChanged((sender, eventArgs) =>
 			{
 				OnColorValuesChanged();
@@ -66,7 +66,7 @@ namespace Windows.UI.ViewManagement
 			return desiredColor switch
 			{
 
-#if __MACOS__
+#if __MACOS__ && NET6_0_OR_GREATER
 				UIColorType.Background => NSColor.ControlBackground,
 				UIColorType.Foreground => NSColor.ControlText,
 				UIColorType.Accent => NSColor.ControlAccent,

--- a/src/Uno.UWP/UI/ViewManagement/UISettings.cs
+++ b/src/Uno.UWP/UI/ViewManagement/UISettings.cs
@@ -7,7 +7,7 @@ using Uno.Helpers.Theming;
 using Windows.Foundation;
 using Windows.UI.Core;
 #if __MACOS__
-	using AppKit; 
+using AppKit; 
 #endif
 
 namespace Windows.UI.ViewManagement

--- a/src/Uno.UWP/UI/ViewManagement/UISettings.cs
+++ b/src/Uno.UWP/UI/ViewManagement/UISettings.cs
@@ -6,6 +6,9 @@ using Uno;
 using Uno.Helpers.Theming;
 using Windows.Foundation;
 using Windows.UI.Core;
+#if __MACOS__
+	using AppKit; 
+#endif
 
 namespace Windows.UI.ViewManagement
 {
@@ -23,6 +26,15 @@ namespace Windows.UI.ViewManagement
 		{
 			_weakReference = new WeakReference<UISettings>(this);
 			_instances.TryAdd(_weakReference, null);
+
+
+#if  __MACOS__
+			NSColor.Notifications.ObserveSystemColorsChanged((sender, eventArgs) =>
+			{
+				OnColorValuesChanged();
+			});
+#endif
+
 		}
 
 		~UISettings()
@@ -53,6 +65,12 @@ namespace Windows.UI.ViewManagement
 			var systemTheme = SystemThemeHelper.SystemTheme;
 			return desiredColor switch
 			{
+
+#if __MACOS__
+				UIColorType.Background => NSColor.ControlBackground,
+				UIColorType.Foreground => NSColor.ControlText,
+				UIColorType.Accent => NSColor.ControlAccent,
+#else
 				UIColorType.Background =>
 					systemTheme == SystemTheme.Light ? Colors.White : Colors.Black,
 				UIColorType.Foreground =>
@@ -60,6 +78,8 @@ namespace Windows.UI.ViewManagement
 				// The accent color values match SystemResources.xaml in Uno.UI
 				// as we can't access Application resources from here directly.
 				UIColorType.Accent => Color.FromArgb(255, 51, 153, 255),
+#endif
+
 				UIColorType.AccentDark1 => Color.FromArgb(255, 0, 90, 158),
 				UIColorType.AccentDark2 => Color.FromArgb(255, 0, 66, 117),
 				UIColorType.AccentDark3 => Color.FromArgb(255, 0, 38, 66),


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6767


## PR Type

What kind of change does this PR introduce?
 
- Bugfix 


## What is the current behavior?

Uno Apps were not able to detect custom color changes made by the user. 

## What is the new behavior?

Now, the app can detect the custom changes using using UISettings.ColorValuesChanged
and retry the colors by UISettings.GetColorValue().

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

  
## Other information

Valid to know: AppKit doesn't have all UITypes available on uno. So, some are still hardcoded on SystemResources.xaml.
