### PR TITLE
ci: Adjuts winui-generated branch

### DIFF
--- a/.github/workflows/winui-autoconvert.yml
+++ b/.github/workflows/winui-autoconvert.yml
@@ -69,6 +69,4 @@ jobs:
       run: |
         git add .
         git commit -m "Update WinUI Autoconvert from $env:GITHUB_SHA"
-        git checkout generated/$env:GITHUB_REF_NAME/winui-autoconvert
-        git merge -X ours $env:GITHUB_REF_NAME
-        git push origin generated/$env:GITHUB_REF_NAME/winui-autoconvert
+        git push origin generated/$env:GITHUB_REF_NAME/winui-autoconvert -f


### PR DESCRIPTION
The change uses a forced overwrite of the branch instead of trying a merge. This branch will keep using the latest conversion at this time, until we can find a better synchronization solution and keep the history.