### PR TITLE
fix(ios): nested page's CommandBar desync when returning from controller

### DIFF
--- a/src/Uno.UI/Controls/CommandBar/CommandBarHelper.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBar/CommandBarHelper.iOS.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using UIKit;
+using Uno.UI.Extensions;
 
 namespace Uno.UI.Controls
 {
@@ -119,7 +120,15 @@ namespace Uno.UI.Controls
 		private static CommandBar? FindTopCommandBar(this UIViewController controller)
 		{
 			return (controller.View as Page)?.TopAppBar as CommandBar
-				?? controller.View.FindFirstChild<CommandBar?>();
+				?? FindTopCommandBar(controller.View);
+		}
+
+		internal static CommandBar? FindTopCommandBar(UIView? view)
+		{
+			return view.FindFirstDescendant<CommandBar>(
+				x => x is not Frame, // prevent looking into the nested page
+				_ => true
+			);
 		}
 	}
 }

--- a/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
@@ -764,7 +764,7 @@ namespace Uno.UI.Controls
 
 			internal CommandBar GetCommandBar()
 			{
-				return Page.TopAppBar as CommandBar ?? Page.FindFirstChild<CommandBar>();
+				return Page.TopAppBar as CommandBar ?? CommandBarHelper.FindTopCommandBar(Page);
 			}
 
 			public override string ToString()

--- a/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
@@ -1,0 +1,255 @@
+﻿#nullable enable
+
+#if NETSTANDARD2_0 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+#define NULLABLE_ATTRIBUTE_NOT_SUPPORTED
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+
+#if __IOS__
+using UIKit;
+using _View = UIKit.UIView;
+#elif __MACOS__
+using AppKit;
+using _View = AppKit.NSView;
+#elif __ANDROID__
+using _View = Android.Views.View;
+#else
+using _View = Windows.UI.Xaml.DependencyObject;
+#endif
+
+namespace Uno.UI.Extensions;
+
+public static partial class ViewExtensions
+{
+	/// <summary>
+	/// Produces a text representation of the visual tree.
+	/// </summary>
+	/// <param name="reference">Any node of the visual tree</param>
+	public static string TreeGraph(this _View reference) => TreeGraph(reference, DescribeVTNode);
+
+	/// <summary>
+	/// Produces a text representation of the visual tree, using the provided method of description.
+	/// </summary>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <param name="describe">A function to describe a visual tree node in a single line.</param>
+	/// <returns></returns>
+	public static string TreeGraph(this _View reference, Func<_View, string> describe)
+	{
+		var buffer = new StringBuilder();
+		Walk(reference);
+		return buffer.ToString();
+
+		void Walk(_View o, int depth = 0)
+		{
+			Print(o, depth);
+			foreach (var child in EnumerateChildren(o))
+			{
+				Walk(child, depth + 1);
+			}
+		}
+		void Print(_View o, int depth)
+		{
+			buffer
+				.Append(new string(' ', depth * 4))
+				.Append(describe(o))
+				.AppendLine();
+		}
+	}
+
+	private static string DescribeVTNode(object x)
+	{
+		return new StringBuilder()
+			.Append(x.GetType().Name)
+			.Append((x as FrameworkElement)?.Name is string { Length: > 0 } xname ? $"#{xname}" : string.Empty)
+			.Append($" // {string.Join(", ", GetDetails())}")
+			.ToString();
+
+#if !NULLABLE_ATTRIBUTE_NOT_SUPPORTED
+		bool TryGetDpValue<T>(object owner, string property, [NotNullWhen(true)] out T? value)
+#else
+		bool TryGetDpValue<T>(object owner, string property, out T? value)
+#endif
+		{
+			if (owner is DependencyObject @do &&
+				owner.GetType().GetProperty($"{property}Property", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?.GetValue(null, null) is DependencyProperty dp)
+			{
+				value = (T)@do.GetValue(dp);
+				return true;
+			}
+
+			value = default;
+			return false;
+		}
+		string FormatCornerRadius(CornerRadius x)
+		{
+			// format: uniform, [left,top,right,bottom]
+			if (x.TopLeft == x.TopRight && x.TopRight == x.BottomRight && x.BottomRight == x.BottomLeft) return $"{x.TopLeft}";
+			return $"[{x.TopLeft},{x.TopRight},{x.BottomRight},{x.BottomLeft}]";
+		}
+		string FormatThickness(Thickness x)
+		{
+			// format: uniform, [same-left-right,same-top-bottom], [left,top,right,bottom]
+			if (x.Left == x.Top && x.Top == x.Right && x.Right == x.Bottom) return $"{x.Left}";
+			if (x.Left == x.Right && x.Top == x.Bottom) return $"[{x.Left},{x.Top}]";
+			return $"[{x.Left},{x.Top},{x.Right},{x.Bottom}]";
+		}
+		IEnumerable<string> GetDetails()
+		{
+			if (x is FrameworkElement fe)
+			{
+				yield return $"Actual={fe.ActualWidth}x{fe.ActualHeight}";
+				yield return $"HV={fe.HorizontalAlignment}/{fe.VerticalAlignment}";
+			}
+			if (TryGetDpValue<CornerRadius>(x, "CornerRadius", out var cr)) yield return $"CornerRadius={FormatCornerRadius(cr)}";
+			if (TryGetDpValue<Thickness>(x, "Margin", out var margin)) yield return $"Margin={FormatThickness(margin)}";
+			if (TryGetDpValue<Thickness>(x, "Padding", out var padding)) yield return $"Padding={FormatThickness(padding)}";
+
+			if (TryGetDpValue<double>(x, "Opacity", out var opacity)) yield return $"Opacity={opacity}";
+			if (TryGetDpValue<Visibility>(x, "Visibility", out var visibility)) yield return $"Visibility={visibility}";
+		}
+	}
+
+	/// <summary>
+	/// Returns the first ancestor of a specified type.
+	/// </summary>
+	/// <typeparam name="T">The type of ancestor to find.</typeparam>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <remarks>First Counting from the <paramref name="reference"/> and not from the root of tree.</remarks>
+	public static T? FindFirstAncestor<T>(this _View? reference) => EnumerateAncestors(reference)
+		.OfType<T>()
+		.FirstOrDefault();
+
+	/// <summary>
+	/// Returns the first ancestor of a specified type that satisfies the <paramref name="predicate"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of ancestor to find.</typeparam>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <param name="predicate">A function to test each node for a condition.</param>
+	/// <remarks>First Counting from the <paramref name="reference"/> and not from the root of tree.</remarks>
+	public static T? FindFirstAncestor<T>(this _View? reference, Func<T, bool> predicate) => EnumerateAncestors(reference)
+		.OfType<T>()
+		.FirstOrDefault(predicate);
+
+	/// <summary>
+	/// Returns the first descendant of a specified type.
+	/// </summary>
+	/// <typeparam name="T">The type of descendant to find.</typeparam>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <remarks>The crawling is done depth first.</remarks>
+	public static T? FindFirstDescendant<T>(this _View? reference) => EnumerateDescendants(reference)
+		.OfType<T>()
+		.FirstOrDefault();
+
+	/// <summary>
+	/// Returns the first descendant of a specified type that satisfies the <paramref name="predicate"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of descendant to find.</typeparam>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <param name="predicate">A function to test each node for a condition.</param>
+	/// <remarks>The crawling is done depth first.</remarks>
+	public static T? FindFirstDescendant<T>(this _View? reference, Func<T, bool> predicate) => EnumerateDescendants(reference)
+		.OfType<T>()
+		.FirstOrDefault(predicate);
+
+	/// <summary>
+	/// Returns the first descendant of a specified type that satisfies the <paramref name="predicate"/> whose ancestors (up to <paramref name="reference"/>) and itself satisfy the <paramref name="hierarchyPredicate"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of descendant to find.</typeparam>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <param name="hierarchyPredicate">A function to test each ancestor for a condition.</param>
+	/// <param name="predicate">A function to test each descendant for a condition.</param>
+	/// <remarks>The crawling is done depth first.</remarks>
+	public static T? FindFirstDescendant<T>(this _View? reference, Func<_View, bool> hierarchyPredicate, Func<T, bool> predicate) => EnumerateDescendants(reference, hierarchyPredicate)
+		.OfType<T>()
+		.FirstOrDefault(predicate);
+
+	/// <summary>
+	/// Returns all the visual descendants of a node.
+	/// </summary>
+	/// <param name="reference">Any node of the visual tree</param>
+	public static IEnumerable<_View> EnumerateDescendants(this _View? reference) => EnumerateDescendants(reference, x => true);
+
+	/// <summary>
+	/// Returns all the visual descendants of a node that satisfies the <paramref name="hierarchyPredicate"/>.
+	/// </summary>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <param name="hierarchyPredicate"></param>
+	/// <returns></returns>
+	public static IEnumerable<_View> EnumerateDescendants(this _View? reference, Func<_View, bool> hierarchyPredicate)
+	{
+		foreach (var child in reference.EnumerateChildren().Where(hierarchyPredicate))
+		{
+			yield return child;
+			foreach (var grandchild in child.EnumerateDescendants(hierarchyPredicate))
+			{
+				yield return grandchild;
+			}
+		}
+	}
+
+	// note: methods for retrieving children/ancestors exist with varying signatures.
+	// re-implementing them with unified & more inclusive signature for convenience.
+#if __IOS__ || __MACOS__
+	private static IEnumerable<_View> EnumerateAncestors(this _View? o)
+	{
+		if (o is null) yield break;
+		while (o.Superview is _View parent)
+		{
+			yield return o = parent;
+		}
+	}
+
+	private static IEnumerable<_View> EnumerateChildren(this _View? o)
+	{
+		if (o is null) return Enumerable.Empty<_View>();
+		return o.Subviews;
+	}
+#elif __ANDROID__
+	private static IEnumerable<_View> EnumerateAncestors(this _View? o)
+	{
+		if (o is null) yield break;
+
+		while (o.Parent is _View parent)
+		{
+			yield return o = parent;
+		}
+	}
+
+	private static IEnumerable<_View> EnumerateChildren(this _View? reference)
+	{
+		if (reference is Android.Views.ViewGroup vg)
+		{
+			return Enumerable
+				.Range(0, vg.ChildCount)
+				.Select(vg.GetChildAt)
+				.Where(x => x != null).Cast<_View>();
+		}
+
+		return Enumerable.Empty<_View>();
+	}
+#else
+	private static IEnumerable<_View> EnumerateAncestors(this _View? o)
+	{
+		if (o is null) yield break;
+		while (VisualTreeHelper.GetParent(o) is { } parent)
+		{
+			yield return o = parent;
+		}
+	}
+
+	private static IEnumerable<_View> EnumerateChildren(this _View? reference)
+	{
+		return Enumerable
+			.Range(0, VisualTreeHelper.GetChildrenCount(reference))
+			.Select(x => VisualTreeHelper.GetChild(reference, x));
+	}
+#endif
+}

--- a/src/Uno.UI/NativeFramePresenter.Android.cs
+++ b/src/Uno.UI/NativeFramePresenter.Android.cs
@@ -1,24 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
-using Uno.Extensions;
-using Uno.Foundation.Logging;
+using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using Windows.UI.Xaml.Media.Animation;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.Threading.Tasks;
 using Android.App;
 using Android.Views.Animations;
 using Android.Views;
+using Uno.Extensions;
 using Uno.Extensions.Specialized;
-using System.Threading;
-using Windows.UI.Core;
+using Uno.Foundation.Logging;
 using Uno.Disposables;
+using Uno.UI.Extensions;
 
 namespace Uno.UI.Controls
 {
@@ -76,7 +77,11 @@ namespace Uno.UI.Controls
 				: Visibility.Collapsed;
 
 			var page = _frame?.CurrentEntry?.Instance;
-			var commandBar = page?.TopAppBar ?? page?.FindFirstChild<CommandBar>();
+			var commandBar = page?.TopAppBar as CommandBar ?? page.FindFirstDescendant<CommandBar>(
+				x => x is not Frame, // prevent looking into the nested page
+				_ => true
+			);
+
 			commandBar?.SetValue(BackButtonVisibilityProperty, backButtonVisibility);
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): re: unoplatform/uno.toolkit.ui#307

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When navigating to an external view/controller and back, the NavigationBar re-initializes with the UIViewController (native concept) with the wrong instance of NavigationBar (toolkit control). This desync prevents the NavigationBar from updating.

## What is the new behavior?

^ not happening anymore.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->