### PR TITLE
perf(iOSmacOS): Directly convert from `Color` to `CGColor`

### DIFF
--- a/src/Uno.UWP/UI/Color.iOS.cs
+++ b/src/Uno.UWP/UI/Color.iOS.cs
@@ -11,7 +11,7 @@ namespace Windows.UI
 	public partial struct Color : IFormattable
 	{
 		public static implicit operator UIKit.UIColor(Color color) => UIKit.UIColor.FromRGBA(color.R, color.G, color.B, color.A);
-		public static implicit operator CGColor(Color color) => new CGColor(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
+		public static implicit operator CGColor(Color color) => CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
 
 		public static implicit operator Color(UIKit.UIColor color) => color.CGColor;
 

--- a/src/Uno.UWP/UI/Color.iOS.cs
+++ b/src/Uno.UWP/UI/Color.iOS.cs
@@ -1,5 +1,6 @@
 ﻿#if __IOS__
 using System;
+using CoreGraphics;
 
 #if NET6_0_OR_GREATER
 using ObjCRuntime;
@@ -10,7 +11,7 @@ namespace Windows.UI
 	public partial struct Color : IFormattable
 	{
 		public static implicit operator UIKit.UIColor(Color color) => UIKit.UIColor.FromRGBA(color.R, color.G, color.B, color.A);
-		public static implicit operator CoreGraphics.CGColor(Color color) => UIKit.UIColor.FromRGBA(color.R, color.G, color.B, color.A).CGColor;
+		public static implicit operator CGColor(Color color) => new CGColor(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
 
 		public static implicit operator Color(UIKit.UIColor color) => color.CGColor;
 

--- a/src/Uno.UWP/UI/Color.macOS.cs
+++ b/src/Uno.UWP/UI/Color.macOS.cs
@@ -1,5 +1,6 @@
-﻿#if __MACOS__
+#if __MACOS__
 using System;
+using CoreGraphics;
 
 #if NET6_0_OR_GREATER
 using ObjCRuntime;
@@ -10,7 +11,7 @@ namespace Windows.UI
 	public partial struct Color : IFormattable
 	{
 		public static implicit operator AppKit.NSColor(Color color) => AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A);
-		public static implicit operator CoreGraphics.CGColor(Color color) => AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A).CGColor;
+		public static implicit operator CGColor(Color color) => new CGColor(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
 
 		public static implicit operator Color(AppKit.NSColor color) => color.CGColor;
 

--- a/src/Uno.UWP/UI/Color.macOS.cs
+++ b/src/Uno.UWP/UI/Color.macOS.cs
@@ -11,7 +11,7 @@ namespace Windows.UI
 	public partial struct Color : IFormattable
 	{
 		public static implicit operator AppKit.NSColor(Color color) => AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A);
-		public static implicit operator CGColor(Color color) => new CGColor(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
+		public static implicit operator CGColor(Color color) => CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
 
 		public static implicit operator Color(AppKit.NSColor color) => color.CGColor;
 


### PR DESCRIPTION
- Avoid creating a temporary `NSColor` on macOS
- Avoid creating a temporary `UIColor` on iOS

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Converting a `Color` to `CGColor` creates an intermediary `NSColor` (macOS) or `UIColor` (iOS).

In addition of requiring extra allocations and disposal both `NSColor` and `UIColor` are `NSObject` subclasses and uses ObjC calls (slower than p/invokes) while `CGColor` uses C-based API (p/invokes).


## What is the new behavior?

Direct conversion of `Color` into `CGColor`.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

The following results (on coreclr) shows the cost of both creating and disposing the instances needed to convert a `Color` into a `CGColor` instance.

```
BenchmarkDotNet=v0.12.1, OS=macOS 12.4 (21F79) [Darwin 21.5.0]
Apple M1, 1 CPU, 8 logical and 8 physical cores
.NET Core SDK=6.0.301
  [Host] : .NET Core 6.0 (CoreCLR 6.0.522.21309, CoreFX 6.0.522.21309), Arm64 RyuJIT

Job=InProcess  Toolchain=InProcessEmitToolchain  IterationCount=3
LaunchCount=1  WarmupCount=3
```

|                Method |      Mean |     Error |    StdDev | Ratio |
|---------------------- |----------:|----------:|----------:|------:|
| Color_NSColor_CGColor | 17.240 ms | 45.169 ms | 2.4759 ms |  1.00 |
|         Color_CGColor |  3.923 ms | 10.895 ms | 0.5972 ms |  0.23 |

[Benchmark Source Code](https://gist.github.com/spouliot/09459b963d549f365985af2b9d216b72)


The effect of this PR is below the threshold (around 5%) for Dope to show significant results (in dopes/sec).

Originally `op_Implicit(Color)` looked quite a bigger target but dotnet-trace/speedscope merge all API with the same name... that's not often a problem because, in C#, different return types needs different method names - but that's not the case for `op_*` methods (and most calls, hence time, are spent in another conversion method).



Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
