### PR TITLE
fix(skia): Restore original canvas state for Software renderer

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/SoftwareRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/SoftwareRenderSurface.cs
@@ -100,15 +100,21 @@ namespace Uno.UI.Runtime.Skia
 			}
 
 			var canvas = _surface.Canvas;
-			canvas.Clear(SKColors.White);
-			canvas.Scale(_dpi);
 
-			WUX.Window.Current.Compositor.Render(_surface);
+			using (new SKAutoCanvasRestore(canvas, true))
+			{
+				canvas.Clear(SKColors.White);
+				canvas.Scale(_dpi);
+
+				WUX.Window.Current.Compositor.Render(_surface);
+			}
 
 			_gtkSurface!.MarkDirty();
+			cr.Save();
 			cr.Scale(1 / _dpi, 1 / _dpi);
 			cr.SetSourceSurface(_gtkSurface, 0, 0);
 			cr.Paint();
+			cr.Restore();
 
 			if (this.Log().IsEnabled(LogLevel.Trace))
 			{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When the DPI scaling is not 1, the scale applied to the skia canvas can accumulate and make the surface rendering unuseable.

## What is the new behavior?

The software renderer works on a high dpi screen.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
