### PR TITLE
chore: Break-down the `When_StretchAndAlignment` test to four batches

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Shape_Fill_StretchAndAlignment.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Shape_Fill_StretchAndAlignment.cs
@@ -18,25 +18,44 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.ImageBrushTests
 		private const string red = "#ED1C24";
 		private const string green = "#008000";
 		private const string white = "#FFFFFF";
+
+		private const int SingleStretchTestTimeout = 3 * 60 * 1000;
+		
 		private readonly ExpectedColor[] _expectedColors = GetExpectedColors();
 
 		[Test]
 		[AutoRetry]
-		[Timeout(8 * 60 * 1000)]
-		public void When_StretchAndAlignment()
+		[Timeout(SingleStretchTestTimeout)]
+		public void When_Stretch_None_And_Alignment() => When_StretchAndAlignment(Stretch.None);
+
+		[Test]
+		[AutoRetry]
+		[Timeout(SingleStretchTestTimeout)]
+		public void When_Stretch_Fill_And_Alignment() => When_StretchAndAlignment(Stretch.Fill);
+
+		[Test]
+		[AutoRetry]
+		[Timeout(SingleStretchTestTimeout)]
+		public void When_Stretch_UniformToFill_And_Alignment() => When_StretchAndAlignment(Stretch.UniformToFill);
+
+		[Test]
+		[AutoRetry]
+		[Timeout(SingleStretchTestTimeout)]
+		public void When_Stretch_Uniform_And_Alignment() => When_StretchAndAlignment(Stretch.Uniform);
+
+		private void When_StretchAndAlignment(Stretch stretch)
 		{
 			try
 			{
 				Run("UITests.Windows_UI_Xaml_Media.ImageBrushTests.ImageBrushShapeStretchesAlignments");
 				_app.SetOrientationPortrait();
 
-
 				_app.WaitForElement("MyRectangle");
 
+				SetProperty("MyStretch", "SelectedIndex", ((int)stretch).ToString());
 
-				foreach (var expected in _expectedColors)
+				foreach (var expected in _expectedColors.Where(e => e.Stretch == stretch))
 				{
-					SetProperty("MyStretch", "SelectedIndex", ((int)expected.Stretch).ToString());
 					SetProperty("MyAlignmentX", "SelectedIndex", ((int)expected.AlignmentX).ToString());
 					SetProperty("MyAlignmentY", "SelectedIndex", ((int)expected.AlignmentY).ToString());
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Shape_Fill_StretchAndAlignment.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Shape_Fill_StretchAndAlignment.cs
@@ -22,7 +22,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.ImageBrushTests
 
 		[Test]
 		[AutoRetry]
-		[Timeout(7 * 60 * 1000)]
+		[Timeout(8 * 60 * 1000)]
 		public void When_StretchAndAlignment()
 		{
 			try


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

This test often fails, most likely because the successful runs finish just below 7 minutes. Increasing the timeout to 8 so that there is higher chance the test will manage to succeed in time.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
