### PR TITLE
Misc performance improvements in XAML generation

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -67,12 +67,18 @@
     Force the compilation using Roslyn Generators on net6.0 and later
     -->
     <UnoUIUseRoslynSourceGenerators Condition="$(TargetFramework.StartsWith('net6'))">true</UnoUIUseRoslynSourceGenerators>
-	  
-    <!--
+
+	<!--
     Force the compilation using Roslyn Generators on net461 (Unit Tests)
     -->
-    <UnoUIUseRoslynSourceGenerators Condition="'$(TargetFramework)'=='net461'">true</UnoUIUseRoslynSourceGenerators>
-  </PropertyGroup>
+	  <UnoUIUseRoslynSourceGenerators Condition="'$(TargetFramework)'=='net461'">true</UnoUIUseRoslynSourceGenerators>
+	  
+    <!--
+    Force the compilation using Roslyn Generators for Skia targets
+    -->
+    
+    <UnoUIUseRoslynSourceGenerators Condition="'$(MSBuildProjectName)'!='' and $(MSBuildProjectName.EndsWith('Skia'))">true</UnoUIUseRoslynSourceGenerators>
+</PropertyGroup>
 
   <!--
   Adjust the output paths for runtime project in order for those
@@ -197,13 +203,13 @@
     <AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(UnoDisableNetAnalyzers)'==''">
     <!-- Enable all the latest CA rules from 'Microsoft.CodeAnalysis.NetAnalyzers' as build warnings by default. Specific rules are disabled or downgraded in repo's editorconfig. -->
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(UnoDisableNetAnalyzers)'==''">
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -472,7 +472,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 						{
 							var propertyName = dependencyProperty.TrimEnd("Property");
 
-							var getMethod = ownerType.GetMethods().FirstOrDefault(m => m.Name == "Get" + propertyName && m.Parameters.Length == 1 && m.IsLocallyPublic(_currentModule!));
+							var getMethod = ownerType.GetMethodsWithName("Get" + propertyName).FirstOrDefault(m => m.Parameters.Length == 1 && m.IsLocallyPublic(_currentModule!));
 
 							if (getMethod == null)
 							{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -225,9 +225,9 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			private void WriteToStringOverride(INamedTypeSymbol typeSymbol, IndentedStringBuilder builder)
 			{
 				var hasNoToString = typeSymbol
-					.GetMethods()
+					.GetMethodsWithName("ToString")
 					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-					.None(m => m.Name == "ToString");
+					.None();
 
 				if (hasNoToString)
 				{
@@ -239,9 +239,9 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			{
 				var isiosView = typeSymbol.Is(_iosViewSymbol);
 				var hasNoWillMoveToSuperviewMethod = typeSymbol
-					.GetMethods()
+					.GetMethodsWithName("WillMoveToSuperview")
 					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-					.None(m => m.Name == "WillMoveToSuperview");
+					.None();
 
 				var overridesWillMoveToSuperview = isiosView && hasNoWillMoveToSuperviewMethod;
 
@@ -278,9 +278,9 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			{
 				var isiosView = typeSymbol.Is(_macosViewSymbol);
 				var hasNoWillMoveToSuperviewMethod = typeSymbol
-					.GetMethods()
+					.GetMethodsWithName("ViewWillMoveToSuperview")
 					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-					.None(m => m.Name == "ViewWillMoveToSuperview");
+					.None();
 
 				var overridesWillMoveToSuperview = isiosView && hasNoWillMoveToSuperviewMethod;
 
@@ -323,9 +323,9 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				var implementsIFrameworkElement = typeSymbol.Interfaces.Any(t => SymbolEqualityComparer.Default.Equals(t, _iFrameworkElementSymbol));
 				var hasOverridesAttachedToWindowAndroid = isAndroidView &&
 					typeSymbol
-					.GetMethods()
+					.GetMethodsWithName("OnAttachedToWindow")
 					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-					.None(m => m.Name == "OnAttachedToWindow");
+					.None();
 
 				if (isAndroidView || isAndroidActivity || isAndroidFragment)
 				{
@@ -448,8 +448,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			{
 				var hasOverridesAttachedToWindowiOS = typeSymbol.Is(_iosViewSymbol) &&
 									typeSymbol
-									.GetMethods()
-									.Where(m => m.Name == "MovedToWindow")
+									.GetMethodsWithName("MovedToWindow")
 									.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
 									.None();
 
@@ -495,8 +494,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			{
 				var hasOverridesAttachedToWindowiOS = typeSymbol.Is(_macosViewSymbol) &&
 									typeSymbol
-									.GetMethods()
-									.Where(m => m.Name == "ViewDidMoveToWindow")
+									.GetMethodsWithName("ViewDidMoveToWindow")
 									.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
 									.None();
 
@@ -839,11 +837,10 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			private void WriteAndroidEqualityOverride(INamedTypeSymbol typeSymbol, IndentedStringBuilder builder)
 			{
 				var hasEqualityOverride = typeSymbol
-					.GetMethods()
-					.Where(m => m.Name == "Equals")
+					.GetMethodsWithName("Equals")
 					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
 					.None()
-					&& (typeSymbol.BaseType?.GetMethods().None(m => m.Name == "Equals" && m.IsSealed) ?? true);
+					&& (typeSymbol.BaseType?.GetMethodsWithName("Equals").None(m => m.IsSealed) ?? true);
 
 				if (hasEqualityOverride && typeSymbol.Is(_androidViewSymbol))
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -226,8 +226,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			{
 				var hasNoToString = typeSymbol
 					.GetMethodsWithName("ToString")
-					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-					.None();
+					.None(m => IsNotDependencyObjectGeneratorSourceFile(m));
 
 				if (hasNoToString)
 				{
@@ -240,8 +239,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				var isiosView = typeSymbol.Is(_iosViewSymbol);
 				var hasNoWillMoveToSuperviewMethod = typeSymbol
 					.GetMethodsWithName("WillMoveToSuperview")
-					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-					.None();
+					.None(m => IsNotDependencyObjectGeneratorSourceFile(m));
 
 				var overridesWillMoveToSuperview = isiosView && hasNoWillMoveToSuperviewMethod;
 
@@ -279,8 +277,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				var isiosView = typeSymbol.Is(_macosViewSymbol);
 				var hasNoWillMoveToSuperviewMethod = typeSymbol
 					.GetMethodsWithName("ViewWillMoveToSuperview")
-					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-					.None();
+					.None(m => IsNotDependencyObjectGeneratorSourceFile(m));
 
 				var overridesWillMoveToSuperview = isiosView && hasNoWillMoveToSuperviewMethod;
 
@@ -324,8 +321,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				var hasOverridesAttachedToWindowAndroid = isAndroidView &&
 					typeSymbol
 					.GetMethodsWithName("OnAttachedToWindow")
-					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-					.None();
+					.None(m => IsNotDependencyObjectGeneratorSourceFile(m));
 
 				if (isAndroidView || isAndroidActivity || isAndroidFragment)
 				{
@@ -449,8 +445,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				var hasOverridesAttachedToWindowiOS = typeSymbol.Is(_iosViewSymbol) &&
 									typeSymbol
 									.GetMethodsWithName("MovedToWindow")
-									.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-									.None();
+									.None(m => IsNotDependencyObjectGeneratorSourceFile(m));
 
 				if (hasOverridesAttachedToWindowiOS)
 				{
@@ -838,8 +833,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			{
 				var hasEqualityOverride = typeSymbol
 					.GetMethodsWithName("Equals")
-					.Where(m => IsNotDependencyObjectGeneratorSourceFile(m))
-					.None()
+					.None(m => IsNotDependencyObjectGeneratorSourceFile(m))
 					&& (typeSymbol.BaseType?.GetMethodsWithName("Equals").None(m => m.IsSealed) ?? true);
 
 				if (hasEqualityOverride && typeSymbol.Is(_androidViewSymbol))

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyPropertyGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyPropertyGenerator.cs
@@ -175,8 +175,8 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			{
 				var propertyName = memberSymbol.Name.TrimEnd("Property", StringComparison.Ordinal);
 
-				var getMethodSymbol = ownerType.GetMethodsWithName("Get" + propertyName).FirstOrDefault();
-				var setMethodSymbol = ownerType.GetMethodsWithName("Set" + propertyName).FirstOrDefault();
+				var getMethodSymbol = ownerType.GetFirstMethodWithName("Get" + propertyName);
+				var setMethodSymbol = ownerType.GetFirstMethodWithName("Set" + propertyName);
 
 				if (getMethodSymbol == null)
 				{
@@ -282,7 +282,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 					}
 				}
 
-				if (coerceCallback || propertyOwnerType.GetMethodsWithName("Coerce" + propertyName).Any())
+				if (coerceCallback || propertyOwnerType.GetFirstMethodWithName("Coerce" + propertyName) is not null)
 				{
 					builder.AppendLineIndented($"\t\t, coerceValueCallback: (instance, baseValue) => Coerce{propertyName}(instance, ({propertyTypeName})baseValue)");
 				}
@@ -398,7 +398,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 					builder.AppendLineIndented($"\t\t, backingFieldUpdateCallback: On{propertyName}BackingFieldUpdate");
 				}
 
-				if (coerceCallback || propertySymbol.ContainingType.GetMethodsWithName("Coerce" + propertyName).Any())
+				if (coerceCallback || propertySymbol.ContainingType.GetFirstMethodWithName("Coerce" + propertyName) is not null)
 				{
 					builder.AppendLineIndented($"\t\t, coerceValueCallback: (instance, baseValue) => (({containingTypeName})instance).Coerce{propertyName}(baseValue)");
 				}
@@ -483,7 +483,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				var defaultValueMethodName = $"Get{propertyName}DefaultValue()";
 				if (defaultValue.HasValue && !string.IsNullOrEmpty(defaultValue.Value.Key))
 				{
-					if (ownerType.GetMethodsWithName(defaultValueMethodName).Any())
+					if (ownerType.GetFirstMethodWithName(defaultValueMethodName) is not null)
 					{
 						builder.AppendLineIndented($"#error The generated property {propertyName} cannot contains both a DefaultValue and the {defaultValueMethodName} method.");
 					}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyPropertyGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyPropertyGenerator.cs
@@ -175,8 +175,8 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			{
 				var propertyName = memberSymbol.Name.TrimEnd("Property", StringComparison.Ordinal);
 
-				var getMethodSymbol = ownerType.GetMethods().FirstOrDefault(m => m.Name == "Get" + propertyName);
-				var setMethodSymbol = ownerType.GetMethods().FirstOrDefault(m => m.Name == "Set" + propertyName);
+				var getMethodSymbol = ownerType.GetMethodsWithName("Get" + propertyName).FirstOrDefault();
+				var setMethodSymbol = ownerType.GetMethodsWithName("Set" + propertyName).FirstOrDefault();
 
 				if (getMethodSymbol == null)
 				{
@@ -282,13 +282,13 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 					}
 				}
 
-				if (coerceCallback || propertyOwnerType.GetMethods().Any(m => m.Name == "Coerce" + propertyName))
+				if (coerceCallback || propertyOwnerType.GetMethodsWithName("Coerce" + propertyName).Any())
 				{
 					builder.AppendLineIndented($"\t\t, coerceValueCallback: (instance, baseValue) => Coerce{propertyName}(instance, ({propertyTypeName})baseValue)");
 				}
 
 				changedCallbackName ??= $"On{propertyName}Changed";
-				var propertyChangedMethods = propertyOwnerType.GetMethods().Where(m => m.Name == changedCallbackName).ToArray();
+				var propertyChangedMethods = propertyOwnerType.GetMethodsWithName(changedCallbackName).ToArray();
 				if (changedCallback || (propertyChangedMethods?.Any() ?? false))
 				{
 					if (propertyChangedMethods.FirstOrDefault(IsCallbackWithDPChangedArgs) is { } callbackWithEventArgs)
@@ -330,7 +330,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			{
 				var propertyName = memberSymbol.Name.TrimEnd("Property", StringComparison.Ordinal);
 
-				var propertySymbol = ownerType.GetProperties().FirstOrDefault(m => m.Name == propertyName);
+				var propertySymbol = ownerType.GetPropertiesWithName(propertyName).FirstOrDefault();
 
 				if(propertySymbol == null)
 				{
@@ -398,13 +398,13 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 					builder.AppendLineIndented($"\t\t, backingFieldUpdateCallback: On{propertyName}BackingFieldUpdate");
 				}
 
-				if (coerceCallback || propertySymbol.ContainingType.GetMethods().Any(m => m.Name == "Coerce" + propertyName))
+				if (coerceCallback || propertySymbol.ContainingType.GetMethodsWithName("Coerce" + propertyName).Any())
 				{
 					builder.AppendLineIndented($"\t\t, coerceValueCallback: (instance, baseValue) => (({containingTypeName})instance).Coerce{propertyName}(baseValue)");
 				}
 
 				changedCallbackName ??= $"On{propertyName}Changed";
-				var propertyChangedMethods = propertySymbol.ContainingType.GetMethods().Where(m => m.Name == changedCallbackName).ToArray();
+				var propertyChangedMethods = propertySymbol.ContainingType.GetMethodsWithName(changedCallbackName).ToArray();
 				if (changedCallback || propertyChangedMethods.Any())
 				{
 					if (propertyChangedMethods.FirstOrDefault(IsCallbackWithDPChangedArgs) is { } callbackWithEventArgs)
@@ -483,7 +483,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				var defaultValueMethodName = $"Get{propertyName}DefaultValue()";
 				if (defaultValue.HasValue && !string.IsNullOrEmpty(defaultValue.Value.Key))
 				{
-					if (ownerType.GetMethods().Any(m => m.Name == defaultValueMethodName))
+					if (ownerType.GetMethodsWithName(defaultValueMethodName).Any())
 					{
 						builder.AppendLineIndented($"#error The generated property {propertyName} cannot contains both a DefaultValue and the {defaultValueMethodName} method.");
 					}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.ApplicationInsights.DataContracts;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -265,6 +266,21 @@ namespace Microsoft.CodeAnalysis
 
 		public static IEnumerable<IMethodSymbol> GetMethodsWithName(this ITypeSymbol resolvedType, string name)
 			=> resolvedType.GetMembers(name).OfType<IMethodSymbol>();
+
+		public static IMethodSymbol? GetFirstMethodWithName(this ITypeSymbol resolvedType, string name)
+		{
+			var members = resolvedType.GetMembers(name);
+
+			for (int i = 0; i < members.Length; i++)
+			{
+				if (members[i] is IMethodSymbol method)
+				{
+					return method;
+				}
+			}
+
+			return null;
+		}
 
 		public static IEnumerable<IFieldSymbol> GetFields(this ITypeSymbol resolvedType)
 			=> resolvedType.GetMembers().OfType<IFieldSymbol>();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/SymbolExtensions.cs
@@ -125,6 +125,8 @@ namespace Microsoft.CodeAnalysis
 
 		public static IEnumerable<IPropertySymbol> GetProperties(this INamedTypeSymbol symbol) => symbol.GetMembers().OfType<IPropertySymbol>();
 
+		public static IEnumerable<IPropertySymbol> GetPropertiesWithName(this INamedTypeSymbol symbol, string name) => symbol.GetMembers(name).OfType<IPropertySymbol>();
+
 		public static IEnumerable<IEventSymbol> GetAllEvents(this INamedTypeSymbol? symbol)
 		{
 			do

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -53,6 +53,7 @@
 		<PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis">
 			<Version>3.8.0</Version>
+			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>
 		<PackageReference Include="Mono.Cecil">
 			<Version>0.10.1</Version>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/XBindExpressionParser.PathRewrite.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/XBindExpressionParser.PathRewrite.cs
@@ -19,7 +19,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 	internal static partial class XBindExpressionParser
 	{
 		private const string XBindSubstitute = "↔↔";
-		private static readonly Regex NamedParam = new Regex(@"^(\w*)=(.*?)");
+		private static readonly Regex NamedParam = new(@"^(\w*)=(.*?)", RegexOptions.Compiled);
+		private static readonly Regex DocumentPaths = new("\"{x:Bind\\s(.*?)}\"", RegexOptions.Singleline | RegexOptions.Compiled);
 
 		/// <summary>
 		/// Rewrites all x:Bind expression Path property to be compatible with the System.Xaml parser.
@@ -34,13 +35,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator.Utils
 		/// </remarks>
 		internal static string RewriteDocumentPaths(string markup)
 		{
-			var result =
-				Regex.Replace(
-					markup,
-					 "\"{x:Bind\\s(.*?)}\"",
-					e => $"\"{{x:Bind {RewriteParameters(e.Groups[1].Value.Trim())}}}\"",
-					RegexOptions.Singleline
-				);
+			var result =DocumentPaths.Replace(
+				markup,
+				e => $"\"{{x:Bind {RewriteParameters(e.Groups[1].Value.Trim())}}}\""
+			);
 
 			return result;
 		}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -56,6 +56,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private readonly string _projectFullPath;
 		private readonly bool _outputSourceComments = true;
 		private readonly bool _xamlResourcesTrimming;
+		private bool _shouldWriteErrorOnInvalidXaml;
 		private readonly RoslynMetadataHelper _metadataHelper;
 
 		/// <summary>
@@ -166,7 +167,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			if (bool.TryParse(context.GetMSBuildPropertyValue("ShouldWriteErrorOnInvalidXaml"), out var shouldWriteErrorOnInvalidXaml))
 			{
-				XamlFileGenerator.ShouldWriteErrorOnInvalidXaml = shouldWriteErrorOnInvalidXaml;
+				_shouldWriteErrorOnInvalidXaml = shouldWriteErrorOnInvalidXaml;
 			}
 
 			if (!bool.TryParse(context.GetMSBuildPropertyValue("IsUiAutomationMappingEnabled") ?? "", out _isUiAutomationMappingEnabled))
@@ -336,6 +337,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									isUiAutomationMappingEnabled: _isUiAutomationMappingEnabled,
 									uiAutomationMappings: _uiAutomationMappings,
 									defaultLanguage: _defaultLanguage,
+									shouldWriteErrorOnInvalidXaml: _shouldWriteErrorOnInvalidXaml,
 									isWasm: _isWasm,
 									isDebug: _isDebug,
 									isHotReloadEnabled: _isHotReloadEnabled,

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -735,7 +735,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								{
 									foreach (var ambientResource in _ambientGlobalResources)
 									{
-										if (ambientResource.GetMethods().Any(m => m.Name == "Initialize"))
+										if (ambientResource.GetMethodsWithName("Initialize").Any())
 										{
 											writer.AppendLineIndented($"global::{ambientResource.GetFullName()}.Initialize();");
 										}
@@ -744,7 +744,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									foreach (var ambientResource in _ambientGlobalResources)
 									{
 										// Note: we do *not* call RegisterDefaultStyles for the current assembly, because those styles are treated as implicit styles, not default styles
-										if (ambientResource.GetMethods().Any(m => m.Name == "RegisterDefaultStyles"))
+										if (ambientResource.GetMethodsWithName("RegisterDefaultStyles").Any())
 										{
 											writer.AppendLineIndented($"global::{ambientResource.GetFullName()}.RegisterDefaultStyles();");
 										}
@@ -752,7 +752,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 									foreach (var ambientResource in _ambientGlobalResources)
 									{
-										if (ambientResource.GetMethods().Any(m => m.Name == "RegisterResourceDictionariesBySource"))
+										if (ambientResource.GetMethodsWithName("RegisterResourceDictionariesBySource").Any())
 										{
 											writer.AppendLineIndented($"global::{ambientResource.GetFullName()}.RegisterResourceDictionariesBySource();");
 										}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -735,7 +735,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								{
 									foreach (var ambientResource in _ambientGlobalResources)
 									{
-										if (ambientResource.GetMethodsWithName("Initialize").Any())
+										if (ambientResource.GetFirstMethodWithName("Initialize") is not null)
 										{
 											writer.AppendLineIndented($"global::{ambientResource.GetFullName()}.Initialize();");
 										}
@@ -744,7 +744,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									foreach (var ambientResource in _ambientGlobalResources)
 									{
 										// Note: we do *not* call RegisterDefaultStyles for the current assembly, because those styles are treated as implicit styles, not default styles
-										if (ambientResource.GetMethodsWithName("RegisterDefaultStyles").Any())
+										if (ambientResource.GetFirstMethodWithName("RegisterDefaultStyles") is not null)
 										{
 											writer.AppendLineIndented($"global::{ambientResource.GetFullName()}.RegisterDefaultStyles();");
 										}
@@ -752,7 +752,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 									foreach (var ambientResource in _ambientGlobalResources)
 									{
-										if (ambientResource.GetMethodsWithName("RegisterResourceDictionariesBySource").Any())
+										if (ambientResource.GetFirstMethodWithName("RegisterResourceDictionariesBySource") is not null)
 										{
 											writer.AppendLineIndented($"global::{ambientResource.GetFullName()}.RegisterResourceDictionariesBySource();");
 										}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -419,7 +419,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					var resolvedType = type;
 
 					var property = resolvedType.GetAllPropertiesWithName(propertyName).FirstOrDefault();
-					var setMethod = resolvedType.GetMethodsWithName("Set" + propertyName).FirstOrDefault();
+					var setMethod = resolvedType.GetFirstMethodWithName("Set" + propertyName);
 
 					if (property != null)
 					{
@@ -556,7 +556,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					return true;
 				}
 
-				var setMethod = type?.GetMethodsWithName("Set" + name).FirstOrDefault();
+				var setMethod = type?.GetFirstMethodWithName("Set" + name);
 				if (setMethod is { IsStatic: true, Parameters: { Length: 2 } })
 				{
 					return true;
@@ -584,7 +584,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			do
 			{
-				var setMethod = type?.GetMethodsWithName("Set" + name).FirstOrDefault();
+				var setMethod = type?.GetFirstMethodWithName("Set" + name);
 
 				if (setMethod != null && setMethod.IsStatic && setMethod.Parameters.Length == 2)
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -419,7 +419,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					var resolvedType = type;
 
 					var property = resolvedType.GetAllPropertiesWithName(propertyName).FirstOrDefault();
-					var setMethod = resolvedType.GetMethods().FirstOrDefault(p => p.Name == "Set" + propertyName);
+					var setMethod = resolvedType.GetMethodsWithName("Set" + propertyName).FirstOrDefault();
 
 					if (property != null)
 					{
@@ -556,7 +556,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					return true;
 				}
 
-				var setMethod = type?.GetMethods().FirstOrDefault(p => p.Name == "Set" + name);
+				var setMethod = type?.GetMethodsWithName("Set" + name).FirstOrDefault();
 				if (setMethod is { IsStatic: true, Parameters: { Length: 2 } })
 				{
 					return true;
@@ -584,7 +584,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			do
 			{
-				var setMethod = type?.GetMethods().FirstOrDefault(p => p.Name == "Set" + name);
+				var setMethod = type?.GetMethodsWithName("Set" + name).FirstOrDefault();
 
 				if (setMethod != null && setMethod.IsStatic && setMethod.Parameters.Length == 2)
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3237,7 +3237,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 									var getterMethod = $"Get{member.Member.Name}";
 
-									if (ownerType.GetMethodsWithName(getterMethod).Any())
+									if (ownerType.GetFirstMethodWithName(getterMethod) is not null)
 									{
 										// Attached property
 										writer.AppendLineIndented(
@@ -3672,14 +3672,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 										};
 									}
 
-									var method = currentType?.GetMethodsWithName(parts.Last()).FirstOrDefault()
+									var method = currentType?.GetFirstMethodWithName(parts.Last())
 										?? throw new InvalidOperationException($"Failed to find {parts.Last()} on {currentType}");
 
 									return method;
 								}
 								else
 								{
-									return sourceType?.GetMethodsWithName(eventTarget ?? "").FirstOrDefault()
+									return sourceType?.GetFirstMethodWithName(eventTarget ?? "")
 										?? throw new InvalidOperationException($"Failed to find {eventTarget} on {sourceType}");
 								}
 							}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -223,6 +223,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			bool isUiAutomationMappingEnabled,
 			Dictionary<string, string[]> uiAutomationMappings,
 			string defaultLanguage,
+			bool shouldWriteErrorOnInvalidXaml,
 			bool isWasm,
 			bool isDebug,
 			bool isHotReloadEnabled,
@@ -287,6 +288,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			_iOSViewSymbol = FindType("UIKit.UIView");
 			_appKitViewSymbol = FindType("AppKit.NSView");
 			_xamlConversionTypes = _metadataHelper.GetAllTypesAttributedWith(GetType(XamlConstants.Types.CreateFromStringAttribute)).ToList();
+			ShouldWriteErrorOnInvalidXaml = shouldWriteErrorOnInvalidXaml;
 
 			_isWasm = isWasm;
 
@@ -298,7 +300,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// Indicates if the code generation should write #error in the generated code (and break at compile time) or write a // Warning, which would be silent.
 		/// </summary>
 		/// <remarks>Initial behavior is to write // Warning, hence the default value to false, but we suggest setting this to true.</remarks>
-		public static bool ShouldWriteErrorOnInvalidXaml { get; set; }
+		public bool ShouldWriteErrorOnInvalidXaml { get; }
 
 		public string GenerateFile()
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3237,7 +3237,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 									var getterMethod = $"Get{member.Member.Name}";
 
-									if (ownerType.GetMethods().Any(m => m.Name == getterMethod))
+									if (ownerType.GetMethodsWithName(getterMethod).Any())
 									{
 										// Attached property
 										writer.AppendLineIndented(
@@ -3672,14 +3672,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 										};
 									}
 
-									var method = currentType?.GetMethods().FirstOrDefault(m => m.Name == parts.Last())
+									var method = currentType?.GetMethodsWithName(parts.Last()).FirstOrDefault()
 										?? throw new InvalidOperationException($"Failed to find {parts.Last()} on {currentType}");
 
 									return method;
 								}
 								else
 								{
-									return sourceType?.GetMethods().FirstOrDefault(m => m.Name == eventTarget)
+									return sourceType?.GetMethodsWithName(eventTarget ?? "").FirstOrDefault()
 										?? throw new InvalidOperationException($"Failed to find {eventTarget} on {sourceType}");
 								}
 							}
@@ -4334,9 +4334,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			if (_metadataHelper.FindTypeByFullName(className) is INamedTypeSymbol typeSymbol)
 			{
-				var isStaticMethod = typeSymbol.GetMethods().Any(m => m.IsStatic && m.Name == memberName);
-				var isStaticProperty = typeSymbol.GetProperties().Any(m => m.Name == memberName && m.IsStatic);
-				var isStaticField = typeSymbol.GetFields().Any(m => m.Name == memberName && m.IsStatic);
+				var isStaticMethod = typeSymbol.GetMethodsWithName(memberName).Any(m => m.IsStatic);
+				var isStaticProperty = typeSymbol.GetPropertiesWithName(memberName).Any(m => m.IsStatic);
+				var isStaticField = typeSymbol.GetFieldsWithName(memberName).Any(m => m.IsStatic);
 				var isEnum = typeSymbol.TypeKind == TypeKind.Enum;
 
 				return isStaticMethod || isStaticProperty || isStaticField || (!isTopLevelMember && isEnum);
@@ -4817,10 +4817,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 
 				var hasImplictToString = propertyType
-					.GetMethods()
-					.Any(m =>
-						m.Name == "op_Implicit"
-						&& m.Parameters.FirstOrDefault().SelectOrDefault(p => SymbolEqualityComparer.Default.Equals(p?.Type, _stringSymbol))
+					.GetMethodsWithName("op_Implicit")
+					.Any(m => m.Parameters.FirstOrDefault().SelectOrDefault(p => SymbolEqualityComparer.Default.Equals(p?.Type, _stringSymbol))
 					);
 
 				if (hasImplictToString

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
@@ -95,17 +95,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private XmlReader ApplyIgnorables(string file)
 		{
-			var adjusted = File.ReadAllText(file);
+			var originalString = File.ReadAllText(file);
+			StringBuilder adjusted;
 
 			var document = new XmlDocument();
-			document.LoadXml(adjusted);
+			document.LoadXml(originalString);
 
 			var (ignorables, shouldCreateIgnorable) = FindIgnorables(document);
 			var conditionals = FindConditionals(document);
 
 			shouldCreateIgnorable |= conditionals.ExcludedConditionals.Count > 0;
 
-			var hasxBind = adjusted.Contains("{x:Bind", StringComparison.Ordinal);
+			var hasxBind = originalString.Contains("{x:Bind", StringComparison.Ordinal);
 
 			if (ignorables == null && !shouldCreateIgnorable && !hasxBind)
 			{
@@ -131,15 +132,15 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 #if DEBUG
 				Console.WriteLine("Ignorable XAML namespaces: {0} for {1}", ignorables.Value, file);
 #endif
+				adjusted = new StringBuilder(originalString);
 
 				// change the namespaces using textreplace, to keep the formatting and have proper
 				// line/position reporting.
-				adjusted = adjusted
+				adjusted
 					.Replace(
 						"Ignorable=\"{0}\"".InvariantCultureFormat(originalIgnorables),
 						"Ignorable=\"{0}\"".InvariantCultureFormat(ignorables.Value)
-					)
-					.TrimEnd("\r\n");
+					);
 			}
 			else
 			{
@@ -165,18 +166,17 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				var replacement = "{0}{1} {2}:Ignorable=\"{3}\"".InvariantCultureFormat(targetLine, mcString, mcName, newIgnoredFlat);
 				adjusted = ReplaceFirst(
-						adjusted,
-						targetLine,
-						replacement
-					)
-					.TrimEnd("\r\n");
+					originalString,
+					targetLine,
+					replacement
+				);
 			}
 
 			// Replace the ignored namespaces with unique urns so that same urn that are placed in Ignored attribute
 			// are ignored independently.
 			foreach (var n in newIgnored)
 			{
-				adjusted = adjusted
+				adjusted
 					.Replace(
 						"xmlns:{0}=\"{1}\"".InvariantCultureFormat(n, document.DocumentElement?.GetNamespaceOfPrefix(n)),
 						"xmlns:{0}=\"{1}\"".InvariantCultureFormat(n, Guid.NewGuid())
@@ -193,7 +193,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 					if (!originalPrefix.StartsWith("using:"))
 					{
-						adjusted = adjusted
+						adjusted
 							.Replace(
 								"xmlns:{0}=\"{1}\"".InvariantCultureFormat(n, document.DocumentElement.GetNamespaceOfPrefix(n)),
 								"xmlns:{0}=\"{1}\"".InvariantCultureFormat(n, document.DocumentElement.GetNamespaceOfPrefix(""))
@@ -206,7 +206,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				var valueSplit = includedCond.Value.Split('?');
 				// Strip the conditional part, so the namespace can be parsed correctly by the Xaml reader
-				adjusted = adjusted
+				adjusted
 					.Replace(
 						includedCond.OuterXml,
 						"{0}=\"{1}\"".InvariantCultureFormat(includedCond.Name, valueSplit[0])
@@ -219,20 +219,29 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				// support quotes in positional markup extensions parameters.
 				// Note that the UWP preprocessor does not need to apply those replacements as the
 				// x:Bind expressions are being removed during the first phase and replaced by "connections".
-				adjusted = XBindExpressionParser.RewriteDocumentPaths(adjusted);
+				adjusted = new(XBindExpressionParser.RewriteDocumentPaths(adjusted.ToString()));
 			}
 
-			return XmlReader.Create(new StringReader(adjusted));
+			return XmlReader.Create(new StringReader(adjusted.ToString().TrimEnd("\r\n")));
 		}
 
-		private static string ReplaceFirst(string targetString, string oldValue, string newValue)
+		private static StringBuilder ReplaceFirst(string targetString, string oldValue, string newValue)
 		{
 			var index = targetString.IndexOf(oldValue, StringComparison.InvariantCulture);
 			if (index < 0)
 			{
 				throw new InvalidOperationException();
 			}
-			return targetString.Substring(0, index) + newValue + targetString.Substring(index + oldValue.Length);
+
+			var result = new StringBuilder(targetString.Length + newValue.Length);
+
+			result.Append(targetString, 0, index);
+			result.Append(newValue);
+
+			var secondBlockStart = index + oldValue.Length;
+			result.Append(targetString, secondBlockStart, targetString.Length - secondBlockStart);
+
+			return result;
 		}
 
 		private (XmlNode? Ignorables, bool ShouldCreateIgnorable) FindIgnorables(XmlDocument document)

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -11,8 +11,8 @@
 
   <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" />
   <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.Assets.RetargetAssets_v0" />
-  <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerHintGeneratorTask_v0" />
-  <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerDefinitionMergerTask_v0" />
+  <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerHintGeneratorTask_v0" TaskFactory="TaskHostFactory" />
+  <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.LinkerHintsGenerator.LinkerDefinitionMergerTask_v0" TaskFactory="TaskHostFactory" />
 
   <!--
   This task transforms all the Content files and PRIResources into resources files compatible for each platform.
@@ -87,7 +87,11 @@
   -->
 
   <Target Name="_UnoLinkerHintsSubstitutionsMerge"
-	  Condition="'$(UnoXamlResourcesTrimming)'=='true'"
+	  Condition="
+		'$(DesignTimeBuild)' != 'true'
+		and '$(BuildingInsideUnoSourceGenerator)' == ''
+		and '$(SkipCompilerExecution)' == ''
+		and '$(UnoXamlResourcesTrimming)'=='true'"
 	  AfterTargets="CoreCompile">
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/7506

## PR Type

What kind of change does this PR introduce?
- Perf

## What is the new behavior?

- perf: Remove unused Uno.CodeGen from SamplesApp.Skia
- perf: Use GetXXWithName for members lookups
- fix: Don't use static storage for errors on invalid properties 
- perf: Enable Roslyn-based generators for internal Uno-Skia build
- perf: Don't copy roslyn binaries to the output to enable VBCSCompiler… 
- perf: Enhance lookups in FindSubElementByName 
- ci: use GetMethodsWithName
- perf: Reduce memory allocations when parsing XAML files

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
