### PR TITLE
fix(VisibleBoundsPadding): Ensure the proper root is used to compute relative bounds

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Toolkit/VisibleBoundsPadding_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Toolkit/VisibleBoundsPadding_Tests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using NUnit.Framework;
+using SamplesApp.UITests.Extensions;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Toolkit
+{
+	[TestFixture]
+	public partial class VisibleBoundsPadding_Tests : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)]
+		public void When_Inside_Modal()
+		{
+			const string Blue = "#0000FF";
+
+			Run("UITests.Toolkit.VisibleBoundsPadding_Modal_Test");
+
+			App.FastTap("SafeArea_Launch_Modal_Button");
+
+			App.WaitForElement("ContainerGrid");
+			App.FastTap("ChangeLayoutButton");
+
+			var containerGrid = App.GetPhysicalRect("ContainerGrid");
+			var testRectangle = App.GetPhysicalRect("TestRectangle");
+
+			using var screenshot = TakeScreenshot("SafeArea_Modal_After_Relayout");
+
+			var safeAreaBottomInset = containerGrid.Bottom - testRectangle.Bottom;
+			Assert.Greater(safeAreaBottomInset, 0);
+
+			for (int i = 1; i < safeAreaBottomInset; i++)
+			{
+				ImageAssert.HasPixels(
+					screenshot,
+					ExpectedPixels
+						.At(containerGrid.CenterX / 2, containerGrid.Bottom - i)
+						.Named($"SafeArea_Modal_Bottom_{i}")
+						.Pixel(Blue));
+			}
+
+			App.FastTap("CloseModalButton");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Toolkit/VisibleBoundsPadding_Modal.xaml
+++ b/src/SamplesApp/UITests.Shared/Toolkit/VisibleBoundsPadding_Modal.xaml
@@ -1,0 +1,43 @@
+﻿<Page x:Class="UITests.Toolkit.VisibleBoundsPadding_Modal"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Toolkit"
+	  xmlns:toolkit="using:Uno.UI.Toolkit"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid toolkit:VisibleBoundsPadding.PaddingMask="All"
+		  Background="Blue"
+		  AutomationProperties.AutomationId="ContainerGrid">
+		<Rectangle Fill="Red"
+				   AutomationProperties.AutomationId="TestRectangle" />
+
+		<StackPanel>
+			<Grid>
+				<Button Content="Change Layout"
+						AutomationProperties.AutomationId="ChangeLayoutButton"
+						x:Name="ChangeLayoutButton"
+						HorizontalAlignment="Left"
+						Click="Button_Click" />
+
+				<Button Content="Close Modal"
+						AutomationProperties.AutomationId="CloseModalButton"
+						x:Name="CloseModalButton"
+						HorizontalAlignment="Right"
+						Click="CloseModalClick" />
+			</Grid>
+			<Rectangle Fill="Blue"
+					   Height="100"
+					   Width="100" />
+			<Rectangle x:Name="LayoutRectangle"
+					   Fill="Blue"
+					   Height="100"
+					   Width="100" />
+			<Rectangle Fill="Blue"
+					   Height="100"
+					   Width="100" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Toolkit/VisibleBoundsPadding_Modal.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Toolkit/VisibleBoundsPadding_Modal.xaml.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#if __IOS__
+using UIKit;
+#endif
+
+namespace UITests.Toolkit
+{
+	public partial class VisibleBoundsPadding_Modal : Page
+	{
+		public VisibleBoundsPadding_Modal()
+		{
+			this.InitializeComponent();
+		}
+
+		private void Button_Click(object sender, RoutedEventArgs e)
+		{
+			LayoutRectangle.Visibility = LayoutRectangle.Visibility == Visibility.Collapsed ? Visibility.Visible : Visibility.Collapsed;
+		}
+
+		private void CloseModalClick(object sender, RoutedEventArgs e)
+		{
+#if __IOS__
+			UIApplication.SharedApplication.KeyWindow.RootViewController.DismissModalViewController(animated: false);
+#endif
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Toolkit/VisibleBoundsPadding_Modal_Test.xaml
+++ b/src/SamplesApp/UITests.Shared/Toolkit/VisibleBoundsPadding_Modal_Test.xaml
@@ -1,0 +1,17 @@
+﻿<Page x:Class="UITests.Toolkit.VisibleBoundsPadding_Modal_Test"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Toolkit"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Button HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				AutomationProperties.AutomationId="VBP_Launch_Modal_Button"
+				Click="LaunchModalSample"
+				Content="Show Modal Sample" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Toolkit/VisibleBoundsPadding_Modal_Test.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Toolkit/VisibleBoundsPadding_Modal_Test.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+
+#if __IOS__
+using UIKit;
+#endif
+
+namespace UITests.Toolkit
+{
+	[Sample("Toolkit")]
+	public partial class VisibleBoundsPadding_Modal_Test : Page
+	{
+		public VisibleBoundsPadding_Modal_Test()
+		{
+			this.InitializeComponent();
+		}
+		private void LaunchModalSample(object sender, RoutedEventArgs e)
+		{
+#if __IOS__
+			var vc = new UIViewController { View = new VisibleBoundsPadding_Modal() };
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+			{
+				// Esnure the behavior of the iPad modal presentation mimics that of the iPhone
+				vc.PreferredContentSize = Windows.UI.Xaml.Window.Current.Bounds.ToCGRect().Size;
+				vc.ModalPresentationStyle = UIModalPresentationStyle.FormSheet;
+			}
+			UIApplication.SharedApplication.KeyWindow.RootViewController.PresentModalViewController(vc, true);
+#endif
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -397,6 +397,14 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Toolkit\VisibleBoundsPadding_Modal.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Toolkit\VisibleBoundsPadding_Modal_Test.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Uno_Web\Http\CookieManagerTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5149,6 +5157,12 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevationView_Clipping.xaml.cs">
       <DependentUpon>ElevationView_Clipping.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Toolkit\VisibleBoundsPadding_Modal.xaml.cs">
+      <DependentUpon>VisibleBoundsPadding_Modal.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Toolkit\VisibleBoundsPadding_Modal_Test.xaml.cs">
+      <DependentUpon>VisibleBoundsPadding_Modal_Test.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Uno_Web\Http\CookieManagerTests.xaml.cs">
       <DependentUpon>CookieManagerTests.xaml</DependentUpon>

--- a/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
+++ b/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
@@ -240,7 +240,9 @@ namespace Uno.UI.Toolkit
 					// If the owner view is scrollable, the visibility of interest is that of the scroll viewport.
 					var fixedControl = scrollAncestor ?? Owner;
 
-					var controlBounds = GetRelativeBounds(fixedControl, Window.Current.Content);
+					// Using relativeTo: null instead of Window.Current.Content since there are cases when the current UIElement
+					// may be outside the bounds of the current Window content, for example, when the element is hosted in a modal window.
+					var controlBounds = GetRelativeBounds(fixedControl, relativeTo: null);
 
 					visibilityPadding = CalculateVisibilityPadding(OffsetVisibleBounds, controlBounds);
 
@@ -371,7 +373,7 @@ namespace Uno.UI.Toolkit
 				return Owner?.FindFirstParent<ScrollViewer>();
 			}
 
-			private static Rect GetRelativeBounds(FrameworkElement boundsOf, UIElement relativeTo)
+			private static Rect GetRelativeBounds(FrameworkElement boundsOf, UIElement? relativeTo)
 			{
 				return boundsOf
 					.TransformToVisual(relativeTo)


### PR DESCRIPTION
closes https://github.com/unoplatform/nventive-private/issues/412


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

VisibleBoundsPadding calculates improper offsets when the control is within a native iOS Modal window. We were using `TransformToVisual` relative to `Windows.Current.Content` which results in an offset of X=16, Y=47 since the Window.Content (white background) is no longer at position 0,0 while a modal (red background) is being displayed

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/4793020/191300674-3b13a735-d18b-4d44-8276-0f6eab7df0f9.png)

## What is the new behavior?

Use `TransformToVisual(null)` to ensure that the root of the XAML tree is used for the transformation