### PR TITLE
[Framebuffer] Support Application.Exit and terminal console interception

### DIFF
--- a/doc/articles/features/using-linux-framebuffer.md
+++ b/doc/articles/features/using-linux-framebuffer.md
@@ -18,21 +18,35 @@ dotnet new unoapp -o MyApp
 
 You'll get a set of projects, including one named `MyApp.Skia.Linux.FrameBuffer`.
 
-You can build this app by navigating to the `MyApp..Skia.Linux.FrameBuffer` and type the following:
+You can build this app by navigating to the `MyApp.Skia.Linux.FrameBuffer` and type the following:
 
 ```
 dotnet run
 ```
 
+The app will start and display on the first available framebuffer device. To change the active framebuffer, set the device name in the `FRAMEBUFFER` environment variable.
+
+`dotnet run` uses the `Debug` configuration, which will show logging information in the current terminal and may overwrite the UI content.
+
+To read the logging information, either:
+- Launch the application from a different terminal (through SSH, for instance)
+- Launch the app using `dotnet run > logging.txt 2>&1`, then launch `tail -f logging.txt` in another terminal.
+
+Once the application is running, you can exit the application with:
+- `Ctrl+C`
+- `F12`, a key configuration found in the `Program.cs` file of your project which invokes `Application.Current.Exit()`
+
+## Creating a standalone app
 You can create a standalone publication folder using the following:
 
 ```
 dotnet publish -c Release -r linux-x64 --self-contained true
 ```
 
-The app will start and display on the first available framebuffer device.
+> [!NOTE]
+> When using the `Release` configuration, logging is disabled for performance considerations. You can restore logging in the App.xaml.cs file.
 
-Documentation on other hardware targets are [available here](https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0-supported-os.md).
+Documentation on other hardware targets are [available here](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md).
 
 ## DPI Scaling support
 Whenever possible, the `FrameBufferHost` will try to detect the actual DPI scale to use when rendering the UI, based on the physical information provided by the FrameBuffer driver. If the value cannot be determined, a scale of `1.0` is used.

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -618,9 +618,7 @@ namespace SamplesApp
 		public void AssertIssue8356()
 		{
 #if __SKIA__
-			string SUT = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Title;
-			string value = Windows.ApplicationModel.Package.Current.DisplayName;
-			Assert.AreEqual(SUT, value);
+			Uno.UI.RuntimeTests.Tests.Windows_UI_ViewManagement_ApplicationView.Given_ApplicationView.StartupTitle = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Title;
 #endif
 		}
 

--- a/src/SamplesApp/SamplesApp.Skia.Linux.FrameBuffer/Program.cs
+++ b/src/SamplesApp/SamplesApp.Skia.Linux.FrameBuffer/Program.cs
@@ -3,6 +3,8 @@ using SkiaSharp;
 using Uno.Foundation.Extensibility;
 using System.Threading;
 using Uno.UI.Runtime.Skia;
+using Windows.UI.Xaml;
+using Windows.UI.Core;
 
 namespace SkiaSharpExample
 {
@@ -16,7 +18,18 @@ namespace SkiaSharpExample
 				SamplesApp.App.ConfigureFilters(); // Enable tracing of the host
 
 				Console.CursorVisible = false;
-				var host = new FrameBufferHost(() => new SamplesApp.App(), args);
+				var host = new FrameBufferHost(() =>
+				{
+					CoreWindow.GetForCurrentThread().KeyDown += (s, e) =>
+					{
+						if (e.VirtualKey == Windows.System.VirtualKey.F12)
+						{
+							Application.Current.Exit();
+						}
+					};
+
+					return new SamplesApp.App();
+				}, args);
 				host.Run();
 			}
 			finally

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -761,6 +761,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ApplicationTests\Given_Application.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping4273.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5346,6 +5350,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_ViewManagement\UISettingsTests.xaml.cs">
       <DependentUpon>UISettingsTests.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ApplicationTests\Given_Application.xaml.cs">
+      <DependentUpon>Given_Application.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\ButtonClippingTestsControl.xaml.cs">
       <DependentUpon>ButtonClippingTestsControl.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ApplicationTests/Given_Application.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ApplicationTests/Given_Application.xaml
@@ -1,0 +1,14 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml.ApplicationTests.Given_Application"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.ApplicationTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+		<Button Content="Force exit"
+				Click="{x:Bind OnForceExit}" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ApplicationTests/Given_Application.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ApplicationTests/Given_Application.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml.ApplicationTests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[SampleControlInfo("Application")]
+	public sealed partial class Given_Application : Page
+	{
+		public Given_Application()
+		{
+			this.InitializeComponent();
+		}
+
+		public void OnForceExit()
+		{
+			Application.Current.Exit();
+		}
+	}
+}

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Linux.FrameBuffer/Program.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Linux.FrameBuffer/Program.cs
@@ -11,7 +11,23 @@ namespace $ext_safeprojectname$
 			{
 				Console.CursorVisible = false;
 
-				var host = new FrameBufferHost(() => new App());
+				var host = new FrameBufferHost(() =>
+				{
+					// Framebuffer applications don't have a WindowManager to rely
+					// on. To close the application, we can hook onto CoreWindow events
+					// which dispatch keyboard input, and close the application as a result.
+					// This block can be moved to App.xaml.cs if it does not interfere with other
+					// platforms that may use the same keys.
+					CoreWindow.GetForCurrentThread().KeyDown += (s, e) =>
+					{
+						if (e.VirtualKey == Windows.System.VirtualKey.F12)
+						{
+							Application.Current.Exit();
+						}
+					};
+
+					return new App();
+				});
 				host.Run();
 			}
 			finally

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/ApplicationExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/ApplicationExtension.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Uno.UI.Xaml;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Runtime.Skia
+{
+	internal class ApplicationExtension : IApplicationExtension
+	{
+		private readonly Application _owner;
+
+		public ApplicationExtension(Application owner)
+		{
+			_owner = owner ?? throw new ArgumentNullException(nameof(owner));
+		}
+
+		public bool CanExit => true;
+
+		/// <summary>
+		/// Determines if <see cref="Application.Exit()"/> has been called.
+		/// </summary>
+		internal bool ShouldExit { get; private set; }
+
+#pragma warning disable CS0067 // The event is never used
+		public event EventHandler? SystemThemeChanged;
+#pragma warning restore CS0067 // The event is never used
+
+		internal event EventHandler? ExitRequested;
+
+		public void Exit()
+		{
+			ShouldExit = true;
+			ExitRequested?.Invoke(this, EventArgs.Empty);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement_ApplicationView/Given_Control.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement_ApplicationView/Given_Control.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UI.Extensions;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_ViewManagement_ApplicationView
+{
+	[TestClass]
+	public class Given_ApplicationView
+	{
+		public static string StartupTitle { get; set; }
+
+#if __SKIA__
+		[TestMethod]
+		public async Task When_StartupTitle_Is_Defined()
+		{
+			Assert.AreEqual(Windows.ApplicationModel.Package.Current.DisplayName, StartupTitle);
+		}
+#endif
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/discussions/9473

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Adds support for `Application.Exit`
- Support for terminal keyboard interception to avoid characters to be visible

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
