### PR TITLE
fix: Reset NSObject InFinalizerQueue after calling ReRegisterForFinalize

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -152,6 +152,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 					builder.AppendLineInvariant($"using Uno.Disposables;");
 					builder.AppendLineInvariant($"using System.Runtime.CompilerServices;");
 					builder.AppendLineInvariant($"using Uno.UI;");
+					builder.AppendLineInvariant($"using Uno.UI.Controls;");
 					builder.AppendLineInvariant($"using Uno.UI.DataBinding;");
 					builder.AppendLineInvariant($"using Windows.UI.Xaml;");
 					builder.AppendLineInvariant($"using Windows.UI.Xaml.Data;");
@@ -690,6 +691,11 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 						{{
 							GC.ReRegisterForFinalize(this);
 
+#if !(NET6_0_OR_GREATER && __MACOS__)
+							// net6.0-macos uses CoreCLR (not mono) and the notification mechanism is different
+							// workaround for mono's https://github.com/xamarin/xamarin-macios/issues/15089
+							NSObjectMemoryRepresentation.RemoveInFinalizerQueueFlag(this);
+#endif
 							Dispatcher.RunIdleAsync(_ => Dispose());
 						}}
 					}}

--- a/src/Uno.UI/Controls/DisposeHelper.iOSmacOS.cs
+++ b/src/Uno.UI/Controls/DisposeHelper.iOSmacOS.cs
@@ -1,0 +1,35 @@
+// net6.0-macos uses CoreCLR (not mono) and the notification mechanism is different
+#if __IOS__ || (__MACOS__ && !NET6_0_OR_GREATER)
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Foundation;
+using ObjCRuntime;
+
+#if !NET6_0_OR_GREATER
+using NativeHandle = System.IntPtr;
+#endif
+
+namespace Uno.UI.Controls;
+
+// this represent the memory layout of the managed NSObject class
+// part of the workaround for https://github.com/xamarin/xamarin-macios/issues/15089
+[StructLayout (LayoutKind.Sequential)]
+class NSObjectMemoryRepresentation {
+	NativeHandle handle;
+	IntPtr classHandle;
+	public byte flags;
+
+	public const byte InFinalizerQueue = 16; // see NSObject2.cs
+
+	static public void RemoveInFinalizerQueueFlag (NSObject obj)
+	{
+		// once re-registered, the object is not anymore in the finalizer queue
+		// workaround for https://github.com/xamarin/xamarin-macios/issues/15089
+		var poker = Unsafe.As<NSObjectMemoryRepresentation>(obj);
+		poker.flags = (byte)(poker.flags & ~InFinalizerQueue);
+	}
+}
+
+#endif


### PR DESCRIPTION
- This unsafe operation is kind of _safe'ish_ as
  - `NSObject` has a `[StructLayout (LayoutKind.Sequential)]` attribute
  - Its layout is known to the xamarin native runtime
- IOW any changes would be breaking changes and well advertised.
- net6-macos uses CoreCLR (not mono) and this issue does not happen

GitHub Issue (If applicable): closes #8688

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On iOS `Tried to create a managed reference from an object that already has a managed reference` warnings appears at runtime.

That meant a new, short-lived, managed instance was created when trying to dispose of the first one.

## What is the new behavior?

There's no more warnings (and no more extra managed instance created).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

This second PR (first was [1]) is meant to be **reverted** once the
Xamarin SDK issue [2] is fixed.

[1] First PR @ https://github.com/unoplatform/uno/pull/8854
[2] https://github.com/xamarin/xamarin-macios/issues/15089

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
