### PR TITLE
[Framebuffer] Support for DPI scaling and 16 bits RGB565 color depth

### DIFF
--- a/doc/articles/features/using-linux-framebuffer.md
+++ b/doc/articles/features/using-linux-framebuffer.md
@@ -34,6 +34,13 @@ The app will start and display on the first available framebuffer device.
 
 Documentation on other hardware targets are [available here](https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0-supported-os.md).
 
+## DPI Scaling support
+Whenever possible, the `FrameBufferHost` will try to detect the actual DPI scale to use when rendering the UI, based on the physical information provided by the FrameBuffer driver. If the value cannot be determined, a scale of `1.0` is used.
+
+The automatic scaling can be overriden in two ways:
+- Set a value using `FrameBufferHost.DisplayScale`
+- Set a value through the `UNO_DISPLAY_SCALE_OVERRIDE` environment variable. This value has precedence over the value specified in `FrameBufferHost.DisplayScale`
+
 ## Additional dependencies
 
 If your device is significantly trimmed down for installed packages, you'll need to install :

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkDisplayInformationExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkDisplayInformationExtension.cs
@@ -35,6 +35,8 @@ internal class GtkDisplayInformationExtension : IDisplayInformationExtension
 
 	public ResolutionScale ResolutionScale => (ResolutionScale)(int)(RawPixelsPerViewPixel * 100.0);
 
+	public double? DiagonalSizeInInches => null;
+
 	private void OnDpiChanged(object? sender, EventArgs args)
 	{
 		_dpi = GetLogicalDpi();

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/CoreWindowExtension.Touch.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/CoreWindowExtension.Touch.cs
@@ -41,8 +41,8 @@ namespace Uno.UI.Runtime.Skia
 					|| rawEventType == LIBINPUT_EVENT_TOUCH_MOTION)
 				{
 					currentPosition = new Point(
-						x: libinput_event_touch_get_x_transformed(rawTouchEvent, (int)_displayInformation.ScreenWidthInRawPixels),
-						y: libinput_event_touch_get_y_transformed(rawTouchEvent, (int)_displayInformation.ScreenHeightInRawPixels));
+						x: libinput_event_touch_get_x_transformed(rawTouchEvent, (int)(_displayInformation.ScreenWidthInRawPixels / _displayInformation.RawPixelsPerViewPixel)),
+						y: libinput_event_touch_get_y_transformed(rawTouchEvent, (int)(_displayInformation.ScreenHeightInRawPixels /_displayInformation.RawPixelsPerViewPixel)));
 
 					_activePointers[pointerId] = currentPosition;
 				}

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/DisplayInformationExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/DisplayInformationExtension.cs
@@ -1,31 +1,108 @@
-﻿using Uno.WinUI.Runtime.Skia.LinuxFB;
+﻿using System;
+using System.Globalization;
+using Uno.WinUI.Runtime.Skia.LinuxFB;
 using Windows.Graphics.Display;
 
 namespace Uno.UI.Runtime.Skia
 {
 	internal class DisplayInformationExtension : IDisplayInformationExtension
 	{
-		private readonly DisplayInformation _displayInformation;
-		public Renderer? Renderer { get; set; }
+		private const string EnvironmentUnoDisplayScaleOverride = "UNO_DISPLAY_SCALE_OVERRIDE";
+		private const double MillimetersToInches = 0.0393700787;
 
-		public DisplayInformationExtension(object owner)
+		private readonly DisplayInformation _displayInformation;
+		private readonly float? _scaleOverride;
+		private DisplayInformationDetails _details = new DisplayInformationDetails(0, 0, DisplayInformation.BaseDpi, 1, ResolutionScale.Scale100Percent, null);
+		private Renderer? _renderer;
+
+		private record DisplayInformationDetails(
+			uint ScreenWidthInRawPixels,
+			uint ScreenHeightInRawPixels,
+			float LogicalDpi,
+			double RawPixelsPerViewPixel,
+			ResolutionScale ResolutionScale,
+			double? DiagonalSizeInInches);
+
+		public Renderer? Renderer
 		{
-			_displayInformation = (DisplayInformation)owner;
+			get => _renderer;
+			set
+			{
+				_renderer = value;
+				UpdateDetails();
+			}
 		}
 
-		public DisplayOrientations CurrentOrientation => DisplayOrientations.Landscape;
+		public DisplayInformationExtension(object owner, float? scaleOverride)
+		{
+			_displayInformation = (DisplayInformation)owner;
+			_scaleOverride = scaleOverride;
+
+			if(float.TryParse(
+				Environment.GetEnvironmentVariable(EnvironmentUnoDisplayScaleOverride),
+				NumberStyles.Any,
+				CultureInfo.InvariantCulture,
+				out var environmentScaleOverride))
+			{
+				_scaleOverride = environmentScaleOverride;
+			}
+		}
+
+		private void UpdateDetails()
+		{
+			if (_details.ScreenWidthInRawPixels == 0
+				&& Renderer != null)
+			{
+				var frameBufferDevice = Renderer.FrameBufferDevice;
+
+				var screenWidthInInches = frameBufferDevice.ScreenPhysicalDimensions.Width * MillimetersToInches;
+				var screenHeightInInches = frameBufferDevice.ScreenPhysicalDimensions.Height * MillimetersToInches;
+
+				var dpi = frameBufferDevice.ScreenPhysicalDimensions.Width switch
+				{
+					-1.0 => DisplayInformation.BaseDpi,
+					_ => (float)(frameBufferDevice.ScreenSize.Width / screenWidthInInches)
+				};
+
+				var diagonalSizeInInches = frameBufferDevice.ScreenPhysicalDimensions.Width switch
+				{
+					-1 => (double?)null,
+					_ => Math.Sqrt(screenWidthInInches * screenWidthInInches + screenHeightInInches * screenHeightInInches)
+				};
+
+				var rawScale = _scaleOverride is not null
+					? (float)_scaleOverride
+					: dpi / DisplayInformation.BaseDpi;
+
+				var flooredScale = FloorScale(rawScale);
+
+				_details = new(
+					(uint)frameBufferDevice.ScreenSize.Width,
+					(uint)frameBufferDevice.ScreenSize.Height,
+					flooredScale * DisplayInformation.BaseDpi,
+					flooredScale,
+					(ResolutionScale)(int)(flooredScale * 100.0),
+					diagonalSizeInInches
+				);
+			}
+		}
+
+		public DisplayOrientations CurrentOrientation
+			=> DisplayOrientations.Landscape;
 
 		public uint ScreenHeightInRawPixels
-			=> (uint)(Renderer?.PixelSize.Height ?? 0);
+			=> _details.ScreenHeightInRawPixels;
 
 		public uint ScreenWidthInRawPixels
-			=> (uint)(Renderer?.PixelSize.Width ?? 0);
+			=> _details.ScreenWidthInRawPixels;
 
-		public float LogicalDpi => DisplayInformation.BaseDpi;
+		public float LogicalDpi => _details.LogicalDpi;
 
-		public double RawPixelsPerViewPixel => LogicalDpi / DisplayInformation.BaseDpi;
+		public double RawPixelsPerViewPixel => _details.RawPixelsPerViewPixel;
 
-		public ResolutionScale ResolutionScale => (ResolutionScale)(int)(RawPixelsPerViewPixel * 100.0);
+		public ResolutionScale ResolutionScale => _details.ResolutionScale;
+
+		public double? DiagonalSizeInInches => _details.DiagonalSizeInInches;
 
 		public void StartDpiChanged()
 		{
@@ -36,5 +113,27 @@ namespace Uno.UI.Runtime.Skia
 		{
 
 		}
+
+		private static float FloorScale(float rawDpi)
+			=> rawDpi switch
+			{
+				> 5.00f => 5.00f,
+				> 4.50f => 4.50f,
+				> 4.00f => 4.00f,
+				> 3.50f => 3.50f,
+				> 3.00f => 3.00f,
+				> 2.50f => 2.50f,
+				> 2.25f => 2.25f,
+				> 2.00f => 2.00f,
+				> 1.80f => 1.80f,
+				> 1.75f => 1.75f,
+				> 1.60f => 1.60f,
+				> 1.50f => 1.50f,
+				> 1.40f => 1.40f,
+				> 1.25f => 1.25f,
+				> 1.20f => 1.20f,
+				> 1.00f => 1.00f,
+				_ => 1.00f,
+			};
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
@@ -7,6 +7,7 @@ using Uno.Extensions;
 using WUX = Windows.UI.Xaml;
 using Uno.UI.Runtime.Skia.Native;
 using Uno.Foundation.Logging;
+using Windows.Graphics.Display;
 
 namespace Uno.UI.Runtime.Skia
 {
@@ -15,53 +16,51 @@ namespace Uno.UI.Runtime.Skia
 		private FrameBufferDevice _fbDev;
 		private SKBitmap? bitmap;
 		private int renderCount = 0;
+		private DisplayInformation? _displayInformation;
 
 		public Renderer()
 		{
 			_fbDev = new FrameBufferDevice();
 			_fbDev.Init();
 
-			var resolution = _fbDev.ScreenSize;
-			
-			WUX.Window.Current.OnNativeSizeChanged(new Windows.Foundation.Size(resolution.Width, resolution.Height));
+			WUX.Window.Current.ToString();
 		}
 
-		public Size PixelSize => _fbDev.ScreenSize;
+		public FrameBufferDevice FrameBufferDevice => _fbDev;
 
 		internal void InvalidateRender() => Invalidate();
 
 		void Invalidate()
 		{
-			int width, height;
-
 			if (this.Log().IsEnabled(LogLevel.Trace))
 			{
 				this.Log().Trace($"Render {renderCount++}");
 			}
 
-			var dpi = 1;
+			_displayInformation ??= DisplayInformation.GetForCurrentView();
 
-			var resolution = _fbDev.ScreenSize;
+			var scale = _displayInformation.RawPixelsPerViewPixel;
 
-			width = (int)resolution.Width;
-			height = (int)resolution.Height;
+			var rawScreenSize = _fbDev.ScreenSize;
 
-			var scaledWidth = (int)(width * dpi);
-			var scaledHeight = (int)(height * dpi);
+			int width = (int)rawScreenSize.Width;
+			int height = (int)rawScreenSize.Height;
 
-			var info = new SKImageInfo(scaledWidth, scaledHeight, SKImageInfo.PlatformColorType, SKAlphaType.Premul);
+			var info = new SKImageInfo(width, height, _fbDev.PixelFormat, SKAlphaType.Premul);
 
 			// reset the bitmap if the size has changed
 			if (bitmap == null || info.Width != bitmap.Width || info.Height != bitmap.Height)
 			{
-				bitmap = new SKBitmap(scaledWidth, scaledHeight, _fbDev.PixelFormat, SKAlphaType.Premul);
+				bitmap = new SKBitmap(width, height, _fbDev.PixelFormat, SKAlphaType.Premul);
+
+				WUX.Window.Current.OnNativeSizeChanged(new Windows.Foundation.Size(rawScreenSize.Width / scale, rawScreenSize.Height / scale));
 			}
 
 			using (var surface = SKSurface.Create(info, bitmap.GetPixels(out _)))
 			{
 				surface.Canvas.Clear(SKColors.White);
 
-				surface.Canvas.Scale((float)dpi);
+				surface.Canvas.Scale((float)scale);
 
 				WUX.Window.Current.Compositor.Render(surface);
 

--- a/src/Uno.UI.Runtime.Skia.Tizen/TizenDisplayInformationExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Tizen/TizenDisplayInformationExtension.cs
@@ -31,6 +31,8 @@ namespace Uno.UI.Runtime.Skia
 
 		public ResolutionScale ResolutionScale => (ResolutionScale)(int)(LogicalDpi / 1.60f);
 
+		public double? DiagonalSizeInInches => null;
+
 		private int GetDpi()
 		{
 			// TV has fixed DPI value (72)

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfDisplayInformationExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfDisplayInformationExtension.cs
@@ -31,6 +31,8 @@ namespace Uno.UI.Skia.Platform
 
 		public ResolutionScale ResolutionScale => (ResolutionScale)(int)(RawPixelsPerViewPixel * 100.0);
 
+		public double? DiagonalSizeInInches => null;
+
 		private void OnDpiChanged(object sender, DpiChangedEventArgs e)
 		{
 			_dpi = GetDpi();

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.skia.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.skia.cs
@@ -32,4 +32,6 @@ public sealed partial class DisplayInformation
 	public double RawPixelsPerViewPixel => _displayInformationExtension.RawPixelsPerViewPixel;
 
 	public ResolutionScale ResolutionScale => _displayInformationExtension.ResolutionScale;
+
+	public double? DiagonalSizeInInches => _displayInformationExtension.DiagonalSizeInInches;
 }

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.unsupported.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.unsupported.cs
@@ -37,7 +37,7 @@ namespace Windows.Graphics.Display
 		public float RawDpiY { get; private set; } = 0;
 #endif
 
-#if __WASM__ || __IOS__ || __MACOS__ || NET461 || __SKIA__ || __NETSTD_REFERENCE__
+#if __WASM__ || __IOS__ || __MACOS__ || NET461 || __NETSTD_REFERENCE__
 		/// <summary>
 		/// Diagonal size of the display in inches.
 		/// </summary>
@@ -45,7 +45,7 @@ namespace Windows.Graphics.Display
 		/// As per <see href="https://docs.microsoft.com/en-us/uwp/api/windows.graphics.display.displayinformation.diagonalsizeininches#property-value">Docs</see> 
 		/// defaults to null if not set
 		/// </remarks>
-		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("__IOS__", "NET461", "__WASM__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public double? DiagonalSizeInInches { get; private set; }
 #endif
 

--- a/src/Uno.UWP/Graphics/Display/IDisplayInformationExtension.skia.cs
+++ b/src/Uno.UWP/Graphics/Display/IDisplayInformationExtension.skia.cs
@@ -14,4 +14,6 @@ public interface IDisplayInformationExtension
 	double RawPixelsPerViewPixel { get; }
 
 	ResolutionScale ResolutionScale { get; }
+
+	double? DiagonalSizeInInches { get; }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/pull/9395, closes https://github.com/unoplatform/uno/issues/9394, https://github.com/unoplatform/uno/discussions/8737

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

- Adds Framebuffer DPI scaling support, overridable from an environment variable
- Adds Framebuffer 16 Bits RGB565 color depth.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
