### PR TITLE
Improve android build time and assembly size

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -8850,6 +8850,38 @@
 	</IgnoreSet>
 	<IgnoreSet baseVersion="4.4.20">
 		<Types>
+			<!-- BEGIN Android Resources ignore -->
+			<Member fullName="Uno.UWP.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Windows.Foundation.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.Foundation.Logging.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.Composition.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.Dispatching.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.FluentTheme.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.FluentTheme.v1.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.FluentTheme.v2.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.Toolkit.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.Xaml.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UWP.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Windows.Foundation.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.Foundation.Logging.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.Composition.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.Dispatching.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.FluentTheme.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.FluentTheme.v1.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.FluentTheme.v2.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.Toolkit.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.Xaml.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UWP.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Windows.Foundation.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.BindingHelper.Android.net6.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.Composition.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.Dispatching.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.FluentTheme.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.FluentTheme.v1.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.FluentTheme.v2.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.UI.Toolkit.Resource" reason="Unused public member, performance improvement" />
+			<Member fullName="Uno.Xaml.net6.Resource" reason="Unused public member, performance improvement" />
+			<!-- END Android Resources ignore -->
 		</Types>
 		<Methods>
 			<Member
@@ -8938,6 +8970,7 @@
 			<!-- END iOS 16 workaround -->
 		</Properties>
 	</IgnoreSet>
+	
 	<!--
 	Supported nodes (please keep at the bottom of this file):
 	<IgnoreSet baseVersion="0.0.0">

--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -495,7 +495,7 @@
 			<PackageNamePrefix Condition="'$(UNO_UWP_BUILD)'=='true'">Uno.UI</PackageNamePrefix>
 		</PropertyGroup>
 
-		<Exec Command="dotnet tool install --tool-path $(MSBuildThisFileDirectory)\tools Uno.PackageDiff --version 1.1.0-dev.11" IgnoreExitCode="true" />
+		<Exec Command="dotnet tool install --tool-path $(MSBuildThisFileDirectory)\tools Uno.PackageDiff --version 1.1.0-dev.14" IgnoreExitCode="true" />
 		<Exec Command="$(MSBuildThisFileDirectory)\tools\generatepkgdiff.exe --base=$(PackageNamePrefix) --other=$(PackageNamePrefix).$(GITVERSION_SemVer).nupkg --diffignore=PackageDiffIgnore.xml --outfile=$(OutputDir)\ApiDiff.$(GITVERSION_SemVer).md" />
 	</Target>
 	

--- a/doc/articles/uno-development/building-uno-ui.md
+++ b/doc/articles/uno-development/building-uno-ui.md
@@ -122,3 +122,28 @@ To run the synchronization tool:
 - Run the `run-api-sync-tool.cmd` script; make sure to follow the instructions
 
 Note that as of Uno 3.10, the tool is manually run for the UWP part of the build and automatically run as part of the CI during the WinUI part of the build.
+
+### Android Resources ID generation
+
+To workaround a performance issue, all `Resource.designer.cs` generation is disabled for class libraries in this repo.
+
+If you need to add a new `@(AndroidResource)` value to be used from C# code inside of Uno.UI libraries:
+
+1. Comment out the `<PropertyGroup>` in `Directory.Build.targets` that sets `$(AndroidGenerateResourceDesigner)` and `$(AndroidUseIntermediateDesignerFile)` to `false`.
+
+2. Build Uno.UI as you normally would. You will get compiler errors about duplicate fields, but `obj\Debug\net6.0-android\Resource.designer.cs` should now be generated.
+
+3. Open `obj\Debug\net6.0-android\Resource.designer.cs`, and find the
+   field you need such as:
+
+```csharp
+// aapt resource value: 0x7F010000
+public static int foo = 2130771968;
+```
+
+4. Copy this field to the `Resource.designer.cs` checked into source
+   control, such as: `src/Uno.UI/Resources/Resource.designer.g.Android.cs`
+
+5. Restore the commented code in `Directory.Build.targets`.
+
+_This performance optimization is inspired from @jonathanpeppers's performance work done in https://github.com/dotnet/maui/pull/2606. Thanks Jonathan!_

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -194,16 +194,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!--
-        This works around the fact that AndroidResgenFile is
-        automatically included as compiled file, even if AndroidUseIntermediateDesignerFile
-        is set to true.
-        -->
-    <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-    <AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- Enable performance CA rules from 'Microsoft.CodeAnalysis.NetAnalyzers' as build warnings by default. Specific rules are disabled or downgraded in repo's editorconfig. -->
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisModePerformance>AllEnabledByDefault</AnalysisModePerformance>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -6,7 +6,31 @@
 	<Product>$(AssemblyName) ($(TargetFramework) $(UnoRuntimeIdentifier))</Product>
   </PropertyGroup>
 
-  <Target Name="AndroidResourceGenWorkaround" BeforeTargets="Build" Condition="'$(AndroidUseIntermediateDesignerFile)'=='True' and $(IsMonoAndroid) and '$(TargetFramework)'!='net6.0-android'">
+	<!--
+	Comment out this section if you need to update Resource.designer.cs files.
+	See DEVELOPMENT.md#Android for details.
+	-->
+	<Choose>
+		<When Condition="'$(TargetPlatformIdentifier)' == 'Android' and '$(AndroidApplication)' != 'true'">
+			<PropertyGroup >
+				<AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
+				<AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
+			</PropertyGroup>
+		</When>
+		<Otherwise>
+			<PropertyGroup>
+				<!--
+				This works around the fact that AndroidResgenFile is
+				automatically included as compiled file, even if AndroidUseIntermediateDesignerFile
+				is set to true.
+				-->
+				<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
+				<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
+			</PropertyGroup>
+		</Otherwise>
+	</Choose>
+
+	<Target Name="AndroidResourceGenWorkaround" BeforeTargets="Build" Condition="'$(AndroidUseIntermediateDesignerFile)'=='True' and $(IsMonoAndroid) and '$(TargetFramework)'!='net6.0-android'">
 	<MakeDir Directories="obj\$(TargetFramework)\Resources" />
 	<WriteLinesToFile File="$(AndroidResgenFile)" Lines="// Empty Content from uno.ui Directory.Build.targets." />
   </Target>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,7 +11,7 @@
 	See DEVELOPMENT.md#Android for details.
 	-->
 	<Choose>
-		<When Condition="'$(TargetPlatformIdentifier)' == 'Android' and '$(AndroidApplication)' != 'true'">
+		<When Condition="('$(TargetPlatformIdentifier)' == 'Android' or '$(TargetFrameworkIdentifier)'=='MonoAndroid') and '$(AndroidApplication)' != 'true'">
 			<PropertyGroup >
 				<AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
 				<AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>

--- a/src/PlatformItemGroups.props
+++ b/src/PlatformItemGroups.props
@@ -41,8 +41,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(_IsAndroid)">
-    <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-    <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <DefineConstants>$(DefineConstants);__ANDROID__;XAMARIN;MONOANDROID5_0;XAMARIN_ANDROID</DefineConstants>
 	<SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
   </PropertyGroup>

--- a/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
+++ b/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
@@ -5,8 +5,6 @@
 
 		<DisableBuildTargetFramework>true</DisableBuildTargetFramework>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
 		<OutputPath>bin\$(Configuration)\$(TargetFramework)\</OutputPath>

--- a/src/SourceGenerators/System.Xaml/Uno.Xaml.net6.csproj
+++ b/src/SourceGenerators/System.Xaml/Uno.Xaml.net6.csproj
@@ -9,8 +9,6 @@
 		<DisableBuildTargetFramework>true</DisableBuildTargetFramework>
 		<AssemblyName>Uno.Xaml</AssemblyName>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
 		<OutputPath>bin\$(Configuration)\$(TargetFramework)\</OutputPath>

--- a/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
+++ b/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
@@ -7,9 +7,6 @@
 	<PropertyGroup>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<DefaultLanguage>en-US</DefaultLanguage>
-
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -10,9 +10,6 @@
 	<PropertyGroup>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<DefaultLanguage>en-US</DefaultLanguage>
-
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">

--- a/src/Uno.CrossTargetting.props
+++ b/src/Uno.CrossTargetting.props
@@ -98,8 +98,6 @@
 
   <PropertyGroup Condition="$(IsMonoAndroid)">
 	<DefineConstants>$(DefineConstants);XAMARIN;XAMARIN_ANDROID</DefineConstants>
-	<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-	<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' != 'uap10.0.18362' and '$(TargetFramework)'!='net5.0-windows10.0.18362.0' ">

--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
@@ -4,9 +4,6 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<NoWarn>1701;1702;1705;109</NoWarn>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
 

--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.net6.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.net6.csproj
@@ -5,9 +5,6 @@
 		<NoWarn>1701;1702;1705;109</NoWarn>
 		<AssemblyName>Uno.UI.BindingHelper.Android</AssemblyName>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
 

--- a/src/Uno.UI.Composition/Uno.UI.Composition.csproj
+++ b/src/Uno.UI.Composition/Uno.UI.Composition.csproj
@@ -15,9 +15,6 @@
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO</DefineConstants>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		

--- a/src/Uno.UI.Composition/Uno.UI.Composition.net6.csproj
+++ b/src/Uno.UI.Composition/Uno.UI.Composition.net6.csproj
@@ -18,9 +18,6 @@
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO</DefineConstants>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		

--- a/src/Uno.UI.Dispatching/Uno.UI.Dispatching.csproj
+++ b/src/Uno.UI.Dispatching/Uno.UI.Dispatching.csproj
@@ -15,9 +15,6 @@
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO;IS_UNO_UI_DISPATCHING_PROJECT</DefineConstants>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		

--- a/src/Uno.UI.Dispatching/Uno.UI.Dispatching.net6.csproj
+++ b/src/Uno.UI.Dispatching/Uno.UI.Dispatching.net6.csproj
@@ -18,9 +18,6 @@
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO;IS_UNO_UI_DISPATCHING_PROJECT</DefineConstants>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Skia.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Skia.csproj
@@ -11,9 +11,6 @@
 	<PropertyGroup>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Wasm.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Wasm.csproj
@@ -11,9 +11,6 @@
 	<PropertyGroup>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.csproj
@@ -12,9 +12,6 @@
 	<PropertyGroup>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.net6.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.net6.csproj
@@ -18,9 +18,6 @@
 
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		

--- a/src/Uno.UI.XamlHost/Uno.UI.XamlHost.net6.csproj
+++ b/src/Uno.UI.XamlHost/Uno.UI.XamlHost.net6.csproj
@@ -18,9 +18,6 @@
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO;IS_UNO_UI_XamlHost_PROJECT</DefineConstants>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		

--- a/src/Uno.UI/Resources/Resource.designer.g.Android.cs
+++ b/src/Uno.UI/Resources/Resource.designer.g.Android.cs
@@ -1,5 +1,12 @@
 ﻿namespace Uno.UI;
 
+//
+// This file is manually maintained and should not be modified to add partial qualifiers. If you
+// get a build error make sure that the Resource.designer.cs generation is effectively disabled.
+//
+// See the `doc/articles/building-uno-uid.md` documentation on how to modify this file.
+//
+
 [System.CodeDom.Compiler.GeneratedCode("Xamarin.Android.Build.Tasks", "12.3.99.48")]
 public class Resource
 {

--- a/src/Uno.UI/Resources/Resource.designer.g.Android.cs
+++ b/src/Uno.UI/Resources/Resource.designer.g.Android.cs
@@ -1,0 +1,32 @@
+﻿namespace Uno.UI;
+
+[System.CodeDom.Compiler.GeneratedCode("Xamarin.Android.Build.Tasks", "12.3.99.48")]
+public class Resource
+{
+	public class Styleable
+	{
+		public static int[] View =
+			new int[48]
+			{
+				16842752, 16842852, 16842853, 16842854, 16842855, 16842856, 16842857, 16842879, 16842960, 16842961,
+				16842962, 16842963, 16842964, 16842965, 16842966, 16842967, 16842968, 16842969, 16842970, 16842971,
+				16842972, 16842973, 16842974, 16842975, 16842976, 16842977, 16842978, 16842979, 16842980, 16842981,
+				16842982, 16842983, 16842984, 16842985, 16843071, 16843072, 16843285, 16843286, 16843342, 16843358,
+				16843375, 16843379, 16843432, 16843433, 16843434, 2130903238, 2130903239, 2130903304
+			};
+
+		static Styleable()
+		{
+			global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+		}
+
+		private Styleable()
+		{
+		}
+	}
+
+	static Resource()
+	{
+		global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+	}
+}

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -20,9 +20,6 @@
 
 		<UnoRuntimeIdentifier Condition="'$(TargetFramework)'=='netstandard2.0'">Reference</UnoRuntimeIdentifier>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 

--- a/src/Uno.UI/Uno.UI.net6.csproj
+++ b/src/Uno.UI/Uno.UI.net6.csproj
@@ -28,9 +28,6 @@
 
 		<UnoRuntimeIdentifier Condition="'$(TargetFramework)'=='netstandard2.0'">Reference</UnoRuntimeIdentifier>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -15,9 +15,6 @@
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO;HAS_UMBRELLA_UI;HAS_UMBRELLA_BINDING;HAS_CRIPPLEDREFLECTION</DefineConstants>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		

--- a/src/Uno.UWP/Uno.net6.csproj
+++ b/src/Uno.UWP/Uno.net6.csproj
@@ -18,9 +18,6 @@
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO;HAS_UMBRELLA_UI;HAS_UMBRELLA_BINDING;HAS_CRIPPLEDREFLECTION</DefineConstants>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
-
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

The Uno.UI build now skips the creation of android resources designer classes, which are not used by uno itself (or in very rare occasions), therefore making the build significantly faster, but also reduces the size of the app and provides better startup time.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
