### PR TITLE
feat: Add the ability to disable `_knownMissingTypes` validation

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -225,7 +225,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 
 					GenerateTypeTable(writer);
 
-					writer.AppendLineInvariant(@"#if DEBUG");
+					writer.AppendLineInvariant(@"#if DEBUG && !UNO_DISABLE_KNOWN_MISSING_TYPES");
 					writer.AppendLineInvariant(@"private global::System.Collections.Generic.List<global::System.Type> _knownMissingTypes = new global::System.Collections.Generic.List<global::System.Type>();");
 					writer.AppendLineInvariant(@"#endif");
 
@@ -641,7 +641,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 				{
 					writer.AppendLineInvariant(@"var bindableType = GetBindableTypeByFullName(type.FullName);");
 
-					writer.AppendLineInvariant(@"#if DEBUG");
+					writer.AppendLineInvariant(@"#if DEBUG && !UNO_DISABLE_KNOWN_MISSING_TYPES");
 					using (writer.BlockInvariant(@"lock(_knownMissingTypes)"))
 					{
 						using (writer.BlockInvariant(@"if(bindableType == null && !_knownMissingTypes.Contains(type) && !type.IsGenericType && !type.IsAbstract)"))


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Known missing types validation can be disabled by defining the `UNO_DISABLE_KNOWN_MISSING_TYPES` constant.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
