### PR TITLE
feat: TextBox Character Casing on all platforms

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -595,7 +595,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 		[AutoRetry] 
 		public void TextBox_CharacterCasingDefault_ShouldAcceptAllCasing_Test()
 		{
-			const string text = "Uno Platform";
+			const string text = "Uno";
 
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_CharacterCasing");
 
@@ -605,14 +605,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			defaultCasingTextBox.ClearText();
 			defaultCasingTextBox.EnterTextAndDismiss(text);
 
-			_app.WaitForText(defaultCasingTextBox, "Uno Platform");
+			_app.WaitForText(defaultCasingTextBox, "Uno");
 		}
 
 		[Test]
 		[AutoRetry] 
 		public void TextBox_CharacterCasingLower_ShouldBeAllLower_Test()
 		{
-			const string text = "Uno Platform";
+			const string text = "Uno";
 
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_CharacterCasing");
 
@@ -622,14 +622,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			lowerCasingTextBox.ClearText();
 			lowerCasingTextBox.EnterTextAndDismiss(text);
 
-			_app.WaitForText(lowerCasingTextBox, "uno platform"); 
+			_app.WaitForText(lowerCasingTextBox, "uno"); 
 		}
 
 		[Test]
 		[AutoRetry]
 		public void TextBox_CharacterCasingUpper_ShouldBeAllUpper_Test()
 		{
-			const string text = "Uno Platform";
+			const string text = "Uno";
 
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_CharacterCasing");
 
@@ -639,7 +639,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			upperCasingTextBox.ClearText();
 			upperCasingTextBox.EnterTextAndDismiss(text);
 
-			_app.WaitForText(upperCasingTextBox, "UNO PLATFORM");
+			_app.WaitForText(upperCasingTextBox, "UNO");
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -605,7 +605,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			defaultCasingTextBox.ClearText();
 			defaultCasingTextBox.EnterTextAndDismiss(text);
 
-			Assert.AreEqual(text, defaultCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
+			_app.WaitForText(defaultCasingTextBox, "Uno Platform");
 		}
 
 		[Test]
@@ -622,8 +622,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			lowerCasingTextBox.ClearText();
 			lowerCasingTextBox.EnterTextAndDismiss(text);
 
-			Assert.AreEqual("uno platform", lowerCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
-
+			_app.WaitForText(lowerCasingTextBox, "uno platform"); 
 		}
 
 		[Test]
@@ -638,9 +637,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			upperCasingTextBox.FastTap();
 			upperCasingTextBox.ClearText();
-			upperCasingTextBox.EnterTextAndDismiss(text); 
+			upperCasingTextBox.EnterTextAndDismiss(text);
 
-			Assert.AreEqual("UNO PLATFORM", upperCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
+			_app.WaitForText(upperCasingTextBox, "UNO PLATFORM");
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -575,8 +575,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 		}
 
 		[Test]
-		[AutoRetry]
-		[ActivePlatforms(Platform.Android)]
+		[AutoRetry] 
 		public void TextBox_CharacterCasingNormal_ShouldAcceptAllCasing_Test()
 		{
 			const string text = "Uno Platform";
@@ -587,14 +586,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			normalCasingTextBox.FastTap();
 			normalCasingTextBox.ClearText();
-			normalCasingTextBox.EnterText(text);
+			normalCasingTextBox.EnterTextAndDismiss(text);
 
 			Assert.AreEqual(text, normalCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
 		}
 
 		[Test]
-		[AutoRetry]
-		[ActivePlatforms(Platform.Android)]
+		[AutoRetry] 
 		public void TextBox_CharacterCasingDefault_ShouldAcceptAllCasing_Test()
 		{
 			const string text = "Uno Platform";
@@ -605,14 +603,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			defaultCasingTextBox.FastTap();
 			defaultCasingTextBox.ClearText();
-			defaultCasingTextBox.EnterText(text);
+			defaultCasingTextBox.EnterTextAndDismiss(text);
 
 			Assert.AreEqual(text, defaultCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
 		}
 
 		[Test]
-		[AutoRetry]
-		[ActivePlatforms(Platform.Android)]
+		[AutoRetry] 
 		public void TextBox_CharacterCasingLower_ShouldBeAllLower_Test()
 		{
 			const string text = "Uno Platform";
@@ -623,14 +620,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			lowerCasingTextBox.FastTap();
 			lowerCasingTextBox.ClearText();
-			lowerCasingTextBox.EnterText(text);
+			lowerCasingTextBox.EnterTextAndDismiss(text);
 
-			Assert.AreEqual(text.ToLowerInvariant(), lowerCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
+			Assert.AreEqual("uno platform", lowerCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
+
 		}
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Android)]
 		public void TextBox_CharacterCasingUpper_ShouldBeAllUpper_Test()
 		{
 			const string text = "Uno Platform";
@@ -641,9 +638,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 			upperCasingTextBox.FastTap();
 			upperCasingTextBox.ClearText();
-			upperCasingTextBox.EnterText(text);
+			upperCasingTextBox.EnterTextAndDismiss(text); 
 
-			Assert.AreEqual(text.ToUpperInvariant(), upperCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
+			Assert.AreEqual("UNO PLATFORM", upperCasingTextBox.GetDependencyPropertyValue("Text")?.ToString());
 		}
 
 		[Test]

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -559,45 +559,8 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		partial void OnTextCharacterCasingChangedPartial(DependencyPropertyChangedEventArgs e)
-		{
-			if (_textBoxView == null)
-			{
-				return;
-			}
-
-			var casing = (CharacterCasing)e.NewValue;
-
-			UpdateCasing(casing);
-		}
-
-		private void UpdateCasing(CharacterCasing characterCasing)
-		{
-			var currentFilters = _textBoxView.GetFilters()?.ToList() ?? new List<IInputFilter>();
-
-			//Remove any casing filters before applying new ones.
-			currentFilters.Remove(a => a is InputFilterAllLower || a is InputFilterAllCaps);
-
-			switch (characterCasing)
-			{
-				case CharacterCasing.Lower:
-					var lowerFilter = new List<IInputFilter>(currentFilters)
-										{
-											new InputFilterAllLower()
-										};
-					_textBoxView.SetFilters(lowerFilter.ToArray());
-
-					break;
-				case CharacterCasing.Upper:
-					var upperFilter = new List<IInputFilter>(currentFilters)
-										{
-											new InputFilterAllCaps()
-										};
-					_textBoxView.SetFilters(upperFilter.ToArray());
-
-					break;
-				case CharacterCasing.Normal:
-					break;
-			}
+		{ 
+			_textBoxView?.SetTextNative(CasingText); 
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -231,7 +231,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (!_isInputModifyingText)
 			{
-				_textBoxView?.SetTextNative(Text);
+				_textBoxView?.SetTextNative(CasingText);
 			}
 
 			UpdatePlaceholderVisibility();
@@ -264,11 +264,24 @@ namespace Windows.UI.Xaml.Controls
 					_isTextChangedPending = false;
 				}
 			}
-			
-			_textBoxView?.SetTextNative(Text);
-		
+
+			//Everytime we change the Text property, the cursor turns to 0 / start 
+			var ss = SelectionStart;
+
+			_textBoxView?.SetTextNative(CasingText);
+
+			SelectionStart = ss;
+
+
 		}
 
+		internal string CasingText
+			=> CharacterCasing switch
+			{
+				CharacterCasing.Lower => Text.ToLower(),
+				CharacterCasing.Upper => Text.ToUpper(),
+				_ => Text,
+			}; 
 
 		private void UpdatePlaceholderVisibility()
 		{
@@ -305,9 +318,9 @@ namespace Windows.UI.Xaml.Controls
 			return baseString;
 		}
 
-#endregion
+		#endregion
 
-#region Description DependencyProperty
+		#region Description DependencyProperty
 
 		public
 #if __IOS__ || __MACOS__
@@ -344,7 +357,7 @@ namespace Windows.UI.Xaml.Controls
 				descriptionPresenter.Visibility = Description != null ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
-#endregion
+		#endregion
 
 		protected override void OnFontSizeChanged(double oldValue, double newValue)
 		{
@@ -376,7 +389,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnForegroundColorChangedPartial(Brush newValue);
 
-#region PlaceholderText DependencyProperty
+		#region PlaceholderText DependencyProperty
 
 		public string PlaceholderText
 		{
@@ -392,9 +405,9 @@ namespace Windows.UI.Xaml.Controls
 				new FrameworkPropertyMetadata(defaultValue: string.Empty)
 			);
 
-#endregion
+		#endregion
 
-#region InputScope DependencyProperty
+		#region InputScope DependencyProperty
 
 		public InputScope InputScope
 		{
@@ -425,9 +438,9 @@ namespace Windows.UI.Xaml.Controls
 		protected void OnInputScopeChanged(DependencyPropertyChangedEventArgs e) => OnInputScopeChangedPartial(e);
 		partial void OnInputScopeChangedPartial(DependencyPropertyChangedEventArgs e);
 
-#endregion
+		#endregion
 
-#region MaxLength DependencyProperty
+		#region MaxLength DependencyProperty
 
 		public int MaxLength
 		{
@@ -450,9 +463,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnMaxLengthChangedPartial(DependencyPropertyChangedEventArgs e);
 
-#endregion
+		#endregion
 
-#region AcceptsReturn DependencyProperty
+		#region AcceptsReturn DependencyProperty
 
 		public bool AcceptsReturn
 		{
@@ -489,9 +502,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnAcceptsReturnChangedPartial(DependencyPropertyChangedEventArgs e);
 
-#endregion
+		#endregion
 
-#region TextWrapping DependencyProperty
+		#region TextWrapping DependencyProperty
 		public TextWrapping TextWrapping
 		{
 			get => (TextWrapping)this.GetValue(TextWrappingProperty);
@@ -516,10 +529,10 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextWrappingChangedPartial(DependencyPropertyChangedEventArgs e);
 
-#endregion
+		#endregion
 
-#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+#if NET461 || __NETSTD_REFERENCE__
+		[Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 #endif
 		public CharacterCasing CharacterCasing
 		{
@@ -527,8 +540,8 @@ namespace Windows.UI.Xaml.Controls
 			set => this.SetValue(CharacterCasingProperty, value);
 		}
 
-#if __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+#if NET461 || __NETSTD_REFERENCE__
+		[Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 #endif
 		public static DependencyProperty CharacterCasingProperty { get; } =
 			DependencyProperty.Register(
@@ -547,7 +560,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnTextCharacterCasingChangedPartial(DependencyPropertyChangedEventArgs e);
 
-#region IsReadOnly DependencyProperty
+		#region IsReadOnly DependencyProperty
 
 		public bool IsReadOnly
 		{
@@ -574,9 +587,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsReadonlyChangedPartial(DependencyPropertyChangedEventArgs e);
 
-#endregion
+		#endregion
 
-#region Header DependencyProperties
+		#region Header DependencyProperties
 
 		public object Header
 		{
@@ -620,9 +633,9 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-#endregion
+		#endregion
 
-#region IsSpellCheckEnabled DependencyProperty
+		#region IsSpellCheckEnabled DependencyProperty
 
 		public bool IsSpellCheckEnabled
 		{
@@ -645,9 +658,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsSpellCheckEnabledChangedPartial(DependencyPropertyChangedEventArgs e);
 
-#endregion
+		#endregion
 
-#region IsTextPredictionEnabled DependencyProperty
+		#region IsTextPredictionEnabled DependencyProperty
 
 		[Uno.NotImplemented]
 		public bool IsTextPredictionEnabled
@@ -672,9 +685,9 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnIsTextPredictionEnabledChangedPartial(DependencyPropertyChangedEventArgs e);
 
-#endregion
+		#endregion
 
-#region TextAlignment DependencyProperty
+		#region TextAlignment DependencyProperty
 
 #if XAMARIN_ANDROID
 		public new TextAlignment TextAlignment
@@ -995,7 +1008,7 @@ namespace Windows.UI.Xaml.Controls
 			UpdateKeyboardThemePartial();
 		}
 
-		partial void UpdateKeyboardThemePartial();		
+		partial void UpdateKeyboardThemePartial();
 
 		private protected override void OnIsEnabledChanged(IsEnabledChangedEventArgs e)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -365,5 +365,10 @@ namespace Windows.UI.Xaml.Controls
 
 			_textBoxView.KeyboardAppearance = appearance;
 		}
+
+		partial void OnTextCharacterCasingChangedPartial(DependencyPropertyChangedEventArgs e)
+		{
+			_textBoxView?.SetTextNative(CasingText);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.macOS.cs
@@ -236,5 +236,10 @@ namespace Windows.UI.Xaml.Controls
 
 			_isSecured = isSecure;
 		}
+
+		partial void OnTextCharacterCasingChangedPartial(DependencyPropertyChangedEventArgs e)
+		{
+			_textBoxView?.SetTextNative(CasingText);
+		} 
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Xaml.Controls
 		private TextBoxView _textBoxView;
 
 		internal TextBoxView TextBoxView => _textBoxView;
-		
+
 		internal ContentControl ContentElement => _contentElement;
 
 		partial void OnForegroundColorChangedPartial(Brush newValue) => TextBoxView?.OnForegroundChanged(newValue);
@@ -46,5 +46,14 @@ namespace Windows.UI.Xaml.Controls
 
 
 		protected void SetIsPassword(bool isPassword) => TextBoxView?.SetIsPassword(isPassword);
+
+
+		partial void OnTextCharacterCasingChangedPartial(DependencyPropertyChangedEventArgs e)
+		{
+			_textBoxView?.UpdateTextFromNative(CasingText);
+		}
+		 
+
+
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -173,5 +173,12 @@ namespace Windows.UI.Xaml.Controls
 				_textBoxView.SelectionEnd = _textBoxView.SelectionStart + value;
 			}
 		}
+
+
+		partial void OnTextCharacterCasingChangedPartial(DependencyPropertyChangedEventArgs e)
+		{
+			_textBoxView?.SetProperty("value", CasingText);
+		} 
 	}
 }
+

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -116,6 +116,7 @@ namespace Windows.UI.Xaml.Controls
 			if (textBox != null)
 			{
 				var text = textBox.ProcessTextInput(newText);
+
 				if (text != newText)
 				{
 					SetTextNative(text);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8634
 
## PR Type
 
- Feature 

## What is the current behavior?

TextBox Character Casing was not implemented on all platforms.

## What is the new behavior?

Now, implemented for Skia, Android, iOS, macOS and WASM.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
 

## Other information

To be honest, UWP seams to have a little bug: When you change the CharacterCasing property, dynamically, it only applies when the TextBox get focus. Uno doesn't have this issue.