### PR TITLE
test: Adjust weak reference testing for implicit capture change in behavior

### DIFF
--- a/src/Uno.UI.Tests/WeakReferencePool/Given_WeakReferencePool.cs
+++ b/src/Uno.UI.Tests/WeakReferencePool/Given_WeakReferencePool.cs
@@ -145,6 +145,10 @@ namespace Uno.UI.Tests
 
 			void ScopedTest()
 			{
+				// This change is needed after some unknown scoped references 
+				// changes in .NET Framework. Adding an explicit method to contain
+				// the references makes the test work properly.
+
 				Assert.IsNotNull(r.ownerRef.Target);
 				Assert.IsNotNull(r.targetRef.Target);
 				Assert.IsNotNull(r.refref.Target);

--- a/src/Uno.UI.Tests/WeakReferencePool/Given_WeakReferencePool.cs
+++ b/src/Uno.UI.Tests/WeakReferencePool/Given_WeakReferencePool.cs
@@ -143,13 +143,18 @@ namespace Uno.UI.Tests
 
 			var r = CreateUnreferenced();
 
-			Assert.IsNotNull(r.ownerRef.Target);
-			Assert.IsNotNull(r.targetRef.Target);
-			Assert.IsNotNull(r.refref.Target);
+			void ScopedTest()
+			{
+				Assert.IsNotNull(r.ownerRef.Target);
+				Assert.IsNotNull(r.targetRef.Target);
+				Assert.IsNotNull(r.refref.Target);
 
-			Assert.AreEqual(0, WeakReferencePool.PooledReferences);
+				Assert.AreEqual(0, WeakReferencePool.PooledReferences);
+			}
 
-			GCCondition(5, () => r.refref.Target == null);
+			ScopedTest();
+
+			GCCondition(50, () => r.refref.Target == null);
 
 			Assert.IsNull(r.refref.Target);
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

`When_WeakReferenceProvider_Collected` is now passing properly, with scoped testing of collected references updated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
