### PR TITLE
fix(pointers): Fix tests randomly failing on CI

### DIFF
--- a/src/Uno.UI/UI/Xaml/RoutedEvent.cs
+++ b/src/Uno.UI/UI/Xaml/RoutedEvent.cs
@@ -60,5 +60,9 @@ namespace Windows.UI.Xaml
 		internal bool IsGestureEvent { get; }
 		[Pure]
 		internal bool IsDragAndDropEvent { get; }
+
+		/// <inheritdoc />
+		public override string ToString()
+			=> Name;
 	}
 }


### PR DESCRIPTION
## Bugfix
Fix CI not passing due to flaky test in pointers

## What is the current behavior?
Depending of the load of the build server, the inertia might kick-in driving to an invalid code path (we were validating the inertia of another test)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
