### PR TITLE
perf(iOSmacOS):  calls  getter too many times

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
@@ -71,19 +71,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private CGRect GetDrawRect(CGRect rect)
-		{
-			// Reduce available size by Padding
-			rect.Width -= (nfloat)(Padding.Left + Padding.Right);
-			rect.Height -= (nfloat)(Padding.Top + Padding.Bottom);
-
-			// Offset drawing location by Padding
-			rect.X += (nfloat)Padding.Left;
-			rect.Y += (nfloat)Padding.Top;
-
-			return rect;
-		}
-
 		/// <summary>
 		/// Invalidates the last cached measure
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOSmacOS.cs
@@ -1,0 +1,28 @@
+using System;
+using CoreGraphics;
+
+#if NET6_0_OR_GREATER
+using ObjCRuntime;
+#endif
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class TextBlock
+	{
+		private CGRect GetDrawRect(CGRect rect)
+		{
+			// avoid calling the getter for each property
+			var padding = Padding;
+
+			// Reduce available size by Padding
+			rect.Width -= (nfloat)(padding.Left + padding.Right);
+			rect.Height -= (nfloat)(padding.Top + padding.Bottom);
+
+			// Offset drawing location by Padding
+			rect.X += (nfloat)padding.Left;
+			rect.Y += (nfloat)padding.Top;
+
+			return rect;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.macOS.cs
@@ -78,19 +78,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private CGRect GetDrawRect(CGRect rect)
-		{
-			// Reduce available size by Padding
-			rect.Width -= (nfloat)(Padding.Left + Padding.Right);
-			rect.Height -= (nfloat)(Padding.Top + Padding.Bottom);
-
-			// Offset drawing location by Padding
-			rect.X += (nfloat)Padding.Left;
-			rect.Y += (nfloat)Padding.Top;
-
-			return rect;
-		}
-
 		/// <summary>
 		/// Invalidates the last cached measure
 		/// </summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Both iOS and macOS _identical_ versions of `GetDrawRect` are calling 6 times `get_Padding`.

```cil
.method private hidebysig 
	instance valuetype [Microsoft.macOS]CoreGraphics.CGRect GetDrawRect (
		valuetype [Microsoft.macOS]CoreGraphics.CGRect ''
	) cil managed 
{
	// Method begins at RVA 0xb6740
	// Code size 180 (0xb4)
	.maxstack 4
	.locals init (
		[0] valuetype Windows.UI.Xaml.Thickness
	)

	// P_0.Width -= (NFloat)(Padding.Left + Padding.Right);
	IL_0000: ldarga.s 1
	IL_0002: dup
	IL_0003: call instance valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [Microsoft.macOS]CoreGraphics.CGRect::get_Width()
	IL_0008: ldarg.0
	IL_0009: call instance valuetype Windows.UI.Xaml.Thickness Windows.UI.Xaml.Controls.TextBlock::get_Padding()
	IL_000e: stloc.0
	IL_000f: ldloca.s 0
	IL_0011: call instance float64 Windows.UI.Xaml.Thickness::get_Left()
	IL_0016: ldarg.0
	IL_0017: call instance valuetype Windows.UI.Xaml.Thickness Windows.UI.Xaml.Controls.TextBlock::get_Padding()
	IL_001c: stloc.0
	IL_001d: ldloca.s 0
	IL_001f: call instance float64 Windows.UI.Xaml.Thickness::get_Right()
	IL_0024: add
	IL_0025: call valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [System.Private.CoreLib]System.Runtime.InteropServices.NFloat::op_Explicit(float64)
	IL_002a: call valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [System.Private.CoreLib]System.Runtime.InteropServices.NFloat::op_Subtraction(valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat, valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat)
	// P_0.Height -= (NFloat)(Padding.Top + Padding.Bottom);
	IL_002f: call instance void [Microsoft.macOS]CoreGraphics.CGRect::set_Width(valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat)
	IL_0034: ldarga.s 1
	IL_0036: dup
	IL_0037: call instance valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [Microsoft.macOS]CoreGraphics.CGRect::get_Height()
	IL_003c: ldarg.0
	IL_003d: call instance valuetype Windows.UI.Xaml.Thickness Windows.UI.Xaml.Controls.TextBlock::get_Padding()
	IL_0042: stloc.0
	IL_0043: ldloca.s 0
	IL_0045: call instance float64 Windows.UI.Xaml.Thickness::get_Top()
	IL_004a: ldarg.0
	IL_004b: call instance valuetype Windows.UI.Xaml.Thickness Windows.UI.Xaml.Controls.TextBlock::get_Padding()
	IL_0050: stloc.0
	IL_0051: ldloca.s 0
	IL_0053: call instance float64 Windows.UI.Xaml.Thickness::get_Bottom()
	IL_0058: add
	IL_0059: call valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [System.Private.CoreLib]System.Runtime.InteropServices.NFloat::op_Explicit(float64)
	IL_005e: call valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [System.Private.CoreLib]System.Runtime.InteropServices.NFloat::op_Subtraction(valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat, valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat)
	// P_0.X += (NFloat)Padding.Left;
	IL_0063: call instance void [Microsoft.macOS]CoreGraphics.CGRect::set_Height(valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat)
	IL_0068: ldarga.s 1
	IL_006a: dup
	IL_006b: call instance valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [Microsoft.macOS]CoreGraphics.CGRect::get_X()
	IL_0070: ldarg.0
	IL_0071: call instance valuetype Windows.UI.Xaml.Thickness Windows.UI.Xaml.Controls.TextBlock::get_Padding()
	IL_0076: stloc.0
	IL_0077: ldloca.s 0
	IL_0079: call instance float64 Windows.UI.Xaml.Thickness::get_Left()
	IL_007e: call valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [System.Private.CoreLib]System.Runtime.InteropServices.NFloat::op_Explicit(float64)
	IL_0083: call valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [System.Private.CoreLib]System.Runtime.InteropServices.NFloat::op_Addition(valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat, valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat)
	// P_0.Y += (NFloat)Padding.Top;
	IL_0088: call instance void [Microsoft.macOS]CoreGraphics.CGRect::set_X(valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat)
	IL_008d: ldarga.s 1
	IL_008f: dup
	IL_0090: call instance valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [Microsoft.macOS]CoreGraphics.CGRect::get_Y()
	IL_0095: ldarg.0
	IL_0096: call instance valuetype Windows.UI.Xaml.Thickness Windows.UI.Xaml.Controls.TextBlock::get_Padding()
	IL_009b: stloc.0
	IL_009c: ldloca.s 0
	IL_009e: call instance float64 Windows.UI.Xaml.Thickness::get_Top()
	IL_00a3: call valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [System.Private.CoreLib]System.Runtime.InteropServices.NFloat::op_Explicit(float64)
	IL_00a8: call valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat [System.Private.CoreLib]System.Runtime.InteropServices.NFloat::op_Addition(valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat, valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat)
	// return P_0;
	IL_00ad: call instance void [Microsoft.macOS]CoreGraphics.CGRect::set_Y(valuetype [System.Private.CoreLib]System.Runtime.InteropServices.NFloat)
	IL_00b2: ldarg.1
	IL_00b3: ret
} // end of method TextBlock::GetDrawRect
```


## What is the new behavior?

The updated, shared `GetDrawRect` method calls `get_Padding` only once.

```cil
.method private hidebysig 
	instance valuetype [Xamarin.Mac]CoreGraphics.CGRect GetDrawRect (
		valuetype [Xamarin.Mac]CoreGraphics.CGRect rect
	) cil managed 
{
	// Method begins at RVA 0xc7dec
	// Code size 145 (0x91)
	.maxstack 4
	.locals init (
		[0] valuetype Windows.UI.Xaml.Thickness
	)

	// Thickness padding = Padding;
	IL_0000: ldarg.0
	IL_0001: call instance valuetype Windows.UI.Xaml.Thickness Windows.UI.Xaml.Controls.TextBlock::get_Padding()
	IL_0006: stloc.0
	// rect.Width -= (nfloat)(padding.Left + padding.Right);
	IL_0007: ldarga.s rect
	IL_0009: dup
	IL_000a: call instance valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]CoreGraphics.CGRect::get_Width()
	IL_000f: ldloca.s 0
	IL_0011: call instance float64 Windows.UI.Xaml.Thickness::get_Left()
	IL_0016: ldloca.s 0
	IL_0018: call instance float64 Windows.UI.Xaml.Thickness::get_Right()
	IL_001d: add
	IL_001e: call valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]System.nfloat::op_Explicit(float64)
	IL_0023: call valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]System.nfloat::op_Subtraction(valuetype [Xamarin.Mac]System.nfloat, valuetype [Xamarin.Mac]System.nfloat)
	// rect.Height -= (nfloat)(padding.Top + padding.Bottom);
	IL_0028: call instance void [Xamarin.Mac]CoreGraphics.CGRect::set_Width(valuetype [Xamarin.Mac]System.nfloat)
	IL_002d: ldarga.s rect
	IL_002f: dup
	IL_0030: call instance valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]CoreGraphics.CGRect::get_Height()
	IL_0035: ldloca.s 0
	IL_0037: call instance float64 Windows.UI.Xaml.Thickness::get_Top()
	IL_003c: ldloca.s 0
	IL_003e: call instance float64 Windows.UI.Xaml.Thickness::get_Bottom()
	IL_0043: add
	IL_0044: call valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]System.nfloat::op_Explicit(float64)
	IL_0049: call valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]System.nfloat::op_Subtraction(valuetype [Xamarin.Mac]System.nfloat, valuetype [Xamarin.Mac]System.nfloat)
	// rect.X += (nfloat)padding.Left;
	IL_004e: call instance void [Xamarin.Mac]CoreGraphics.CGRect::set_Height(valuetype [Xamarin.Mac]System.nfloat)
	IL_0053: ldarga.s rect
	IL_0055: dup
	IL_0056: call instance valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]CoreGraphics.CGRect::get_X()
	IL_005b: ldloca.s 0
	IL_005d: call instance float64 Windows.UI.Xaml.Thickness::get_Left()
	IL_0062: call valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]System.nfloat::op_Explicit(float64)
	IL_0067: call valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]System.nfloat::op_Addition(valuetype [Xamarin.Mac]System.nfloat, valuetype [Xamarin.Mac]System.nfloat)
	// rect.Y += (nfloat)padding.Top;
	IL_006c: call instance void [Xamarin.Mac]CoreGraphics.CGRect::set_X(valuetype [Xamarin.Mac]System.nfloat)
	IL_0071: ldarga.s rect
	IL_0073: dup
	IL_0074: call instance valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]CoreGraphics.CGRect::get_Y()
	IL_0079: ldloca.s 0
	IL_007b: call instance float64 Windows.UI.Xaml.Thickness::get_Top()
	IL_0080: call valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]System.nfloat::op_Explicit(float64)
	IL_0085: call valuetype [Xamarin.Mac]System.nfloat [Xamarin.Mac]System.nfloat::op_Addition(valuetype [Xamarin.Mac]System.nfloat, valuetype [Xamarin.Mac]System.nfloat)
	// return rect;
	IL_008a: call instance void [Xamarin.Mac]CoreGraphics.CGRect::set_Y(valuetype [Xamarin.Mac]System.nfloat)
	IL_008f: ldarg.1
	IL_0090: ret
} // end of method TextBlock::GetDrawRect
```


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

While the extra calls are inefficient the `GetDrawRect` method is not visible in the Dope flamegraph. IOW the impact is minimal - at least for Dope.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
