### PR TITLE
docs: fixed malformed link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For a larger example and features demo:
 * Supported platforms:
     * Windows 10 and Windows 11 (via the standard UWP and WinUI Toolkit)
     * Windows 7 (via Skia)
-    * iOS, macOS and Android (via [Xamarin](https://www.visualstudio.com/xamarin/) and [.NET] (https://dotnet.microsoft.com/))
+    * iOS, macOS and Android (via [Xamarin](https://www.visualstudio.com/xamarin/) and [.NET](https://dotnet.microsoft.com/))
     * WebAssembly through the [.NET Runtime WebAssembly SDK](https://github.com/dotnet/runtime/tree/main/src/mono/wasm)
     * Linux through Skia (Gtk and FrameBuffer)
 * Dev loop:


### PR DESCRIPTION
## PR Type

#### What kind of change does this PR introduce?
- Documentation content changes

## What is the current behavior?
The link for https://dotnet.microsoft.com/ doesn't render properly in the [README.md](https://github.com/unoplatform/uno/blob/master/README.md) markdown.

#### Before
> [.NET] (https://dotnet.microsoft.com/)

## What is the new behavior?
The link for https://dotnet.microsoft.com/ is rendered properly in the [README.md](https://github.com/unoplatform/uno/blob/master/README.md) markdown.

#### After
> [.NET](https://dotnet.microsoft.com/)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
N/A

#### Internal Issue (if applicable)
N/A
