### PR TITLE
fix: Adjust `DataWriter.StoreAsync`

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8863,6 +8863,9 @@
 				fullName="System.Void Windows.Graphics.Imaging.BitmapEncoder::.ctor()"
 				reason="Add private ctor for initialize BitmapEncoder" />
 			<!-- END BitmapEncoder API -->
+			<Member
+				fullName="System.Void Windows.Storage.Streams.DataWriterStoreOperation..ctor()"
+				reason="Not part of UWP API" />
 		</Methods>
 		<Properties>
 			<Member

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ContentDialog/UnoSamples_Tests.ContentDialog.cs
@@ -384,7 +384,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.ContentDialogTests.ContentDialog_Simple");
 
 			var showDialogButton = _app.Marked("showDialog1");
-			var statusBarBackground = _app.Marked("statusBarBackground");
 			var dialogSpace = _app.Marked("DialogSpace"); // from ContentDialog default ControlTemplate
 			var primaryButton = _app.Marked("PrimaryButton");
 
@@ -417,15 +416,15 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ContentDialogTests
 			{
 				if (AppInitializer.GetLocalPlatform() == Platform.Android)
 				{
-					// the status bar area needs to be excluded for image comparison
+					// the status bar area should be excluded for image comparison
+					// 24dp is default height of status bar
 					var screen = _app.GetScreenDimensions();
-					var statusBarRect = _app.GetRect(statusBarBackground);
 
 					return new Rectangle(
 						0,
-						(int)statusBarRect.Height,
+						24,
 						(int)screen.Width,
-						(int)screen.Height - (int)statusBarRect.Height
+						(int)screen.Height - 24
 					);
 				}
 				else

--- a/src/Uno.UWP/Storage/Streams/DataWriter.cs
+++ b/src/Uno.UWP/Storage/Streams/DataWriter.cs
@@ -12,8 +12,8 @@ namespace Windows.Storage.Streams
 	/// </summary>
 	public sealed partial class DataWriter : IDataWriter, IDisposable
 	{
-		private MemoryStream _memoryStream = null;
 		private readonly IOutputStream _outputStream = null;
+		private MemoryStream _memoryStream = null;
 
 		/// <summary>
 		/// Creates and initializes a new instance of the data writer.
@@ -292,7 +292,7 @@ namespace Windows.Storage.Streams
 		{
 			var cancelToken = new CancellationTokenSource();
 			var inBuffer = _memoryStream.GetBuffer();
-			await _outputStream.WriteAsync(inBuffer, 0, inBuffer.Length, cancelToken.Token);
+			await _outputStream.WriteAsync(inBuffer, 0, (int)_memoryStream.Length, cancelToken.Token);
 			await _outputStream.FlushAsync();
 			return (uint)inBuffer.Length;
 		}

--- a/src/Uno.UWP/Storage/Streams/DataWriter.cs
+++ b/src/Uno.UWP/Storage/Streams/DataWriter.cs
@@ -285,28 +285,16 @@ namespace Windows.Storage.Streams
 		}
 
 
-		public DataWriterStoreOperation StoreAsync()
+		public DataWriterStoreOperation StoreAsync() =>
+			new DataWriterStoreOperation(StoreTaskAsync().AsAsyncOperation<uint>());
+
+		private async Task<uint> StoreTaskAsync()
 		{
-			var dwStore = new DataWriterStoreOperation();
-			Task.Run(async () =>
-			{
-				try
-				{
-					var cancelToken = new CancellationTokenSource();
-					var inBuffer = _memoryStream.GetBuffer();
-					await _outputStream.WriteAsync(inBuffer, 0, inBuffer.Length, cancelToken.Token);
-					await _outputStream.FlushAsync().AsTask();
-					dwStore.Status = AsyncStatus.Completed;
-					dwStore.Result = (uint)inBuffer.Length;
-					dwStore.Completed.Invoke(dwStore, dwStore.Status);
-				}
-				catch (Exception ex)
-				{
-					dwStore.ErrorCode = ex;
-					dwStore.Status = AsyncStatus.Error;
-				}
-			});
-			return dwStore;
+			var cancelToken = new CancellationTokenSource();
+			var inBuffer = _memoryStream.GetBuffer();
+			await _outputStream.WriteAsync(inBuffer, 0, inBuffer.Length, cancelToken.Token);
+			await _outputStream.FlushAsync();
+			return (uint)inBuffer.Length;
 		}
 	}
 }

--- a/src/Uno.UWP/Storage/Streams/DataWriterStoreOperation.cs
+++ b/src/Uno.UWP/Storage/Streams/DataWriterStoreOperation.cs
@@ -6,49 +6,59 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation;
 
-namespace Windows.Storage.Streams
+namespace Windows.Storage.Streams;
+
+/// <summary>
+/// Commits data in a buffer to a backing store.
+/// </summary>
+public partial class DataWriterStoreOperation : IAsyncOperation<uint>, IAsyncInfo, IAsyncOperationInternal<uint>
 {
-	public partial class DataWriterStoreOperation : IAsyncOperation<uint>, IAsyncInfo
+	private readonly IAsyncOperationInternal<uint> _asyncOperation;
+
+	internal DataWriterStoreOperation(IAsyncOperation<uint> asyncOperation)
 	{
-		private readonly CancellationTokenSource _cts = new CancellationTokenSource();
-		private AsyncOperationCompletedHandler<uint> _onCompleted;
-		private AsyncStatus _status;
-		public DataWriterStoreOperation()
-		{
-			Status = AsyncStatus.Started;
-		}
-
-		public AsyncOperationCompletedHandler<uint> Completed
-		{
-			get { return _onCompleted; }
-			set
-			{
-				_onCompleted = value;
-				if (Status != AsyncStatus.Started) { value?.Invoke(this, Status); }
-			}
-		}
-
-		public Exception ErrorCode { get; set; }
-
-		public uint Id { get; set; }
-
-		public AsyncStatus Status
-		{
-			get => _status;
-			set => _status = value;
-		}
-
-		public void Cancel() => _cts.Cancel();
-
-		public void Close()
-		{
-			_cts.Cancel();
-			_cts.Dispose();
-		}
-		public uint Result { get; set; }
-		public uint GetResults()
-		{
-			return Status == AsyncStatus.Completed ? Result : 0;
-		}
+		_asyncOperation = (IAsyncOperationInternal<uint>)asyncOperation;
 	}
+
+	/// <summary>
+	/// Gets or sets the handler to call when the data store operation is complete.
+	/// </summary>
+	public AsyncOperationCompletedHandler<uint> Completed
+	{
+		get => _asyncOperation.Completed;
+		set => _asyncOperation.Completed = value;
+	}
+
+	/// <summary>
+	/// Gets the error code for the data store operation if it fails.
+	/// </summary>
+	public Exception ErrorCode => _asyncOperation.ErrorCode;
+
+	/// <summary>
+	/// Gets a unique identifier that represents the data store operation.
+	/// </summary>
+	public uint Id => _asyncOperation.Id;
+
+	/// <summary>
+	/// Gets the current status of the data store operation.
+	/// </summary>
+	public AsyncStatus Status => _asyncOperation.Status;
+
+	/// <summary>
+	/// Requests the cancellation of the data store operation.
+	/// </summary>
+	public void Cancel() => _asyncOperation.Cancel();
+
+	/// <summary>
+	/// Requests that work associated with the data store operation should stop.
+	/// </summary>
+	public void Close() => _asyncOperation.Close();
+
+	/// <summary>
+	/// Returns the result of the data store operation.
+	/// </summary>
+	/// <returns></returns>
+	public uint GetResults() => _asyncOperation.GetResults();
+
+	Task<uint> IAsyncOperationInternal<uint>.Task => _asyncOperation.Task;
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In its original form, the `StoreAsync` test finished before the assert was actually checked.

## What is the new behavior?

- Using `await` for async calls
- Checking the file contents after writing.
- Delegating async logic to `AsyncOperation`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
