### PR TITLE
WASM `Storage.Pickers` improvements

### DIFF
--- a/src/Uno.UI.Runtime.WebAssembly/Storage/Pickers/PickerSupportInformation.cs
+++ b/src/Uno.UI.Runtime.WebAssembly/Storage/Pickers/PickerSupportInformation.cs
@@ -1,0 +1,33 @@
+﻿using Windows.Storage.Pickers;
+
+namespace Uno.Storage.Pickers;
+
+/// <summary>
+/// Provides information about the runtime support for storage pickers on WebAssembly.
+/// </summary>
+public static class FileSystemAccessApiInformation
+{
+	/// <summary>
+	/// Checks whether the File System Access API file open picker is available.
+	/// </summary>
+	/// <returns>A value indicating whether the picker is supported.</returns>
+	public static bool IsOpenPickerSupported => FileOpenPicker.IsNativePickerSupported();
+
+	/// <summary>
+	/// Checks whether the File System Access API file save picker is available.
+	/// </summary>
+	/// <returns>A value indicating whether the picker is supported.</returns>
+	public static bool IsSavePickerSupported => FileSavePicker.IsNativePickerSupported();
+
+	/// <summary>
+	/// Checks whether both file open and file save pickers from the File System Access API are available.
+	/// </summary>
+	/// <returns>A value indicating whether the picker is supported.</returns>
+	public static bool AreFilePickersSupported => IsOpenPickerSupported && IsSavePickerSupported;
+
+	/// <summary>
+	/// Checks whether the File System Access API folder open picker is available.
+	/// </summary>
+	/// <returns>A value indicating whether the picker is supported.</returns>
+	public static bool IsFolderPickerSupported => FolderPicker.IsNativePickerSupported();
+}

--- a/src/Uno.UWP/AssemblyInfo.cs
+++ b/src/Uno.UWP/AssemblyInfo.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("Uno.UI")]
 [assembly: InternalsVisibleTo("Uno.UI.Wasm")]
+[assembly: InternalsVisibleTo("Uno.UI.Runtime.WebAssembly")]
 [assembly: InternalsVisibleTo("Uno.UI.RuntimeTests")]
 [assembly: InternalsVisibleTo("Uno.UI.Tests")]
 [assembly: InternalsVisibleTo("Uno.UI.Toolkit")]

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
@@ -19,6 +19,12 @@ namespace Windows.Storage.Pickers
 	{
 		private const string JsType = "Windows.Storage.Pickers.FileOpenPicker";
 
+		internal static bool IsNativePickerSupported()
+		{
+			var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
+			return bool.TryParse(isSupportedString, out var isSupported) && isSupported;
+		}
+
 		private async Task<StorageFile?> PickSingleFileTaskAsync(CancellationToken token)
 		{
 			var files = await PickFilesAsync(false, token);
@@ -48,12 +54,6 @@ namespace Windows.Storage.Pickers
 			}
 
 			throw new NotSupportedException("Could not handle the request using any picker implementation.");
-		}
-
-		private bool IsNativePickerSupported()
-		{
-			var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
-			return bool.TryParse(isSupportedString, out var isSupported) && isSupported;
 		}
 
 		private async Task<FilePickerSelectedFilesArray> NativePickerPickFilesAsync(bool multiple, CancellationToken token)

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.wasm.cs
@@ -19,10 +19,17 @@ namespace Windows.Storage.Pickers
 	{
 		private const string JsType = "Windows.Storage.Pickers.FileOpenPicker";
 
+		private static bool? _fileSystemAccessApiSupported;
+
 		internal static bool IsNativePickerSupported()
 		{
-			var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
-			return bool.TryParse(isSupportedString, out var isSupported) && isSupported;
+			if (_fileSystemAccessApiSupported is null)
+			{
+				var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
+				_fileSystemAccessApiSupported = bool.TryParse(isSupportedString, out var isSupported) && isSupported;
+			}
+
+			return _fileSystemAccessApiSupported.Value;
 		}
 
 		private async Task<StorageFile?> PickSingleFileTaskAsync(CancellationToken token)

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
@@ -19,10 +19,17 @@ namespace Windows.Storage.Pickers
 	{
 		private const string JsType = "Windows.Storage.Pickers.FileSavePicker";
 
+		private static bool? _fileSystemAccessApiSupported;
+
 		internal static bool IsNativePickerSupported()
 		{
-			var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
-			return bool.TryParse(isSupportedString, out var isSupported) && isSupported;
+			if (_fileSystemAccessApiSupported is null)
+			{
+				var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
+				_fileSystemAccessApiSupported = bool.TryParse(isSupportedString, out var isSupported) && isSupported;
+			}
+
+			return _fileSystemAccessApiSupported.Value;
 		}
 
 		private async Task<StorageFile?> PickSaveFileTaskAsync(CancellationToken token)

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.wasm.cs
@@ -19,6 +19,12 @@ namespace Windows.Storage.Pickers
 	{
 		private const string JsType = "Windows.Storage.Pickers.FileSavePicker";
 
+		internal static bool IsNativePickerSupported()
+		{
+			var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
+			return bool.TryParse(isSupportedString, out var isSupported) && isSupported;
+		}
+
 		private async Task<StorageFile?> PickSaveFileTaskAsync(CancellationToken token)
 		{
 			var fileSystemAccessApiEnabled = WinRTFeatureConfiguration.Storage.Pickers.WasmConfiguration
@@ -37,12 +43,6 @@ namespace Windows.Storage.Pickers
 			}
 
 			throw new NotSupportedException("Could not handle the request using any picker implementation.");
-		}
-
-		private bool IsNativePickerSupported()
-		{
-			var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
-			return bool.TryParse(isSupportedString, out var isSupported) && isSupported;
 		}
 
 		private async Task<StorageFile?> NativePickerPickSaveFileAsync(CancellationToken token)

--- a/src/Uno.UWP/Storage/Pickers/FolderPicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPicker.wasm.cs
@@ -14,10 +14,17 @@ namespace Windows.Storage.Pickers
 	{
 		private const string JsType = "Windows.Storage.Pickers.FolderPicker";
 
+		private static bool? _fileSystemAccessApiSupported;
+
 		internal static bool IsNativePickerSupported()
 		{
-			var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
-			return bool.TryParse(isSupportedString, out var isSupported) && isSupported;
+			if (_fileSystemAccessApiSupported is null)
+			{
+				var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
+				_fileSystemAccessApiSupported = bool.TryParse(isSupportedString, out var isSupported) && isSupported;
+			}
+
+			return _fileSystemAccessApiSupported.Value;
 		}
 
 		private async Task<StorageFolder?> PickSingleFolderTaskAsync(CancellationToken token)

--- a/src/Uno.UWP/Storage/Pickers/FolderPicker.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPicker.wasm.cs
@@ -14,6 +14,12 @@ namespace Windows.Storage.Pickers
 	{
 		private const string JsType = "Windows.Storage.Pickers.FolderPicker";
 
+		internal static bool IsNativePickerSupported()
+		{
+			var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
+			return bool.TryParse(isSupportedString, out var isSupported) && isSupported;
+		}
+
 		private async Task<StorageFolder?> PickSingleFolderTaskAsync(CancellationToken token)
 		{
 			if (!IsNativePickerSupported())
@@ -35,12 +41,6 @@ namespace Windows.Storage.Pickers
 			var info = JsonHelper.Deserialize<NativeStorageItemInfo>(pickedFolderJson);
 
 			return StorageFolder.GetFromNativeInfo(info, null);
-		}
-
-		private bool IsNativePickerSupported()
-		{
-			var isSupportedString = WebAssemblyRuntime.InvokeJS($"{JsType}.isNativeSupported()");
-			return bool.TryParse(isSupportedString, out var isSupported) && isSupported;
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Feature
- Documentation content changes

## What is the current behavior?

- There is no API to detect whether WASM File System Access API is available
- Docs don't explain `CachedFileManager` well

## What is the new behavior?

- API added
- Docs improved

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
