### PR TITLE
fix: Ensure static registrar is enabled when the iOS simulator is used

### DIFF
--- a/build/uno.winui.common.targets
+++ b/build/uno.winui.common.targets
@@ -194,4 +194,22 @@
 					 Condition="'$(_CurrentTrimmedAndroidSDLVersion)' &lt; '$(UnoUIMinAndroidSDKVersion)'" />
 	</Target>
 
+	<!-- Validation for https://github.com/unoplatform/uno/issues/9430 and the static registrar requirement -->
+	<Target Name="_ValidateIOSStaticRegistrar"
+			BeforeTargets="BeforeBuild"
+			Condition="
+			'$(UnoDisableValidateIOSStaticRegistrar)'==''
+			and (
+				('$(TargetFramework)'=='net6.0-ios' and '$(RuntimeIdentifier)'=='iossimulator-x64')
+				or ('$(ProjectTypeGuids)'=='{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}' and '$(Platform)'=='iPhoneSimulator')
+			)
+			and (
+				'$(MtouchExtraArgs)'!=''
+				and !$(MtouchExtraArgs.Contains('--registrar:static'))
+				and !$(MtouchExtraArgs.Contains('--registrar=static'))
+			)
+			">
+		<Error Text="Building for the iOS Simulator requires the use of the static registrar. Make sure that `MtouchExtraArgs` contains `--registrar:static`. See https://github.com/unoplatform/uno/issues/9430 for more details." />
+	</Target>
+
 </Project>

--- a/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
+++ b/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
@@ -34,7 +34,39 @@
 	<PropertyGroup>
 		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
 	</PropertyGroup>
-	
+
+	<Choose>
+
+		<When Condition="'$(TargetFramework)'=='net6.0-ios'">
+			<PropertyGroup Condition="'$(TargetFramework)'=='net6.0-ios'">
+				<MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+
+				<!-- See https://github.com/unoplatform/uno/issues/9430 for more details. -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
+
+				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
+			</PropertyGroup>
+			<ItemGroup>
+				<PackageReference Include="Uno.Extensions.Logging.OSLog" Version="1.4.0" />
+			</ItemGroup>
+		</When>
+
+		<When Condition="'$(TargetFramework)'=='net6.0-maccatalyst'">
+			<PropertyGroup>
+				<!-- Configure the GC -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+
+				<!-- Required for unknown crash as of .NET 6 Mobile Preview 13 -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
+
+				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
+			</PropertyGroup>
+		</When>
+	</Choose>
+
+
 	<PropertyGroup Condition="'$(TargetFramework)'=='net6.0-ios'">
 		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
 	</PropertyGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Mobile/UnoQuickStart.Mobile.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Mobile/UnoQuickStart.Mobile.csproj
@@ -46,7 +46,10 @@
 		<When Condition="'$(TargetFramework)'=='net6.0-ios'">
 		  	<PropertyGroup Condition="'$(TargetFramework)'=='net6.0-ios'">
 				<MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
-								
+
+				<!-- See https://github.com/unoplatform/uno/issues/9430 for more details. -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
+
 				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
 				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
 			</PropertyGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate.net6/Mobile/UnoQuickStart.Mobile.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.net6/Mobile/UnoQuickStart.Mobile.csproj
@@ -43,6 +43,9 @@
 		<When Condition="'$(TargetFramework)'=='net6.0-ios'">
 		  	<PropertyGroup Condition="'$(TargetFramework)'=='net6.0-ios'">
 				<MtouchExtraArgs>$(MtouchExtraArgs) --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+
+				<!-- See https://github.com/unoplatform/uno/issues/9430 for more details. -->
+				<MtouchExtraArgs>$(MtouchExtraArgs) --registrar:static</MtouchExtraArgs>
 								
 				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
 				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>

--- a/src/SolutionTemplate/UnoSolutionTemplate/iOS/UnoQuickStart.iOS.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/iOS/UnoQuickStart.iOS.csproj
@@ -25,7 +25,7 @@
 		<MtouchArch>x86_64</MtouchArch>
 		<MtouchLink>None</MtouchLink>
 		<MtouchDebug>true</MtouchDebug>
-		<MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+		<MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep --registrar=static</MtouchExtraArgs>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
 		<DebugType>portable</DebugType>
@@ -36,7 +36,7 @@
 		<MtouchLink>None</MtouchLink>
 		<MtouchArch>x86_64</MtouchArch>
 		<ConsolePause>false</ConsolePause>
-		<MtouchExtraArgs>--setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
+		<MtouchExtraArgs>--setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep --registrar=static</MtouchExtraArgs>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
 		<DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/9430

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Fail the build when the static registrar is not detected when building for the iPhone Simulator.
- Adjusted templates to include static registrar requirement

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
