### PR TITLE
fix(macOS): Remove warning/usage for deprecated `userSpaceScaleFactor`

### DIFF
--- a/src/Uno.UI/Extensions/ViewHelper.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.iOSmacOS.cs
@@ -30,8 +30,8 @@ namespace Uno.UI
 		public static readonly nfloat MainScreenScale = UIScreen.MainScreen.Scale;
 		public static readonly bool IsRetinaDisplay = UIScreen.MainScreen.Scale > 1.0f;
 #elif __MACOS__
-		public static readonly nfloat MainScreenScale = NSScreen.MainScreen.UserSpaceScaleFactor;
-		public static readonly bool IsRetinaDisplay = NSScreen.MainScreen.UserSpaceScaleFactor > 1.0f;
+		public static readonly nfloat MainScreenScale = NSScreen.MainScreen.BackingScaleFactor;
+		public static readonly bool IsRetinaDisplay = NSScreen.MainScreen.BackingScaleFactor > 1.0f;
 #endif
 
 		private static double _rectangleRoundingEpsilon = 0.05;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

At application startup an ugly warning is printed on macOS because a deprecated API is called.

```
2022-06-11 11:35:32.259 DopeTestUno.macOS[79018:2398769] *** WARNING: Method userSpaceScaleFactor in class NSView is deprecated on 10.7 and later. It should not be used in new applications. Use convertRectToBacking: instead. 
```

## What is the new behavior?

No warning is printed when starting an app on macOS

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

For its usage here the deprecated API can be replaced with `backingScaleFactor`, instead of the proposed (inside the warning message) `convertRectToBacking:`.
https://developer.apple.com/documentation/appkit/nsscreen/1388385-backingscalefactor?language=objc

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
