### PR TITLE
fix(xaml): binding trailing space error message

### DIFF
--- a/src/SourceGenerators/System.Xaml/System.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/ParsedMarkupExtensionInfo.cs
@@ -49,12 +49,12 @@ namespace Uno.Xaml
 
 			if (raw.Length == 0 || raw[0] != '{')
 			{
-				throw Error("Invalid markup extension attribute. It should begin with '{{', but was {0}", raw);
+				throw Error("Invalid markup extension attribute. Expected '{{' not found at the start: \"{0}\"", raw);
 			}
 
 			if (raw.Length >= 2 && raw[1] == '}')
 			{
-				throw Error("Markup extension can not begin with an '{}' escape: '{0}'", raw);
+				throw Error("Markup extension can not begin with an '{}' escape: \"{0}\"", raw);
 			}
 
 			var ret = new ParsedMarkupExtensionInfo();
@@ -62,7 +62,13 @@ namespace Uno.Xaml
 			{
 				// Any character after the final closing bracket is not accepted. Therefore, the last character should be '}'.
 				// Ideally, we should still ran the entire markup through the parser to get a more meaningful error.
-				throw Error("Expected '}}' in the markup extension attribute: '{0}'", raw);
+				if (raw.TrimEnd() is string trimmed && trimmed[trimmed.Length - 1] == '}')
+				{
+					// Technically this is salvageable, but since uwp throws on this, we will do the same.
+					throw Error("White space is not allowed after end of markup extension: \"{0}\"", raw);
+				}
+
+				throw Error("Expected '}}' in the markup extension attribute: \"{0}\"", raw);
 			}
 
 			var nameSeparatorIndex = raw.IndexOf(' ');


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9273

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
misleading error message is shown when binding expression contains trailing space:
\<Example Binding="{Binding} " />
^ Expected '}' in the markup extension attribute: '{Binding} '

## What is the new behavior?
a more appropriate message (same as uwp) is shown: White space is not allowed after end of markup extension: "{Binding} "

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Both source generator and XamlReader.Load goes through `ParsedMarkupExtensionInfo`.