### PR TITLE
fix: `ContentPresenter` content alignment

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
@@ -14,6 +14,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 [TestClass]
 [RunsOnUIThread]
 [RequiresFullWindow]
+#if __MACOS__
+[Ignore("Currently fails on macOS, part of #9282! epic")]
+#endif
 public class Given_ContentPresenter
 {
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+[TestClass]
+[RunsOnUIThread]
+[RequiresFullWindow]
+public class Given_ContentPresenter
+{
+	[TestMethod]
+	public void When_Content_Alignment_Set_Default_Alignment_Not_Overriden()
+	{
+		var contentPresenter = new ContentPresenter()
+		{
+			HorizontalContentAlignment = HorizontalAlignment.Center
+		};
+		var border = new Border();
+		contentPresenter.Content = border;
+
+		Assert.AreEqual(HorizontalAlignment.Center, contentPresenter.HorizontalContentAlignment);
+		Assert.AreEqual(HorizontalAlignment.Stretch, border.HorizontalAlignment);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using Private.Infrastructure;
+using Windows.Foundation;
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 
@@ -25,5 +28,154 @@ public class Given_ContentPresenter
 
 		Assert.AreEqual(HorizontalAlignment.Center, contentPresenter.HorizontalContentAlignment);
 		Assert.AreEqual(HorizontalAlignment.Stretch, border.HorizontalAlignment);
+	}
+
+	public static IEnumerable<object[]> GetAlignments()
+	{
+		var configurations = new List<AlignmentTestConfiguration>();
+		// Centered content
+
+		foreach (var outerHorizontalAlignment in Enum.GetValues(typeof(HorizontalAlignment)).OfType<HorizontalAlignment>())
+		{
+			foreach (var outerVerticalAlignment in Enum.GetValues(typeof(VerticalAlignment)).OfType<VerticalAlignment>())
+			{
+				foreach (var innerHorizontalAlignment in Enum.GetValues(typeof(HorizontalAlignment)).OfType<HorizontalAlignment>())
+				{
+					foreach (var innerVerticalAlignment in Enum.GetValues(typeof(VerticalAlignment)).OfType<VerticalAlignment>())
+					{
+						double expectedX = 0;
+						if (outerHorizontalAlignment == HorizontalAlignment.Center)
+						{
+							expectedX = 50;
+						}
+						else if (outerHorizontalAlignment == HorizontalAlignment.Right)
+						{
+							expectedX = 100;
+						}
+						else if (outerHorizontalAlignment == HorizontalAlignment.Stretch)
+						{
+							// Inner alignment matters only now
+							if (innerHorizontalAlignment == HorizontalAlignment.Center)
+							{
+								expectedX = 50;
+							}
+							else if (innerHorizontalAlignment == HorizontalAlignment.Right)
+							{
+								expectedX = 100;
+							}
+						}
+
+						double expectedY = 0;
+						if (outerVerticalAlignment == VerticalAlignment.Center)
+						{
+							expectedY = 50;
+						}
+						else if (outerVerticalAlignment == VerticalAlignment.Bottom)
+						{
+							expectedY = 100;
+						}
+						else if (outerVerticalAlignment == VerticalAlignment.Stretch)
+						{
+							// Inner alignment matters only now
+							if (innerVerticalAlignment == VerticalAlignment.Center)
+							{
+								expectedY = 50;
+							}
+							else if (innerVerticalAlignment == VerticalAlignment.Bottom)
+							{
+								expectedY = 100;
+							}
+						}
+
+						double expectedWidth = 100;
+						if (outerHorizontalAlignment == HorizontalAlignment.Stretch &&
+							innerHorizontalAlignment == HorizontalAlignment.Stretch)
+						{
+							expectedWidth = 200;
+						}
+
+						double expectedHeight = 100;
+						if (outerVerticalAlignment == VerticalAlignment.Stretch &&
+							innerVerticalAlignment == VerticalAlignment.Stretch)
+						{
+							expectedHeight = 200;
+						}
+
+						configurations.Add(new AlignmentTestConfiguration(
+							outerHorizontalAlignment,
+							outerVerticalAlignment,
+							innerHorizontalAlignment,
+							innerVerticalAlignment,
+							new Point(expectedX, expectedY),
+							new Size(expectedWidth, expectedHeight)
+						));
+					}
+				}
+			}
+		}
+
+		return configurations.Select(c => new object[] { c });
+	}
+
+	[TestMethod]
+	[DynamicData(nameof(GetAlignments), DynamicDataSourceType.Method)]
+	public async Task When_Content_Aligned_Position_And_Size(AlignmentTestConfiguration configuration)
+	{
+		var contentPresenter = new ContentPresenter()
+		{
+			HorizontalContentAlignment = configuration.OuterHorizontal,
+			VerticalContentAlignment = configuration.OuterVertical,
+			Width = 200,
+			Height = 200,
+			Background = new SolidColorBrush(Colors.Red)
+		};
+		var border = new Border()
+		{
+			HorizontalAlignment = configuration.InnerHorizontal,
+			VerticalAlignment = configuration.InnerVertical,
+			Background = new SolidColorBrush(Colors.Blue),
+			MinWidth = 100,
+			MinHeight = 100
+		};
+		contentPresenter.Content = border;
+		TestServices.WindowHelper.WindowContent = contentPresenter;
+
+		await TestServices.WindowHelper.WaitForLoaded(contentPresenter);
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var transform = border.TransformToVisual(contentPresenter);
+		var point = transform.TransformPoint(new Point());
+		Assert.AreEqual(configuration.ExpectedPosition, point);
+		Assert.AreEqual(configuration.ExpectedSize, new Size(border.ActualWidth, border.ActualHeight));
+	}
+
+	public class AlignmentTestConfiguration
+	{
+		public AlignmentTestConfiguration(HorizontalAlignment outerHorizontal, VerticalAlignment outerVertical, HorizontalAlignment innerHorizontal, VerticalAlignment innerVertical, Point expectedPosition, Size expectedSize)
+		{
+			OuterHorizontal = outerHorizontal;
+			OuterVertical = outerVertical;
+			InnerHorizontal = innerHorizontal;
+			InnerVertical = innerVertical;
+			ExpectedPosition = expectedPosition;
+			ExpectedSize = expectedSize;
+		}
+
+		public HorizontalAlignment OuterHorizontal { get; }
+
+		public VerticalAlignment OuterVertical { get; }
+
+		public HorizontalAlignment InnerHorizontal { get; }
+
+		public VerticalAlignment InnerVertical { get; }
+
+		public Point ExpectedPosition { get; }
+
+		public Size ExpectedSize { get; }
+
+		public override string ToString()
+		{
+			return $"{OuterHorizontal}/{OuterVertical}/{InnerHorizontal}/{InnerVertical}/{ExpectedPosition}/{ExpectedSize}";
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -1016,13 +1016,16 @@ namespace Windows.UI.Xaml.Controls
 					finalSize.Width - padding.Left - padding.Right - borderThickness.Left - borderThickness.Right,
 					finalSize.Height - padding.Top - padding.Bottom - borderThickness.Top - borderThickness.Bottom
 				);
-				
+
 				var availableSize = new Size(innerRect.Width, innerRect.Height);
 
+				// Using GetElementDesiredSize to properly handle native controls.
+				var desiredSize = GetElementDesiredSize(child);
+
 				var contentWidth = HorizontalContentAlignment == HorizontalAlignment.Stretch ?
-					availableSize.Width : child.DesiredSize.Width;
+					availableSize.Width : desiredSize.Width;
 				var contentHeight = VerticalContentAlignment == VerticalAlignment.Stretch ?
-					availableSize.Height : child.DesiredSize.Height;
+					availableSize.Height : desiredSize.Height;
 				var contentSize = new Size(contentWidth, contentHeight);
 
 				var offset = CalculateContentOffset(availableSize, contentSize);
@@ -1033,7 +1036,7 @@ namespace Windows.UI.Xaml.Controls
 					contentSize.Width,
 					contentSize.Height);
 
-				base.ArrangeElement(child, arrangeRect);
+				ArrangeElement(child, arrangeRect);
 			}
 
 			return finalSize;

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -1030,7 +1030,7 @@ namespace Windows.UI.Xaml.Controls
 
 				var offset = CalculateContentOffset(availableSize, contentSize);
 
-				var arrangeRect = new Rect(
+				var arrangeRect = new Windows.Foundation.Rect(
 					innerRect.X + offset.X,
 					innerRect.Y + offset.Y,
 					contentSize.Width,


### PR DESCRIPTION


GitHub Issue (If applicable): closes #9361

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Previously content alignement properties on ContentPresenter were overriding the alignment of the child, which did not work properly in many cases (especially when the alignment was directly set on the content element). Instead ContentPresenter should arrange the content based on the content alignment properties.

## What is the new behavior?

Content presenter alignment behaves correctly.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
