### PR TITLE
fix(gtk): [Linux] Ensure that missing libGLESv2.so does not break the runtime

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/OpenGLESRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/OpenGLESRenderSurface.cs
@@ -110,9 +110,24 @@ namespace Uno.UI.Runtime.Skia
 		{
 			var glInterface = GRGlInterface.CreateGles(proc =>
 			{
-				if (NativeContext.TryGetProcAddress(proc, out var addr))
+				try
 				{
-					return addr;
+					if (NativeContext.TryGetProcAddress(proc, out var addr))
+					{
+						return addr;
+					}
+				}
+				catch(Exception e)
+				{
+					// In this context, the lamda is executed from a native context, where
+					// unhandled exceptions terminate the process. In this case, we can simply
+					// return NULL, causing glInterface to be null in return.
+
+
+					if (typeof(OpenGLESRenderSurface).Log().IsEnabled(LogLevel.Debug))
+					{
+						typeof(OpenGLESRenderSurface).Log().Debug($"OpenGL ES is not available {e.Message}");
+					}
 				}
 
 				return IntPtr.Zero;


### PR DESCRIPTION
GitHub Issue (If applicable): #9099

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Avoids native exceptions raised during opengl detection to terminate the app.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
