### PR TITLE
fix: Adjust new net6 library from vsix

### DIFF
--- a/src/SolutionTemplate/UnoLibraryTemplate.net6/CrossTargetedLibrary.csproj
+++ b/src/SolutionTemplate/UnoLibraryTemplate.net6/CrossTargetedLibrary.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="Uno.WinUI" Version="4.2.6" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.18362'">
+	<ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows10.0.18362'">
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
 
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22000.24" />

--- a/src/SolutionTemplate/UnoLibraryTemplate.net6/CrossTargetedLibrary.csproj
+++ b/src/SolutionTemplate/UnoLibraryTemplate.net6/CrossTargetedLibrary.csproj
@@ -17,7 +17,7 @@
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22000.24" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'!='net6.0-windows10.0.18362'">
 		<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 		<Compile Update="**\*.xaml.cs">
 			<DependentUpon>%(Filename)</DependentUpon>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/discussions/8880

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adjust the default net6 library vsix template.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
