### PR TITLE
fix: Fixed AccessViolationException that occurs in GLibSharp.dll after storage picker interaction

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileOpenPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileOpenPickerExtension.cs
@@ -41,7 +41,7 @@ namespace Uno.Extensions.Storage.Pickers
 				commitText = _picker.CommitButtonText;
 			}
 
-			FileChooserDialog dialog = new FileChooserDialog(
+			using FileChooserDialog dialog = new FileChooserDialog(
 				"Open",
 				GtkHost.Window,
 				FileChooserAction.Open,
@@ -77,8 +77,6 @@ namespace Uno.Extensions.Storage.Pickers
 				}
 			}
 
-			dialog.Dispose();
-			dialog.Destroy();
 			return files.ToArray();
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileOpenPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileOpenPickerExtension.cs
@@ -77,6 +77,7 @@ namespace Uno.Extensions.Storage.Pickers
 				}
 			}
 
+			dialog.Dispose();
 			dialog.Destroy();
 			return files.ToArray();
 		}

--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileSavePickerExtension.cs
@@ -49,6 +49,7 @@ namespace Uno.Extensions.Storage.Pickers
 				file = await StorageFile.GetFileFromPathAsync(dialog.Filename);				
 			}
 
+			dialog.Dispose();
 			dialog.Destroy();
 			return file;
 		}

--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileSavePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FileSavePickerExtension.cs
@@ -28,7 +28,7 @@ namespace Uno.Extensions.Storage.Pickers
 				commitText = _picker.CommitButtonText;
 			}
 
-			FileChooserDialog dialog = new FileChooserDialog(
+			using FileChooserDialog dialog = new FileChooserDialog(
 			"Save File",
 			GtkHost.Window,
 			FileChooserAction.Save,
@@ -49,8 +49,7 @@ namespace Uno.Extensions.Storage.Pickers
 				file = await StorageFile.GetFileFromPathAsync(dialog.Filename);				
 			}
 
-			dialog.Dispose();
-			dialog.Destroy();
+			
 			return file;
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FolderPickerExtension.cs
@@ -49,6 +49,7 @@ namespace Uno.Extensions.Storage.Pickers
 				folder = await StorageFolder.GetFolderFromPathAsync(dialog.Filename);
 			}
 
+			dialog.Dispose();
 			dialog.Destroy();
 			return folder;
 		}

--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/Storage/Pickers/FolderPickerExtension.cs
@@ -27,7 +27,7 @@ namespace Uno.Extensions.Storage.Pickers
 				commitText = _picker.CommitButtonText;
 			}
 
-			FileChooserDialog dialog = new FileChooserDialog(
+			using FileChooserDialog dialog = new FileChooserDialog(
 				"Select Folder",
 				GtkHost.Window,
 				FileChooserAction.SelectFolder,
@@ -49,8 +49,6 @@ namespace Uno.Extensions.Storage.Pickers
 				folder = await StorageFolder.GetFolderFromPathAsync(dialog.Filename);
 			}
 
-			dialog.Dispose();
-			dialog.Destroy();
 			return folder;
 		}
 	}


### PR DESCRIPTION


GitHub Issue (If applicable): #6334

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

After interacting with a picker dialog on Skia.GTK and dismissing them with one of the action buttons (Cancel, Save, Open, Select Folder), GTK crashes with the exception:

```
An unhandled exception of type 'System.AccessViolationException' occurred in GLibSharp.dll
Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Exception does't appear, storage picker works fine
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

Fixes #6334
<!-- Please provide any additional information if necessary -->


<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
