### PR TITLE
fix(xbind): Ensure source updates update the target during a two-way binding

### DIFF
--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -164,7 +164,7 @@ namespace Windows.UI.Xaml.Data
 		/// <param name="value">The expected current value of the target</param>
 		public void UpdateSource(object value)
 		{
-			if (_IsCurrentlyPushing || _IsCurrentlyPushingTwoWay)
+			if ((_IsCurrentlyPushing || _IsCurrentlyPushingTwoWay))
 			{
 				return;
 			}
@@ -594,8 +594,21 @@ namespace Windows.UI.Xaml.Data
 
 		private void SetTargetValueSafe(object v)
 		{
-			if (_IsCurrentlyPushingTwoWay)
+			if (_IsCurrentlyPushingTwoWay && ParentBinding.CompiledSource == null)
 			{
+				// For normal bindings, the source update through a converter
+				// is ignored. Therefore, only the ConvertBack method is invoked as
+				// the UpdateSource method is ignored because a two-way binding is
+				// in progress.
+				//
+				// For x:Bind, a source update through the converter raises
+				// a property change, which is in turn sent back to the target
+				// after another Convert invocation.
+				//
+				// There is no loop happening because the binding engine is ignoring
+				// the UpdateSource invocation from the target as a two-way binding
+				// is still happening.
+
 				return;
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/7696

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Aligns `x:Bind` source update bind back behavior with WinUI, which is allows the target update (while a normal binding does not).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
