### PR TITLE
[Wasm] Ensures that TextBlock measure cache gets cleared when a font is loaded

### DIFF
--- a/doc/articles/features/custom-fonts.md
+++ b/doc/articles/features/custom-fonts.md
@@ -155,9 +155,11 @@ public static void main(string[] orgs)
     // You can add more than one, but preload too many fonts could hurt user experience.
     // IMPORTANT: The string parameter should be exactly the same string (including casing)
     //            used as FontFamily in the application.
-    Windows.UI.Xaml.Media.FontFamilyHelper.PreloadAsync("ms-appx:///Assets/Fonts/yourfont01.ttf#ApplicationFont01");
-    Windows.UI.Xaml.Media.FontFamilyHelper.PreloadAsync("https://fonts.cdnfonts.com/s/71084/antikythera.woff#Antikythera");
-    Windows.UI.Xaml.Media.FontFamilyHelper.PreloadAsync("Roboto");
+    Uno.UI.Xaml.Media.FontFamilyHelper.PreloadAsync("ms-appx:///Assets/Fonts/yourfont01.ttf#ApplicationFont01");
+    Uno.UI.Xaml.Media.FontFamilyHelper.PreloadAsync("https://fonts.cdnfonts.com/s/71084/antikythera.woff#Antikythera");
+
+    // Preloads a font which has been specified as a CSS font, either with a data uri or a remote resource.
+    Uno.UI.Xaml.Media.FontFamilyHelper.PreloadAsync("Roboto");
     
     Windows.UI.Xaml.Application.Start(_ => _app = new App());
 ```

--- a/src/Uno.UI.Runtime.WebAssembly/Xaml/Media/FontFamilyHelper.cs
+++ b/src/Uno.UI.Runtime.WebAssembly/Xaml/Media/FontFamilyHelper.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Media;
+
+namespace Uno.UI.Xaml.Media;
+
+/// <summary>
+/// WebAssembly specific <see cref="FontFamily"/> helper
+/// </summary>
+public partial class FontFamilyHelper
+{
+	/// <summary>
+	/// Pre-loads a font to minimize loading time and prevent potential text re-layouts.
+	/// </summary>
+	/// <returns>True is the font loaded successfuly, otherwise false.</returns>
+	public static Task<bool> PreloadAsync(FontFamily family)
+		=> FontFamily.PreloadAsync(family);
+
+	/// <summary>
+	/// Pre-loads a font to minimize loading time and prevent potential text re-layouts.
+	/// </summary>
+	/// <returns>True is the font loaded successfuly, otherwise false.</returns>
+	public static Task<bool> PreloadAsync(string familyName)
+		=> PreloadAsync(new FontFamily(familyName));
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -17,7 +17,6 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private const int MaxMeasureCache = 50;
 
-		private static TextBlockMeasureCache _cache = new TextBlockMeasureCache();
 		private bool _fontStyleChanged;
 		private bool _fontWeightChanged;
 		private bool _textChanged;
@@ -102,7 +101,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (UseInlinesFastPath)
 			{
-				if (_cache.FindMeasuredSize(this, availableSize) is Size desiredSize)
+				if (TextBlockMeasureCache.Instance.FindMeasuredSize(this, availableSize) is Size desiredSize)
 				{
 					UnoMetrics.TextBlock.MeasureCacheHits++;
 					return desiredSize;
@@ -112,7 +111,7 @@ namespace Windows.UI.Xaml.Controls
 					UnoMetrics.TextBlock.MeasureCacheMisses++;
 					desiredSize = MeasureView(availableSize);
 
-					_cache.CacheMeasure(this, availableSize, desiredSize);
+					TextBlockMeasureCache.Instance.CacheMeasure(this, availableSize, desiredSize);
 
 					return desiredSize;
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Windows.Foundation;
 using Uno;
 using CachedSize = Uno.CachedTuple<double, double>;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
@@ -89,6 +89,8 @@ namespace Windows.UI.Xaml.Controls
 			private readonly int _characterSpacing;
 			private readonly TextDecorations _textDecorations;
 
+			public FontFamily FontFamily => _fontFamily;
+
 			internal bool IsWrapping => _textWrapping != TextWrapping.NoWrap;
 			internal bool IsClipping => _textTrimming != TextTrimming.None;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
@@ -101,29 +101,6 @@ namespace Windows.UI.Xaml.Controls
 			entry.CacheMeasure(availableSize, measuredSize);
 		}
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="fontFamily"></param>
-		internal void Clear(FontFamily fontFamily)
-		{
-			List<MeasureKey> keysToRemove = new();
-
-			foreach(var item in _queue)
-			{
-				if (item.FontFamily.CssFontName == fontFamily.CssFontName)
-				{
-					keysToRemove.Add(item);
-				}
-			}
-
-			foreach(var keyToRemove in keysToRemove)
-			{
-				_queue.Remove(keyToRemove);
-				_entries.Remove(keyToRemove);
-			}
-		}
-
 		private void Scavenge()
 		{
 			while (_queue.Count >= MaxMeasureKeyEntries)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
@@ -8,6 +8,7 @@ using Uno;
 using Uno.Extensions;
 using Uno.UI;
 using Uno.Foundation.Logging;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -23,6 +24,8 @@ namespace Windows.UI.Xaml.Controls
 
 		private readonly Dictionary<MeasureKey, MeasureEntry> _entries = new Dictionary<MeasureKey, MeasureEntry>(new MeasureKey.Comparer());
 		private readonly LinkedList<MeasureKey> _queue = new LinkedList<MeasureKey>();
+		
+		public static readonly TextBlockMeasureCache Instance = new TextBlockMeasureCache();
 
 		/// <summary>
 		/// Finds a cached measure for the provided <see cref="TextBlock"/> characteristics
@@ -96,6 +99,29 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			entry.CacheMeasure(availableSize, measuredSize);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="fontFamily"></param>
+		internal void Clear(FontFamily fontFamily)
+		{
+			List<MeasureKey> keysToRemove = new();
+
+			foreach(var item in _queue)
+			{
+				if (item.FontFamily.CssFontName == fontFamily.CssFontName)
+				{
+					keysToRemove.Add(item);
+				}
+			}
+
+			foreach(var keyToRemove in keysToRemove)
+			{
+				_queue.Remove(keyToRemove);
+				_entries.Remove(keyToRemove);
+			}
 		}
 
 		private void Scavenge()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.wasm.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Windows.Foundation;
+
+using Uno;
+using Uno.Extensions;
+using Uno.UI;
+using Uno.Foundation.Logging;
+using Windows.UI.Xaml.Media;
+
+namespace Windows.UI.Xaml.Controls
+{
+	/// <summary>
+	/// A TextBlock measure cache for non-formatted text.
+	/// </summary>
+	internal partial class TextBlockMeasureCache
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="fontFamily"></param>
+		internal void Clear(FontFamily fontFamily)
+		{
+			List<MeasureKey> keysToRemove = new();
+
+			foreach(var item in _queue)
+			{
+				if (item.FontFamily.CssFontName == fontFamily.CssFontName)
+				{
+					keysToRemove.Add(item);
+				}
+			}
+
+			foreach(var keyToRemove in keysToRemove)
+			{
+				_queue.Remove(keyToRemove);
+				_entries.Remove(keyToRemove);
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/FontFamilyLoader.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FontFamilyLoader.wasm.cs
@@ -72,6 +72,8 @@ internal class FontFamilyLoader
 
 			if (loader._waitingList is { Count: > 0 })
 			{
+				Controls.TextBlockMeasureCache.Instance.Clear(loader._fontFamily);
+				
 				foreach (var waiting in loader._waitingList)
 				{
 					if (waiting.IsAlive && waiting.Target is UIElement ue)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Ensures that TextBlock measure cache gets cleared when a font is loaded
- Adds missing `FontHelper` visible from Wasm apps

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
