### PR TITLE
fix(generators): Don't run `TSBindingsGenerator` and `DependencyPropertyGenerator` outside of Uno.UI

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyPropertyGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyPropertyGenerator.cs
@@ -25,7 +25,10 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 
 		public void Execute(GeneratorExecutionContext context)
 		{
-			if (PlatformHelper.IsValidPlatform(context))
+			if (PlatformHelper.IsValidPlatform(context)
+
+				// This generator is only valid inside of Uno.UI
+				&& (context.Compilation.AssemblyName?.Equals("Uno.UI", StringComparison.OrdinalIgnoreCase) ?? false))
 			{
 				var visitor = new SerializationMethodsGenerator(context);
 				visitor.Visit(context.Compilation.SourceModule);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/TSBindings/TSBindingsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/TSBindings/TSBindingsGenerator.cs
@@ -34,7 +34,11 @@ namespace Uno.UI.SourceGenerators.TSBindings
 
 		public void Execute(GeneratorExecutionContext context)
 		{
-			if (!DesignTimeHelper.IsDesignTime(context) && PlatformHelper.IsValidPlatform(context))
+			if (!DesignTimeHelper.IsDesignTime(context)
+				&& PlatformHelper.IsValidPlatform(context)
+
+				// This generator is only valid inside of Uno.UI
+				&& context.Compilation.AssemblyName.Equals("Uno.UI", StringComparison.OrdinalIgnoreCase))
 			{
 				_bindingsPaths = context.GetMSBuildPropertyValue("TSBindingsPath")?.ToString();
 				_sourceAssemblies = context.GetMSBuildItems("TSBindingAssemblySource").Select(i => i.Identity).ToArray();


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9018

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

`TSBindingsGenerator` and `DependencyPropertyGenerator` should not run outside of Uno.UI as they depend on internal attributes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
