### PR TITLE
fix(iOSmacOS): Obsolete the use of readonly fields

### DIFF
--- a/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOSmacOS.cs
@@ -487,17 +487,14 @@ namespace AppKit
 
 		public static void AddBorder(this _View thisButton, float borderThickness = 1, _Color borderColor = null)
 		{
+			var layer = thisButton.Layer;
 			if (borderColor != null)
 			{
-				thisButton.Layer.BorderColor = borderColor.CGColor;
+				layer.BorderColor = borderColor.CGColor;
 			}
 			if (borderThickness > 0)
 			{
-				if (Math.Abs(borderThickness - 1f) < float.Epsilon && ViewHelper.IsRetinaDisplay)
-				{
-					borderThickness = (float)ViewHelper.OnePixel;
-				}
-				thisButton.Layer.BorderWidth = borderThickness;
+				layer.BorderWidth = ViewHelper.GetConvertedPixel(borderThickness);
 			}
 		}
 

--- a/src/Uno.UI/Extensions/ViewHelper.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.iOSmacOS.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.CompilerServices;
 using Uno.UI.Extensions;
@@ -28,14 +29,18 @@ namespace Uno.UI
 	public static class ViewHelper
 	{
 #if __IOS__
-		[Obsolete("This return the value from the original screen. Use 'DisplayInformation.RawPixelsPerViewPixel' to get the value for the current screen.")]
+		// This return the value from the original screen. Use 'DisplayInformation.RawPixelsPerViewPixel' to get the value for the current screen.
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly nfloat MainScreenScale = UIScreen.MainScreen.Scale;
-		[Obsolete("This return the value from the original screen. Use 'DisplayInformation.RawPixelsPerViewPixel > 1.0f' for the current screen.")]
+		// This return the value from the original screen. Use 'DisplayInformation.RawPixelsPerViewPixel > 1.0f' for the current screen.
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly bool IsRetinaDisplay = MainScreenScale > 1.0f;
 #elif __MACOS__
-		[Obsolete("This return the value from the original screen. Use 'DisplayInformation.RawPixelsPerViewPixel' to get the value for the current screen.")]
+		// This return the value from the original screen. Use 'DisplayInformation.RawPixelsPerViewPixel' to get the value for the current screen.
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly nfloat MainScreenScale = NSScreen.MainScreen.BackingScaleFactor;
-		[Obsolete("This return the value from the original screen. Use 'DisplayInformation.RawPixelsPerViewPixel > 1.0f' for the current screen.")]
+		// This return the value from the original screen. Use 'DisplayInformation.RawPixelsPerViewPixel > 1.0f' for the current screen.
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly bool IsRetinaDisplay = MainScreenScale > 1.0f;
 #endif
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9027

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`ViewHelper` has C# `readonly` fields for `MainScreenScale` and `IsRetinaDisplay` that are evaluated only once. IOW they are set to the current screen when the evaluation is done and moving the window to a different screen will not update the values.


## What is the new behavior?

Both `readonly` fields are now decorated with `[Obsolete]` attributes giving update instructions to directly use (now cached) `DisplayInformation` properties. This ensure the current (screen) values will be given for every call during the app lifetime.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
