### PR TITLE
fix(net6): [Android] Adjust for proper assets base path

### DIFF
--- a/build/uno.winui.single-project.targets
+++ b/build/uno.winui.single-project.targets
@@ -51,7 +51,7 @@
 		<AndroidProjectFolder Condition=" '$(AndroidProjectFolder)' == '' ">Android\</AndroidProjectFolder>
 		<AndroidManifest>$(AndroidProjectFolder)AndroidManifest.xml</AndroidManifest>
 		<MonoAndroidResourcePrefix>$(AndroidProjectFolder)Resources</MonoAndroidResourcePrefix>
-		<MonoAndroidAssetsPrefix>$(AndroidProjectFolder)Assets;Assets</MonoAndroidAssetsPrefix>
+		<MonoAndroidAssetsPrefix>$(AndroidProjectFolder)Assets</MonoAndroidAssetsPrefix>
 
 		<!-- iOS -->
 		<EnableDefaultiOSItems>false</EnableDefaultiOSItems>

--- a/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.cs
@@ -26,6 +26,8 @@ namespace Uno.UI.Tasks.Assets
 		[Required]
 		public string TargetPlatform { get; set; }
 
+		public string AndroidAssetsPrefix { get; set; }
+
 		[Required]
 		public string DefaultLanguage { get; set; }
 
@@ -53,7 +55,7 @@ namespace Uno.UI.Tasks.Assets
 					break;
 				case "android":
 					resourceToTargetPath = resource => AndroidResourceConverter.Convert(resource, DefaultLanguage);
-					pathEncoder = AndroidResourceNameEncoder.EncodeFileSystemPath;
+					pathEncoder = s => AndroidResourceNameEncoder.EncodeFileSystemPath(s, AndroidAssetsPrefix ?? "Assets");
 					break;
 				default:
 					Log.LogMessage($"Skipping unknown platform {TargetPlatform}");
@@ -62,7 +64,7 @@ namespace Uno.UI.Tasks.Assets
 
 			Assets = ContentItems.ToArray();
 			RetargetedAssets = Assets
-				.Select((Func<ITaskItem, TaskItem>)(asset => ProcessContentItem(asset, resourceToTargetPath, pathEncoder)))
+				.Select(asset => ProcessContentItem(asset, resourceToTargetPath, pathEncoder))
 				.Where(a => a != null)
 				.ToArray();
 

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -62,6 +62,7 @@
 						TargetPlatform="$(XamarinProjectType)"
 						DefaultLanguage="$(DefaultLanguage)"
 						ContentItems="@(Content)"
+						AndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
 						Condition="'$(XamarinProjectType)'!=''">
 	  <Output TaskParameter="Assets"
 					  ItemName="Assets" />

--- a/src/Uno.UWP/Helpers/AndroidResourceNameEncoder.cs
+++ b/src/Uno.UWP/Helpers/AndroidResourceNameEncoder.cs
@@ -46,9 +46,9 @@ namespace Uno
 			return key;
 		}
 
-		public static string EncodeFileSystemPath(string path)
+		public static string EncodeFileSystemPath(string path, string prefix = "Assets")
 			// Android assets need to placed in the Assets folder
-			=> global::System.IO.Path.Combine("Assets", EncodePath(path, global::System.IO.Path.DirectorySeparatorChar));
+			=> global::System.IO.Path.Combine(prefix, EncodePath(path, global::System.IO.Path.DirectorySeparatorChar));
 
 		public static string EncodeResourcePath(string path)
 			=> EncodePath(path, '/');


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Properly sets the android base path for content files. The testing for this is implicitly done in the android runtime tests, which are currently disabled until stabilized in net6-andoid.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
