### PR TITLE
fix(pointers): Make sure to update manipulation first before raising pointer released event

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/EventsSequences.xaml.cs
@@ -144,9 +144,30 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 		private void ValidateTranslatedTapTest(object sender, RoutedEventArgs e)
 		{
 			var args = new EventSequenceValidator(_translatedTapResult);
+			var isInertialManip = _translatedTapResult.Any(arg => arg.evt == ManipulationInertiaStartingEvent);
 			var result = false;
 			switch (PointerType)
 			{
+				case PointerDeviceType.Mouse when isInertialManip:
+				case PointerDeviceType.Pen when isInertialManip && PenSupportsHover:
+					result = args.One(PointerEnteredEvent)
+						&& args.MaybeSome(PointerMovedEvent)
+						&& args.One(PointerPressedEvent)
+						&& args.One(ManipulationStartingEvent)
+						&& args.Some(PointerMovedEvent)
+						&& args.One(ManipulationStartedEvent)
+						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
+						// && args.One(TappedEvent) // No tap as we moved too far
+						&& args.One(ManipulationInertiaStartingEvent)
+						&& args.MaybeSome(ManipulationDeltaEvent)
+						&& args.One(PointerReleasedEvent)
+						&& args.MaybeSome(PointerMovedEvent, ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
+						&& args.MaybeSome(PointerMovedEvent)
+						&& args.One(PointerExitedEvent)
+						&& args.End();
+					break;
+
 				case PointerDeviceType.Mouse:
 				case PointerDeviceType.Pen when PenSupportsHover:
 					result = args.One(PointerEnteredEvent)
@@ -157,12 +178,28 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						&& args.One(ManipulationStartedEvent)
 						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
 						// && args.One(TappedEvent) // No tap as we moved too far
-						&& args.One(PointerReleasedEvent)
-						&& args.MaybeOne(ManipulationInertiaStartingEvent)
-						&& args.MaybeSome(PointerMovedEvent, ManipulationDeltaEvent)
 						&& args.One(ManipulationCompletedEvent)
+						&& args.One(PointerReleasedEvent)
 						&& args.MaybeSome(PointerMovedEvent)
 						&& args.One(PointerExitedEvent)
+						&& args.End();
+					break;
+
+				case PointerDeviceType.Pen when isInertialManip:
+				case PointerDeviceType.Touch when isInertialManip:
+					result = args.One(PointerEnteredEvent)
+						&& args.One(PointerPressedEvent)
+						&& args.One(ManipulationStartingEvent)
+						&& args.Some(PointerMovedEvent)
+						&& args.One(ManipulationStartedEvent)
+						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
+						// && args.One(TappedEvent) // No tap as we moved too far
+						&& args.One(ManipulationInertiaStartingEvent)
+						&& args.Some(ManipulationDeltaEvent)
+						&& args.One(PointerReleasedEvent)
+						&& args.One(PointerExitedEvent)
+						&& args.Some(ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
 						&& args.End();
 					break;
 
@@ -175,12 +212,9 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						&& args.One(ManipulationStartedEvent)
 						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
 						// && args.One(TappedEvent) // No tap as we moved too far
-						&& args.One(PointerReleasedEvent)
-						&& args.MaybeOne(ManipulationInertiaStartingEvent)
-						&& args.MaybeOne(PointerExitedEvent)
-						&& args.MaybeSome(ManipulationDeltaEvent)
 						&& args.One(ManipulationCompletedEvent)
-						&& args.MaybeOne(PointerExitedEvent) // If no inertia
+						&& args.One(PointerReleasedEvent)
+						&& args.One(PointerExitedEvent)
 						&& args.End();
 					break;
 			}
@@ -194,9 +228,30 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 			// Pointer pressed and released are handled by the ButtonBase
 
 			var args = new EventSequenceValidator(_translatedClickResult);
+			var isInertialManip = _translatedTapResult.Any(arg => arg.evt == ManipulationInertiaStartingEvent);
 			var result = false;
 			switch (PointerType)
 			{
+				case PointerDeviceType.Mouse when isInertialManip:
+				case PointerDeviceType.Pen when isInertialManip && PenSupportsHover:
+					result = args.One(PointerEnteredEvent)
+						&& args.MaybeSome(PointerMovedEvent)
+						&& args.One(ManipulationStartingEvent)
+						&& args.Some(PointerMovedEvent)
+						&& args.One(ManipulationStartedEvent)
+						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
+						&& args.MaybeOne(ManipulationInertiaStartingEvent)
+						&& args.MaybeSome(ManipulationDeltaEvent)
+						&& args.Click()
+						&& args.One(PointerCaptureLostEvent)
+						// && args.One(TappedEvent) // No tap as we moved too far
+						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
+						&& args.MaybeSome(PointerMovedEvent)
+						&& args.One(PointerExitedEvent)
+						&& args.End();
+					break;
+
 				case PointerDeviceType.Mouse:
 				case PointerDeviceType.Pen when PenSupportsHover:
 					result = args.One(PointerEnteredEvent)
@@ -205,14 +260,30 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						&& args.Some(PointerMovedEvent)
 						&& args.One(ManipulationStartedEvent)
 						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
 						&& args.Click()
 						&& args.One(PointerCaptureLostEvent)
 						// && args.One(TappedEvent) // No tap as we moved too far
-						&& args.MaybeOne(ManipulationInertiaStartingEvent)
-						&& args.MaybeSome(PointerMovedEvent, ManipulationDeltaEvent)
-						&& args.One(ManipulationCompletedEvent)
 						&& args.MaybeSome(PointerMovedEvent)
 						&& args.One(PointerExitedEvent)
+						&& args.End();
+					break;
+
+				case PointerDeviceType.Pen when isInertialManip:
+				case PointerDeviceType.Touch when isInertialManip:
+					result = args.One(PointerEnteredEvent)
+						&& args.One(ManipulationStartingEvent)
+						&& args.Some(PointerMovedEvent)
+						&& args.One(ManipulationStartedEvent)
+						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
+						&& args.One(ManipulationInertiaStartingEvent)
+						&& args.MaybeSome(ManipulationDeltaEvent)
+						&& args.Click()
+						&& args.One(PointerCaptureLostEvent)
+						// && args.One(TappedEvent) // No tap as we moved too far
+						&& args.One(PointerExitedEvent)
+						&& args.Some(ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
 						&& args.End();
 					break;
 
@@ -223,14 +294,10 @@ namespace UITests.Shared.Windows_UI_Input.PointersTests
 						&& args.Some(PointerMovedEvent)
 						&& args.One(ManipulationStartedEvent)
 						&& args.Some(PointerMovedEvent, ManipulationDeltaEvent)
+						&& args.One(ManipulationCompletedEvent)
 						&& args.Click()
 						&& args.One(PointerCaptureLostEvent)
-						// && args.One(TappedEvent) // No tap as we moved too far
-						&& args.MaybeOne(ManipulationInertiaStartingEvent)
-						&& args.MaybeOne(PointerExitedEvent)
-						&& args.MaybeSome(ManipulationDeltaEvent)
-						&& args.One(ManipulationCompletedEvent)
-						&& args.MaybeOne(PointerExitedEvent) // If no inertia
+						&& args.One(PointerExitedEvent)
 						&& args.End();
 					break;
 			}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1004,6 +1004,15 @@ namespace Windows.UI.Xaml
 				ctx = ctx.WithMode(ctx.Mode | BubblingMode.IgnoreElement);
 			}
 
+			// Note: We process the UpEvent between Release and Exited as the gestures like "Tap"
+			//		 are fired between those events.
+			var currentPoint = default(PointerPoint);
+			if (IsGestureRecognizerCreated)
+			{
+				currentPoint = args.GetCurrentPoint(this);
+				GestureRecognizer.ProcessBeforeUpEvent(currentPoint, !ctx.IsInternal || isOverOrCaptured);
+			}
+
 			handledInManaged |= SetPressed(args, false, ctx);
 
 			// Note: We process the UpEvent between Release and Exited as the gestures like "Tap"
@@ -1014,7 +1023,7 @@ namespace Windows.UI.Xaml
 				// if they are bubbling in managed it means that they where handled a child control,
 				// so we should not use them for gesture recognition.
 				var isDragging = GestureRecognizer.IsDragging;
-				GestureRecognizer.ProcessUpEvent(args.GetCurrentPoint(this), !ctx.IsInternal || isOverOrCaptured);
+				GestureRecognizer.ProcessUpEvent(currentPoint, !ctx.IsInternal || isOverOrCaptured);
 				if (isDragging && !ctx.IsInternal)
 				{
 					global::Windows.UI.Xaml.Window.Current.DragDrop.ProcessDropped(args);

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -124,6 +124,13 @@ namespace Windows.UI.Input
 			_manipulation?.Update(value);
 		}
 
+		// Manipulation <Completed|InertiaStaring> has to be raised BEFORE the pointer up
+		// The allows users to update the manipulation before anything else.
+		internal void ProcessBeforeUpEvent(PointerPoint value, bool isRelevant)
+		{
+			_manipulation?.Remove(value);
+		}
+
 		public void ProcessUpEvent(PointerPoint value) => ProcessUpEvent(value, true);
 
 		internal void ProcessUpEvent(PointerPoint value, bool isRelevant)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/7951

## Bugfix
Make sure to update manipulation first before raising pointer released event

## What is the current behavior?
`PointerReleased` event is raised before the `Manipulation<InertiaStarting|Completed>`.

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
