### PR TITLE
Fix: Add quotation marks on font family 

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBlockTests/TextBlockTests.cs
@@ -147,6 +147,31 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // Disabled for Mobile because the error only occurs on WASM
+		public void When_FontFamily_Changed()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_FontFamily");
+
+			var rectNoNumber = _app.GetLogicalRect("testBlockNoNumber");
+			var widthNoNumber = rectNoNumber.Width;
+			var heightNoNumber = rectNoNumber.Height;
+
+			var rectWithNumber = _app.GetLogicalRect("testBlockWithNumber");
+			var widthWithNumber = rectWithNumber.Width;
+			var heightWithNumber = rectNoNumber.Height;
+
+			var rectDefault = _app.GetLogicalRect("testBlockDefault");
+			var widthDefault = rectDefault.Width;
+			var heightDefault = rectNoNumber.Height;
+
+			using var _ = new AssertionScope();
+			Assert.AreNotEqual(widthNoNumber, widthWithNumber);
+			Assert.AreNotEqual(widthNoNumber, widthDefault);
+			Assert.AreNotEqual(widthWithNumber, widthDefault);
+		}
+
+		[Test]
+		[AutoRetry]
 		public void When_Foreground_Brush_Color_Changed()
 		{
 			Run("Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_BrushColorChanging");
@@ -311,7 +336,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBlockTests
 				(borderRect, textRect) = GetRects(borderName, textName);
 				textRect.X.Should()
 					.BeApproximately(
-						borderRect.X + (borderRect.Width - textRect.Width)/2f,
+						borderRect.X + (borderRect.Width - textRect.Width) / 2f,
 						precision,
 						"X - center");
 				textRect.Width.Should().BeLessThan(borderRect.Width, "Width - center");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1489,6 +1489,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FontFamily.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Wrap.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5789,6 +5793,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\RelativePanelTests\RelativePanel_Simple.xaml.cs">
       <DependentUpon>RelativePanel_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FontFamily.xaml.cs">
+      <DependentUpon>TextBlock_FontFamily.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Wrap.xaml.cs">
       <DependentUpon>TextBox_Wrap.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/InlineTextInSpan.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/InlineTextInSpan.xaml.cs
@@ -1,4 +1,8 @@
 ﻿using Uno.UI.Samples.Controls;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Text;
 using Windows.UI.Xaml.Controls;
 
 namespace UITests.Windows_UI_Xaml.UIElementTests

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontFamily.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontFamily.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_FontFamily"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <StackPanel>
+		<TextBlock x:Name="testBlockNoNumber" FontSize="20" Text="Test Font Start Without Number" FontFamily="Sintya" />
+		<TextBlock x:Name="testBlockWithNumber" FontSize="20" Text="Test Font Start With Number" FontFamily="2Dumb" />
+		<TextBlock x:Name="testBlockDefault" FontSize="20" Text="Test Font Start With Number" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontFamily.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontFamily.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Text;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[Sample("TextBlock")]
+    public sealed partial class TextBlock_FontFamily : UserControl
+    {
+        public TextBlock_FontFamily()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.TextHelper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.TextHelper.wasm.cs
@@ -89,8 +89,7 @@ namespace Windows.UI.Xaml
 					{
 						value = FontFamily.Default;
 					}
-
-					this.SetStyle("font-family", value.ParsedSource);
+					Uno.UI.Xaml.WindowManagerInterop.SetFontFamily(HtmlId, _uid);
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -787,6 +787,69 @@ namespace Uno.UI.Xaml
 		}
 		#endregion
 
+		#region SetFontFamily
+
+		internal static void SetFontFamily(IntPtr htmlId, string fontname)
+		{
+			fontname = AddQuotationMarks(fontname);
+			if (UseJavascriptEval)
+			{
+				var command = $"Uno.UI.WindowManager.current.setFontFamily(\"{htmlId}\", \"{fontname}\");";
+				WebAssemblyRuntime.InvokeJS(command);
+			}
+			else
+			{
+				var parms = new WindowManagerSetFontFamily()
+				{
+					HtmlId = htmlId,
+					Fontfamily = fontname,
+				};
+
+				TSInteropMarshaller.InvokeJS("Uno:setFontFamilyNative", parms);
+			}
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct WindowManagerSetFontFamily
+		{
+			public IntPtr HtmlId;
+
+			[MarshalAs(TSInteropMarshaller.LPUTF8Str)]
+			public string Fontfamily;
+		}
+
+
+		/**
+		 * Define if the fontName needs add quotation marks.
+		*/
+		private static bool NeedQuotationMarks(string fontName)
+		{
+			//Split white-space characters 
+			var myArray = fontName.Split(null);
+			foreach (var word in myArray)
+			{
+				var isnum = System.Text.RegularExpressions.Regex.IsMatch(word.Substring(0, 1), @"/^\d+$/");
+				if (isnum)
+					return true;
+			}
+			return false;
+		}
+
+		/**
+		* Add quotation marks on fontName if is necessary.
+		*/
+		private static string AddQuotationMarks(string fontName)
+		{
+			if (NeedQuotationMarks(fontName))
+			{
+				return "'" + fontName + "'";
+			}
+
+			return fontName;
+		}
+		#endregion
+
 		#region SetVisibility
 
 		internal static void SetVisibility(IntPtr htmlId, bool visible)

--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -239,6 +239,12 @@ declare namespace Uno.UI {
         setXUidNative(pParam: number): boolean;
         private setXUidInternal;
         /**
+            * Set font-family for an element.
+            *
+            */
+        setFontFamilyNative(elementId: number, fontname: string): string;
+        private setFontFamilyInternal;
+        /**
             * Sets the visibility of the specified element
             */
         setVisibility(elementId: number, visible: boolean): string;
@@ -1453,6 +1459,10 @@ declare class WindowManagerSetElementTransformParams {
     M31: number;
     M32: number;
     static unmarshal(pData: number): WindowManagerSetElementTransformParams;
+}
+declare class WindowManagerSetFontFamily {
+    HtmlId: number;
+    Fontfamily: string;
 }
 declare class WindowManagerSetNameParams {
     HtmlId: number;

--- a/src/Uno.UI/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI/WasmScripts/Uno.UI.js
@@ -617,6 +617,18 @@ var Uno;
                 this.getView(elementId).setAttribute("xuid", name);
             }
             /**
+                * Set font-family for an element.
+                *
+                */
+            setFontFamilyNative(elementId, fontname) {
+                this.setFontFamilyInternal(elementId, fontname);
+                return "ok";
+            }
+            setFontFamilyInternal(elementId, fontname) {
+                const elementStyle = this.getView(elementId).style;
+                elementStyle.setProperty('font-family', fontname);
+            }
+            /**
                 * Sets the visibility of the specified element
                 */
             setVisibility(elementId, visible) {
@@ -5317,6 +5329,9 @@ class WindowManagerSetElementTransformParams {
         }
         return ret;
     }
+}
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class WindowManagerSetFontFamily {
 }
 /* TSBindingsGenerator Generated code -- this code is regenerated on each build */
 class WindowManagerSetNameParams {

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -376,6 +376,24 @@ namespace Uno.UI {
 			this.getView(elementId).setAttribute("xuid", name);
 		}
 
+
+		/**
+			* Set font-family for an element.
+			*
+			*/
+		public setFontFamilyNative(elementId: number, fontname: string): string {
+			this.setFontFamilyInternal(elementId, fontname);
+			return "ok";
+		}
+
+		private setFontFamilyInternal(elementId: number, fontname: string): void {
+
+			const elementStyle = this.getView(elementId).style;
+
+			elementStyle.setProperty('font-family', fontname);
+
+		}
+
 		/**
 			* Sets the visibility of the specified element
 			*/
@@ -565,7 +583,6 @@ namespace Uno.UI {
 			for (let i = 0; i < params.Pairs_Length; i += 2) {
 				const key = pairs[i];
 				const value = pairs[i + 1];
-
 				elementStyle.setProperty(key, value);
 			}
 
@@ -1876,7 +1893,6 @@ namespace Uno.UI {
 		public selectInputRange(elementId: number, start: number, length: number) {
 			(this.getView(elementId) as HTMLInputElement).setSelectionRange(start, start + length);
 		}
-
 	}
 
 	if (typeof define === "function") {

--- a/src/Uno.UI/tsBindings/WindowManagerSetFontFamily.ts
+++ b/src/Uno.UI/tsBindings/WindowManagerSetFontFamily.ts
@@ -1,0 +1,7 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class WindowManagerSetFontFamily
+{
+	/* Pack=4 */
+	public HtmlId : number;
+	public Fontfamily : string;
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7395

## PR Type

- Bugfix


## What is the current behavior?

Load custom font family starting with number does not work.


## What is the new behavior?

The custom font family starting with number is now loaded.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Internal Issue (If applicable):
