### PR TITLE
fix: Wrong CLI command for exlcuding mobile in get started

### DIFF
--- a/doc/articles/get-started-dotnet-new.md
+++ b/doc/articles/get-started-dotnet-new.md
@@ -82,7 +82,7 @@ dotnet new unoapp-uwp-net6 -o MyApp
 A more advanced example that will not generate the android and macOS heads:
 
 ```
-dotnet new unoapp-uwp-net6 -o MyApp -mobile=false
+dotnet new unoapp-uwp-net6 -o MyApp --Mobile=false
 ```
 
 ## Uno Platform Extensions


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Documentation content changes
- Project automation
- Other... Please describe:

## What is the current behavior?

Currently in the "Get Started" guide the `dotnet new` command has invalid parameters:
```sh
dotnet new unoapp-uwp-net6 -o MyApp -mobile=false
```

`-mobile` does not exist. Either `-m` or `--Mobile`. For the sake of introduction the long form is preferred.

## What is the new behavior?
The new version takes `--Mobile` as argument.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
