### PR TITLE
fix(filesavepicker): Avoid possible `IndexOutOfRangeException` on macOS

### DIFF
--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.macOS.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.macOS.cs
@@ -49,7 +49,8 @@ namespace Windows.Storage.Pickers
 				_ => NSSearchPathDirectory.UserDirectory
 			};
 
-			return NSFileManager.DefaultManager.GetUrls(specialFolder, NSSearchPathDomain.User)[0].AbsoluteString;
+			var urls = NSFileManager.DefaultManager.GetUrls(specialFolder, NSSearchPathDomain.User);
+			return (urls.Length == 0) ? NSFileManager.HomeDirectory : urls[0].AbsoluteString;
 		}
 
 		private string[] GetFileTypes() => FileTypeChoices.SelectMany(x => x.Value.Select(val => val.TrimStart(new[] { '.' }))).ToArray();


### PR DESCRIPTION
`NSFileManager.DefaultManager.GetUrls` can return an empty array, which
leads to an `IndexOutOfRangeException`. I get this when I run Uno's
SamplesApp.macOS using the default **ComputerFolder** start location and
clicking on `Pick save file`.

If an empty array is returned then the code will fallback to the user
home directory using a different API `NSHomeDirectory`.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

A `IndexOutOfRangeException` is thrown, on macOS when I run Uno's
SamplesApp.macOS using the default **ComputerFolder** start location and
clicking on `Pick save file`.

## What is the new behavior?

No exception, the file dialog is shown.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

That result is a bit unexpected but

```csharp
var url = NSFileManager.DefaultManager.GetUrl(specialFolder, NSSearchPathDomain.User, null, false, out var error);
```

returns a `null url` and `error` is also `null`.


Also clicking on `Pick suggested save file` works... but that calls 
`FileOpenPicker` (not `FileSavePicker`) and I'm not sure if it's
by design or not. Pinging test code author @MartinZikmund 


Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
