### PR TITLE
fix: AutoSuggestBox.QuerySubmitted ChosenSuggestion should be null when selection does not match

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxChosenSuggestion.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/AutoSuggestBoxTests/AutoSuggestBoxChosenSuggestion.xaml.cs
@@ -55,7 +55,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.AutoSuggestBoxTests
 			{
 				await new ContentDialog
 				{
-					Content = "e.ChosenSuggestion == NULL: this is wrong !!!",
+					Content = $"e.ChosenSuggestion == NULL because the selectiopn does not match. The Text inputted is '{sender.Text}'!",
 					PrimaryButtonText = "OK",
 					RequestedTheme = ElementTheme.Default,
 					XamlRoot = XamlRoot,

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -329,7 +329,16 @@ namespace Windows.UI.Xaml.Controls
 	    {
 			var finalResult = _suggestionsList.SelectedItem ?? GetObjectText(Text);
 
-			QuerySubmitted?.Invoke(this, new AutoSuggestBoxQuerySubmittedEventArgs(finalResult is "" ? null : finalResult, userInput));			
+			var isSelected = _suggestionsList.Items.FirstOrDefault(it => it?.ToString() == Text) is not null;
+
+			if (isSelected)
+			{
+				QuerySubmitted?.Invoke(this, new AutoSuggestBoxQuerySubmittedEventArgs(finalResult is "" ? null : finalResult, userInput));
+			}
+			else
+			{
+				QuerySubmitted?.Invoke(this, new AutoSuggestBoxQuerySubmittedEventArgs(null, userInput));
+			}
 
 			IsSuggestionListOpen = false;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

According to windows.ui.xaml.controls.autosuggestbox documentation the event arg e.ChosenSuggestion should be null when the selected text does not match any item on the suggestion list.

https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.autosuggestbox?view=winrt-22621

- Bugfix
-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
