### PR TITLE
fix(DatePicker): Ensure proper native picker readability when the system theme is overriden

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -9,6 +9,7 @@ using Uno.Foundation.Logging;
 
 using Uno.UI;
 using Windows.Globalization;
+using Uno.Helpers.Theming;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -62,6 +63,7 @@ namespace Windows.UI.Xaml.Controls
 			_picker.Calendar = new NSCalendar(NSCalendarType.Gregorian);
 
 			UpdatePickerStyle();
+			UpdateTheme();
 
 			UpdatePickerValue(Date, animated: false);
 
@@ -232,6 +234,25 @@ namespace Windows.UI.Xaml.Controls
 																			? UIDatePickerStyle.Wheels
 																			: UIDatePickerStyle.Inline;
 			}
+		}
+
+		private void UpdateTheme()
+		{
+			// Force the background of the UIDatePicker to allow for proper
+			// readability.
+			UIDatePicker.Appearance.BackgroundColor =
+				SystemThemeHelper.SystemTheme == SystemTheme.Dark
+				? UIColor.Black
+				: UIColor.White;
+
+			// UIDatePicker does not allow for fine-grained control of its appearance:
+			// https://developer.apple.com/documentation/uikit/uidatepicker
+			//
+			// UIDatePicker.Appearance.TintColor does not have any effect either, even when set
+			// before the control is attached to the visual tree.
+			//
+			// Additionally, as of iOS 15, the following action does not have an effect on the UIDatePicker
+			// _picker.SetValueForKey(UIColor.Yellow, new NSString("textColor"));
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/nventive-private/issues/393

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Applies a best-effort UIDatePicker theme adjustment when the app's theme overrides the system theme.

System Dark Theme on App Dark theme:
![image](https://user-images.githubusercontent.com/5839577/173066759-eabfa13c-262f-4396-8d5c-8d020af1fddd.png)

System Dark Theme on App Light theme:
![image](https://user-images.githubusercontent.com/5839577/173066895-169f9611-e40b-414a-88e0-8d89cc285742.png)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
