### PR TITLE
fix: missing guarding leads to crashes under Android prior to API 23

### DIFF
--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
@@ -176,7 +176,8 @@ namespace Windows.UI.Xaml.Input
 					break;
 			}
 
-			if (updates.TryGetValue(_nativeEvent.ActionButton, out var update))
+			if (Android.OS.Build.VERSION.SdkInt >= BuildVersionCodes.M // ActionButton was introduced with API 23 (https://developer.android.com/reference/android/view/MotionEvent.html#getActionButton())
+				&& updates.TryGetValue(_nativeEvent.ActionButton, out var update))
 			{
 				props.PointerUpdateKind = update;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8702

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
Pointer events lead to crashing apps under Android prior to SDK 23.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Works

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
