### PR TITLE
fix: `Frame.Navigated` should occur before `Page.NavigatedFrom` and `Page.NavigatedTo`

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -398,10 +398,10 @@ namespace Windows.UI.Xaml.Controls
 			SetValue(SourcePageTypeProperty, entry.SourcePageType);
 			SetValue(CurrentSourcePageTypeProperty, entry.SourcePageType);
 
+			Navigated?.Invoke(this, navigationEvent);
+			
 			previousEntry?.Instance.OnNavigatedFrom(navigationEvent);
 			CurrentEntry.Instance.OnNavigatedTo(navigationEvent);
-
-			Navigated?.Invoke(this, navigationEvent);
 
 			return true;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9251

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Order of events is incorrect.

## What is the new behavior?

Order of events is in line with WinUI

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
