### PR TITLE
fix(codegen): Serialize XamlGenerator executions

### DIFF
--- a/doc/articles/uno-development/troubleshooting-source-generation.md
+++ b/doc/articles/uno-development/troubleshooting-source-generation.md
@@ -29,6 +29,19 @@ It is possible to step into the XAML generator by adding the following property:
 ```
 Setting this property will popup a Debugger window allowing the selection of a visual studio instance, giving the ability to set breakpoints and trace the generator.
 
+## Historical dumping of generated XAML files
+In the context of hot reload, troubleshooting the generator's state may be useful. In this case, the generator maintains a state in order to work around the current edition limitations (e.g. editing lambdas is not possible in .NET 6).
+
+In order to see all the generated files historically, set the following property in the project:
+```xml
+<PropertyGroup>
+    <UnoXamlHistoricalOutputGenerationPath>$(MSBuildThisFileDirectory)obj\generation-history</UnoXamlHistoricalOutputGenerationPath>
+</PropertyGroup>
+```
+
+> [!WARNING]
+> Setting this property will generate a lot of data, particularly when editing files in the editor, as most key strokes invoke the source generators.
+
 ## Troubleshooting Uno.SourceGeneration based generation
 
 When building, if you're having build error messages that looks like one of those:

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -52,6 +52,7 @@
 		<CompilerVisibleProperty Include="BuildingProject" />
 		<CompilerVisibleProperty Include="DesignTimeBuild" />
 		<CompilerVisibleProperty Include="UnoUISourceGeneratorDebuggerBreak" />
+		<CompilerVisibleProperty Include="UnoXamlHistoricalOutputGenerationPath" />
 		<CompilerVisibleProperty Include="IsHotReloadHost" />
 
 		<CompilerVisibleProperty Include="UseWPF" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Lock the current generator instance, as it may be invoked concurrently in the context of omnisharp when saving and editing a file fast enough, causing corruption issues in the `GenerationRunInfoManager`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
