### PR TITLE
fix(gen): Report error diagnostic on SnapShotTestGenerator exceptions and avoid Workspaces dependency

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -92,7 +92,7 @@
     <PackageReference Include="Xamarin.AndroidX.AppCompat.AppCompatResources">
       <Version>1.3.1.3</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Browser"  Version="1.0.0" />
+    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
+++ b/src/SamplesApp/SamplesApp.UITests.Generator/SnapShotTestGenerator.cs
@@ -46,10 +46,10 @@ namespace Uno.Samples.UITest.Generator
 						sb.Append(loaderException.ToString());
 					}
 
-					throw new Exception(sb.ToString());
+					context.ReportDiagnostic(Diagnostic.Create("SnapshotGenerator001", "Generation", sb.ToString(), DiagnosticSeverity.Error, DiagnosticSeverity.Error, true, 0, "ReflectionTypeLoadException"));
 				}
 
-				throw;
+				context.ReportDiagnostic(Diagnostic.Create("SnapshotGenerator002", "Generation", e.ToString(), DiagnosticSeverity.Error, DiagnosticSeverity.Error, true, 0, "Exception"));
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UITests.Generator/Uno.Samples.UITest.Generator.csproj
+++ b/src/SamplesApp/SamplesApp.UITests.Generator/Uno.Samples.UITest.Generator.csproj
@@ -5,26 +5,10 @@
 		<DebugSymbols>true</DebugSymbols>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<LangVersion>10.0</LangVersion>
-
-		<!-- Required to get roslyn workspaces files to be present -->
-		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-		<PackageReference Include="Microsoft.CodeAnalysis">
-
-			<!--
-			This version needs to be aligned with the CI build override MicrosoftNetCompilerVersionOverride, as long as
-			SnapShotTestGenerator uses an inner Roslyn Workspace to generate the snapshots test.
-			-->
-			<Version>4.0.1</Version>
-			
-			<!-- Workspaces need to be included (and without ExcludeAssets) to allow for SnapShotTestGenerator to run properly -->
-			<!--<ExcludeAssets>runtime</ExcludeAssets>-->
-		</PackageReference>
-
-		<PackageReference Include="System.ValueTuple" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-1.final" PrivateAssets="all" />
 	</ItemGroup>
 	
 	<Import Project="..\..\SourceGenerators\SourceGeneratorHelpers\SourceGeneratorHelpers.projitems" Label="Shared" />


### PR DESCRIPTION
### First commit 4a0580d

The generator was crashing, and the exception was turning into a compiler warning. Since we don't yet treat all warnings as errors, this was missed.

It was likely broken due to version mismatch described here https://github.com/unoplatform/uno/blob/2738b04461e4e798a77afce8afd4d2fb8065b795/src/SamplesApp/SamplesApp.UITests.Generator/Uno.Samples.UITest.Generator.csproj#L17-L21

This commit (4a0580d) turns the exception into an error diagnostic, so that CI fails if any exception is thrown.

In the next commits, I'll get rid of the Workspaces dependency completely.

------

### Second commit b40a776

This commit moves us away from using Workspaces APIs.

------

### Third commit c1b654e

This commit is minor code cleanup.