### PR TITLE
fix(dotnetnew): Fix incorrect restore in unoapp-winui

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/Uno.ProjectTemplates.Dotnet.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/Uno.ProjectTemplates.Dotnet.csproj
@@ -120,8 +120,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Content Update="content\unoapp-net6\UnoQuickStart-vsmac.slnf">
+	  <Content Update="content\unoapp\UnoQuickStart-vsmac.slnf">
 	    <PackagePath>content\unoapp</PackagePath>
+	  </Content>
+	  <Content Update="content\unoapp-net6\UnoQuickStart-vsmac.slnf">
+	    <PackagePath>content\unoapp-net6</PackagePath>
 	  </Content>
 	  <Content Update="content\unoapp-winui-net6\UnoWinUIQuickStart-vsmac.slnf">
 	    <PackagePath>content\unoapp-winui-net6</PackagePath>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp-winui/.template.config/template.json
@@ -189,15 +189,15 @@
     },
     {
       "condition": "skia-gtk",
-      "path": "UnoWinUIQuickStart.macOS\\UnoWinUIQuickStart.Skia.Gtk.csproj"
+      "path": "UnoWinUIQuickStart.Skia.Gtk\\UnoWinUIQuickStart.Skia.Gtk.csproj"
     },
     {
       "condition": "skia-wpf",
-      "path": "UnoWinUIQuickStart.macOS\\UnoWinUIQuickStart.Skia.WPF.csproj"
+      "path": "UnoWinUIQuickStart.Skia.WPF\\UnoWinUIQuickStart.Skia.WPF.csproj"
     },
     {
       "condition": "skia-wpf",
-      "path": "UnoWinUIQuickStart.macOS\\UnoWinUIQuickStart.Skia.WPF.Host.csproj"
+      "path": "UnoWinUIQuickStart.Skia.WPF.Host\\UnoWinUIQuickStart.Skia.WPF.Host.csproj"
     }
   ],
   "sources": [

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -382,10 +382,10 @@
   </Target>
 
   <Target Name="UnoLogGeneratorsType" BeforeTargets="CoreCompile;_UnoSourceGenerator">
-	<Message Importance="high"
+	<Message Importance="low"
 		   Condition="'$(UnoUIUseRoslynSourceGenerators)'=='true'"
 		   Text="Uno.UI is using Roslyn generators" />
-	<Message Importance="high"
+	<Message Importance="low"
 		   Condition="'$(UnoUIUseRoslynSourceGenerators)'==''"
 		   Text="Uno.UI is using Uno.SourceGenerators" />
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`dotnet new unoapp-winui` does not show error messages.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
