### PR TITLE
fix(Skia): [TextBlock] Fix rendering when font properties change

### DIFF
--- a/src/Uno.UI/UI/Xaml/Documents/Inline.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/Inline.skia.cs
@@ -65,6 +65,8 @@ namespace Windows.UI.Xaml.Documents
 
 		internal float BelowBaselineHeight => Paint.FontMetrics.Descent;
 
+		protected override void InvalidateFontInfo() => _fontInfo = null;
+
 		private static FontDetails GetFont(
 			string? name,
 			FontWeight weight,
@@ -99,9 +101,9 @@ namespace Windows.UI.Xaml.Documents
 				// FromFontFamilyName may return null: https://github.com/mono/SkiaSharp/issues/1058
 				if (skTypeFace == null)
 				{
-					if (typeof(Run).Log().IsEnabled(LogLevel.Warning))
+					if (typeof(Inline).Log().IsEnabled(LogLevel.Warning))
 					{
-						typeof(Run).Log().LogWarning($"The font {name} could not be found, using system default");
+						typeof(Inline).Log().LogWarning($"The font {name} could not be found, using system default");
 					}
 
 					skTypeFace = SKTypeface.FromFamilyName(null, skWeight, skWidth, skSlant);

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.skia.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.UI.Xaml.Documents
+{
+	partial class TextElement
+	{
+		protected virtual void InvalidateFontInfo() { }
+
+		partial void OnFontFamilyChangedPartial()
+		{
+			InvalidateFontInfo();
+		}
+
+		partial void OnFontStyleChangedPartial()
+		{
+			InvalidateFontInfo();
+		}
+
+		partial void OnFontWeightChangedPartial()
+		{
+			InvalidateFontInfo();
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9090

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Changing font properties (i.e. FontFamily, Weight, Stretch, Style) after the TextBlock is rendered has no effect.


## What is the new behavior?

Font properties result in rendering being updated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
