### PR TITLE
fix(droid): FlipView not displaying items correctly

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/FlipView/NativePagedView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/FlipView/NativePagedView.Android.cs
@@ -41,10 +41,12 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var measuredSize = ((ILayouterElement)this).OnMeasureInternal(widthMeasureSpec, heightMeasureSpec);
 
+			var logicalMeasuredSize = measuredSize.PhysicalToLogicalPixels();
+
 			//We call ViewPager.OnMeasure here, because it creates the page views.
 			base.OnMeasure(
-				ViewHelper.SpecFromLogicalSize(measuredSize.Width),
-				ViewHelper.SpecFromLogicalSize(measuredSize.Height)
+				ViewHelper.SpecFromLogicalSize(logicalMeasuredSize.Width),
+				ViewHelper.SpecFromLogicalSize(logicalMeasuredSize.Height)
 			);
 
 			IFrameworkElementHelper.OnMeasureOverride(this);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8637

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
When using the `FlipVliew` (or Selector and swiping to change the selected item, the new item selected is not displayed correctly.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
