### PR TITLE
fix: Make `Clipboard.GetContentAsync` reliable

### DIFF
--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Windows.UI.Core;
 using Uno.Extensions.Specialized;
 using Uno.Foundation;
+using System.Threading;
 
 namespace Windows.ApplicationModel.DataTransfer
 {
@@ -36,25 +37,15 @@ namespace Windows.ApplicationModel.DataTransfer
 		{
 			var dataPackage = new DataPackage();
 
-			dataPackage.SetDataProvider(
-				StandardDataFormats.Text,
-				async ct =>
-				{
-					var text = string.Empty;
-					await Uno.UI.Dispatching.CoreDispatcher.Main.RunAsync(
-						Uno.UI.Dispatching.CoreDispatcherPriority.High,
-						async _ => text = await GetClipboardText());
-
-					return text;
-				});
+			dataPackage.SetDataProvider(StandardDataFormats.Text, async ct => await GetClipboardText(ct));
 			
 			return dataPackage.GetView();
 		}
 
-		private static async Task<string> GetClipboardText()
+		private static async Task<string> GetClipboardText(CancellationToken ct)
 		{
 			var command = $"{JsType}.getText();";
-			var text = await WebAssemblyRuntime.InvokeAsync(command);
+			var text = await WebAssemblyRuntime.InvokeAsync(command, ct);
 
 			return text;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8884

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Previously we were executing the GetClipboardText method on UI thread which was unnecessary, and as it was executed asynchronously, it did not necessarily wait for the actual promise on JS side to finish executing. Therefore in most cases just the initial empty string content was returned.

## What is the new behavior?

Reliable!


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
