### PR TITLE
fix: case-insensitive linker ref paths

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
@@ -307,9 +307,10 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			string RewriteReferencePath(string referencePath, string unoUIPackageBasePath, string unoRuntimeIdentifier)
 			{
 				var separator = Path.DirectorySeparatorChar;
+				unoRuntimeIdentifier = unoRuntimeIdentifier.ToLowerInvariant();
 
 				return
-					(unoRuntimeIdentifier == "Skia" || unoRuntimeIdentifier == "WebAssembly") &&
+					(unoRuntimeIdentifier == "skia" || unoRuntimeIdentifier == "webassembly") &&
 						referencePath.StartsWith(unoUIPackageBasePath) ?
 							referencePath.Replace($"lib{separator}netstandard2.0", $"uno-runtime{separator}{unoRuntimeIdentifier}") :
 								referencePath;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Reference Paths were written with the string "Skia" or "WebAssembly" in the path. This causes issues for builds on *nix environment since the file system may be case-sensitive.
Example: `/__w/1/s/.nuget/uno.ui/4.5.0-dev.328/uno-runtime/WebAssembly/Uno.Foundation.dll` does not match the actual path of `/__w/1/s/.nuget/uno.ui/4.5.0-dev.328/uno-runtime/webassembly/Uno.Foundation.dll`