### PR TITLE
fix(TextBlock): [Skia] Fix RTL segment ordering

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1501,6 +1501,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text_Arabic.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Wrap.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5813,6 +5817,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\RelativePanelTests\RelativePanel_Simple.xaml.cs">
       <DependentUpon>RelativePanel_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text_Arabic.xaml.cs">
+      <DependentUpon>Simple_Text_Arabic.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Wrap.xaml.cs">
       <DependentUpon>TextBox_Wrap.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text_Arabic.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text_Arabic.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Simple_Text_Arabic"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock Text="اللغة العربية" FontWeight="Bold" FontSize="40" />
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text_Arabic.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text_Arabic.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Simple_Text_Arabic")]
+	public sealed partial class Simple_Text_Arabic : UserControl
+	{
+		public Simple_Text_Arabic()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -303,9 +303,9 @@ namespace Windows.UI.Xaml.Documents
 				y += line.Height;
 				float baselineOffsetY = line.BaselineOffsetY;
 
-				for (int s = 0; s < line.SegmentSpans.Count; s++)
+				for (int s = 0; s < line.RenderOrderedSegmentSpans.Count; s++)
 				{
-					var segmentSpan = line.SegmentSpans[s];
+					var segmentSpan = line.RenderOrderedSegmentSpans[s];
 
 					if (segmentSpan.GlyphsLength == 0)
 					{
@@ -330,7 +330,7 @@ namespace Windows.UI.Xaml.Documents
 					if ((decorations & allDecorations) != 0)
 					{
 						var metrics = paint.FontMetrics;
-						float width = s == line.SegmentSpans.Count - 1 ? segmentSpan.WidthWithoutTrailingSpaces : segmentSpan.Width;
+						float width = s == line.RenderOrderedSegmentSpans.Count - 1 ? segmentSpan.WidthWithoutTrailingSpaces : segmentSpan.Width;
 
 						if ((decorations & TextDecorations.Underline) != 0)
 						{
@@ -388,7 +388,9 @@ namespace Windows.UI.Xaml.Documents
 								var glyphInfo = segment.Glyphs[segmentSpan.GlyphsStart + j];
 
 								if (glyphInfo.AdvanceX > 0)
+								{
 									x += segmentSpan.CharacterSpacing;
+								}
 
 								glyphs[j] = glyphInfo.GlyphId;
 								positions[j] = new SKPoint(x + glyphInfo.OffsetX, glyphInfo.OffsetY);
@@ -455,7 +457,7 @@ namespace Windows.UI.Xaml.Documents
 
 			do
 			{
-				span = line.SegmentSpans[i++];
+				span = line.RenderOrderedSegmentSpans[i++];
 				spanX += span.Width;
 
 				if (point.X <= spanX && (extendedSelection || point.X >= spanX - span.Width))
@@ -464,7 +466,7 @@ namespace Windows.UI.Xaml.Documents
 				}
 
 				spanX += justifySpaceOffset * span.TrailingSpaces;
-			} while (i < line.SegmentSpans.Count);
+			} while (i < line.RenderOrderedSegmentSpans.Count);
 
 			return extendedSelection ? span : null;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6783

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Runs of RTL text segments render in reverse order.


## What is the new behavior?

RTL segments render in the correct order.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
