### PR TITLE
fix(timepicker): [iOS] Ensure proper native picker readability when the system theme is overriden

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Controls
 			_picker.Calendar = new NSCalendar(NSCalendarType.Gregorian);
 
 			UpdatePickerStyle();
-			UpdateTheme();
+			OverrideUIDatePickerTheme();
 
 			UpdatePickerValue(Date, animated: false);
 
@@ -236,7 +236,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private void UpdateTheme()
+		internal static void OverrideUIDatePickerTheme()
 		{
 			// Force the background of the UIDatePicker to allow for proper
 			// readability.

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UIKit;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
+using Uno.Helpers.Theming;
 using Uno.UI;
 using Uno.UI.Extensions;
 using Windows.Globalization;
@@ -37,6 +38,7 @@ namespace Windows.UI.Xaml.Controls
 			_picker.Mode = UIDatePickerMode.Time;
 
 			UpdatePickerStyle();
+			DatePickerSelector.OverrideUIDatePickerTheme();
 			SetPickerTime(Time.RoundToNextMinuteInterval(MinuteIncrement));
 			SetPickerClockIdentifier(ClockIdentifier);
 			SaveInitialTime();
@@ -51,6 +53,7 @@ namespace Windows.UI.Xaml.Controls
 				parent.RemoveChild(_picker);
 				parent.AddSubview(_picker);
 			}
+
 		}
 
 		private void OnEditingDidBegin(object sender, EventArgs e)
@@ -67,6 +70,7 @@ namespace Windows.UI.Xaml.Controls
 		public void Initialize()
 		{
 			UpdatePickerStyle();
+			DatePickerSelector.OverrideUIDatePickerTheme();
 			SetPickerClockIdentifier(ClockIdentifier);
 			SetPickerMinuteIncrement(MinuteIncrement);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change is needed when `TimePicker` is used before any DatePicker, related to the same way https://github.com/unoplatform/uno/pull/9005 was done.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
