### PR TITLE
chore: Ignore Lamp test page in snapshot tests

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_Devices/LampTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/LampTests.xaml.cs
@@ -11,11 +11,12 @@ using EventHandler = System.EventHandler;
 
 namespace UITests.Shared.Windows_Devices
 {
-	[SampleControlInfo(
+	[Sample(
 		"Windows.Devices",
-		"Lamp",
-		description: "Demonstrates the Windows.Devices.Lights.Lamp",
-		viewModelType: typeof(LampTestsViewModel))]
+		Name = "Lamp",
+		Description = "Demonstrates the Windows.Devices.Lights.Lamp",
+		ViewModelType = typeof(LampTestsViewModel),
+		IgnoreInSnapshotTests = true)]
 	public sealed partial class LampTests : Page
 	{
 		public LampTests()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

For an unclear reason the Windows.Devices.Lamp test page often fails in Snapshot tests. it is possible that the root cause is one of the previous pages in some way, as there is nothing special about this sample.

## What is the new behavior?

Ignoring sample in snapshot tests 🤷‍♂️


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
