### PR TITLE
fix: Handle `ScrollViewer` scroll to top in Android `RefreshContainer`

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerScrollTop.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerScrollTop.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+    x:Class="UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests.RefreshContainerScrollTop"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<mux:RefreshContainer>
+		<ScrollViewer>
+			<StackPanel x:Name="StackParent">
+			</StackPanel>
+		</ScrollViewer>
+	</mux:RefreshContainer>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerScrollTop.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerScrollTop.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Uno.UI.Samples.Controls;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using RefreshVisualizer = Microsoft.UI.Xaml.Controls.RefreshVisualizer;
+using RefreshVisualizerState = Microsoft.UI.Xaml.Controls.RefreshVisualizerState;
+using RefreshRequestedEventArgs = Microsoft.UI.Xaml.Controls.RefreshRequestedEventArgs;
+using RefreshInteractionRatioChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshInteractionRatioChangedEventArgs;
+using RefreshStateChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshStateChangedEventArgs;
+using RefreshPullDirection = Microsoft.UI.Xaml.Controls.RefreshPullDirection;
+using System.Threading.Tasks;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests
+{
+	[Sample("PullToRefresh")]
+    public sealed partial class RefreshContainerScrollTop : Page
+    {
+        public RefreshContainerScrollTop()
+        {
+            this.InitializeComponent();
+
+			for (int i = 0; i < 40; i++)
+			{
+				var textBlock = new TextBlock()
+				{
+					Text = "Hello " + i,
+					FontSize = 40,
+					Margin = ThicknessHelper.FromUniformLength(20)
+				};
+				StackParent.Children.Add(textBlock);
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -269,6 +269,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerScrollTop.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshVisualizerPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5006,6 +5010,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerTheming.xaml.cs">
       <DependentUpon>RefreshContainerTheming.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerScrollTop.xaml.cs">
+      <DependentUpon>RefreshContainerScrollTop.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshVisualizerPage.xaml.cs">
       <DependentUpon>RefreshVisualizerPage.xaml</DependentUpon>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/Native/NativeRefreshControl.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/Native/NativeRefreshControl.Android.cs
@@ -15,6 +15,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using ScrollView = Android.Widget.ScrollView;
+using UnoScrollViewer = Windows.UI.Xaml.Controls.ScrollViewer;
 
 namespace Uno.UI.Xaml.Controls;
 
@@ -54,10 +55,17 @@ public partial class NativeRefreshControl : SwipeRefreshLayout, IShadowChildrenP
 
 		if (_descendantScrollable != null)
 		{
+			if (_descendantScrollable is UnoScrollViewer unoScrollViewer)
+			{
+				return unoScrollViewer.VerticalOffset > 0;
+			}
+			else
+			{
 #pragma warning disable CS0618 // Type or member is obsolete
-			var canScrollUp = ViewCompat.CanScrollVertically(_descendantScrollable, -1);
+				var canScrollUp = ViewCompat.CanScrollVertically(_descendantScrollable, -1);
 #pragma warning restore CS0618 // Type or member is obsolete
-			return canScrollUp;
+				return canScrollUp;
+			}
 		}
 		return base.CanChildScrollUp();
 	}
@@ -179,7 +187,7 @@ public partial class NativeRefreshControl : SwipeRefreshLayout, IShadowChildrenP
 					// (False specifies that the element will not be discovered as a descendant scroller)
 					var element = (child as FrameworkElement);
 					
-					if (v is ScrollView || v is AbsListView || v is RecyclerView)
+					if (v is ScrollView || v is AbsListView || v is RecyclerView || v is UnoScrollViewer)
 					{
 						yield return v;
 					}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9578

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Currently the `RefreshContainer` starts refreshing regardless of `ScrollViewer` offset.


## What is the new behavior?

Fixed.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
