### PR TITLE
ci: Split iOS runtime tests in groups for faster retries

### DIFF
--- a/build/ci/.azure-devops-ios-tests-run.yml
+++ b/build/ci/.azure-devops-ios-tests-run.yml
@@ -146,7 +146,7 @@ jobs:
     condition: always()
     inputs:
       testResultsFiles: '$(build.sourcesdirectory)/build/RuntimeTestResults*.xml'
-      testRunTitle: 'iOS Runtime Tests Run'
+      testRunTitle: 'iOS Runtime Tests Run ($(Agent.JobName))'
       testResultsFormat: 'NUnit'
       failTaskOnFailedTests: true
 

--- a/build/ci/.azure-devops-ios-tests-run.yml
+++ b/build/ci/.azure-devops-ios-tests-run.yml
@@ -98,6 +98,8 @@ jobs:
       UITEST_SNAPSHOTS_ONLY: "${{ parameters.UITEST_SNAPSHOTS_ONLY }}"
       UITEST_SNAPSHOTS_GROUP: "${{ parameters.UITEST_SNAPSHOTS_GROUP }}"
       UITEST_AUTOMATED_GROUP: "${{ parameters.UITEST_AUTOMATED_GROUP }}"
+      UITEST_RUNTIME_TEST_GROUP: "${{ parameters.UITEST_RUNTIME_TEST_GROUP }}"
+      UITEST_RUNTIME_TEST_GROUP_COUNT: "${{ parameters.UITEST_RUNTIME_TEST_GROUP_COUNT }}"
       UITEST_TEST_TIMEOUT: "${{ parameters.UITEST_TEST_TIMEOUT }}"
       UNO_UITEST_IOSBUNDLE_PATH: "$(build.sourcesdirectory)/build/ios-uitest-build/SamplesApp.app"
 
@@ -125,6 +127,8 @@ jobs:
       UITEST_SNAPSHOTS_ONLY: "${{ parameters.UITEST_SNAPSHOTS_ONLY }}"
       UITEST_SNAPSHOTS_GROUP: "${{ parameters.UITEST_SNAPSHOTS_GROUP }}"
       UITEST_AUTOMATED_GROUP: "${{ parameters.UITEST_AUTOMATED_GROUP }}"
+      UITEST_RUNTIME_TEST_GROUP: "${{ parameters.UITEST_RUNTIME_TEST_GROUP }}"
+      UITEST_RUNTIME_TEST_GROUP_COUNT: "${{ parameters.UITEST_RUNTIME_TEST_GROUP_COUNT }}"
       UITEST_TEST_TIMEOUT: "${{ parameters.UITEST_TEST_TIMEOUT }}"
       UNO_UITEST_IOSBUNDLE_PATH: "$(build.sourcesdirectory)/build/ios-uitest-build/SamplesApp.app"
 

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -102,6 +102,9 @@ jobs:
     xCodeRoot: ${{ parameters.xCodeRootTest }}
     XamarinSDKVersion: ${{ parameters.XamarinSDKVersionTest }}
 
+##
+## Runtime tests
+##
 - template: .azure-devops-ios-tests-run.yml
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
@@ -112,6 +115,40 @@ jobs:
     UITEST_SNAPSHOTS_ONLY: false
     UITEST_TEST_TIMEOUT: '3600000'
     UITEST_AUTOMATED_GROUP: 4
+    UITEST_RUNTIME_TEST_GROUP: 0
+    UITEST_RUNTIME_TEST_GROUP_COUNT: 3
+    UITEST_ALLOW_RERUN: 'false'
+    xCodeRoot: ${{ parameters.xCodeRootTest }}
+    XamarinSDKVersion: ${{ parameters.XamarinSDKVersionTest }}
+
+- template: .azure-devops-ios-tests-run.yml
+  parameters:
+    nugetPackages: $(NUGET_PACKAGES)
+    JobName: 'iOS_Automated_Tests_Runtime_Tests'
+    JobDisplayName: 'iOS Automated Runtime Tests'
+    JobTimeoutInMinutes: 60
+    vmImage: ${{ parameters.vmImageTest }}
+    UITEST_SNAPSHOTS_ONLY: false
+    UITEST_TEST_TIMEOUT: '3600000'
+    UITEST_AUTOMATED_GROUP: 4
+    UITEST_RUNTIME_TEST_GROUP: 1
+    UITEST_RUNTIME_TEST_GROUP_COUNT: 3
+    UITEST_ALLOW_RERUN: 'false'
+    xCodeRoot: ${{ parameters.xCodeRootTest }}
+    XamarinSDKVersion: ${{ parameters.XamarinSDKVersionTest }}
+
+- template: .azure-devops-ios-tests-run.yml
+  parameters:
+    nugetPackages: $(NUGET_PACKAGES)
+    JobName: 'iOS_Automated_Tests_Runtime_Tests'
+    JobDisplayName: 'iOS Automated Runtime Tests'
+    JobTimeoutInMinutes: 60
+    vmImage: ${{ parameters.vmImageTest }}
+    UITEST_SNAPSHOTS_ONLY: false
+    UITEST_TEST_TIMEOUT: '3600000'
+    UITEST_AUTOMATED_GROUP: 4
+    UITEST_RUNTIME_TEST_GROUP: 2
+    UITEST_RUNTIME_TEST_GROUP_COUNT: 3
     UITEST_ALLOW_RERUN: 'false'
     xCodeRoot: ${{ parameters.xCodeRootTest }}
     XamarinSDKVersion: ${{ parameters.XamarinSDKVersionTest }}

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -109,7 +109,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Runtime_Tests_group_0'
-    JobDisplayName: 'iOS Automated Runtime Tests (group 0)'
+    JobDisplayName: 'iOS Automated Runtime Tests Group 0'
     JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -125,7 +125,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Runtime_Tests_group_1'
-    JobDisplayName: 'iOS Automated Runtime Tests (group 1)'
+    JobDisplayName: 'iOS Automated Runtime Tests Group 1'
     JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -141,7 +141,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Runtime_Tests_group_2'
-    JobDisplayName: 'iOS Automated Runtime Tests (group 2)'
+    JobDisplayName: 'iOS Automated Runtime Tests Group 2'
     JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -108,8 +108,8 @@ jobs:
 - template: .azure-devops-ios-tests-run.yml
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
-    JobName: 'iOS_Automated_Tests_Runtime_Tests'
-    JobDisplayName: 'iOS Automated Runtime Tests'
+    JobName: 'iOS_Automated_Tests_Runtime_Tests_group_0'
+    JobDisplayName: 'iOS Automated Runtime Tests (group 0)'
     JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -124,8 +124,8 @@ jobs:
 - template: .azure-devops-ios-tests-run.yml
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
-    JobName: 'iOS_Automated_Tests_Runtime_Tests'
-    JobDisplayName: 'iOS Automated Runtime Tests'
+    JobName: 'iOS_Automated_Tests_Runtime_Tests_group_1'
+    JobDisplayName: 'iOS Automated Runtime Tests (group 1)'
     JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -140,8 +140,8 @@ jobs:
 - template: .azure-devops-ios-tests-run.yml
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
-    JobName: 'iOS_Automated_Tests_Runtime_Tests'
-    JobDisplayName: 'iOS Automated Runtime Tests'
+    JobName: 'iOS_Automated_Tests_Runtime_Tests_group_2'
+    JobDisplayName: 'iOS Automated Runtime Tests (group 2)'
     JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -83,7 +83,7 @@ export UNO_UITEST_PLATFORM=iOS
 export UNO_UITEST_SCREENSHOT_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/screenshots/$SCREENSHOTS_FOLDERNAME
 
 export UNO_ORIGINAL_TEST_RESULTS=$BUILD_SOURCESDIRECTORY/build/TestResult-original.xml
-export UNO_TESTS_FAILED_LIST=$BUILD_SOURCESDIRECTORY/build/uitests-failure-results/failed-tests-ios-$SCREENSHOTS_FOLDERNAME-${UITEST_SNAPSHOTS_GROUP=automated}-${UITEST_AUTOMATED_GROUP=automated}.txt
+export UNO_TESTS_FAILED_LIST=$BUILD_SOURCESDIRECTORY/build/uitests-failure-results/failed-tests-ios-$SCREENSHOTS_FOLDERNAME-${UITEST_SNAPSHOTS_GROUP=automated}-${UITEST_AUTOMATED_GROUP=automated}-${UITEST_RUNTIME_TEST_GROUP=automated}.txt
 export UNO_TESTS_RESPONSE_FILE=$BUILD_SOURCESDIRECTORY/build/nunit.response
 export UNO_TESTS_LOCAL_TESTS_FILE=$BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.UITests/bin/Release/SamplesApp.UITests.dll
 export UNO_UITEST_BENCHMARKS_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/benchmarks/ios-automated
@@ -168,7 +168,7 @@ date
 # export the simulator logs
 export LOG_FILEPATH=$UNO_UITEST_SCREENSHOT_PATH/_logs
 export TMP_LOG_FILEPATH=/tmp/DeviceLog-`date +"%Y%m%d%H%M%S"`.logarchive
-export LOG_FILEPATH_FULL=$LOG_FILEPATH/DeviceLog-$UITEST_AUTOMATED_GROUP-`date +"%Y%m%d%H%M%S"`.txt
+export LOG_FILEPATH_FULL=$LOG_FILEPATH/DeviceLog-$UITEST_AUTOMATED_GROUP-${UITEST_RUNTIME_TEST_GROUP=automated}-`date +"%Y%m%d%H%M%S"`.txt
 
 mkdir -p $LOG_FILEPATH
 xcrun simctl spawn booted log collect --output $TMP_LOG_FILEPATH

--- a/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/RuntimeTests.cs
@@ -22,6 +22,8 @@ namespace SamplesApp.UITests.Runtime
 		private readonly TimeSpan TestRunTimeout = TimeSpan.FromMinutes(2);
 		private const string TestResultsOutputFilePath = "UNO_UITEST_RUNTIMETESTS_RESULTS_FILE_PATH";
 		private const string TestResultsOutputTempFilePath = "UNO_UITEST_RUNTIMETESTS_RESULTS_TEMP_FILE_PATH";
+		private const string TestGroupVariable = "UITEST_RUNTIME_TEST_GROUP";
+		private const string TestGroupCountVariable = "UITEST_RUNTIME_TEST_GROUP_COUNT";
 
 		[Test]
 		[AutoRetry(tryCount: 1)]
@@ -50,6 +52,13 @@ namespace SamplesApp.UITests.Runtime
 			{
 				// Used to disable showing the test output visually
 				unitTestsControl.SetDependencyPropertyValue("IsRunningOnCI", "true");
+
+				// Used to perform test grouping on CI to reduce the impact of re-runs
+				if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(TestGroupVariable)))
+				{
+					unitTestsControl.SetDependencyPropertyValue("CITestGroup", Environment.GetEnvironmentVariable(TestGroupVariable));
+					unitTestsControl.SetDependencyPropertyValue("CITestGroupCount", Environment.GetEnvironmentVariable(TestGroupCountVariable));
+				}
 			}
 
 			_app.FastTap(runButton);

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -128,7 +128,7 @@ namespace Uno.UI.Samples.Tests
 		}
 
 		public static readonly DependencyProperty CITestGroupProperty =
-			DependencyProperty.Register("CITestGroup", typeof(bool), typeof(UnitTestsControl), new PropertyMetadata(-1));
+			DependencyProperty.Register("CITestGroup", typeof(int), typeof(UnitTestsControl), new PropertyMetadata(-1));
 
 		/// <summary>
 		/// Defines the test group for splitting runtime tests on CI
@@ -140,7 +140,7 @@ namespace Uno.UI.Samples.Tests
 		}
 
 		public static readonly DependencyProperty CITestGroupCountProperty =
-			DependencyProperty.Register("CITestGroupCount", typeof(bool), typeof(UnitTestsControl), new PropertyMetadata(-1));
+			DependencyProperty.Register("CITestGroupCount", typeof(int), typeof(UnitTestsControl), new PropertyMetadata(-1));
 
 		public string NUnitTestResultsDocument
 		{

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -919,13 +919,13 @@ namespace Uno.UI.Samples.Tests
 
 		private static SHA1 _sha1 = SHA1.Create();
 
-		private ulong GetTypeTestGroup(Type type)
+		private int GetTypeTestGroup(Type type)
 		{
 			// Compute a stable hash of the full metadata name
 			var buffer = Encoding.UTF8.GetBytes(type.FullName);
 			var hash = _sha1.ComputeHash(buffer);
 
-			return BitConverter.ToUInt64(hash, 0);
+			return (int)BitConverter.ToUInt64(hash, 0);
 		}
 
 		private static UnitTestClassInfo BuildType(Type type)


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/8167

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Splits iOS runtime tests in smaller groups to make retries faster. This is needed because of the iOS issue https://github.com/unoplatform/uno/issues/8167.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
