### PR TITLE
fix: Add FrameworkReference to winui projects

### DIFF
--- a/doc/articles/features/winapp-sdk-specifics.md
+++ b/doc/articles/features/winapp-sdk-specifics.md
@@ -1,4 +1,36 @@
-# Specific considerations for WinAppSDK 
+# Specific considerations for WinAppSDK
+
+## Adjusting Windows SDK References
+
+When building a WinUI3 app, you may encounter the following error message:
+
+```
+error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.
+```
+
+This indicates that your application, or current .NET SDK is using a version of the Windows .NET SDK which is lower than the SDKs used to compile any of your projects dependent nuget packages.
+
+To fix this, find or add the following block in your Windows `.csproj` file:
+```xml
+<ItemGroup>
+    <!--
+	If you encounter this error message:
+		
+		error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.
+
+	This means that the two packages below must be aligned with the "build" version number of
+	the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
+	must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
+	-->
+
+	<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
+	<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+</ItemGroup>
+```
+
+To find the appropriate version:
+- The two `FrameworkReference` packages must be aligned with the "build" version number (`22000` in the example above) of the "Microsoft.Windows.SDK.BuildTools" package defined earlier in the project
+- The "revision" version number (`25` in the example above) must be the highest found in the versions of https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
 
 ## Unpackaged application support
 By default the **Uno Platform App** Visual Studio template creates a packaged application. If you want to add unpackaged support, you'll need to do the following:

--- a/doc/articles/get-started-wizard.md
+++ b/doc/articles/get-started-wizard.md
@@ -42,6 +42,10 @@ Event handlers [cannot be automatically](https://github.com/unoplatform/uno/issu
 
 A workaround is to use the [`x:Bind` to events feature](features/windows-ui-xaml-xbind.md#examples). This feature allows to use a simpler syntax like `<Button Click="{x:Bind MyClick}" />` and declare a simple method `private void MyClick() { }` in the code-behind.
 
+#### error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
+
+See [this article](features/winapp-sdk-specifics.md#adjusting-windows-sdk-references) to solve this issue.
+
 #### Build error `Failed to generate AOT layout`
 
 When building for WebAssembly with AOT mode enabled, the following error may appear:

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows/UnoWinUIQuickStart.Windows.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui-net6/UnoWinUIQuickStart.Windows/UnoWinUIQuickStart.Windows.csproj
@@ -45,5 +45,19 @@
 		<ProjectCapability Include="Msix"/>
 	</ItemGroup>
 
+	<ItemGroup>
+		<!--
+		If you encounter this error message:
+		
+			error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.
+
+		This means that the two packages below must be aligned with the "build" version number of
+		the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
+		must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
+		-->
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+	</ItemGroup>
+
 	<Import Project="..\UnoWinUIQuickStart.Shared\UnoWinUIQuickStart.Shared.projitems" Label="Shared" />
 </Project>

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/WinUI/UnoQuickStart.Windows.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/WinUI/UnoQuickStart.Windows.csproj
@@ -37,6 +37,20 @@
 	<ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
 		<ProjectCapability Include="Msix"/>
 	</ItemGroup>
+	
+	<ItemGroup>
+		<!--
+		If you encounter this error message:
+		
+			error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.
 
+		This means that the two packages below must be aligned with the "build" version number of
+		the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
+		must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
+		-->
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.25" />
+		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.25" />
+	</ItemGroup>
+	
 	<Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adds in-projects hints to fix this error message:

```
error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll. Please update to a newer .NET SDK in order to reference this assembly.
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
