### PR TITLE
feat: Targets with constants moved to an earlier stage.

### DIFF
--- a/build/uno.winui.common.targets
+++ b/build/uno.winui.common.targets
@@ -16,8 +16,8 @@
 
 	<Import Project="$(SourceGeneratorBasePath)Uno.UI.SourceGenerators.props" />
 	<Import Project="$(UnoUIMSBuildTasksTargetPath)Uno.UI.Tasks.targets" />
-	<Target Name="_UnoWinUICommonFeatureDefines"
-            BeforeTargets="BeforeCompile">
+
+	<Target Name="_UnoWinUICommonFeatureDefines" AfterTargets="PrepareForBuild">
 
 		<!-- 
 			Defines Uno features. 
@@ -28,20 +28,15 @@
 			of breaking changes.
 		-->
 		<PropertyGroup>
-			<UnoDefineConstants>$(UnoDefineConstants);HAS_UNO</UnoDefineConstants>
-			<UnoDefineConstants Condition="$(_IsUnoWinUIPackage)">$(UnoDefineConstants);HAS_UNO_WINUI</UnoDefineConstants>
-			<UnoDefineConstants>$(UnoDefineConstants);UNO_HAS_FRAMEWORKELEMENT_MEASUREOVERRIDE</UnoDefineConstants>
-			<UnoDefineConstants>$(UnoDefineConstants);UNO_HAS_NO_IDEPENDENCYOBJECT</UnoDefineConstants>
+			<DefineConstants>$(DefineConstants);HAS_UNO</DefineConstants>
+			<DefineConstants Condition="$(_IsUnoWinUIPackage)">$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
+			<DefineConstants>$(DefineConstants);UNO_HAS_FRAMEWORKELEMENT_MEASUREOVERRIDE</DefineConstants>
+			<DefineConstants>$(DefineConstants);UNO_HAS_NO_IDEPENDENCYOBJECT</DefineConstants>
 		</PropertyGroup>
 
 		<PropertyGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETStandard' or '$(TargetFrameworkIdentifier)'=='.NETCoreApp'">
-			<UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API</UnoDefineConstants>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API</DefineConstants>
 		</PropertyGroup>
-
-		<!-- Merge the UnoDefineConstants with the existing constants -->
-		<CreateProperty Value="$(DefineConstants);$(UnoDefineConstants)">
-			<Output TaskParameter="Value" PropertyName="DefineConstants" />
-		</CreateProperty>
 
 	</Target>
 

--- a/src/Common.targets
+++ b/src/Common.targets
@@ -1,31 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!--
-  This target needs to be defined in all projects
-  until we can override the Publish to not fail for cross-target
-  projects that don't publish anything.
-  -->
-  <Target Name="CreateAppPackage" />
+	<!--
+	This target needs to be defined in all projects
+	until we can override the Publish to not fail for cross-target
+	projects that don't publish anything.
+	-->
+	<Target Name="CreateAppPackage" />
 
 	<PropertyGroup>
 		<!-- Enable ShouldWriteErrorOnInvalidXaml for all the sample and test projects of this solution -->
 		<ShouldWriteErrorOnInvalidXaml>True</ShouldWriteErrorOnInvalidXaml>
 	</PropertyGroup>
+	
+	<Target Name="_UnoCommonFeatureDefines" AfterTargets="PrepareForBuild">
 
-	<Target Name="_UnoCommonFeatureDefines" BeforeTargets="BeforeCompile">
-
-		<PropertyGroup>
-			<UnoDefineConstants Condition="'$(MSBuildVersion)' &gt;= '15.4'">$(UnoDefineConstants);__IOS_11__</UnoDefineConstants>
+		<PropertyGroup Condition="'$(MSBuildVersion)' &gt;= '15.4'">
+			<DefineConstants>$(DefineConstants);__IOS_11__</DefineConstants>
 		</PropertyGroup>
 
-		<!-- Merge the UnoDefineConstants with the existing constants -->
-		<CreateProperty Value="$(DefineConstants);$(UnoDefineConstants)">
-			<Output TaskParameter="Value" PropertyName="DefineConstants" />
-		</CreateProperty>
-
 	</Target>
-  
-  <!-- Import the override as the nuget tooling in VS is skipping ItemGroup conditions for legacy projects -->
-  <Import Project="roslyn-override.targets" Condition="'$(MicrosoftNetCompilerVersionOverride)'!=''"/>
+
+	<!-- Import the override as the nuget tooling in VS is skipping ItemGroup conditions for legacy projects -->
+	<Import Project="roslyn-override.targets" Condition="'$(MicrosoftNetCompilerVersionOverride)'!=''"/>
+
 </Project>

--- a/src/Uno.UI.Runtime.Skia.Gtk/buildTransitive/Uno.UI.Runtime.Skia.Gtk.targets
+++ b/src/Uno.UI.Runtime.Skia.Gtk/buildTransitive/Uno.UI.Runtime.Skia.Gtk.targets
@@ -1,21 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-  </PropertyGroup>
-  
-  <Target Name="_UnoSkiaGtkFeatureDefines"
-		  BeforeTargets="PrepareForBuild">
+	<Target Name="_UnoSkiaGtkFeatureDefines" AfterTargets="PrepareForBuild">
 
-	<PropertyGroup>
-	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_GTK</UnoDefineConstants>
-	</PropertyGroup>
+		<PropertyGroup>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_GTK</DefineConstants>
+		</PropertyGroup>
 
-	<!-- Merge the UnoDefineConstants with the existing constants -->
-	<CreateProperty Value="$(DefineConstants);$(UnoDefineConstants)">
-	  <Output TaskParameter="Value" PropertyName="DefineConstants" />
-	</CreateProperty>
-
-  </Target>
+	</Target>
 
 </Project>

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/buildTransitive/Uno.UI.Runtime.Skia.Linux.FrameBuffer.targets
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/buildTransitive/Uno.UI.Runtime.Skia.Linux.FrameBuffer.targets
@@ -1,21 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-  </PropertyGroup>
-  
-  <Target Name="_UnoSkiaLinuxFBFeatureDefines"
-		  BeforeTargets="PrepareForBuild">
+	<Target Name="_UnoSkiaLinuxFBFeatureDefines" AfterTargets="PrepareForBuild">
 
-	<PropertyGroup>
-	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_LINUX_FB</UnoDefineConstants>
-	</PropertyGroup>
+		<PropertyGroup>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_LINUX_FB</DefineConstants>
+		</PropertyGroup>
 
-	<!-- Merge the UnoDefineConstants with the existing constants -->
-	<CreateProperty Value="$(DefineConstants);$(UnoDefineConstants)">
-	  <Output TaskParameter="Value" PropertyName="DefineConstants" />
-	</CreateProperty>
-
-  </Target>
+	</Target>
 
 </Project>

--- a/src/Uno.UI.Runtime.Skia.Tizen/buildTransitive/Uno.UI.Runtime.Skia.Tizen.targets
+++ b/src/Uno.UI.Runtime.Skia.Tizen/buildTransitive/Uno.UI.Runtime.Skia.Tizen.targets
@@ -1,21 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-  </PropertyGroup>
-  
-  <Target Name="_UnoSkiaTizenFeatureDefines"
-		  BeforeTargets="PrepareForBuild">
+	<Target Name="_UnoSkiaTizenFeatureDefines" AfterTargets="PrepareForBuild">
 
-	<PropertyGroup>
-	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_TIZEN</UnoDefineConstants>
-	</PropertyGroup>
+		<PropertyGroup>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_TIZEN</DefineConstants>
+		</PropertyGroup>
 
-	<!-- Merge the UnoDefineConstants with the existing constants -->
-	<CreateProperty Value="$(DefineConstants);$(UnoDefineConstants)">
-	  <Output TaskParameter="Value" PropertyName="DefineConstants" />
-	</CreateProperty>
-
-  </Target>
+	</Target>
 
 </Project>

--- a/src/Uno.UI.Runtime.Skia.Wpf/buildTransitive/Uno.UI.Runtime.Skia.Wpf.targets
+++ b/src/Uno.UI.Runtime.Skia.Wpf/buildTransitive/Uno.UI.Runtime.Skia.Wpf.targets
@@ -1,17 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
-  <Target Name="_UnoSkiaWpfFeatureDefines"
-		  BeforeTargets="PrepareForBuild">
 
-	<PropertyGroup>
-	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WPF</UnoDefineConstants>
-	</PropertyGroup>
+	<Target Name="_UnoSkiaWpfFeatureDefines" AfterTargets="PrepareForBuild">
 
-	<!-- Merge the UnoDefineConstants with the existing constants -->
-	<CreateProperty Value="$(DefineConstants);$(UnoDefineConstants)">
-	  <Output TaskParameter="Value" PropertyName="DefineConstants" />
-	</CreateProperty>
-  </Target>
+		<PropertyGroup>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WPF</DefineConstants>
+		</PropertyGroup>
+
+	</Target>
 
 </Project>

--- a/src/Uno.UI.Runtime.WebAssembly/buildTransitive/Uno.UI.Runtime.WebAssembly.targets
+++ b/src/Uno.UI.Runtime.WebAssembly/buildTransitive/Uno.UI.Runtime.WebAssembly.targets
@@ -1,21 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-  </PropertyGroup>
+	<Target Name="_UnoSkiaWasmFeatureDefines" AfterTargets="PrepareForBuild">
 
-  <Target Name="_UnoSkiaWasmFeatureDefines"
-		  BeforeTargets="PrepareForBuild">
+		<PropertyGroup>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_WASM;__WASM__</DefineConstants>
+		</PropertyGroup>
 
-	<PropertyGroup>
-	  <UnoDefineConstants>$(UnoDefineConstants);UNO_REFERENCE_API;HAS_UNO_WASM;__WASM__</UnoDefineConstants>
-	</PropertyGroup>
-
-	<!-- Merge the UnoDefineConstants with the existing constants -->
-	<CreateProperty Value="$(DefineConstants);$(UnoDefineConstants)">
-	  <Output TaskParameter="Value" PropertyName="DefineConstants" />
-	</CreateProperty>
-  </Target>
+	</Target>
 
   <Target Name="_ForceUnoUIRuntimeWasm"
 	  BeforeTargets="BeforeCompile">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #
According this discussion: https://github.com/unoplatform/uno/discussions/9145
The first PR for this, while fixing the name collision, didn't fix the availability of the constants and led to new research.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
Feature

## What is the current behavior?
At the moment, constants are added after the .editorconfig file with visible properties is generated, which generators use to access values. Here is the relevant code that shows which Targets are executed and in what order to allow generators to access properties.
https://github.com/dotnet/roslyn/blob/1c3cdb0b85a8496a8f5108faab046924360b6017/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets#L155-L196
Based on this, I believe that the optimal place to add constants would be `AfterTargets="PrepareForBuild"`. This also applies to other projects - https://github.com/dotnet/ef6tools/blob/c9988fc28258290118e60dc6d9ccb3fe8c6073d6/setup/wix/EFToolsWillowMsi.wixproj#L77 Generators that rely on these constants will need to use code like this:
```xml
<Target Name="CreateDefineConstants" BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun;GenerateMSBuildEditorConfigFileCore">

    <PropertyGroup>
      <Generator_DefineConstants>$(DefineConstants.Replace(';',','))</Generator_DefineConstants>
    </PropertyGroup>

  </Target>
```

## What is the new behavior?
Targets are run at an earlier stage. In addition, the association of properties has been simplified, and duplication of constants in runtime projects due to the reuse of `UnoDefineConstants` has been fixed. This output is given by this target in the Skia.WPF project:
```xml
  <Target Name="Test" BeforeTargets="CoreCompile">
    <Message Importance="high" Text="Test $(DefineConstants)"/>
  </Target>
```
```
1>Test TRACE;HAS_UNO;HAS_WINUI;HAS_UNO_WINUI;RELEASE;NET;NET6_0;NETCOREAPP;UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WPF;UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WPF;HAS_UNO;HAS_UNO_WINUI;UNO_HAS_FRAMEWORKELEMENT_MEASUREOVERRIDE;UNO_HAS_NO_IDEPENDENCYOBJECT;UNO_REFERENCE_API
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
