### PR TITLE
build: Remove workaround to remove analyzers

### DIFF
--- a/src/T4Generator/T4Generator.csproj
+++ b/src/T4Generator/T4Generator.csproj
@@ -22,19 +22,4 @@
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
 	
-	<Target Name="_ForceRemoveAnalyzers" BeforeTargets="CoreCompile">
-		<!-- Workaround for Linux and macos when building against mono where Analyzers 2.9.x depend on unknown members. This should not happen when building
-		     with "dotnet build"
-
-		CSC : error AD0001: Analyzer 'Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.CompareSymbolsCorrectlyAnalyzer' threw an exception of type
-				  'System.TypeLoadException' with message 'Could not load type of field 'Analyzer.Utilities.Extensions.IOperationExtensions:s_operationToCfgCache'
-					(0) due to: Could not resolve type with token 01000075 from typeref (expected class 'Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph' in
-					assembly 'Microsoft.CodeAnalysis, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35') assembly:Microsoft.CodeAnalysis, Version=2.9.0.0,
-					Culture=neutral, PublicKeyToken=31bf3856ad364e35 type:Microsoft.CodeAnalysis.FlowAnalysis.ControlFlowGraph member:(null)'.
-		-->
-		<ItemGroup>
-			<Analyzer Remove="@(Analyzer)" />
-		</ItemGroup>
-	</Target>
-
 </Project>


### PR DESCRIPTION
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes


## What is the current behavior?

Analyzers are not run on T4Generator project.

## What is the new behavior?

Analyzers are now run on T4Generator project


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
