### PR TITLE
feat: Include repository path in Samples app title bar

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -151,7 +151,7 @@ namespace SamplesApp
 				repositoryPath = fullPath.Substring(0, index);
 			}
 
-			ApplicationView.GetForCurrentView().Title += " (" + repositoryPath + ")";			
+			ApplicationView.GetForCurrentView().Title += $" ({repositoryPath})";
 		}
 #endif
 

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -131,11 +131,29 @@ namespace SamplesApp
 			AssertIssue8641NativeOverlayInitialized();
 
 			Windows.UI.Xaml.Window.Current.Activate();
-
+			
 			ApplicationView.GetForCurrentView().Title = "Uno Samples";
+#if __SKIA__ && DEBUG
+			AppendRepositoryPathToTitleBar();			
+#endif
 
 			HandleLaunchArguments(e);
 		}
+
+#if __SKIA__ && DEBUG
+		private void AppendRepositoryPathToTitleBar()
+		{
+			var fullPath = Package.Current.InstalledLocation.Path;
+			var srcSamplesApp = $"{Path.DirectorySeparatorChar}src{Path.DirectorySeparatorChar}SamplesApp";
+			var repositoryPath = fullPath;			
+			if (fullPath.IndexOf(srcSamplesApp) is int index && index > 0)
+			{
+				repositoryPath = fullPath.Substring(0, index);
+			}
+
+			ApplicationView.GetForCurrentView().Title += " (" + repositoryPath + ")";			
+		}
+#endif
 
 		private static async Task<bool> HandleSkiaAutoScreenshots(LaunchActivatedEventArgs e)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

When debugging Uno in multiple instances, it is sometimes hard to tell which window belongs to which instance.

## What is the new behavior?

Samples app shows path in its title bar when debugging.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.