### PR TITLE
fix(net6): Restore partial support for MUX progressring

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSource.iOSmacOS.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSource.iOSmacOS.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 	partial class LottieVisualSourceBase
 	{
 #if !__MACOS__
-		private NativeProgressRing? _nativeProgressRing;
+		private BindableUIActivityIndicatorView? _nativeProgressRing;
 		private IDisposable? _colorDisposable;
 #endif
 
@@ -299,7 +299,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 #if !__MACOS__
 			if (_player?.TemplatedParent is Microsoft.UI.Xaml.Controls.ProgressRing progress)
 			{
-				_nativeProgressRing ??= new NativeProgressRing();
+				_nativeProgressRing ??= new BindableUIActivityIndicatorView();
 
 #if __IOS__
 				_player?.Add(_nativeProgressRing);

--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSource.iOSmacOS.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSource.iOSmacOS.cs
@@ -228,17 +228,23 @@ using Windows.UI.Xaml.Controls;
 using Foundation;
 using System.Threading.Tasks;
 using Uno.Disposables;
-using Uno.UI.Views.Controls;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml;
 using Uno.Foundation.Logging;
+
+#if !__MACOS__
+using Uno.UI.Views.Controls;
+#endif
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie
 {
 	partial class LottieVisualSourceBase
 	{
+#if !__MACOS__
 		private NativeProgressRing? _nativeProgressRing;
 		private IDisposable? _colorDisposable;
+#endif
+
 		private bool _warnOnce;
 
 		public bool UseHardwareAcceleration { get; set; } = true;
@@ -249,18 +255,22 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
 		public void Play(double fromProgress, double toProgress, bool looped)
 		{
+#if !__MACOS__
 			if (_nativeProgressRing != null)
 			{
 				_nativeProgressRing.StartAnimating();
 			}
+#endif
 		}
 
 		public void Stop()
 		{
+#if !__MACOS__
 			if (_nativeProgressRing != null)
 			{
 				_nativeProgressRing.StopAnimating();
 			}
+#endif
 		}
 
 		public void Pause()
@@ -286,6 +296,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
 		private bool TryLoadProgressRing()
 		{
+#if !__MACOS__
 			if (_player?.TemplatedParent is Microsoft.UI.Xaml.Controls.ProgressRing progress)
 			{
 				_nativeProgressRing ??= new NativeProgressRing();
@@ -313,12 +324,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
 				return true;
 			}
+#endif
 
 			return false;
 		}
 
 		public void Unload()
 		{
+#if !__MACOS__
 			if (_player?.TemplatedParent is Microsoft.UI.Xaml.Controls.ProgressRing progress)
 			{
 				_colorDisposable?.Dispose();
@@ -326,6 +339,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 				_nativeProgressRing?.RemoveFromSuperview();
 				_nativeProgressRing = null;
 			}
+#endif
 		}
 
 		private Size CompositionSize => default;

--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSource.iOSmacOS.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSource.iOSmacOS.cs
@@ -231,6 +231,7 @@ using Uno.Disposables;
 using Uno.UI.Views.Controls;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml;
+using Uno.Foundation.Logging;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie
 {
@@ -238,6 +239,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 	{
 		private NativeProgressRing? _nativeProgressRing;
 		private IDisposable? _colorDisposable;
+		private bool _warnOnce;
 
 		public bool UseHardwareAcceleration { get; set; } = true;
 
@@ -275,6 +277,15 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
 		public void Load()
 		{
+			if (!TryLoadProgressRing() && !_warnOnce)
+			{
+				_warnOnce = true;
+				this.Log().Warn("LottieVisualSource is not available on this platform. See https://github.com/mono/SkiaSharp/issues/1787");
+			}
+		}
+
+		private bool TryLoadProgressRing()
+		{
 			if (_player?.TemplatedParent is Microsoft.UI.Xaml.Controls.ProgressRing progress)
 			{
 				_nativeProgressRing ??= new NativeProgressRing();
@@ -299,7 +310,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 				_colorDisposable = progress.RegisterDisposablePropertyChangedCallback(Microsoft.UI.Xaml.Controls.ProgressRing.ForegroundProperty, UpdateColorCallback);
 
 				UpdateColor();
+
+				return true;
 			}
+
+			return false;
 		}
 
 		public void Unload()

--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.Android.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.Android.cs
@@ -282,6 +282,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 		private double _toProgress;
 		private bool _looped;
 		private IDisposable? _colorDisposable;
+		private bool _warnOnce;
 
 		public bool UseHardwareAcceleration { get; set; } = true;
 
@@ -329,7 +330,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
 		public void Load()
 		{
-			TryLoadProgressRing();
+			if(!TryLoadProgressRing()&& !_warnOnce)
+			{
+				_warnOnce = true;
+				this.Log().Warn("LottieVisualSource is not available on this platform. See https://github.com/mono/SkiaSharp/issues/1787");
+			}
 		}
 
 		public void Unload()
@@ -337,7 +342,7 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 			TryUnloadProgressRing();
 		}
 
-		private void TryLoadProgressRing()
+		private bool TryLoadProgressRing()
 		{
 			if (_player?.TemplatedParent is Microsoft.UI.Xaml.Controls.ProgressRing progress)
 			{

--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.Android.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.Android.cs
@@ -273,6 +273,7 @@ using Uno.UI.Controls;
 using Android.Graphics;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml;
+using Uno.Foundation.Logging;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie
 {
@@ -368,7 +369,11 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 				_bindableProgressBar.SetProgress((int)(_toProgress * 100), _looped);
 
 				UpdateColor();
+
+				return true;
 			}
+
+			return false;
 		}
 
 

--- a/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.net6.csproj
+++ b/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.net6.csproj
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
-		<PackageReference Include="Com.Airbnb.Android.Lottie" Version="4.1.0" PrivateAssets="none" />
+		<!--<PackageReference Include="Com.Airbnb.Android.Lottie" Version="4.1.0" PrivateAssets="none" />-->
 		<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
 	</ItemGroup>
 

--- a/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
+++ b/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
@@ -108,7 +108,7 @@
 		<ProjectReference Include="..\..\Uno.UI.FluentTheme\Uno.UI.FluentTheme.net6.csproj" />
 		<ProjectReference Include="..\..\AddIns\Uno.UI.MSAL\Uno.UI.MSAL.net6.csproj" />
 		<ProjectReference Include="..\..\Uno.UI.Adapter.Microsoft.Extensions.Logging\Uno.UI.Adapter.Microsoft.Extensions.Logging.net6.csproj" />
-		<ProjectReference Include="..\..\Uno.UI.Foldable\Uno.UI.Foldable.net6.csproj"/>
+		<ProjectReference Include="..\..\Uno.UI.Foldable\Uno.UI.Foldable.net6.csproj" />
 		
 		<!--
 		<ProjectReference Include="..\..\Uno.UI.Maps\Uno.UI.Maps.net6.csproj"/>
@@ -118,6 +118,7 @@
 	
 	<ItemGroup>
 	  <Folder Include="MacOS\" />
+	  <Folder Include="obj\" />
 	  <Folder Include="Properties\" />
 	</ItemGroup>
 	

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -7,7 +7,17 @@
 
   <PropertyGroup>
 	<_isRoslynAnalyzerAvailable Condition="'$(MSBuildVersion)' &gt;= '16.8'">true</_isRoslynAnalyzerAvailable>
-	<_canUseRoslynAnalyzer Condition="'$(LangVersion)' == 'preview' or ('$(LangVersion)'!='' and $(LangVersion.Contains('.')) and '$(LangVersion)'&gt;='9.0')">true</_canUseRoslynAnalyzer>
+	  
+	<_canUseRoslynAnalyzer Condition="
+							'$(LangVersion)' == 'preview'
+							Or '$(LangVersion)' == 'latest'
+							Or '$(LangVersion)' == 'latestMajor'
+							Or '$(LangVersion)' == 'default'
+							Or (
+								'$(LangVersion)'!=''
+								and $([MSBuild]::VersionGreaterThan($(LangVersion), '9.0'))
+							)">true</_canUseRoslynAnalyzer>
+
 	<UnoUIUseRoslynSourceGenerators Condition="'$(UnoUIUseRoslynSourceGenerators)'=='' and '$(_isRoslynAnalyzerAvailable)' == 'true' and '$(_canUseRoslynAnalyzer)'=='true'">true</UnoUIUseRoslynSourceGenerators>
 	<UnoUIUseRoslynSourceGenerators Condition="'$(UnoUIUseRoslynSourceGenerators)'==''">false</UnoUIUseRoslynSourceGenerators>
 
@@ -372,7 +382,7 @@
   </Target>
 
   <Target Name="UnoLogGeneratorsType" BeforeTargets="CoreCompile;_UnoSourceGenerator">
-	<Message
+	<Message Importance="high"
 		   Condition="'$(UnoUIUseRoslynSourceGenerators)'=='true'"
 		   Text="Uno.UI is using Roslyn generators" />
 	<Message Importance="high"

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.Diagnostics.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.Diagnostics.cs
@@ -4,33 +4,46 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 {
 	public static class XamlCodeGenerationDiagnostics
 	{
-		internal const string Title         = "XAML Generation Failed";
+		internal const string Title = "XAML Generation Failed";
 		internal const string MessageFormat = "{0}";
-		internal const string Description   = "XAML Generation Failed";
-		internal const string Category      = "XAML";
+		internal const string XamlGenerationFailureDescription = "XAML Generation Failed";
+		internal const string XamlCategory = "XAML";
+		internal const string ResourcesCategory = "Resources";
 
 		public static readonly DiagnosticDescriptor GenericXamlErrorRule = new DiagnosticDescriptor(
 #pragma warning disable RS2008 // Enable analyzer release tracking
-		                                                                                   "UXAML0001",
+																						   "UXAML0001",
 #pragma warning restore RS2008 // Enable analyzer release tracking
-		                                                                                   Title,
-		                                                                                   MessageFormat,
-		                                                                                   Category,
-		                                                                                   DiagnosticSeverity.Error,
-		                                                                                   isEnabledByDefault: true,
-		                                                                                   description: Description
-		                                                                                  );
+																						   Title,
+																						   MessageFormat,
+																						   XamlCategory,
+																						   DiagnosticSeverity.Error,
+																						   isEnabledByDefault: true,
+																						   description: XamlGenerationFailureDescription
+																						  );
 
 		public static readonly DiagnosticDescriptor GenericXamlWarningRule = new DiagnosticDescriptor(
 #pragma warning disable RS2008 // Enable analyzer release tracking
-		                                                                                     "UXAML0002",
+																							 "UXAML0002",
 #pragma warning restore RS2008 // Enable analyzer release tracking
-		                                                                                     Title,
-		                                                                                     MessageFormat,
-		                                                                                     Category,
-		                                                                                     DiagnosticSeverity.Warning,
-		                                                                                     isEnabledByDefault: true,
-		                                                                                     description: Description
-		                                                                                    );
+																							 Title,
+																							 MessageFormat,
+																							 XamlCategory,
+																							 DiagnosticSeverity.Warning,
+																							 isEnabledByDefault: true,
+																							 description: XamlGenerationFailureDescription
+																							);
+
+		public static readonly DiagnosticDescriptor ResourceParsingFailureRule = new DiagnosticDescriptor(
+#pragma warning disable RS2008 // Enable analyzer release tracking
+																							 "UXAML0003",
+#pragma warning restore RS2008 // Enable analyzer release tracking
+																							 Title,
+																							 MessageFormat,
+																							 ResourcesCategory,
+																							 DiagnosticSeverity.Error,
+																							 isEnabledByDefault: true,
+																							 description: "Resource Generation Failed"
+																							);
 	}
 }

--- a/src/Uno.UI.TestComparer/Program.cs
+++ b/src/Uno.UI.TestComparer/Program.cs
@@ -354,17 +354,22 @@ namespace Umbrella.UI.TestComparer
 
 		private static string BuildSymlink(string basePath, string symlinksBasePath, int folderIndex, string originalFilePath)
 		{
-			var relativeSourceFilePath = Path.GetRelativePath(basePath, originalFilePath);
-			var targetLinkPath = Path.Combine(symlinksBasePath, Path.GetDirectoryName(relativeSourceFilePath), $"{folderIndex}-{Path.GetFileName(relativeSourceFilePath)}");
-
-			Directory.CreateDirectory(Path.GetDirectoryName(targetLinkPath));
-
-			if (!File.Exists(targetLinkPath))
+			if (!string.IsNullOrEmpty(originalFilePath))
 			{
-				File.CreateSymbolicLink(targetLinkPath, originalFilePath);
+				var relativeSourceFilePath = Path.GetRelativePath(basePath, originalFilePath);
+				var targetLinkPath = Path.Combine(symlinksBasePath, Path.GetDirectoryName(relativeSourceFilePath), $"{folderIndex}-{Path.GetFileName(relativeSourceFilePath)}");
+
+				Directory.CreateDirectory(Path.GetDirectoryName(targetLinkPath));
+
+				if (!File.Exists(targetLinkPath))
+				{
+					File.CreateSymbolicLink(targetLinkPath, originalFilePath);
+				}
+
+				return targetLinkPath;
 			}
 
-			return targetLinkPath;
+			return null;
 		}
 
 		private static string SanitizeTestName(string testName)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Show the native progress ring in place of the MUX progressring.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
