### PR TITLE
fix: UWP Samples app runtime tests attempt to use DP from non-UI thread

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -63,6 +63,12 @@ namespace Uno.UI.Samples.Tests
 		private List<TestCaseResult> _testCases = new List<TestCaseResult>();
 		private TestRun _currentRun;
 
+		// On WinUI/UWP dependency properties cannot be accessed outside of
+		// UI thread. This field caches the current value so it can be accessed
+		// asynchronously during test enumeration.
+		private int _ciTestsGroupCountCache = -1;
+		private int _ciTestGroupCache = -1;
+		
 		public UnitTestsControl()
 		{
 			this.InitializeComponent();
@@ -128,7 +134,13 @@ namespace Uno.UI.Samples.Tests
 		}
 
 		public static readonly DependencyProperty CITestGroupProperty =
-			DependencyProperty.Register("CITestGroup", typeof(int), typeof(UnitTestsControl), new PropertyMetadata(-1));
+			DependencyProperty.Register("CITestGroup", typeof(int), typeof(UnitTestsControl), new PropertyMetadata(-1, OnCITestGroupChanged));
+
+		private static void OnCITestGroupChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var unitTestsControl = (UnitTestsControl)d;
+			unitTestsControl._ciTestGroupCache = (int)e.NewValue;
+		}
 
 		/// <summary>
 		/// Defines the test group for splitting runtime tests on CI
@@ -140,7 +152,13 @@ namespace Uno.UI.Samples.Tests
 		}
 
 		public static readonly DependencyProperty CITestGroupCountProperty =
-			DependencyProperty.Register("CITestGroupCount", typeof(int), typeof(UnitTestsControl), new PropertyMetadata(-1));
+			DependencyProperty.Register("CITestGroupCount", typeof(int), typeof(UnitTestsControl), new PropertyMetadata(-1, OnCITestsGroupCountChanged));
+
+		private static void OnCITestsGroupCountChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var unitTestsControl = (UnitTestsControl)d;
+			unitTestsControl._ciTestsGroupCountCache = (int)e.NewValue;
+		}
 
 		public string NUnitTestResultsDocument
 		{
@@ -910,7 +928,7 @@ namespace Uno.UI.Samples.Tests
 
 			return from type in types
 				   where type.GetTypeInfo().GetCustomAttribute(typeof(TestClassAttribute)) != null
-				   where CITestGroupCount == -1 || (CITestGroupCount != -1 && (GetTypeTestGroup(type) % CITestGroupCount) == CITestGroup)
+				   where _ciTestsGroupCountCache == -1 || (_ciTestsGroupCountCache != -1 && (GetTypeTestGroup(type) % _ciTestsGroupCountCache) == _ciTestGroupCache)
 				   orderby type.Name
 				   let info = BuildType(type)
 				   where info.Type is { }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9083

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

UWP Runtime tests fail immediately as test enumeration attempts to retrieve dependency properties from non-UI thread

## What is the new behavior?

Value of DPs is cached to fields which are accessed instead of DPs during the enumeration.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
