### PR TITLE
fix: Adjust net6-winui dotnet new

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/.template.config/template.json
@@ -165,15 +165,15 @@
     },
     {
       "condition": "skia-gtk",
-      "path": "UnoWinUIQuickStart.macOS\\UnoWinUIQuickStart.Skia.Gtk.csproj"
+      "path": "UnoWinUIQuickStart.Skia.Gtk\\UnoWinUIQuickStart.Skia.Gtk.csproj"
     },
     {
       "condition": "skia-wpf",
-      "path": "UnoWinUIQuickStart.macOS\\UnoWinUIQuickStart.Skia.WPF.csproj"
+      "path": "UnoWinUIQuickStart.Skia.WPF\\UnoWinUIQuickStart.Skia.WPF.csproj"
     },
     {
       "condition": "skia-wpf",
-      "path": "UnoWinUIQuickStart.macOS\\UnoWinUIQuickStart.Skia.WPF.Host.csproj"
+      "path": "UnoWinUIQuickStart.Skia.WPF.Host\\UnoWinUIQuickStart.Skia.WPF.Host.csproj"
     }
   ],
   "sources": [


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/8775

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes invalid `dotnet new unoapp-winui-net6` restore targets

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
