### PR TITLE
fix: RefreshContainer content alignment

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
@@ -12,6 +12,9 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 	public partial class Given_RefreshContainer
 	{
 		[TestMethod]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 		public async Task When_Stretch_Child()
 		{
 			var grid = new Grid();
@@ -31,7 +34,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 
 			child.Child = grandChild;
 			refreshContainer.Content = child;
-			grid.Add(refreshContainer);
+			grid.Children.Add(refreshContainer);
 			
 			WindowHelper.WindowContent = grid;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
@@ -14,6 +14,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Stretch_Child()
 		{
+			var grid = new Grid();
 			var refreshContainer = new Microsoft.UI.Xaml.Controls.RefreshContainer();
 			var child = new Border()
 			{
@@ -30,8 +31,9 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 
 			child.Child = grandChild;
 			refreshContainer.Content = child;
-
-			WindowHelper.WindowContent = refreshContainer;
+			grid.Add(refreshContainer);
+			
+			WindowHelper.WindowContent = grid;
 
 			await WindowHelper.WaitForLoaded(grandChild);
 			await WindowHelper.WaitForLoaded(refreshContainer);

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
+{
+	[TestClass]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public partial class Given_RefreshContainer
+	{
+		[TestMethod]
+		public async Task When_Stretch_Child()
+		{
+			var refreshContainer = new Microsoft.UI.Xaml.Controls.RefreshContainer();
+			var child = new Border()
+			{
+				Background = new SolidColorBrush(Colors.Red),
+				HorizontalAlignment = Windows.UI.Xaml.HorizontalAlignment.Stretch,
+				VerticalAlignment = Windows.UI.Xaml.VerticalAlignment.Stretch,
+			};
+			var grandChild = new Border()
+			{
+				Background = new SolidColorBrush(Colors.Blue),
+				Width = 10,
+				Height = 10,
+			};
+
+			child.Child = grandChild;
+			refreshContainer.Content = child;
+
+			WindowHelper.WindowContent = refreshContainer;
+
+			await WindowHelper.WaitForLoaded(grandChild);
+			await WindowHelper.WaitForLoaded(refreshContainer);
+
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsTrue(child.ActualWidth > 50);
+			Assert.IsTrue(child.ActualHeight > 50);
+		}
+	}
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/Native/NativeRefreshControl.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/Native/NativeRefreshControl.Android.cs
@@ -104,9 +104,6 @@ public partial class NativeRefreshControl : SwipeRefreshLayout, IShadowChildrenP
 		// the child at an invalid location when the visibility changes.
 
 		_layouter.Arrange(newSize);
-
-		// base.OnLayout is not invoked in the mixin to allow for the clipping algorithms
-		base.OnLayout(changed, left, top, right, bottom);
 	}
 	
 	private class NativeRefreshControlLayouter : Layouter
@@ -148,16 +145,11 @@ public partial class NativeRefreshControl : SwipeRefreshLayout, IShadowChildrenP
 
 			if (child != null)
 			{
-				var desiredChildSize = LayoutInformation.GetDesiredSize(child);
-
-				var width = Math.Max(slotSize.Width, desiredChildSize.Width);
-				var height = Math.Max(slotSize.Height, desiredChildSize.Height);
-
 				ArrangeChild(child, new Rect(
 					0,
 					0,
-					width,
-					height
+					slotSize.Width,
+					slotSize.Height
 				));
 
 				// Give opportunity to the the content to define the viewport size itself

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/RefreshContainer/RefreshContainer.xaml
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/RefreshContainer/RefreshContainer.xaml
@@ -18,12 +18,13 @@
 		<Setter Property="Template">
 			<Setter.Value>
 			<ControlTemplate TargetType="local:RefreshContainer">
-				<Grid x:Name="Root" Background="{TemplateBinding Background}" >
-				<ContentPresenter x:Name="ContentPresenter"
-								  Content="{TemplateBinding Content}"
-								  ContentTemplate="{TemplateBinding ContentTemplate}"
-								  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-								  Background="Transparent"/>
+				<Grid x:Name="Root" Background="{TemplateBinding Background}">
+					<!-- Uno workaround: template-bind ContentTemplateSelector because it's not automatically propagated from the ContentControl #6452 -->
+					<ContentPresenter x:Name="ContentPresenter"
+								Content="{TemplateBinding Content}"
+								ContentTemplate="{TemplateBinding ContentTemplate}"
+								ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+								Background="Transparent"/>
 				<Grid x:Name="RefreshVisualizerPresenter"/>
 				</Grid>
 			</ControlTemplate>
@@ -41,6 +42,7 @@
 					<Grid x:Name="Root">
 						<uno:NativeRefreshControl x:Name="NativeRefreshControl">
 							<uno:NativeRefreshControl.Content>
+								<!-- Uno workaround: template-bind ContentTemplateSelector because it's not automatically propagated from the ContentControl #6452 -->
 								<ContentPresenter x:Name="ContentPresenter"
 									Content="{TemplateBinding Content}"
 									ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/RefreshContainer/RefreshContainer.xaml
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/RefreshContainer/RefreshContainer.xaml
@@ -19,7 +19,11 @@
 			<Setter.Value>
 			<ControlTemplate TargetType="local:RefreshContainer">
 				<Grid x:Name="Root" Background="{TemplateBinding Background}" >
-				<ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" Background="Transparent"/>
+				<ContentPresenter x:Name="ContentPresenter"
+								  Content="{TemplateBinding Content}"
+								  ContentTemplate="{TemplateBinding ContentTemplate}"
+								  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+								  Background="Transparent"/>
 				<Grid x:Name="RefreshVisualizerPresenter"/>
 				</Grid>
 			</ControlTemplate>
@@ -37,7 +41,11 @@
 					<Grid x:Name="Root">
 						<uno:NativeRefreshControl x:Name="NativeRefreshControl">
 							<uno:NativeRefreshControl.Content>
-								<ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" Background="Transparent" />
+								<ContentPresenter x:Name="ContentPresenter"
+									Content="{TemplateBinding Content}"
+									ContentTemplate="{TemplateBinding ContentTemplate}"
+									ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+									Background="Transparent"/>
 							</uno:NativeRefreshControl.Content>
 						</uno:NativeRefreshControl>
 						<Grid x:Name="RefreshVisualizerPresenter"/>

--- a/src/Uno.UI/UI/Xaml/Style/mergedstyles.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/mergedstyles.xaml
@@ -6856,7 +6856,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="controls:RefreshContainer">
           <Grid x:Name="Root" Background="{TemplateBinding Background}">
-            <ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" Background="Transparent" />
+            <ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" Background="Transparent" />
             <Grid x:Name="RefreshVisualizerPresenter" />
           </Grid>
         </ControlTemplate>
@@ -6873,7 +6873,7 @@
           <Grid x:Name="Root">
             <uno:NativeRefreshControl x:Name="NativeRefreshControl">
               <uno:NativeRefreshControl.Content>
-                <ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" Background="Transparent" />
+                <ContentPresenter x:Name="ContentPresenter" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" Background="Transparent" />
               </uno:NativeRefreshControl.Content>
             </uno:NativeRefreshControl>
             <Grid x:Name="RefreshVisualizerPresenter" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9761

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`RefreshContainer` content alignment is broken by native android layouting repeated after our arrange.

## What is the new behavior?

- Avoid second native layout after our arrange
- Ensure `ContentTemplate` and `ContentTemplateSelector` are properly applied.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
