### PR TITLE
docs: Visual studio link moved up

### DIFF
--- a/doc/articles/get-started.md
+++ b/doc/articles/get-started.md
@@ -8,13 +8,12 @@ To set up your development environment, first select the operating system you're
 
 # [**Windows**](#tab/windows)
 
-If you're developing on Windows, we recommend you use **Visual Studio 2022**, for the richest XAML development experience and broadest platform coverage. 
+If you're developing on Windows, we recommend you use [**Visual Studio 2022**](get-started-vs-2022.md), for the richest XAML development experience and broadest platform coverage. 
 
 If you already use and love **JetBrains Rider** or **Visual Studio Code**, you can also use them to develop Uno Platform applications. Check the support matrix below to see which target platforms they support.
 
 **Choose the IDE you want to use:**
 
- - [Get started with Visual Studio 2022 for Windows](get-started-vs-2022.md)
  - [Get started with VS Code, Codespaces and GitPod](get-started-vscode.md)
  - [Get started with Rider](get-started-rider.md)
 


### PR DESCRIPTION
Linked the preferred experience in the first sentence. No need to make the user seek the link below.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

- Documentation content changes


## What is the current behavior?

Visual studio 2022 link is in list

## What is the new behavior?

Link for Visual Studio 2022 is in the beginning to improve UX 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
