### PR TITLE
fix: Adjust for net6/7 debugging in VS 2022 17.4 Preview 1

### DIFF
--- a/build/uno.winui.single-project.targets
+++ b/build/uno.winui.single-project.targets
@@ -120,6 +120,10 @@
 				<ProjectCapability Include="SingleTargetBuildForStartupProjects" Condition=" '$(EnableSingleTargetBuildForStartupProjects)' != 'false' " />
 
 				<ProjectCapability Include="UseMauiCore" />
+
+				<!-- Required since VS 2022 17.4 Preview 1 -->
+				<ProjectCapability Include="MauiCore" />
+				<ProjectCapability Include="Maui" />
 			</ItemGroup>
 
 

--- a/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
+++ b/src/SamplesApp/SamplesApp.net6mobile/SamplesApp.net6mobile.csproj
@@ -35,6 +35,11 @@
 		<SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<!-- Shows applied capabilities in a new VS project node -->
+		<ProjectCapability Include="DiagnoseCapabilities" />
+	</ItemGroup>
+
 	<Choose>
 
 		<When Condition="'$(TargetFramework)'=='net6.0-ios'">
@@ -75,7 +80,7 @@
 		<SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
 		<AndroidUseAssemblyStore>false</AndroidUseAssemblyStore>
 	</PropertyGroup>
-
+	
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
 		<TargetFrameworks>$(UnoTargetFrameworkOverride)</TargetFrameworks>
 	</PropertyGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/discussions/9513

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Additional capabilities are required for the debugging tooling to be available in VS 17.4 Preview 1 and later.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
