### PR TITLE
ci: Unify CI task names

### DIFF
--- a/build/ci/.azure-devops-android-tests.yml
+++ b/build/ci/.azure-devops-android-tests.yml
@@ -7,7 +7,7 @@ parameters:
 jobs:
 
 - job: Android_Build_Net6_For_Tests
-  displayName: 'Android UI Tests (Net6 Build)'
+  displayName: 'Android Samples App Build (.NET 6)'
 
   pool:
     vmImage: ${{ parameters.vmMacOSImage }}
@@ -51,7 +51,7 @@ jobs:
       ArtifactType: Container
 
 - job: Android_Build_For_Tests
-  displayName: 'Android UI Tests (Build)'
+  displayName: 'Android Samples App Build (Xamarin)'
 
   pool:
     vmImage: ${{ parameters.vmMacOSImage }}
@@ -97,7 +97,7 @@ jobs:
       ArtifactType: Container
 
 - job: Android_Tests
-  displayName: 'Android UI Tests (Run)'
+  displayName: 'Android'
   dependsOn:
   - Android_Build_For_Tests
   - Android_Build_Net6_For_Tests
@@ -119,7 +119,7 @@ jobs:
       #  ANDROID_SIMULATOR_APILEVEL: 21
       #  UITEST_TEST_MODE_NAME: Automated
 
-      Android_9.0_Group_01:
+      'UI Tests (Group 1)':
         ANDROID_SIMULATOR_APILEVEL: 28
         UITEST_TEST_MODE_NAME: Automated
         UNO_UITEST_BUCKET_ID: 1 ## Note: Align with UNO_UITEST_BUCKET_COUNT
@@ -129,7 +129,7 @@ jobs:
         ALLOW_RERUN: true
         UITEST_TEST_TIMEOUT: '270000'
 
-      Android_9.0_Group_02:
+      'UI Tests (Group 2)':
         ANDROID_SIMULATOR_APILEVEL: 28
         UITEST_TEST_MODE_NAME: Automated
         UNO_UITEST_BUCKET_ID: 2 ## Note: Align with UNO_UITEST_BUCKET_COUNT
@@ -139,7 +139,7 @@ jobs:
         ALLOW_RERUN: true
         UITEST_TEST_TIMEOUT: '270000'
 
-      Android_9.0_Group_03:
+      'UI Tests (Group 3)':
         ANDROID_SIMULATOR_APILEVEL: 28
         UITEST_TEST_MODE_NAME: Automated
         UNO_UITEST_BUCKET_ID: 3 ## Note: Align with UNO_UITEST_BUCKET_COUNT
@@ -149,7 +149,7 @@ jobs:
         UITEST_TEST_TIMEOUT: '270000'
         ALLOW_RERUN: true
 
-      Android_9.0_Snapshots:
+      'Snapshot Tests':
         ANDROID_SIMULATOR_APILEVEL: 28
         UITEST_TEST_MODE_NAME: Snapshots
         UNO_UITEST_BUCKET_ID: Snapshots
@@ -159,7 +159,7 @@ jobs:
         ALLOW_RERUN: true
         UITEST_TEST_TIMEOUT: '270000'
 
-      Android_9.0_RuntimeTests:
+      'Runtime Tests':
         ANDROID_SIMULATOR_APILEVEL: 28
         UITEST_TEST_MODE_NAME: RuntimeTests
         UNO_UITEST_BUCKET_ID: RuntimeTests

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -7,7 +7,7 @@ parameters:
 
 jobs:
 - job: iOS_Build
-  displayName: 'iOS Samples App UI Tests (Build)'
+  displayName: 'iOS Samples App Build'
 
   dependsOn: Pipeline_Validations
 
@@ -64,7 +64,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Group_01'
-    JobDisplayName: 'iOS Automated Tests Group 01'
+    JobDisplayName: 'iOS UI Tests (Group 1)'
     JobTimeoutInMinutes: 90
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -78,7 +78,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Group_02'
-    JobDisplayName: 'iOS Automated Tests Group 02'
+    JobDisplayName: 'iOS UI Tests (Group 2)'
     JobTimeoutInMinutes: 90
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -92,7 +92,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Automated_Tests_Group_03'
-    JobDisplayName: 'iOS Automated Tests Group 03'
+    JobDisplayName: 'iOS UI Tests (Group 3)'
     JobTimeoutInMinutes: 90
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -108,8 +108,8 @@ jobs:
 - template: .azure-devops-ios-tests-run.yml
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
-    JobName: 'iOS_Automated_Tests_Runtime_Tests_group_0'
-    JobDisplayName: 'iOS Automated Runtime Tests Group 0'
+    JobName: 'iOS_Automated_Tests_Runtime_Tests_group_01'
+    JobDisplayName: 'iOS Runtime Tests (Group 1)'
     JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -124,8 +124,8 @@ jobs:
 - template: .azure-devops-ios-tests-run.yml
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
-    JobName: 'iOS_Automated_Tests_Runtime_Tests_group_1'
-    JobDisplayName: 'iOS Automated Runtime Tests Group 1'
+    JobName: 'iOS_Automated_Tests_Runtime_Tests_group_02'
+    JobDisplayName: 'iOS Runtime Tests (Group 2)'
     JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -140,8 +140,8 @@ jobs:
 - template: .azure-devops-ios-tests-run.yml
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
-    JobName: 'iOS_Automated_Tests_Runtime_Tests_group_2'
-    JobDisplayName: 'iOS Automated Runtime Tests Group 2'
+    JobName: 'iOS_Automated_Tests_Runtime_Tests_group_03'
+    JobDisplayName: 'iOS Runtime Tests (Group 3)'
     JobTimeoutInMinutes: 60
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: false
@@ -170,7 +170,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Snapshot_Tests_Group_01'
-    JobDisplayName: 'iOS Snapshot Tests Group 01'
+    JobDisplayName: 'iOS Snapshot Tests (Group 1)'
     JobTimeoutInMinutes: 45
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: true
@@ -184,7 +184,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Snapshot_Tests_Group_02'
-    JobDisplayName: 'iOS Snapshot Tests Group 02'
+    JobDisplayName: 'iOS Snapshot Tests (Group 2)'
     JobTimeoutInMinutes: 70
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: true
@@ -198,7 +198,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Snapshot_Tests_Group_03'
-    JobDisplayName: 'iOS Snapshot Tests Group 03'
+    JobDisplayName: 'iOS Snapshot Tests (Group 3)'
     JobTimeoutInMinutes: 45
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: true
@@ -212,7 +212,7 @@ jobs:
   parameters:
     nugetPackages: $(NUGET_PACKAGES)
     JobName: 'iOS_Snapshot_Tests_Group_04'
-    JobDisplayName: 'iOS Snapshot Tests Group 04'
+    JobDisplayName: 'iOS Snapshot Tests (Group 4)'
     JobTimeoutInMinutes: 45
     vmImage: ${{ parameters.vmImageTest }}
     UITEST_SNAPSHOTS_ONLY: true

--- a/build/ci/.azure-devops-macos.yml
+++ b/build/ci/.azure-devops-macos.yml
@@ -79,7 +79,7 @@ jobs:
 
 - job: macOS_Runtime_Tests
   timeoutInMinutes: 90
-  displayName: macOS SamplesApp Runtime Tests
+  displayName: macOS Runtime Tests
 
   variables:
     CI_Build: true
@@ -136,7 +136,7 @@ jobs:
 
 - job: macOS_Screenshot_Tests
   timeoutInMinutes: 100
-  displayName: macOS SamplesApp Screenshot Test
+  displayName: macOS Snapshot Tests
 
   variables:
     CI_Build: true
@@ -180,10 +180,10 @@ jobs:
   - script: |
         timeout 90m /Applications/SamplesApp.macOS.app/Contents/MacOS/SamplesApp.macOS --auto-screenshots=$(build.artifactstagingdirectory)/screenshots/macOS-screenshots
 
-    displayName: Run macOS UI Snapshot Tests
+    displayName: Run macOS Snapshot Tests
 
   - task: PublishBuildArtifacts@1
-    displayName: Publish macOS Screenshots
+    displayName: Publish macOS Snapshots
     condition: always()
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)

--- a/build/ci/.azure-devops-samplesapp-uitests-build.yml
+++ b/build/ci/.azure-devops-samplesapp-uitests-build.yml
@@ -3,7 +3,7 @@ parameters:
 
 jobs:
 - job: SamplesApp_UITests_Build
-  displayName: 'SamplesApp UI Tests (Build)'
+  displayName: 'UI Tests Build'
   
   pool:
     vmImage: ${{ parameters.vmImage }}
@@ -32,7 +32,7 @@ jobs:
       msbuildArguments: /r /m /p:Configuration=Release /detailedsummary /m # /bl:$(build.artifactstagingdirectory)\build.binlog
 
   - task: CopyFiles@2
-    displayName: 'Publish Wasm UITest binaries'
+    displayName: 'Publish UI Test binaries'
     inputs:
       SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.UITests/bin/Release
       Contents: '**/*.*'

--- a/build/ci/.azure-devops-uap.yml
+++ b/build/ci/.azure-devops-uap.yml
@@ -3,7 +3,7 @@ parameters:
 
 jobs:
 - job: UAP_Build
-  displayName: 'UWP Samples App'
+  displayName: 'UWP Samples App Build'
 
   pool:
     vmImage: ${{ parameters.vmImage }}

--- a/build/ci/.azure-devops-wasm-cs9-preview-validation.yml
+++ b/build/ci/.azure-devops-wasm-cs9-preview-validation.yml
@@ -3,7 +3,7 @@ parameters:
 
 jobs:
 - job: Wasm_cs9_Build
-  displayName: 'WebAssembly Samples App Build'
+  displayName: 'WebAssembly Samples App Build (.NET Standard 2.0)'
   container: nv-bionic-wasm
 
   pool:
@@ -46,5 +46,5 @@ jobs:
     condition: always()
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)
-      ArtifactName: wasm-uitest-binaries
+      ArtifactName: wasm-samplesapp-binaries
       ArtifactType: Container

--- a/build/ci/.azure-devops-wasm-uitests.yml
+++ b/build/ci/.azure-devops-wasm-uitests.yml
@@ -2,8 +2,8 @@ parameters:
   vmImage: ''
 
 jobs:
-- job: Wasm_UITests_Build
-  displayName: 'WebAssembly UI Tests (Build)'
+- job: Wasm_SamplesApp_Build
+  displayName: 'WebAssembly Samples App Build (.NET 5)'
   container: nv-bionic-wasm
 
   dependsOn: Pipeline_Validations
@@ -55,14 +55,14 @@ jobs:
     condition: always()
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)
-      ArtifactName: wasm-uitest-binaries
+      ArtifactName: wasm-samplesapp-binaries
       ArtifactType: Container
 
 
 - job: Wasm_UITests_Snap
-  displayName: 'WebAssembly UI Tests (Snapshots Run)'
+  displayName: 'WebAssembly Snapshot Tests'
   dependsOn:
-  - Wasm_UITests_Build
+  - Wasm_SamplesApp_Build
   - SamplesApp_UITests_Build
 
   container: nv-bionic-wasm
@@ -81,12 +81,13 @@ jobs:
   - template: templates/dotnet-install.yml
 
   - task: DownloadBuildArtifacts@0
+    displayName: 'Download Samples App Binaries'
     inputs:
-        artifactName: wasm-uitest-binaries
+        artifactName: wasm-samplesapp-binaries
         downloadPath: '$(build.sourcesdirectory)/build'
 
   - task: DownloadBuildArtifacts@0
-    displayName: 'Download iOS SamplesApp UnitTests'
+    displayName: 'Download UI Test Binaries'
     inputs:
         artifactName: samplesapp-uitest-binaries
         downloadPath: '$(build.sourcesdirectory)/build'
@@ -102,7 +103,7 @@ jobs:
       dotnet tool uninstall dotnet-serve --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
       dotnet tool install dotnet-serve --version 1.8.15 --tool-path $BUILD_SOURCESDIRECTORY/build/tools || true
       export PATH="$PATH:$BUILD_SOURCESDIRECTORY/build/tools"
-      $BUILD_SOURCESDIRECTORY/build/tools/dotnet-serve -p 8000 -d "$BUILD_SOURCESDIRECTORY/build/wasm-uitest-binaries/site-net5.0" &
+      $BUILD_SOURCESDIRECTORY/build/tools/dotnet-serve -p 8000 -d "$BUILD_SOURCESDIRECTORY/build/wasm-samplesapp-binaries/site-net5.0" &
       cd $BUILD_SOURCESDIRECTORY/src/SamplesApp/SamplesApp.Wasm.UITests
       npm install
       node app
@@ -132,25 +133,25 @@ jobs:
 
 
 - job: Wasm_UITests_Automated
-  displayName: 'WebAssembly UI Tests (Automated Run)'
+  displayName: 'WebAssembly'
   dependsOn:
-  - Wasm_UITests_Build
+  - Wasm_SamplesApp_Build
   - SamplesApp_UITests_Build
   container: nv-bionic-wasm
 
   strategy:
     matrix:
-      net5_default:
+      'UI Tests (.NET 5)':
         SITE_SUFFIX: 'net5.0'
         UITEST_AUTOMATED_GROUP: 'Default'
         UITEST_TEST_TIMEOUT: '120000'
 
-      net5_runtimetests:
+      'Runtime Tests (.NET 5)':
         SITE_SUFFIX: 'net5.0'
         UITEST_AUTOMATED_GROUP: 'RuntimeTests'
         UITEST_TEST_TIMEOUT: '1800000'
 
-      net5_benchmarks:
+      'Benchmarks (.NET 5)':
         SITE_SUFFIX: 'net5.0'
         UITEST_AUTOMATED_GROUP: 'Benchmarks'
         UITEST_TEST_TIMEOUT: '120000'
@@ -174,13 +175,7 @@ jobs:
 
   - task: DownloadBuildArtifacts@0
     inputs:
-        artifactName: wasm-uitest-binaries
-        downloadPath: '$(build.sourcesdirectory)/build'
-
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download iOS SamplesApp UnitTests'
-    inputs:
-        artifactName: samplesapp-uitest-binaries
+        artifactName: wasm-samplesapp-binaries
         downloadPath: '$(build.sourcesdirectory)/build'
 
   - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

- Currently each platform has its own "naming convention" for CI tasks
- In many cases the important info is hidden "behind the fold" in GitHub UI:
![image](https://user-images.githubusercontent.com/1075116/179348663-f117b4fa-ad94-4d0d-8014-cbcca600b05a.png)


## What is the new behavior?

- Unify naming conventions
- Make the names shorter


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
