### PR TITLE
[Gtk] macOS and GL additional validations

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -433,7 +433,7 @@ namespace SamplesApp
 				builder.AddFilter("Uno.UI.RemoteControl", LogLevel.Information);
 
 				// Display Skia related information
-				builder.AddFilter("Uno.UI.Runtime.Skia", LogLevel.Information);
+				builder.AddFilter("Uno.UI.Runtime.Skia", LogLevel.Debug);
 
 				// builder.AddFilter("Uno.Foundation.WebAssemblyRuntime", LogLevel.Debug );
 				// builder.AddFilter("Windows.UI.Xaml.Controls.PopupPanel", LogLevel.Debug );

--- a/src/Uno.UI.Runtime.Skia.Gtk/GLValidationSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GLValidationSurface.cs
@@ -86,6 +86,8 @@ namespace Uno.UI.Runtime.Skia
 			{
 				if (OpenGLRenderSurface.IsSupported)
 				{
+					OpenGLRenderSurface.TryValidateExtensions();
+
 					using var ctx = OpenGLRenderSurface.CreateGRGLContext();
 
 					if (ctx != null)

--- a/src/Uno.UI.Runtime.Skia.Gtk/GLValidationSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GLValidationSurface.cs
@@ -22,6 +22,7 @@ namespace Uno.UI.Runtime.Skia
 			HasDepthBuffer = false;
 			HasStencilBuffer = false;
 			AutoRender = true;
+			SetRequiredVersion(3, 3);
 
 			Render += GLValidationSurface_Render;
 			Realized += GLValidationSurface_Realized;

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -169,6 +169,20 @@ namespace Uno.UI.Runtime.Skia
 		{
 			TryReadRenderSurfaceTypeEnvironment();
 
+			if(!OpenGLRenderSurface.IsSupported && !OpenGLESRenderSurface.IsSupported)
+			{
+				// Pre-validation is required to avoid initializing OpenGL on macOS
+				// where the whole app may get visually corrupted even if OpenGL is not
+				// used in the app.
+
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"Neither OpenGL or OpenGL ES are supporting, using software rendering");
+				}
+
+				RenderSurfaceType = Skia.RenderSurfaceType.Software;
+			}
+
 			if (RenderSurfaceType == null)
 			{
 				// Create a temporary surface to automatically detect

--- a/src/Uno.UI.Runtime.Skia.Gtk/OpenGLRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/OpenGLRenderSurface.cs
@@ -49,36 +49,10 @@ namespace Uno.UI.Runtime.Skia
 				try
 				{
 					var isAvailable = NativeContext.TryGetProcAddress("glGetString", out var getString);
-					var extensions = new GL(NativeContext).GetStringS(GLEnum.Extensions);
-					var hasARBVertexArrayObject = extensions?.Contains("GL_ARB_vertex_array_object");
 
 					if (typeof(OpenGLESRenderSurface).Log().IsEnabled(LogLevel.Debug))
 					{
-						typeof(OpenGLESRenderSurface).Log().Debug($"OpenGL support: isAvailable:{isAvailable} isMacOs:{isMacOs} hasARBVertexArrayObject:{hasARBVertexArrayObject}");
-					}
-
-					if (hasARBVertexArrayObject.HasValue
-						&& hasARBVertexArrayObject == false
-						&& typeof(OpenGLESRenderSurface).Log().IsEnabled(LogLevel.Error))
-					{
-						// In this case, the GTK runtime will terminate the app
-						// if some OpenGL extensions cannot be found. This can happen
-						// when the target video device does not provide the required support.
-						//
-						// For example, this is the error that may be raised:
-						//
-						// No provider of glGenVertexArrays found.  Requires one of:
-						// Desktop OpenGL 3.0
-
-						// GL_ARB_vertex_array_object
-						// OpenGL ES 3.0
-						// GL_APPLE_vertex_array_object
-						// GL_OES_vertex_array_object
-
-
-						typeof(OpenGLESRenderSurface).Log().Error(
-							$"OpenGL support on this system is missing extension \"GL_ARB_vertex_array_object\", you may need to enable software " +
-							$"rendering. (https://platform.uno/docs/articles/features/using-skia-gtk.html#changing-the-rendering-target)");
+						typeof(OpenGLESRenderSurface).Log().Debug($"OpenGL support: isAvailable:{isAvailable} isMacOs:{isMacOs}");
 					}
 
 					return isAvailable && !isMacOs;
@@ -93,6 +67,42 @@ namespace Uno.UI.Runtime.Skia
 					return false;
 				}
 			}
+		}
+
+		public static void TryValidateExtensions()
+		{
+			if (typeof(OpenGLESRenderSurface).Log().IsEnabled(LogLevel.Debug))
+			{
+				typeof(OpenGLESRenderSurface).Log().Debug($"Validating OpenGL Extensions");
+			}
+
+			var extensions = new GL(NativeContext).GetStringS(GLEnum.Extensions);
+			var hasARBVertexArrayObject = extensions?.Contains("GL_ARB_vertex_array_object");
+
+			if (hasARBVertexArrayObject.HasValue
+				&& hasARBVertexArrayObject == false
+				&& typeof(OpenGLESRenderSurface).Log().IsEnabled(LogLevel.Error))
+			{
+				// In this case, the GTK runtime will terminate the app
+				// if some OpenGL extensions cannot be found. This can happen
+				// when the target video device does not provide the required support.
+				//
+				// For example, this is the error that may be raised:
+				//
+				// No provider of glGenVertexArrays found.  Requires one of:
+				// Desktop OpenGL 3.0
+
+				// GL_ARB_vertex_array_object
+				// OpenGL ES 3.0
+				// GL_APPLE_vertex_array_object
+				// GL_OES_vertex_array_object
+
+
+				typeof(OpenGLESRenderSurface).Log().Error(
+					$"OpenGL support on this system is missing extension \"GL_ARB_vertex_array_object\", you may need to enable software " +
+					$"rendering. (https://platform.uno/docs/articles/features/using-skia-gtk.html#changing-the-rendering-target)");
+			}
+
 		}
 
 		protected override (int framebuffer, int stencil, int samples) GetGLBuffers()

--- a/src/Uno.UI.Runtime.Skia.Gtk/OpenGLRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/OpenGLRenderSurface.cs
@@ -48,7 +48,38 @@ namespace Uno.UI.Runtime.Skia
 
 				try
 				{
-					var isAvailable = NativeContext.TryGetProcAddress("glGetString", out _);
+					var isAvailable = NativeContext.TryGetProcAddress("glGetString", out var getString);
+					var extensions = new GL(NativeContext).GetStringS(GLEnum.Extensions);
+					var hasARBVertexArrayObject = extensions?.Contains("GL_ARB_vertex_array_object");
+
+					if (typeof(OpenGLESRenderSurface).Log().IsEnabled(LogLevel.Debug))
+					{
+						typeof(OpenGLESRenderSurface).Log().Debug($"OpenGL support: isAvailable:{isAvailable} isMacOs:{isMacOs} hasARBVertexArrayObject:{hasARBVertexArrayObject}");
+					}
+
+					if (hasARBVertexArrayObject.HasValue
+						&& hasARBVertexArrayObject == false
+						&& typeof(OpenGLESRenderSurface).Log().IsEnabled(LogLevel.Error))
+					{
+						// In this case, the GTK runtime will terminate the app
+						// if some OpenGL extensions cannot be found. This can happen
+						// when the target video device does not provide the required support.
+						//
+						// For example, this is the error that may be raised:
+						//
+						// No provider of glGenVertexArrays found.  Requires one of:
+						// Desktop OpenGL 3.0
+
+						// GL_ARB_vertex_array_object
+						// OpenGL ES 3.0
+						// GL_APPLE_vertex_array_object
+						// GL_OES_vertex_array_object
+
+
+						typeof(OpenGLESRenderSurface).Log().Error(
+							$"OpenGL support on this system is missing extension \"GL_ARB_vertex_array_object\", you may need to enable software " +
+							$"rendering. (https://platform.uno/docs/articles/features/using-skia-gtk.html#changing-the-rendering-target)");
+					}
 
 					return isAvailable && !isMacOs;
 				}


### PR DESCRIPTION
GitHub Issue (If applicable): #9099 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

fix(gtk): Align validation surface to the OpenGLRender surface version
fix(gtk): Pre-validate OpenGL support to avoid initializing on macOS
fix(gtk): Show an error message when GL_ARB_vertex_array_object is not available.
