### PR TITLE
Setting DP to UnsetValue should clear bindings

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
@@ -1815,6 +1815,17 @@ namespace Uno.UI.Tests.BinderTests
 			Assert.AreEqual(42, SUT.GetValue(MyDependencyObjectWithDefaultValueOverride.MyPropertyProperty));
 		}
 
+		[TestMethod]
+		public void ClearValue()
+		{
+			var SUT = new MainPage();
+			Assert.AreEqual(true, SUT.MyCheckBox.IsChecked);
+			Assert.AreEqual(true, SUT.MyModel.IsChecked);
+			SUT.MyButton.RaiseClick();
+			Assert.AreEqual(false, SUT.MyCheckBox.IsChecked);
+			Assert.AreEqual(true, SUT.MyModel.IsChecked);
+		}
+
 		private class MyDependencyObject : FrameworkElement
 		{
 			internal static readonly DependencyProperty PropAProperty = DependencyProperty.Register(
@@ -2075,4 +2086,72 @@ namespace Uno.UI.Tests.BinderTests
 
 
 	#endregion
+    public sealed partial class MainPage : Page
+	{
+		public readonly Button MyButton;
+		public readonly CheckBox MyCheckBox;
+		public readonly Model MyModel;
+
+		public class Model
+		{
+			private bool isChecked = true;
+
+			public bool IsChecked
+			{
+				get => isChecked;
+				set
+				{
+					if (isChecked == value)
+						return;
+
+					isChecked = value;                                                              // !!! place breakpoint here to see the difference between WASM and WindowsAppSDK
+				}
+			}
+		}
+
+		public MainPage()
+		{
+			MyCheckBox = new CheckBox();
+			MyCheckBox.Unchecked += CheckBox_CheckedChanged;
+			MyCheckBox.Checked += CheckBox_CheckedChanged;
+			MyButton = new Button
+			{
+				Content = "Click me",
+			};
+			MyModel = new Model();
+			Content = new StackPanel
+			{
+				Orientation = Orientation.Horizontal,
+				Children =
+				{
+					MyCheckBox.Bind(MyModel, nameof(Model.IsChecked)),
+					MyButton.OnClick((s, e) => MyCheckBox.ClearValue(CheckBox.IsCheckedProperty)),     // !!! this will set Model.IsChecked = false, which is wrong. It only should 'remove' the binding,
+				}
+			};
+		}
+
+		private void CheckBox_CheckedChanged(object sender, RoutedEventArgs e) { }
+	}
+
+	public static class Extensions
+	{
+		public static TElement Bind<TElement>(this TElement element, object source, string path = null, IValueConverter converter = null, object converterParameter = null, BindingMode mode = BindingMode.TwoWay) where TElement : FrameworkElement
+		{
+			element.SetBinding(CheckBox.IsCheckedProperty, new Binding
+			{
+				Converter = converter,
+				ConverterParameter = converterParameter ?? element,
+				Mode = mode,
+				Path = string.IsNullOrEmpty(path) ? null : new PropertyPath(path),
+				Source = source ?? element,
+			});
+			return element;
+		}
+
+		public static TElement OnClick<TElement>(this TElement element, RoutedEventHandler handler) where TElement : Button
+		{
+			element.Click += handler;
+			return element;
+		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -564,7 +564,7 @@ namespace Windows.UI.Xaml
 
 		private void OnDependencyPropertyChanged(DependencyPropertyDetails propertyDetails, DependencyPropertyChangedEventArgs args, bool isUnsetValue)
 		{
-			if (isUnsetValue && propertyDetails.GetBinding() is not { ParentBinding.RelativeSource.Mode: RelativeSourceMode.TemplatedParent })
+			if (isUnsetValue && args.OldPrecedence == DependencyPropertyValuePrecedences.Local)
 			{
 				propertyDetails.ClearBinding();
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -509,7 +509,7 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// Sets the specified source <paramref name="value"/> on <paramref name="property"/>
 		/// </summary>
-		internal void SetBindingValue(DependencyPropertyDetails propertyDetails, object value)
+		private void SetBindingValue(DependencyPropertyDetails propertyDetails, object value)
 		{
 			var unregisteringInheritedProperties = _unregisteringInheritedProperties || _parentUnregisteringInheritedProperties;
 			if (unregisteringInheritedProperties)
@@ -562,9 +562,17 @@ namespace Windows.UI.Xaml
 			return null;
 		}
 
-		private void OnDependencyPropertyChanged(DependencyPropertyDetails propertyDetails, DependencyPropertyChangedEventArgs args)
+		private void OnDependencyPropertyChanged(DependencyPropertyDetails propertyDetails, DependencyPropertyChangedEventArgs args, bool isUnsetValue)
 		{
-			SetBindingValue(propertyDetails, args.NewValue);
+			if (isUnsetValue)
+			{
+				propertyDetails.ClearBinding();
+			}
+			else
+			{
+				SetBindingValue(propertyDetails, args.NewValue);
+			}
+
 
 			GetPropertyInheritanceConfiguration(
 				propertyDetails: propertyDetails,

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -564,7 +564,7 @@ namespace Windows.UI.Xaml
 
 		private void OnDependencyPropertyChanged(DependencyPropertyDetails propertyDetails, DependencyPropertyChangedEventArgs args, bool isUnsetValue)
 		{
-			if (isUnsetValue)
+			if (isUnsetValue && propertyDetails.GetBinding() is not { ParentBinding.RelativeSource.Mode: RelativeSourceMode.TemplatedParent })
 			{
 				propertyDetails.ClearBinding();
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -498,7 +498,7 @@ namespace Windows.UI.Xaml
 						);
 					}
 
-					RaiseCallbacks(actualInstanceAlias, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence);
+					RaiseCallbacks(actualInstanceAlias, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence, value == DependencyProperty.UnsetValue);
 				}
 #if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
 				finally
@@ -1714,7 +1714,8 @@ namespace Windows.UI.Xaml
 			object? previousValue,
 			DependencyPropertyValuePrecedences previousPrecedence,
 			object? newValue,
-			DependencyPropertyValuePrecedences newPrecedence
+			DependencyPropertyValuePrecedences newPrecedence,
+			bool isUnsetValue
 		)
 		{
 			var hasPropagationBypass = _propagationBypass.Count != 0 || _propagationBypassed.Count != 0;
@@ -1731,7 +1732,7 @@ namespace Windows.UI.Xaml
 					_propagationBypassed[propertyPath!] = previousValue;
 				}
 
-				InvokeCallbacks(actualInstanceAlias, propertyDetails.Property, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence, bypassesPropagation);
+				InvokeCallbacks(actualInstanceAlias, propertyDetails.Property, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence, isUnsetValue, bypassesPropagation);
 			}
 			else if (
 				hasPropagationBypass
@@ -1744,7 +1745,7 @@ namespace Windows.UI.Xaml
 				var unpropagatedPrevious = _propagationBypassed[propertyPath!];
 				_propagationBypassed.Remove(propertyPath!);
 
-				InvokeCallbacks(actualInstanceAlias, propertyDetails.Property, propertyDetails, unpropagatedPrevious, previousPrecedence, newValue, newPrecedence);
+				InvokeCallbacks(actualInstanceAlias, propertyDetails.Property, propertyDetails, unpropagatedPrevious, previousPrecedence, newValue, newPrecedence, isUnsetValue);
 			}
 			else if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 			{
@@ -1762,6 +1763,7 @@ namespace Windows.UI.Xaml
 			DependencyPropertyValuePrecedences previousPrecedence,
 			object? newValue,
 			DependencyPropertyValuePrecedences newPrecedence,
+			bool isUnsetValue,
 			bool bypassesPropagation = false
 		)
 		{
@@ -1824,7 +1826,7 @@ namespace Windows.UI.Xaml
 			propertyMetadata.RaisePropertyChanged(actualInstanceAlias, eventArgs);
 
 			// Ensure binding is propagated
-			OnDependencyPropertyChanged(propertyDetails, eventArgs);
+			OnDependencyPropertyChanged(propertyDetails, eventArgs, isUnsetValue);
 
 			// Raise the common property change callback of WinUI
 			// This is raised *after* the data bound properties are updated


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9640

## PR Type

What kind of change does this PR introduce?


- Bugfix

## What is the current behavior?

Calling `ClearValue` or `SetValue` with `DependencyProperty.UnsetValue` doesn't clear bindings.


## What is the new behavior?

Binding is cleared, as in UWP


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
