### PR TITLE
fix(measure_dirty_path): recycled ItemsControl not re-measuring

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -358,8 +358,47 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(third.Style, containerStyle);
 		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_NestedItemsControl_RecycleTemplate()
+		{
+			var template = (DataTemplate)XamlReader.Load(@"
+				<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+					<ItemsControl ItemsSource='{Binding NestedSource}'
+								  BorderBrush='Black' BorderThickness='1'>
+						<ItemsControl.ItemTemplate>
+							<DataTemplate>
+								<Rectangle Fill='Red' Height='50' Width='50' />
+							</DataTemplate>
+						</ItemsControl.ItemTemplate>
+					</ItemsControl>
+				</DataTemplate>
+			".Replace('\'', '"'));
+			var initialSource = new object[] { new { NestedSource = new object[1] }, };
+			var resetSource = new object[] { new { NestedSource = new object[0] }, };
+			var SUT = new ItemsControl()
+			{
+				ItemsSource = initialSource,
+				ItemTemplate = template,
+			};
+			WindowHelper.WindowContent = SUT;
+
+			var item = default(ContentPresenter);
+
+			// [initial stage]: load the nested ItemsControl with items, so it has an initial height
+			await WindowHelper.WaitForLoaded(SUT);
+			await WindowHelper.WaitFor(() => (item = SUT.ContainerFromItem(initialSource[0]) as ContentPresenter) != null, message: "initial state: failed to find the item");
+			Assert.AreEqual(50, item.ActualHeight, delta: 1.0, "initial state: expecting the item to have an starting height of 50");
+
+			// [reset stage]: ItemsSource is reset with empty NestedSource, and we expected the height to be RE-measured
+			SUT.ItemsSource = resetSource;
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(() => (item = SUT.ContainerFromItem(resetSource[0]) as ContentPresenter) != null, message: "reset state: failed to find the item");
+			Assert.AreEqual(0, item.ActualHeight, "reset state: expecting the item's height to be remeasured to 0");
+		}
 
 	}
+
 	internal partial class ContentControlItemsControl : ItemsControl
 	{
 		protected override DependencyObject GetContainerForItemOverride() => new ContentControl();

--- a/src/Uno.UI/UI/Xaml/UIElementCollection.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementCollection.cs
@@ -83,6 +83,11 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
+			if (_owner is FrameworkElement fe)
+			{
+				fe.InvalidateMeasure();
+			}
+
 			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, items.ToList()));
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/nventive-private#388

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

ItemsPresenter of an recycled ItemsControl are not marked as measure dirty when its data-context changes, causing it to keep its old size before being recycled.

## What is the new behavior?

Should not happen.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->