### PR TITLE
chore: Avoid duplicate usings for WinUI build

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItem.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItem.cs
@@ -5,14 +5,16 @@
 #nullable enable
 
 using System.Collections.ObjectModel;
-using Microsoft.UI.Xaml.Automation.Peers;
 using Uno.Disposables;
 using Uno.UI.Helpers.WinUI;
 using Windows.Devices.Input;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+#if !HAS_UNO_WINUI // Avoid duplicate using for WinUI build
 using Windows.UI.Xaml.Automation.Peers;
+#endif
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PipsPager/PipsPager.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PipsPager/PipsPager.cs
@@ -4,14 +4,16 @@
 
 using System;
 using System.Collections.ObjectModel;
-using Microsoft.UI.Xaml.Automation.Peers;
 using Uno.Disposables;
 using Uno.UI.Helpers.WinUI;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+#if !HAS_UNO_WINUI // Avoid duplicate using for WinUI build
 using Windows.UI.Xaml.Automation.Peers;
+#endif
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;


### PR DESCRIPTION
GitHub Issue (If applicable): 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The WinUI revert branch cannot be built locally as there are duplicate namespaces.

## What is the new behavior?

Avoid duplicate namespaces.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
