### PR TITLE
fix(rc): Adjust socket selection for non-faulted connections on net6 mobile

### DIFF
--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -127,7 +127,19 @@ namespace Uno.UI.RemoteControl
 						this.Log().Trace($"Connecting to [{serverUri}]");
 					}
 
-					await s.ConnectAsync(serverUri, ct);
+					try
+					{
+						await s.ConnectAsync(serverUri, ct);
+					}
+					catch(Exception e)
+					{
+						if (this.Log().IsEnabled(LogLevel.Trace))
+						{
+							this.Log().Trace($"Connecting to [{serverUri}] failed: {e.Message}");
+						}
+
+						throw;
+					}
 
 					return (serverUri, s);
 				}
@@ -147,6 +159,21 @@ namespace Uno.UI.RemoteControl
 
 					var timeout = Task.Delay(30000);
 					var completed = await Task.WhenAny(connections.Select(c => c.task).Concat(timeout));
+
+					// Wait for any non-faulted task
+					while (!completed.IsCompletedSuccessfully)
+					{
+						var tasks = connections.Select(c => c.task).Where(t => t.Status != TaskStatus.Faulted).ToArray();
+
+						if (tasks.Length > 0)
+						{
+							completed = await Task.WhenAny(tasks.Concat(timeout));
+						}
+						else
+						{
+							break;
+						}
+					}
 
 					foreach (var connection in connections)
 					{

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -161,7 +161,7 @@ namespace Uno.UI.RemoteControl
 					var completed = await Task.WhenAny(connections.Select(c => c.task).Concat(timeout));
 
 					// Wait for any non-faulted task
-					while (!completed.IsCompletedSuccessfully)
+					while (completed.IsFaulted)
 					{
 						var tasks = connections.Select(c => c.task).Where(t => t.Status != TaskStatus.Faulted).ToArray();
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes socket selection for net6 mobile hot reload on windows.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
