### PR TITLE
fix: Ensure culture is not set to invariant culture in WSL

### DIFF
--- a/src/Uno.UI/UI/Xaml/Application.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Application.skia.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using Uno.UI;
 using Uno.UI.Xaml;
 using Uno.Foundation.Extensibility;
+using System.Globalization;
 
 namespace Windows.UI.Xaml
 {
@@ -29,6 +30,8 @@ namespace Windows.UI.Xaml
 		public Application()
 		{
 			Current = this;
+			SetCurrentLanguage();
+			
 			Package.SetEntryAssembly(this.GetType().Assembly);
 
 			if (!_startInvoked)
@@ -39,6 +42,27 @@ namespace Windows.UI.Xaml
 			ApiExtensibility.CreateInstance(this, out _applicationExtension);
 
 			CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Normal, Initialize);
+		}
+
+		private void SetCurrentLanguage()
+		{
+			if (CultureInfo.CurrentUICulture.IetfLanguageTag == "" &&
+				CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "iv")
+			{
+				try
+				{
+					// Fallback to English
+					var cultureInfo = CultureInfo.CreateSpecificCulture("en");
+					CultureInfo.CurrentUICulture = cultureInfo;
+					CultureInfo.CurrentCulture = cultureInfo;
+					Thread.CurrentThread.CurrentCulture = cultureInfo;
+					Thread.CurrentThread.CurrentUICulture = cultureInfo;
+				}
+				catch (Exception ex)
+				{
+					this.Log().Error($"Failed to set default culture", ex);
+				}
+			}
 		}
 
 		internal static void StartWithArguments(global::Windows.UI.Xaml.ApplicationInitializationCallback callback)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8661

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Under WSL, the default locale is set to invariant UTF-8:

<img width="275" alt="image" src="https://user-images.githubusercontent.com/1075116/190189834-0f64f2a8-37d0-4397-a934-ceca86dd9cf2.png">

Under this configuration, the `CurrentUICulture` is set to a culture with same attributes as `InvariantCulture` (but not the same instance, `==` returns `false`). This leads to most WinUI controls resources not being loaded (as they are specific culture, e.g. `en-US`).

## What is the new behavior?

During Skia application initialization, we check whether `CurrentUICulture` is invariant, and if yes, we fall back to English.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.