### PR TITLE
fix(pointers): Improve support of touch screens on linux (Skia GTK)

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkCoreWindowExtension.cs
@@ -1,6 +1,11 @@
-﻿using System;
+﻿#nullable enable
+//#define TRACE_NATIVE_POINTER_EVENTS
+
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Gdk;
 using Gtk;
 using Uno.Extensions;
@@ -25,7 +30,7 @@ namespace Uno.UI.Runtime.Skia
 
 		private const int _maxKnownDevices = 63;
 		private const int _knownDeviceScavengeCount = 16;
-		private readonly Dictionary<PointerIdentifier, (Gdk.Device dev, uint ts)> _knownDevices = new Dictionary<PointerIdentifier, (Gdk.Device dev, uint ts)>(_maxKnownDevices + 1);
+		private readonly Dictionary<PointerIdentifier, (Gdk.Device dev, uint ts)> _knownDevices = new(_maxKnownDevices + 1);
 
 		internal const Gdk.EventMask RequestedEvents =
 			Gdk.EventMask.EnterNotifyMask
@@ -46,7 +51,6 @@ namespace Uno.UI.Runtime.Skia
 			set => GtkHost.Window.Window.Cursor = value.ToCursor();
 		}
 
-
 		public GtkCoreWindowExtension(object owner)
 		{
 			_owner = (CoreWindow)owner;
@@ -58,15 +62,15 @@ namespace Uno.UI.Runtime.Skia
 			GtkHost.EventBox.AddEvents((int)RequestedEvents);
 
 			// Use GtkEventBox to fix Wayland titlebar events
-			GtkHost.EventBox.EnterNotifyEvent += OnWindowEnterEvent;
-			GtkHost.EventBox.LeaveNotifyEvent += OnWindowLeaveEvent;
-			GtkHost.EventBox.ButtonPressEvent += OnWindowButtonPressEvent;
-			GtkHost.EventBox.ButtonReleaseEvent += OnWindowButtonReleaseEvent;
-			GtkHost.EventBox.MotionNotifyEvent += OnWindowMotionEvent;
-			GtkHost.EventBox.ScrollEvent += OnWindowScrollEvent;
-			GtkHost.EventBox.TouchEvent += OnWindowTouchEvent;
-			GtkHost.EventBox.ProximityInEvent += OnWindowProximityInEvent;
-			GtkHost.EventBox.ProximityOutEvent += OnWindowProximityOutEvent;
+			GtkHost.EventBox.EnterNotifyEvent += OnEnterEvent;
+			GtkHost.EventBox.LeaveNotifyEvent += OnLeaveEvent;
+			GtkHost.EventBox.ButtonPressEvent += OnButtonPressEvent;
+			GtkHost.EventBox.ButtonReleaseEvent += OnButtonReleaseEvent;
+			GtkHost.EventBox.MotionNotifyEvent += OnMotionEvent;
+			GtkHost.EventBox.ScrollEvent += OnScrollEvent;
+			GtkHost.EventBox.Touched += OnTouchedEvent; //Note: we don't use the TouchEvent for the reason explained in the UnoEventBox!
+			GtkHost.EventBox.ProximityInEvent += OnProximityInEvent;
+			GtkHost.EventBox.ProximityOutEvent += OnProximityOutEvent;
 
 			InitializeKeyboard();
 		}
@@ -99,7 +103,7 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void OnWindowEnterEvent(object o, EnterNotifyEventArgs args)
+		private void OnEnterEvent(object o, EnterNotifyEventArgs args)
 		{
 			try
 			{
@@ -114,16 +118,14 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void OnWindowLeaveEvent(object o, LeaveNotifyEventArgs args)
+		private void OnLeaveEvent(object o, LeaveNotifyEventArgs args)
 		{
 			try
 			{
-				// The Ungrab mode event is triggered after click 
-				// even when the pointer does not leave the window.
-				// This may need to be removed when we implement
-				// native pointer capture support properly.
+				// The Ungrab mode event is triggered after click even when the pointer does not leave the window.
+				// This may need to be removed when we implement native pointer capture support properly.
 				if (args.Event.Mode != CrossingMode.Ungrab)
-				{
+				{	
 					if (AsPointerArgs(args.Event) is { } ptArgs)
 					{
 						RaisePointerExited(ptArgs);
@@ -136,12 +138,23 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void OnWindowButtonPressEvent(object o, ButtonPressEventArgs args)
+		private void OnButtonPressEvent(object o, ButtonPressEventArgs args)
 		{
 			try
 			{
 				if (AsPointerArgs(args.Event) is { } ptArgs)
 				{
+					// On some devices (e.g. raspberryPI - seems to be devices that are not supporting multi-touch?),
+					// touch events are not going through the OnTouchEvent but are instead sent as "emulated" mouse (cf. EventHelper.GetPointerEmulated).
+					// For that kind of devices we are also supporting the touch in On<Press|Release>Event and we inject the missing Entered and Exited events.
+					// Note: When a device properly send the touch events through the OnTouchEvent,
+					//		 system does not "emulate the mouse" so this method should not be invoked.
+					//		 That's the purpose of the UnoEventBox.
+					if (ptArgs.CurrentPoint.PointerDeviceType is PointerDeviceType.Touch)
+					{
+						RaisePointerEntered(ptArgs);
+					}
+
 					RaisePointerPressed(ptArgs);
 				}
 			}
@@ -151,13 +164,19 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void OnWindowButtonReleaseEvent(object o, ButtonReleaseEventArgs args)
+		private void OnButtonReleaseEvent(object o, ButtonReleaseEventArgs args)
 		{
 			try
 			{
 				if (AsPointerArgs(args.Event) is { } ptArgs)
 				{
 					RaisePointerReleased(ptArgs);
+
+					if (ptArgs.CurrentPoint.PointerDeviceType is PointerDeviceType.Touch)
+					{
+						// Cf. OnButtonPressEvent
+						RaisePointerExited(ptArgs);
+					}
 				}
 			}
 			catch (Exception e)
@@ -166,7 +185,7 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void OnWindowMotionEvent(object o, MotionNotifyEventArgs args) // a.k.a. move
+		private void OnMotionEvent(object o, MotionNotifyEventArgs args) // a.k.a. move
 		{
 			try
 			{
@@ -181,7 +200,7 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void OnWindowScrollEvent(object o, ScrollEventArgs args)
+		private void OnScrollEvent(object o, ScrollEventArgs args)
 		{
 			try
 			{
@@ -196,13 +215,11 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void OnWindowTouchEvent(object o, TouchEventArgs args)
+		private void OnTouchedEvent(object? o, EventTouch evt)
 		{
 			try
 			{
-				// Note: We DO NOT used the args.Event as it's causing an InvalidCastException as of 2021-03-09
-				if (args.Args.FirstOrDefault() is Gdk.Event evt
-					&& AsPointerArgs(evt) is { } ptArgs)
+				if (AsPointerArgs(evt) is { } ptArgs)
 				{
 					switch (evt.Type)
 					{
@@ -216,12 +233,14 @@ namespace Uno.UI.Runtime.Skia
 							RaisePointerExited(ptArgs);
 							break;
 
-						case EventType.TouchCancel:
+						case EventType.TouchUpdate:
 							RaisePointerMoved(ptArgs);
 							break;
-					}
 
-					RaisePointerMoved(ptArgs);
+						case EventType.TouchCancel:
+							RaisePointerCancelled(ptArgs);
+							break;
+					}
 				}
 			}
 			catch (Exception e)
@@ -230,7 +249,7 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void OnWindowProximityOutEvent(object o, ProximityOutEventArgs args)
+		private void OnProximityOutEvent(object o, ProximityOutEventArgs args)
 		{
 			try
 			{
@@ -245,7 +264,7 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private void OnWindowProximityInEvent(object o, ProximityInEventArgs args)
+		private void OnProximityInEvent(object o, ProximityInEventArgs args)
 		{
 			try
 			{
@@ -281,38 +300,48 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
-		private PointerEventArgs AsPointerArgs(Event evt)
+		private PointerEventArgs? AsPointerArgs(EventTouch evt)
+			=> AsPointerArgs(
+				evt.Device, PointerDeviceType.Touch, (uint?)evt.Sequence?.Handle ?? 1u,
+				evt.Type, evt.Time,
+				evt.XRoot, evt.YRoot,
+				evt.X, evt.Y,
+				(ModifierType)evt.State,
+				evt: null);
+
+		private PointerEventArgs? AsPointerArgs(Event evt)
 		{
 			var dev = EventHelper.GetSourceDevice(evt); // We use GetSourceDevice (and not GetDevice) in order to get the TouchScreen device
-			var pointerDevice = ToPointerDevice(dev);
-			var pointerDeviceType = pointerDevice.PointerDeviceType;
-
-			if (pointerDeviceType == PointerDeviceType.Touch)
-			{
-				var type = evt.Type;
-				if (type != EventType.TouchBegin
-					&& type != EventType.TouchUpdate
-					&& type != EventType.TouchEnd
-					&& type != EventType.TouchCancel)
-				{
-					// Touch events are sent twice by the OnWindowTouchEvent and the ButtonPressed/Released and MotionEvent.
-					// As the pointerId (a.k.a sequence) is available only for touch events, we mute events coming from the mouse handlers.
-					return null;
-				}
-			}
-
+			var type = evt.Type;
 			var time = EventHelper.GetTime(evt);
-			EventHelper.GetRootCoords(evt, out var x, out var y);
-			var rawPosition = new Windows.Foundation.Point(x, y);
-			EventHelper.GetCoords(evt, out x, out y);
-			var position = new Windows.Foundation.Point(x, y);
+			EventHelper.GetRootCoords(evt, out var rootX, out var rootY);
+			EventHelper.GetCoords(evt, out var x, out var y);
 			EventHelper.GetState(evt, out var state);
 
-			var pointerId = 1u;
+			return AsPointerArgs(
+				dev, GetDeviceType(dev), 1u,
+				type, time,
+				rootX, rootY,
+				x, y,
+				state,
+				evt);
+		}
+
+		private PointerEventArgs? AsPointerArgs(
+			Gdk.Device dev, PointerDeviceType devType, uint pointerId,
+			EventType evtType, uint time,
+			double rootX, double rootY,
+			double x, double y,
+			ModifierType state,
+			Event? evt)
+		{
+			var pointerDevice = PointerDevice.For(devType);
+			var rawPosition = new Windows.Foundation.Point(rootX, rootY);
+			var position = new Windows.Foundation.Point(x, y);
 			var modifiers = GetKeyModifiers(state);
 			var properties = new PointerPointProperties();
 
-			switch (evt.Type)
+			switch (evtType)
 			{
 				case EventType.TouchBegin:
 					properties.PointerUpdateKind = PointerUpdateKind.LeftButtonPressed;
@@ -323,7 +352,7 @@ namespace Uno.UI.Runtime.Skia
 					properties.PointerUpdateKind = PointerUpdateKind.LeftButtonReleased;
 					break;
 
-				case EventType.ButtonPress when EventHelper.GetButton(evt, out var button):
+				case EventType.ButtonPress when EventHelper.GetButton(evt!, out var button):
 					properties.PointerUpdateKind = button switch
 					{
 						1 => LeftButtonPressed,
@@ -335,7 +364,7 @@ namespace Uno.UI.Runtime.Skia
 					};
 					break;
 
-				case EventType.ButtonRelease when EventHelper.GetButton(evt, out var button):
+				case EventType.ButtonRelease when EventHelper.GetButton(evt!, out var button):
 					properties.PointerUpdateKind = button switch
 					{
 						1 => LeftButtonReleased,
@@ -347,7 +376,7 @@ namespace Uno.UI.Runtime.Skia
 					};
 					break;
 
-				case EventType.Scroll when EventHelper.GetScrollDeltas(evt, out var scrollX, out var scrollY):
+				case EventType.Scroll when EventHelper.GetScrollDeltas(evt!, out var scrollX, out var scrollY):
 					var isHorizontal = scrollY == 0;
 					properties.IsHorizontalMouseWheel = isHorizontal;
 					properties.MouseWheelDelta = (int)(isHorizontal ? scrollX : scrollY);
@@ -362,8 +391,7 @@ namespace Uno.UI.Runtime.Skia
 				// https://gtk-rs.org/docs/gdk/struct.ModifierType.html
 
 				case PointerDeviceType.Touch:
-					properties.IsLeftButtonPressed = evt.Type != EventType.TouchEnd && evt.Type != EventType.TouchCancel;
-					pointerId = ((uint?)EventHelper.GetEventSequence(evt)?.Handle) ?? 0u;
+					properties.IsLeftButtonPressed = evtType is not EventType.TouchEnd and not EventType.TouchCancel;
 					break;
 
 				case PointerDeviceType.Mouse:
@@ -380,10 +408,18 @@ namespace Uno.UI.Runtime.Skia
 					// We accept it as a known limitation that with uno the flag is set as soon as the barrel is pressed,
 					// not matter is the pen was already in contact with the screen or not.
 					properties.IsRightButtonPressed = properties.IsBarrelButtonPressed;
-					properties.IsEraser = dev.Source == InputSource.Eraser;
-					if (EventHelper.GetAxis(evt, AxisUse.Pressure, out var pressure))
+					properties.IsEraser = dev.Source is InputSource.Eraser;
+					if (EventHelper.GetAxis(evt!, AxisUse.Pressure, out var pressure))
 					{
 						properties.Pressure = (float)Math.Min(1.0, pressure);
+					}
+					if (EventHelper.GetAxis(evt!, AxisUse.Xtilt, out var xTilt))
+					{
+						properties.XTilt = (float)xTilt;
+					}
+					if (EventHelper.GetAxis(evt!, AxisUse.Ytilt, out var yTilt))
+					{
+						properties.YTilt = (float)yTilt;
 					}
 					break;
 			}
@@ -426,7 +462,7 @@ namespace Uno.UI.Runtime.Skia
 			return modifiers;
 		}
 
-		private static PointerDevice ToPointerDevice(Gdk.Device sourceDevice)
+		private static PointerDeviceType GetDeviceType(Gdk.Device sourceDevice)
 		{
 			switch (sourceDevice.Source)
 			{
@@ -436,48 +472,88 @@ namespace Uno.UI.Runtime.Skia
 				case InputSource.Eraser:
 				case InputSource.TabletPad: // the device is a "pad", a collection of buttons, rings and strips found in drawing tablets.
 				case InputSource.Cursor: // the device is a graphics tablet “puck” or similar device.
-					return PointerDevice.For(PointerDeviceType.Pen);
+					return PointerDeviceType.Pen;
 
 				case InputSource.Touchscreen:
-					return PointerDevice.For(PointerDeviceType.Touch);
+					return PointerDeviceType.Touch;
 
 				case InputSource.Mouse:
 				default:
-					return PointerDevice.For(PointerDeviceType.Mouse);
+					return PointerDeviceType.Mouse;
 			}
 		}
 
 		private static bool IsPressed(ModifierType state, ModifierType mask, PointerUpdateKind update, PointerUpdateKind pressed, PointerUpdateKind released)
 			=> update == pressed || (state.HasFlag(mask) && update != released);
 
-		private void RaisePointerExited(PointerEventArgs ptArgs)
+
+#if TRACE_NATIVE_POINTER_EVENTS
+		private void RaisePointerEntered(PointerEventArgs ptArgs, [CallerMemberName] string caller = null)
 		{
+			Trace($"[Entered] ({caller}) {ptArgs}");
+			_ownerEvents.RaisePointerEntered(ptArgs);
+		}
+
+		private void RaisePointerExited(PointerEventArgs ptArgs, [CallerMemberName] string caller = null)
+		{
+			Trace($"[Exited] ({caller}) {ptArgs}");
 			_ownerEvents.RaisePointerExited(ptArgs);
 		}
 
-		private void RaisePointerPressed(PointerEventArgs ptArgs)
+		private void RaisePointerPressed(PointerEventArgs ptArgs, [CallerMemberName] string caller = null)
 		{
+			Trace($"[Pressed] ({caller}) {ptArgs}");
 			_ownerEvents.RaisePointerPressed(ptArgs);
 		}
 
-		private void RaisePointerReleased(PointerEventArgs ptArgs)
+		private void RaisePointerReleased(PointerEventArgs ptArgs, [CallerMemberName] string caller = null)
 		{
+			Trace($"[Released] ({caller}) {ptArgs}");
 			_ownerEvents.RaisePointerReleased(ptArgs);
 		}
 
-		private void RaisePointerMoved(PointerEventArgs ptArgs)
+		private void RaisePointerMoved(PointerEventArgs ptArgs, [CallerMemberName] string caller = null)
 		{
+			Trace($"[Moved] ({caller}) {ptArgs}");
 			_ownerEvents.RaisePointerMoved(ptArgs);
 		}
 
-		private void RaisePointerWheelChanged(PointerEventArgs ptArgs)
+		private void RaisePointerCancelled(PointerEventArgs ptArgs, [CallerMemberName] string caller = null)
 		{
+			Trace($"[Cancelled] ({caller}) {ptArgs}");
+			_ownerEvents.RaisePointerCancelled(ptArgs);
+		}
+
+		private void RaisePointerWheelChanged(PointerEventArgs ptArgs, [CallerMemberName] string caller = null)
+		{
+			Trace($"[Wheel] ({caller}) {ptArgs}");
 			_ownerEvents.RaisePointerWheelChanged(ptArgs);
 		}
 
+		private void Trace(string text)
+			=> Console.WriteLine(text);
+
+#else
 		private void RaisePointerEntered(PointerEventArgs ptArgs)
-		{
-			_ownerEvents.RaisePointerEntered(ptArgs);
-		}
+			=> _ownerEvents.RaisePointerEntered(ptArgs);
+
+		private void RaisePointerExited(PointerEventArgs ptArgs)
+			=> _ownerEvents.RaisePointerExited(ptArgs);
+
+		private void RaisePointerPressed(PointerEventArgs ptArgs)
+			=> _ownerEvents.RaisePointerPressed(ptArgs);
+
+		private void RaisePointerReleased(PointerEventArgs ptArgs)
+			=> _ownerEvents.RaisePointerReleased(ptArgs);
+
+		private void RaisePointerMoved(PointerEventArgs ptArgs)
+			=> _ownerEvents.RaisePointerMoved(ptArgs);
+
+		private void RaisePointerCancelled(PointerEventArgs ptArgs)
+			=> _ownerEvents.RaisePointerCancelled(ptArgs);
+
+		private void RaisePointerWheelChanged(PointerEventArgs ptArgs)
+			=> _ownerEvents.RaisePointerWheelChanged(ptArgs);
+#endif
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -43,14 +43,14 @@ namespace Uno.UI.Runtime.Skia
 		private readonly Func<WUX.Application> _appBuilder;
 		private IRenderSurface _renderSurface;
 		private static Gtk.Window _window;
-		private static Gtk.EventBox _eventBox;
+		private static UnoEventBox _eventBox;
 		private Widget _area;
 		private Fixed _fix;
 		private GtkDisplayInformationExtension _displayInformationExtension;
 		private CompositeDisposable _registrations = new();
 
 		public static Gtk.Window Window => _window;
-		public static Gtk.EventBox EventBox => _eventBox;
+		internal static UnoEventBox EventBox => _eventBox;
 
 		/// <summary>
 		/// Gets or sets the current Skia Render surface type.
@@ -154,7 +154,7 @@ namespace Uno.UI.Runtime.Skia
 
 			var overlay = new Overlay();
 
-			_eventBox = new EventBox();
+			_eventBox = new UnoEventBox();
 
 			_renderSurface = BuildRenderSurfaceType();
 			_area = (Widget)_renderSurface;

--- a/src/Uno.UI.Runtime.Skia.Gtk/UnoEventBox.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UnoEventBox.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using Gdk;
+using Gtk;
+
+namespace Uno.UI.Runtime.Skia;
+
+internal class UnoEventBox : EventBox
+{
+	// On some windowing platforms, multitouch devices perform pointer emulation,
+	// this works by granting a “pointer emulating” hint to one of the currently interacting touch sequences,
+	// which will be reported on every GdkEventTouch event from that sequence.
+	// By default, if a widget didn’t request touch events by setting GDK_TOUCH_MASK on its event mask and didn’t override GtkWidget::touch-event,
+	// GTK will transform these “pointer emulating” events into semantically similar GdkEventButton and GdkEventMotion events.
+	//
+	// If the widget sets GDK_TOUCH_MASK on its event mask and doesn’t chain up on GtkWidget::touch-event,
+	// only touch events will be received, and no pointer emulation will be performed.
+	//
+	// https://docs.gtk.org/gtk3/input-handling.html#touch-events
+
+	/// <inheritdoc />
+	protected override bool OnTouchEvent(EventTouch evnt)
+	{
+		Touched?.Invoke(this, evnt);
+		return true;
+	}
+
+	public event EventHandler<EventTouch> Touched;
+
+	/// <inheritdoc />
+	protected override bool OnMotionNotifyEvent(EventMotion evnt)
+		=> base.OnMotionNotifyEvent(evnt);
+}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/8465

## Bugfix
Improve support of touch screens on linux (Skia GTK)

## What is the current behavior?
On touch devices which are sending event through the "touch handler" we are receiving touch events twice (first as "emulated mouse" and then as real "touch"). So in "mouse events handlers", we are filtering out events issued by touch input device.

The issue is that on some devices (like Raspberry PI), we are getting only the "emulated" events through the "mouse handlers", driving touch pointers to be completely ignored.

## What is the new behavior?
We have updated the subscription to native events, in order get touch event only once, so are no longer filtering-out events issued by touch devices in the "mouse events handlers".

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
