### PR TITLE
fix(framebuffer): Mark dispatcher thread properly

### DIFF
--- a/src/Uno.UI-Skia-only.slnf
+++ b/src/Uno.UI-Skia-only.slnf
@@ -7,6 +7,7 @@
       "SamplesApp\\Benchmarks.Shared\\SamplesApp.Benchmarks.shproj",
       "SamplesApp\\SamplesApp.Shared\\SamplesApp.Shared.shproj",
       "SamplesApp\\SamplesApp.Skia.Gtk\\SamplesApp.Skia.Gtk.csproj",
+      "SamplesApp\\SamplesApp.Skia.Linux.FrameBuffer\\SamplesApp.Skia.Linux.FrameBuffer.csproj",
       "SamplesApp\\SamplesApp.Skia.Tizen\\SamplesApp.Skia.Tizen.csproj",
       "SamplesApp\\SamplesApp.Skia.WPF\\SamplesApp.Skia.WPF.csproj",
       "SamplesApp\\SamplesApp.Skia\\SamplesApp.Skia.csproj",

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
@@ -50,6 +50,8 @@ namespace Uno.UI.Runtime.Skia
 
 		private void Initialize()
 		{
+			_isDispatcherThread = true;
+
 			ApiExtensibility.Register(typeof(Windows.UI.Core.ICoreWindowExtension), o => new CoreWindowExtension(o));
 			ApiExtensibility.Register(typeof(Windows.UI.ViewManagement.IApplicationViewExtension), o => new ApplicationViewExtension(o));
 			ApiExtensibility.Register(typeof(Windows.Graphics.Display.IDisplayInformationExtension), o => _displayInformationExtension ??= new DisplayInformationExtension(o));


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The `DependencyObject.DispatcherQueue` property may be null when running under Linux FrameBufferHost.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
