### PR TITLE
fix: Align resource conversion for empty values

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4818,9 +4818,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			if (_resourceKeys.Any(k => k == fullKey))
 			{
-				var resourceNameString = resourceFileName == null ? "" : $"\"{resourceFileName}\"";
+				var resourceNameString = resourceFileName == null ? "null" : $"\"{resourceFileName}\"";
 
-				return $"global::Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView({resourceNameString}).GetString(\"{fullKey}\")";
+				return $"global::Uno.UI.Helpers.MarkupHelper.GetResourceStringForXUid({resourceNameString}, \"{fullKey}\")";
 			}
 
 			return null;

--- a/src/Uno.UI.Tests/ResourceLoader/Given_ResourceLoader.cs
+++ b/src/Uno.UI.Tests/ResourceLoader/Given_ResourceLoader.cs
@@ -38,6 +38,14 @@ namespace Uno.UI.Tests.ResourceLoaderTests
 		}
 
 		[TestMethod]
+		public void When_Empty_Resource()
+		{
+			_ResourceLoader.DefaultLanguage = "en";
+
+			Assert.AreEqual("", _ResourceLoader.GetForCurrentView().GetString("TestEmptyResource"));
+		}
+
+		[TestMethod]
 		public void When_ResourceFile_Neutral_Both()
 		{
 			void setResources(string language)

--- a/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.Designer.cs
+++ b/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace Uno.UI.Tests.ResourceLoader.Strings.en {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to App70-en.
+        /// </summary>
+        internal static string ApplicationName {
+            get {
+                return ResourceManager.GetString("ApplicationName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Text in &apos;en&apos;.
+        /// </summary>
+        internal static string Given_ResourceLoader_When_LocalizedResource {
+            get {
+                return ResourceManager.GetString("Given_ResourceLoader.When_LocalizedResource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to .
         /// </summary>
         internal static string TestEmptyConverterText_ValueIfNotNull {
@@ -84,6 +102,15 @@ namespace Uno.UI.Tests.ResourceLoader.Strings.en {
         internal static string TestEmptyResource {
             get {
                 return ResourceManager.GetString("TestEmptyResource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Header in &apos;en&apos;.
+        /// </summary>
+        internal static string ThemeRadioButtons_Header {
+            get {
+                return ResourceManager.GetString("ThemeRadioButtons.Header", resourceCulture);
             }
         }
     }

--- a/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.Designer.cs
+++ b/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Uno.UI.Tests.ResourceLoader.Strings.en {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -61,29 +61,29 @@ namespace Uno.UI.Tests.ResourceLoader.Strings.en {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to App70-en.
+        ///   Looks up a localized string similar to .
         /// </summary>
-        internal static string ApplicationName {
+        internal static string TestEmptyConverterText_ValueIfNotNull {
             get {
-                return ResourceManager.GetString("ApplicationName", resourceCulture);
+                return ResourceManager.GetString("TestEmptyConverterText.ValueIfNotNull", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Text in &apos;en&apos;.
+        ///   Looks up a localized string similar to Test.
         /// </summary>
-        internal static string Given_ResourceLoader_When_LocalizedResource {
+        internal static string TestEmptyConverterText_ValueIfNull {
             get {
-                return ResourceManager.GetString("Given_ResourceLoader.When_LocalizedResource", resourceCulture);
+                return ResourceManager.GetString("TestEmptyConverterText.ValueIfNull", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Header in &apos;en&apos;.
+        ///   Looks up a localized string similar to .
         /// </summary>
-        internal static string ThemeRadioButtons_Header {
+        internal static string TestEmptyResource {
             get {
-                return ResourceManager.GetString("ThemeRadioButtons.Header", resourceCulture);
+                return ResourceManager.GetString("TestEmptyResource", resourceCulture);
             }
         }
     }

--- a/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.resw
+++ b/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.resw
@@ -117,6 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+	<data name="ApplicationName" xml:space="preserve">
+    <value>App70-en</value>
+  </data>
+	<data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
+    <value>Text in 'en'</value>
+  </data>
+	<data name="ThemeRadioButtons.Header" xml:space="preserve">
+    <value>Header in 'en'</value>
+  </data>
   <data name="TestEmptyConverterText.ValueIfNotNull" xml:space="preserve">
     <value />
   </data>

--- a/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.resw
+++ b/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.resw
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationName" xml:space="preserve">
-    <value>App70-en</value>
+  <data name="TestEmptyConverterText.ValueIfNotNull" xml:space="preserve">
+    <value />
   </data>
-  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'en'</value>
+  <data name="TestEmptyConverterText.ValueIfNull" xml:space="preserve">
+    <value>Test</value>
   </data>
-  <data name="ThemeRadioButtons.Header" xml:space="preserve">
-    <value>Header in 'en'</value>
+  <data name="TestEmptyResource" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XUidTests/Controls/When_Empty_XUid.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XUidTests/Controls/When_Empty_XUid.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl x:Class="Uno.UI.Tests.Windows_UI_Xaml_Markup.XUidTests.Controls.When_Empty_XUid"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XUidTests.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<UserControl.Resources>
+		<local:TestEmptyConverter x:Key="TestEmptyConverterText"
+								  x:Uid="TestEmptyConverterText" />
+
+	</UserControl.Resources>
+
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XUidTests/Controls/When_Empty_XUid.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XUidTests/Controls/When_Empty_XUid.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XUidTests.Controls
+{
+	public sealed partial class When_Empty_XUid : UserControl
+	{
+		public When_Empty_XUid()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public class TestEmptyConverter : IValueConverter
+	{
+		public TestEmptyConverter()
+		{
+			ValueIfNull = null;
+			ValueIfNotNull = null;
+		}
+
+		public object ValueIfNull { get; set; }
+
+		public object ValueIfNotNull { get; set; }
+
+		public object Convert(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
+		public object ConvertBack(object value, Type targetType, object parameter, string language) => throw new NotImplementedException();
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XUidTests/Given_xUid.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XUidTests/Given_xUid.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.App.Xaml;
+using Uno.UI.Tests.Helpers;
+using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using _ResourceLoader = Windows.ApplicationModel.Resources.ResourceLoader;
+using Uno.UI.Helpers;
+using Uno.UI.Tests.Windows_UI_Xaml_Markup.XUidTests.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XUidTests
+{
+	[TestClass]
+	public class Given_xUid
+	{
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+		}
+
+		[TestMethod]
+		public void When_EmptyXUid()
+		{
+			var SUT = new When_Empty_XUid();
+			var conv = (TestEmptyConverter)SUT.Resources["TestEmptyConverterText"];
+
+			Assert.IsNull(conv.ValueIfNotNull);
+			Assert.AreEqual("Test", conv.ValueIfNull);
+		}
+	}
+}

--- a/src/Uno.UI/Helpers/MarkupHelper.cs
+++ b/src/Uno.UI/Helpers/MarkupHelper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using Uno.UI.DataBinding;
 using Uno.UI.Xaml.Markup;
+using Windows.ApplicationModel.Resources;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 
@@ -36,6 +37,23 @@ namespace Uno.UI.Helpers
 		/// <returns>A the x:Uid value</returns>
 		public static string GetXUid(object target)
 			=> target is IXUidProvider provider ? provider.Uid : "";
+
+		/// <summary>
+		/// Gets a resource string for an x:Uid bound property.
+		/// </summary>
+		/// <remarks>
+		/// Returns null when the resource is an empty string.
+		/// </remarks>
+		public static string? GetResourceStringForXUid(string viewName, string resourceName)
+		{
+			var loader = viewName is not null
+				? ResourceLoader.GetForCurrentView(viewName)
+				: ResourceLoader.GetForCurrentView();
+
+			return loader.GetString(resourceName) is { Length: > 0 } value
+						? value
+						: null;
+		}
 
 		/// <summary>
 		/// Sets a builder for markup-lazy properties in <see cref="VisualState"/>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/8800

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

x:Uid assigned string empty values are now returning null to align with the WinUI behavior.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
