### PR TITLE
fix: WASM root element loading logic

### DIFF
--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -166,34 +166,25 @@ namespace Windows.UI.Xaml
 				{
 					throw new InvalidOperationException("The root visual could not be created.");
 				}
-			}
 
-			_rootBorder.Child = _content = content;
-			if (content != null)
-			{
-				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded && !_rootVisual.IsLoaded)
+				// Load the root element in DOM
+				
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded)
 				{
 					UIElement.LoadingRootElement(_rootVisual);
 				}
 
-				WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.setRootContent({_rootVisual.HtmlId});");
+				WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.setRootElement({_rootVisual.HtmlId});");
 
-				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded && !_rootVisual.IsLoaded)
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded)
 				{
 					UIElement.RootElementLoaded(_rootVisual);
 				}
-			}
-			else
-			{
-				WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.setRootContent();");
-
-				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded && _rootVisual.IsLoaded)
-				{
-					UIElement.RootElementUnloaded(_rootVisual);
-				}
+				
+				UpdateRootAttributes();
 			}
 
-			UpdateRootAttributes();
+			_rootBorder.Child = _content = content;
 		}
 
 		private UIElement InternalGetContent() => _content;

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -100,6 +100,7 @@ declare namespace MonoSupport {
         private static registrations;
         private static methodMap;
         private static _isUnoRegistered;
+        private static dispatcherCallback;
         /**
          * Registers a instance for a specified identier
          * @param identifier the scope name
@@ -126,7 +127,6 @@ declare namespace MonoSupport {
          */
         private static cacheMethod;
         private static getMethodMapId;
-        private static dispatcherCallback;
         static invokeOnMainThread(): void;
     }
 }
@@ -175,7 +175,7 @@ declare namespace Uno.UI {
             */
         static initNative(pParams: number): boolean;
         private containerElement;
-        private rootContent;
+        private rootElement;
         private cursorStyleElement;
         private allActiveElementsById;
         private uiElementRegistrations;
@@ -429,9 +429,9 @@ declare namespace Uno.UI {
          */
         private getEventExtractor;
         /**
-            * Set or replace the root content element.
+            * Set or replace the root element.
             */
-        setRootContent(elementId?: number): string;
+        setRootElement(elementId?: number): string;
         /**
             * Set a view as a child of another one.
             *

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -140,7 +140,7 @@ namespace Uno.UI {
 		}
 
 		private containerElement: HTMLDivElement;
-		private rootContent: HTMLElement;
+		private rootElement: HTMLElement;
 
 		private cursorStyleElement: HTMLElement;
 
@@ -1026,21 +1026,21 @@ namespace Uno.UI {
 		}
 
 		/**
-			* Set or replace the root content element.
+			* Set or replace the root element.
 			*/
-		public setRootContent(elementId?: number): string {
-			if (this.rootContent && Number(this.rootContent.id) === elementId) {
+		public setRootElement(elementId?: number): string {
+			if (this.rootElement && Number(this.rootElement.id) === elementId) {
 				return null; // nothing to do
 			}
 
-			if (this.rootContent) {
+			if (this.rootElement) {
 				// Remove existing
-				this.containerElement.removeChild(this.rootContent);
+				this.containerElement.removeChild(this.rootElement);
 
 				if (WindowManager.isLoadEventsEnabled) {
-					this.dispatchEvent(this.rootContent, "unloaded");
+					this.dispatchEvent(this.rootElement, "unloaded");
 				}
-				this.rootContent.classList.remove(WindowManager.unoRootClassName);
+				this.rootElement.classList.remove(WindowManager.unoRootClassName);
 			}
 
 			if (!elementId) {
@@ -1051,16 +1051,16 @@ namespace Uno.UI {
 			const newRootElement = this.getView(elementId) as HTMLElement;
 			newRootElement.classList.add(WindowManager.unoRootClassName);
 
-			this.rootContent = newRootElement;
+			this.rootElement = newRootElement;
 
 			if (WindowManager.isLoadEventsEnabled) {
-				this.dispatchEvent(this.rootContent, "loading");
+				this.dispatchEvent(this.rootElement, "loading");
 			}
 
-			this.containerElement.appendChild(this.rootContent);
+			this.containerElement.appendChild(this.rootElement);
 
 			if (WindowManager.isLoadEventsEnabled) {
-				this.dispatchEvent(this.rootContent, "loaded");
+				this.dispatchEvent(this.rootElement, "loaded");
 			}
 			this.setAsArranged(newRootElement); // patch because root is not measured/arranged
 
@@ -1805,7 +1805,7 @@ namespace Uno.UI {
 		}
 
 		private getIsConnectedToRootElement(element: HTMLElement | SVGElement): boolean {
-			const rootElement = this.rootContent;
+			const rootElement = this.rootElement;
 
 			if (!rootElement) {
 				return false;


### PR DESCRIPTION

GitHub Issue (If applicable): closes #9194

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Previously the root element of a WASM Window was "loaded" each time its content was set. This is unnecessary, as the root element should load only once initially and then only its actual content should load and unload. Additionally, setting null content caused WASM window to get into an inconsistent state that prevented the user to set the content back.

## What is the new behavior?

Adjusted to match the logic in other targets.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
