### PR TITLE
XamlReader support for `ThemeDictionaries` and `MergedDictionaries`

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1246,6 +1246,9 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			var c2 = (Color)panel.Resources["c2"];
 			var b2 = (SolidColorBrush)panel.Resources["b2"];
 
+			Assert.AreEqual(b2.Color, c2);
+			Assert.AreEqual(Colors.Green, b2.Color);
+
 			r.ForceLoaded();
 
 			c2 = (Color)panel.Resources["c2"];
@@ -1266,6 +1269,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			var c2 = (Color)panel.Resources["c2"];
 			var b2 = (SolidColorBrush)panel.Resources["b2"];
 
+			Assert.AreEqual(b2.Color, c2);
+
 			r.ForceLoaded();
 
 			c2 = (Color)panel.Resources["c2"];
@@ -1285,6 +1290,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 
 			var c2 = (Color)panel.Resources["c2"];
 			var b2 = (SolidColorBrush)panel.Resources["b2"];
+
+			Assert.AreEqual(b2.Color, c2);
 
 			r.ForceLoaded();
 
@@ -1308,6 +1315,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 
 			var c2 = (Color)panel.Resources["c2"];
 			var b2 = (SolidColorBrush)panel.Resources["b2"];
+
+			Assert.AreEqual(b2.Color, c2);
 
 			r.ForceLoaded();
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1254,6 +1254,98 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.AreEqual(b2.Color, c2);
 		}
 
+		[TestMethod]
+		public void When_StaticResource_In_Explicit_ResourceDictionary()
+		{
+			var s = GetContent(nameof(When_StaticResource_In_Explicit_ResourceDictionary));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			var panel = r.FindName("panel") as StackPanel;
+			Assert.IsNotNull(panel);
+
+			var c2 = (Color)panel.Resources["c2"];
+			var b2 = (SolidColorBrush)panel.Resources["b2"];
+
+			r.ForceLoaded();
+
+			c2 = (Color)panel.Resources["c2"];
+			b2 = (SolidColorBrush)panel.Resources["b2"];
+
+			Assert.AreEqual(b2.Color, c2);
+		}
+
+		[TestMethod]
+		public void When_StaticResource_In_Explicit_ResourceDictionary_And_ThemeResources()
+		{
+			var s = GetContent(nameof(When_StaticResource_In_Explicit_ResourceDictionary_And_ThemeResources));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			var panel = r.FindName("panel") as StackPanel;
+			Assert.IsNotNull(panel);
+
+			var c2 = (Color)panel.Resources["c2"];
+			var b2 = (SolidColorBrush)panel.Resources["b2"];
+
+			r.ForceLoaded();
+
+			c2 = (Color)panel.Resources["c2"];
+			b2 = (SolidColorBrush)panel.Resources["b2"];
+
+			var c3 = (Color)panel.Resources["c3"];
+			var b3 = (SolidColorBrush)panel.Resources["b3"];
+
+			Assert.AreEqual(b3.Color, c3);
+		}
+
+		[TestMethod]
+		public void When_StaticResource_In_Explicit_ResourceDictionary_And_MergedDictionaries()
+		{
+			var s = GetContent(nameof(When_StaticResource_In_Explicit_ResourceDictionary_And_MergedDictionaries));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			var panel = r.FindName("panel") as StackPanel;
+			Assert.IsNotNull(panel);
+
+			var c2 = (Color)panel.Resources["c2"];
+			var b2 = (SolidColorBrush)panel.Resources["b2"];
+
+			r.ForceLoaded();
+
+			c2 = (Color)panel.Resources["c2"];
+			b2 = (SolidColorBrush)panel.Resources["b2"];
+
+			Assert.AreEqual(b2.Color, c2);
+
+			var c3 = (Color)panel.Resources["c3"];
+			var b3 = (SolidColorBrush)panel.Resources["b3"];
+
+			Assert.AreEqual(b3.Color, c3);
+
+			var c4 = (Color)panel.Resources["c4"];
+			var b4 = (SolidColorBrush)panel.Resources["b4"];
+
+			Assert.AreEqual(b4.Color, c4);
+		}
+
+		[TestMethod]
+		public void When_StaticResource_MergedDictionaries_Fluent()
+		{
+			var s = GetContent(nameof(When_StaticResource_MergedDictionaries_Fluent));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			var panel = r.FindName("panel") as StackPanel;
+			Assert.IsNotNull(panel);
+
+			var t1 = (Color)panel.Resources["c1"];
+
+			r.ForceLoaded();
+
+			var b1 = (SolidColorBrush)panel.Resources["b1"];
+
+			Assert.AreEqual(t1, Colors.Red);
+			Assert.AreEqual(t1, b1.Color);
+		}
+
 		/// <summary>
 		/// XamlReader.Load the xaml and type-check result.
 		/// </summary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1247,7 +1247,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			var b2 = (SolidColorBrush)panel.Resources["b2"];
 
 			Assert.AreEqual(b2.Color, c2);
-			Assert.AreEqual(Colors.Green, b2.Color);
+			Assert.AreEqual(Windows.UI.Colors.Green, b2.Color);
 
 			r.ForceLoaded();
 
@@ -1351,7 +1351,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 
 			var b1 = (SolidColorBrush)panel.Resources["b1"];
 
-			Assert.AreEqual(t1, Colors.Red);
+			Assert.AreEqual(t1, Windows.UI.Colors.Red);
 			Assert.AreEqual(t1, b1.Color);
 		}
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/TestCodedResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/TestCodedResourceDictionary.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
+{
+    public class TestCodedResourceDictionary : ResourceDictionary
+    {
+		public TestCodedResourceDictionary()
+		{
+			this["c1"] = Colors.Red;
+		}
+    }
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StaticResource_In_Explicit_ResourceDictionary.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StaticResource_In_Explicit_ResourceDictionary.xamltest
@@ -1,0 +1,15 @@
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Name="testPage">
+
+	<StackPanel x:Name="panel" Spacing="20" HorizontalAlignment="Left">
+		<StackPanel.Resources>
+			<ResourceDictionary>
+				<SolidColorBrush x:Key="b1">Red</SolidColorBrush>
+
+				<Color x:Key="c2">Green</Color>
+				<SolidColorBrush x:Key="b2" Color="{StaticResource c2}" />
+			</ResourceDictionary>
+		</StackPanel.Resources>
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StaticResource_In_Explicit_ResourceDictionary_And_MergedDictionaries.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StaticResource_In_Explicit_ResourceDictionary_And_MergedDictionaries.xamltest
@@ -1,0 +1,26 @@
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Name="testPage">
+
+	<StackPanel x:Name="panel" Spacing="20" HorizontalAlignment="Left">
+		<StackPanel.Resources>
+			<ResourceDictionary>
+				<ResourceDictionary.MergedDictionaries>
+					<ResourceDictionary>
+						<Color x:Key="c3">Blue</Color>
+					</ResourceDictionary>
+					<ResourceDictionary>
+						<Color x:Key="c4">Purple</Color>
+					</ResourceDictionary>
+				</ResourceDictionary.MergedDictionaries>
+
+				<SolidColorBrush x:Key="b1">Red</SolidColorBrush>
+
+				<Color x:Key="c2">Green</Color>
+				<SolidColorBrush x:Key="b2" Color="{StaticResource c2}" />
+				<SolidColorBrush x:Key="b3" Color="{StaticResource c3}" />
+				<SolidColorBrush x:Key="b4" Color="{StaticResource c4}" />
+			</ResourceDictionary>
+		</StackPanel.Resources>
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StaticResource_In_Explicit_ResourceDictionary_And_ThemeResources.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StaticResource_In_Explicit_ResourceDictionary_And_ThemeResources.xamltest
@@ -1,0 +1,25 @@
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Name="testPage">
+
+	<StackPanel x:Name="panel" Spacing="20" HorizontalAlignment="Left">
+		<StackPanel.Resources>
+			<ResourceDictionary>
+				<ResourceDictionary.ThemeDictionaries>
+					<ResourceDictionary x:Key="Light">
+						<Color x:Key="c3">Blue</Color>
+					</ResourceDictionary>
+					<ResourceDictionary x:Key="Dark">
+						<Color x:Key="c3">Purple</Color>
+					</ResourceDictionary>
+				</ResourceDictionary.ThemeDictionaries>
+
+				<SolidColorBrush x:Key="b1">Red</SolidColorBrush>
+
+				<Color x:Key="c2">Green</Color>
+				<SolidColorBrush x:Key="b2" Color="{StaticResource c2}" />
+				<SolidColorBrush x:Key="b3" Color="{StaticResource c3}" />
+			</ResourceDictionary>
+		</StackPanel.Resources>
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StaticResource_MergedDictionaries_Fluent.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_StaticResource_MergedDictionaries_Fluent.xamltest
@@ -1,0 +1,16 @@
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Name="testPage">
+
+	<StackPanel x:Name="panel" Spacing="20" HorizontalAlignment="Left">
+		<StackPanel.Resources>
+			<ResourceDictionary>
+				<ResourceDictionary.MergedDictionaries>
+					<TestCodedResourceDictionary xmlns="using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests" />
+				</ResourceDictionary.MergedDictionaries>
+
+				<SolidColorBrush x:Key="b1" Color="{StaticResource c1}" />
+			</ResourceDictionary>
+		</StackPanel.Resources>
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -577,7 +577,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 						throw new InvalidOperationException($"The property {propertyInfo} does not provide a getter (Line {member.LineNumber}:{member.LinePosition}");
 					}
 
-					var targetDictionary = (ResourceDictionary)propertyInfo.GetMethod.Invoke(instance, null);
+					var targetDictionary = (ResourceDictionary)propertyInfo.GetMethod.Invoke(instance, null)!;
 
 					var dictionaryObjects = member.Objects;
 

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -308,9 +308,19 @@ namespace Windows.UI.Xaml.Markup.Reader
 					}
 				}
 
-				var fullName = isKnownNamespace ? ns?.Prefix + ":" + type.Name : type.Name;
+				string getFullName()
+				{
+					if (!isKnownNamespace && type.PreferredXamlNamespace.StartsWith("using:"))
+					{
+						return type.PreferredXamlNamespace.TrimStart("using:") + "." + type.Name;
+					}
+					else
+					{
+						return isKnownNamespace ? ns?.Prefix + ":" + type.Name : type.Name;
+					}
+				}
 
-				return _findType(fullName);
+				return _findType(getFullName());
 			}
 			else
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9548

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

- Adds `XamlReader` support for `ThemeDictionaries`
- Adds `XamlReader` support for `MergedDictionaries`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
