### PR TITLE
fix: AutoSuggestBox Reason with inconsistency

### DIFF
--- a/build/test-scripts/android-uitest-run.sh
+++ b/build/test-scripts/android-uitest-run.sh
@@ -150,6 +150,10 @@ fi
 
 echo "$BUILD_SOURCESDIRECTORY/build/samplesapp-uitest-binaries/SamplesApp.UITests.dll" >> $UNO_TESTS_RESPONSE_FILE
 
+## Show the tests list
+mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
+    @$UNO_TESTS_RESPONSE_FILE --explore || true
+
 ## Run NUnit tests
 mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
     @$UNO_TESTS_RESPONSE_FILE || true

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -157,6 +157,11 @@ fi
 echo Response file:
 cat $UNO_TESTS_RESPONSE_FILE
 
+## Show the tests list
+mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
+    @$UNO_TESTS_RESPONSE_FILE --explore \
+	|| true
+
 ## Run NUnit tests
 mono $BUILD_SOURCESDIRECTORY/build/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
     @$UNO_TESTS_RESPONSE_FILE \

--- a/build/test-scripts/wasm-run-automated-uitests.sh
+++ b/build/test-scripts/wasm-run-automated-uitests.sh
@@ -68,6 +68,10 @@ echo "$BUILD_SOURCESDIRECTORY/build/samplesapp-uitest-binaries/SamplesApp.UITest
 ## Install NUnit
 mono $BUILD_SOURCESDIRECTORY/build/nuget/NuGet.exe install NUnit.ConsoleRunner -Version $NUNIT_VERSION
 
+## Show the tests list
+mono $BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
+    @$UNO_TESTS_RESPONSE_FILE --explore || true
+
 ## Run the tests
 mono $BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
     @$UNO_TESTS_RESPONSE_FILE || true

--- a/build/test-scripts/wasm-run-automated-uitests.sh
+++ b/build/test-scripts/wasm-run-automated-uitests.sh
@@ -76,6 +76,9 @@ mono $BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/NUnit.ConsoleRunner.$NUN
 mono $BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/NUnit.ConsoleRunner.$NUNIT_VERSION/tools/nunit3-console.exe \
     @$UNO_TESTS_RESPONSE_FILE || true
 
+## Copy the results file to the results folder
+cp --backup=t $UNO_ORIGINAL_TEST_RESULTS $UNO_UITEST_SCREENSHOT_PATH
+
 ## Export the failed tests list for reuse in a pipeline retry
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool
 mkdir -p $(dirname ${UNO_TESTS_FAILED_LIST})

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxTests.cs
@@ -25,5 +25,24 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			using var screenshot = TakeScreenshot("AutoSuggestBox Description", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
 			ImageAssert.HasColorAt(screenshot, autoSuggestBoxRect.X + autoSuggestBoxRect.Width / 2, autoSuggestBoxRect.Y + autoSuggestBoxRect.Height - 50, Color.Red);
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS, Platform.Browser)] // Android not working currently. https://github.com/unoplatform/uno/issues/8836
+		public void AutoSuggestBox_Reason()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests.AutoSuggestBox_Reason", skipInitialScreenshot: true);
+			var SUT = _app.Marked("ReasonAutoSuggestBox");
+			_app.WaitForElement(SUT);
+
+			_app.FastTap("btnPopulate");
+			_app.WaitForText("txtConsole", "ProgrammaticChange");
+			//Entering Text as User
+			SUT.EnterText("m");
+			_app.WaitForText("txtConsole", "UserInput");
+
+			//Missing SuggestionChosen
+			//Uno UI Test does not support keyboard yet
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxTests.cs
@@ -11,14 +11,14 @@ using Uno.UITest;
 using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
-namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests
 {
 	[TestFixture]
 	public partial class AutoSuggestBoxTests : SampleControlUITestBase
 	{
 		[Test]
 		[AutoRetry]
-		public void PasswordBox_With_Description()
+		public void AutoSuggestBox_With_Description()
 		{
 			Run("UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests.AutoSuggestBox_Description", skipInitialScreenshot: true);
 			var autoSuggestBoxRect = ToPhysicalRect(_app.WaitForElement("DescriptionAutoSuggestBox")[0].Rect);

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1113,6 +1113,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_Reason.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Generic.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5337,6 +5341,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_Icons.xaml.cs">
       <DependentUpon>AutoSuggestBox_Icons.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_Reason.xaml.cs">
+      <DependentUpon>AutoSuggestBox_Reason.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\MeasuredBitmapIcon.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Sizing.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBox_Reason.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBox_Reason.xaml
@@ -1,0 +1,15 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests.AutoSuggestBox_Reason"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<StackPanel>
+		<TextBlock x:Name="txtConsole"></TextBlock>
+		<Button Click="PopulateClick" x:Name="btnPopulate">Populate</Button>
+		<AutoSuggestBox x:Name="ReasonAutoSuggestBox"/>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBox_Reason.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBox_Reason.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.AutoSuggestBoxTests
+{
+	[Sample("AutoSuggestBox")]
+	public sealed partial class AutoSuggestBox_Reason : Page
+	{
+
+		public List<string> SampleList = new List<string>
+		{
+			"Africa",
+			"America",
+			"Europe",
+		};
+
+		public AutoSuggestBox_Reason()
+		{
+			this.InitializeComponent();
+
+			ReasonAutoSuggestBox.ItemsSource = SampleList;
+			ReasonAutoSuggestBox.TextChanged += (s, e) =>
+			{
+				txtConsole.Text = e.Reason.ToString();
+			};
+		}
+		public void PopulateClick(object sender, RoutedEventArgs e)
+		{
+			ReasonAutoSuggestBox.Text = "A";
+		}
+
+
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -28,7 +28,7 @@ namespace Windows.UI.Xaml.Controls
 		private Grid _layoutRoot;
 		private ListView _suggestionsList;
 		private Button _queryButton;
-		private AutoSuggestionBoxTextChangeReason _textChangeReason;
+		private AutoSuggestionBoxTextChangeReason _textChangeReason = AutoSuggestionBoxTextChangeReason.ProgrammaticChange;
 		private string userInput;
 		private BindingPath _textBoxBinding;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7957


## PR Type

- Bugfix

## What is the current behavior?

Default value was UserInput when should be Programmaticaly 

## What is the new behavior?

Now it works exactly like Windows


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
 

