### PR TITLE
fix: WPF Skia input on initial page load

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -30,8 +30,11 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Logging;
 using Uno;
-using Uno.UI.Xaml.Controls.Extensions;
 using Uno.Foundation.Extensibility;
+
+#if __SKIA__
+using Uno.UI.Xaml.Controls.Extensions;
+#endif
 
 #if !HAS_UNO
 using Uno.Logging;
@@ -570,7 +573,6 @@ namespace SamplesApp
 		/// <seealso href="https://github.com/unoplatform/uno/issues/1741"/>
 		public void AssertIssue1790ApplicationSettingsUsable()
 		{
-#if !__SKIA__ // SKIA TODO
 			void AssertIsUsable(Windows.Storage.ApplicationDataContainer container)
 			{
 				const string issue1790 = nameof(issue1790);
@@ -583,7 +585,6 @@ namespace SamplesApp
 
 			AssertIsUsable(Windows.Storage.ApplicationData.Current.LocalSettings);
 			AssertIsUsable(Windows.Storage.ApplicationData.Current.RoamingSettings);
-#endif
 		}
 
 		/// <summary>

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -30,10 +30,10 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Logging;
 using Uno;
-using Uno.Foundation.Extensibility;
 
 #if __SKIA__
 using Uno.UI.Xaml.Controls.Extensions;
+using Uno.Foundation.Extensibility;
 #endif
 
 #if !HAS_UNO

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -43,6 +43,8 @@ namespace Uno.UI.Runtime.Skia.GTK.Extensions.UI.Xaml.Controls
 			_window = window ?? throw new ArgumentNullException(nameof(window));
 		}
 
+		public bool IsNativeOverlayLayerInitialized => GetWindowTextInputLayer() is not null;
+
 		public static TextBoxViewExtension? ActiveTextBoxView { get; private set; }
 
 		private Fixed GetWindowTextInputLayer()

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -23,6 +23,8 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			_owner = owner ?? throw new ArgumentNullException(nameof(owner));
 		}
 
+		public bool IsNativeOverlayLayerInitialized => GetWindowTextInputLayer() is not null;
+		
 		private WpfCanvas? GetWindowTextInputLayer() => WpfHost.Current?.NativeOverlayLayer;
 
 		public void StartEntry()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/ITextBoxExtension.skia.cs
@@ -5,6 +5,8 @@ namespace Uno.UI.Xaml.Controls.Extensions
 {
 	internal interface ITextBoxViewExtension
     {
+		bool IsNativeOverlayLayerInitialized { get; }
+		
 		void StartEntry();
 
 		void EndEntry();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8641 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When initial app page has an input field as first focusable element, exception is thrown.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

- Exception is no longer thrown
- Enabled app settings test during Samples app startup


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
