### PR TITLE
perf(macOS): Cache DisplayInformation properties

### DIFF
--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.macOS.cs
@@ -14,17 +14,8 @@ namespace Windows.Graphics.Display
 
 		public DisplayOrientations CurrentOrientation
 		{
-			get
-			{
-				if (NSScreen.MainScreen.Frame.Width > NSScreen.MainScreen.Frame.Height)
-				{
-					return DisplayOrientations.Landscape;
-				}
-				else
-				{
-					return DisplayOrientations.Portrait;
-				}
-			}
+			get;
+			private set;
 		}
 
 		/// <summary>
@@ -36,33 +27,69 @@ namespace Windows.Graphics.Display
 
 		public uint ScreenHeightInRawPixels
 		{
-			get
-			{
-				var screenSize = NSScreen.MainScreen.Frame.Size;
-				var scale = NSScreen.MainScreen.BackingScaleFactor;
-				return (uint)(screenSize.Height * scale);
-			}
+			get;
+			private set;
 		}
 
 		public uint ScreenWidthInRawPixels
 		{
-			get
-			{
-				var screenSize = NSScreen.MainScreen.Frame.Size;
-				var scale = NSScreen.MainScreen.BackingScaleFactor;
-				return (uint)(screenSize.Width * scale);
-			}
+			get;
+			private set;
 		}
 
-		public double RawPixelsPerViewPixel => NSScreen.MainScreen.BackingScaleFactor;
+		public double RawPixelsPerViewPixel
+		{
+			get;
+			private set;
+		}
 
 		/// <summary>
 		/// Scale of 1 is considered @1x, which is the equivalent of 96.0 or 100% for UWP.
 		/// https://developer.apple.com/documentation/uikit/uiscreen/1617836-scale
 		/// </summary>
-		public float LogicalDpi => (float)(NSScreen.MainScreen.BackingScaleFactor * BaseDpi);
+		public float LogicalDpi
+		{
+			get;
+			private set;
+		}
 
-		public ResolutionScale ResolutionScale => (ResolutionScale)(int)(NSScreen.MainScreen.BackingScaleFactor * 100.0);
+		public ResolutionScale ResolutionScale
+		{
+			get;
+			private set;
+		}
+
+		private void Update()
+		{
+			var screen = NSScreen.MainScreen;
+			var rect = screen.ConvertRectToBacking(screen.Frame);
+
+			ScreenHeightInRawPixels = (uint)rect.Height;
+			ScreenWidthInRawPixels = (uint)rect.Width;
+			RawPixelsPerViewPixel = screen.BackingScaleFactor;
+
+			CurrentOrientation = ScreenWidthInRawPixels > ScreenHeightInRawPixels
+				? DisplayOrientations.Landscape : DisplayOrientations.Portrait;
+
+			LogicalDpi = (float)(RawPixelsPerViewPixel * BaseDpi);
+
+			ResolutionScale = (ResolutionScale)(int)(RawPixelsPerViewPixel * 100.0);
+		}
+
+		partial void Initialize()
+		{
+			NSNotificationCenter
+				.DefaultCenter
+				.AddObserver(
+					NSWindow.DidChangeScreenNotification,
+					n =>
+					{
+						Update();
+					}
+				);
+			// we are notified on changes but we're already on a screen so let's initialize
+			Update();
+		}
 
 		partial void StartOrientationChanged() => ObserveDisplayMetricsChanges();
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9098

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Calling `DisplayInformation` properties requires several, slow native (ObjC) calls.

## What is the new behavior?

Subscribe to notifications to let us know the `NSWindow` (macOS) or `UIScreen` (macOS) have changed screen (or resolution) so we can cache the values between calls.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
