### PR TITLE
feat: implement CoreWindows.Bounds

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_CoreWindow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_CoreWindow.cs
@@ -18,9 +18,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			var w = new Windows.UI.Xaml.Window();
 			var vb = ApplicationView.GetForCurrentView().VisibleBounds; 
 			var SUT = w.CoreWindow.Bounds;
-
+#if __IOS__
+			Assert.AreEqual(w.Bounds.Width, SUT.Width);
+			Assert.AreEqual(w.Bounds.Height, SUT.Height);
+#else
 			Assert.AreEqual(vb.Width, SUT.Width);
 			Assert.AreEqual(vb.Height, SUT.Height); 
+#endif
 		}
 #endif
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_CoreWindow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_CoreWindow.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.ViewManagement;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
+{
+	[TestClass]
+	public class Given_CoreWindow
+	{
+#if !WINDOWS_UWP
+		[TestMethod]
+		[RunsOnUIThread]
+		public void CoreWindow_Bounds_Implemented()
+		{ 
+			var w = new Windows.UI.Xaml.Window();
+			var vb = ApplicationView.GetForCurrentView().VisibleBounds; 
+			var SUT = w.CoreWindow.Bounds;
+
+			Assert.AreEqual(vb.Width, SUT.Width);
+			Assert.AreEqual(vb.Height, SUT.Height); 
+		}
+#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreWindow.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.UI.Core/CoreWindow.cs
@@ -50,16 +50,6 @@ namespace Windows.UI.Core
 		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.Foundation.Rect Bounds
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member Rect CoreWindow.Bounds is not implemented in Uno.");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Foundation.Collections.IPropertySet CustomProperties
 		{
 			get

--- a/src/Uno.UWP/UI/Core/CoreWindow.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.cs
@@ -9,6 +9,7 @@ using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Input;
 using Uno.Foundation.Logging;
+using Windows.UI.ViewManagement;
 
 namespace Windows.UI.Core
 {
@@ -52,6 +53,10 @@ namespace Windows.UI.Core
 
 		internal static CoreWindow? Main { get; private set; }
 
+		/// <summary>
+		/// Gets a Rect value containing the height and width of the application window in units of effective (view) pixels.
+		/// </summary>
+		public Rect Bounds { get; private set; }
 		/// <summary>
 		/// Gets the event dispatcher for the window.
 		/// </summary>
@@ -125,7 +130,16 @@ namespace Windows.UI.Core
 		}
 
 		internal void OnSizeChanged(WindowSizeChangedEventArgs windowSizeChangedEventArgs)
-			=> SizeChanged?.Invoke(this, windowSizeChangedEventArgs);
+		{
+			//Windows.Bounds doesn't implemment X an Y Windows Origin as well.
+			var newBounds = new Rect(0,0,windowSizeChangedEventArgs.Size.Width, windowSizeChangedEventArgs.Size.Height);
+			if (newBounds != Bounds)
+			{
+				Bounds = newBounds;
+			}
+
+			SizeChanged?.Invoke(this, windowSizeChangedEventArgs);
+		}
 
 		internal interface IPointerEventArgs
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7630
 
## PR Type

What kind of change does this PR introduce?

- Feature 

## What is the current behavior?

CoreWindow Bounds property wasn't implemented.


## What is the new behavior?

Implemented like Windows Bounds property.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
