### PR TITLE
fix: Avoid null-ref, fallback to VisibleBounds is XamlRoot is null

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -69,13 +69,13 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			else
 			{
 				Rect visibleBounds;
-				if (XamlRoot.VisualTree.ContentRoot.Type == ContentRootType.CoreWindow)
+				if (XamlRoot is not { } xamlRoot || xamlRoot.VisualTree.ContentRoot.Type == ContentRootType.CoreWindow)
 				{
 					visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
 				}
 				else
 				{
-					visibleBounds = XamlRoot.Bounds;
+					visibleBounds = xamlRoot.Bounds;
 				}
 				visibleBounds.Width = Math.Min(availableSize.Width, visibleBounds.Width);
 				visibleBounds.Height = Math.Min(availableSize.Height, visibleBounds.Height);
@@ -165,14 +165,15 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				// Defer to the popup owner the responsibility to place the popup (e.g. ComboBox)
 
 				Rect visibleBounds;
-				if (XamlRoot.VisualTree.ContentRoot.Type == ContentRootType.CoreWindow)
+				if (XamlRoot is { } xamlRoot && xamlRoot.VisualTree.ContentRoot.Type != ContentRootType.CoreWindow)
 				{
-					visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
+					visibleBounds = xamlRoot.Bounds;
 				}
 				else
 				{
-					visibleBounds = XamlRoot.Bounds;
+					visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
 				}
+
 				visibleBounds.Width = Math.Min(finalSize.Width, visibleBounds.Width);
 				visibleBounds.Height = Math.Min(finalSize.Height, visibleBounds.Height);
 


### PR DESCRIPTION
https://github.com/unoplatform/uno/issues/9943

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

ComboBox Popup will not display on iOS as a result of a null ref within the layout logic of PopupPanel

## What is the new behavior?

PopupPanel does not crash and the combobox popup is displayed