### PR TITLE
fix(TextBox): [Android] restores AcceptsReturn ability to display text on multiple lines

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -332,6 +332,41 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			textbox.ActualHeight.Should().Be(originalActualHeigth);
 		}
 
+
+		[TestMethod]
+		public async Task When_AcceptsReturn_Set()
+		{
+			var textbox = new TextBox();
+
+			textbox.Width = 100;
+			StackPanel panel = new() { Orientation = Orientation.Vertical };
+			panel.Children.Add(textbox);
+			WindowHelper.WindowContent = panel;
+			await WindowHelper.WaitForLoaded(textbox);
+			var originalActualHeigth = textbox.ActualHeight;
+			textbox.AcceptsReturn = true;
+			textbox.Text = "Sed ut perspiciatis unde omnis iste natus \nerror sit voluptatem accusantium doloremaaaaaaaaaaaaaaaaaa";
+			await WindowHelper.WaitForIdle();
+			textbox.ActualHeight.Should().BeGreaterThan(originalActualHeigth * 2);
+		}
+
+		[TestMethod]
+		public async Task When_AcceptsReturn_Set_On_Init()
+		{
+			var textbox = new TextBox();
+			textbox.AcceptsReturn = true;
+			textbox.Text = "Sed ut perspiciatis unde omnis iste natus \nerror sit voluptatem accusantium doloremaaaaaaaaaaaaaaaaaa";
+			textbox.Width = 100;
+
+			StackPanel panel = new() { Orientation = Orientation.Vertical };
+			panel.Children.Add(textbox);
+			WindowHelper.WindowContent = panel;
+			await WindowHelper.WaitForLoaded(textbox);
+			var originalActualHeigth = textbox.ActualHeight;
+			textbox.AcceptsReturn = false;
+			await WindowHelper.WaitForIdle();
+			textbox.ActualHeight.Should().BeLessThan(originalActualHeigth / 2);
+		}
 #endif
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -373,7 +373,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var acceptsReturn = (bool)e.NewValue;
 			_textBoxView?.SetHorizontallyScrolling(!acceptsReturn);
-			_textBoxView?.SetMaxLines(acceptsReturn ? int.MaxValue : 1);
+			_textBoxView?.UpdateSingleLineMode();
 
 			UpdateInputScope(InputScope);
 		}
@@ -382,7 +382,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_textBoxView != null && e.NewValue is TextWrapping textWrapping)
 			{
-				_textBoxView.SetSingleLine(textWrapping == TextWrapping.NoWrap);
+				_textBoxView.UpdateSingleLineMode();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml.Controls
 			_ownerRef = WeakReferencePool.RentWeakReference(this, owner);
 			InitializeBinder();
 
-			base.SetSingleLine(owner.TextWrapping == TextWrapping.NoWrap);
+			UpdateSingleLineMode();
 
 			//This Background color is set to remove the native android underline on the EditText.
 			this.SetBackgroundColor(Colors.Transparent);
@@ -61,6 +61,16 @@ namespace Windows.UI.Xaml.Controls
 				 Android.Views.ViewGroup.LayoutParams.WrapContent,
 				 Android.Views.ViewGroup.LayoutParams.WrapContent
 			);
+		}
+
+		internal void UpdateSingleLineMode()
+		{
+			if (Owner is { } owner)
+			{
+				SetMaxLines(owner.AcceptsReturn ? int.MaxValue : 1);
+
+				base.SetSingleLine(owner.TextWrapping == TextWrapping.NoWrap && !owner.AcceptsReturn);
+			}
 		}
 
 		internal void SetTextNative(string text)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9158

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Restores the ability for TextBox on Android to have text on multiple lines when AcceptsReturn is set to true. 
- Enables TextBox height validation on all platforms.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
