### PR TITLE
docs: Non-UI APIs ToC, improved docs

### DIFF
--- a/doc/articles/features/PasswordVault.md
+++ b/doc/articles/features/PasswordVault.md
@@ -23,7 +23,7 @@
 
 ## `PasswordVault`
 
-The `PasswordVault` is designed to be safe place to store user's credentials and tokens.
+The `PasswordVault` is designed to be a safe place to store the user's credentials and tokens.
 It's backed by the hardware encryption mechanism of each platform, which provides a high level of security.
 However, the `PasswordVault` does **not** offer any memory security feature.
 
@@ -32,13 +32,13 @@ Below see the implementation information for each platform:
 ### [**Android**](#tab/android)
 The implementation uses the `AndroidKeyStore` which was introduced with API 18 (4.3).
 The `KeyStore` is used to generate a symmetric key which is then used to encrypt and decrypt a file persisted in the application directory.
-The key is managed by the `KeyStore` itself, which usually uses hardware component to persist it. The key is not even accessible to the application.
+The key is managed by the `KeyStore` itself, which usually uses the hardware component to persist it. The key is not even accessible to the application.
 
 More info: https://developer.android.com/reference/java/security/KeyStore
 
 ### [**iOS**](#tab/iOS)
 The `PasswordVault` is directly stored in the iOS `KeyChain` which is the recommended way to store secrets on iOS devices.
-It's backed by hardware components which ensure that the data is almost impossible to retrieve if not granted.
+It's backed by hardware components that ensure that the data is almost impossible to retrieve if not granted.
 
 More info: https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/storing_keys_in_the_keychain
 

--- a/doc/articles/features/PasswordVault.md
+++ b/doc/articles/features/PasswordVault.md
@@ -1,38 +1,48 @@
-# PasswordVault
 
-The `PasswordVault` is a credentials manager that is persisted using a secured storage.
-More info about its usage can be found here https://docs.microsoft.com/en-us/uwp/api/windows.security.credentials.passwordvault
+<!-- For available Markdown syntax, check out https://guides.github.com/features/mastering-markdown/ -->
 
-## Supported platforms
+# Credentials storage
 
-|                      | Android | iOS     | macOS   | Wasm    |
-| -------------------- | ------- | ------- | ------- | ------- |
-| `PasswordVault`      | Yes     | Yes     | No      | No      |
-| `PasswordCredential` | Partial | Partial | Partial | Partial |
+<!-- Leave the infotip below in place, and add a link to the UWP documentation for the feature or control you're documenting. If the feature has no UWP equivalent, you should be using the Uno-only feature template: .feature-template-uno-only.md -->
 
-## Security
+> [!TIP]
+> This article covers Uno-specific information for `Windows.Security.Credentials.PasswordVault` API. For a full description of the feature and instructions on using it, consult the UWP documentation: https://docs.microsoft.com/en-us/uwp/api/windows.security.credentials.passwordvault
+
+ * The `PasswordVault` is a credentials manager that is persisted using a secured storage.
+ * `PasswordCredential` is used to manipulate passwords in the vault.
+
+## Supported features
+
+| Feature        |  Windows  | Android |  iOS  |  Web (WASM)  | macOS | Linux (Skia)  | Win 7 (Skia) | Tizen |
+|---------------|-------|-------|-------|-------|-------|-------|-|-|
+| `PasswordVault`         | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ | ✖ |
+| `PasswordCredential` | ✔ | Partial | Partial | Partial | Partial | ✖ | ✖ | ✖ |
+
+
+<!-- Add any additional information on platform-specific limitations and constraints -->
+
+## `PasswordVault`
 
 The `PasswordVault` is designed to be safe place to store user's credentials and tokens.
 It's backed by the hardware encryption mechanism of each platform, which provides a high level of security.
 However, the `PasswordVault` does **not** offer any memory security feature.
 
-### Android
-The implementation uses the __AndroidKeyStore__ which was introduced with API 18 (4.3).
+Below see the implementation information for each platform:
+
+### [**Android**](#tab/android)
+The implementation uses the `AndroidKeyStore` which was introduced with API 18 (4.3).
 The `KeyStore` is used to generate a symmetric key which is then used to encrypt and decrypt a file persisted in the application directory.
 The key is managed by the `KeyStore` itself, which usually uses hardware component to persist it. The key is not even accessible to the application.
 
 More info: https://developer.android.com/reference/java/security/KeyStore
 
-### iOS
+### [**iOS**](#tab/iOS)
 The `PasswordVault` is directly stored in the iOS `KeyChain` which is the recommended way to store secrets on iOS devices.
 It's backed by hardware components which ensure that the data is almost impossible to retrieve if not granted.
 
 More info: https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/storing_keys_in_the_keychain
 
-### macOS
-This platform was not evaluated.
-
-### Wasm
+### [**WebAssembly**](#tab/WebAssembly)
 There is no way to persist a secured data in a Web browser. Even if we generate a key to encrypt it,
 there is no safe place to store this key except by relying on server components, which broke the offline support (and Progressive Web App).
 So currently we preferred to **not** implement the `PasswordVault`. It will throw a `NotSupportedException` when you try to create a new instance.
@@ -43,3 +53,22 @@ This means that the[`RetrievePassword`](https://docs.microsoft.com/en-us/uwp/api
 but we recommend to still use it in order to ensure cross-platform compatibility.
 
 The [`Properties`](https://docs.microsoft.com/en-us/uwp/api/windows.security.credentials.passwordcredential.properties#Windows_Security_Credentials_PasswordCredential_Properties) is not implemented.
+
+## Sample
+
+### Storing a credential
+
+```c#
+var vault = new Windows.Security.Credentials.PasswordVault();
+vault.Add(new Windows.Security.Credentials.PasswordCredential(
+    "My App", username, password));
+```
+
+### Retrieving a credential
+
+```c#
+var vault = new Windows.Security.Credentials.PasswordVault();
+var credential = vault.Retrieve("My App", userName);
+credential.RetrievePassword();
+var password = loginCredential.Password;
+```

--- a/doc/articles/features/windows-applicationmodel-calls.md
+++ b/doc/articles/features/windows-applicationmodel-calls.md
@@ -1,19 +1,42 @@
-# Uno Support for Windows.ApplicationModel.Calls
+# Phone calls
 
-## `PhoneCallManager`
+> [!TIP]
+> This article covers Uno-specific information for YourFeature. For a full description of the feature and instructions on using it, consult the UWP documentation: https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.calls.phonecallmanager?view=winrt-22000
 
-### Limitations
+ * `Windows.ApplicationModel.Calls.PhoneCallManager` allows apps to present a phone call UI to the user to allow them to initiate a call.
+ * The current call state can be checked using `IsCallActive` and `IsCallIncoming` properties.
+ * `CallStateChanged` event is raised when a call is incoming, accepted or dropped.
 
-**Android**
-- `RequestStoreAsync` method is not implemented
-- Second parameter of `ShowPhoneCallUI` is ignored (`displayName` of the dialer cannot be set)
+## Supported features
 
-**iOS**
-- `RequestStoreAsync` and `ShowPhoneCallSettingsUI` methods are not implemented
-- Second parameter of `ShowPhoneCallUI` is ignored (`displayName` of the dialer cannot be set)
+| Feature        |  Windows  | Android |  iOS  |  Web (WASM)  | macOS | Linux (Skia)  | Win 7 (Skia) | 
+|---------------|-------|-------|-------|-------|-------|-------|-|
+| `ShowPhoneCallUI`  | ✔ | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ |
+| `ShowPhoneCallSettingsUI`     | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ | ✖ |
+| `CallStateChanged`     | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ |
+| `IsCallActive`     | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ |
+| `IsCallActive`     | ✔ | ✔ | ✔ | ✖ | ✖ | ✖ | ✖ |
 
-**WASM**
-- Only implements the `ShowPhoneCallUI` method. Similarly to the other platforms the `displayName` parameter is not used
+## Examples
 
-**macOS**
-- Only implements the `ShowPhoneCallUI` method. Similarly to the other platforms the `displayName` parameter is not used
+### Show phone call UI
+
+```c#
+PhoneCallManager.ShowPhoneCallUI("123456789", "Jon Doe");
+```
+
+### Observe phone call state
+
+```c#
+PhoneCallManager.CallStateChanged += PhoneCallManager_CallStateChanged;
+
+private void PhoneCallManager_CallStateChanged(object sender, object e)
+{
+    var isCallActive = PhoneCallManager.IsCallActive;
+    var isCallIncoming = PhoneCallManager.IsCallIncoming;
+}
+```
+
+## Limitations
+
+For the `ShowPhoneCallUI` method, the second parameter (`displayName`) is not utilized on non-Windows targets - only the phone number is displayed to the user.

--- a/doc/articles/features/windows-applicationmodel-calls.md
+++ b/doc/articles/features/windows-applicationmodel-calls.md
@@ -1,7 +1,7 @@
 # Phone calls
 
 > [!TIP]
-> This article covers Uno-specific information for YourFeature. For a full description of the feature and instructions on using it, consult the UWP documentation: https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.calls.phonecallmanager?view=winrt-22000
+> This article covers Uno-specific information for `PhoneCallManager`. For a full description of the feature and instructions on using it, consult the UWP documentation: https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.calls.phonecallmanager?view=winrt-22000
 
  * `Windows.ApplicationModel.Calls.PhoneCallManager` allows apps to present a phone call UI to the user to allow them to initiate a call.
  * The current call state can be checked using `IsCallActive` and `IsCallIncoming` properties.

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -220,68 +220,68 @@
               href: controls/TimePicker.md
             - name: ToggleSwitch
               href: controls/ToggleSwitch.md
-        - name: WinRT features
+        - name: Non-UI APIs
           items:
-            - name: PasswordVault
+            - name: App Close Handling
+              href: features/windows-ui-core-preview.md
+            - name: App Suspension
+              href: features/windows-ui-xaml-application.md
+            - name: Badge Notifications
+              href: features/windows-ui-notifications.md
+            - name: Bluetooth
+              href: features/bluetoothdevice.md
+            - name: Contacts
+              href: features/windows-applicationmodel-contacts.md
+            - name: Credential Storage
               href: features/PasswordVault.md
+            - name: Device Enumeration
+              href: features/windows-devices-enumeration.md
+            - name: Device Information
+              href: features/windows-system-profile.md
+            - name: E-mail
+              href: features/windows-applicationmodel-email.md
+            - name: File Management
+              href: features/windows-storage.md
+            - name: File and Folder Pickers
+              href: features/windows-storage-pickers.md
+            - name: Flashlight
+              href: features/windows-devices-lights.md
+            - name: Geolocation (GPS)
+              href: features/windows-devices-geolocation.md
+            - name: Haptics
+              href: features/windows-devices-haptics.md
+            - name: Jump List (Quick Actions)
+              href: features/windows-ui-startscreen.md
+            - name: Keeping Screen On
+              href: features/windows-system-display.md
+            - name: MIDI
+              href: features/windows-devices-midi.md
+            - name: Network Information
+              href: features/windows-networking.md
+            - name: Package Information
+              href: features/windows-applicationmodel.md
+            - name: Personalization
+              href: features/windows-system-userprofile.md
+            - name: Phone Calls
+              href: features/windows-applicationmodel-calls.md
             - name: PowerManager
               href: features/windows-system-power.md
+            - name: Sharing
+              href: features/windows-applicationmodel-datatransfer.md
+            - name: SMS
+              href: features/windows-applicationmodel-chat.md
+            - name: Sensors
+              href: features/windows-devices-sensors.md
             - name: Speech Recognition
               href: features/SpeechRecognition.md
+            - name: Title Bar Customization
+              href: features/windows-ui-viewmanagement.md
+            - name: URI Launcher
+              href: features/windows-system.md
+            - name: Vibration
+              href: features/windows-phone-devices-notification-vibrationdevice.md
             - name: Web Authentication Broker
               href: features/web-authentication-broker.md
-            - name: Windows.ApplicationModel
-              href: features/windows-applicationmodel.md
-            - name: Windows.ApplicationModel.Calls
-              href: features/windows-applicationmodel-calls.md
-            - name: Windows.ApplicationModel.Chat
-              href: features/windows-applicationmodel-chat.md
-            - name: Windows.ApplicationModel.Contacts
-              href: features/windows-applicationmodel-contacts.md
-            - name: Windows.ApplicationModel.DataTransfer
-              href: features/windows-applicationmodel-datatransfer.md
-            - name: Windows.ApplicationModel.Email
-              href: features/windows-applicationmodel-email.md
-            - name: Windows.Devices.Enumeration
-              href: features/windows-devices-enumeration.md
-            - name: Windows.Devices.Haptics
-              href: features/windows-devices-haptics.md
-            - name: Windows.Devices.Lights
-              href: features/windows-devices-lights.md
-            - name: Windows.Devices.Midi
-              href: features/windows-devices-midi.md
-            - name: Windows.Devices.Sensors
-              href: features/windows-devices-sensors.md
-            - name: Windows.Networking
-              href: features/windows-networking.md
-            - name: Windows.Phone.Devices.Notification
-              href: features/windows-phone-devices-notification-vibrationdevice.md
-            - name: Windows.UI.Core.Preview
-              href: features/windows-ui-core-preview.md
-            - name: Windows.UI.StartScreen
-              href: features/windows-ui-startscreen.md
-            - name: Windows.UI.Notifications
-              href: features/windows-ui-notifications.md
-            - name: Windows.UI.Xaml.Application
-              href: features/windows-ui-xaml-application.md
-            - name: Windows.Devices.Geolocation
-              href: features/windows-devices-geolocation.md
-            - name: Windows.System
-              href: features/windows-system.md
-            - name: Windows.System.Display
-              href: features/windows-system-display.md
-            - name: Windows.System.Profile
-              href: features/windows-system-profile.md
-            - name: Windows.System.UserProfile
-              href: features/windows-system-userprofile.md
-            - name: Windows.Storage
-              href: features/windows-storage.md
-            - name: Windows.Storage.Pickers
-              href: features/windows-storage-pickers.md
-            - name: Windows.UI.ViewManagement
-              href: features/windows-ui-viewmanagement.md
-            - name: Windows.Devices.Bluetooth.BluetoothDevice
-              href: features/bluetoothdevice.md
         - name: Uno features
           items:
             - name: Uno.UI.Toolkit


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

- Non UI docs are hidden under WinRT features, which most people won't check, plus the article names don't make sense


## What is the new behavior?

- Better ToC
- `PasswordVault` docs rewritten
- `PhoneCallManager` docs rewritten

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
