### PR TITLE
feat(xaml): add support for raw numerical enum values

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4755,22 +4755,52 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						return $"\"{memberValue}\"";
 				}
 
-				var isEnum = propertyType
-					.TypeKind == TypeKind.Enum;
-
+				var isEnum = propertyType.TypeKind == TypeKind.Enum;
 				if (isEnum)
 				{
-					var validFlags = propertyType.GetFields().Select(field => field.Name);
-					var actualFlags = GetMemberValue().Split(',').Select(part => part.Trim());
+					var value = GetMemberValue();
+					var isEnumSigned = propertyType.EnumUnderlyingType!.SpecialType switch
+					{
+						// CS1008 Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
+						SpecialType.System_Byte => false,
+						SpecialType.System_SByte => true,
+						SpecialType.System_Int16 => true,
+						SpecialType.System_UInt16 => false,
+						SpecialType.System_Int32 => true,
+						SpecialType.System_UInt32 => false,
+						SpecialType.System_Int64 => true,
+						SpecialType.System_UInt64 => false,
 
-					var invalidFlags = actualFlags.Except(validFlags, StringComparer.OrdinalIgnoreCase);
+						_ => throw new Exception($"The enum underlying type '{propertyType.EnumUnderlyingType}' is not expected."),
+					};
+
+					var definedFlags = propertyType.GetFields().Select(field => field.Name).ToArray();
+					var flags = value.Split(',')
+						.Select(x => x.Trim())
+						.Select(x => new
+						{
+							Text = x,
+							DefinedName = definedFlags.FirstOrDefault(y => y.Equals(x, StringComparison.OrdinalIgnoreCase)),
+							IsValidNumeric = x.SkipWhile((c, i) => isEnumSigned && i == 0 && c == '-').All(char.IsNumber),
+						})
+						.ToArray();
+
+					// FIXME: UWP throws on undefined numerical value for some enum type like <StackPanel Orientation="2" />, but not on some others (eg: user-defined enums)".
+					// Setting the same Orientation to 2 in code behind is fine however...
+					// Given the logic is not well understood, we are ignoring this behavior here.
+					var invalidFlags = flags.Where(x => x.DefinedName == null && !x.IsValidNumeric).ToArray();
 					if (invalidFlags.Any())
 					{
-						throw new Exception($"The following values are not valid members of the '{propertyType.Name}' enumeration: {string.Join(", ", invalidFlags)}");
+						throw new Exception($"Failed to create a '{propertyType.GetFullName()}' from the text '{value}'.");
 					}
 
-					var finalFlags = validFlags.Intersect(actualFlags, StringComparer.OrdinalIgnoreCase);
-					return string.Join("|", finalFlags.Select(flag => $"{propertyType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}.{flag}"));
+					var globalizedEnumType = propertyType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+					var values = flags.Select(x => x.DefinedName is { }
+						? $"{globalizedEnumType}.{x.DefinedName}" // x.Text may not be properly cased
+						: $"({globalizedEnumType})({x.Text})" // Parentheses are needed to cast negative value (CS0075)
+					).ToArray();
+
+					return string.Join("|", values);
 				}
 
 				var hasImplictToString = propertyType

--- a/src/SourceGenerators/XamlGenerationTests/RawNumericalEnumValue.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/RawNumericalEnumValue.xaml
@@ -1,0 +1,43 @@
+﻿<UserControl x:Class="XamlGenerationTests.Shared.RawNumericalEnumValue"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:void="Reach into the Void and claim your prize."
+			 xmlns:local="using:XamlGenerationTests.Shared"
+			 mc:Ignorable="d void">
+	
+	<StackPanel>
+		<!-- fyi 'void:' is used to comment out code -->
+
+		<!-- Raw numerical enum values are valid -->
+		<StackPanel Orientation="0" />
+		<StackPanel Orientation="1" />
+
+		<!-- Assigning undefined value for StackPanel::Orientation will cause runtime exception on Uwp: -->
+		<!-- XamlParseException: Failed to create a 'Windows.UI.Xaml.Controls.Orientation' from the text '2'. -->
+		<!-- Yet, if nothing will happens if you do the same in the code behind... -->
+		<void:StackPanel Orientation="2" />
+
+		<!-- However, it is perfectly fine on this example below: -->
+		<local:RawNumericalEnumValueTest SomeEnumProperty="312" />
+
+		<!-- Negative numbers are usually fine, EXCEPT for unsigned enum -->
+		<local:RawNumericalEnumValueTest SomeEnumProperty="-312" />
+		<void:RawNumericalEnumValueTest SomeUnsignedEnumProperty="-312" />
+
+		<!-- As with string literal enum, having leading or trailing space are fine -->
+		<StackPanel Orientation="   0" />
+		<StackPanel Orientation="0   " />
+		<StackPanel Orientation="   0   " />
+		
+		<!-- space or digit sperator are illegal however -->
+		<void:RawNumericalEnumValueTest SomeEnumProperty="3 1 2" />
+		<void:RawNumericalEnumValueTest SomeEnumProperty="3_1_2" />
+
+		<!-- multiple flag numbers with are fine too, even for unknown ones or without [Flags] on the enum type -->
+		<local:RawNumericalEnumValueTest SomeFlagEnumProperty="3,12" />
+		<local:RawNumericalEnumValueTest SomeEnumProperty="3,12" />
+	</StackPanel>
+
+</UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/RawNumericalEnumValue.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/RawNumericalEnumValue.xaml.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace XamlGenerationTests.Shared
+{
+	public partial class RawNumericalEnumValue : UserControl
+	{
+	}
+
+	public partial class RawNumericalEnumValueTest : Control
+	{
+		public enum MyEnum { }
+		public enum MyUnsignedEnum : uint { }
+		[Flags] public enum MyFlagEnum
+		{
+			None = 0,
+			Qwe = 1 << 0,
+			Asd = 1 << 1,
+			Zxc = 1 << 2,
+		}
+
+		#region DependencyProperty: SomeEnumProperty
+
+		public static DependencyProperty SomeEnumPropertyProperty { get; } = DependencyProperty.Register(
+			nameof(SomeEnumProperty),
+			typeof(MyEnum),
+			typeof(RawNumericalEnumValue),
+			new PropertyMetadata(default(MyEnum)));
+
+		public MyEnum SomeEnumProperty
+		{
+			get => (MyEnum)GetValue(SomeEnumPropertyProperty);
+			set => SetValue(SomeEnumPropertyProperty, value);
+		}
+
+		#endregion
+		#region DependencyProperty: SomeUnsignedEnumProperty
+
+		public static DependencyProperty SomeUnsignedEnumPropertyProperty { get; } = DependencyProperty.Register(
+			nameof(SomeUnsignedEnumProperty),
+			typeof(MyUnsignedEnum),
+			typeof(RawNumericalEnumValue),
+			new PropertyMetadata(default(MyUnsignedEnum)));
+
+		public MyUnsignedEnum SomeUnsignedEnumProperty
+		{
+			get => (MyUnsignedEnum)GetValue(SomeUnsignedEnumPropertyProperty);
+			set => SetValue(SomeUnsignedEnumPropertyProperty, value);
+		}
+
+		#endregion
+		#region DependencyProperty: SomeFlagEnumProperty
+
+		public static DependencyProperty SomeFlagEnumPropertyProperty { get; } = DependencyProperty.Register(
+			nameof(SomeFlagEnumProperty),
+			typeof(MyFlagEnum),
+			typeof(RawNumericalEnumValue),
+			new PropertyMetadata(default(MyFlagEnum)));
+
+		public MyFlagEnum SomeFlagEnumProperty
+		{
+			get => (MyFlagEnum)GetValue(SomeFlagEnumPropertyProperty);
+			set => SetValue(SomeFlagEnumPropertyProperty, value);
+		}
+
+		#endregion
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_XamlReader
+	{
+		[TestMethod]
+		public void When_Enum_HasNumericalValue()
+		{
+			XamlReader.Load(@"
+				<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+					Orientation='0' />
+			".Replace('\'', '"'));
+		}
+	}
+}

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -53,10 +53,8 @@ namespace Uno.UI.DataBinding
 		{
 			output = null;
 
-			if (
-				input is string stringInput
-				&& FastStringConvert(outputType, stringInput, ref output)
-			)
+			if (input is string stringInput &&
+				FastStringConvert(outputType, stringInput, ref output))
 			{
 				return true;
 			}
@@ -154,7 +152,7 @@ namespace Uno.UI.DataBinding
 		{
 			if (input is double doubleInput)
 			{
-				if(outputType == typeof(float))
+				if (outputType == typeof(float))
 				{
 					output = (float)doubleInput;
 					return true;
@@ -363,33 +361,75 @@ namespace Uno.UI.DataBinding
 
 		private static bool FastStringToInputScope(Type outputType, string input, ref object output)
 		{
-			if (outputType == typeof(Windows.UI.Xaml.Input.InputScope))
+			if (outputType != typeof(Windows.UI.Xaml.Input.InputScope)) return false;
+
+			var nameValue = input.ToLowerInvariant().Trim() switch
 			{
-				object nameValue = null;
-				if (FastEnumConvert(typeof(Windows.UI.Xaml.Input.InputScopeNameValue), input, ref nameValue))
+				"0" or "default" => Windows.UI.Xaml.Input.InputScopeNameValue.Default,
+				"1" or "url" => Windows.UI.Xaml.Input.InputScopeNameValue.Url,
+				"5" or "emailsmtpaddress" => Windows.UI.Xaml.Input.InputScopeNameValue.EmailSmtpAddress,
+				"7" or "personalfullname" => Windows.UI.Xaml.Input.InputScopeNameValue.PersonalFullName,
+				"20" or "currencyamountandsymbol" => Windows.UI.Xaml.Input.InputScopeNameValue.CurrencyAmountAndSymbol,
+				"21" or "currencyamount" => Windows.UI.Xaml.Input.InputScopeNameValue.CurrencyAmount,
+				"23" or "datemonthnumber" => Windows.UI.Xaml.Input.InputScopeNameValue.DateMonthNumber,
+				"24" or "datedaynumber" => Windows.UI.Xaml.Input.InputScopeNameValue.DateDayNumber,
+				"25" or "dateyear" => Windows.UI.Xaml.Input.InputScopeNameValue.DateYear,
+				"28" or "digits" => Windows.UI.Xaml.Input.InputScopeNameValue.Digits,
+				"29" or "number" => Windows.UI.Xaml.Input.InputScopeNameValue.Number,
+				"31" or "password" => Windows.UI.Xaml.Input.InputScopeNameValue.Password,
+				"32" or "telephonenumber" => Windows.UI.Xaml.Input.InputScopeNameValue.TelephoneNumber,
+				"33" or "telephonecountrycode" => Windows.UI.Xaml.Input.InputScopeNameValue.TelephoneCountryCode,
+				"34" or "telephoneareacode" => Windows.UI.Xaml.Input.InputScopeNameValue.TelephoneAreaCode,
+				"35" or "telephonelocalnumber" => Windows.UI.Xaml.Input.InputScopeNameValue.TelephoneLocalNumber,
+				"37" or "timehour" => Windows.UI.Xaml.Input.InputScopeNameValue.TimeHour,
+				"38" or "timeminutesorseconds" => Windows.UI.Xaml.Input.InputScopeNameValue.TimeMinutesOrSeconds,
+				"39" or "numberfullwidth" => Windows.UI.Xaml.Input.InputScopeNameValue.NumberFullWidth,
+				"40" or "alphanumerichalfwidth" => Windows.UI.Xaml.Input.InputScopeNameValue.AlphanumericHalfWidth,
+				"41" or "alphanumericfullwidth" => Windows.UI.Xaml.Input.InputScopeNameValue.AlphanumericFullWidth,
+				"44" or "hiragana" => Windows.UI.Xaml.Input.InputScopeNameValue.Hiragana,
+				"45" or "katakanahalfwidth" => Windows.UI.Xaml.Input.InputScopeNameValue.KatakanaHalfWidth,
+				"46" or "katakanafullwidth" => Windows.UI.Xaml.Input.InputScopeNameValue.KatakanaFullWidth,
+				"47" or "hanja" => Windows.UI.Xaml.Input.InputScopeNameValue.Hanja,
+				"48" or "hangulhalfwidth" => Windows.UI.Xaml.Input.InputScopeNameValue.HangulHalfWidth,
+				"49" or "hangulfullwidth" => Windows.UI.Xaml.Input.InputScopeNameValue.HangulFullWidth,
+				"50" or "search" => Windows.UI.Xaml.Input.InputScopeNameValue.Search,
+				"51" or "formula" => Windows.UI.Xaml.Input.InputScopeNameValue.Formula,
+				"52" or "searchincremental" => Windows.UI.Xaml.Input.InputScopeNameValue.SearchIncremental,
+				"53" or "chinesehalfwidth" => Windows.UI.Xaml.Input.InputScopeNameValue.ChineseHalfWidth,
+				"54" or "chinesefullwidth" => Windows.UI.Xaml.Input.InputScopeNameValue.ChineseFullWidth,
+				"55" or "nativescript" => Windows.UI.Xaml.Input.InputScopeNameValue.NativeScript,
+				"57" or "text" => Windows.UI.Xaml.Input.InputScopeNameValue.Text,
+				"58" or "chat" => Windows.UI.Xaml.Input.InputScopeNameValue.Chat,
+				"59" or "nameorphonenumber" => Windows.UI.Xaml.Input.InputScopeNameValue.NameOrPhoneNumber,
+				"60" or "emailnameoraddress" => Windows.UI.Xaml.Input.InputScopeNameValue.EmailNameOrAddress,
+				"62" or "maps" => Windows.UI.Xaml.Input.InputScopeNameValue.Maps,
+				"63" or "numericpassword" => Windows.UI.Xaml.Input.InputScopeNameValue.NumericPassword,
+				"64" or "numericpin" => Windows.UI.Xaml.Input.InputScopeNameValue.NumericPin,
+				"65" or "alphanumericpin" => Windows.UI.Xaml.Input.InputScopeNameValue.AlphanumericPin,
+				"67" or "formulanumber" => Windows.UI.Xaml.Input.InputScopeNameValue.FormulaNumber,
+				"68" or "chatwithoutemoji" => Windows.UI.Xaml.Input.InputScopeNameValue.ChatWithoutEmoji,
+
+				_ => throw new InvalidOperationException($"Failed to create a '{outputType.FullName}' from the text '{input}'."),
+			};
+			output = new Windows.UI.Xaml.Input.InputScope
+			{
+				Names =
 				{
-					output = new Windows.UI.Xaml.Input.InputScope
+					new Windows.UI.Xaml.Input.InputScopeName
 					{
-						Names = {
-							new Windows.UI.Xaml.Input.InputScopeName
-							{
-								NameValue = (Windows.UI.Xaml.Input.InputScopeNameValue)nameValue
-							}
-						}
-					};
-
-					return true;
+						NameValue = nameValue
+					}
 				}
-			}
+			};
 
-			return false;
+			return true;
 		}
 
 		private static bool FastStringToToolTip(Type outputType, string input, ref object output)
 		{
 			if (outputType == typeof(Windows.UI.Xaml.Controls.ToolTip))
 			{
-				output = new Windows.UI.Xaml.Controls.ToolTip {Content = input};
+				output = new Windows.UI.Xaml.Controls.ToolTip { Content = input };
 				return true;
 			}
 
@@ -406,7 +446,6 @@ namespace Uno.UI.DataBinding
 
 			return false;
 		}
-
 
 		private static bool FastStringToKeySpline(Type outputType, string input, ref object output)
 		{
@@ -585,44 +624,20 @@ namespace Uno.UI.DataBinding
 
 		private static bool FastStringToTextAlignmentConvert(Type outputType, string input, ref object output)
 		{
-			if (outputType == typeof(TextAlignment))
+			if (outputType != typeof(TextAlignment)) return false;
+
+			output = input.ToLowerInvariant().Trim() switch
 			{
-				switch (input.ToLowerInvariant())
-				{
-					case "center":
-						output = TextAlignment.Center;
-						return true;
+				"0" or "center" => TextAlignment.Center,
+				"1" or "left" or "start" => TextAlignment.Left,
+				"2" or "right" or "end" => TextAlignment.Right,
+				"3" or "justify" => TextAlignment.Justify,
+				"4" or "detectfromcontent" => TextAlignment.DetectFromContent,
 
-					case "left":
-						output = TextAlignment.Left;
-						return true;
+				_ => throw new InvalidOperationException($"Failed to create a '{outputType.FullName}' from the text '{input}'."),
+			};
 
-					case "start":
-						output = TextAlignment.Start;
-						return true;
-
-					case "right":
-						output = TextAlignment.Right;
-						return true;
-
-					case "end":
-						output = TextAlignment.End;
-						return true;
-
-					case "justify":
-						output = TextAlignment.Justify;
-						return true;
-
-					case "detectfromcontent":
-						output = TextAlignment.DetectFromContent;
-						return true;
-
-					default:
-						throw new InvalidOperationException($"The value {input} is not a valid {nameof(TextAlignment)}");
-				}
-			}
-
-			return false;
+			return true;
 		}
 
 		private static bool FastStringToGridLengthConvert(Type outputType, string input, ref object output)
@@ -801,24 +816,18 @@ namespace Uno.UI.DataBinding
 
 		private static bool FastStringToOrientationConvert(Type outputType, string input, ref object output)
 		{
-			if (outputType == typeof(Windows.UI.Xaml.Controls.Orientation))
+			if (outputType != typeof(Windows.UI.Xaml.Controls.Orientation)) return false;
+
+			var lowered = input.ToLowerInvariant();
+			output = input.ToLowerInvariant().Trim() switch
 			{
-				switch (input.ToLowerInvariant())
-				{
-					case "vertical":
-						output = Windows.UI.Xaml.Controls.Orientation.Vertical;
-						return true;
+				"0" or "vertical" => Windows.UI.Xaml.Controls.Orientation.Vertical,
+				"1" or "horizontal" => Windows.UI.Xaml.Controls.Orientation.Horizontal,
 
-					case "horizontal":
-						output = Windows.UI.Xaml.Controls.Orientation.Horizontal;
-						return true;
+				_ => throw new InvalidOperationException($"Failed to create a '{outputType.FullName}' from the text '{input}'."),
+			};
 
-					default:
-						throw new InvalidOperationException($"The value {input} is not a valid {nameof(Windows.UI.Xaml.Controls.Orientation)}");
-				}
-			}
-
-			return false;
+			return true;
 		}
 
 		private static bool FastStringToThicknessConvert(Type outputType, string input, ref object output)
@@ -834,152 +843,84 @@ namespace Uno.UI.DataBinding
 
 		private static bool FastStringToVerticalAlignmentConvert(Type outputType, string input, ref object output)
 		{
-			if (outputType == typeof(VerticalAlignment))
+			if (outputType != typeof(VerticalAlignment)) return false;
+
+			output = input.ToLowerInvariant().Trim() switch
 			{
-				switch (input.ToLowerInvariant())
-				{
-					case "center":
-						output = VerticalAlignment.Center;
-						return true;
+				"0" or "top" => VerticalAlignment.Top,
+				"1" or "center" => VerticalAlignment.Center,
+				"2" or "bottom" => VerticalAlignment.Bottom,
+				"3" or "stretch" => VerticalAlignment.Stretch,
 
-					case "top":
-						output = VerticalAlignment.Top;
-						return true;
+				_ => throw new InvalidOperationException($"Failed to create a '{outputType.FullName}' from the text '{input}'."),
+			};
 
-					case "bottom":
-						output = VerticalAlignment.Bottom;
-						return true;
-
-					case "stretch":
-						output = VerticalAlignment.Stretch;
-						return true;
-
-					default:
-						throw new InvalidOperationException($"The value {input} is not a valid {nameof(VerticalAlignment)}");
-				}
-			}
-
-			return false;
+			return true;
 		}
 
 		private static bool FastStringToHorizontalAlignmentConvert(Type outputType, string input, ref object output)
 		{
-			if (outputType == typeof(HorizontalAlignment))
+			if (outputType != typeof(HorizontalAlignment)) return false;
+
+			output = input.ToLowerInvariant().Trim() switch
 			{
-				switch (input.ToLowerInvariant())
-				{
-					case "center":
-						output = HorizontalAlignment.Center;
-						return true;
+				"0" or "left" => HorizontalAlignment.Left,
+				"1" or "center" => HorizontalAlignment.Center,
+				"2" or "right" => HorizontalAlignment.Right,
+				"3" or "stretch" => HorizontalAlignment.Stretch,
 
-					case "left":
-						output = HorizontalAlignment.Left;
-						return true;
+				_ => throw new InvalidOperationException($"Failed to create a '{outputType.FullName}' from the text '{input}'."),
+			};
 
-					case "right":
-						output = HorizontalAlignment.Right;
-						return true;
-
-					case "stretch":
-						output = HorizontalAlignment.Stretch;
-						return true;
-
-					default:
-						throw new InvalidOperationException($"The value {input} is not a valid {nameof(HorizontalAlignment)}");
-				}
-			}
-
-			return false;
+			return true;
 		}
 
 		private static bool FastStringToVisibilityConvert(Type outputType, string input, ref object output)
 		{
-			if (outputType == typeof(Visibility))
+			if (outputType != typeof(Visibility)) return false;
+
+			output = input.ToLowerInvariant().Trim() switch
 			{
-				switch (input.ToLowerInvariant())
-				{
-					case "visible":
-						output = Visibility.Visible;
-						return true;
+				"0" or "visible" => Visibility.Visible,
+				"1" or "collapsed" => Visibility.Collapsed,
 
-					case "collapsed":
-						output = Visibility.Collapsed;
-						return true;
+				_ => throw new InvalidOperationException($"Failed to create a '{outputType.FullName}' from the text '{input}'."),
+			};
 
-					default:
-						throw new InvalidOperationException($"The value {input} is not a valid {nameof(Visibility)}");
-				}
-			}
-
-			return false;
+			return true;
 		}
 
 		private static bool FastStringToFontWeightConvert(Type outputType, string input, ref object output)
 		{
-			if (outputType == typeof(FontWeight))
+			if (outputType != typeof(FontWeight)) return false;
+
+			// Note that list is hard coded to avoid the cold path cost of reflection.
+			output = input.ToLowerInvariant().Trim() switch
 			{
-				// Note that list is hard coded to avoid the cold path cost of reflection.
+				"100" or "thin" => FontWeights.Thin,
+				"200" or "extralight" => FontWeights.ExtraLight,
+				"250" or "semilight" => FontWeights.SemiLight,
+				"300" or "light" => FontWeights.Light,
+				"400" or "normal" => FontWeights.Normal,
+				"500" or "medium" => FontWeights.Medium,
+				"600" or "semibold" => FontWeights.SemiBold,
+				"700" or "bold" => FontWeights.Bold,
+				"800" or "extrabold" => FontWeights.ExtraBold,
+				"900" or "black" => FontWeights.Black,
+				"950" or "extrablack" => FontWeights.ExtraBlack,
 
-				switch (input.ToLowerInvariant())
-				{
-					case "thin":
-						output = FontWeights.Thin;
-						return true;
-					case "extralight":
-						output = FontWeights.ExtraLight;
-						return true;
-					case "ultralight":
-						output = FontWeights.UltraLight;
-						return true;
-					case "semilight":
-						output = FontWeights.SemiLight;
-						return true;
-					case "light":
-						output = FontWeights.Light;
-						return true;
-					case "normal":
-						output = FontWeights.Normal;
-						return true;
-					case "regular":
-						output = FontWeights.Regular;
-						return true;
-					case "medium":
-						output = FontWeights.Medium;
-						return true;
-					case "semibold":
-						output = FontWeights.SemiBold;
-						return true;
-					case "demibold":
-						output = FontWeights.DemiBold;
-						return true;
-					case "bold":
-						output = FontWeights.Bold;
-						return true;
-					case "ultrabold":
-						output = FontWeights.UltraBold;
-						return true;
-					case "extrabold":
-						output = FontWeights.ExtraBold;
-						return true;
-					case "black":
-						output = FontWeights.Black;
-						return true;
-					case "heavy":
-						output = FontWeights.Heavy;
-						return true;
-					case "extrablack":
-						output = FontWeights.ExtraBlack;
-						return true;
-					case "ultrablack":
-						output = FontWeights.UltraBlack;
-						return true;
+				// legacy wpf aliases
+				"ultralight" => FontWeights.UltraLight, // 200 ExtraLight
+				"regular" => FontWeights.Regular, // 400 Normal
+				"demibold" => FontWeights.DemiBold, // 600 SemiBold
+				"ultrabold" => FontWeights.UltraBold, // 800 ExtraBold
+				"heavy" => FontWeights.Heavy, // 900 Black
+				"ultrablack" => FontWeights.UltraBlack, // 950 ExtraBlack
 
-					default:
-						throw new InvalidOperationException($"The value {input} is not a valid {nameof(FontWeight)}");
-				}
-			}
+				_ => throw new InvalidOperationException($"Failed to create a '{outputType.FullName}' from the text '{input}'."),
+			};
 
-			return false;
+			return true;
 		}
 
 		private static bool FastStringToUriConvert(Type outputType, string input, ref object output)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9067

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Raw numerical enum values (ex: `<StackPanel Orientation="2" />`) are not supported in xaml.

## What is the new behavior?
Added support for raw numerical enum values

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
It is only the fast path (FastStringToXYZ; no reflection) code that doesn't support numerical values, so we only need to fix these.
Everything else that isn't optimized uses Enum.Parse which handles numerical value already, like `<ListView SelectionMode="2" />` works without this fix.