### PR TITLE
perf(macOS): Avoid calling `Subviews` getter inside `Dispose`

### DIFF
--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -4,14 +4,16 @@ using Uno.UI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Uno.UI.Extensions;
 using Windows.UI.Xaml;
 using Uno.Foundation.Logging;
 using Uno.UI.Controls;
-
-#if NET6_0_OR_GREATER
 using ObjCRuntime;
+
+#if !NET6_0_OR_GREATER
+using NativeHandle = System.IntPtr;
 #endif
 
 #if XAMARIN_IOS_UNIFIED
@@ -686,6 +688,31 @@ namespace AppKit
 #elif __MACOS__
 			view.NeedsDisplay = true;
 #endif
+		}
+
+#if __MACOS__
+		static readonly NativeHandle selSubviewsHandle = Selector.GetHandle("subviews");
+#endif
+
+		[DllImport("/usr/lib/libobjc.dylib", EntryPoint="objc_msgSendSuper")]
+		private extern static NativeHandle NativeHandle_objc_msgSendSuper(NativeHandle receiver, IntPtr selector);
+
+		private static NativeHandle GetSubviewsHandle(this _View view)
+		{
+#if __IOS__
+			return NativeHandle_objc_msgSendSuper(view.SuperHandle, Selector.GetHandle("subviews"));
+#elif __MACOS__
+			return NativeHandle_objc_msgSendSuper(view.SuperHandle, selSubviewsHandle);
+#endif
+		}
+
+		[DllImport("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
+		private extern static /* CFIndex */ nint CFArrayGetCount(/* CFArrayRef */ NativeHandle theArray);
+
+		internal static nint GetSubviewsCount(this _View view)
+		{
+			var handle = view.GetSubviewsHandle();
+			return CFArrayGetCount(handle);
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Calling `Subviews` creates a managed `NSView[]` array and fill it with `NSView` instances - most of them should already exists in managed land, but still need to be retrieved with `GetNSObject`.

This is costly **when** the only thing we want is to know if any items are present in the array. IOW **when** we do not care about the element themselves (which is why this optimization cannot, as is, be applied to iOS).

<img width="961" alt="Screen Shot 2022-06-10 at 1 43 19 PM" src="https://user-images.githubusercontent.com/260465/173210216-7bc4c9d4-bfc9-4bc1-b83d-e9aa11fc5221.png">

Note: Unseen here is the GC time spent to collect the temporary `NSView` managed arrays.

## What is the new behavior?

Adding a specialized utility method that gets the `NSArray` handle out of `Subviews` and query the number of elements using `CFArray` p/invokes (faster than going thru another ObjC call). Since `NSArray` and `CFArray` are toll-free bridged so this is perfectly safe.

https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Toll-FreeBridgin/Toll-FreeBridgin.html

<img width="961" alt="Screen Shot 2022-06-10 at 4 26 47 PM" src="https://user-images.githubusercontent.com/260465/173210219-e327bc25-8072-48be-8881-65576be41a11.png">

Note: the scale is different. Look at the percentage: 28% before versus 3.1% after.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Note: there might be potential to reuse the helper method elsewhere inside Uno (macOS and iOS). Just because it does not show in Dope does not means it can't be useful in other situations :-)


### Dope running on Xamarin.Mac Legacy

macOS 12.4 / Legacy / arm64  | Build   | Change    | Reuse   | Grid    |
-----------------------------|--------:|----------:|--------:|--------:|
Xamarin.Mac Legacy (454e16a) | 1574.60 | 440982.29 | 1950.91 | 6602.72 |
Xamarin.Mac Legacy (dispose) | 1588.88 | 479364.65 | 1962.81 | 6567.98 |
Impact                       |   1.01x |     1.09x |   1.01x |   0.99x |

Note: I consider anything less than 5% can be hidden inside the noise of the [sporadic GC pauses](https://github.com/unoplatform/uno/issues/8890#issuecomment-1151488957). It's better to assume no performance changes.

### Dope running on net6.0-macos

macOS 12.4 / net6.0-macos / arm64 | Build   | Change    |
----------------------------------|--------:|----------:|
net-6.0 (w/pinvoke wrappers)      | 1467.18 | 385994.96 |
net-6.0 (dispose)                 | 1500.32 | 535083.55 |
Impact                            |   1.02x |     1.38x |

This is much more than I expected. I double checked everything (in case the `ConformsToProtocol` fix was still present) and ran the benchmarks multiple times with similar results.

### Legacy vs net6.0-macos

macOS 12.4 / arm64 | Build   | Change    | Reuse   | Grid    |
-------------------|--------:|----------:|--------:|--------:|
Xamarin.Mac Legacy | 1588.88 | 479364.65 | 1962.81 | 6567.98 |
net-6.0            | 1500.32 | 535083.55 |   N/A   |   N/A   |
Impact             |   0.94x |     1.12x |   N/A   |   N/A   |

The **Change** benchmark is now faster when executed on CoreCLR.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
