### PR TITLE
Chore: Add Uno.UI.Lottie package in template projects

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -169,6 +169,9 @@
 		<XmlPoke XmlInputPath="%(_sdkProject.Identity)"
 							 Query="//PackageReference[@Include='Uno.UI.Runtime.WebAssembly']/@Version"
 							 Value="$(GitVersion_SemVer)" />
+		<XmlPoke XmlInputPath="%(_sdkProject.Identity)"
+							 Query="//PackageReference[@Include='Uno.UI.Lottie']/@Version"
+							 Value="$(GitVersion_SemVer)" />
 
 		<!-- Update templates for Uno.WinUI -->
 		<XmlPoke XmlInputPath="%(_sdkProject.Identity)"
@@ -194,6 +197,9 @@
 							 Value="$(GitVersion_SemVer)" />
 		<XmlPoke XmlInputPath="%(_sdkProject.Identity)"
 							 Query="//PackageReference[@Include='Uno.WinUI.Runtime.WebAssembly']/@Version"
+							 Value="$(GitVersion_SemVer)" />
+		<XmlPoke XmlInputPath="%(_sdkProject.Identity)"
+							 Query="//PackageReference[@Include='Uno.WinUI.Lottie']/@Version"
 							 Value="$(GitVersion_SemVer)" />
 
 

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Mobile/UnoQuickStart.Mobile.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Mobile/UnoQuickStart.Mobile.csproj
@@ -29,6 +29,7 @@
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.2.6" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.6" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+		<PackageReference Include="Uno.UI.Lottie" Version="4.5.9" />
 	</ItemGroup>
 
 	<Choose>

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Gtk/UnoQuickStart.Skia.Gtk.csproj
@@ -21,6 +21,7 @@
 		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.2.6" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.2.6" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="3.0.5" />
+		<PackageReference Include="Uno.UI.Lottie" Version="4.5.9" />
 	</ItemGroup>
 
 	<Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" />

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Linux.FrameBuffer/UnoQuickStart.Skia.Linux.FrameBuffer.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.Linux.FrameBuffer/UnoQuickStart.Skia.Linux.FrameBuffer.csproj
@@ -21,6 +21,7 @@
 		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.2.6" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.2.6" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.6" />
+		<PackageReference Include="Uno.UI.Lottie" Version="4.5.9" />
 	</ItemGroup>
 
 	<Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" />

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.WPF/UnoQuickStart.Skia.WPF.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Skia.WPF/UnoQuickStart.Skia.WPF.csproj
@@ -24,6 +24,7 @@
 		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.2.6" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.2.6" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="3.0.5" />
+		<PackageReference Include="Uno.UI.Lottie" Version="4.5.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/Wasm/UnoQuickStart.Wasm.csproj
@@ -56,6 +56,7 @@
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.6" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
+		<PackageReference Include="Uno.UI.Lottie" Version="4.5.9" />
 	</ItemGroup>
 
 	<Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" Condition="Exists('..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems')" />

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/WinUI/UnoQuickStart.Windows.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.net6/WinUI/UnoQuickStart.Windows.csproj
@@ -27,6 +27,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.196" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
+		<PackageReference Include="Uno.UI.Lottie" Version="4.5.9" />
 
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9812

## PR Type

What kind of change does this PR introduce?
Adds the Uno.UI.Lottie package in all template projects.

## What is the current behavior?

Controls like ProgressRing not working by default.


## What is the new behavior?

Controls like ProgressRing working by default.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information


Internal Issue (If applicable):
