### PR TITLE
fix(codegen): Don't warn on CA1001 by default (disposable fields) for generated code

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -169,9 +169,9 @@
 	<IncludeXamlNamespaces Condition="'$(XamarinProjectType)'=='net461'" Include="not_netstdref" />
 
 	<!--
-				A list of analyzer suppressions to include in every generated class.
-				This is required for roslyn analyzers that do not support the GeneratedCodeAttribute.
-			-->
+		A list of analyzer suppressions to include in every generated class.
+		This is required for roslyn analyzers that do not support the GeneratedCodeAttribute.
+	-->
 	<XamlGeneratorAnalyzerSuppressions Include="nventive.Usage-NV0056" />
 	<XamlGeneratorAnalyzerSuppressions Include="nventive.Usage-NV0058" />
 	<XamlGeneratorAnalyzerSuppressions Include="nventive.Usage-NV1003" />
@@ -180,6 +180,12 @@
 	<XamlGeneratorAnalyzerSuppressions Include="nventive.Usage-NV2003" />
 	<XamlGeneratorAnalyzerSuppressions Include="nventive.Usage-NV2004" />
 	<XamlGeneratorAnalyzerSuppressions Include="nventive.Usage-NV2005" />
+
+	<!--
+		Ignore disposable fields, Uno manages those on its own.
+		https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1001
+	-->
+	<XamlGeneratorAnalyzerSuppressions Include="dotnet-CA1001" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -49,6 +49,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			private readonly INamedTypeSymbol? _iFrameworkElementSymbol;
 			private readonly INamedTypeSymbol? _frameworkElementSymbol;
 			private readonly bool _isUnoSolution;
+			private readonly string[] _analyzerSuppressions;
 
 			public SerializationMethodsGenerator(GeneratorExecutionContext context)
 			{
@@ -68,6 +69,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				_iFrameworkElementSymbol = comp.GetTypeByMetadataName(XamlConstants.Types.IFrameworkElement);
 				_frameworkElementSymbol = comp.GetTypeByMetadataName("Windows.UI.Xaml.FrameworkElement");
 				_isUnoSolution = _context.GetMSBuildPropertyValue("_IsUnoUISolution") == "true";
+				_analyzerSuppressions = context.GetMSBuildPropertyValue("XamlGeneratorAnalyzerSuppressionsProperty").Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 			}
 
 			public override void VisitNamedType(INamedTypeSymbol type)
@@ -163,6 +165,8 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 							{
 								builder.AppendLineInvariant(@"[global::Windows.UI.Xaml.Data.Bindable]");
 							}
+
+							AnalyzerSuppressionsGenerator.Generate(builder, _analyzerSuppressions);
 
 							var internalDependencyObject = _isUnoSolution && !typeSymbol.IsSealed ? ", IDependencyObjectInternal" : "";
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Disposable private fields in XAML-generated classes are now excluded from CA1001.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
