### PR TITLE
fix: Use fully qualified name lookup for xClass resolution

### DIFF
--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlSchemaContext.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlSchemaContext.cs
@@ -120,7 +120,9 @@ namespace Uno.Xaml
 		XamlType [] empty_xaml_types = new XamlType [0];
 		List<XamlType> run_time_types = new List<XamlType> ();
 		object gate = new object();
+#if SUPPORTS_LOAD_ASSEMBLIES
 		Action unhookAssemblyLoad;
+#endif
 
 		public bool FullyQualifyAssemblyNamesInClrNamespaces { get; private set; }
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/IsExternalInit.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/IsExternalInit.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Linq;
+
+#if !NET5_0
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit
+{
+}
+#endif

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/Nullable.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/Nullable.cs
@@ -1,0 +1,208 @@
+﻿// https://github.com/dotnet/runtime/blob/527f9ae88a0ee216b44d556f9bdc84037fe0ebda/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+
+#pragma warning disable
+#define INTERNAL_NULLABLE_ATTRIBUTES
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if NETSTANDARD2_0 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+	/// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class AllowNullAttribute : Attribute
+	{ }
+
+	/// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class DisallowNullAttribute : Attribute
+	{ }
+
+	/// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class MaybeNullAttribute : Attribute
+	{ }
+
+	/// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class NotNullAttribute : Attribute
+	{ }
+
+	/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class MaybeNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter may be null.
+		/// </param>
+		public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+	}
+
+	/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class NotNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+	}
+
+	/// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+	[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class NotNullIfNotNullAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the associated parameter name.</summary>
+		/// <param name="parameterName">
+		/// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+		/// </param>
+		public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+		/// <summary>Gets the associated parameter name.</summary>
+		public string ParameterName { get; }
+	}
+
+	/// <summary>Applied to a method that will never return under any circumstance.</summary>
+	[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class DoesNotReturnAttribute : Attribute
+	{ }
+
+	/// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+	[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class DoesNotReturnIfAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified parameter value.</summary>
+		/// <param name="parameterValue">
+		/// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+		/// the associated parameter matches this value.
+		/// </param>
+		public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+		/// <summary>Gets the condition parameter value.</summary>
+		public bool ParameterValue { get; }
+	}
+#endif
+
+#if NETSTANDARD2_0 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class MemberNotNullAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with a field or property member.</summary>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(string member) => Members = new[] { member };
+
+		/// <summary>Initializes the attribute with the list of field and property members.</summary>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute(params string[] members) => Members = members;
+
+		/// <summary>Gets field or property member names.</summary>
+		public string[] Members { get; }
+	}
+
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+		sealed class MemberNotNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullWhenAttribute(bool returnValue, string member)
+		{
+			ReturnValue = returnValue;
+			Members = new[] { member };
+		}
+
+		/// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+		{
+			ReturnValue = returnValue;
+			Members = members;
+		}
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+
+		/// <summary>Gets field or property member names.</summary>
+		public string[] Members { get; }
+	}
+#endif
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -375,7 +375,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 
 				return outputFiles.ToArray();
-
 			}
 			catch (OperationCanceledException)
 			{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -26,11 +26,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private readonly static Func<INamedTypeSymbol, string, INamedTypeSymbol> _getAttachedPropertyType;
 		private readonly static Func<INamedTypeSymbol, bool> _isTypeImplemented;
 
-		record XClassName(string ns, string className, INamedTypeSymbol? symbol)
+		record XClassName(string Namespace, string ClassName, INamedTypeSymbol? Symbol)
 		{
 			public override string ToString()
-				=> symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Included))
-				?? ns + "." + className;
+				=> Symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Included))
+				?? Namespace + "." + ClassName;
 		}
 
 		private void InitCaches()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -19,12 +19,19 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private Func<XamlMember, IEventSymbol?>? _findEventType;
 		private Func<INamedTypeSymbol, Dictionary<string, IEventSymbol>>? _getEventsForType;
 		private Func<INamedTypeSymbol, string[]>? _findLocalizableDeclaredProperties;
-		private (string ns, string className) _className;
+		private XClassName? _xClassName;
 		private string[]? _clrNamespaces;
 		private readonly static Func<INamedTypeSymbol, IPropertySymbol?> _findContentProperty;
 		private readonly static Func<INamedTypeSymbol, string, bool> _isAttachedProperty;
 		private readonly static Func<INamedTypeSymbol, string, INamedTypeSymbol> _getAttachedPropertyType;
 		private readonly static Func<INamedTypeSymbol, bool> _isTypeImplemented;
+
+		record XClassName(string ns, string className, INamedTypeSymbol? symbol)
+		{
+			public override string ToString()
+				=> symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Included))
+				?? ns + "." + className;
+		}
 
 		private void InitCaches()
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -354,7 +354,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			EnsureXClassName();
 
 			var xamlDefinedBaseType = GetType(topLevelControl.Type);
-			var fullClassName = _xClassName.ns + "." + _xClassName.className;
+			var fullClassName = _xClassName.Namespace + "." + _xClassName.ClassName;
 			var classDefinedBaseType = FindType(fullClassName)?.BaseType;
 
 			if (!SymbolEqualityComparer.Default.Equals(xamlDefinedBaseType, classDefinedBaseType))
@@ -455,16 +455,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				_xClassName = GetClassName(topLevelControl);
 
-				using (writer.BlockInvariant("namespace {0}", _xClassName.ns))
+				using (writer.BlockInvariant("namespace {0}", _xClassName.Namespace))
 				{
 					AnalyzerSuppressionsGenerator.Generate(writer, _analyzerSuppressions);
 					TryGenerateWarningForInconsistentBaseType(writer, topLevelControl);
 
 					var controlBaseType = GetType(topLevelControl.Type);
 
-					using (writer.BlockInvariant("partial class {0} : {1}", _xClassName.className, controlBaseType.ToDisplayString()))
+					using (writer.BlockInvariant("partial class {0} : {1}", _xClassName.ClassName, controlBaseType.ToDisplayString()))
 					{
-						using (Scope(_xClassName.ns, _xClassName.className))
+						using (Scope(_xClassName.Namespace, _xClassName.ClassName))
 						{
 							if (_generationRunFileInfo.RunInfo.Index == 0)
 							{
@@ -489,7 +489,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 									BuildComponentFields(componentBuilder);
 
-									BuildCompiledBindings(componentBuilder, _xClassName.className);
+									BuildCompiledBindings(componentBuilder, _xClassName.ClassName);
 
 									_generationRunFileInfo.SetAppliedTypes(_xamlAppliedTypes);
 									_generationRunFileInfo.ComponentCode = componentBuilder.ToString();
@@ -549,7 +549,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 
 				EnsureXClassName();
-				BuildCompiledBindingsInitializer(writer, _xClassName.className, controlBaseType);
+				BuildCompiledBindingsInitializer(writer, _xClassName.ClassName, controlBaseType);
 
 				if (isDirectUserControlChild)
 				{
@@ -605,7 +605,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			writer.AppendLineInvariant($"#if __ANDROID__");
 #if NETSTANDARD
-			writer.AppendLineInvariant($"global::Uno.Helpers.DrawableHelper.SetDrawableResolver(global::{_xClassName?.ns}.App.DrawableResourcesIdResolver.Resolve);");
+			writer.AppendLineInvariant($"global::Uno.Helpers.DrawableHelper.SetDrawableResolver(global::{_xClassName?.Namespace}.App.DrawableResourcesIdResolver.Resolve);");
 #else
 			writer.AppendLineInvariant($"global::Uno.Helpers.DrawableHelper.Drawables = typeof(global::{_defaultNamespace}.Resource.Drawable);");
 #endif
@@ -1577,15 +1577,15 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			TryAnnotateWithGeneratorSource(writer);
 			var className = FindClassName(topLevelControl);
 
-			if (className?.ns != null)
+			if (className?.Namespace != null)
 			{
 				var controlBaseType = GetType(topLevelControl.Type);
 
-				using (writer.BlockInvariant("namespace {0}", className.ns))
+				using (writer.BlockInvariant("namespace {0}", className.Namespace))
 				{
-					using (writer.BlockInvariant("public sealed partial class {0} : {1}", className.className, GetGlobalizedTypeName(controlBaseType.ToDisplayString())))
+					using (writer.BlockInvariant("public sealed partial class {0} : {1}", className.ClassName, GetGlobalizedTypeName(controlBaseType.ToDisplayString())))
 					{
-						using (Scope(className.ns, className.className!))
+						using (Scope(className.Namespace, className.ClassName!))
 						{
 							using (writer.BlockInvariant("public void InitializeComponent()"))
 							{
@@ -3691,17 +3691,17 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							}
 							else
 							{
-								if (_xClassName?.symbol != null)
+								if (_xClassName?.Symbol != null)
 								{
 									return (
 										$"{member.Member.Name}_{sanitizedEventTarget}_That.Target as {_xClassName}",
 										$"({eventSource} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference",
-										FindTargetMethodSymbol(_xClassName.symbol)
+										FindTargetMethodSymbol(_xClassName.Symbol)
 									);
 								}
 								else
 								{
-									throw new Exception($"Unable to find the type {_xClassName?.ns}.{_xClassName?.className}");
+									throw new Exception($"Unable to find the type {_xClassName?.Namespace}.{_xClassName?.ClassName}");
 								}
 							}
 						}
@@ -3766,7 +3766,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				writeEvent("");
 			}
-			else if (_xClassName?.className != null)
+			else if (_xClassName?.ClassName != null)
 			{
 				writeEvent(CurrentResourceOwner?.Name);
 			}
@@ -4263,7 +4263,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private ITypeSymbol GetXBindPropertyPathType(string propertyPath, INamedTypeSymbol? rootType = null)
 		{
 			ITypeSymbol currentType = rootType
-				?? _xClassName?.symbol
+				?? _xClassName?.Symbol
 				?? throw new InvalidCastException($"Unable to find type {_xClassName}");
 
 			var parts = propertyPath.Split('.');
@@ -4310,7 +4310,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var isTopLevelMember = lastDotIndex == -1;
 
 			var className = isTopLevelMember
-				? _xClassName?.ns + "." + _xClassName?.className
+				? _xClassName?.Namespace + "." + _xClassName?.ClassName
 				: fullMemberName.Substring(0, lastDotIndex);
 
 			var memberName = isTopLevelMember

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -20,6 +20,7 @@ using Uno.Disposables;
 using Uno.UI.SourceGenerators.BindableTypeProviders;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Uno.UI.SourceGenerators.Helpers;
 
 #if NETFRAMEWORK
@@ -350,8 +351,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private void TryGenerateWarningForInconsistentBaseType(IndentedStringBuilder writer, XamlObjectDefinition topLevelControl)
 		{
+			EnsureXClassName();
+
 			var xamlDefinedBaseType = GetType(topLevelControl.Type);
-			var fullClassName = _className.ns + "." + _className.className;
+			var fullClassName = _xClassName.ns + "." + _xClassName.className;
 			var classDefinedBaseType = FindType(fullClassName)?.BaseType;
 
 			if (!SymbolEqualityComparer.Default.Equals(xamlDefinedBaseType, classDefinedBaseType))
@@ -450,18 +453,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 			else
 			{
-				_className = GetClassName(topLevelControl);
+				_xClassName = GetClassName(topLevelControl);
 
-				using (writer.BlockInvariant("namespace {0}", _className.ns))
+				using (writer.BlockInvariant("namespace {0}", _xClassName.ns))
 				{
 					AnalyzerSuppressionsGenerator.Generate(writer, _analyzerSuppressions);
 					TryGenerateWarningForInconsistentBaseType(writer, topLevelControl);
 
 					var controlBaseType = GetType(topLevelControl.Type);
 
-					using (writer.BlockInvariant("partial class {0} : {1}", _className.className, controlBaseType.ToDisplayString()))
+					using (writer.BlockInvariant("partial class {0} : {1}", _xClassName.className, controlBaseType.ToDisplayString()))
 					{
-						using (Scope(_className.ns, _className.className))
+						using (Scope(_xClassName.ns, _xClassName.className))
 						{
 							if (_generationRunFileInfo.RunInfo.Index == 0)
 							{
@@ -486,7 +489,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 									BuildComponentFields(componentBuilder);
 
-									BuildCompiledBindings(componentBuilder, _className.className);
+									BuildCompiledBindings(componentBuilder, _xClassName.className);
 
 									_generationRunFileInfo.SetAppliedTypes(_xamlAppliedTypes);
 									_generationRunFileInfo.ComponentCode = componentBuilder.ToString();
@@ -545,7 +548,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					BuildNamedResources(writer, _namedResources);
 				}
 
-				BuildCompiledBindingsInitializer(writer, _className.className, controlBaseType);
+				EnsureXClassName();
+				BuildCompiledBindingsInitializer(writer, _xClassName.className, controlBaseType);
 
 				if (isDirectUserControlChild)
 				{
@@ -601,7 +605,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			writer.AppendLineInvariant($"#if __ANDROID__");
 #if NETSTANDARD
-			writer.AppendLineInvariant($"global::Uno.Helpers.DrawableHelper.SetDrawableResolver(global::{_className.ns}.App.DrawableResourcesIdResolver.Resolve);");
+			writer.AppendLineInvariant($"global::Uno.Helpers.DrawableHelper.SetDrawableResolver(global::{_xClassName?.ns}.App.DrawableResourcesIdResolver.Resolve);");
 #else
 			writer.AppendLineInvariant($"global::Uno.Helpers.DrawableHelper.Drawables = typeof(global::{_defaultNamespace}.Resource.Drawable);");
 #endif
@@ -1573,7 +1577,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			TryAnnotateWithGeneratorSource(writer);
 			var className = FindClassName(topLevelControl);
 
-			if (className.ns != null)
+			if (className?.ns != null)
 			{
 				var controlBaseType = GetType(topLevelControl.Type);
 
@@ -2156,19 +2160,19 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return member;
 		}
 
-		private (string ns, string className) GetClassName(XamlObjectDefinition control)
+		private XClassName GetClassName(XamlObjectDefinition control)
 		{
 			var classMember = FindClassName(control);
 
-			if (classMember.ns == null)
+			if (classMember == null)
 			{
 				throw new Exception("Unable to find class name for toplevel control");
 			}
 
-			return classMember!;
+			return classMember;
 		}
 
-		private static (string? ns, string? className) FindClassName(XamlObjectDefinition control)
+		private XClassName? FindClassName(XamlObjectDefinition control)
 		{
 			var classMember = control.Members.FirstOrDefault(m => m.Member.Name == "Class");
 
@@ -2178,11 +2182,20 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				var index = fullName.LastIndexOf('.');
 
-				return (fullName.Substring(0, index), fullName.Substring(index + 1));
+				return new(fullName.Substring(0, index), fullName.Substring(index + 1), FindType(fullName));
 			}
 			else
 			{
-				return (null, null);
+				return null;
+			}
+		}
+
+		[MemberNotNull(nameof(_xClassName))]
+		private void EnsureXClassName()
+		{
+			if (_xClassName == null)
+			{
+				throw new Exception($"Unable to find x:Class on the top level element");
 			}
 		}
 
@@ -3678,12 +3691,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							}
 							else
 							{
-
-								return (
-									$"{member.Member.Name}_{sanitizedEventTarget}_That.Target as {_className.className}",
-									$"({eventSource} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference",
-									FindTargetMethodSymbol(FindType(_className.className))
-								);
+								if (_xClassName?.symbol != null)
+								{
+									return (
+										$"{member.Member.Name}_{sanitizedEventTarget}_That.Target as {_xClassName}",
+										$"({eventSource} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference",
+										FindTargetMethodSymbol(_xClassName.symbol)
+									);
+								}
+								else
+								{
+									throw new Exception($"Unable to find the type {_xClassName?.ns}.{_xClassName?.className}");
+								}
 							}
 						}
 
@@ -3721,6 +3740,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					}
 					else
 					{
+						EnsureXClassName();
+
 						// x:Bind to second-level method generates invalid code
 						// sanitizing member.Value so that "ViewModel.SearchBreeds" becomes "ViewModel_SearchBreeds"
 						var sanitizedMemberValue = SanitizeResourceName(member.Value?.ToString());
@@ -3732,7 +3753,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						//
 						writer.AppendLineInvariant($"var {member.Member.Name}_{sanitizedMemberValue}_That = ({eventSource} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;");
 
-						writer.AppendLineInvariant($"/* second level */ {closureName}.{member.Member.Name} += ({parms}) => ({member.Member.Name}_{sanitizedMemberValue}_That.Target as {_className.className})?.{member.Value}({parms});");
+						writer.AppendLineInvariant($"/* second level */ {closureName}.{member.Member.Name} += ({parms}) => ({member.Member.Name}_{sanitizedMemberValue}_That.Target as {_xClassName})?.{member.Value}({parms});");
 					}
 				}
 				else
@@ -3745,7 +3766,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				writeEvent("");
 			}
-			else if (_className.className != null)
+			else if (_xClassName?.className != null)
 			{
 				writeEvent(CurrentResourceOwner?.Name);
 			}
@@ -4192,6 +4213,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 			else
 			{
+				EnsureXClassName();
+
 				var originalRawFunction = rawFunction;
 				rawFunction = string.IsNullOrEmpty(rawFunction) ? "___ctx" : XBindExpressionParser.Rewrite("___tctx", rawFunction, IsStaticMember);
 
@@ -4216,7 +4239,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							{
 								var targetPropertyType = GetXBindPropertyPathType(propertyPaths.properties[0]).ToDisplayString(NullableFlowState.None);
 								return $"(___ctx, __value) => {{ " +
-									$"if(___ctx is global::{_className.ns + "." + _className.className} ___tctx) " +
+									$"if(___ctx is {_xClassName} ___tctx) " +
 									$"{rawFunction} = ({targetPropertyType})global::Windows.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof({targetPropertyType}), __value);" +
 									$" }}";
 							}
@@ -4232,14 +4255,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					}
 				}
 
-				var bindFunction = $"___ctx is global::{_className.ns + "." + _className.className} ___tctx ? (object)({rawFunction}) : null";
+				var bindFunction = $"___ctx is {_xClassName} ___tctx ? (object)({rawFunction}) : null";
 				return $".BindingApply(___b =>  /*defaultBindMode{GetDefaultBindMode()} {originalRawFunction}*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, this, ___ctx => {bindFunction}, {buildBindBack()} {pathsArray}))";
 			}
 		}
 
 		private ITypeSymbol GetXBindPropertyPathType(string propertyPath, INamedTypeSymbol? rootType = null)
 		{
-			ITypeSymbol currentType = rootType ?? GetType(_className.ns + "." + _className.className);
+			ITypeSymbol currentType = rootType
+				?? _xClassName?.symbol
+				?? throw new InvalidCastException($"Unable to find type {_xClassName}");
 
 			var parts = propertyPath.Split('.');
 
@@ -4285,7 +4310,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var isTopLevelMember = lastDotIndex == -1;
 
 			var className = isTopLevelMember
-				? _className.ns + "." + _className.className
+				? _xClassName?.ns + "." + _xClassName?.className
 				: fullMemberName.Substring(0, lastDotIndex);
 
 			var memberName = isTopLevelMember
@@ -5952,6 +5977,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 							if (hasLoadMarkup || hasVisibilityMarkup)
 							{
+
 								var members = new List<XamlMemberDefinition>();
 
 								if (hasLoadMarkup)
@@ -5968,11 +5994,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								if ((!_isTopLevelDictionary || isInsideFrameworkTemplate)
 									&& (HasXBindMarkupExtension(definition) || HasMarkupExtensionNeedingComponent(definition)))
 								{
-									var componentName = $"_component_{ CurrentScope.ComponentCount}";
+									var componentName = $"_component_{CurrentScope.ComponentCount}";
 									writer.AppendLineInvariant($"this.{componentName} = {closureName};");
 
 									if (!isInsideFrameworkTemplate)
 									{
+										EnsureXClassName();
+
 										writer.AppendLineInvariant($"var {componentName}_update_That = ({CurrentResourceOwnerName} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;");
 
 										if (nameMember != null)
@@ -5982,7 +6010,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 										using (writer.BlockInvariant($"void {componentName}_update(global::Windows.UI.Xaml.ElementStub sender)"))
 										{
-											using (writer.BlockInvariant($"if ({componentName}_update_That.Target is {_className.className} that)"))
+											using (writer.BlockInvariant($"if ({componentName}_update_That.Target is {_xClassName} that)"))
 											{
 
 												using (writer.BlockInvariant($"if (sender.IsMaterialized)"))
@@ -6000,7 +6028,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 											// ElementStub will be unloaded **after** the stubbed control has been created
 											// in order for the _component_XXX to be filled, and Bindings.Update() to do its work.
 
-											using (writer.BlockInvariant($"if ({componentName}_update_That.Target is {_className.className} that)"))
+											using (writer.BlockInvariant($"if ({componentName}_update_That.Target is {_xClassName} that)"))
 											{
 												if (CurrentXLoadScope != null)
 												{
@@ -6071,6 +6099,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			return null;
 		}
+
 
 		/// <summary>
 		/// Set the active DefaultBindMode, if x:DefaultBindMode is defined on this <paramref name="xamlObjectDefinition"/>.

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_SameClassName.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_SameClassName.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.Binding_SameClassName"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<Button Click="{x:Bind VM.OnClick}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_SameClassName.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/Binding_SameClassName.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	using VmType = Controls_Binding.Binding_SameClassName;
+
+	public sealed partial class Binding_SameClassName : UserControl
+	{
+		public Binding_SameClassName()
+		{
+			this.InitializeComponent();
+		}
+
+		public static readonly DependencyProperty VMProperty =
+		   DependencyProperty.Register(
+			   nameof(VM),
+			   typeof(VmType),
+			   typeof(Binding_SameClassName),
+			   null);
+
+		public VmType VM
+		{
+			get => (VmType)GetValue(VMProperty);
+			set => SetValue(VMProperty, value);
+		}
+	}
+}
+
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls_Binding
+{
+	public class Binding_SameClassName
+	{
+		public void OnClick()
+		{
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9013

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Uses fully qualified type for `x:Class` resolution and avoid ambiguities on names uses with xBind types.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
