### PR TITLE
fix(pointers): [iOS] Fix frame id capping to uint.MaxValue

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ContentControl.cs
+++ b/src/SamplesApp/SamplesApp.UITests/UnoSamples_Tests.ContentControl.cs
@@ -44,11 +44,11 @@ namespace SamplesApp.UITests
 		{
 			Run("Uno.UI.Samples.Content.UITests.ContentPresenter.ContentPresenter_Changing_ContentTemplate");
 
-			Assert.IsFalse(_app.Marked("ContentViewBorder").HasResults());
+			Assert.IsFalse(_app.Marked("ContentViewBorder").HasResults(), "Failed to get ContentViewBorder (1)");
 
 			_app.FastTap(c => c.Marked("ToggleTemplateButton"));
 
-			Assert.IsTrue(_app.Marked("ContentViewBorder").HasResults());
+			Assert.IsTrue(_app.Marked("ContentViewBorder").HasResults(), "Failed to get ContentViewBorder (2)");
 
 		}
 
@@ -58,11 +58,11 @@ namespace SamplesApp.UITests
 		{
 			Run("Uno.UI.Samples.Content.UITests.ContentControlTestsControl.ContentControl_Changing_ContentTemplate");
 
-			Assert.IsFalse(_app.Marked("ContentViewBorder").HasResults());
+			Assert.IsFalse(_app.Marked("ContentViewBorder").HasResults(), "Failed to get ContentViewBorder (1)");
 
 			_app.FastTap(c => c.Marked("ToggleTemplateButton"));
 
-			Assert.IsTrue(_app.Marked("ContentViewBorder").HasResults());
+			Assert.IsTrue(_app.Marked("ContentViewBorder").HasResults(), "Failed to get ContentViewBorder (2)");
 
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.iOS.cs
@@ -34,7 +34,10 @@ namespace Windows.UI.Xaml
 
 			public uint Id { get; }
 
-			public uint LastManagedOnlyFrameId { get; set; }
+			// The first frameId can be zero, and we're comparing it when handling
+			// TouchesBegan. Setting it to -1 by default allows for handling the
+			// "unset" value with a minimal performance cost.
+			public long LastManagedOnlyFrameId { get; set; } = -1;
 
 			public PointerRoutedEventArgs DownArgs { get; set; }
 


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/253

## Bugfix
The `PointerRoutedEventArgs.FrameId` caps to `uint.MaxValue` after about 10 days after last reboot of the device.

## What is the current behavior?
With latest versions of iOS, 10 days after last system reboot, the computed frame ID was overflowing the `uint` capacity, and cast was not resetting to 0 as expected.

The visible effect was to break Drag and Drop with latest versions of iOS.

## What is the new behavior?
- The `FrameId` resolution has been reduced to 120 frames per seconds (120Hz, 8.33 ms per frame)
- It's not computed relative to the first frame since the app launch (was relative to system up-time)
- We are explicitly ensure a reset to 0 in case of overflow of `uint`.

Note: `FrameId` will now be reset to 0 after 1.13 of application run-time.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
