### PR TITLE
fix: Retain refresh-ability of `RefreshContainer` through navigation

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigation.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigation.xaml
@@ -1,0 +1,15 @@
+﻿<Page
+    x:Class="UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests.RefreshContainerNavigation"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<Frame x:Name="PageFrame" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigation.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Uno.UI.Samples.Controls;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using RefreshVisualizer = Microsoft.UI.Xaml.Controls.RefreshVisualizer;
+using RefreshVisualizerState = Microsoft.UI.Xaml.Controls.RefreshVisualizerState;
+using RefreshRequestedEventArgs = Microsoft.UI.Xaml.Controls.RefreshRequestedEventArgs;
+using RefreshInteractionRatioChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshInteractionRatioChangedEventArgs;
+using RefreshStateChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshStateChangedEventArgs;
+using RefreshPullDirection = Microsoft.UI.Xaml.Controls.RefreshPullDirection;
+using System.Threading.Tasks;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests
+{
+	[Sample("PullToRefresh")]
+    public sealed partial class RefreshContainerNavigation : Page
+    {
+        public RefreshContainerNavigation()
+        {
+            this.InitializeComponent();
+
+			PageFrame.Navigate(typeof(RefreshContainerNavigationFirstPage));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigationFirstPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigationFirstPage.xaml
@@ -1,0 +1,25 @@
+﻿<Page
+    x:Class="UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests.RefreshContainerNavigationFirstPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Button Click="ButtonClick" Grid.Row="0">Navigate</Button>
+        <mux:RefreshContainer Grid.Row="1">
+            <ScrollViewer>
+                <StackPanel x:Name="StackParent">
+                </StackPanel>
+            </ScrollViewer>
+        </mux:RefreshContainer>
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigationFirstPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigationFirstPage.xaml.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Uno.UI.Samples.Controls;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using RefreshVisualizer = Microsoft.UI.Xaml.Controls.RefreshVisualizer;
+using RefreshVisualizerState = Microsoft.UI.Xaml.Controls.RefreshVisualizerState;
+using RefreshRequestedEventArgs = Microsoft.UI.Xaml.Controls.RefreshRequestedEventArgs;
+using RefreshInteractionRatioChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshInteractionRatioChangedEventArgs;
+using RefreshStateChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshStateChangedEventArgs;
+using RefreshPullDirection = Microsoft.UI.Xaml.Controls.RefreshPullDirection;
+using System.Threading.Tasks;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests
+{
+    public sealed partial class RefreshContainerNavigationFirstPage : Page
+    {
+        public RefreshContainerNavigationFirstPage()
+        {
+            this.InitializeComponent();
+
+			for (int i = 0; i < 40; i++)
+			{
+				var textBlock = new TextBlock()
+				{
+					Text = "Hello " + i,
+					FontSize = 40,
+					Margin = ThicknessHelper.FromUniformLength(20)
+				};
+				StackParent.Children.Add(textBlock);
+			}
+		}
+
+		private void ButtonClick(object sender, RoutedEventArgs e)
+		{
+			Frame.Navigate(typeof(RefreshContainerNavigationSecondPage));
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigationSecondPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigationSecondPage.xaml
@@ -1,0 +1,15 @@
+﻿<Page
+    x:Class="UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests.RefreshContainerNavigationSecondPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <Button Click="ButtonClick">Navigate back</Button>
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigationSecondPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerNavigationSecondPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Uno.UI.Samples.Controls;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using RefreshVisualizer = Microsoft.UI.Xaml.Controls.RefreshVisualizer;
+using RefreshVisualizerState = Microsoft.UI.Xaml.Controls.RefreshVisualizerState;
+using RefreshRequestedEventArgs = Microsoft.UI.Xaml.Controls.RefreshRequestedEventArgs;
+using RefreshInteractionRatioChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshInteractionRatioChangedEventArgs;
+using RefreshStateChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshStateChangedEventArgs;
+using RefreshPullDirection = Microsoft.UI.Xaml.Controls.RefreshPullDirection;
+using System.Threading.Tasks;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests
+{
+    public sealed partial class RefreshContainerNavigationSecondPage : Page
+    {
+        public RefreshContainerNavigationSecondPage()
+        {
+            this.InitializeComponent();
+		}
+		
+		private void ButtonClick(object sender, RoutedEventArgs e)
+		{
+			Frame.GoBack();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -273,6 +273,18 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerNavigation.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerNavigationFirstPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerNavigationSecondPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshVisualizerPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5013,6 +5025,15 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerScrollTop.xaml.cs">
       <DependentUpon>RefreshContainerScrollTop.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerNavigation.xaml.cs">
+      <DependentUpon>RefreshContainerNavigation.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerNavigationFirstPage.xaml.cs">
+      <DependentUpon>RefreshContainerNavigationFirstPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerNavigationSecondPage.xaml.cs">
+      <DependentUpon>RefreshContainerNavigationSecondPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshVisualizerPage.xaml.cs">
       <DependentUpon>RefreshVisualizerPage.xaml</DependentUpon>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/Native/RefreshContainer.iOS.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/Native/RefreshContainer.iOS.cs
@@ -90,6 +90,7 @@ public partial class RefreshContainer : ContentControl
 			_refreshControl.EndRefreshing();
 			_refreshSubscription.Disposable = null;
 		}
+		_nativeScrollViewAttachment.Disposable = null;
 	}
 
 	protected override void OnContentChanged(object oldValue, object newValue)
@@ -111,6 +112,8 @@ public partial class RefreshContainer : ContentControl
 		// Inject the UIRefreshControl into the first scrollable element found in the hierarchy		
 		if (this.FindFirstChild<UIScrollView>() is { } scrollView)
 		{
+			_nativeScrollViewAttachment.Disposable = null;
+
 			_ownerScrollView = scrollView;
 
 			foreach (var existingRefresh in scrollView.Subviews.OfType<NativeRefreshControl>())


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

After unloading `RefreshContainer`, reloading it again does not allow refreshing.

## What is the new behavior?

Refreshing is possible even after unloading and reloading.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
