### PR TITLE
fix(net6): Restore ElevatedView templated parent support

### DIFF
--- a/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
+++ b/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
@@ -8,8 +8,6 @@
 		<AssemblyName>SamplesApp</AssemblyName>
 		<DefineConstants>$(DefineConstants);XAMARIN;HAS_UNO</DefineConstants>
 		<IsUnoHead>true</IsUnoHead>
-
-		<PublishTrimmed>false</PublishTrimmed>
 		
 		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">iossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
@@ -35,13 +33,6 @@
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net6.0-ios'">
 		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
-
-		<!--
-			Workaround for
-			tools\msbuild\iOS\Xamarin.iOS.Common.After.targets(368,3): error MSB3371: The file "obj\Release\net6.0-ios\iossimulator-x64\linked\Link.semaphore"
-			cannot be created. Could not find a part of the path 'C:\a\1\s\src\SamplesApp\SamplesApp.net6mobile\obj\Release\net6.0-ios\iossimulator-x64\linked\Link.semaphore'.
-		-->
-		<PublishTrimmed>false</PublishTrimmed>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition="'$(TargetFramework)'=='net6.0-android'">

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -20,7 +20,7 @@ namespace Uno.UI.Toolkit
 	[TemplatePart(Name = "PART_Border", Type = typeof(Border))]
 	[TemplatePart(Name = "PART_ShadowHost", Type = typeof(Grid))]
 	public sealed partial class ElevatedView : Control
-#if !NETFX_CORE && !NETCOREAPP
+#if HAS_UNO
 		, ICustomClippingElement
 #endif
 	{
@@ -59,7 +59,7 @@ namespace Uno.UI.Toolkit
 		{
 			DefaultStyleKey = typeof(ElevatedView);
 
-#if !NETFX_CORE && !NETCOREAPP
+#if HAS_UNO
 			Loaded += (snd, evt) => SynchronizeContentTemplatedParent();
 
 			// Patch to deactivate the clipping by ContentControl
@@ -114,7 +114,7 @@ namespace Uno.UI.Toolkit
 			set => SetValue(ElevatedContentProperty, value);
 		}
 
-#if !NETFX_CORE && !NETCOREAPP
+#if HAS_UNO
 		public new static DependencyProperty BackgroundProperty { get ; } = DependencyProperty.Register(
 			"Background",
 			typeof(Brush),
@@ -178,7 +178,7 @@ namespace Uno.UI.Toolkit
 				return; // not initialized yet
 			}
 
-#if !NETFX_CORE && !NETCOREAPP
+#if HAS_UNO
 			SynchronizeContentTemplatedParent();
 #endif
 
@@ -199,13 +199,13 @@ namespace Uno.UI.Toolkit
 				_border.SetElevationInternal(Elevation, ShadowColor);
 #elif __SKIA__
 				this.SetElevationInternal(Elevation, ShadowColor);
-#elif NETFX_CORE || NETCOREAPP
+#elif (NETFX_CORE || NETCOREAPP) && !HAS_UNO
 				_border.SetElevationInternal(Elevation, ShadowColor, _shadowHost as DependencyObject, CornerRadius);
 #endif
 			}
 		}
 
-#if !NETFX_CORE && !NETCOREAPP
+#if HAS_UNO
 		bool ICustomClippingElement.AllowClippingToLayoutSlot => false; // Never clip, since it will remove the shadow
 
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => false;

--- a/src/Uno.UI.Toolkit/UIElementExtensions.cs
+++ b/src/Uno.UI.Toolkit/UIElementExtensions.cs
@@ -15,7 +15,7 @@ using Uno.Extensions;
 using Uno.Foundation.Logging;
 #endif
 
-#if NETCOREAPP
+#if NETCOREAPP && !HAS_UNO
 using Microsoft.UI;
 #endif
 
@@ -75,7 +75,7 @@ namespace Uno.UI.Toolkit
 
 #if __IOS__ || __MACOS__
 		internal static void SetElevationInternal(this DependencyObject element, double elevation, Color shadowColor, CGPath path = null)
-#elif NETFX_CORE || NETCOREAPP
+#elif (NETFX_CORE || NETCOREAPP) && !HAS_UNO
 		internal static void SetElevationInternal(this DependencyObject element, double elevation, Color shadowColor, DependencyObject host = null, CornerRadius cornerRadius = default(CornerRadius))
 #else
 		internal static void SetElevationInternal(this DependencyObject element, double elevation, Color shadowColor)
@@ -163,7 +163,7 @@ namespace Uno.UI.Toolkit
 				var shadow = new ShadowState(dx, dy, sigmaX, sigmaY, shadowColor);
 				visual.ShadowState = shadow;
 			}
-#elif NETFX_CORE || NETCOREAPP
+#elif (NETFX_CORE || NETCOREAPP) && !HAS_UNO
 			if (element is UIElement uiElement)
 			{
 				var compositor = ElementCompositionPreview.GetElementVisual(uiElement).Compositor;
@@ -236,7 +236,7 @@ namespace Uno.UI.Toolkit
 #endif
 		}
 
-#endregion
+		#endregion
 
 		internal static Thickness GetPadding(this UIElement uiElement)
 		{
@@ -354,7 +354,7 @@ namespace Uno.UI.Toolkit
 				uiElement.Log().Warn($"The {propertyName} dependency property does not exist on {type}");
 #endif
 			}
-#if !NETFX_CORE && !NETCOREAPP
+#if HAS_UNO
 			else if (property.Type != propertyType)
 			{
 				uiElement.Log().Warn($"The {propertyName} dependency property {type} is not of the {propertyType} Type.");


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/8701, closes https://github.com/unoplatform/uno/issues/8690, closes https://github.com/unoplatform/uno/issues/8691, closes https://github.com/unoplatform/uno/issues/8705, closes https://github.com/unoplatform/uno/issues/8700, closes https://github.com/unoplatform/uno/issues/8692, closes https://github.com/unoplatform/uno/issues/8709

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores TemplatedParent support for ElevatedView content.
