### PR TITLE
perf: Avoid unnecessary `SetStyle` call for TextBox

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -50,8 +50,6 @@ namespace Windows.UI.Xaml.Controls
 			{
 				AddHandler(PointerReleasedEvent, (PointerEventHandler)OnHeaderClick, true);
 			}
-
-			SetStyle("cursor", "text");
 		}
 
 		partial void OnTappedPartial()

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -155,6 +155,10 @@ embed.uno-frameworkelement.uno-unarranged {
   background-color: transparent;
 }
 
+.uno-textbox {
+    cursor: text;
+}
+
 .uno-textelement {
   position: relative;
 }


### PR DESCRIPTION
It looks like ***all*** `TextBox`es have `cursor: text;` styling. This PR adds it to `Uno.UI.css` to avoid `SetStyle` calls.

FYI @Xiaoy312 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Performance

## What is the current behavior?

`SetStyle("cursor", "text")` is called for every `TextBox`


## What is the new behavior?

Now `cursor: text;` is set for all `TextBox`es via `Uno.UI.css` and unnecessary `SetStyle` calls are eliminated.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
