### PR TITLE
chore(test): Move ImageBrush_Stretch to runtime test

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Stretch.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Stretch.cs
@@ -16,7 +16,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.ImageBrushTests
 		[Test]
 		[AutoRetry]
 
-		[ActivePlatforms(Platform.Browser, Platform.iOS)] // Android behaves differently. See https://github.com/unoplatform/uno/pull/7238#issuecomment-937667565
+		// Other platforms are tested in RuntimeTests:
+		// src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrushStretch.cs
+		// This UI Test can be deleted once we can test Wasm in RuntimeTests.
+		// This is currently blocked due to lack of support for RenderTargetBitmap on Wasm.
+		[ActivePlatforms(Platform.Browser)] 
 		public void When_Stretch()
 		{
 			Run("UITests.Windows_UI_Xaml_Media.ImageBrushTests.ImageBrush_Stretch");

--- a/src/Uno.UI.RuntimeTests/Helpers/ImageAssert.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/ImageAssert.cs
@@ -28,17 +28,17 @@ namespace Uno.UI.RuntimeTests.Helpers;
 /// </summary>
 public static partial class ImageAssert
 {
-#region HasColorAt
-	public static Task HasColorAt(RawBitmap screenshot, float x, float y, string expectedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
+	#region HasColorAt
+	public static void HasColorAt(RawBitmap screenshot, float x, float y, string expectedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
 		=> HasColorAtImpl(screenshot, (int)x, (int)y, (Color)XamlBindingHelper.ConvertValue(typeof(Color), expectedColorCode), tolerance, line);
 
-	public static Task HasColorAt(RawBitmap screenshot, float x, float y, Color expectedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
+	public static void HasColorAt(RawBitmap screenshot, float x, float y, Color expectedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
 		=> HasColorAtImpl(screenshot, (int)x, (int)y, expectedColor, tolerance, line);
 
-	public static Task HasColorAtChild(RawBitmap screenshot, UIElement child, double x, double y, string expectedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
+	public static void HasColorAtChild(RawBitmap screenshot, UIElement child, double x, double y, string expectedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
 		=> HasColorAtChild(screenshot, child, (int)x, (int)y, (Color)XamlBindingHelper.ConvertValue(typeof(Color), expectedColorCode), tolerance, line);
-	
-	public static async Task HasColorAtChild(RawBitmap screenshot, UIElement child, double x, double y, Color expectedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
+
+	public static void HasColorAtChild(RawBitmap screenshot, UIElement child, double x, double y, Color expectedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
 	{
 		var point = child.TransformToVisual(screenshot.RenderedElement).TransformPoint(new Windows.Foundation.Point(x, y));
 		HasColorAtImpl(screenshot, (int)point.X, (int)point.Y, expectedColor, tolerance, line);
@@ -65,10 +65,8 @@ public static partial class ImageAssert
 		Assert.Fail($"Expected '{ToArgbCode(expectedColor)}' in rectangle '{rect}'.");
 	}
 
-	private static async Task HasColorAtImpl(RawBitmap screenshot, int x, int y, Color expectedColor, byte tolerance, int line)
+	private static void HasColorAtImpl(RawBitmap screenshot, int x, int y, Color expectedColor, byte tolerance, int line)
 	{
-		await screenshot.Populate();
-
 		var bitmap = screenshot;
 
 		if (bitmap.Width <= x || bitmap.Height <= y)
@@ -99,20 +97,18 @@ public static partial class ImageAssert
 				.ToString();
 		}
 	}
-#endregion
+	#endregion
 
-#region DoesNotHaveColorAt
-	public static Task DoesNotHaveColorAt(RawBitmap screenshot, float x, float y, string excludedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
+	#region DoesNotHaveColorAt
+	public static void DoesNotHaveColorAt(RawBitmap screenshot, float x, float y, string excludedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
 		=> DoesNotHaveColorAtImpl(screenshot, (int)x, (int)y, (Color)XamlBindingHelper.ConvertValue(typeof(Color), excludedColorCode), tolerance, line);
 
-	public static Task DoesNotHaveColorAt(RawBitmap screenshot, float x, float y, Color excludedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
+	public static void DoesNotHaveColorAt(RawBitmap screenshot, float x, float y, Color excludedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
 		=> DoesNotHaveColorAtImpl(screenshot, (int)x, (int)y, excludedColor, tolerance, line);
 
-	private static async Task DoesNotHaveColorAtImpl(RawBitmap screenshot, int x, int y, Color excludedColor, byte tolerance, int line)
+	private static void DoesNotHaveColorAtImpl(RawBitmap screenshot, int x, int y, Color excludedColor, byte tolerance, int line)
 	{
 		var bitmap = screenshot;
-		await bitmap.Populate();
-
 		if (bitmap.Width <= x || bitmap.Height <= y)
 		{
 			Assert.Fail(WithContext($"Coordinates ({x}, {y}) falls outside of screenshot dimension {bitmap.Size}"));
@@ -140,13 +136,11 @@ public static partial class ImageAssert
 				.ToString();
 		}
 	}
-#endregion
+	#endregion
 
-#region HasPixels
-	public static async Task HasPixels(RawBitmap actual, params ExpectedPixels[] expectations)
+	#region HasPixels
+	public static void HasPixels(RawBitmap actual, params ExpectedPixels[] expectations)
 	{
-		await actual.Populate();
-
 		var bitmap = actual;
 		using var assertionScope = new AssertionScope("ImageAssert");
 
@@ -166,5 +160,5 @@ public static partial class ImageAssert
 			}
 		}
 	}
-#endregion
+	#endregion
 }

--- a/src/Uno.UI.RuntimeTests/Helpers/RawBitmap.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/RawBitmap.cs
@@ -25,10 +25,18 @@ namespace Uno.UI.RuntimeTests.Helpers
 	{
 		private byte[]? _pixels;
 
-		public RawBitmap(RenderTargetBitmap bitmap, UIElement renderedElement)
+		private RawBitmap(RenderTargetBitmap bitmap, UIElement renderedElement)
 		{
 			Bitmap = bitmap;
 			RenderedElement = renderedElement;
+		}
+
+		public static async Task<RawBitmap> From(RenderTargetBitmap bitmap, UIElement renderedElement)
+		{
+			var raw = new RawBitmap(bitmap, renderedElement);
+			await raw.Populate();
+
+			return raw;
 		}
 
 		public Size Size => new(Bitmap.PixelWidth, Bitmap.PixelHeight);
@@ -42,10 +50,10 @@ namespace Uno.UI.RuntimeTests.Helpers
 		public UIElement RenderedElement { get; }
 
 		public RenderTargetBitmap Bitmap { get; }
-	
+
 		public Color GetPixel(int x, int y)
 		{
-			if(_pixels is null)
+			if (_pixels is null)
 			{
 				throw new InvalidOperationException("Populate must be invoked first");
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_Opacity.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_Opacity.cs
@@ -48,27 +48,27 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await renderer.RenderAsync(SUT);
 
-			var si = new RawBitmap(renderer, SUT);
+			var si = await RawBitmap.From(renderer, SUT);
 
 			var width = SUT.tbOpacity1_0.ActualWidth;
 			var height = SUT.tbOpacity1_0.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.tbOpacity1_0, (width / 4) * 3, height / 2, Colors.Black);
+			ImageAssert.HasColorAtChild(si, SUT.tbOpacity1_0, (width / 4) * 3, height / 2, Colors.Black);
 
 			width = SUT.tbOpacity0_5.ActualWidth;
 			height = SUT.tbOpacity0_5.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.tbOpacity0_5, (width / 4) * 3, height / 2, "#FF808080");
+			ImageAssert.HasColorAtChild(si, SUT.tbOpacity0_5, (width / 4) * 3, height / 2, "#FF808080");
 
 			width = SUT.tbOpacity0_1.ActualWidth;
 			height = SUT.tbOpacity0_1.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.tbOpacity0_1, (width / 4) * 3, height / 2, "#0xFFE6E6E6");
+			ImageAssert.HasColorAtChild(si, SUT.tbOpacity0_1, (width / 4) * 3, height / 2, "#FFE6E6E6");
 
 			width = SUT.border0_5.ActualWidth;
 			height = SUT.border0_5.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.border0_5, 2, 2, "#FFFF8080");
+			ImageAssert.HasColorAtChild(si, SUT.border0_5, 2, 2, "#FFFF8080");
 
 			width = SUT.ImageOpacity0_5.ActualWidth;
 			height = SUT.ImageOpacity0_5.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.ImageOpacity0_5, width / 2, height / 2, "#FFFEF3C2");
+			ImageAssert.HasColorAtChild(si, SUT.ImageOpacity0_5, width / 2, height / 2, "#FFFEF3C2");
 		}
 
 		[TestMethod]
@@ -84,30 +84,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			
 			await renderer.RenderAsync(SUT);
 
-			var si = new RawBitmap(renderer, SUT);
+			var si = await RawBitmap.From(renderer, SUT);
 			var width = SUT.tbInnerOpacity1_0.ActualWidth;
 			var height = SUT.tbInnerOpacity1_0.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.tbInnerOpacity1_0, (width / 4) * 3.3, height / 2, "#FF808080");
+			ImageAssert.HasColorAtChild(si, SUT.tbInnerOpacity1_0, (width / 4) * 3.3, height / 2, "#FF808080");
 
 			width = SUT.tbInnerOpacity0_5.ActualWidth;
 			height = SUT.tbInnerOpacity0_5.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.tbInnerOpacity0_5, (width / 4) * 3.3, height / 2, "#FFC0C0C0");
+			ImageAssert.HasColorAtChild(si, SUT.tbInnerOpacity0_5, (width / 4) * 3.3, height / 2, "#FFC0C0C0");
 
 			width = SUT.tbInnerOpacity0_1.ActualWidth;
 			height = SUT.tbInnerOpacity0_1.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.tbInnerOpacity0_1, (width / 4) * 3.3, height / 2, "#FFF3F3F3");
+			ImageAssert.HasColorAtChild(si, SUT.tbInnerOpacity0_1, (width / 4) * 3.3, height / 2, "#FFF3F3F3");
 
 			width = SUT.BorderInnerOpacity0_5.ActualWidth;
 			height = SUT.BorderInnerOpacity0_5.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.BorderInnerOpacity0_5, 2, 2, "#FFFFC0C0");
+			ImageAssert.HasColorAtChild(si, SUT.BorderInnerOpacity0_5, 2, 2, "#FFFFC0C0");
 
 			width = SUT.tbBorderInnerOpacity0_5.ActualWidth;
 			height = SUT.tbBorderInnerOpacity0_5.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.tbBorderInnerOpacity0_5, (width / 4) * 3.3, height / 2, "#FFC09090");
+			ImageAssert.HasColorAtChild(si, SUT.tbBorderInnerOpacity0_5, (width / 4) * 3.3, height / 2, "#FFC09090");
 
 			width = SUT.ImageInner0_5.ActualWidth;
 			height = SUT.ImageInner0_5.ActualHeight;
-			await ImageAssert.HasColorAtChild(si, SUT.ImageInner0_5, width / 2, height / 2, "#FFFEF9E1");
+			ImageAssert.HasColorAtChild(si, SUT.ImageInner0_5, width / 2, height / 2, "#FFFEF9E1");
 		}
 #endif
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrushStretch.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrushStretch.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions.Formatting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+using static Private.Infrastructure.TestServices;
+using ImageBrush = Windows.UI.Xaml.Media.ImageBrush;
+
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Given_ImageBrushStretch
+	{
+		[DataRow(Stretch.Fill)]
+		[DataRow(Stretch.UniformToFill)]
+		#if !__SKIA__ //Stretch.Uniform create a Mosaic in Skia. See https://github.com/unoplatform/uno/issues/10021
+		[DataRow(Stretch.Uniform)]
+		#endif
+		[DataRow(Stretch.None)]
+
+		[TestMethod]
+		public async Task When_Stretch(Stretch stretch)
+		{
+			const string Redish = "#FFEB1C24";
+			const string Yellowish = "#FFFEF200";
+			const string Greenish = "#FF0ED145";
+			const string White = "#FFFFFFFF";
+			#if __MACOS__
+				Assert.Inconclusive(); // Colors are not interpreted the same way on MacOS
+			#endif
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+
+			var brush = new ImageBrush
+			{
+				ImageSource = new BitmapImage(new Uri("ms-appx:///Assets/colored-ellipse.jpg"))
+			};
+
+			var SUT = new Border
+			{
+				Width = 100,
+				Height = 100,
+				BorderThickness = new Thickness(2),
+				BorderBrush = new SolidColorBrush(Windows.UI.Color.FromArgb(255, 255, 0, 0)),
+				Background = brush,
+			};
+			WindowHelper.WindowContent = SUT;
+			WindowHelper.WaitForLoaded(SUT);
+
+			var renderer = new RenderTargetBitmap();
+			const float BorderOffset = 8;
+			float width = (float)SUT.Width, height = (float)SUT.Height;
+			float centerX = width / 2, centerY = height / 2;
+
+			var expectations = stretch switch
+			{
+				// All edges are red-ish
+				Stretch.Fill => (Top: Redish, Bottom: Redish, Left: Redish, Right: Redish),
+				// Top and bottom are red-ish. Left and right are yellow-ish
+				Stretch.UniformToFill => (Top: Redish, Bottom: Redish, Left: Yellowish, Right: Yellowish),
+				// Top and bottom are same as backround. Left and right are red-ish
+				Stretch.Uniform => (Top: White, Bottom: White, Left: Redish, Right: Redish),
+				// Everything is green-ish
+				Stretch.None => (Top: Greenish, Bottom: Greenish, Left: Greenish, Right: Greenish),
+
+				_ => throw new ArgumentOutOfRangeException($"unexpected stretch: {stretch}"),
+			};
+
+			var bitmap = await UpdateStretchAndScreenshot(stretch);
+			ImageAssert.HasColorAt(bitmap, centerX, BorderOffset, expectations.Top, tolerance: 5);
+			ImageAssert.HasColorAt(bitmap, centerX, height - BorderOffset, expectations.Bottom, tolerance: 5);
+			ImageAssert.HasColorAt(bitmap, BorderOffset, centerY, expectations.Left, tolerance: 5);
+			ImageAssert.HasColorAt(bitmap, width - BorderOffset, centerY, expectations.Right, tolerance: 5);
+
+			async Task<RawBitmap> UpdateStretchAndScreenshot(Stretch stretch)
+			{
+				brush.Stretch = stretch;
+
+				await WindowHelper.WaitForIdle();
+				await renderer.RenderAsync(SUT);
+
+				return await RawBitmap.From(renderer, SUT);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Issue  #9811
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

Bugfix
- Feature
- Code style update (formatting)
Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
The test Was in Sample app test. The test is broken in different subtests according to the stretch tested.
The test did not work on Android du to failing Stretch.None  section of the test.

## What is the new behavior?

The test is now in Runtime app test. The test doe not work on WASM anymore du to the lack of an equivalent of screenshot.

Stretch.Uniform does not work on skia anymore since it is making a mosaic pattern. 
I included MACOS in functioning build but I could not test it. 
I did not includes Android since it was already failing on of the test previously and I was not able to test it, my build was running in a not enough memory exception.  

I did not move the images from Sample App folder in case it would be important for other tests. 

In order to make this test actually test something in Runtimes, I had, with a lot of help of Xiaotian modify the Runtime AppTest class. Because of the usage of async functions some of these test where on a different thread and did pass the test in Runtimes no matter what parameter they had. Since I did not found a way to make that test fail without the fix, The fix of the test is also included in that task.  That fix required some modification on the  Given_FrameworkElement_Opacity that previously never failed either. I can also make a separate pull request if you prefer.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): #9811
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
