### PR TITLE
Dev/dr/capt man bubble

### DIFF
--- a/src/Uno.UI.RuntimeTests/UITestsImport.props
+++ b/src/Uno.UI.RuntimeTests/UITestsImport.props
@@ -2,12 +2,13 @@
 
 	<ItemGroup>
 		<!-- File path or directy with globbing relative to SamplesApp\SamplesApp.UITests directory -->
-		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\NestedHandling_Tests.cs" />
-		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\PointersOriginalSource_Tests.cs" />
-		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\HitTest_Clipping_Tests.cs" />
-		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\Nested_Sequence_Tests.cs" />
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Controls\ListViewTests\Selection_Pointers.cs" />
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Controls\SwipeControlTests\SwipeControlTests.cs" />
+		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\Capture_Tests.cs" />
+		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\HitTest_Clipping_Tests.cs" />
+		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\Nested_Sequence_Tests.cs" />
+		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\NestedHandling_Tests.cs" />
+	  <UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\PointersOriginalSource_Tests.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1138,6 +1138,7 @@ namespace Windows.UI.Xaml
 				return args.Handled;
 			}
 
+			var originalPending = _pendingRaisedEvent;
 			try
 			{
 				_pendingRaisedEvent = (this, evt, args);
@@ -1155,7 +1156,7 @@ namespace Windows.UI.Xaml
 			}
 			finally
 			{
-				_pendingRaisedEvent = (null, null, null);
+				_pendingRaisedEvent = originalPending;
 			}
 		}
 		#endregion


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/9315

## Bugfix
Capture are not working properly when event are bubbling in managed (Skia)

## What is the current behavior?
Capture is released by parent control on bubbling when not capturing from the top most element

## What is the new behavior?
Captures are working

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
