### PR TITLE
fix: re-use of native path instances and further optimizations

### DIFF
--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
@@ -1,7 +1,5 @@
 ﻿using Windows.Foundation;
-using Android.Graphics;
 using Uno.UI;
-using Rect = Windows.Foundation.Rect;
 
 namespace Windows.UI.Xaml.Shapes
 {
@@ -17,37 +15,6 @@ namespace Windows.UI.Xaml.Shapes
 
 		/// <inheritdoc />
 		protected override Size ArrangeOverride(Size finalSize)
-		{
-			var (shapeSize, renderingArea) = ArrangeRelativeShape(finalSize);
-
-			Render(renderingArea.Width > 0 && renderingArea.Height > 0
-				? GetPath(renderingArea)
-				: null);
-
-			return shapeSize;
-		}
-
-		private Android.Graphics.Path GetPath(Rect availableSize)
-		{
-			var output = new Android.Graphics.Path();
-
-			//Android's path rendering logic rounds values down to the nearest int, make sure we round up here instead using the ViewHelper scaling logic
-			var physicalRenderingArea = availableSize.LogicalToPhysicalPixels();
-			if (FrameRoundingAdjustment is { } fra)
-			{
-				physicalRenderingArea.Height += fra.Height;
-				physicalRenderingArea.Width += fra.Width;
-			}
-
-			var logicalRenderingArea = physicalRenderingArea.PhysicalToLogicalPixels();
-			logicalRenderingArea.X = availableSize.X;
-			logicalRenderingArea.Y = availableSize.Y;
-
-			output.AddOval(
-				logicalRenderingArea.ToRectF(),
-				Android.Graphics.Path.Direction.Cw);
-
-			return output;
-		}
+			=> base.BasicArrangeOverride(finalSize, path => { path.AddOval(_logicalRenderingArea.ToRectF(), Android.Graphics.Path.Direction.Cw); });
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Line.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Line.Android.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Shapes
 
 		private Android.Graphics.Path GetPath()
 		{
-			var output = new Android.Graphics.Path();
+			var output = GetOrCreatePath();
 
 			output.MoveTo((float)X1, (float)Y1);
 			output.LineTo((float)X2, (float)Y2);

--- a/src/Uno.UI/UI/Xaml/Shapes/Polygon.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polygon.Android.cs
@@ -22,7 +22,7 @@ namespace Windows.UI.Xaml.Shapes
 				return null;
 			}
 
-			var output = new Android.Graphics.Path();
+			var output = GetOrCreatePath();
 			var startingPoint = coords[0];
 
 			output.MoveTo((float)startingPoint.X, (float)startingPoint.Y);

--- a/src/Uno.UI/UI/Xaml/Shapes/Polyline.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polyline.Android.cs
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Shapes
 			{
 				return null;
 			}
-			var output = new Android.Graphics.Path();
+			var output = GetOrCreatePath();
 
 			output.MoveTo((float)coords[0].X, (float)coords[0].Y);
 			for (var i = 1; i < coords.Count; i++)

--- a/src/Uno.UI/UI/Xaml/Shapes/Rectangle.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Rectangle.Android.cs
@@ -1,11 +1,5 @@
-﻿using Windows.UI.Composition;
-using Windows.Foundation;
-using Windows.Graphics;
-using Android.Graphics;
+﻿using Windows.Foundation;
 using Uno.UI;
-using System;
-using Rect = Windows.Foundation.Rect;
-using Android.Views;
 
 namespace Windows.UI.Xaml.Shapes
 {
@@ -26,37 +20,6 @@ namespace Windows.UI.Xaml.Shapes
 
 		/// <inheritdoc />
 		protected override Size ArrangeOverride(Size finalSize)
-		{
-			var (shapeSize, renderingArea) = ArrangeRelativeShape(finalSize);
-
-			Android.Graphics.Path path;
-
-			if (renderingArea.Width > 0 && renderingArea.Height > 0)
-			{
-				path = new Android.Graphics.Path();
-
-			//Android's path rendering logic rounds values down to the nearest int, make sure we round up here instead using the ViewHelper scaling logic. However we only want to round the height and width, not the frame offsets.
-			var physicalRenderingArea = renderingArea.LogicalToPhysicalPixels();
-			if (FrameRoundingAdjustment is { } fra)
-			{
-				physicalRenderingArea.Height += fra.Height;
-				physicalRenderingArea.Width += fra.Width;
-			}
-
-			var logicalRenderingArea = physicalRenderingArea.PhysicalToLogicalPixels();
-			logicalRenderingArea.X = renderingArea.X;
-			logicalRenderingArea.Y = renderingArea.Y;
-
-			path.AddRoundRect(logicalRenderingArea.ToRectF(), (float)RadiusX, (float)RadiusY, Android.Graphics.Path.Direction.Cw);
-			}
-			else
-			{
-				path = null;
-			}
-
-			Render(path);
-
-			return shapeSize;
-		}
+			=> base.BasicArrangeOverride(finalSize, path => { path.AddRoundRect(_logicalRenderingArea.ToRectF(), (float)RadiusX, (float)RadiusY, Android.Graphics.Path.Direction.Cw); });
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.Android.cs
@@ -1,19 +1,10 @@
 ﻿using Android.Graphics;
-using Windows.UI.Xaml.Controls;
-using System;
 using Uno.Foundation.Logging;
-using Uno.Extensions;
-using System.Drawing;
 using Uno.UI;
-using Windows.UI.Xaml.Media;
 using System.Linq;
-using Uno.Disposables;
-using System.Collections.Generic;
-using Android.Graphics.Drawables;
-using Android.Graphics.Drawables.Shapes;
-using Android.Views;
-using System.Numerics;
+using Windows.UI.Xaml.Media;
 using Canvas = Android.Graphics.Canvas;
+using System;
 
 namespace Windows.UI.Xaml.Shapes
 {
@@ -21,6 +12,7 @@ namespace Windows.UI.Xaml.Shapes
 	{
 		private Android.Graphics.Path _path;
 		private Windows.Foundation.Rect _drawArea;
+		protected Windows.Foundation.Rect _logicalRenderingArea;
 
 		protected bool HasStroke
 		{
@@ -67,11 +59,17 @@ namespace Windows.UI.Xaml.Shapes
 			double renderOriginX = 0d,
 			double renderOriginY = 0d)
 		{
-			_path = path;
-			if (_path == null)
+			if (path == null)
 			{
+				if (_path != null)
+				{
+					_path = null;
+					_drawArea = new RectF();
+					Invalidate();
+				}
 				return;
 			}
+			_path = path;
 
 			var matrix = new Android.Graphics.Matrix();
 
@@ -81,7 +79,7 @@ namespace Windows.UI.Xaml.Shapes
 			_path.Transform(matrix);
 
 			_drawArea = GetPathBoundingBox(_path);
-			
+
 			_drawArea.Width = size?.Width ?? _drawArea.Width;
 			_drawArea.Height = size?.Height ?? _drawArea.Height;
 
@@ -173,6 +171,62 @@ namespace Windows.UI.Xaml.Shapes
 			var pathBounds = new RectF();
 			path.ComputeBounds(pathBounds, true);
 			return pathBounds;
+		}
+
+		protected Android.Graphics.Path GetOrCreatePath()
+		{
+			Android.Graphics.Path path;
+			if (_path != null)
+			{
+				path = _path;
+				path.Reset();
+			}
+			else
+			{
+				path = new Android.Graphics.Path();
+			}
+			return path;
+		}
+
+		protected Windows.Foundation.Rect TransformToLogical(Windows.Foundation.Rect renderingArea)
+		{
+			//Android's path rendering logic rounds values down to the nearest int, make sure we round up here instead using the ViewHelper scaling logic
+			var physicalRenderingArea = renderingArea.LogicalToPhysicalPixels();
+			if (FrameRoundingAdjustment is { } fra)
+			{
+				physicalRenderingArea.Height += fra.Height;
+				physicalRenderingArea.Width += fra.Width;
+			}
+
+			var logicalRenderingArea = physicalRenderingArea.PhysicalToLogicalPixels();
+			logicalRenderingArea.X = renderingArea.X;
+			logicalRenderingArea.Y = renderingArea.Y;
+
+			return logicalRenderingArea;
+		}
+
+		protected Windows.Foundation.Size BasicArrangeOverride(Windows.Foundation.Size finalSize, Action<Android.Graphics.Path> action)
+		{
+			var (shapeSize, renderingArea) = ArrangeRelativeShape(finalSize);
+
+			if (renderingArea.Width > 0 && renderingArea.Height > 0)
+			{
+				var logicalRenderingArea = TransformToLogical(renderingArea);
+
+				if (!_logicalRenderingArea.Equals(logicalRenderingArea))
+				{
+					_logicalRenderingArea = logicalRenderingArea;
+					Android.Graphics.Path path = GetOrCreatePath();
+					action(path);
+					Render(path);
+				}
+			}
+			else if (_path != null)
+			{
+				Render(null);
+			}
+
+			return shapeSize;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.Android.cs
@@ -175,17 +175,8 @@ namespace Windows.UI.Xaml.Shapes
 
 		protected Android.Graphics.Path GetOrCreatePath()
 		{
-			Android.Graphics.Path path;
-			if (_path != null)
-			{
-				path = _path;
-				path.Reset();
-			}
-			else
-			{
-				path = new Android.Graphics.Path();
-			}
-			return path;
+			_path?.Reset();
+			return _path ?? new Android.Graphics.Path();
 		}
 
 		protected Windows.Foundation.Rect TransformToLogical(Windows.Foundation.Rect renderingArea)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6896

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Native Android path object is created on each Arrange.

## What is the new behavior?

The path element is only created once, on subsequent calls it will be reused and resetted instead.
For rectangle and ellipse it will furthermore ensure that the rendering area actually changed before it triggers rendering again.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Checked shapes with SamplesApp.Android before and after applying the code changes. The visual results seem to be identical.