### PR TITLE
fix(iOS): ListView empty items when scrolling

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -743,7 +743,11 @@ namespace Windows.UI.Xaml.Controls
 
 					ContentView.AddSubview(value);
 
-
+					// Calling these methods: Layouter.ArrangeChild() and UpdateContentLayoutSlots()
+					// everytime we set the Content is required to fix an issue where the
+					// OS is not triggering the Callback LayoutSubViews() at times making the Children to render
+					// with the wrong size.
+					// Layouter.ArrangeChild() will skip if called with the same values.
 					Layouter.ArrangeChild(value, new Rect(0, 0, (float)Frame.Width, (float)Frame.Height));
 
 					// The item has to be arranged relative to this internal container (at 0,0),

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -743,6 +743,14 @@ namespace Windows.UI.Xaml.Controls
 
 					ContentView.AddSubview(value);
 
+
+					Layouter.ArrangeChild(value, new Rect(0, 0, (float)Frame.Width, (float)Frame.Height));
+
+					// The item has to be arranged relative to this internal container (at 0,0),
+					// but doing this the LayoutSlot[WithMargins] has been updated,
+					// so we fakely re-inject the relative position of the item in its parent.
+					UpdateContentLayoutSlots(Frame);
+
 					ClearMeasuredSize();
 					_contentChangedDisposable.Disposable = value?.RegisterDisposablePropertyChangedCallback(ContentControl.ContentProperty, (_, __) => _measuredContentSize = null);
 				}
@@ -769,6 +777,8 @@ namespace Windows.UI.Xaml.Controls
 				try
 				{
 					base.Frame = value;
+					UpdateContentLayoutSlots(value);
+
 					UpdateContentViewFrame();
 				}
 				catch


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9416

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

- Bugfix

## What is the current behavior?
When Scrolling over a ListView some items are not properly measured (not visible because of their size)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
