### PR TITLE
fix(skia): Ensure that visuals rendering happens in the correct order

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurfaceBase.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurfaceBase.cs
@@ -60,7 +60,12 @@ namespace Uno.UI.Runtime.Skia
 
 			HasDepthBuffer = false;
 			HasStencilBuffer = false;
-			AutoRender = true;
+
+			// AutoRender must be disabled to avoid having the GLArea re-render the
+			// composition Visuals after pointer interactions, causing undefined behaviors
+			// for Visuals being updated during a pointer interaction, while not having measured
+			// and arranged properly.
+			AutoRender = false;
 		}
 
 		public Widget Widget => this;


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9813

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that Visuals rendering happens only when requested.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
