### PR TITLE
fix: Window Title by Manifest in SKIA WPF 

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -200,6 +200,8 @@ namespace Uno.UI.Skia.Platform
 			}
 
 			WinUI.Application.StartWithArguments(CreateApp);
+
+			WpfApplication.Current.MainWindow.Title = Windows.ApplicationModel.Package.Current.DisplayName;
 		}
 
 		private void MainWindow_StateChanged(object? sender, EventArgs e)


### PR DESCRIPTION
Need to correct the Visual Studio Template to add the Package.appxmanifest to the WPF.

GitHub Issue (If applicable): closes #8356
 
## PR Type

What kind of change does this PR introduce?
 
- Bugfix 

## What is the current behavior?

Wasn't working on SKIA WPF.

## What is the new behavior?

Now works fine on both platforms.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

 
## Other information
**Attention!!!!**
The VS template must be updated to include the Package.appxmanifest inside the SKIA.WPF project!!

