### PR TITLE
fix(framebuffer): Use scanline copy to adjust for padding when required

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FrameBufferDevice.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FrameBufferDevice.cs
@@ -43,8 +43,8 @@ namespace Uno.UI.Runtime.Skia
 			_screenInfo.bits_per_pixel switch
 			{
 				32 => _screenInfo.blue.offset == 16
-					? SKColorType.Rgba8888
-					: SKColorType.Bgra8888,
+					? SKColorType.Bgra8888
+					: SKColorType.Rgba8888,
 				16 => _screenInfo.red.offset == 11
 					? SKColorType.Rgb565
 					: throw new NotSupportedException($"RGB555 is not supported by Uno Platform"),


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9422

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- The Framebuffer renderer now takes into account the possible padding of scanlines
- Fixes invalid 32bits pixel format

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
