### PR TITLE
chore: Remove the need to automatically merge PR's from allcontributors bot

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,10 +30,3 @@ pull_request_rules:
         method: merge
         # https://doc.mergify.io/strict-workflow.html
         # https://doc.mergify.io/actions.html#label
-
-  - name: automatic merge for allcontributors pull requests
-    conditions:
-      - author=allcontributors[bot]
-    actions:
-      merge:
-        method: merge


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Other: Clean up for automation

## Description

Remove the need to automatically merge PR's from allcontributors bot

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

