### PR TITLE
fix(MenyFlyoutPresenter): Fix TemplatedParent propagation in MenuFlyoutPresenter

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ButtonControls/Button_Flyout_TemplateBinding.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ButtonControls/Button_Flyout_TemplateBinding.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ButtonControls.Button_Flyout_TemplateBinding"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ButtonControls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<UserControl.Resources>
+		<Style x:Key="CustomControlStyle"
+			   TargetType="local:CustomControl">
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate>
+						<Button x:Name="innerButton" Content="Click me">
+							<Button.Flyout>
+								<MenuFlyout>
+									<MenuFlyoutItem x:Name="innerFlyoutItem"
+													Text="{Binding CustomProperty, RelativeSource={RelativeSource Mode=TemplatedParent}, FallbackValue='The binding has failed'}" />
+								</MenuFlyout>
+							</Button.Flyout>
+						</Button>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+		<local:CustomControl CustomProperty="42"
+							 Style="{StaticResource CustomControlStyle}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ButtonControls/Button_Flyout_TemplateBinding.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ButtonControls/Button_Flyout_TemplateBinding.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ButtonControls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Button_Flyout_TemplateBinding : UserControl
+	{
+		public Button_Flyout_TemplateBinding()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public partial class CustomControl : Control
+	{
+		public int CustomProperty
+		{
+			get => (int)GetValue(CustomPropertyProperty);
+			set => SetValue(CustomPropertyProperty, value);
+		}
+
+		public static readonly DependencyProperty CustomPropertyProperty =
+			DependencyProperty.Register("CustomProperty", typeof(int), typeof(CustomControl), new PropertyMetadata(0));
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -11,7 +11,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
-using static Windows.UI.Xaml.Controls.CollectionChangedOperation;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -55,6 +54,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsFalse(firstButton.Focus(FocusState.Programmatic));
 		}
 
+#if HAS_UNO
 		[TestMethod]
 		public async Task When_Button_Flyout_TemplateBinding()
 		{
@@ -86,6 +86,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				VisualTreeHelper.CloseAllPopups();
 			}
 		}
+#endif
 
 		private async Task RunIsExecutingCommandCommon(IsExecutingCommand command)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -5,7 +5,6 @@ using System.Windows.Input;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Uno.Extensions;
-using Uno.UI.Xaml.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -1,11 +1,17 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
+using Uno.Extensions;
+using Uno.UI.Xaml.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using static Private.Infrastructure.TestServices;
+using static Windows.UI.Xaml.Controls.CollectionChangedOperation;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -47,6 +53,38 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			// The button cannot be refocused
 			Assert.IsFalse(firstButton.Focus(FocusState.Programmatic));
+		}
+
+		[TestMethod]
+		public async Task When_Button_Flyout_TemplateBinding()
+		{
+			try
+			{
+				var SUT = new Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ButtonControls.Button_Flyout_TemplateBinding();
+
+				WindowHelper.WindowContent = SUT;
+
+				await WindowHelper.WaitForIdle();
+
+				var innerButton = SUT.FindName("innerButton") as Button;
+				Assert.IsNotNull(innerButton);
+				innerButton.RaiseClick();
+
+				await TestServices.WindowHelper.WaitForIdle();
+
+				var popups = VisualTreeHelper.GetOpenPopups(Windows.UI.Xaml.Window.Current);
+
+				var innerFlyoutItem = popups.Select(p
+					=> ((p.Child as MenuFlyoutPresenter)?.TemplatedRoot as FrameworkElement)?.FindName("innerFlyoutItem") as MenuFlyoutItem).Trim().FirstOrDefault();
+
+				Assert.IsNotNull(innerFlyoutItem);
+
+				Assert.AreEqual("42", innerFlyoutItem.Text);
+			}
+			finally
+			{
+				VisualTreeHelper.CloseAllPopups();
+			}
 		}
 
 		private async Task RunIsExecutingCommandCommon(IsExecutingCommand command)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -53,7 +53,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsFalse(firstButton.Focus(FocusState.Programmatic));
 		}
 
-#if HAS_UNO
+#if HAS_UNO && !__MACOS__
 		[TestMethod]
 		public async Task When_Button_Flyout_TemplateBinding()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -343,6 +343,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			OnOpening();
 			Opening?.Invoke(this, EventArgs.Empty);
 			Open();
+			SynchronizeContentTemplatedParent();
 			IsOpen = true;
 
 			// **************************************************************************************
@@ -360,6 +361,16 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			});
 		}
 
+		private void SynchronizeContentTemplatedParent()
+		{
+			// Manual propagation of the templated parent to the content property
+			// until we get the propagation running properly
+			if (_popup.Child is FrameworkElement content)
+			{
+				content.TemplatedParent = TemplatedParent;
+			}
+		}
+		
 		private void SetTargetPosition(Point targetPoint)
 		{
 			m_isTargetPositionSet = true;

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutPresenter.cs
@@ -221,8 +221,19 @@ namespace Windows.UI.Xaml.Controls
 			var spMenuFlyoutItemBase = pElement as MenuFlyoutItemBase;
 
 			spMenuFlyoutItemBase.SetParentMenuFlyoutPresenter(this);
+
+			SynchronizeTemplatedParent(spMenuFlyoutItemBase);
 		}
 
+		private void SynchronizeTemplatedParent(MenuFlyoutItemBase spMenuFlyoutItemBase)
+		{
+			// Manual propagation of the templated parent to the content properly
+			// until we get the propagation running properly
+			if (spMenuFlyoutItemBase is FrameworkElement content)
+			{
+				content.TemplatedParent = TemplatedParent;
+			}
+		}
 
 		protected override void ClearContainerForItemOverride(
 			 DependencyObject pElement,


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/1884

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Manually propagates the `TemplatedParent` to the children of `MenuFlyoutPresenter`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
