### PR TITLE
fix(Wasm): Fix BorderRadius not rendering properly when it's greater than half of width or height

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/BorderTests/Border_Tests.cs
@@ -55,6 +55,31 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.BorderTests
 				ExpectedPixels.At(sample.Right - eighth, sample.Bottom - eighth).Named("bottom right corner").Pixel(white),
 				ExpectedPixels.At(sample.X + eighth, sample.Bottom - eighth).Named("bottom left corner").Pixel(white)
 			);
+
+#if __WASM__
+			// See https://github.com/unoplatform/uno/issues/5440 for the scenario being tested.
+			var sample2 = _app.GetPhysicalRect("Sample2");
+
+			var top = sample2.Y + 1;
+			ImageAssert.HasColorAt(result, sample2.CenterX, top, Color.Red, tolerance: 20);
+			ImageAssert.HasColorAt(result, sample2.CenterX + 25, top, Color.White);
+			ImageAssert.HasColorAt(result, sample2.CenterX - 25, top, Color.White);
+
+			var bottom = sample2.Bottom - 1;
+			ImageAssert.HasColorAt(result, sample2.CenterX, bottom, Color.Red, tolerance: 20);
+			ImageAssert.HasColorAt(result, sample2.CenterX + 20, bottom, Color.White);
+			ImageAssert.HasColorAt(result, sample2.CenterX - 20, bottom, Color.White);
+
+			var right = sample2.Right - 1;
+			ImageAssert.HasColorAt(result, right, sample2.CenterY, Color.Red, tolerance: 20);
+			ImageAssert.HasColorAt(result, right, sample2.CenterY - 10, Color.White);
+			ImageAssert.HasColorAt(result, right, sample2.CenterY + 10, Color.White);
+
+			var left = sample2.X + 2;
+			ImageAssert.HasColorAt(result, left, sample2.CenterY, Color.Red, tolerance: 20);
+			ImageAssert.HasColorAt(result, left, sample2.CenterY - 10, Color.White);
+			ImageAssert.HasColorAt(result, left, sample2.CenterY + 10, Color.White);
+#endif
 		}
 
 		[Test]

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/Border_CornerRadius.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BorderTests/Border_CornerRadius.xaml
@@ -18,6 +18,14 @@
 					Height="100"
 					CornerRadius="50" />
 
+			<!-- Sample for https://github.com/unoplatform/uno/issues/5440 -->
+			<Border Height="30" />
+			<Border x:Name="Sample2"
+					Width="128"
+					Height="64"
+					Background="Red"
+					CornerRadius="128" />
+
 			<Border Height="30" />
 			<Border Width="100"
 					Height="50"

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.wasm.cs
@@ -55,7 +55,7 @@ namespace Windows.UI.Xaml.Shapes
 			}
 			else
 			{
-				var borderRadiusCssString = $"{cornerRadius.TopLeft.ToStringInvariant()}px {cornerRadius.TopRight.ToStringInvariant()}px {cornerRadius.BottomRight.ToStringInvariant()}px {cornerRadius.BottomLeft.ToStringInvariant()}px";
+				var borderRadiusCssString = $"min(50%,{cornerRadius.TopLeft.ToStringInvariant()}px) min(50%,{cornerRadius.TopRight.ToStringInvariant()}px) min(50%,{cornerRadius.BottomRight.ToStringInvariant()}px) min(50%,{cornerRadius.BottomLeft.ToStringInvariant()}px)";
 				element.SetStyle(
 					("border-radius", borderRadiusCssString),
 					("overflow", "hidden")); // overflow: hidden is required here because the clipping can't do its job when it's non-rectangular.


### PR DESCRIPTION
GitHub Issue (If applicable): The Wasm part of #5440. Other platforms still need a fix. I'll take a look to see if I'm able to.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

If the CornerRadius is larger than half of element width or larger than half of element height, the clipping is done as a circular shape, which doesn't match UWP/WinUI behavior.


## What is the new behavior?

The CornerRadius is now applied correctly as an elliptic shape.


![image](https://user-images.githubusercontent.com/31348972/192153284-b51adc29-0f5b-4027-b2f1-426a45291ce3.png)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
