### PR TITLE
fix: Updated workaround for iOS 16 `UITextInput.SelectedTextRange` crashes

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8903,6 +8903,12 @@
 			<Member
 				fullName="System.Void Windows.UI.Xaml.Controls.SinglelineTextBoxView::set_SelectedTextRange(UIKit.UITextRange value)"
 				reason="Workaround for iOS 16" />
+			<Member
+				fullName="UIKit.UITextRange Windows.UI.Xaml.Controls.MultilineTextBoxView::get_SelectedTextRange()"
+				reason="Workaround for iOS 16" />
+			<Member
+				fullName="System.Void Windows.UI.Xaml.Controls.MultilineTextBoxView::set_SelectedTextRange(UIKit.UITextRange value)"
+				reason="Workaround for iOS 16" />
 			<!-- END iOS 16 workaround -->
 		</Methods>
 		<Properties>
@@ -8918,6 +8924,9 @@
 			<!-- BEGIN iOS 16 workaround -->
 			<Member
 				fullName="UIKit.UITextRange Windows.UI.Xaml.Controls.SinglelineTextBoxView::SelectedTextRange()"
+				reason="Workaround for iOS 16" />
+			<Member
+				fullName="UIKit.UITextRange Windows.UI.Xaml.Controls.MultilineTextBoxView::SelectedTextRange()"
 				reason="Workaround for iOS 16" />
 			<!-- END iOS 16 workaround -->
 		</Properties>

--- a/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+++ b/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
@@ -28,7 +28,7 @@
     <MtouchArch>x86_64</MtouchArch>
     <MtouchLink>None</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchExtraArgs>--dlsym:Microsoft.Win32.Registry.dll --xml=./LinkerExclusions.xml --linkskip=$(AssemblyName) --setenv=MONO_GC_PARAMS=soft-heap-limit=1024m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+    <MtouchExtraArgs>--dlsym:Microsoft.Win32.Registry.dll --xml=./LinkerExclusions.xml --linkskip=$(AssemblyName) --setenv=MONO_GC_PARAMS=soft-heap-limit=1024m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep  --registrar=static</MtouchExtraArgs>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
   </PropertyGroup>
@@ -42,7 +42,7 @@
     <MtouchLink>None</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <MtouchExtraArgs>--dlsym:Microsoft.Win32.Registry.dll --xml=./LinkerExclusions.xml --linkskip=$(AssemblyName) --setenv=MONO_GC_PARAMS=soft-heap-limit=1024m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+    <MtouchExtraArgs>--dlsym:Microsoft.Win32.Registry.dll --xml=./LinkerExclusions.xml --linkskip=$(AssemblyName) --setenv=MONO_GC_PARAMS=soft-heap-limit=1024m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep  --registrar=static</MtouchExtraArgs>
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">

--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -21,11 +21,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 using Windows.System;
-using Windows.UI.Core;
-
-#if NET6_0_OR_GREATER
 using ObjCRuntime;
-#endif
 
 namespace Uno.UI.Controls
 {
@@ -329,7 +325,8 @@ namespace Uno.UI.Controls
 			}
 			if (multilineTextBoxView != null && multilineTextBoxView.IsFirstResponder)
 			{
-				viewRectInScrollView = multilineTextBoxView.GetCaretRectForPosition(multilineTextBoxView.SelectedTextRange.Start);
+				using var range = Runtime.GetNSObject<UITextRange>(multilineTextBoxView.SelectedTextRange);
+				viewRectInScrollView = multilineTextBoxView.GetCaretRectForPosition(range.Start);
 
 				// We need to add an additional margins because the caret is too tight to the text. The font is cutoff under the keyboard.
 				viewRectInScrollView.Y -= KeyboardMargin;

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -452,15 +452,6 @@ namespace Uno.UI
 			/// </remarks>
 			public static bool UseLegacyInputScope { get; set; }
 #endif
-
-#if __IOS__
-			/// <summary>
-			/// As of iOS 16 Beta 4, the selection events are crashing the application. This feature configuration is added
-			/// to provide the ability to restore the original behavior if/when the underlying UIKit is fixed.
-			/// See https://github.com/unoplatform/uno/issues/9430 for additional details.
-			/// </summary>
-			public static bool IOS16EnableSelectionSupport { get; set; }
-#endif
 		}
 
 		public static class ScrollViewer

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxView.iOS.cs
@@ -14,10 +14,7 @@ using Windows.UI.Xaml.Media;
 using Uno.UI.Controls;
 using Windows.UI;
 using Uno.Disposables;
-
-#if NET6_0_OR_GREATER
 using ObjCRuntime;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -240,17 +237,21 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		public override UITextRange SelectedTextRange
+		/// <summary>
+		/// Workaround for https://github.com/unoplatform/uno/issues/9430
+		/// </summary>
+		[Export("selectedTextRange")]
+		public new IntPtr SelectedTextRange
 		{
 			get
 			{
-				return base.SelectedTextRange;
+				return SinglelineTextBoxView.IntPtr_objc_msgSendSuper(SuperHandle, Selector.GetHandle("selectedTextRange"));
 			}
 			set
 			{
-				if (base.SelectedTextRange != value)
+				if (SelectedTextRange != value)
 				{
-					base.SelectedTextRange = value;
+					SinglelineTextBoxView.void_objc_msgSendSuper(SuperHandle, Selector.GetHandle("setSelectedTextRange:"), value);
 					_textBox.GetTarget()?.OnSelectionChanged();
 				}
 			}
@@ -262,6 +263,6 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public void Select(int start, int length)
-			=> SelectedTextRange = this.GetTextRange(start: start, end: start + length);
+			=> SelectedTextRange = this.GetTextRange(start: start, end: start + length).GetHandle();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
@@ -225,10 +225,10 @@ namespace Windows.UI.Xaml.Controls
 		/// Workaround for https://github.com/unoplatform/uno/issues/9430
 		/// </summary>
 		[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSendSuper")]
-		static extern IntPtr IntPtr_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
+		static internal extern IntPtr IntPtr_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
 
 		[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSendSuper")]
-		static extern void void_objc_msgSendSuper(IntPtr receiver, IntPtr selector, IntPtr arg);
+		static internal extern void void_objc_msgSendSuper(IntPtr receiver, IntPtr selector, IntPtr arg);
 
 		[Export("selectedTextRange")]
 		public new IntPtr SelectedTextRange
@@ -241,7 +241,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				var textBox = TextBox;
 
-				if (textBox != null && IntPtr_objc_msgSendSuper(SuperHandle, Selector.GetHandle("selectedTextRange")) != value)
+				if (textBox != null && SelectedTextRange != value)
 				{
 					void_objc_msgSendSuper(SuperHandle, Selector.GetHandle("setSelectedTextRange:"), value);
 					textBox.OnSelectionChanged();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
@@ -1,8 +1,10 @@
 using CoreGraphics;
+using ObjCRuntime;
 using Uno.UI.DataBinding;
 using Uno.UI.Views.Controls;
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Text;
 using UIKit;
 using Uno.Extensions;
@@ -24,32 +26,12 @@ namespace Windows.UI.Xaml.Controls
 		private readonly WeakReference<TextBox> _textBox;
 		private readonly SerialDisposable _foregroundChanged = new();
 
-		private static bool _issue9430WarnSingle = false;
-
 		public SinglelineTextBoxView(TextBox textBox)
 		{
 			_textBox = new WeakReference<TextBox>(textBox);
 
 			InitializeBinder();
 			Initialize();
-		}
-
-		internal static SinglelineTextBoxView CreateSinglelineTextBoxView(TextBox textBox)
-		{
-			if (UIDevice.CurrentDevice.CheckSystemVersion(16, 0) && !FeatureConfiguration.TextBox.IOS16EnableSelectionSupport)
-			{
-				if (!_issue9430WarnSingle && typeof(SinglelineTextBoxView).Log().IsEnabled(LogLevel.Error))
-				{
-					_issue9430WarnSingle = true;
-					typeof(SinglelineTextBoxView).Log().Error($"TextBox selection events are disabled on iOS 16. See https://github.com/unoplatform/uno/issues/9430 for additional details.");
-				}
-
-				return new SinglelineTextBoxView(textBox);
-			}
-			else
-			{
-				return new SinglelineTextBoxViewWithSelection(textBox);
-			}
 		}
 
 		internal TextBox TextBox => _textBox.GetTarget();
@@ -237,32 +219,31 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public void Select(int start, int length)
-			=> SelectedTextRange = this.GetTextRange(start: start, end: start + length);
-	}
+			=> SelectedTextRange = this.GetTextRange(start: start, end: start + length).GetHandle();
 
-	/// <summary>
-	/// Workaround for https://github.com/unoplatform/uno/issues/9430
-	/// </summary>
-	internal partial class SinglelineTextBoxViewWithSelection : SinglelineTextBoxView
-	{
-		public SinglelineTextBoxViewWithSelection(TextBox textBox)
-			: base(textBox)
-		{
-		}
+		/// <summary>
+		/// Workaround for https://github.com/unoplatform/uno/issues/9430
+		/// </summary>
+		[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSendSuper")]
+		static extern IntPtr IntPtr_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
 
-		public override UITextRange SelectedTextRange
+		[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSendSuper")]
+		static extern void void_objc_msgSendSuper(IntPtr receiver, IntPtr selector, IntPtr arg);
+
+		[Export("selectedTextRange")]
+		public new IntPtr SelectedTextRange
 		{
 			get
 			{
-				return base.SelectedTextRange;
+				return IntPtr_objc_msgSendSuper(SuperHandle, Selector.GetHandle("selectedTextRange"));
 			}
 			set
 			{
 				var textBox = TextBox;
 
-				if (textBox != null && base.SelectedTextRange != value)
+				if (textBox != null && IntPtr_objc_msgSendSuper(SuperHandle, Selector.GetHandle("selectedTextRange")) != value)
 				{
-					base.SelectedTextRange = value;
+					void_objc_msgSendSuper(SuperHandle, Selector.GetHandle("setSelectedTextRange:"), value);
 					textBox.OnSelectionChanged();
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -114,7 +114,7 @@ namespace Windows.UI.Xaml.Controls
 						return;
 					}
 
-					_textBoxView = SinglelineTextBoxView.CreateSinglelineTextBoxView(this);
+					_textBoxView = new SinglelineTextBoxView(this);
 
 					_contentElement.Content = _textBoxView;
 					_textBoxView.SetTextNative(Text);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`UITextInput.SelectedTextRange` crashes on iOS 16 betas

## What is the new behavior?

Updated workaround to avoid the runtime crash while keeping the `UITextInput.SelectedTextRange` functionality available.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Pro: It does not break app compatibility, selection works

Con: This does not work _currently_ with the dynamic registrar [1] which is the default when building for iOS simulators. OTOH there's a workaround for that [2].

[1] Unless building with the iOS SDK for Xcode 14 (currently only previews) once https://github.com/xamarin/xamarin-macios/pull/15712 is merged

[2] Adding `--registrar=static` to the simulator builds will fix this, sadly build times will be longer (so better use [1] asap)


Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
