### PR TITLE
fix(dragdrop): Make sure to disable dragging on LV's ItemContainer

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -15,7 +15,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 	public partial class DragDrop_ListViewReorder_Automated : SampleControlUITestBase
 	{
 		private static readonly string[] _items = new[] { "#FF0018", "#FFA52C", "#FFFF41", "#008018", "#0000F9", "#86007D" };
-		private const int _itemHeight = 100;
+		private const int _itemHeight = 90;
 
 		private static float Item(IAppRect sut, int index) => sut.Y + (index * _itemHeight) + 25;
 
@@ -43,7 +43,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 
 			var after = TakeScreenshot("After", ignoreInSnapshotCompare: true);
 
-			ImageAssert.AreEqual(before, after, sutBounds);
+			// note: we test only 100 pixels width to avoid failure due to scrollbar being visible in "after" screenshot
+			var testBounds = new Rectangle((int)sutBounds.X, (int)sutBounds.Y, 100, (int)sutBounds.Height);
+			ImageAssert.AreEqual(before, after, testBounds);
 		}
 
 		[Test]

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -22,6 +22,33 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		[Test]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
+		public void When_Disabled()
+		{
+			Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_ListView", skipInitialScreenshot: true);
+
+			var sut = _app.Marked("SUT");
+			var mode = _app.Marked("DragMode");
+
+			mode.SetDependencyPropertyValue("IsChecked", "False");
+
+			var before = TakeScreenshot("Before", ignoreInSnapshotCompare: true);
+
+			// Attempt to re-order
+			var sutBounds = _app.Query(sut).Single().Rect;
+			var x = sutBounds.X + 50;
+			var srcY = Item(sutBounds, 1);
+			var dstY = Item(sutBounds, 3);
+
+			_app.DragCoordinates(x, srcY, x, dstY);
+
+			var after = TakeScreenshot("After", ignoreInSnapshotCompare: true);
+
+			ImageAssert.AreEqual(before, after, sutBounds);
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
 		public void When_Reorder_Down() => Test_Reorder(1, 3);
 
 		[Test]

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView.xaml
@@ -22,16 +22,17 @@
 			x:Name="SUT">
 			<ListView.ItemTemplate>
 				<DataTemplate>
-					<Border Background="{Binding}" Width="300" Height="100">
+					<Border Background="{Binding}" Width="300" Height="90">
 						<TextBlock Text="{Binding}" Foreground="Black" />
 					</Border>
 				</DataTemplate>
 			</ListView.ItemTemplate>
 		</ListView>
 
-		<StackPanel Grid.Row="1">
+		<StackPanel Grid.Row="1" Orientation="Horizontal">
+			<CheckBox x:Name="DragMode" IsThreeState="False" IsChecked="True" Content="Allow reorder" Margin="0,0,10,0" />
+			<TextBlock Text="Drag operation: " />
 			<TextBlock x:Name="Operation" Text="--none--" />
-			<CheckBox x:Name="DragMode" IsThreeState="False" IsChecked="True" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_ListView.xaml
@@ -14,9 +14,9 @@
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 		<ListView 
-			CanDragItems="True"
-			CanReorderItems="True"
-			AllowDrop="True"
+			CanDragItems="{Binding IsChecked, ElementName=DragMode}"
+			CanReorderItems="{Binding IsChecked, ElementName=DragMode}"
+			AllowDrop="{Binding IsChecked, ElementName=DragMode}"
 			SelectionMode="Multiple"
 			MinHeight="300"
 			x:Name="SUT">
@@ -29,6 +29,9 @@
 			</ListView.ItemTemplate>
 		</ListView>
 
-		<TextBlock x:Name="Operation" Text="--none--" Grid.Row="1" />
+		<StackPanel Grid.Row="1">
+			<TextBlock x:Name="Operation" Text="--none--" />
+			<CheckBox x:Name="DragMode" IsThreeState="False" IsChecked="True" />
+		</StackPanel>
 	</Grid>
 </Page>

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -106,6 +106,7 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
+			itemContainer.CanDrag = false;
 			itemContainer.DragStarting -= OnItemContainerDragStarting;
 			itemContainer.DropCompleted -= OnItemContainerDragCompleted;
 

--- a/src/Uno.UI/UI/Xaml/DragDrop/DragDropManager.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragDropManager.cs
@@ -102,7 +102,7 @@ namespace Windows.UI.Xaml
 			=> FindOperation(src)?.Aborted(src) ?? DataPackageOperation.None;
 
 		private DragOperation? FindOperation(IDragEventSource src)
-			=> _dragOperations.FirstOrDefault(drag =>  drag.Info.SourceId == src.Id);
+			=> _dragOperations.FirstOrDefault(drag => drag.Info.SourceId == src.Id);
 
 		private void RegisterWindowHandlers()
 		{


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/383

## Bugfix
Make sure to disable dragging on LV's ItemContainer

## What is the current behavior?
If we disable the `LV.CanReorder` while list has been loaded, trying to drag item might break the UI

## What is the new behavior?
We make sure to effectively set the `CanDrag` to false on all items containers

## PR Checklist
- [ ] ~~Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
