### PR TITLE
fix: `Gamepad` readings for non-standard controllers on WASM, flipping Y-axis

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -4933,6 +4933,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Gaming\GamepadReadingTest.xaml.cs">
       <DependentUpon>GamepadReadingTest.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_Gaming\GamepadReadingViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Globalization\Language_Properties.xaml.cs">
       <DependentUpon>Language_Properties.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_Gaming/GamepadReadingTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Gaming/GamepadReadingTest.xaml
@@ -13,12 +13,13 @@
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
 		</Grid.RowDefinitions>
 		<Button Command="{x:Bind ViewModel.UpdateGamepadsCommand}">Get gamepads list</Button>
-		<Button Command="{x:Bind ViewModel.UpdateReadingsCommand}">Get current readings</Button>
-		<ToggleButton IsChecked="{x:Bind ViewModel.IsCheckingAutomatically, Mode=TwoWay}">Check automatically</ToggleButton>
-		<ListView ItemsSource="{x:Bind ViewModel.Gamepads}" SelectionMode="None">
+		<Button Grid.Row="1" Command="{x:Bind ViewModel.UpdateReadingsCommand}">Get current readings</Button>
+		<ToggleButton Grid.Row="2" IsChecked="{x:Bind ViewModel.IsCheckingAutomatically, Mode=TwoWay}">Check automatically</ToggleButton>
+		<ListView Grid.Row="3" ItemsSource="{x:Bind ViewModel.Gamepads}" SelectionMode="None">
 			<ListView.ItemTemplate>
 				<DataTemplate x:DataType="local:GamepadReadingViewModel" x:DefaultBindMode="OneWay">
 					<StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_Gaming/GamepadReadingTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Gaming/GamepadReadingTest.xaml
@@ -9,45 +9,47 @@
 	x:DefaultBindMode="OneWay"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<StackPanel Spacing="8" Padding="8">
-		<Button Command="{x:Bind ViewModel.GetCurrentReadingCommand}">Get current reading</Button>
+	<Grid RowSpacing="8" Padding="8">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Button Command="{x:Bind ViewModel.UpdateGamepadsCommand}">Get gamepads list</Button>
+		<Button Command="{x:Bind ViewModel.UpdateReadingsCommand}">Get current readings</Button>
 		<ToggleButton IsChecked="{x:Bind ViewModel.IsCheckingAutomatically, Mode=TwoWay}">Check automatically</ToggleButton>
-		
-		<TextBlock>
-			<Run Text="Timestamp:" />
-			<Run Text="{x:Bind ViewModel.Timestamp}" />
-		</TextBlock>
-		
-		<TextBlock>
-			<Run Text="Left thumbstick X:" />
-			<Run Text="{x:Bind ViewModel.LeftThumbstickX}" />
-		</TextBlock>
-		<TextBlock>
-			<Run Text="Left thumbstick Y:" />
-			<Run Text="{x:Bind ViewModel.LeftThumbstickY}" />
-		</TextBlock>
-		
-		<TextBlock>
-			<Run Text="Right thumbstick X:" />
-			<Run Text="{x:Bind ViewModel.RightThumbstickX}" />
-		</TextBlock>
-		<TextBlock>
-			<Run Text="Right thumbstick Y:" />
-			<Run Text="{x:Bind ViewModel.RightThumbstickY}" />
-		</TextBlock>
-
-		<TextBlock>
-			<Run Text="Left trigger:" />
-			<Run Text="{x:Bind ViewModel.LeftTrigger}" />
-		</TextBlock>
-		<TextBlock>
-			<Run Text="Right trigger:" />
-			<Run Text="{x:Bind ViewModel.RightTrigger}" />
-		</TextBlock>
-
-		<TextBlock>
-			<Run Text="Buttons:" />
-			<Run Text="{x:Bind ViewModel.Buttons}" />
-		</TextBlock>
-	</StackPanel>
+		<ListView ItemsSource="{x:Bind ViewModel.Gamepads}" SelectionMode="None">
+			<ListView.ItemTemplate>
+				<DataTemplate x:DataType="local:GamepadReadingViewModel" x:DefaultBindMode="OneWay">
+					<StackPanel>
+						<TextBlock Style="{ThemeResource SubtitleTextBlockStyle}">
+                    <Run Text="Gamepad #" /><Run Text="{x:Bind Id}" />
+						</TextBlock>
+						<TextBlock>
+                    <Run FontWeight="Bold" Text="Buttons:" />
+                    <Run Text="{x:Bind Buttons}" />
+						</TextBlock>
+						<TextBlock>
+                    <Run FontWeight="Bold" Text="Left thumbstick:" />
+                    <Run Text="X:" /><Run Text="{x:Bind LeftThumbstickX}" />
+                    <Run Text="Y:" /><Run Text="{x:Bind LeftThumbstickY}" />
+						</TextBlock>
+						<TextBlock>
+                    <Run FontWeight="Bold" Text="Right thumbstick:" />
+                    <Run Text="X:" /><Run Text="{x:Bind RightThumbstickX}" />
+                    <Run Text="Y:" /><Run Text="{x:Bind RightThumbstickY}" />
+						</TextBlock>
+						<TextBlock>
+                    <Run FontWeight="Bold" Text="Left trigger:" />
+                    <Run Text="{x:Bind LeftTrigger}" />
+						</TextBlock>
+						<TextBlock>
+                    <Run FontWeight="Bold" Text="Right trigger:" />
+                    <Run Text="{x:Bind RightTrigger}" />
+						</TextBlock>
+					</StackPanel>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_Gaming/GamepadReadingViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Gaming/GamepadReadingViewModel.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UI.Samples.UITests.Helpers;
+using Windows.Gaming.Input;
+
+namespace UITests.Windows_Gaming
+{
+    internal class GamepadReadingViewModel : ViewModelBase
+    {
+		private static int _id = 0;
+
+		public GamepadReadingViewModel(Gamepad gamepad)
+		{
+			Gamepad = gamepad ?? throw new System.ArgumentNullException(nameof(gamepad));
+			Id = ++_id;
+		}
+
+		public Gamepad Gamepad { get; }
+
+		public int Id { get; }
+
+		public void Update()
+		{
+			var reading = Gamepad.GetCurrentReading();
+			Buttons = reading.Buttons.ToString("g");
+			RightThumbstickX = reading.RightThumbstickX.ToString("0.00");
+			RightThumbstickY = reading.RightThumbstickY.ToString("0.00");
+			LeftThumbstickX = reading.LeftThumbstickX.ToString("0.00");
+			LeftThumbstickY = reading.LeftThumbstickY.ToString("0.00");
+			LeftTrigger = reading.LeftTrigger.ToString("0.00");
+			RightTrigger = reading.RightTrigger.ToString("0.00");
+
+			RaisePropertyChanged("");
+		}
+
+		public string Buttons { get; private set; }
+
+		public string RightThumbstickX { get; private set; }
+
+		public string RightThumbstickY { get; private set; }
+
+		public string LeftThumbstickX { get; private set; }
+
+		public string LeftThumbstickY { get; private set; }
+
+		public string LeftTrigger { get; private set; }
+
+		public string RightTrigger { get; private set; }
+	}
+}

--- a/src/Uno.UWP/Gaming/Input/Gamepad.Android.cs
+++ b/src/Uno.UWP/Gaming/Input/Gamepad.Android.cs
@@ -80,9 +80,9 @@ public partial class Gamepad
 				var inputDevice = motionEvent.Device!;
 
 				reading.LeftThumbstickX = GetCenteredAxis(motionEvent, inputDevice, Axis.X);
-				reading.LeftThumbstickY = GetCenteredAxis(motionEvent, inputDevice, Axis.Y);
+				reading.LeftThumbstickY = -1 * GetCenteredAxis(motionEvent, inputDevice, Axis.Y);
 				reading.RightThumbstickX = GetCenteredAxis(motionEvent, inputDevice, Axis.Z);
-				reading.RightThumbstickY = GetCenteredAxis(motionEvent, inputDevice, Axis.Rz);
+				reading.RightThumbstickY = -1 * GetCenteredAxis(motionEvent, inputDevice, Axis.Rz);
 
 				var leftTrigger = GetCenteredAxis(motionEvent, inputDevice, Axis.Brake);
 				if (leftTrigger == 0)

--- a/src/Uno.UWP/Gaming/Input/Gamepad.wasm.cs
+++ b/src/Uno.UWP/Gaming/Input/Gamepad.wasm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Uno;
 using Uno.Extensions;
@@ -37,42 +38,48 @@ public partial class Gamepad
 		var axesPart = parts[1];
 		var buttonsPart = parts[2];
 
-		var timestampDouble = double.Parse(timestampPart);
+		var timestampDouble = double.Parse(timestampPart, CultureInfo.InvariantCulture);
 		reading.Timestamp = (ulong)(timestampDouble * 1000); // JS timestamp is in milliseconds
 
-		var axes = axesPart.Split('|').Select(double.Parse).ToArray();
+		if (!string.IsNullOrEmpty(axesPart))
+		{
+			var axes = axesPart.Split('|').Select(p => double.Parse(p, CultureInfo.InvariantCulture)).ToArray();
 
-		reading.LeftThumbstickX = GetGamepadValueIfExists(ref axes, 0);
-		reading.LeftThumbstickY = GetGamepadValueIfExists(ref axes, 1);
-		reading.RightThumbstickX = GetGamepadValueIfExists(ref axes, 2);
-		reading.RightThumbstickY = GetGamepadValueIfExists(ref axes, 3);
+			reading.LeftThumbstickX = GetGamepadValueIfExists(ref axes, 0);
+			reading.LeftThumbstickY = -1 * GetGamepadValueIfExists(ref axes, 1);
+			reading.RightThumbstickX = GetGamepadValueIfExists(ref axes, 2);
+			reading.RightThumbstickY = -1 * GetGamepadValueIfExists(ref axes, 3);
+		}
 
-		var buttons = buttonsPart.Split('|').Select(double.Parse).ToArray();
+		if (!string.IsNullOrEmpty(buttonsPart))
+		{
+			var buttons = buttonsPart.Split('|').Select(p => double.Parse(p, CultureInfo.InvariantCulture)).ToArray();
 
-		var pressedButtons = GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 0) ? GamepadButtons.A : GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 1) ? GamepadButtons.B : GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 2) ? GamepadButtons.X : GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 3) ? GamepadButtons.Y : GamepadButtons.None;
+			var pressedButtons = GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 0) ? GamepadButtons.A : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 1) ? GamepadButtons.B : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 2) ? GamepadButtons.X : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 3) ? GamepadButtons.Y : GamepadButtons.None;
 
-		pressedButtons |= IsButtonPressed(ref buttons, 4) ? GamepadButtons.LeftShoulder : GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 5) ? GamepadButtons.RightShoulder : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 4) ? GamepadButtons.LeftShoulder : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 5) ? GamepadButtons.RightShoulder : GamepadButtons.None;
 
-		pressedButtons |= IsButtonPressed(ref buttons, 8) ? GamepadButtons.View : GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 9) ? GamepadButtons.Menu : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 8) ? GamepadButtons.View : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 9) ? GamepadButtons.Menu : GamepadButtons.None;
 
-		pressedButtons |= IsButtonPressed(ref buttons, 10) ? GamepadButtons.LeftThumbstick : GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 11) ? GamepadButtons.RightThumbstick : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 10) ? GamepadButtons.LeftThumbstick : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 11) ? GamepadButtons.RightThumbstick : GamepadButtons.None;
 
-		pressedButtons |= IsButtonPressed(ref buttons, 12) ? GamepadButtons.DPadUp : GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 13) ? GamepadButtons.DPadDown : GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 14) ? GamepadButtons.DPadLeft : GamepadButtons.None;
-		pressedButtons |= IsButtonPressed(ref buttons, 15) ? GamepadButtons.DPadRight : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 12) ? GamepadButtons.DPadUp : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 13) ? GamepadButtons.DPadDown : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 14) ? GamepadButtons.DPadLeft : GamepadButtons.None;
+			pressedButtons |= IsButtonPressed(ref buttons, 15) ? GamepadButtons.DPadRight : GamepadButtons.None;
 
-		reading.Buttons = pressedButtons;
+			reading.Buttons = pressedButtons;
 
-		reading.LeftTrigger = GetGamepadValueIfExists(ref buttons, 6);
-		reading.RightTrigger = GetGamepadValueIfExists(ref buttons, 7);
+			reading.LeftTrigger = GetGamepadValueIfExists(ref buttons, 6);
+			reading.RightTrigger = GetGamepadValueIfExists(ref buttons, 7);
+		}
 
 		return reading;
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Y-axis flipped on Android and WASM
- Readings on WASM break when there are no buttons or no axes

## What is the new behavior?

- Y-axis matches WinUI
- Readings don't break

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
