### PR TITLE
feat: Use `NameProperty` in Skia and WASM

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -19,6 +19,7 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Private.Infrastructure;
 using MUXControlsTestApp.Utilities;
+using Windows.UI.Xaml.Automation;
 #if __IOS__
 using UIKit;
 #endif
@@ -580,6 +581,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			panel.Children.Add(tbNativeTyped);
 
 			Assert.AreEqual(1, panel.Children.Count);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Set_Name()
+		{
+			var SUT = new FrameworkElement();
+			SUT.Name = "Test";
+			var dpName = SUT.GetValue(FrameworkElement.NameProperty);
+			Assert.AreEqual("Test", dpName);
+			var automationId = SUT.GetValue(AutomationProperties.AutomationIdProperty);
+			Assert.AreEqual("Test", automationId);
+		}
+		
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Set_NameProperty()
+		{
+			var SUT = new FrameworkElement();
+			SUT.SetValue(FrameworkElement.NameProperty, "Test");
+			var name = SUT.Name;
+			Assert.AreEqual("Test", name);
+			var automationId = SUT.GetValue(AutomationProperties.AutomationIdProperty);
+			Assert.AreEqual("Test", automationId);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -587,24 +587,20 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_Set_Name()
 		{
-			var SUT = new FrameworkElement();
+			var SUT = new Border();
 			SUT.Name = "Test";
 			var dpName = SUT.GetValue(FrameworkElement.NameProperty);
 			Assert.AreEqual("Test", dpName);
-			var automationId = SUT.GetValue(AutomationProperties.AutomationIdProperty);
-			Assert.AreEqual("Test", automationId);
 		}
 		
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_Set_NameProperty()
 		{
-			var SUT = new FrameworkElement();
+			var SUT = new Border();
 			SUT.SetValue(FrameworkElement.NameProperty, "Test");
 			var name = SUT.Name;
 			Assert.AreEqual("Test", name);
-			var automationId = SUT.GetValue(AutomationProperties.AutomationIdProperty);
-			Assert.AreEqual("Test", automationId);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
@@ -277,8 +277,8 @@ namespace Windows.UI.Xaml
 			typeof(global::Windows.UI.Xaml.FrameworkElement), 
 			new FrameworkPropertyMetadata(default(double)));
 		#endif
-		#if false || false || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
+		#if false || false || NET461 || false || false || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("NET461", "__NETSTD_REFERENCE__")]
 		public static global::Windows.UI.Xaml.DependencyProperty NameProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			nameof(Name), typeof(string), 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.skia.cs
@@ -63,6 +63,11 @@ namespace Windows.UI.Xaml
 			_renderTransform?.UpdateSize(args.NewSize);
 		}
 
+		/// <summary>
+		/// Identifies the Name dependency property.
+		/// </summary>
+		public static new DependencyProperty NameProperty => UIElement.NameProperty;
+
 		#region Margin Dependency Property
 		[GeneratedDependencyProperty(
 			Options = FrameworkPropertyMetadataOptions.AutoConvert | FrameworkPropertyMetadataOptions.AffectsMeasure

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -234,6 +234,11 @@ namespace Windows.UI.Xaml
 
 		internal override bool IsEnabledOverride() => IsEnabled && base.IsEnabledOverride();
 
+		/// <summary>
+		/// Identifies the Name dependency property.
+		/// </summary>
+		public static new DependencyProperty NameProperty => UIElement.NameProperty;
+
 		#region Margin Dependency Property
 		[GeneratedDependencyProperty(
 			Options = FrameworkPropertyMetadataOptions.AutoConvert | FrameworkPropertyMetadataOptions.AffectsMeasure

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -17,6 +17,7 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Uno.UI.Xaml.Input;
 using Uno.UI.Xaml.Core;
 using Uno.UI.DataBinding;
+using Uno.UI.Xaml;
 
 namespace Windows.UI.Xaml
 {
@@ -215,7 +216,26 @@ namespace Windows.UI.Xaml
 
 		internal UIElement FindFirstChild() => _children.FirstOrDefault();
 
-		public string Name { get; set; }
+		#region Name Dependency Property
+
+		private void OnNameChanged(string oldValue, string newValue)
+		{
+			if (FrameworkElementHelper.IsUiAutomationMappingEnabled)
+			{
+				Windows.UI.Xaml.Automation.AutomationProperties.SetAutomationId(this, newValue);
+			}
+		}
+
+		[GeneratedDependencyProperty(DefaultValue = "", ChangedCallback = true)]
+		internal static DependencyProperty NameProperty { get; } = CreateNameProperty();
+
+		public string Name
+		{
+			get => GetNameValue();
+			set => SetNameValue(value);
+		}
+
+		#endregion
 
 		partial void InitializeCapture();
 

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -342,14 +342,26 @@ namespace Windows.UI.Xaml
 		}
 
 		private Rect _arranged;
-		private string _name;
+
+		#region Name Dependency Property
+
+		private void OnNameChanged(string oldValue, string newValue)
+		{
+			if (FrameworkElementHelper.IsUiAutomationMappingEnabled)
+			{
+				Windows.UI.Xaml.Automation.AutomationProperties.SetAutomationId(this, newValue);
+			}
+		}
+
+		[GeneratedDependencyProperty(DefaultValue = "", ChangedCallback = true)]
+		public static DependencyProperty NameProperty { get; } = CreateNameProperty();
 
 		public string Name
 		{
-			get => _name;
+			get => GetNameValue();
 			set
 			{
-				_name = value;
+				SetNameValue(value);
 
 				if (FeatureConfiguration.UIElement.AssignDOMXamlName)
 				{
@@ -357,6 +369,8 @@ namespace Windows.UI.Xaml
 				}
 			}
 		}
+		
+		#endregion
 
 		partial void OnUidChangedPartial()
 		{

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -365,7 +365,7 @@ namespace Windows.UI.Xaml
 
 				if (FeatureConfiguration.UIElement.AssignDOMXamlName)
 				{
-					Uno.UI.Xaml.WindowManagerInterop.SetName(HtmlId, _name);
+					Uno.UI.Xaml.WindowManagerInterop.SetName(HtmlId, value);
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -351,6 +351,11 @@ namespace Windows.UI.Xaml
 			{
 				Windows.UI.Xaml.Automation.AutomationProperties.SetAutomationId(this, newValue);
 			}
+			
+			if (FeatureConfiguration.UIElement.AssignDOMXamlName)
+			{
+				Uno.UI.Xaml.WindowManagerInterop.SetName(HtmlId, newValue);
+			}
 		}
 
 		[GeneratedDependencyProperty(DefaultValue = "", ChangedCallback = true)]
@@ -359,15 +364,7 @@ namespace Windows.UI.Xaml
 		public string Name
 		{
 			get => GetNameValue();
-			set
-			{
-				SetNameValue(value);
-
-				if (FeatureConfiguration.UIElement.AssignDOMXamlName)
-				{
-					Uno.UI.Xaml.WindowManagerInterop.SetName(HtmlId, value);
-				}
-			}
+			set => SetNameValue(value);
 		}
 		
 		#endregion


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8633

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Previously `NameProperty` was not used on Skia and WASM, so setting `Name` did not change its value.

## What is the new behavior?

`NameProperty` is used as backing store for `Name` and their changes also affect `AutomationIdProperty`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.