### PR TITLE
fix: AutoSuggestBox.QuerySubmitted ChosenSuggestion should not be null, patch.

### DIFF
--- a/doc/articles/guides/uno-material-walkthrough.md
+++ b/doc/articles/guides/uno-material-walkthrough.md
@@ -109,7 +109,7 @@ This guide will walk you through the necessary steps to setup and to use the [`U
     </Application.Resources>
     ```
 
-### Section 2: Using Uno.Material library
+### Section 2: Using Uno.Toolkit.UI library
 1. Let's add a few controls with the Material style to `MainPage.xaml`:
     ```xml
     <Page x:Class="UnoMaterialSample.MainPage"
@@ -133,10 +133,10 @@ This guide will walk you through the necessary steps to setup and to use the [`U
         </Grid>
     <Page>
     ```
-1. Now we'll add a few new controls that are defined in the Material package - `Card`, `ChipGroup`, `Chip`, and `Divider`:
+1. Now we'll add a few new controls that are defined in the Toolkit.UI package - `Card`, `ChipGroup`, `Chip`, and `Divider`:
     ```xml
     <Page ...
-          xmlns:material="using:Uno.Material.Controls">
+          xmlns:utu="using:Uno.Toolkit.UI">
 
         <Grid toolkit:VisibleBoundsPadding.PaddingMask="Top" >
             <ScrollViewer>
@@ -145,30 +145,30 @@ This guide will walk you through the necessary steps to setup and to use the [`U
                     <!-- ... -->
 
                     <!-- material controls -->
-                    <material:Divider SubHeader="Uno.Material Controls:" Style="{StaticResource MaterialDividerStyle}" />
-                    <material:Card HeaderContent="Material Design"
+                    <utu:Divider SubHeader="Uno.Material Controls:" Style="{StaticResource MaterialDividerStyle}" />
+                    <utu:Card HeaderContent="Material Design"
                             SupportingContent="Material is a design system created by Google to help teams build high-quality digital experiences for Android, iOS, Flutter, and the web."
                             Style="{StaticResource MaterialOutlinedCardStyle}">
-                        <material:Card.HeaderContentTemplate>
+                        <utu:Card.HeaderContentTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding}" Margin="16,14,16,0" Style="{ThemeResource MaterialHeadline6}" />
                             </DataTemplate>
-                        </material:Card.HeaderContentTemplate>
-                        <material:Card.SupportingContentTemplate>
+                        </utu:Card.HeaderContentTemplate>
+                        <utu:Card.SupportingContentTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding}" Margin="16,0,16,14" Style="{ThemeResource MaterialBody2}" />
                             </DataTemplate>
-                        </material:Card.SupportingContentTemplate>
-                    </material:Card>
-                    <material:ChipGroup SelectionMode="Multiple" Style="{StaticResource MaterialFilledInputChipGroupStyle}">
-                        <material:Chip Content="Uno" />
-                        <material:Chip Content="Material" />
-                        <material:Chip Content="Controls" />
-                    </material:ChipGroup>
+                        </utu:Card.SupportingContentTemplate>
+                    </utu:Card>
+                    <utu:ChipGroup SelectionMode="Multiple" Style="{StaticResource MaterialFilledInputChipGroupStyle}">
+                        <utu:Chip Content="Uno" />
+                        <utu:Chip Content="Material" />
+                        <utu:Chip Content="Controls" />
+                    </utu:ChipGroup>
                 </StackPanel>
             </ScrollViewer>
         </Grid>
-    <Page>
+    </Page>
     ```
 
 > [!TIP]

--- a/src/SamplesApp/SamplesApp.UITests/TestFramework/IsExternalInit.cs
+++ b/src/SamplesApp/SamplesApp.UITests/TestFramework/IsExternalInit.cs
@@ -3,8 +3,7 @@ using System.Linq;
 
 namespace System.Runtime.CompilerServices;
 
-#if !NET5_0 && !NET6_0
-#pragma warning disable CS0436
+#if !NET5_0 && !NET6_0_OR_GREATER
 public class IsExternalInit
 {
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1137,6 +1137,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBoxChosenSuggestion.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Generic.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5536,6 +5540,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_Reason.xaml.cs">
       <DependentUpon>AutoSuggestBox_Reason.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBoxChosenSuggestion.xaml.cs">
+      <DependentUpon>AutoSuggestBoxChosenSuggestion.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\MeasuredBitmapIcon.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Sizing.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxChosenSuggestion.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxChosenSuggestion.xaml
@@ -1,0 +1,25 @@
+<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.AutoSuggestBoxTests.AutoSuggestBoxChosenSuggestion"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:converters="using:UITests.Shared.Windows_UI_Xaml_Controls.AutoSuggestBoxTests"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	
+    <Grid>
+      		<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+			</Grid.RowDefinitions>
+
+
+		<AutoSuggestBox x:Name="autoSuggestBox"  Text="{Binding book.Author}" QuerySubmitted="autoSuggestBox_QuerySubmitted" TextChanged="autoSuggestBox_TextChanged"  VerticalAlignment="Top">
+		</AutoSuggestBox>
+		<TextBlock x:Name="localTextBlock" Grid.Row="0" FontSize="12" />
+		<TextBlock x:Name="logger" Grid.Row="3" FontSize="12" />
+    </Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxChosenSuggestion.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxChosenSuggestion.xaml.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections;
+using System.Linq;
+using Windows.Foundation;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.AutoSuggestBoxTests
+{
+	public class Author
+	{
+		public static Author[] All = new Author[]
+											{
+														new Author { Name = "A0" },
+														new Author { Name = "A1" },
+														new Author { Name = "A2" },
+														new Author { Name = "A3" },
+														new Author { Name = "B0" },
+														new Author { Name = "B1" },
+														new Author { Name = "B2" },
+														new Author { Name = "B3" },
+														new Author { Name = "a0" },
+														new Author { Name = "a1" },
+														new Author { Name = "a2" },
+														new Author { Name = "a3" },
+											};
+
+		public string Name { get; set; } = string.Empty;
+
+		public override string ToString() => Name;
+	}
+
+	public class Book
+	{	
+		public Author Author { get; set; }		
+	}   
+
+	[SampleControlInfo("AutoSuggestBox", nameof(AutoSuggestBoxChosenSuggestion))]
+	public sealed partial class AutoSuggestBoxChosenSuggestion : UserControl
+	{
+		private Book book = new Book { Author = new Author { Name = "A0" } };
+
+        public AutoSuggestBoxChosenSuggestion()
+        {
+            this.InitializeComponent();		
+		}
+
+		private async void autoSuggestBox_QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs e)
+		{
+			if (e.ChosenSuggestion == null)
+			{
+				await new ContentDialog
+				{
+					Content = "e.ChosenSuggestion == NULL: this is wrong !!!",
+					PrimaryButtonText = "OK",
+					RequestedTheme = ElementTheme.Default,
+					XamlRoot = XamlRoot,
+				}.ShowAsync();
+			}
+			else
+			{
+				logger.Text = $"ChosenSuggestion -> {(e.ChosenSuggestion?.ToString() ?? "<null>")}";				
+			}
+		}
+
+		private void autoSuggestBox_TextChanged(AutoSuggestBox s, AutoSuggestBoxTextChangedEventArgs e)
+		{
+			if (e.Reason == AutoSuggestionBoxTextChangeReason.UserInput && s.Text?.Trim() is { Length: > 0 } searchTerm)
+			{
+				s.ItemsSource = Author.All.Where(a => a.Name.StartsWith(searchTerm)).ToList();				
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -96,5 +96,49 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				await WindowHelper.WaitForIdle();
 			}
 		}
+
+		[TestMethod]
+		public async Task When_Choose_Selection()
+		{
+			var SUT = new AutoSuggestBox();
+
+			static void QuerySubmitted(AutoSuggestBox sender, AutoSuggestBoxQuerySubmittedEventArgs args)
+			{
+				if (args.ChosenSuggestion is null)
+				{
+					Assert.Fail();
+				}
+			}
+			Button button = null;
+			try
+			{
+				
+
+				button = new Button();
+				var stack = new StackPanel()
+				{
+					Children =
+					{
+						button,
+						SUT
+					}
+				};
+
+				SUT.QuerySubmitted += QuerySubmitted;
+				SUT.ItemsSource = new List<string>() { "ab", "abc", "abcde" };
+				WindowHelper.WindowContent = stack;
+				await WindowHelper.WaitForIdle();
+				
+
+				SUT.Focus(FocusState.Programmatic);				
+				SUT.Text = "ab";
+				await WindowHelper.WaitForIdle();
+			}
+			finally
+			{	
+				button?.Focus(FocusState.Programmatic); // Unfocus the AutoSuggestBox to ensure popup is closed.
+				await WindowHelper.WaitForIdle();
+			}
+		}		
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Specialized;
+using System.Collections.Generic;
 using System.Linq;
 using Uno.Extensions;
 using Uno.Extensions.Specialized;
@@ -325,8 +326,11 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		private void SubmitSearch()
-		{
-			QuerySubmitted?.Invoke(this, new AutoSuggestBoxQuerySubmittedEventArgs(_suggestionsList.SelectedItem, Text));
+	    {	
+			string finalResult = GetObjectText(Text);
+
+			QuerySubmitted?.Invoke(this, new AutoSuggestBoxQuerySubmittedEventArgs(finalResult is "" ? null : finalResult, userInput));			
+
 			IsSuggestionListOpen = false;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -326,8 +326,8 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		private void SubmitSearch()
-	    {	
-			string finalResult = GetObjectText(Text);
+	    {
+			var finalResult = _suggestionsList.SelectedItem ?? GetObjectText(Text);
 
 			QuerySubmitted?.Invoke(this, new AutoSuggestBoxQuerySubmittedEventArgs(finalResult is "" ? null : finalResult, userInput));			
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -28,7 +28,9 @@ namespace Windows.UI.Xaml.Controls
 		public event DragItemsStartingEventHandler DragItemsStarting;
 		public event TypedEventHandler<ListViewBase, DragItemsCompletedEventArgs> DragItemsCompleted;
 
-		protected bool _isProcessingReorder;
+#pragma warning disable CS0414 // Field currently used only on Android.
+		private bool _isProcessingReorder;
+#pragma warning restore CS0414
 
 		#region CanReorderItems (DP)
 		public static DependencyProperty CanReorderItemsProperty { get; } = DependencyProperty.Register(
@@ -189,8 +191,8 @@ namespace Windows.UI.Xaml.Controls
 
 		private static void OnReorderDragUpdated(object sender, _DragEventArgs dragEventArgs)
 		{
-			var that = sender as ListView;
-			var src = dragEventArgs.DataView.FindRawData(ReorderOwnerFormatId) as ListView;
+			var that = sender as ListViewBase;
+			var src = dragEventArgs.DataView.FindRawData(ReorderOwnerFormatId) as ListViewBase;
 			var item = dragEventArgs.DataView.FindRawData(ReorderItemFormatId);
 			var container = dragEventArgs.DataView.FindRawData(ReorderContainerFormatId) as FrameworkElement; // TODO: This might have changed/been recycled if scrolled 
 			if (that is null || src is null || item is null || container is null || src != that)
@@ -221,8 +223,8 @@ namespace Windows.UI.Xaml.Controls
 
 		private static void OnReorderDragLeave(object sender, _DragEventArgs dragEventArgs)
 		{
-			var that = sender as ListView;
-			var src = dragEventArgs.DataView.FindRawData(ReorderOwnerFormatId) as ListView;
+			var that = sender as ListViewBase;
+			var src = dragEventArgs.DataView.FindRawData(ReorderOwnerFormatId) as ListViewBase;
 			if (that is null || src != that)
 			{
 				if (dragEventArgs.Log().IsEnabled(LogLevel.Warning)) dragEventArgs.Log().Warn("Invalid reorder event.");
@@ -236,11 +238,11 @@ namespace Windows.UI.Xaml.Controls
 
 		private static void OnReorderCompleted(object sender, _DragEventArgs dragEventArgs)
 		{
-			var that = sender as ListView;
+			var that = sender as ListViewBase;
 
 			that?.SetPendingAutoPanVelocity(PanVelocity.Stationary);
 
-			var src = dragEventArgs.DataView.FindRawData(ReorderOwnerFormatId) as ListView;
+			var src = dragEventArgs.DataView.FindRawData(ReorderOwnerFormatId) as ListViewBase;
 			var item = dragEventArgs.DataView.FindRawData(ReorderItemFormatId);
 			var container = dragEventArgs.DataView.FindRawData(ReorderContainerFormatId) as FrameworkElement; // TODO: This might have changed/been recycled if scrolled 
 			if (that is null || src is null || item is null || container is null || src != that)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7778

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Please see attached sample - which is a modified version of what I posted at https://github.com/unoplatform/uno/issues/4382 - and search for '!!!': in the QuerySubmitted event "e.ChosenSuggestion == null" when selection an option from the drop down. This is wrong

## What is the new behavior?
Should work as in WindowsAppSDK desktop

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->