### PR TITLE
fix: invalid xml syntax in crosstargeting_override.props.sample

### DIFF
--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -1,8 +1,8 @@
 <Project ToolsVersion="15.0">
     <!--
-        This file is used to control the platforms compiled by visual studio, and 
+        This file is used to control the platforms compiled by visual studio, and
             allow for a faster build when testing for a single platform.
-    
+
             Instructions:
             1) Copy this file and remove the ".sample" name
             2) Uncomment and adjust the UnoNugetOverrideVersion property below
@@ -12,26 +12,26 @@
   <PropertyGroup>
     <IsUnoUIProject>false</IsUnoUIProject>
     <IsUnoUIProject Condition="'$(AssemblyName)'=='Uno' or '$(AssemblyName)'=='Uno.UI' or '$(AssemblyName)'=='Uno.Foundation'">true</IsUnoUIProject>
-    
+
     <!--
         This property controls the platform built by Visual Studio.
-        
+
         Available build targets and corresponding solution filters:
-        
-        |----------------------------|-----------------------|------------------------------------------------------------------------------------|
-        | UnoTargetFrameworkOverride | Platform              | Solution filter file                                                               |
-        |----------------------------|-----------------------|------------------------------------------------------------------------------------|
-        | uap10.0.18362              | Windows               | Uno.UI-Windows-only.slnf                                                           |
-        | xamarinios10               | iOS                   | Uno.UI-iOS-only.slnf                                                               |
-        | MonoAndroid12.0            | Android 12.0          | Uno.UI-Android-only.slnf                                                           |
-        | netstandard2.0             | WebAssembly, Skia     | Uno.UI-Wasm-only.slnf, Uno.UI-Skia-only.slnf                                       |
-        | net6.0-ios                 | .NET 6 iOS            | Uno.UI-net6-only.slnf                                                              |
-        | net6.0-android             | .NET 6 Android        | Uno.UI-net6-only.slnf                                                              |
-        | net6.0-maccatalyst         | .NET 6 macOS Catalyst | Uno.UI-net6-only.slnf                                                              |
-        | net6.0-macos               | .NET 6 macOS AppKit   | Uno.UI-net6-only.slnf                                                              |
-        | xamarinmac20               | macOS                 | Uno.UI-macOS-only.slnf (VS for Windows), Uno.UI-vs4mac-macOS-only.sln (VS for Mac) |
-        | net461                     | Uno.UI.Tests          | Uno.UI-UnitTests-only.slnf                                                         |
-        |----------------------------|-----------------------|------------------------------------------------------------------------------------|
+
+        ┌────────────────────────────┬───────────────────────┬────────────────────────────────────────────────────────────────────────────────────┐
+        │ UnoTargetFrameworkOverride │ Platform              │ Solution filter file                                                               │
+        ├────────────────────────────┼───────────────────────┼────────────────────────────────────────────────────────────────────────────────────┤
+        │ uap10.0.18362              │ Windows               │ Uno.UI-Windows-only.slnf                                                           │
+        │ xamarinios10               │ iOS                   │ Uno.UI-iOS-only.slnf                                                               │
+        │ MonoAndroid12.0            │ Android 12.0          │ Uno.UI-Android-only.slnf                                                           │
+        │ netstandard2.0             │ WebAssembly, Skia     │ Uno.UI-Wasm-only.slnf, Uno.UI-Skia-only.slnf                                       │
+        │ net6.0-ios                 │ .NET 6 iOS            │ Uno.UI-net6-only.slnf                                                              │
+        │ net6.0-android             │ .NET 6 Android        │ Uno.UI-net6-only.slnf                                                              │
+        │ net6.0-maccatalyst         │ .NET 6 macOS Catalyst │ Uno.UI-net6-only.slnf                                                              │
+        │ net6.0-macos               │ .NET 6 macOS AppKit   │ Uno.UI-net6-only.slnf                                                              │
+        │ xamarinmac20               │ macOS                 │ Uno.UI-macOS-only.slnf (VS for Windows), Uno.UI-vs4mac-macOS-only.sln (VS for Mac) │
+        │ net461                     │ Uno.UI.Tests          │ Uno.UI-UnitTests-only.slnf                                                         │
+        └────────────────────────────┴───────────────────────┴────────────────────────────────────────────────────────────────────────────────────┘
 
         Only one target can be built, and the corresponding solution filter file must
         be loaded in Visual Studio (see next to Uno.UI.sln).
@@ -45,8 +45,8 @@
         *** WARNING ***
     -->
     <!--<UnoTargetFrameworkOverride>netstandard2.0</UnoTargetFrameworkOverride>-->
-    
-    <!-- 
+
+    <!--
     This property allows the override of the nuget local cache.
     Set it to the version you want to override, used in another app.
     You will see the override path in the build output.


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
double-dashes `--` are not permitted within comments

## What is the new behavior?
updated the table with different "border" characters

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
regression from #9829