### PR TITLE
feat: Add missing StaticResourceExtensions for VS intellisense

### DIFF
--- a/src/SourceGenerators/System.Xaml/System.Windows.Markup/StaticResourceExtension.cs
+++ b/src/SourceGenerators/System.Xaml/System.Windows.Markup/StaticResourceExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Markup;
+
+namespace System.Windows
+{
+    [MarkupExtensionReturnType(typeof(object))]
+    public class StaticResourceExtension : MarkupExtension
+    {
+        public StaticResourceExtension()
+        {
+        }
+
+        public StaticResourceExtension(object resourceKey)
+        {
+        }
+
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Uno.UI/XmlnsDefinitionAttribute.cs
+++ b/src/Uno.UI/XmlnsDefinitionAttribute.cs
@@ -4,6 +4,8 @@ using System.Windows.Markup;
 
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", System.Windows.Markup.XamlConstants.BaseXamlNamespace, AssemblyName = "Uno.UI")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml/presentation", System.Windows.Markup.XamlConstants.BaseXamlNamespace, AssemblyName = "Uno.UI")]
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml/presentation", System.Windows.Markup.XamlConstants.RootUINamespace, AssemblyName = "Uno.UI")]
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml/presentation", System.Windows.Markup.XamlConstants.RootUINamespace, AssemblyName = "Uno")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml/presentation", System.Windows.Markup.XamlConstants.Namespaces.Controls, AssemblyName = "Uno.UI")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml/presentation", System.Windows.Markup.XamlConstants.Namespaces.Primitives, AssemblyName = "Uno.UI")]
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml/presentation", System.Windows.Markup.XamlConstants.Namespaces.Text, AssemblyName = "Uno.UI")]


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/982

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Improve intellisense support for `StaticResource` and `Color` starting from VS 17.4 Preview 1.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
