### PR TITLE
fix: Reduce logging verbosity for remote control connection errors

### DIFF
--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -192,9 +192,16 @@ namespace Uno.UI.RemoteControl
 			}
 			catch (Exception ex)
 			{
-				if (this.Log().IsEnabled(LogLevel.Error))
+				if (this.Log().IsEnabled(LogLevel.Warning))
 				{
-					this.Log().LogError($"Failed to connect to the server ({ex})", ex);
+					if (this.Log().IsEnabled(LogLevel.Debug))
+					{
+						this.Log().LogDebug($"Failed to connect to the server ({ex})", ex);
+					}
+					else
+					{
+						this.Log().LogWarning($"The remote control client failed to initialize ({ex.Message}). This generally means that XAML Hot Reload will not be available for this session.");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Remote Control errors will now be less verbose when debug logging is not enabled.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
