### PR TITLE
Allow pre-selecting invalid selection on `Selector` when items are empty

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -306,7 +306,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-		[Ignore] // https://github.com/unoplatform/uno/issues/4686
 		public void When_Index_Is_Out_Of_Range_And_Later_Becomes_Valid()
 		{
 			var comboBox = new ComboBox();
@@ -321,7 +320,53 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-		[Ignore] // https://github.com/unoplatform/uno/issues/4686
+		public void When_Index_Set_With_No_Items_Repeated()
+		{
+			var comboBox = new ComboBox();
+			comboBox.SelectedIndex = 1;
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(1, comboBox.SelectedIndex);
+			comboBox.Items.Clear();
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.SelectedIndex = 2;
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(2, comboBox.SelectedIndex);
+		}
+
+		[TestMethod]
+		public void When_Index_Set_Out_Of_Range_When_Items_Exist()
+		{
+			var comboBox = new ComboBox();
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.ThrowsException<ArgumentException>(() => comboBox.SelectedIndex = 2);
+		}
+
+		[TestMethod]
+		public void When_Index_Set_Negative_Out_Of_Range_When_Items_Exist()
+		{
+			var comboBox = new ComboBox();
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.ThrowsException<ArgumentException>(() => comboBox.SelectedIndex = -2);
+		}
+
+		[TestMethod]
+		public void When_Index_Set_Negative_Out_Of_Range_When_Items_Do_Not_Exist()
+		{
+			var comboBox = new ComboBox();
+			comboBox.SelectedIndex = -2;
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+		}
+
+		[TestMethod]
 		public void When_Index_Is_Explicitly_Set_To_Negative_After_Out_Of_Range_Value()
 		{
 			var comboBox = new ComboBox();

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -441,7 +441,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 					if (selectedIndexToSet >= newIndex)
 					{
 						selectedIndexToSet += c.NewItems.Count;
-						SelectedIndex = selectedIndexToSet;
+						SelectedIndex = Math.Min(NumberOfItems - 1, selectedIndexToSet);
 					}
 					break;
 				case NotifyCollectionChangedAction.Remove:
@@ -456,7 +456,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 						{
 							//Decrement SelectedIndex if items are removed before it
 							selectedIndexToSet -= c.OldItems.Count;
-							SelectedIndex = selectedIndexToSet;
+							SelectedIndex = Math.Max(-1, selectedIndexToSet);
 						}
 					}
 					break;

--- a/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Windows.UI.Xaml.Data;
+﻿using Windows.UI.Xaml.Data;
 
 namespace Windows.UI.Xaml
 {
@@ -32,6 +28,14 @@ namespace Windows.UI.Xaml
 		) : base(defaultValue)
 		{
 			Options = options.WithDefault();
+		}
+
+		internal FrameworkPropertyMetadata(
+			object defaultValue,
+			CoerceValueCallback coerceValueCallback
+		) : base(defaultValue)
+		{
+			CoerceValueCallback = coerceValueCallback;
 		}
 
 		public FrameworkPropertyMetadata(
@@ -166,7 +170,7 @@ namespace Windows.UI.Xaml
 				_isDefaultUpdateSourceTriggerSet = true;
 			}
 		}
-		
+
 		protected internal override void Merge(PropertyMetadata baseMetadata, DependencyProperty dp)
 		{
 			base.Merge(baseMetadata, dp);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When `SelectedIndex` is set to invalid value before items are present, the request is ignored and selection does not work.

## What is the new behavior?

Selected index is set properly when requested item is added.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
