### PR TITLE
feat(BitmapImage): [Skia] Add support for ms-appdata, BitmapImage.ImageOpened/ImageFailed

### DIFF
--- a/build/ci/.azure-devops-unit-tests.yml
+++ b/build/ci/.azure-devops-unit-tests.yml
@@ -49,6 +49,8 @@ jobs:
       msbuildArguments: /r /p:CheckExclusions=True /p:Configuration=Release /nodeReuse:true /detailedsummary /m $(ADDITIONAL_FLAGS) # /bl:$(build.artifactstagingdirectory)\build.binlog
 
   - task: VisualStudioTestPlatformInstaller@1
+    inputs:
+      versionSelector: latestStable
 
   - task: VSTest@2
     inputs:

--- a/src/SamplesApp/SamplesApp.Skia.Gtk/SamplesApp.Skia.Gtk.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.Gtk/SamplesApp.Skia.Gtk.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 		<RollForward>Major</RollForward>
 	</PropertyGroup>
 
@@ -13,32 +13,37 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
-  </PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-	
+	<PropertyGroup>
+		<!-- Workaround for https://github.com/unoplatform/uno/discussions/5007 -->
+		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<Prefer32Bit>true</Prefer32Bit>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Jellyfin.SkiaSharp.NativeAssets.LinuxArm" Version="1.68.0" />
 		<PackageReference Include="SkiaSharp" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" />
 		<PackageReference Include="GtkSharp" Version="3.24.24.4" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
-	  <ProjectReference Include="..\..\SourceGenerators\System.Xaml\Uno.Xaml.csproj" />
-	  <ProjectReference Include="..\..\Uno.Foundation\Uno.Foundation.Skia.csproj" />
-	  <ProjectReference Include="..\..\Uno.UI.Runtime.Skia.Gtk\Uno.UI.Runtime.Skia.Gtk.csproj" />
-	  <ProjectReference Include="..\..\Uno.UI\Uno.UI.Skia.csproj" />
-	  <ProjectReference Include="..\..\Uno.UWP\Uno.Skia.csproj" />
-	  <ProjectReference Include="..\SamplesApp.Skia\SamplesApp.Skia.csproj" />
+		<ProjectReference Include="..\..\SourceGenerators\System.Xaml\Uno.Xaml.csproj" />
+		<ProjectReference Include="..\..\Uno.Foundation\Uno.Foundation.Skia.csproj" />
+		<ProjectReference Include="..\..\Uno.UI.Runtime.Skia.Gtk\Uno.UI.Runtime.Skia.Gtk.csproj" />
+		<ProjectReference Include="..\..\Uno.UI\Uno.UI.Skia.csproj" />
+		<ProjectReference Include="..\..\Uno.UWP\Uno.Skia.csproj" />
+		<ProjectReference Include="..\SamplesApp.Skia\SamplesApp.Skia.csproj" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
-	  <Compile Update="Program.cs" />
+		<Compile Update="Program.cs" />
 	</ItemGroup>
 
 	<Import Project="..\..\..\build\*.Skia.Gtk.props" />

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -9,6 +9,8 @@ using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media.Imaging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
+using Windows.Storage;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 {
@@ -55,6 +57,27 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			}
 
 			Assert.IsTrue(success);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_MsAppData()
+		{
+			var file = await Windows.Storage.StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/ingredient3.png"));
+			await file.CopyAsync(ApplicationData.Current.LocalFolder, "ingredient3.png", NameCollisionOption.ReplaceExisting);
+
+			var image = new Image();
+			WindowHelper.WindowContent = image;
+
+			var sut = new BitmapImage();
+			sut.UriSource = new Uri("ms-appdata:///local/ingredient3.png");
+
+			image.Source = sut;
+
+			TaskCompletionSource<bool> tcs = new();
+			sut.ImageOpened += (s, e) => tcs.TrySetResult(true);
+
+			await tcs.Task;
 		}
 
 #if !WINDOWS_UWP

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.skia.cs
@@ -48,6 +48,12 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 						return OpenFromStream(targetWidth, targetHeight, surface, fileStream);
 					}
+					else if (UriSource.Scheme == "ms-appdata")
+					{
+						using var fileStream = File.OpenRead(FilePath);
+
+						return OpenFromStream(targetWidth, targetHeight, surface, fileStream);
+					}
 				}
 				else if (_stream != null)
 				{
@@ -62,17 +68,20 @@ namespace Windows.UI.Xaml.Media.Imaging
 			return default;
 		}
 
-		private static ImageData OpenFromStream(int? targetWidth, int? targetHeight, SkiaCompositionSurface surface, global::System.IO.Stream imageStream)
+		private ImageData OpenFromStream(int? targetWidth, int? targetHeight, SkiaCompositionSurface surface, global::System.IO.Stream imageStream)
 		{
 			var result = surface.LoadFromStream(targetWidth, targetHeight, imageStream);
 
 			if (result.success)
 			{
+				RaiseImageOpened();
 				return new ImageData { Value = surface };
 			}
 			else
 			{
-				return new ImageData { Error = new InvalidOperationException($"Image load failed ({result.nativeResult})") };
+				var exception = new InvalidOperationException($"Image load failed ({result.nativeResult})");
+				RaiseImageFailed(exception);
+				return new ImageData { Error = exception };
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/8909

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

- `BitmapImage` now supports `ms-appdata://` sources
- `BitmapImage.ImageOpened` and `ImageFailed` are now raised.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
