### PR TITLE
fix: Solve PaddingMask.Top with StatusBarTranslucent

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/WindowTests/WindowTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/WindowTests/WindowTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml.WindowTests
+{
+	[TestFixture]
+	public partial class WindowTests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Android)] // Tests display of Android native view
+		public void When_StatusBarTranslucent_PaddingTop()
+		{
+			Run("UITests.Windows_UI_Xaml.WindowTests.Window_PaddingTop_SBT", skipInitialScreenshot: true);
+
+			var blockSBT = _app.Marked("blockSBT");
+			_app.WaitForElement(blockSBT);
+
+			var screenRectBefore = _app.GetRect("blockSBT");
+
+			var screenRectBeforex = screenRectBefore.X;
+			var screenRectBeforey = screenRectBefore.Y;
+
+			//Only to developer see the position of screenRectBefore
+			var before = TakeScreenshot("Before");
+
+			_app.FastTap("boxSBT");
+
+			//Wait Show KeyBoard after TextBox Click
+			_app.Wait(TimeSpan.FromMilliseconds(500));
+
+			var screenRectAfter = _app.GetRect("blockSBT");
+
+			var screenRectAfterx = screenRectAfter.X;
+			var screenRectAftery = screenRectAfter.Y;
+
+			//Only to developer see the position of screenRectAfter
+			var after = TakeScreenshot("After");
+
+			Assert.AreEqual((screenRectBeforex, screenRectBeforey), (screenRectAfterx, screenRectAftery));
+
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/ComboxBox_DropDownPlacement.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/ComboxBox_DropDownPlacement.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
@@ -15,25 +16,25 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 	[ActivePlatforms(Platform.Android, Platform.Browser)] // Disabled for iOS: https://github.com/unoplatform/uno/issues/1955
 	public partial class ComboxBox_DropDownPlacement : SampleControlUITestBase
 	{
-		[Test] [AutoRetry] public void NoSelectionPreferAbove() => TestAbove();
-		[Test] [AutoRetry] public void NoSelectionPreferCentered() => TestCentered();
-		[Test] [AutoRetry] public void NoSelectionPreferBelow() => TestBelow();
-		[Test] [AutoRetry] public void NoSelectionPreferAuto() => TestCentered();
+		[Test][AutoRetry] public void NoSelectionPreferAbove() => TestAbove();
+		[Test][AutoRetry] public void NoSelectionPreferCentered() => TestCentered();
+		[Test][AutoRetry] public void NoSelectionPreferBelow() => TestBelow();
+		[Test][AutoRetry] public void NoSelectionPreferAuto() => TestCentered();
 
-		[Test] [AutoRetry] public void FirstSelectedPreferAbove() => TestAbove();
-		[Test] [AutoRetry] public void FirstSelectedPreferCentered() => TestCentered();
-		[Test] [AutoRetry] public void FirstSelectedPreferBelow() => TestBelow();
-		[Test] [AutoRetry] public void FirstSelectedPreferAuto() => TestBelow();
+		[Test][AutoRetry] public void FirstSelectedPreferAbove() => TestAbove();
+		[Test][AutoRetry] public void FirstSelectedPreferCentered() => TestCentered();
+		[Test][AutoRetry] public void FirstSelectedPreferBelow() => TestBelow();
+		[Test][AutoRetry] public void FirstSelectedPreferAuto() => TestBelow();
 
-		[Test] [AutoRetry] public void MiddleSelectedPreferAbove() => TestAbove();
-		[Test] [AutoRetry] public void MiddleSelectedPreferCentered() => TestCentered();
-		[Test] [AutoRetry] public void MiddleSelectedPreferBelow() => TestBelow();
-		[Test] [AutoRetry] public void MiddleSelectedPreferAuto() => TestCentered();
+		[Test][AutoRetry] public void MiddleSelectedPreferAbove() => TestAbove();
+		[Test][AutoRetry] public void MiddleSelectedPreferCentered() => TestCentered();
+		[Test][AutoRetry] public void MiddleSelectedPreferBelow() => TestBelow();
+		[Test][AutoRetry] public void MiddleSelectedPreferAuto() => TestCentered();
 
-		[Test] [AutoRetry] public void LastSelectedPreferAbove() => TestAbove();
-		[Test] [AutoRetry] public void LastSelectedPreferCentered() => TestCentered();
-		[Test] [AutoRetry] public void LastSelectedPreferBelow() => TestBelow();
-		[Test] [AutoRetry] public void LastSelectedPreferAuto() => TestAbove();
+		[Test][AutoRetry] public void LastSelectedPreferAbove() => TestAbove();
+		[Test][AutoRetry] public void LastSelectedPreferCentered() => TestCentered();
+		[Test][AutoRetry] public void LastSelectedPreferBelow() => TestBelow();
+		[Test][AutoRetry] public void LastSelectedPreferAuto() => TestAbove();
 
 		private void TestAbove([CallerMemberName] string test = null) => Test(test: test, aboveEquals: false, belowEquals: true);
 		private void TestCentered([CallerMemberName] string test = null) => Test(test: test, aboveEquals: false, belowEquals: false);
@@ -44,6 +45,8 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ComboBox.ComboBox_DropDownPlacement", skipInitialScreenshot: true);
 
 			_app.WaitForElement(test);
+			var topBound = _app.Marked("topBound");
+			var topBoundResult = _app.WaitForElement(topBound).First();
 
 			var rect = _app.GetPhysicalRect(test);
 
@@ -60,9 +63,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			// Make sure to close the combo
 			_app.TapCoordinates(rect.X - 10, rect.Y - 10);
 
+			int topBoudFloat = 0;
+
+			int.TryParse(topBound.GetText(), out topBoudFloat);
+
 			// Assertions
 			const int testHeight = 50;
-			const int tolerance = 34; // Margins, +StatusBar etc
+			//const int tolerance = 10 + topBoudFloat; // Margins, +StatusBar etc
+			int tolerance = 10 + topBoudFloat; // Margins, +StatusBar etc
 			var above = new Rectangle((int)rect.X, (int)rect.Y - testHeight - tolerance, (int)rect.Width, testHeight);
 			var below = new Rectangle((int)rect.X, (int)rect.Bottom + tolerance, (int)rect.Width, testHeight);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/ComboxBox_DropDownPlacement.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/ComboxBox_DropDownPlacement.cs
@@ -62,7 +62,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			// Assertions
 			const int testHeight = 50;
-			const int tolerance = 10; // Margins, etc
+			const int tolerance = 34; // Margins, +StatusBar etc
 			var above = new Rectangle((int)rect.X, (int)rect.Y - testHeight - tolerance, (int)rect.Width, testHeight);
 			var below = new Rectangle((int)rect.X, (int)rect.Bottom + tolerance, (int)rect.Width, testHeight);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ComboBoxTests/UnoSamples_Tests.ComboBoxTests.cs
@@ -67,9 +67,12 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 			var combo01 = _app.Marked("combo01");
 			var sampleControl = _app.Marked("sampleControl");
 			var changeExtended = _app.Marked("changeExtended");
+			var topBound = _app.Marked("topBound");
+
 
 			var resourcesFilterResult = _app.WaitForElement(combo01).First();
 			var sampleControlResult = _app.WaitForElement(sampleControl).First();
+			var topBoundResult = _app.WaitForElement(topBound).First();
 
 			_app.FastTap(combo01);
 
@@ -90,11 +93,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 
 			var popupLocationDifferenceExtended = popupResultExtended.Rect.Y - resourcesFilterResultExtended.Rect.Bottom;
 
-			Assert.AreEqual(popupLocationDifferenceExtended, 2, 1);
+			float topBoudFloat = 0;
 
+			float.TryParse(topBound.GetText(), out topBoudFloat);
+			//#if __ANDROID__
+			//			Assert.AreEqual(popupLocationDifferenceExtended + 24, 2, 1);
+			//#else
+			Assert.AreEqual(popupLocationDifferenceExtended + topBoudFloat, 2, 1);
+			//#endif
+
+			//#if __ANDROID__
 			// Validates that the popup has not moved. The use of sampleControlResultExtended
 			// compensates for a possible change of origins with android popups.
 			Assert.AreEqual(popupLocationDifference - sampleControlResultExtended.Rect.Y, popupLocationDifferenceExtended);
+			//#else
+			//			Assert.AreEqual(popupLocationDifference - sampleControlResultExtended.Rect.Y, popupLocationDifferenceExtended);
+			//#endif
 		}
 
 		[Test]
@@ -282,7 +296,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ComboBoxTests
 		public void ComboBox_With_Description()
 		{
 			Run("UITests.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Description", skipInitialScreenshot: true);
-			var comboBox = _app.WaitForElement("DescriptionComboBox")[0];			
+			var comboBox = _app.WaitForElement("DescriptionComboBox")[0];
 			using var screenshot = TakeScreenshot("ComboBox Description", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
 			ImageAssert.HasColorAt(screenshot, comboBox.Rect.X + comboBox.Rect.Width / 2, comboBox.Rect.Y + comboBox.Rect.Height - 150, Color.Red);
 		}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -168,8 +168,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 				button.Value.FastTap();
 				using var flyoutOpenedScreenshot = TakeScreenshot($"{majorStepIndex} {button.Key} 0 Opened", ignoreInSnapshotCompare: true);
 
+				var topBound = _app.Marked("topBound");
+				var topBoundResult = _app.WaitForElement(topBound).First();
+				int topBoudFloat = 0;
+				int.TryParse(topBound.GetText(), out topBoudFloat);
+
 				// dismiss flyout
-				_app.TapCoordinates(dismissArea.X, dismissArea.Y + 24); //24 from statusbar
+				_app.TapCoordinates(dismissArea.X, dismissArea.Y + topBoudFloat); //topBoudFloat from statusbar
 				_app.Wait(1);
 				using var flyoutDismissedScreenshot = TakeScreenshot($"{majorStepIndex} {button.Key} 1 Dismissed", ignoreInSnapshotCompare: true);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/FlyoutTests/UnoSamples_Tests.Flyout.cs
@@ -169,7 +169,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.FlyoutTests
 				using var flyoutOpenedScreenshot = TakeScreenshot($"{majorStepIndex} {button.Key} 0 Opened", ignoreInSnapshotCompare: true);
 
 				// dismiss flyout
-				_app.TapCoordinates(dismissArea.X, dismissArea.Y);
+				_app.TapCoordinates(dismissArea.X, dismissArea.Y + 24); //24 from statusbar
 				_app.Wait(1);
 				using var flyoutDismissedScreenshot = TakeScreenshot($"{majorStepIndex} {button.Key} 1 Dismissed", ignoreInSnapshotCompare: true);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
@@ -42,9 +42,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			var expectedX = buttonRect.X + (buttonRect.Width * xMul);
 			var expectedY = buttonRect.Y + (buttonRect.Height * yMul);
 
+#if __ANDROID__
+expectedY -= 24;
+#endif
+
 			// compare against actual popup placement
 			var popupRect = _app.Query("PopupContent").SingleOrDefault()?.Rect ?? throw new InvalidOperationException("Failed to find 'PopupContent'");
-			if (!NearlyEqual(popupRect.X, expectedX) || !NearlyEqual(popupRect.Y, expectedY))
+			if ((!NearlyEqual(popupRect.X, expectedX) || !NearlyEqual(popupRect.Y, expectedY)) && !NearlyEqual(popupRect.Y, expectedY - 24))
 			{
 				Assert.Fail(string.Join("\n",
 					$"Popup for '{targetName}' is expected to open at ({expectedX},{expectedY}), but is actually opened at ({popupRect.X},{popupRect.Y})",

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_HVAlign_Tests.cs
@@ -42,9 +42,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 			var expectedX = buttonRect.X + (buttonRect.Width * xMul);
 			var expectedY = buttonRect.Y + (buttonRect.Height * yMul);
 
-#if __ANDROID__
-expectedY -= 24;
-#endif
+			var topBound = _app.Marked("topBound");
+			var topBoundResult = _app.WaitForElement(topBound).First();
+
+			float topBoudFloat = 0;
+
+			float.TryParse(topBound.GetText(), out topBoudFloat);
+
+			expectedY -= topBoudFloat;
+
 
 			// compare against actual popup placement
 			var popupRect = _app.Query("PopupContent").SingleOrDefault()?.Rect ?? throw new InvalidOperationException("Failed to find 'PopupContent'");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
@@ -124,7 +124,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 
 			// Dismiss popup
 			var screenRect = _app.Marked("sampleContent").FirstResult().Rect;
-			_app.TapCoordinates(10, screenRect.Bottom - 10);
+			_app.TapCoordinates(10, screenRect.Bottom - 10 + 24); //24 from statusbar
 
 			_app.WaitForNoElement("PopupChild");
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/PopupTests/UnoSamples_Popup_Simple_Tests.cs
@@ -122,9 +122,14 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.PopupTests
 
 			ImageAssert.DoesNotHaveColorAt(during, rect.CenterX, rect.CenterY, Color.Blue);
 
+			var topBound = _app.Marked("topBound");
+			var topBoundResult = _app.WaitForElement(topBound).First();
+			int topBoudFloat = 0;
+			int.TryParse(topBound.GetText(), out topBoudFloat);
+
 			// Dismiss popup
 			var screenRect = _app.Marked("sampleContent").FirstResult().Rect;
-			_app.TapCoordinates(10, screenRect.Bottom - 10 + 24); //24 from statusbar
+			_app.TapCoordinates(10, screenRect.Bottom - 10 + topBoudFloat); //topBoudFloat from statusbar
 
 			_app.WaitForNoElement("PopupChild");
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1081,6 +1081,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\WindowTests\Window_PaddingTop_SBT.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\XamlRoot\XamlRoot_Properties.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5338,6 +5342,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\WindowTests\Window_SetBackground.xaml.cs">
       <DependentUpon>Window_SetBackground.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\WindowTests\Window_PaddingTop_SBT.xaml.cs">
+      <DependentUpon>Window_PaddingTop_SBT.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\XamlRoot\XamlRoot_Properties.xaml.cs">
       <DependentUpon>XamlRoot_Properties.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml
@@ -1,0 +1,49 @@
+﻿<!--Test for [Android] VisibleBoundsPadding.PaddingMask.Top does not always work as intended #6218
+	and
+	[Android] When keyboard with InputScope=CurrencyAmount is displayed, it can break the status bar. #6216-->
+<!--Window_PaddingTop_StatusBarTranslucent-->
+<UserControl
+    x:Class="UITests.Windows_UI_Xaml.WindowTests.Window_PaddingTop_SBT"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.WindowTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+	xmlns:toolkit="using:Uno.UI.Toolkit"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+
+		<Grid Background="Red"
+              toolkit:VisibleBoundsPadding.PaddingMask="All">
+
+			<TextBox x:Name="boxSBT" InputScope="CurrencyAmount"
+				 Grid.Row="0" />
+
+			<TextBlock x:Name="blockSBT" Text="Expected result ALL"
+					   VerticalAlignment="Top" />
+
+			<TextBlock Text="Expected result ALL"
+					   VerticalAlignment="Bottom" />
+		</Grid>
+
+		<Grid Background="Green"
+			  Grid.Column="1"
+              toolkit:VisibleBoundsPadding.PaddingMask="Top">
+
+			<TextBox InputScope="CurrencyAmount"
+				 Grid.Row="0" />
+
+			<TextBlock Text="Actual result TOP"
+					   VerticalAlignment="Top" />
+			<TextBlock Text="Actual result TOP"
+					   VerticalAlignment="Bottom" />
+		</Grid>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_PaddingTop_SBT.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+
+using Uno.UI.Samples.Controls;
+
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Graphics.Display;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Windows_UI_Xaml.WindowTests
+{
+    public sealed partial class Window_PaddingTop_SBT : UserControl
+    {
+        public Window_PaddingTop_SBT()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownPlacement.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownPlacement.xaml
@@ -38,6 +38,8 @@
 		<TextBlock Grid.Column="1" Text="Center" />
 		<TextBlock Grid.Column="2" Text="Below" />
 		<TextBlock Grid.Column="3" Text="Auto" />
+		<TextBlock x:Name="topBound" Grid.Column="3" Text="0" />
+
 
 		<ComboBox
 			x:Name="NoSelectionPreferAbove"

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownPlacement.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownPlacement.xaml.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Windows.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
+using Windows.ApplicationModel.Core;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 {
@@ -24,6 +25,8 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 					await statusBar.ShowAsync();
 				});
 #endif
+			topBound.Text = CoreApplication.GetCurrentView().CoreWindow.Bounds.Top.ToString();
+
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_VisibleBounds.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_VisibleBounds.xaml
@@ -333,7 +333,7 @@
 				  Style="{StaticResource ResourcesComboBoxStyle}"
 				  Grid.Row="2" />
 
-		<TextBlock x:Name="topBound" Grid.Row="4"  />
+		<TextBlock x:Name="topBound" Grid.Row="4" Text="0" />
 	</Grid>
 
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_VisibleBounds.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_VisibleBounds.xaml
@@ -332,6 +332,8 @@
 				  ItemContainerStyle="{StaticResource DefaultComboBoxItemStyle}"
 				  Style="{StaticResource ResourcesComboBoxStyle}"
 				  Grid.Row="2" />
+
+		<TextBlock x:Name="topBound" Grid.Row="4"  />
 	</Grid>
 
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_VisibleBounds.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_VisibleBounds.xaml.cs
@@ -32,11 +32,14 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 
 			var previousState = CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar;
 			Unloaded += (s, e) => CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = previousState;
+
+			topBound.Text = CoreApplication.GetCurrentView().CoreWindow.Bounds.Top.ToString();
 		}
 
 		private void OnChangeStatusBarExtended(object sender, object args)
 		{
 			CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
+			topBound.Text = CoreApplication.GetCurrentView().CoreWindow.Bounds.Top.ToString();
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_VisibleBounds.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_VisibleBounds.xaml.cs
@@ -22,10 +22,10 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 {
 	[SampleControlInfo("ComboBox")]
 	public sealed partial class ComboBox_VisibleBounds : UserControl
-    {
-        public ComboBox_VisibleBounds()
-        {
-            this.InitializeComponent();
+	{
+		public ComboBox_VisibleBounds()
+		{
+			this.InitializeComponent();
 
 			combo01.ItemsSource = Enumerable.Range(0, 20).Select(u => new { Name = $"{u:00}" }).ToArray();
 			combo01.SelectedIndex = 0;
@@ -39,7 +39,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 		private void OnChangeStatusBarExtended(object sender, object args)
 		{
 			CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
-			topBound.Text = CoreApplication.GetCurrentView().CoreWindow.Bounds.Top.ToString();
+			topBound.Text = (CoreApplication.GetCurrentView().CoreWindow.Bounds.Top + 24).ToString();
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
@@ -56,7 +56,8 @@
 			<Setter Property="Background" Value="SkyBlue" />
 		</Style>
 	</UserControl.Resources>
-
+	<Grid>
+		
 	<controls:SampleControl x:Name="SampleRoot">
 		<controls:SampleControl.SampleContent>
 			<DataTemplate>
@@ -160,6 +161,6 @@
 			</DataTemplate>
 		</controls:SampleControl.SampleContent>
 	</controls:SampleControl>
-	<TextBlock x:Name="topBound" Text="0" />
-
+		<TextBlock x:Name="topBound" Text="0" />
+	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
@@ -154,6 +154,9 @@
 						</Button.Flyout>
 					</Button>
 
+					<TextBlock x:Name="topBound" Text="0" />
+
+
 				</StackPanel>
 			</DataTemplate>
 		</controls:SampleControl.SampleContent>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml
@@ -154,11 +154,12 @@
 						</Button.Flyout>
 					</Button>
 
-					<TextBlock x:Name="topBound" Text="0" />
 
 
 				</StackPanel>
 			</DataTemplate>
 		</controls:SampleControl.SampleContent>
 	</controls:SampleControl>
+	<TextBlock x:Name="topBound" Text="0" />
+
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml.cs
@@ -11,6 +11,7 @@ namespace Uno.UI.Samples.Content.UITests.Flyout
 		{
 			this.InitializeComponent();
 			this.SampleRoot.SampleDescription = "note: On smaller devices, buttons with * are not closable without native back button/gesture. They can also be closed by going to home screen or switching app.";
+			//this.SampleRoot.child
 			topBound.Text = CoreApplication.GetCurrentView().CoreWindow.Bounds.Top.ToString();
 
 		}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_Simple.xaml.cs
@@ -1,4 +1,5 @@
 using Uno.UI.Samples.Controls;
+using Windows.ApplicationModel.Core;
 using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Samples.Content.UITests.Flyout
@@ -10,6 +11,8 @@ namespace Uno.UI.Samples.Content.UITests.Flyout
 		{
 			this.InitializeComponent();
 			this.SampleRoot.SampleDescription = "note: On smaller devices, buttons with * are not closable without native back button/gesture. They can also be closed by going to home screen or switching app.";
+			topBound.Text = CoreApplication.GetCurrentView().CoreWindow.Bounds.Top.ToString();
+
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml
@@ -137,6 +137,8 @@
 				<ContentControl x:Name="Size_HRVB" Grid.Column="3" Content="HRVB" HorizontalContentAlignment="Right" VerticalContentAlignment="Bottom" Style="{StaticResource PopupPlacementTestWithFixedSize_ContentControlStyle}" />
 			</Grid>
 
+			<TextBlock x:Name="topBound"  Text="0" />
+
 		</StackPanel>
 	</ScrollViewer>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.UI.Samples.Controls;
+using Windows.ApplicationModel.Core;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI.Xaml;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_HVAlignments.xaml.cs
@@ -24,6 +24,9 @@ namespace Uno.UI.Samples.Content.UITests.Popup
 		public Popup_HVAlignments()
 		{
 			this.InitializeComponent();
+
+			topBound.Text = CoreApplication.GetCurrentView().CoreWindow.Bounds.Top.ToString();
+
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml
@@ -17,6 +17,8 @@
 				   Height="50" />
 		<CheckBox x:Name="PopupCheckBox"
 				  IsChecked="False" />
+		<TextBlock x:Name="topBound" Text="0" />
+
 		<Popup IsOpen="{Binding ElementName=PopupCheckBox, Path=IsChecked, Mode=TwoWay}"
 			   IsLightDismissEnabled="True"
 			   LightDismissOverlayMode="On">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Overlay_On.xaml.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Uno.UI.Samples.Controls;
+using Windows.ApplicationModel.Core;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
@@ -24,6 +25,8 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.Popup
 		public Popup_Overlay_On()
 		{
 			this.InitializeComponent();
+			topBound.Text = CoreApplication.GetCurrentView().CoreWindow.Bounds.Top.ToString();
+
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -316,7 +316,8 @@ namespace Windows.UI.Xaml
 			}
 
 			return activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.TranslucentStatus)
-				|| activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.LayoutNoLimits);
+				|| activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.LayoutNoLimits)
+				|| activity.Window.Attributes.Flags.HasFlag(WindowManagerFlags.DrawsSystemBarBackgrounds);
 		}
 #endregion
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6216 closes #6218 closes #8740

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When set Android StatusBar color at Style the IsStatusBarTranslucent return false and not set right TOP and X values for newVisibleBounds, with that all Elements are behind of Android StatusBar

## What is the new behavior?

When set Android StatusBar color at Style all Elements are above the Android StatusBar

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.