### PR TITLE
fix(iOS): Text Selection on ReadOnly TextBox

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Constants.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Constants.cs
@@ -12,7 +12,7 @@ namespace SamplesApp.UITests
 		public const string WebAssemblyDefaultUri = "https://localhost:44375/";
 		public const string iOSAppName = "uno.platform.uitestsample";
 		public const string AndroidAppName = "uno.platform.unosampleapp";
-		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (4th generation)";
+		public const string iOSDeviceNameOrId = "iPad Pro (12.9-inch) (5th generation)";
 
 		// Default active platform when running under Visual Studio test runner
 		public const Platform CurrentPlatform =

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -932,43 +932,21 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Selection");
 
-			var myTextBox = _app.WaitForElement("myTextBox").Single().Rect;
 			var readonlyTextBox = _app.WaitForElement("MyReadOnlyTextBox").Single().Rect;
 
-			var centerPointReadOnly = GetCenterPoint(readonlyTextBox);
+			var centerPointReadOnlyX = (int) readonlyTextBox.CenterX;
+			var centerPointReadOnlyY = (int) readonlyTextBox.CenterY;
 
 			// Attempt selection
-			_app.DoubleTapCoordinates(centerPointReadOnly.X, centerPointReadOnly.Y);
+			_app.DoubleTapCoordinates(centerPointReadOnlyX, centerPointReadOnlyY);
 
 			using (var readonlyTextBoxScreenShot = TakeScreenshot("MyReadOnlyTextBox", ignoreInSnapshotCompare: true))
 			{
 				ImageAssert.DoesNotHaveColorAt(readonlyTextBoxScreenShot,
-											   centerPointReadOnly.X,
-											   centerPointReadOnly.Y,
+											   centerPointReadOnlyX,
+											   centerPointReadOnlyY,
 											   Color.White);
 			}
-
-
-			var centerPoint = GetCenterPoint(myTextBox);
-
-			// Attempt selection
-			_app.DoubleTapCoordinates(centerPoint.X, centerPoint.Y);
-
-			using (var selectableScreenshot = TakeScreenshot("myTextBox", ignoreInSnapshotCompare: true))
-			{
-				ImageAssert.DoesNotHaveColorAt(selectableScreenshot,
-											   centerPoint.X,
-											   centerPoint.Y,
-											   Color.White);
-			}
-		}
-
-		private Point GetCenterPoint(IAppRect appRect)
-		{
-			var expanderAppRect = ToPhysicalRect(appRect);
-			var rectangle = expanderAppRect.ToRectangle();
-
-			return new Point(rectangle.Left + rectangle.Width / 2, rectangle.Top + rectangle.Height / 2);
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -931,22 +931,22 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 		public void TextBox_Selection_IsReadOnly()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Selection");
+			
+			var readonlyTextBoxRect = _app.WaitForElement("MyReadOnlyTextBox").Single().Rect;
+			var readonlyTextBox = _app.Marked("MyReadOnlyTextBox");
+			
+			var centerPointReadOnlyX = (int)readonlyTextBoxRect.CenterX;
+			var centerPointReadOnlyY = (int)readonlyTextBoxRect.CenterY;
 
-			var readonlyTextBox = _app.WaitForElement("MyReadOnlyTextBox").Single().Rect;
-
-			var centerPointReadOnlyX = (int) readonlyTextBox.CenterX;
-			var centerPointReadOnlyY = (int) readonlyTextBox.CenterY;
+			// Initial verification			
+			Assert.IsTrue(readonlyTextBox.GetDependencyPropertyValue<bool>("IsReadOnly"));
+			Assert.IsNull(readonlyTextBox.GetDependencyPropertyValue("SelectedText")?.ToString());
 
 			// Attempt selection
 			_app.DoubleTapCoordinates(centerPointReadOnlyX, centerPointReadOnlyY);
 
-			using (var readonlyTextBoxScreenShot = TakeScreenshot("MyReadOnlyTextBox", ignoreInSnapshotCompare: true))
-			{
-				ImageAssert.DoesNotHaveColorAt(readonlyTextBoxScreenShot,
-											   centerPointReadOnlyX,
-											   centerPointReadOnlyY,
-											   Color.White);
-			}
+			// Final verification of SelectedText
+			Assert.IsNotEmpty(readonlyTextBox.GetDependencyPropertyValue("SelectedText")?.ToString());
 		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -924,5 +924,32 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			Assert.Less(buttonRect2.Y, buttonRect.Y);
 			Assert.AreEqual(textBoxRect.Height, buttonRect.Y - buttonRect2.Y);
 		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.iOS)]
+		public void TextBox_Selection_IsReadOnly()
+		{
+			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Selection");
+
+			var myTextBox = _app.WaitForElement("myTextBox").Single().Rect;
+			var readonlyTextBox = _app.WaitForElement("MyReadOnlyTextBox").Single().Rect;
+
+			// Attempt selection
+			_app.DoubleTapCoordinates(myTextBox.CenterX, myTextBox.CenterY);
+
+			using (var selectableScreenshot = TakeScreenshot("myTextBox", ignoreInSnapshotCompare: true))
+			{
+				ImageAssert.DoesNotHaveColorAt(selectableScreenshot, myTextBox.CenterX, myTextBox.CenterY, Color.White);
+			}
+
+			// Attempt selection
+			_app.DoubleTapCoordinates(readonlyTextBox.CenterX, readonlyTextBox.CenterY);
+
+			using (var selectableScreenshot = TakeScreenshot("MyReadOnlyTextBox", ignoreInSnapshotCompare: true))
+			{
+				ImageAssert.DoesNotHaveColorAt(selectableScreenshot, readonlyTextBox.CenterX, readonlyTextBox.CenterY, Color.White);
+			}
+		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -935,21 +935,40 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 			var myTextBox = _app.WaitForElement("myTextBox").Single().Rect;
 			var readonlyTextBox = _app.WaitForElement("MyReadOnlyTextBox").Single().Rect;
 
+			var centerPointReadOnly = GetCenterPoint(readonlyTextBox);
+
 			// Attempt selection
-			_app.DoubleTapCoordinates(myTextBox.CenterX, myTextBox.CenterY);
+			_app.DoubleTapCoordinates(centerPointReadOnly.X, centerPointReadOnly.Y);
+
+			using (var readonlyTextBoxScreenShot = TakeScreenshot("MyReadOnlyTextBox", ignoreInSnapshotCompare: true))
+			{
+				ImageAssert.DoesNotHaveColorAt(readonlyTextBoxScreenShot,
+											   centerPointReadOnly.X,
+											   centerPointReadOnly.Y,
+											   Color.White);
+			}
+
+
+			var centerPoint = GetCenterPoint(myTextBox);
+
+			// Attempt selection
+			_app.DoubleTapCoordinates(centerPoint.X, centerPoint.Y);
 
 			using (var selectableScreenshot = TakeScreenshot("myTextBox", ignoreInSnapshotCompare: true))
 			{
-				ImageAssert.DoesNotHaveColorAt(selectableScreenshot, myTextBox.CenterX, myTextBox.CenterY, Color.White);
+				ImageAssert.DoesNotHaveColorAt(selectableScreenshot,
+											   centerPoint.X,
+											   centerPoint.Y,
+											   Color.White);
 			}
+		}
 
-			// Attempt selection
-			_app.DoubleTapCoordinates(readonlyTextBox.CenterX, readonlyTextBox.CenterY);
+		private Point GetCenterPoint(IAppRect appRect)
+		{
+			var expanderAppRect = ToPhysicalRect(appRect);
+			var rectangle = expanderAppRect.ToRectangle();
 
-			using (var selectableScreenshot = TakeScreenshot("MyReadOnlyTextBox", ignoreInSnapshotCompare: true))
-			{
-				ImageAssert.DoesNotHaveColorAt(selectableScreenshot, readonlyTextBox.CenterX, readonlyTextBox.CenterY, Color.White);
-			}
+			return new Point(rectangle.Left + rectangle.Width / 2, rectangle.Top + rectangle.Height / 2);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
@@ -12,7 +12,7 @@
 
 	<StackPanel Spacing="20">
 		<TextBox x:Name="MyReadOnlyTextBox"
-                 Text="Text Uno Platform oui-readonly-textbox-for-selecction. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                 Text="Text Uno Platform readonly-textbox-for-selection. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
                  IsReadOnly="True" />
 		<Button Click="SelectReadOnly_OnClick" Content="Select ReadOnly"/>
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
@@ -11,8 +11,6 @@
     d:DesignWidth="400">
 
 	<StackPanel Spacing="20">
-		<controls:NumberBox x:Name="startNumber" Value="5" PlaceholderText="Start" />
-		<controls:NumberBox x:Name="lengthNumber" Value="12" PlaceholderText="Length" />
 		<TextBox x:Name="MyReadOnlyTextBox"
                  Text="Text Uno Platform oui-readonly-textbox-for-selecction. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
                  IsReadOnly="True" />
@@ -20,6 +18,10 @@
 
 		<TextBox x:Name="myTextBox"
                  Text="Text Uno Platform non-readonly textbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat." />
+
+		<controls:NumberBox x:Name="startNumber" Value="5" PlaceholderText="Start" />
+		<controls:NumberBox x:Name="lengthNumber" Value="12" PlaceholderText="Length" />
+
         <Button Click="Select_OnClick" Content="Select" />
 		<Button Click="SelectAll_OnClick" Content="Select all" />
 	</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
@@ -11,10 +11,12 @@
     d:DesignWidth="400">
 
 	<StackPanel>
-		<controls:NumberBox x:Name="startNumber" PlaceholderText="Start" />
-		<controls:NumberBox x:Name="lengthNumber" PlaceholderText="Length" />
-		<TextBox x:Name="myTextBox" />
-		<Button Click="Select_OnClick" Content="Select"></Button>
+		<controls:NumberBox x:Name="startNumber" Value="5" PlaceholderText="Start" />
+		<controls:NumberBox x:Name="lengthNumber" Length="12" PlaceholderText="Length" />
+		<TextBox x:Name="myTextBox" Text="Text Uno Platform non-readonly textbox" />
+        <Button Click="Select_OnClick" Content="Select"></Button>
+        <TextBox x:Name="MyReadOnlyTextBox" Text="Text Uno Plaform in the readonly textbox" IsReadOnly="True" />
+		<Button Click="SelectReadOnly_OnClick" Content="Select ReadOnly"></Button>
 		<Button Click="SelectAll_OnClick" Content="Select all"></Button>
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
@@ -10,16 +10,17 @@
     d:DesignHeight="300"
     d:DesignWidth="400">
 
-	<StackPanel>
+	<StackPanel Spacing="20">
 		<controls:NumberBox x:Name="startNumber" Value="5" PlaceholderText="Start" />
 		<controls:NumberBox x:Name="lengthNumber" Value="12" PlaceholderText="Length" />
+		<TextBox x:Name="MyReadOnlyTextBox"
+                 Text="Text Uno Platform oui-readonly-textbox-for-selecction. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                 IsReadOnly="True" />
+		<Button Click="SelectReadOnly_OnClick" Content="Select ReadOnly"/>
+
 		<TextBox x:Name="myTextBox"
                  Text="Text Uno Platform non-readonly textbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat." />
-        <Button Click="Select_OnClick" Content="Select"></Button>
-		<Button Click="SelectAll_OnClick" Content="Select all"></Button>
-        <TextBox x:Name="MyReadOnlyTextBox"
-                 Text="Text Uno Platform non-readonly textbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-                 IsReadOnly="True" />
-		<Button Click="SelectReadOnly_OnClick" Content="Select ReadOnly"></Button>
+        <Button Click="Select_OnClick" Content="Select" />
+		<Button Click="SelectAll_OnClick" Content="Select all" />
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml
@@ -12,11 +12,14 @@
 
 	<StackPanel>
 		<controls:NumberBox x:Name="startNumber" Value="5" PlaceholderText="Start" />
-		<controls:NumberBox x:Name="lengthNumber" Length="12" PlaceholderText="Length" />
-		<TextBox x:Name="myTextBox" Text="Text Uno Platform non-readonly textbox" />
+		<controls:NumberBox x:Name="lengthNumber" Value="12" PlaceholderText="Length" />
+		<TextBox x:Name="myTextBox"
+                 Text="Text Uno Platform non-readonly textbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat." />
         <Button Click="Select_OnClick" Content="Select"></Button>
-        <TextBox x:Name="MyReadOnlyTextBox" Text="Text Uno Plaform in the readonly textbox" IsReadOnly="True" />
-		<Button Click="SelectReadOnly_OnClick" Content="Select ReadOnly"></Button>
 		<Button Click="SelectAll_OnClick" Content="Select all"></Button>
+        <TextBox x:Name="MyReadOnlyTextBox"
+                 Text="Text Uno Platform non-readonly textbox. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+                 IsReadOnly="True" />
+		<Button Click="SelectReadOnly_OnClick" Content="Select ReadOnly"></Button>
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Selection.xaml.cs
@@ -17,6 +17,12 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
 			myTextBox.Select((int)startNumber.Value, (int)lengthNumber.Value);
 		}
 
+		private void SelectReadOnly_OnClick(object sender, RoutedEventArgs args)
+		{
+			MyReadOnlyTextBox.Focus(FocusState.Programmatic);
+			MyReadOnlyTextBox.Select((int)startNumber.Value, (int)lengthNumber.Value);
+		}
+
 		private void SelectAll_OnClick(object sender, RoutedEventArgs args)
 		{
 			myTextBox.Focus(FocusState.Programmatic);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxDelegate.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxDelegate.iOS.cs
@@ -50,34 +50,29 @@ namespace Windows.UI.Xaml.Controls
 
 		public override bool ShouldChangeText(UITextView textView, NSRange range, string text)
 		{
-			var textBox = _textBox.GetTarget();
-			if (textBox != null)
+			if (textView is MultilineTextBoxView bindableTextView)
 			{
-				var bindableTextView = textView as MultilineTextBoxView;
-				if (bindableTextView != null)
+				if (_textBox.GetTarget() is not TextBox textBox)
 				{
-					if (textBox.OnKey(text.FirstOrDefault()))
-					{
-						return false;
-
-					}
-
-					if (textBox.MaxLength > 0)
-					{
-						var newLength = bindableTextView.Text.Length + text.Length - range.Length;
-						return newLength <= textBox.MaxLength;
-					}
-
-					if (_textBox.GetTarget() is not TextBox textBox)
-					{
-						return false;
-					}
-
-					// Both IsReadOnly = true and IsTabStop = false can prevent editing
-					return !textBox.IsReadOnly && textBox.IsTabStop;
+					return false;
 				}
 
-				return true;
+				if (textBox.OnKey(text.FirstOrDefault()))
+				{
+					return false;
+				}
+
+				if (textBox.MaxLength > 0)
+				{
+					// When replacing text from pasting (multiple characters at once)
+					// We should only allow it (return true) when the new text length
+					// is lower or equal to the allowed length (TextBox.MaxLength)
+					var newLength = bindableTextView.Text.Length + text.Length - range.Length;
+					return newLength <= textBox.MaxLength;
+				}
+
+				// Both IsReadOnly = true and IsTabStop = false can prevent editing
+				return !textBox.IsReadOnly && textBox.IsTabStop;
 			}
 
 			return false;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxDelegate.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxDelegate.iOS.cs
@@ -1,9 +1,7 @@
 ﻿using Foundation;
 using Uno.Extensions;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UIKit;
 
 namespace Windows.UI.Xaml.Controls
@@ -57,6 +55,12 @@ namespace Windows.UI.Xaml.Controls
 					return false;
 				}
 
+				// Both IsReadOnly = true and IsTabStop = false can prevent editing
+				if (textBox.IsReadOnly || !textBox.IsTabStop)
+				{
+					return false;
+				}
+
 				if (textBox.OnKey(text.FirstOrDefault()))
 				{
 					return false;
@@ -65,22 +69,18 @@ namespace Windows.UI.Xaml.Controls
 				if (textBox.MaxLength > 0)
 				{
 					// When replacing text from pasting (multiple characters at once)
-					// We should only allow it (return true) when the new text length
+					// we should only allow it (return true) when the new text length
 					// is lower or equal to the allowed length (TextBox.MaxLength)
 					var newLength = bindableTextView.Text.Length + text.Length - range.Length;
 					return newLength <= textBox.MaxLength;
 				}
-
-				// Both IsReadOnly = true and IsTabStop = false can prevent editing
-				return !textBox.IsReadOnly && textBox.IsTabStop;
 			}
 
-			return false;
+			return true;
 		}
 
 		public override bool ShouldEndEditing(UITextView textView)
 		{
-			var bindableTextView = textView as MultilineTextBoxView;
 			return true;
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxDelegate.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxDelegate.iOS.cs
@@ -67,6 +67,14 @@ namespace Windows.UI.Xaml.Controls
 						var newLength = bindableTextView.Text.Length + text.Length - range.Length;
 						return newLength <= textBox.MaxLength;
 					}
+
+					if (_textBox.GetTarget() is not TextBox textBox)
+					{
+						return false;
+					}
+
+					// Both IsReadOnly = true and IsTabStop = false can prevent editing
+					return !textBox.IsReadOnly && textBox.IsTabStop;
 				}
 
 				return true;
@@ -79,17 +87,6 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var bindableTextView = textView as MultilineTextBoxView;
 			return true;
-		}
-
-		public override bool ShouldBeginEditing(UITextView textView)
-		{
-			if (_textBox.GetTarget() is not TextBox textBox)
-			{
-				return false;
-			}
-
-			// Both IsReadOnly = true and IsTabStop = false can prevent editing
-			return !textBox.IsReadOnly && textBox.IsTabStop;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
@@ -27,24 +27,26 @@ namespace Windows.UI.Xaml.Controls
 
 		public override bool ShouldChangeCharacters(UITextField textField, NSRange range, string replacementString)
 		{
-			var textBoxView = textField as SinglelineTextBoxView;
-			if (textBoxView != null)
+			if (textField is SinglelineTextBoxView textBoxView)
 			{
-				if (_textBox.GetTarget()?.OnKey(replacementString.FirstOrDefault()) ?? false)
-                {
-                    return false;
-                }
-
-                if (_textBox.GetTarget()?.MaxLength > 0)
-				{
-					var newLength = textBoxView.Text.Length + replacementString.Length - range.Length;
-					return newLength <= _textBox.GetTarget()?.MaxLength;
-				};
-
 				if (_textBox.GetTarget() is not TextBox textBox)
 				{
 					return false;
 				}
+
+				if (textBox.OnKey(replacementString.FirstOrDefault()))
+                {
+                    return false;
+                }
+
+				if (textBox.MaxLength > 0)
+				{
+					// When replacing text from pasting (multiple characters at once)
+					// We should only allow it (return true) when the new text length
+					// is lower or equal to the allowed length (TextBox.MaxLength)
+					var newLength = textBoxView.Text.Length + replacementString.Length - range.Length;
+					return newLength <= _textBox.GetTarget()?.MaxLength;
+				};
 
 				// Both IsReadOnly = true and IsTabStop = false can prevent editing
 				return !textBox.IsReadOnly && textBox.IsTabStop;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
@@ -30,7 +30,7 @@ namespace Windows.UI.Xaml.Controls
 			var textBoxView = textField as SinglelineTextBoxView;
 			if (textBoxView != null)
 			{
-                if(_textBox.GetTarget()?.OnKey(replacementString.FirstOrDefault()) ?? false)
+				if (_textBox.GetTarget()?.OnKey(replacementString.FirstOrDefault()) ?? false)
                 {
                     return false;
                 }
@@ -40,6 +40,14 @@ namespace Windows.UI.Xaml.Controls
 					var newLength = textBoxView.Text.Length + replacementString.Length - range.Length;
 					return newLength <= _textBox.GetTarget()?.MaxLength;
 				};
+
+				if (_textBox.GetTarget() is not TextBox textBox)
+				{
+					return false;
+				}
+
+				// Both IsReadOnly = true and IsTabStop = false can prevent editing
+				return !textBox.IsReadOnly && textBox.IsTabStop;
 			}
 
 			return true;
@@ -68,17 +76,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			return true;
-		}
-
-		public override bool ShouldBeginEditing(UITextField textField)
-		{
-			if (_textBox.GetTarget() is not TextBox textBox)
-			{
-				return false;
-			}
-
-			// Both IsReadOnly = true and IsTabStop = false can prevent editing
-			return !textBox.IsReadOnly && textBox.IsTabStop;
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
@@ -1,9 +1,7 @@
 ﻿using Foundation;
 using Uno.Extensions;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UIKit;
 using Windows.UI.Core;
 using System.Threading.Tasks;
@@ -12,7 +10,7 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class SinglelineTextBoxDelegate : UITextFieldDelegate
 	{
-		private WeakReference<TextBox> _textBox;
+		private readonly WeakReference<TextBox> _textBox;
 
 		public SinglelineTextBoxDelegate(WeakReference<TextBox> textbox)
 		{
@@ -34,6 +32,12 @@ namespace Windows.UI.Xaml.Controls
 					return false;
 				}
 
+				// Both IsReadOnly = true and IsTabStop = false can prevent editing
+				if (textBox.IsReadOnly || !textBox.IsTabStop)
+				{
+					return false;
+				}
+
 				if (textBox.OnKey(replacementString.FirstOrDefault()))
                 {
                     return false;
@@ -42,14 +46,11 @@ namespace Windows.UI.Xaml.Controls
 				if (textBox.MaxLength > 0)
 				{
 					// When replacing text from pasting (multiple characters at once)
-					// We should only allow it (return true) when the new text length
+					// we should only allow it (return true) when the new text length
 					// is lower or equal to the allowed length (TextBox.MaxLength)
 					var newLength = textBoxView.Text.Length + replacementString.Length - range.Length;
-					return newLength <= _textBox.GetTarget()?.MaxLength;
+					return newLength <= textBox.MaxLength;
 				};
-
-				// Both IsReadOnly = true and IsTabStop = false can prevent editing
-				return !textBox.IsReadOnly && textBox.IsTabStop;
 			}
 
 			return true;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9908 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When a TextBox is set as `Readonly` Text is not selectable.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
