### PR TITLE
feat: Avoid using Skia Host constructors with args

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia.Gtk/Program.cs
+++ b/src/SamplesApp/SamplesApp.Skia.Gtk/Program.cs
@@ -19,7 +19,7 @@ namespace SkiaSharpExample
 				expArgs.ExitApplication = true;
 			};
 
-			var host = new GtkHost(() => new SamplesApp.App(), args);
+			var host = new GtkHost(() => new SamplesApp.App());
 
 			SampleControl.Presentation.SampleChooserViewModel.TakeScreenShot = filePath => host.TakeScreenshot(filePath);
 

--- a/src/SamplesApp/SamplesApp.Skia.Tizen/App.cs
+++ b/src/SamplesApp/SamplesApp.Skia.Tizen/App.cs
@@ -12,7 +12,7 @@ namespace SamplesApp.Skia.Tizen
 	{
 		static void Main(string[] args)
 		{
-			var host = new TizenHost(() => new SamplesApp.App(), args);
+			var host = new TizenHost(() => new SamplesApp.App());
 			host.Run();
 		}
 	}

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Gtk/Program.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Gtk/Program.cs
@@ -14,7 +14,7 @@ namespace $ext_safeprojectname$.Skia.Gtk
 				expArgs.ExitApplication = true;
 			};
 
-			var host = new GtkHost(() => new App(), args);
+			var host = new GtkHost(() => new App());
 
 			host.Run();
 		}

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Linux.FrameBuffer/Program.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Linux.FrameBuffer/Program.cs
@@ -11,7 +11,7 @@ namespace $ext_safeprojectname$
 			{
 				Console.CursorVisible = false;
 
-				var host = new FrameBufferHost(() => new App(), args);
+				var host = new FrameBufferHost(() => new App());
 				host.Run();
 			}
 			finally

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.Gtk/Program.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.Gtk/Program.cs
@@ -14,7 +14,7 @@ namespace $ext_safeprojectname$.Skia.Gtk
 				expArgs.ExitApplication = true;
 			};
 
-			var host = new GtkHost(() => new App(), args);
+			var host = new GtkHost(() => new App());
 
 			host.Run();
 		}

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.Linux.FrameBuffer/Program.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Skia.Linux.FrameBuffer/Program.cs
@@ -11,7 +11,7 @@ namespace $ext_safeprojectname$
 			{
 				Console.CursorVisible = false;
 
-				var host = new FrameBufferHost(() => new App(), args);
+				var host = new FrameBufferHost(() => new App());
 				host.Run();
 			}
 			finally

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.Gtk/Program.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.Gtk/Program.cs
@@ -14,7 +14,7 @@ namespace $ext_safeprojectname$.Skia.Gtk
 				expArgs.ExitApplication = true;
 			};
 
-			var host = new GtkHost(() => new App(), args);
+			var host = new GtkHost(() => new App());
 
 			host.Run();
 		}

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.Linux.FrameBuffer/Program.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.Linux.FrameBuffer/Program.cs
@@ -11,7 +11,7 @@ namespace $ext_safeprojectname$
 			{
 				Console.CursorVisible = false;
 
-				var host = new FrameBufferHost(() => new App(), args);
+				var host = new FrameBufferHost(() => new App());
 				host.Run();
 			}
 			finally

--- a/src/SolutionTemplate/UnoSolutionTemplate/Skia.Tizen/Program.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Skia.Tizen/Program.cs
@@ -7,7 +7,7 @@ namespace $ext_safeprojectname$.Skia.Tizen
 {
 	static void Main(string[] args)
 	{
-		var host = new TizenHost(() => new $ext_safeprojectname$.App(), args);
+		var host = new TizenHost(() => new $ext_safeprojectname$.App());
 		host.Run();
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -31,6 +31,7 @@ using Uno.UI.Runtime.Skia.GTK.System.Profile;
 using Uno.UI.Runtime.Skia.Helpers;
 using Uno.UI.Runtime.Skia.Helpers.Dpi;
 using System.Runtime.InteropServices;
+using System.ComponentModel;
 
 namespace Uno.UI.Runtime.Skia
 {
@@ -57,16 +58,21 @@ namespace Uno.UI.Runtime.Skia
 		/// <remarks>If <c>null</c>, the host will try to determine the most compatible mode.</remarks>
 		public RenderSurfaceType? RenderSurfaceType { get; set; }
 
-		/// <summary>
-		/// Creates a host for a Uno Skia GTK application.
-		/// </summary>
-		/// <param name="appBuilder">App builder.</param>
-		/// <param name="args">Deprecated, value ignored.</param>
-		/// <remarks>
-		/// Args are obsolete and will be removed in the future. Environment.CommandLine is used instead
-		/// to fill LaunchEventArgs.Arguments.
-		/// </remarks>
-		public GtkHost(Func<WUX.Application> appBuilder, string[] args)
+        /// <summary>
+        /// Creates a host for a Uno Skia GTK application.
+        /// </summary>
+        /// <param name="appBuilder">App builder.</param>
+        /// <param name="args">Deprecated, value ignored.</param>
+        /// <remarks>
+        /// Args are obsolete and will be removed in the future. Environment.CommandLine is used instead
+        /// to fill LaunchEventArgs.Arguments.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+		public GtkHost(Func<WUX.Application> appBuilder, string[] args) : this(appBuilder)
+		{
+		}
+
+		public GtkHost(Func<WUX.Application> appBuilder)
 		{
 			_appBuilder = appBuilder;
 		}

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
@@ -5,6 +5,7 @@ using WUX = Windows.UI.Xaml;
 using Uno.WinUI.Runtime.Skia.LinuxFB;
 using Windows.UI.Core;
 using Uno.Foundation.Extensibility;
+using System.ComponentModel;
 
 namespace Uno.UI.Runtime.Skia
 {
@@ -27,7 +28,12 @@ namespace Uno.UI.Runtime.Skia
 		/// Args are obsolete and will be removed in the future. Environment.CommandLine is used instead
 		/// to fill LaunchEventArgs.Arguments.
 		/// </remarks>
-		public FrameBufferHost(Func<WUX.Application> appBuilder, string[] args)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public FrameBufferHost(Func<WUX.Application> appBuilder, string[] args) : this(appBuilder)
+		{
+		}
+
+		public FrameBufferHost(Func<WUX.Application> appBuilder)
 		{
 			_appBuilder = appBuilder;
 

--- a/src/Uno.UI.Runtime.Skia.Tizen/TizenHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/TizenHost.cs
@@ -33,6 +33,7 @@ using Uno.UI.Runtime.Skia.Tizen.ApplicationModel.DataTransfer;
 using Uno.UI.Runtime.Skia.Tizen.System;
 using Uno.Extensions.System;
 using Windows.System.Profile.Internal;
+using System.ComponentModel;
 
 namespace Uno.UI.Runtime.Skia
 {
@@ -51,8 +52,13 @@ namespace Uno.UI.Runtime.Skia
 		/// Creates a host for a Uno Skia Tizen application.
 		/// </summary>
 		/// <param name="appBuilder">App builder.</param>
-		/// <param name="args">Arguments.</param>		
-		public TizenHost(Func<WinUI.Application> appBuilder, string[]? args = null)
+		/// <param name="args">Arguments.</param>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public TizenHost(Func<WinUI.Application> appBuilder, string[]? args = null) : this(appBuilder)
+		{
+		}
+		
+		public TizenHost(Func<WinUI.Application> appBuilder)
 		{
 			Elementary.Initialize();
 			Elementary.ThemeOverlay();

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -91,7 +91,12 @@ namespace Uno.UI.Skia.Platform
 		/// Args are obsolete and will be removed in the future. Environment.CommandLine is used instead
 		/// to fill LaunchEventArgs.Arguments.
 		/// </remarks>
-		public WpfHost(global::System.Windows.Threading.Dispatcher dispatcher, Func<WinUI.Application> appBuilder, string[] args = null)
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public WpfHost(global::System.Windows.Threading.Dispatcher dispatcher, Func<WinUI.Application> appBuilder, string[] args = null) : this(dispatcher, appBuilder)
+		{
+		}
+		
+		public WpfHost(global::System.Windows.Threading.Dispatcher dispatcher, Func<WinUI.Application> appBuilder)
 		{
 			_current = this;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Args are ignored in Skia targets, avoid using host constructors with args.

## What is the new behavior?

Not used


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
