### PR TITLE
fix(ios): border + corner rendering

### DIFF
--- a/src/Uno.UI/Extensions/CGRectExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/CGRectExtensions.iOSmacOS.cs
@@ -69,6 +69,16 @@ namespace Uno.UI.Extensions
 			return Shrink(thisCGRect, numberOfPixels, numberOfPixels, numberOfPixels, numberOfPixels);
 		}
 
+		public static CGRect Shrink(this CGRect rect, Windows.UI.Xaml.Thickness thickness)
+		{
+			rect.X += (nfloat)thickness.Left;
+			rect.Y += (nfloat)thickness.Top;
+			rect.Width -= (nfloat)(thickness.Left + thickness.Right);
+			rect.Height -= (nfloat)(thickness.Top + thickness.Bottom);
+
+			return rect;
+		}
+
 		public static CGRect Shrink(this CGRect thisCGRect, nfloat left, nfloat top, nfloat right, nfloat bottom)
 		{
 			thisCGRect.X += left;

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
@@ -21,7 +21,7 @@ using Rect = Windows.Foundation.Rect;
 
 namespace Windows.UI.Xaml.Controls
 {
-	internal class BorderLayerRenderer
+	partial class BorderLayerRenderer
 	{
 		private const double __opaqueAlpha = 255;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Uno.UI;
+
+namespace Windows.UI.Xaml.Shapes;
+
+internal partial class BorderLayerRenderer
+{
+	/* The border is defined by the inner and outer rounded-rectangles.
+	 * Each rounded rectangle is composed of 4x lines and 4x 90' arcs.
+	 * ╭─────╮
+	 * │A 2 B│
+	 * │1   3│
+	 * │D 4 C│
+	 * ╰─────╯
+	 * Three factors determine the border: BorderThickness, CornerRadius, and AvailableSize.
+	 * What each part affects:
+	 * - CornerRadius="1A2,2B3,3C4,4D1"
+	 * - BorderThickness="D1A,A2B,B3C,C4D"
+	 * - AvailableSize is used to constrain the radius.
+	 *
+	 * note: technically CornerRadius (together with AvailableSize) also affects the adjacent corner,
+	 * as both points on the same axis will compete for what's available when both add up exceeds
+	 * the available length. (see: h/vRatio in CalculateBorderEllipse)
+	 */
+
+	public enum Corner { TopLeft, TopRight, BottomRight, BottomLeft }
+
+	public static Rect CalculateBorderEllipseBbox(Rect bbox, Corner corner, CornerRadius cr, Thickness bt, bool inner = false)
+	{
+		var (cr0, hThickness, vThickness, hComplement, vComplement) = corner switch
+		{
+			Corner.TopLeft => (cr.TopLeft, bt.Left, bt.Top, cr.TopRight, cr.BottomLeft),
+			Corner.TopRight => (cr.TopRight, bt.Right, bt.Top, cr.TopLeft, cr.BottomRight),
+			Corner.BottomRight => (cr.BottomRight, bt.Right, bt.Bottom, cr.BottomLeft, cr.TopRight),
+			Corner.BottomLeft => (cr.BottomLeft, bt.Left, bt.Bottom, cr.BottomRight, cr.TopLeft),
+
+			_ => throw new ArgumentOutOfRangeException($"Invalid corner: {corner}"),
+		};
+
+		// there is still a corner to be painted, albeit not rounded.
+		if (cr0 == 0) return AlignCorner(bbox, corner, default);
+
+		// The ellipse can only grow up to twice the available length.
+		// This is further limited by the ratio between the corner-radius
+		// of that corner and the adjacent corner on the same line.
+		var hRatio = hComplement == 0 ? 1 : (cr0 / (cr0 + hComplement));
+		var vRatio = vComplement == 0 ? 1 : (cr0 / (cr0 + vComplement));
+
+		// if size is empty here, there is still a corner to be painted, just not rounded.
+		var size = new Size(
+			width: Math.Max(0, Math.Min(bbox.Width * 2 * hRatio, cr0 * 2 + (inner ? -hThickness : hThickness))),
+			height: Math.Max(0, Math.Min(bbox.Height * 2 * vRatio, cr0 * 2 + (inner ? -vThickness : vThickness)))
+		);
+		var result = AlignCorner(bbox, corner, size);
+
+		return result;
+	}
+
+	private static Point GetCorner(Rect rect, Corner corner)
+	{
+		return corner switch
+		{
+			Corner.TopLeft => new(rect.Left, rect.Top),
+			Corner.TopRight => new(rect.Right, rect.Top),
+			Corner.BottomRight => new(rect.Right, rect.Bottom),
+			Corner.BottomLeft => new(rect.Left, rect.Bottom),
+
+			_ => throw new ArgumentOutOfRangeException($"Invalid corner: {corner}"),
+		};
+	}
+
+	private static Point GetRelativePoint(Rect rect, int numpadDirection)
+	{
+		var x = numpadDirection switch
+		{
+			1 or 4 or 7 => rect.Left,
+			2 or 5 or 8 => rect.GetMidX(),
+			3 or 6 or 9 => rect.Right,
+
+			_ => throw new ArgumentOutOfRangeException(),
+		};
+		var y = numpadDirection switch
+		{
+			7 or 8 or 9 => rect.Top,
+			4 or 5 or 6 => rect.GetMidY(),
+			1 or 2 or 3 => rect.Bottom,
+
+			_ => throw new ArgumentOutOfRangeException(),
+		};
+
+		return new (x, y);
+	}
+
+	/// <summary>
+	/// Arrange a size on the bounding-<paramref name="bbox"/> so that the borders neighboring
+	/// to the <paramref name="corner"/> are overlapped.
+	/// </summary>
+	/// <remarks>The resulting rect can be outside of the bounding-box.</remarks>
+	private static Rect AlignCorner(Rect bbox, Corner corner, Size size)
+	{
+		// note: the ellipse can project outside the bounding-box
+		// because only a quarter needs to be constrained within.
+		var location = (Point)(corner switch
+		{
+			Corner.TopLeft => new(bbox.Left, bbox.Top),
+			Corner.TopRight => new(bbox.Left + bbox.Width - size.Width, bbox.Top),
+			Corner.BottomRight => new(bbox.Left + bbox.Width - size.Width, bbox.Top + bbox.Height - size.Height),
+			Corner.BottomLeft => new(bbox.Left, bbox.Top + bbox.Height - size.Height),
+
+			_ => throw new ArgumentOutOfRangeException($"Invalid corner: {corner}"),
+		});
+
+		return new(location, size);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -1,15 +1,18 @@
-﻿using CoreAnimation;
-using CoreGraphics;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using Uno.Disposables;
-using Windows.UI.Xaml.Media;
-using Uno.UI.Extensions;
+using System.Linq;
+using Windows.Foundation;
 using Windows.UI;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using CoreAnimation;
+using CoreGraphics;
 using CoreImage;
 using Foundation;
+using Uno.Disposables;
 using Uno.Extensions;
-using Windows.UI.Xaml.Controls;
+using Uno.UI;
+using Uno.UI.Extensions;
 
 #if NET6_0_OR_GREATER
 using ObjCRuntime;
@@ -29,9 +32,9 @@ using _Image = AppKit.NSImage;
 
 namespace Windows.UI.Xaml.Shapes
 {
-	internal class BorderLayerRenderer
+	partial class BorderLayerRenderer
 	{
-		private LayoutState _currentState;
+		private LayoutState _previousLayoutState;
 
 		private SerialDisposable _layerDisposable = new SerialDisposable();
 
@@ -59,22 +62,23 @@ namespace Windows.UI.Xaml.Shapes
 			var bounds = owner.Bounds;
 			var area = new CGRect(0, 0, bounds.Width, bounds.Height);
 
-			var newState = new LayoutState(area, background, backgroundSizing, borderThickness, borderBrush, cornerRadius, backgroundImage);
-			var previousLayoutState = _currentState;
-
-			if (!newState.Equals(previousLayoutState))
+			var newState = new LayoutState(area, borderBrush, borderThickness, cornerRadius, background, backgroundImage, backgroundSizing);
+			if (!newState.Equals(_previousLayoutState))
 			{
 #if __MACOS__
 				owner.WantsLayer = true;
 #endif
 
 				_layerDisposable.Disposable = null;
-				_layerDisposable.Disposable = InnerCreateLayer(owner as UIElement, owner.Layer, newState);
+				_layerDisposable.Disposable = InnerCreateLayer(owner as UIElement, owner.Layer, newState, out var updatedBoundsPath);
 
-				_currentState = newState;
+				_previousLayoutState = newState;
+
+				return updatedBoundsPath;
 			}
 
-			return newState.BoundsPath; // Will be null if not updated !!!
+			
+			return null; // no change
 		}
 
 		/// <summary>
@@ -83,11 +87,19 @@ namespace Windows.UI.Xaml.Shapes
 		internal void Clear()
 		{
 			_layerDisposable.Disposable = null;
-			_currentState = null;
+			_previousLayoutState = null;
 		}
 
-		private static IDisposable InnerCreateLayer(UIElement owner, CALayer parent, LayoutState state)
+		private static IDisposable InnerCreateLayer(UIElement owner, CALayer parent, LayoutState state, out CGPath updatedBoundsPath)
 		{
+			updatedBoundsPath = null;
+
+			// nothing to draw, until the control is measured or when is measured to be 0
+			if (state.Area.IsEmpty)
+			{
+				return Disposable.Empty;
+			}
+
 			var area = state.Area;
 			var background = state.Background;
 			var borderThickness = state.BorderThickness;
@@ -98,45 +110,19 @@ namespace Windows.UI.Xaml.Shapes
 			var disposables = new CompositeDisposable();
 			var sublayers = new List<CALayer>();
 
-			var heightOffset = ((float)borderThickness.Top / 2) + ((float)borderThickness.Bottom / 2);
-			var widthOffset = ((float)borderThickness.Left / 2) + ((float)borderThickness.Right / 2);
-			var halfWidth = (float)area.Width / 2;
-			var halfHeight = (float)area.Height / 2;
-			var adjustedArea = area;
-			adjustedArea = adjustedArea.Shrink(
-				(nfloat)borderThickness.Left,
-				(nfloat)borderThickness.Top,
-				(nfloat)borderThickness.Right,
-				(nfloat)borderThickness.Bottom
-			);
+			var adjustedArea = area.Shrink(borderThickness);
 
 			if (cornerRadius != CornerRadius.None)
 			{
-				var maxOuterRadius = Math.Max(0, Math.Min(halfWidth - widthOffset, halfHeight - heightOffset));
-				var maxInnerRadius = Math.Max(0, Math.Min(halfWidth, halfHeight));
-
-				cornerRadius = new CornerRadius(
-					Math.Min(cornerRadius.TopLeft, maxOuterRadius),
-					Math.Min(cornerRadius.TopRight, maxOuterRadius),
-					Math.Min(cornerRadius.BottomRight, maxOuterRadius),
-					Math.Min(cornerRadius.BottomLeft, maxOuterRadius));
-
-				var innerCornerRadius = new CornerRadius(
-					Math.Min(cornerRadius.TopLeft, maxInnerRadius),
-					Math.Min(cornerRadius.TopRight, maxInnerRadius),
-					Math.Min(cornerRadius.BottomRight, maxInnerRadius),
-					Math.Min(cornerRadius.BottomLeft, maxInnerRadius));
-
 				var outerLayer = new CAShapeLayer();
 				var backgroundLayer = new CAShapeLayer();
 				backgroundLayer.FillColor = null;
 				outerLayer.FillRule = CAShapeLayer.FillRuleEvenOdd;
 				outerLayer.LineWidth = 0;
 
-				
-				var path = GetRoundedRect(cornerRadius, innerCornerRadius, area, adjustedArea);
-				var innerPath = GetRoundedPath(cornerRadius, adjustedArea);
-				var outerPath = GetRoundedPath(cornerRadius, area);
+				var path = GetRoundedBorder(area, adjustedArea, cornerRadius, borderThickness);
+				var outerPath = GetRoundedPath(default, area, cornerRadius, borderThickness);
+				var innerPath = GetRoundedPath(default, adjustedArea, cornerRadius, borderThickness, inner: true);
 
 				var isInnerBorderEdge = backgroundSizing == BackgroundSizing.InnerBorderEdge;
 				var backgroundPath = isInnerBorderEdge ? innerPath : outerPath;
@@ -208,7 +194,6 @@ namespace Windows.UI.Xaml.Shapes
 				parent.AddSublayer(outerLayer);
 				parent.InsertSublayer(backgroundLayer, insertionIndex);
 
-
 				if (borderBrush is SolidColorBrush scbBorder || borderBrush == null)
 				{
 					Brush.AssignAndObserveBrush(borderBrush, color =>
@@ -245,15 +230,15 @@ namespace Windows.UI.Xaml.Shapes
 					owner.ClippingIsSetByCornerRadius = true;
 				}
 
-				state.BoundsPath = outerPath;
+				updatedBoundsPath = outerPath;
 			}
 			else
 			{
 				var backgroundLayer = new CAShapeLayer();
 				backgroundLayer.FillColor = null;
 
-				var innerPath = GetRoundedPath(CornerRadius.None, adjustedArea);
-				var outerPath = GetRoundedPath(CornerRadius.None, area);
+				var outerPath = GetRectangularPath(default, area);
+				var innerPath = GetRectangularPath(default, adjustedArea, inner: true);
 
 				var isInnerBorderEdge = backgroundSizing == BackgroundSizing.InnerBorderEdge;
 				var backgroundPath = isInnerBorderEdge ? innerPath : outerPath;
@@ -292,7 +277,7 @@ namespace Windows.UI.Xaml.Shapes
 					Brush.AssignAndObserveBrush(unsupportedCompositionBrush, color => backgroundLayer.FillColor = color)
 						.DisposeWith(disposables);
 
-					// This is required because changing the CornerRadius changes the background drawing 
+					// This is required because changing the CornerRadius changes the background drawing
 					// implementation and we don't want a rectangular background behind a rounded background.
 					Disposable.Create(() => backgroundLayer.FillColor = null)
 						.DisposeWith(disposables);
@@ -304,7 +289,7 @@ namespace Windows.UI.Xaml.Shapes
 
 				if (borderThickness != Thickness.Empty)
 				{
-					var borderPath = GetRoundedRect(CornerRadius.None, CornerRadius.None, area, adjustedArea);
+					var borderPath = GetRectangularBorder(area, adjustedArea);
 					var layer = new CAShapeLayer();
 
 					layer.FillRule = CAShapeLayer.FillRuleEvenOdd;
@@ -351,8 +336,7 @@ namespace Windows.UI.Xaml.Shapes
 					FillColor = _Color.White.CGColor,
 				};
 
-				
-				state.BoundsPath = outerPath;
+				updatedBoundsPath = outerPath;
 			}
 
 			disposables.Add(() =>
@@ -373,41 +357,129 @@ namespace Windows.UI.Xaml.Shapes
 		}
 
 		/// <summary>
-		/// Creates a rounded-rectangle path from the nominated bounds and corner radius.
+		/// Get a path that describes the rounded border.
 		/// </summary>
-		private static CGPath GetRoundedRect(CornerRadius cornerRadius, CornerRadius innerCornerRadius, CGRect area, CGRect insetArea)
+		private static CGPath GetRoundedBorder(Rect bbox, Rect innerBbox, CornerRadius cr, Thickness bt)
 		{
 			var path = new CGPath();
 
-			GetRoundedPath(cornerRadius, area, path);
-			GetRoundedPath(innerCornerRadius, insetArea, path, clockwise: false);
+			if (bbox is { Width: > 0, Height: > 0 })
+			{
+				GetRoundedPath(path, bbox, cr, bt);
+
+				if (innerBbox is { Width: > 0, Height: > 0 })
+				{
+					GetRoundedPath(path, innerBbox, cr, bt, inner: true);
+				}
+			}
+
 			return path;
 		}
 
-		private static CGPath GetRoundedPath(CornerRadius cornerRadius, CGRect area, CGPath path = null, bool clockwise = true)
+		/// <summary>
+		/// Get the inner/outer contours of the rounded border.
+		/// </summary>
+		private static CGPath GetRoundedPath(CGPath path, Rect bbox, CornerRadius cr, Thickness bt, bool inner = false)
 		{
-			path ??= new CGPath();
-			// How AddArcToPoint works:
-			// http://www.twistedape.me.uk/blog/2013/09/23/what-arctopointdoes/
+			path ??= new();
 
-			if (clockwise)
+			/* reference diagram:
+			 *  outer   inner
+			 * A1───2B D6───5C
+			 * 0     3 7     4
+			 * 7     4 0     3
+			 * D6───5C A1───2B
+			 */
+
+			// the inner contour needs to be drawn in counter-clockwise (against the outer one),
+			// otherwise the gradient brush paint will not exclude the inner region.
+			var corners = !inner
+				? new[] { Corner.TopLeft, Corner.TopRight, Corner.BottomRight, Corner.BottomLeft }  // outer -> clockwise
+				: new[] { Corner.BottomLeft, Corner.BottomRight, Corner.TopRight, Corner.TopLeft }; // inner -> counter-clockwise
+
+			for (int i = 0; i < corners.Length; i++)
 			{
-				path.MoveToPoint(area.GetMidX(), area.Y);
-				path.AddArcToPoint(area.Right, area.Top, area.Right, area.GetMidY(), (float)cornerRadius.TopRight);
-				path.AddArcToPoint(area.Right, area.Bottom, area.GetMidX(), area.Bottom, (float)cornerRadius.BottomRight);
-				path.AddArcToPoint(area.Left, area.Bottom, area.Left, area.GetMidY(), (float)cornerRadius.BottomLeft);
-				path.AddArcToPoint(area.Left, area.Top, area.GetMidX(), area.Top, (float)cornerRadius.TopLeft);
-				path.AddLineToPoint(area.GetMidX(), area.Y);
+				var corner = corners[i];
+				var cornerBbox = CalculateBorderEllipseBbox(bbox, corner, cr, bt, inner);
+
+				if (i == 0)
+				{
+					// p0 and p7 are not necessarily the same point, so it needs to be calculated from cornerBbox and not bbox.
+					// note: here, we are looking for mid-point between A-0, not p0.
+					path.MoveToPoint(GetRelativePoint(cornerBbox, numpadDirection: 4));
+				}
+
+				// no rounded corner to draw if there is no area
+				if (cornerBbox.Width > 0 && cornerBbox.Height > 0)
+				{
+					var pCorner = GetCorner(cornerBbox, corner);
+					var pNextMid = GetRelativePoint(cornerBbox, numpadDirection: (!inner
+						? new[] { 8, 6, 2, 4 }
+						: new[] { 2, 6, 8, 4 }
+					)[i]);
+
+					// given that AddArcToPoint can only draw arc of a circle (with equal width, height, and diameter),
+					// we have to scale the Y-axis, so that the ellipse becomes a perfect circle,
+					// and use a reverse scale transform on the drawing of arc to achieve the desired result.
+					var scaleY = cornerBbox.Width / cornerBbox.Height;
+					var scaleTransform = CGAffineTransform.MakeScale(1, (nfloat)(cornerBbox.Height / cornerBbox.Width));
+					pCorner.Y *= scaleY;
+					pNextMid.Y *= scaleY;
+
+					// How AddArcToPoint works: https://stackoverflow.com/a/18992153
+					path.AddArcToPoint(scaleTransform, (nfloat)pCorner.X, (nfloat)pCorner.Y, (nfloat)pNextMid.X, (nfloat)pNextMid.Y, radius: (nfloat)cornerBbox.Width / 2);
+				}
+				else
+				{
+					// however, we still need to drawn a line to that corner
+					path.AddLineToPoint(GetCorner(cornerBbox, corner));
+				}
 			}
-			else
+
+			path.CloseSubpath();
+
+			return path;
+		}
+
+		/// <summary>
+		/// Get a path that describes the border.
+		/// </summary>
+		private static CGPath GetRectangularBorder(Rect bbox, Rect innerBbox)
+		{
+			var path = new CGPath();
+
+			if (bbox is { Width: > 0, Height: > 0 })
 			{
-				path.MoveToPoint(area.GetMidX(), area.Y);
-				path.AddArcToPoint(area.Left, area.Top, area.Left, area.GetMidY(), (float)cornerRadius.TopLeft);
-				path.AddArcToPoint(area.Left, area.Bottom, area.GetMidX(), area.Bottom, (float)cornerRadius.BottomLeft);
-				path.AddArcToPoint(area.Right, area.Bottom, area.Right, area.GetMidY(), (float)cornerRadius.BottomRight);
-				path.AddArcToPoint(area.Right, area.Top, area.GetMidX(), area.Top, (float)cornerRadius.TopRight);
-				path.AddLineToPoint(area.GetMidX(), area.Y);
+				GetRectangularPath(path, bbox);
+
+				if (innerBbox is { Width: > 0, Height: > 0 })
+				{
+					GetRectangularPath(path, innerBbox, inner: true);
+				}
 			}
+
+			return path;
+		}
+
+		/// <summary>
+		/// Get the inner/outer contours of the rectangular border.
+		/// </summary>
+		private static CGPath GetRectangularPath(CGPath path, Rect bbox, bool inner = false)
+		{
+			path ??= new();
+
+			// the inner contour needs to be drawn in counter-clockwise (against the outer one),
+			// otherwise the gradient brush paint will not exclude the inner region.
+			var corners = !inner
+				? new[] { Corner.TopLeft, Corner.TopRight, Corner.BottomRight, Corner.BottomLeft }  // outer -> clockwise
+				: new[] { Corner.BottomLeft, Corner.BottomRight, Corner.TopRight, Corner.TopLeft }; // inner -> counter-clockwise
+
+			path.MoveToPoint(GetRelativePoint(bbox, 4));
+			foreach (var corner in corners)
+			{
+				path.AddLineToPoint(GetCorner(bbox, corner));
+			}
+			path.CloseSubpath();
 
 			return path;
 		}
@@ -487,50 +559,12 @@ namespace Windows.UI.Xaml.Shapes
 			sublayers.Add(gradientContainerLayer);
 		}
 
-		private class LayoutState : IEquatable<LayoutState>
+		private record LayoutState(
+			CGRect Area,
+			Brush BorderBrush, Thickness BorderThickness, CornerRadius CornerRadius,
+			Brush Background, _Image BackgroundImage, BackgroundSizing BackgroundSizing)
 		{
-			public readonly CGRect Area;
-			public readonly Brush Background;
-			public readonly BackgroundSizing BackgroundSizing;
-			public readonly Brush BorderBrush;
-			public readonly Thickness BorderThickness;
-			public readonly CornerRadius CornerRadius;
-			public readonly _Image BackgroundImage;
-
-			internal CGPath BoundsPath { get; set; }
-
-			public LayoutState(
-				CGRect area,
-				Brush background,
-				BackgroundSizing backgroundSizing,
-				Thickness borderThickness,
-				Brush borderBrush,
-				CornerRadius cornerRadius,
-				_Image backgroundImage)
-			{
-				Area = area;
-				Background = background;
-				BackgroundSizing = backgroundSizing;
-				BorderBrush = borderBrush;
-				CornerRadius = cornerRadius;
-				BorderThickness = borderThickness;
-				BackgroundImage = backgroundImage;
-			}
-
-			public override int GetHashCode()
-				=> (Background?.GetHashCode() ?? 0 + BorderBrush?.GetHashCode() ?? 0) + (int)BackgroundSizing;
-
-			public override bool Equals(object obj) => Equals(obj as LayoutState);
-
-			public bool Equals(LayoutState other) =>
-				other != null
-				&& other.Area == Area
-				&& (other.Background?.Equals(Background) ?? false)
-				&& other.BackgroundSizing == BackgroundSizing
-				&& (other.BorderBrush?.Equals(BorderBrush) ?? false)
-				&& other.BorderThickness == BorderThickness
-				&& other.CornerRadius == CornerRadius
-				&& ReferenceEquals(other.BackgroundImage, BackgroundImage);
+			// internal CGPath BoundsPath { get; set; }
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.net.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.net.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Shapes
 {
-	internal class BorderLayerRenderer
+	partial class BorderLayerRenderer
 	{
 		public void UpdateLayer(
 			UIElement element,

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.netstdref.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.netstdref.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Shapes
 {
-	internal partial class BorderLayerRenderer
+	partial class BorderLayerRenderer
 	{
 		public void UpdateLayer(
 			FrameworkElement owner,

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
@@ -16,7 +16,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Windows.UI.Xaml.Shapes
 {
-	internal class BorderLayerRenderer
+	partial class BorderLayerRenderer
 	{
 		private LayoutState _currentState;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.wasm.cs
@@ -8,7 +8,7 @@ using Uno.UI.Xaml;
 
 namespace Windows.UI.Xaml.Shapes
 {
-	internal class BorderLayerRenderer
+	partial class BorderLayerRenderer
 	{
 		private Brush _background;
 		private (Brush, Thickness) _border;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9208

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

iOS border can only be drawn with perfect circles, not ellipses.

## What is the new behavior?

iOS border should support most of the scenarios.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
re: #5440, #6891

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->