### PR TITLE
fix: Never enable the interpreter on net6.0-macos

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Mobile/UnoQuickStart.Mobile.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Mobile/UnoQuickStart.Mobile.csproj
@@ -12,9 +12,9 @@
 		<!-- Debugger workaround https://github.com/dotnet/maui-samples/blob/8aa6b8780b12e97b157514c3bdc54bb4a13001cd/HelloMacCatalyst/HelloMacCatalyst.csproj#L7 -->
 		<!-- <MtouchExtraArgs Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">$(MtouchExtraArgs) -setenv:MONO_THREADS_SUSPEND=preemptive</MtouchExtraArgs> -->
 
-		<!-- Required for C# Hot Reload -->
+		<!-- Required for C# Hot Reload, except for macOS which uses CoreCLR (not Mono) -->
 		<!-- Disabled because of https://github.com/dotnet/runtime/issues/68808 -->
-		<!--<UseInterpreter Condition="'$(Configuration)' == 'Debug' and '$(TargetFramework)' != 'net6.0-maccatalyst'">True</UseInterpreter>-->
+		<!--<UseInterpreter Condition="'$(Configuration)' == 'Debug' and '$(TargetFramework)' != 'net6.0-maccatalyst' and '$(TargetFramework)' != 'net6.0-macos'">True</UseInterpreter>-->
 
 		<IsUnoHead>true</IsUnoHead>
 

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Mobile/UnoQuickStart.Mobile.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Mobile/UnoQuickStart.Mobile.csproj
@@ -12,8 +12,8 @@
 		<!-- Debugger workaround https://github.com/dotnet/maui-samples/blob/8aa6b8780b12e97b157514c3bdc54bb4a13001cd/HelloMacCatalyst/HelloMacCatalyst.csproj#L7 -->
 		<!-- <MtouchExtraArgs Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">$(MtouchExtraArgs) -setenv:MONO_THREADS_SUSPEND=preemptive</MtouchExtraArgs> -->
 
-		<!-- Required for C# Hot Reload -->
-		<UseInterpreter Condition="'$(Configuration)' == 'Debug' and '$(TargetFramework)' != 'net6.0-maccatalyst'">True</UseInterpreter>
+		<!-- Required for C# Hot Reload, except for macOS which uses CoreCLR (not Mono) -->
+		<UseInterpreter Condition="'$(Configuration)' == 'Debug' and '$(TargetFramework)' != 'net6.0-maccatalyst' and '$(TargetFramework)' != 'net6.0-macos'">True</UseInterpreter>
 
 		<IsUnoHead>true</IsUnoHead>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9093


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The **Mono** interpreter gets enabled in templates for `net6.0-macos`.

## What is the new behavior?

Never enable the interpreter for `net6.0-macos` as it's based on CoreCLR (not Mono).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
