### PR TITLE
fix(TextBox): [iOS] Add temporary workaround for iOS 16 on selection with UITextField

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8896,6 +8896,14 @@
 			<Member
 				fullName="System.Threading.Tasks.Task Uno.AuthenticationBroker.WebAuthenticationBrokerProvider.LaunchBrowserCore(Windows.Security.Authentication.Web.WebAuthenticationOptions options, System.Uri requestUri, System.Uri callbackUri, System.Threading.CancellationToken ct)"
 				reason="Protected method no longer used or required" />
+			<!-- BEGIN iOS 16 workaround -->
+			<Member
+				fullName="UIKit.UITextRange Windows.UI.Xaml.Controls.SinglelineTextBoxView::get_SelectedTextRange()"
+				reason="Workaround for iOS 16" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Controls.SinglelineTextBoxView::set_SelectedTextRange(UIKit.UITextRange value)"
+				reason="Workaround for iOS 16" />
+			<!-- END iOS 16 workaround -->
 		</Methods>
 		<Properties>
 			<Member
@@ -8907,6 +8915,11 @@
 			<Member
 				fullName="System.Boolean Windows.UI.Xaml.Controls.SinglelineTextBoxView::SecureTextEntry()"
 				reason="Removed no-longer-needed override" />
+			<!-- BEGIN iOS 16 workaround -->
+			<Member
+				fullName="UIKit.UITextRange Windows.UI.Xaml.Controls.SinglelineTextBoxView::SelectedTextRange()"
+				reason="Workaround for iOS 16" />
+			<!-- END iOS 16 workaround -->
 		</Properties>
 	</IgnoreSet>
 	<!--

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -434,6 +434,7 @@ namespace Uno.UI
 
 		public static class TextBox
 		{
+
 			/// <summary>
 			/// Determines if the caret is visible or not.
 			/// </summary>
@@ -450,6 +451,15 @@ namespace Uno.UI
 			/// This is available on Android only
 			/// </remarks>
 			public static bool UseLegacyInputScope { get; set; }
+#endif
+
+#if __IOS__
+			/// <summary>
+			/// As of iOS 16 Beta 4, the selection events are crashing the application. This feature configuration is added
+			/// to provide the ability to restore the original behavior if/when the underlying UIKit is fixed.
+			/// See https://github.com/unoplatform/uno/issues/9430 for additional details.
+			/// </summary>
+			public static bool IOS16EnableSelectionSupport { get; set; }
 #endif
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -114,7 +114,7 @@ namespace Windows.UI.Xaml.Controls
 						return;
 					}
 
-					_textBoxView = new SinglelineTextBoxView(this);
+					_textBoxView = SinglelineTextBoxView.CreateSinglelineTextBoxView(this);
 
 					_contentElement.Content = _textBoxView;
 					_textBoxView.SetTextNative(Text);


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/9430

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change is needed to make the `SinglelineTextBoxView.SelectedTextRange` conditional, and avoid changing the value provided to UIKit. This breaks the use of `TextBox.SelectionChanged`, but can be restored by using the `FeatureConfiguration.TextBox.IOS16EnableSelectionSupport` feature flag if the issue ends up being fixed in UIKit. 

See https://github.com/unoplatform/uno/issues/9430 for more details.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
