### PR TITLE
fix: Fallback for foldable detection

### DIFF
--- a/src/Uno.UI.Foldable/FoldableApplicationViewSpanningRects.Android.cs
+++ b/src/Uno.UI.Foldable/FoldableApplicationViewSpanningRects.Android.cs
@@ -239,6 +239,8 @@ namespace Uno.UI.Foldable
 			}
 		}
 
+		public bool SupportsSpanning => HasFoldFeature || FoldableHingeAngleSensor.HasHinge;
+
         public Rect Bounds
         {
 			get {

--- a/src/Uno.UI.Foldable/FoldableHingeAngleSensor.Android.cs
+++ b/src/Uno.UI.Foldable/FoldableHingeAngleSensor.Android.cs
@@ -31,7 +31,8 @@ namespace Uno.UI.Foldable
     {
 		const string HINGE_SENSOR_NAME = "hinge"; // works on multiple OEM devices
 
-		SensorManager _sensorManager;
+		private static SensorManager _sensorManager;
+	
 		Sensor _hingeSensor;
 		HingeSensorEventListener _sensorListener;
 
@@ -45,16 +46,23 @@ namespace Uno.UI.Foldable
 
 		public FoldableHingeAngleSensor(object owner)
 		{
+			_hingeSensor = GetHingeSensor();
+		}
+
+		internal static bool HasHinge => GetHingeSensor() is not null;
+
+		private static Sensor GetHingeSensor()
+		{
 			if (!(ContextHelper.Current is Activity currentActivity))
 			{
 				throw new InvalidOperationException("FoldableHingeAngleSensor must be initialized on the UI Thread");
 			}
 
-			_sensorManager = SensorManager.FromContext(currentActivity);
+			_sensorManager ??= SensorManager.FromContext(currentActivity);
 
 			var sensors = _sensorManager.GetSensorList(Android.Hardware.SensorType.All);
 
-			_hingeSensor = sensors.FirstOrDefault(s => s.Name.Contains(HINGE_SENSOR_NAME, StringComparison.OrdinalIgnoreCase)); // NAME - generic foldable device/s
+			return sensors.FirstOrDefault(s => s.Name.Contains(HINGE_SENSOR_NAME, StringComparison.OrdinalIgnoreCase)); // NAME - generic foldable device/s
 		}
 
 		public event EventHandler<NativeHingeAngleReading> ReadingChanged

--- a/src/Uno.UI.Foldable/FoldableHingeAngleSensor.Android.cs
+++ b/src/Uno.UI.Foldable/FoldableHingeAngleSensor.Android.cs
@@ -60,6 +60,11 @@ namespace Uno.UI.Foldable
 
 			_sensorManager ??= SensorManager.FromContext(currentActivity);
 
+			if (_sensorManager is null)
+			{
+				return null;
+			}
+			
 			var sensors = _sensorManager.GetSensorList(Android.Hardware.SensorType.All);
 
 			return sensors.FirstOrDefault(s => s.Name.Contains(HINGE_SENSOR_NAME, StringComparison.OrdinalIgnoreCase)); // NAME - generic foldable device/s

--- a/src/Uno.UWP/Devices/Sensors/Helpers/INativeDualScreenProvider.cs
+++ b/src/Uno.UWP/Devices/Sensors/Helpers/INativeDualScreenProvider.cs
@@ -8,5 +8,7 @@ namespace Uno.Devices.Sensors
 		bool IsDualScreen { get; }
 
 		bool? IsSpanned { get; }
+
+		bool SupportsSpanning { get; }
 	}
 }

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.cs
@@ -143,7 +143,7 @@ namespace Windows.UI.ViewManagement
 			}
 			else if (viewMode == ApplicationViewMode.Spanning)
 			{
-				return (_applicationViewSpanningRects as INativeDualScreenProvider)?.IsDualScreen == true;
+				return (_applicationViewSpanningRects as INativeDualScreenProvider)?.SupportsSpanning == true;
 			}
 
 			return false;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When running on Surface Duo `ApplicationView.IsViewModeSupported(ApplicationViewMode.Spanning)` returns `false`

## What is the new behavior?

To detect foldable we check both `HasFoldFeature` and `HasHinge`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
