### PR TITLE
docs: reordered perquisites

### DIFF
--- a/doc/articles/get-started-vs-2022.md
+++ b/doc/articles/get-started-vs-2022.md
@@ -11,9 +11,9 @@ This getting started will guide you through the creation of an Uno Platform App 
 ## Prerequisites
 To create Uno Platform applications you will need [**Visual Studio 2022 17.3 (Preview 2 or later)**](https://visualstudio.microsoft.com/vs/preview/):
 
-1. **Universal Windows Platform** workload installed.
+1. **ASP**.**NET and web** workload installed, along with .NET 6.0 (for WebAssembly development)
 
-    ![visual-studio-installer-uwp](Assets/quick-start/vs-install-uwp.png)
+    ![visual-studio-installer-web](Assets/quick-start/vs-install-web.png)
 
 1. **.NET Multi-platform App UI development** workload installed.
 
@@ -21,11 +21,11 @@ To create Uno Platform applications you will need [**Visual Studio 2022 17.3 (Pr
 
 1. **.NET desktop development** workload installed.
 
-    ![visual-studio-installer-dotnet](Assets/quick-start/vs-install-dotnet.png)
+    ![visual-studio-installer-dotnet](Assets/quick-start/vs-install-dotnet.png)    
+    
+1. **Universal Windows Platform** workload installed.
 
-1. **ASP**.**NET and web** workload installed, along with .NET 6.0 (for WebAssembly development)
-
-    ![visual-studio-installer-web](Assets/quick-start/vs-install-web.png)
+    ![visual-studio-installer-uwp](Assets/quick-start/vs-install-uwp.png)
 
 > [!NOTE]
 > For information about connecting Visual Studio to a Mac build host to build iOS apps, see [Pairing to a Mac for Xamarin.iOS development](https://docs.microsoft.com/en-us/xamarin/ios/get-started/installation/windows/connecting-to-mac/).


### PR DESCRIPTION
List the prerequisites in the same order the Visual Studio Experience does it.  

ASP.NET, MAUI, .NET Framework, UWP.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

- Documentation content changes

## What is the current behavior?

UWP is 1st and ASP .NET is fourth on list

## What is the new behavior?

Relisted to be in same order as VS experience. UWP and ASP swapped spots


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
