### PR TITLE
perf(iOSmacOS): Reduce nfloat / float / double conversions

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOSmacOS.cs
@@ -66,8 +66,8 @@ namespace Windows.UI.Xaml
 
 		protected Size SizeFromUISize(CGSize size)
 		{
-			var width = nfloat.IsNaN(size.Width) ? float.PositiveInfinity : size.Width;
-			var height = nfloat.IsNaN(size.Height) ? float.PositiveInfinity : size.Height;
+			var width = nfloat.IsNaN(size.Width) ? double.PositiveInfinity : (double)size.Width;
+			var height = nfloat.IsNaN(size.Height) ? double.PositiveInfinity : (double)size.Height;
 
 			return new Size(width, height).PhysicalToLogicalPixels();
 		}
@@ -76,8 +76,8 @@ namespace Windows.UI.Xaml
 		{
 			var size = SizeFromUISize(rect.Size);
 			var location = new Point(
-				nfloat.IsNaN(rect.X) ? float.PositiveInfinity : rect.X,
-				nfloat.IsNaN(rect.Y) ? float.PositiveInfinity : rect.Y);
+				nfloat.IsNaN(rect.X) ? double.PositiveInfinity : (double)rect.X,
+				nfloat.IsNaN(rect.Y) ? double.PositiveInfinity : (double)rect.Y);
 
 			return new Rect(location.LogicalToPhysicalPixels(), size.LogicalToPhysicalPixels());
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Sometimes `var` and `implicit` conversions can play tricks behind our backs...

Here's the code decompiled:

```csharp
protected Size SizeFromUISize(CGSize P_0)
{
	NFloat nFloat = (NFloat.IsNaN(P_0.Width) ? ((NFloat)float.PositiveInfinity) : P_0.Width);
	NFloat nFloat2 = (NFloat.IsNaN(P_0.Height) ? ((NFloat)float.PositiveInfinity) : P_0.Height);
	return ViewHelper.PhysicalToLogicalPixels(new Size(nFloat, nFloat2));
}
```

So `var` is... `nfloat` and `PositiveInfinity` gets casted, twice.

Also the `Size` arguments are implicitely casted from `nfloat` to `double` - but that's basically free on 64bits platforms (so almost everywhere).


## What is the new behavior?

- Explicit (instead of implicit) `nfloat` to `double` making the `var` `double`.
- No casts are needed on `PositiveInfinity`.
- No other implicit casts.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
