### PR TITLE
fix: Fix PasswordBox on WPF

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -236,6 +236,9 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 		private System.Windows.Controls.PasswordBox CreatePasswordControl()
 		{
 			var passwordBox = new System.Windows.Controls.PasswordBox();
+			passwordBox.BorderBrush = System.Windows.Media.Brushes.Transparent;
+			passwordBox.Background = System.Windows.Media.Brushes.Transparent;
+			passwordBox.BorderThickness = new Thickness(0);
 			passwordBox.PasswordChanged += PasswordBoxViewPasswordChanged;
 			return passwordBox;
 		}

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -311,11 +311,13 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			if (_currentTextBoxInputWidget != null)
 			{
 				_currentTextBoxInputWidget.Foreground = wpfBrush;
+				_currentTextBoxInputWidget.CaretBrush = wpfBrush;
 			}
 
 			if (_currentPasswordBoxInputWidget != null)
 			{
 				_currentPasswordBoxInputWidget.Foreground = wpfBrush;
+				_currentPasswordBoxInputWidget.CaretBrush = wpfBrush;
 			}
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextBoxViewExtension.cs
@@ -3,9 +3,7 @@
 using System;
 using System.Windows;
 using Windows.UI.Xaml.Controls;
-using Uno.Disposables;
 using Uno.UI.Runtime.Skia.WPF.Controls;
-using Uno.UI.Skia.Platform;
 using Uno.UI.Xaml.Controls.Extensions;
 using Point = Windows.Foundation.Point;
 using WpfCanvas = System.Windows.Controls.Canvas;
@@ -17,11 +15,17 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 	{
 		private readonly TextBoxView _owner;
 		private ContentControl? _contentElement;
-		private WpfTextViewTextBox? _currentInputWidget;
+
+		private WpfTextViewTextBox? _currentTextBoxInputWidget;
+		private System.Windows.Controls.PasswordBox? _currentPasswordBoxInputWidget;
+
+		private readonly bool _isPasswordBox;
+		private bool _isPasswordRevealed;
 
 		public TextBoxViewExtension(TextBoxView owner)
 		{
 			_owner = owner ?? throw new ArgumentNullException(nameof(owner));
+			_isPasswordBox = owner.TextBox is PasswordBox;
 		}
 
 		private WpfCanvas? GetWindowTextInputLayer()
@@ -53,7 +57,14 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 
 			if (textInputLayer.Children.Count == 0)
 			{
-				textInputLayer.Children.Add(_currentInputWidget!);
+				textInputLayer.Children.Add(_currentTextBoxInputWidget!);
+
+				if (_isPasswordBox)
+				{
+					textInputLayer.Children.Add(_currentPasswordBoxInputWidget!);
+					_currentPasswordBoxInputWidget!.Visibility = _isPasswordRevealed ? Visibility.Collapsed : Visibility.Visible;
+					_currentTextBoxInputWidget!.Visibility = _isPasswordRevealed ? Visibility.Visible : Visibility.Collapsed;
+				}
 			}
 
 			UpdateNativeView();
@@ -61,31 +72,45 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 
 			InvalidateLayout();
 
-			_currentInputWidget!.Focus();
+			if (_isPasswordBox && !_isPasswordRevealed)
+			{
+				_currentPasswordBoxInputWidget!.Focus();
+			}
+			else
+			{
+				_currentTextBoxInputWidget!.Focus();
+			}
 		}
 
 		public void EndEntry()
 		{
-			if (_currentInputWidget is null)
+			if (_currentTextBoxInputWidget is null)
 			{
 				// No entry is in progress.
 				return;
 			}
 
-			if (GetInputText() is { } inputText)
-			{
-				_owner.UpdateTextFromNative(inputText);
-			}
+			_owner.UpdateTextFromNative(_currentTextBoxInputWidget.Text);
 
 			_contentElement = null;
 
 			var textInputLayer = GetWindowTextInputLayer();
-			textInputLayer?.Children.Remove(_currentInputWidget);
+			if (textInputLayer is null)
+			{
+				return;
+			}
+
+			textInputLayer.Children.Remove(_currentTextBoxInputWidget);
+
+			if (_currentPasswordBoxInputWidget is not null)
+			{
+				textInputLayer.Children.Remove(_currentPasswordBoxInputWidget);
+			}
 		}
 
 		public void UpdateNativeView()
 		{
-			if (_currentInputWidget == null)
+			if ((_isPasswordBox && _currentPasswordBoxInputWidget == null) || _currentTextBoxInputWidget == null)
 			{
 				// If the input widget does not exist, we don't need to update it.
 				return;
@@ -98,15 +123,33 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 				return;
 			}
 
-			EnsureWidgetForAcceptsReturn();
+			updateCommon(_currentTextBoxInputWidget);
+			updateCommon(_currentPasswordBoxInputWidget);
 
-			_currentInputWidget.FontSize = textBox.FontSize;
-			_currentInputWidget.FontWeight = FontWeight.FromOpenTypeWeight(textBox.FontWeight.Weight);
-			_currentInputWidget.AcceptsReturn = textBox.AcceptsReturn;
-			_currentInputWidget.TextWrapping = textBox.AcceptsReturn ? TextWrapping.Wrap : TextWrapping.NoWrap;
-			_currentInputWidget.MaxLength = textBox.MaxLength;
-			_currentInputWidget.IsReadOnly = textBox.IsReadOnly;
-			_currentInputWidget.Foreground = textBox.Foreground.ToWpfBrush();
+			if (_currentTextBoxInputWidget is not null)
+			{
+				_currentTextBoxInputWidget.AcceptsReturn = textBox.AcceptsReturn;
+				_currentTextBoxInputWidget.TextWrapping = textBox.AcceptsReturn ? TextWrapping.Wrap : TextWrapping.NoWrap;
+				_currentTextBoxInputWidget.MaxLength = textBox.MaxLength;
+				_currentTextBoxInputWidget.IsReadOnly = textBox.IsReadOnly;
+			}
+
+			if (_currentPasswordBoxInputWidget is not null)
+			{
+				_currentPasswordBoxInputWidget.MaxLength = textBox.MaxLength;
+			}
+
+			void updateCommon(System.Windows.Controls.Control? control)
+			{
+				if (control is null)
+				{
+					return;
+				}
+
+				control.FontSize = textBox.FontSize;
+				control.FontWeight = FontWeight.FromOpenTypeWeight(textBox.FontWeight.Weight);
+				control.Foreground = textBox.Foreground.ToWpfBrush();
+			}
 		}
 
 		public void InvalidateLayout()
@@ -118,46 +161,69 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 		public void UpdateSize()
 		{
 			var textInputLayer = GetWindowTextInputLayer();
-			if (_contentElement == null || _currentInputWidget == null || textInputLayer == null)
+			if (_contentElement == null|| textInputLayer == null)
 			{
 				return;
 			}
 
-			if (textInputLayer.Children.Contains(_currentInputWidget))
+			updateSizeCore(_currentTextBoxInputWidget);
+			updateSizeCore(_currentPasswordBoxInputWidget);
+
+			void updateSizeCore(FrameworkElement? frameworkElement)
 			{
-				_currentInputWidget.Width = _contentElement.ActualWidth;
-				_currentInputWidget.Height = _contentElement.ActualHeight;
+				if (frameworkElement is not null && textInputLayer.Children.Contains(frameworkElement))
+				{
+					frameworkElement.Width = _contentElement.ActualWidth;
+					frameworkElement.Height = _contentElement.ActualHeight;
+				}
 			}
 		}
 
 		public void UpdatePosition()
 		{
 			var textInputLayer = GetWindowTextInputLayer();
-			if (_contentElement == null || _currentInputWidget == null || textInputLayer == null)
+			if (_contentElement == null || textInputLayer == null)
 			{
 				return;
 			}
 
 			var transformToRoot = _contentElement.TransformToVisual(Windows.UI.Xaml.Window.Current.Content);
 			var point = transformToRoot.TransformPoint(new Point(0, 0));
-			if (textInputLayer.Children.Contains(_currentInputWidget))
+
+			updatePositionCore(_currentTextBoxInputWidget);
+			updatePositionCore(_currentPasswordBoxInputWidget);
+
+			void updatePositionCore(FrameworkElement? frameworkElement)
 			{
-				WpfCanvas.SetLeft(_currentInputWidget, point.X);
-				WpfCanvas.SetTop(_currentInputWidget, point.Y);
+				if (frameworkElement is not null && textInputLayer.Children.Contains(frameworkElement))
+				{
+					WpfCanvas.SetLeft(frameworkElement, point.X);
+					WpfCanvas.SetTop(frameworkElement, point.Y);
+				}
 			}
 		}
 
 		public void SetTextNative(string text)
 		{
-			if (_currentInputWidget != null)
+			if (_currentTextBoxInputWidget != null && _currentTextBoxInputWidget.Text != text)
 			{
-				_currentInputWidget.Text = text;
+				_currentTextBoxInputWidget.Text = text;
+			}
+
+			if (_currentPasswordBoxInputWidget != null && _currentPasswordBoxInputWidget.Password != text)
+			{
+				_currentPasswordBoxInputWidget.Password = text;
 			}
 		}
 
 		private void EnsureWidgetForAcceptsReturn()
 		{
-			_currentInputWidget ??= CreateInputControl();
+			_currentTextBoxInputWidget ??= CreateInputControl();
+			if (_isPasswordBox)
+			{
+				_currentPasswordBoxInputWidget ??= CreatePasswordControl();
+				_currentTextBoxInputWidget.Visibility = Visibility.Collapsed;
+			}
 		}
 
 		private WpfTextViewTextBox CreateInputControl()
@@ -167,40 +233,86 @@ namespace Uno.UI.Runtime.Skia.WPF.Extensions.UI.Xaml.Controls
 			return textView;
 		}
 
-		private void WpfTextViewTextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+		private System.Windows.Controls.PasswordBox CreatePasswordControl()
 		{
-			if (_currentInputWidget != null)
-			{
-				_owner.UpdateTextFromNative(_currentInputWidget.Text);
-			}
+			var passwordBox = new System.Windows.Controls.PasswordBox();
+			passwordBox.PasswordChanged += PasswordBoxViewPasswordChanged;
+			return passwordBox;
 		}
 
-		private string? GetInputText() => _currentInputWidget?.Text;
+		private void PasswordBoxViewPasswordChanged(object sender, System.Windows.RoutedEventArgs e)
+		{
+			_owner.UpdateTextFromNative(_currentPasswordBoxInputWidget!.Password);
+		}
+
+		private void WpfTextViewTextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+		{
+			_owner.UpdateTextFromNative(_currentTextBoxInputWidget!.Text);
+		}
 
 		public void SetIsPassword(bool isPassword)
 		{
-			// No support for now.
+			_isPasswordRevealed = !isPassword;
+			if (_owner.TextBox is { } textBox)
+			{
+				if (_currentTextBoxInputWidget is not null)
+				{
+					_currentTextBoxInputWidget.Visibility = isPassword ? Visibility.Collapsed : Visibility.Visible;
+					if (_currentPasswordBoxInputWidget is not null)
+					{
+						_currentPasswordBoxInputWidget.Visibility = isPassword ? Visibility.Visible : Visibility.Collapsed;
+					}
+					
+				}
+			}
 		}
 
 		public void Select(int start, int length)
 		{
-			if (_currentInputWidget == null)
+			if (_isPasswordBox)
+			{
+				return;
+			}
+
+			if (_currentTextBoxInputWidget == null)
 			{
 				this.StartEntry();
 			}
 
-			_currentInputWidget!.Select(start, length);
+			_currentTextBoxInputWidget!.Select(start, length);
 		}
 
-		public int GetSelectionStart() => _currentInputWidget?.SelectionStart ?? 0;
+		public int GetSelectionStart()
+		{
+			if (!_isPasswordBox)
+			{
+				return _currentTextBoxInputWidget?.SelectionStart ?? 0;
+			}
 
-		public int GetSelectionLength() => _currentInputWidget?.SelectionLength ?? 0;
+			return 0;
+		}
+
+		public int GetSelectionLength()
+		{
+			if (!_isPasswordBox)
+			{
+				return _currentTextBoxInputWidget?.SelectionLength ?? 0;
+			}
+
+			return 0;
+		}
 
 		public void SetForeground(Windows.UI.Xaml.Media.Brush brush)
 		{
-			if (_currentInputWidget != null)
+			var wpfBrush = brush.ToWpfBrush();
+			if (_currentTextBoxInputWidget != null)
 			{
-				_currentInputWidget.Foreground = brush.ToWpfBrush();
+				_currentTextBoxInputWidget.Foreground = wpfBrush;
+			}
+
+			if (_currentPasswordBoxInputWidget != null)
+			{
+				_currentPasswordBoxInputWidget.Foreground = wpfBrush;
 			}
 		}
 	}

--- a/src/Uno.UI.Runtime.Skia.Wpf/Themes/Generic.xaml
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Themes/Generic.xaml
@@ -2,8 +2,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:platform="clr-namespace:Uno.UI.Skia.Platform"
-    xmlns:controls="clr-namespace:Uno.UI.Runtime.Skia.WPF.Controls"
-	xmlns:wpf="clr-namespace:System.Windows.Controls">
+    xmlns:controls="clr-namespace:Uno.UI.Runtime.Skia.WPF.Controls">
 
     <Style TargetType="{x:Type platform:WpfHost}">
         <Setter Property="Template">
@@ -54,40 +53,4 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
-
-	<!--<Style TargetType="{x:Type wpf:PasswordBox}">
-		<Setter Property="SnapsToDevicePixels" Value="True" />
-		<Setter Property="KeyboardNavigation.TabNavigation" Value="None" />
-		<Setter Property="FocusVisualStyle" Value="{x:Null}" />
-		<Setter Property="MinWidth" Value="0" />
-		<Setter Property="MinHeight" Value="0" />
-		<Setter Property="AllowDrop" Value="true" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type wpf:PasswordBox}">
-					<Border Name="Border"
-							CornerRadius="0"
-							Margin="{TemplateBinding Margin}"
-							Padding="{TemplateBinding Padding}"
-							BorderThickness="0">
-						<Border.Background>
-							<SolidColorBrush Color="Transparent" />
-						</Border.Background>
-						<Border.BorderBrush>
-							<SolidColorBrush Color="Transparent" />
-						</Border.BorderBrush>
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Normal" />
-								<VisualState x:Name="Disabled" />
-								<VisualState x:Name="ReadOnly" />
-								<VisualState x:Name="MouseOver" />
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-						<ScrollViewer Margin="0" x:Name="PART_ContentHost" />
-					</Border>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>-->
 </ResourceDictionary>

--- a/src/Uno.UI.Runtime.Skia.Wpf/Themes/Generic.xaml
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Themes/Generic.xaml
@@ -2,7 +2,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:platform="clr-namespace:Uno.UI.Skia.Platform"
-    xmlns:controls="clr-namespace:Uno.UI.Runtime.Skia.WPF.Controls">
+    xmlns:controls="clr-namespace:Uno.UI.Runtime.Skia.WPF.Controls"
+	xmlns:wpf="clr-namespace:System.Windows.Controls">
 
     <Style TargetType="{x:Type platform:WpfHost}">
         <Setter Property="Template">
@@ -53,4 +54,40 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+
+	<!--<Style TargetType="{x:Type wpf:PasswordBox}">
+		<Setter Property="SnapsToDevicePixels" Value="True" />
+		<Setter Property="KeyboardNavigation.TabNavigation" Value="None" />
+		<Setter Property="FocusVisualStyle" Value="{x:Null}" />
+		<Setter Property="MinWidth" Value="0" />
+		<Setter Property="MinHeight" Value="0" />
+		<Setter Property="AllowDrop" Value="true" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type wpf:PasswordBox}">
+					<Border Name="Border"
+							CornerRadius="0"
+							Margin="{TemplateBinding Margin}"
+							Padding="{TemplateBinding Padding}"
+							BorderThickness="0">
+						<Border.Background>
+							<SolidColorBrush Color="Transparent" />
+						</Border.Background>
+						<Border.BorderBrush>
+							<SolidColorBrush Color="Transparent" />
+						</Border.BorderBrush>
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="Disabled" />
+								<VisualState x:Name="ReadOnly" />
+								<VisualState x:Name="MouseOver" />
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+						<ScrollViewer Margin="0" x:Name="PART_ContentHost" />
+					</Border>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</Style>-->
 </ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9544


https://user-images.githubusercontent.com/31348972/186964932-e1424a30-28ad-4976-8da7-59cdec15a299.mp4

Needs a bit of improvement. @MartinZikmund Since you worked on something similar, can you help with what's remaining?


## PR Type

What kind of change does this PR introduce?


- Bugfix

## What is the current behavior?

WPF is not obscuring password in PasswordBox.


## What is the new behavior?

WPF is now obscuring password in PasswordBox.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
