### PR TITLE
fix(skia): Fail safe on invariant culture

### DIFF
--- a/src/Uno.UWP/Globalization/ApplicationLanguages.cs
+++ b/src/Uno.UWP/Globalization/ApplicationLanguages.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Uno.Foundation.Logging;
 using Uno.UI;
 
 namespace Windows.Globalization
@@ -79,11 +80,28 @@ namespace Windows.Globalization
 				Languages = languages.Distinct().ToArray();
 			}
 
-			var primaryLanguage = Languages.First();
-			var primaryCulture = CreateCulture(primaryLanguage);
+			var primaryLanguage = Languages.FirstOrDefault();
 
-			CultureInfo.CurrentCulture = primaryCulture;
-			CultureInfo.CurrentUICulture = primaryCulture;
+			if(primaryLanguage is not null)
+			{
+				if (typeof(ApplicationLanguages).Log().IsEnabled(LogLevel.Debug))
+				{
+					typeof(ApplicationLanguages).Log().Debug($"Using {primaryLanguage} as primary language");
+				}
+
+				var primaryCulture = CreateCulture(primaryLanguage);
+
+				CultureInfo.CurrentCulture = primaryCulture;
+				CultureInfo.CurrentUICulture = primaryCulture;
+			}
+			else
+			{
+				if (typeof(ApplicationLanguages).Log().IsEnabled(LogLevel.Warning))
+				{
+					typeof(ApplicationLanguages).Log().Warn($"Unable to determine the default culture, using invariant culture");
+				}
+			}
+
 		}
 
 		private static Regex _cultureFormatRegex;


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9652

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Failure do detect current culture does raise an exception, uses invariant culture instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
