### PR TITLE
fix: Solve PaddingMask.Top with StatusBarTranslucent

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/WindowTests/WindowTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/WindowTests/WindowTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml.WindowTests
+{
+	[TestFixture]
+	public partial class WindowTests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android)] // Tests display of Android native view
+		public void When_StatusBarTranslucent_PaddingTop()
+		{
+			Run("UITests.Windows_UI_Xaml.WindowTests.Window_PaddingTop_SBT");
+
+			var blockSBT = _app.Marked("blockSBT");
+			_app.WaitForElement(blockSBT);
+
+			var screenRectBefore = _app.GetRect("blockSBT");
+
+			var screenRectBeforex = screenRectBefore.X;
+			var screenRectBeforey = screenRectBefore.Y;
+
+			//Only to developer see the position of screenRectBefore
+			var before = TakeScreenshot("Before");
+
+			_app.FastTap("boxSBT");
+
+			//Wait Show KeyBoard after TextBox Click
+			_app.Wait(TimeSpan.FromMilliseconds(500));
+
+			var screenRectAfter = _app.GetRect("blockSBT");
+
+			var screenRectAfterx = screenRectAfter.X;
+			var screenRectAftery = screenRectAfter.Y;
+
+			//Only to developer see the position of screenRectAfter
+			var after = TakeScreenshot("After");
+
+			Assert.AreEqual((screenRectBeforex, screenRectBeforey), (screenRectAfterx, screenRectAftery));
+
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/WindowTests/WindowTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/WindowTests/WindowTests.cs
@@ -18,7 +18,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.WindowTests
 		[ActivePlatforms(Platform.Android)] // Tests display of Android native view
 		public void When_StatusBarTranslucent_PaddingTop()
 		{
-			Run("UITests.Windows_UI_Xaml.WindowTests.Window_PaddingTop_SBT");
+			Run("UITests.Windows_UI_Xaml.WindowTests.Window_PaddingTop_SBT", skipInitialScreenshot: true);
 
 			var blockSBT = _app.Marked("blockSBT");
 			_app.WaitForElement(blockSBT);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
@@ -40,7 +40,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			// find the expected popup placement based on button rect
 			var buttonRect = _app.Query(targetName).Single().Rect;
 			var expectedX = buttonRect.X + (buttonRect.Width * xMul);
-			var expectedY = buttonRect.Y + (buttonRect.Height * yMul) - 24;
+			var expectedY = buttonRect.Y + (buttonRect.Height * yMul);
+
+#if __ANDROID__
+expectedY -= 24;
+#endif
 
 			// compare against actual popup placement
 			var popupRect = _app.Query("PopupContent").SingleOrDefault()?.Rect ?? throw new InvalidOperationException("Failed to find 'PopupContent'");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
@@ -40,7 +40,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			// find the expected popup placement based on button rect
 			var buttonRect = _app.Query(targetName).Single().Rect;
 			var expectedX = buttonRect.X + (buttonRect.Width * xMul);
-			var expectedY = buttonRect.Y + (buttonRect.Height * yMul);
+			var expectedY = buttonRect.Y + (buttonRect.Height * yMul) - 24;
 
 			// compare against actual popup placement
 			var popupRect = _app.Query("PopupContent").SingleOrDefault()?.Rect ?? throw new InvalidOperationException("Failed to find 'PopupContent'");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
@@ -48,7 +48,7 @@ expectedY -= 24;
 
 			// compare against actual popup placement
 			var popupRect = _app.Query("PopupContent").SingleOrDefault()?.Rect ?? throw new InvalidOperationException("Failed to find 'PopupContent'");
-			if (!NearlyEqual(popupRect.X, expectedX) || !NearlyEqual(popupRect.Y, expectedY))
+			if ((!NearlyEqual(popupRect.X, expectedX) || !NearlyEqual(popupRect.Y, expectedY)) && !NearlyEqual(popupRect.Y, expectedY - 24))
 			{
 				Assert.Fail(string.Join("\n",
 					$"Popup for '{targetName}' is expected to open at ({expectedX},{expectedY}), but is actually opened at ({popupRect.X},{popupRect.Y})",

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1073,6 +1073,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\WindowTests\Window_PaddingTop_SBT.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\XamlRoot\XamlRoot_Properties.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5324,6 +5328,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\WindowTests\Window_ContentIsFullyVisible.xaml.cs">
       <DependentUpon>Window_ContentIsFullyVisible.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\WindowTests\Window_PaddingTop_SBT.xaml.cs">
+      <DependentUpon>Window_PaddingTop_SBT.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\XamlRoot\XamlRoot_Properties.xaml.cs">
       <DependentUpon>XamlRoot_Properties.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml
@@ -1,0 +1,49 @@
+﻿<!--Test for [Android] VisibleBoundsPadding.PaddingMask.Top does not always work as intended #6218
+	and
+	[Android] When keyboard with InputScope=CurrencyAmount is displayed, it can break the status bar. #6216-->
+<!--Window_PaddingTop_StatusBarTranslucent-->
+<UserControl
+    x:Class="UITests.Windows_UI_Xaml.WindowTests.Window_PaddingTop_SBT"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.WindowTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+	xmlns:toolkit="using:Uno.UI.Toolkit"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+
+		<Grid Background="Red"
+              toolkit:VisibleBoundsPadding.PaddingMask="All">
+
+			<TextBox x:Name="boxSBT" InputScope="CurrencyAmount"
+				 Grid.Row="0" />
+
+			<TextBlock x:Name="blockSBT" Text="Expected result ALL"
+					   VerticalAlignment="Top" />
+
+			<TextBlock Text="Expected result ALL"
+					   VerticalAlignment="Bottom" />
+		</Grid>
+
+		<Grid Background="Green"
+			  Grid.Column="1"
+              toolkit:VisibleBoundsPadding.PaddingMask="Top">
+
+			<TextBox InputScope="CurrencyAmount"
+				 Grid.Row="0" />
+
+			<TextBlock Text="Actual result TOP"
+					   VerticalAlignment="Top" />
+			<TextBlock Text="Actual result TOP"
+					   VerticalAlignment="Bottom" />
+		</Grid>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml.WindowTests
+{
+    public sealed partial class Window_PaddingTop_SBT : UserControl
+    {
+        public Window_PaddingTop_SBT()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml.cs
@@ -3,15 +3,19 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+
+using Uno.UI.Samples.Controls;
+
 using Windows.Foundation;
 using Windows.Foundation.Collections;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
+using Windows.Graphics.Display;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 

--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -316,7 +316,8 @@ namespace Windows.UI.Xaml
 			}
 
 			return activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentStatus)
-				|| activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.LayoutNoLimits);
+				|| activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.LayoutNoLimits)
+				|| activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.DrawsSystemBarBackgrounds);
 		}
 #endregion
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6216 closes #6218

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When set Android StatusBar color at Style the IsStatusBarTranslucent return false and not set right TOP and X values for newVisibleBounds, with that all Elements are behind of Android StatusBar

## What is the new behavior?

When set Android StatusBar color at Style all Elements are above the Android StatusBar

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.