### PR TITLE
fix: Ensure `Window.Current` is set when `Window` is newed up

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_Window.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_Window.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.ApplicationModel.Activation;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml;
+
+// These tests will become invalid when multi-window support is added #8341
+[TestClass]
+public class Given_Window
+{
+	[TestMethod]
+	public void New_Window_Becomes_Current()
+	{
+		var window = new Windows.UI.Xaml.Window();
+		window.Activate();
+		Assert.AreEqual(window, Windows.UI.Xaml.Window.Current);
+	}
+
+	[TestMethod]
+	public void New_Window_Does_Not_Override_Current()
+	{
+		var existingCurrent = Windows.UI.Xaml.Window.Current;
+		var window = new Windows.UI.Xaml.Window();
+		window.Activate();
+		Assert.AreEqual(existingCurrent, Windows.UI.Xaml.Window.Current);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -23,10 +23,7 @@ namespace Windows.UI.Xaml
 {
 	public sealed partial class Window
 	{
-		private static Window _current;
-		private RootVisual _rootVisual;
 		private Border _rootBorder;
-		private UIElement _content;
 
 		public Window()
 		{
@@ -61,21 +58,7 @@ namespace Windows.UI.Xaml
 			_rootBorder.Child = _content = value;
 		}
 
-		private UIElement InternalGetContent() => _content;
-
-		private UIElement InternalGetRootElement() => _rootVisual;
-
 		internal UIElement MainContent => _rootVisual;
-
-		private static Window InternalGetCurrentWindow()
-		{
-			if (_current == null)
-			{
-				_current = new Window();
-			}
-
-			return _current;
-		}
 
 		internal void RaiseNativeSizeChanged()
 		{

--- a/src/Uno.UI/UI/Xaml/Window.Desktop.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Desktop.cs
@@ -15,8 +15,6 @@ namespace Windows.UI.Xaml
 {
 	public sealed partial class Window
 	{
-		private static Window _current;
-		
 		private bool _isActive;
 
 		public Window()

--- a/src/Uno.UI/UI/Xaml/Window.Desktop.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Desktop.cs
@@ -16,9 +16,8 @@ namespace Windows.UI.Xaml
 	public sealed partial class Window
 	{
 		private static Window _current;
-		private RootVisual _rootVisual;
+		
 		private bool _isActive;
-		private UIElement _content;
 
 		public Window()
 		{
@@ -56,20 +55,6 @@ namespace Windows.UI.Xaml
 			{
 				(_content as FrameworkElement)?.ForceLoaded();
 			}
-		}
-
-		private UIElement InternalGetContent() => _content;
-
-		private UIElement InternalGetRootElement() => _content;
-
-		private static Window InternalGetCurrentWindow()
-		{
-			if (_current == null)
-			{
-				_current = new Window();
-			}
-
-			return _current;
 		}
 
 		internal void SetWindowSize(Size size)

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -21,6 +21,11 @@ namespace Windows.UI.Xaml
 	/// </summary>
 	public sealed partial class Window
 	{
+		private static Window _current;
+		
+		private UIElement _content;
+		private RootVisual _rootVisual;
+
 		private CoreWindowActivationState? _lastActivationState;
 		private Brush _background;
 
@@ -158,6 +163,14 @@ namespace Windows.UI.Xaml
 
 		public void Activate()
 		{
+			// Currently Uno supports only single window,
+			// for compatibility with WinUI we set the first activated
+			// as Current
+			if (_current is null)
+			{
+				_current = this;
+			}
+
 			InternalActivate();
 
 			OnActivated(CoreWindowActivationState.CodeActivated);
@@ -271,6 +284,12 @@ namespace Windows.UI.Xaml
 				(h, s, e) =>
 					(h as EventHandler)?.Invoke(s, (EventArgs)e)
 			);
+
+		private static Window InternalGetCurrentWindow() => _current ??= new Window();
+
+		private UIElement InternalGetContent() => _content!;
+
+		private UIElement InternalGetRootElement() => _rootVisual!;
 
 		#region Drag and Drop
 		private DragRoot _dragRoot;

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -165,11 +165,8 @@ namespace Windows.UI.Xaml
 		{
 			// Currently Uno supports only single window,
 			// for compatibility with WinUI we set the first activated
-			// as Current
-			if (_current is null)
-			{
-				_current = this;
-			}
+			// as Current #8341
+			_current ??= this;
 
 			InternalActivate();
 

--- a/src/Uno.UI/UI/Xaml/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.iOS.cs
@@ -20,11 +20,8 @@ namespace Windows.UI.Xaml
 	{
 		private Uno.UI.Controls.Window _nativeWindow;
 
-		private static Window _current;
-		private RootVisual _rootVisual;
 		private Border _rootBorder;
 		private RootViewController _mainController;
-		private UIElement _content;
 		private NSObject _orientationRegistration;
 
 		/// <summary>
@@ -108,20 +105,6 @@ namespace Windows.UI.Xaml
 			_rootBorder.Child?.RemoveFromSuperview();
 			_rootBorder.Child = null;
 			_rootBorder.Child = _content = value;
-		}
-
-		private UIElement InternalGetContent() => _content;
-
-		private UIElement InternalGetRootElement() => _rootVisual;
-
-		private static Window InternalGetCurrentWindow()
-		{
-			if (_current == null)
-			{
-				_current = new Window();
-			}
-
-			return _current;
 		}
 
 		internal void RaiseNativeSizeChanged(CGSize size)

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -20,10 +20,7 @@ namespace Windows.UI.Xaml
 	{
 		private Uno.UI.Controls.Window _window;
 
-		private static Window _current;
 		private RootViewController _mainController;
-		private UIElement _content;
-		private RootVisual _rootVisual;
 		private Border _rootBorder;
 		private object _windowResizeNotificationObject;
 
@@ -120,20 +117,6 @@ namespace Windows.UI.Xaml
 			var trackingArea = new NSTrackingArea(Bounds, options, _rootVisual, null);
 
 			_rootVisual.AddTrackingArea(trackingArea);
-		}
-
-		private UIElement InternalGetContent() => _content;
-
-		private UIElement InternalGetRootElement() => _rootVisual;
-
-		private static Window InternalGetCurrentWindow()
-		{
-			if (_current == null)
-			{
-				_current = new Window();
-			}
-
-			return _current;
 		}
 
 		internal void RaiseNativeSizeChanged(CGSize size)

--- a/src/Uno.UI/UI/Xaml/Window.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Window.skia.cs
@@ -16,11 +16,8 @@ namespace Windows.UI.Xaml
 {
 	public sealed partial class Window
 	{
-		private static Window? _current;
-		private RootVisual? _rootVisual;
 		// private ScrollViewer _rootScrollViewer;
 		private Border? _rootBorder;
-		private UIElement? _content;
 
 		public Window()
 		{
@@ -88,19 +85,5 @@ namespace Windows.UI.Xaml
 				_rootBorder.Child = _content = content;
 			}
 		}
-
-		private UIElement InternalGetContent() => _content!;
-
-		private UIElement InternalGetRootElement() => _rootVisual!;
-
-		private static Window InternalGetCurrentWindow()
-		{
-			if (_current == null)
-			{
-				_current = new Window();
-			}
-
-			return _current;
-		}		
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -25,11 +25,8 @@ namespace Windows.UI.Xaml
 {
 	public sealed partial class Window
 	{
-		private static Window _current;
-		private RootVisual _rootVisual;
 		private ScrollViewer _rootScrollViewer;
 		private Border _rootBorder;
-		private UIElement _content;
 		private bool _invalidateRequested;
 
 		public Window()
@@ -186,12 +183,6 @@ namespace Windows.UI.Xaml
 
 			_rootBorder.Child = _content = content;
 		}
-
-		private UIElement InternalGetContent() => _content;
-
-		private UIElement InternalGetRootElement() => _rootVisual!;
-
-		private static Window InternalGetCurrentWindow() => _current ??= new Window();
 
 		internal void UpdateRootAttributes()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In case user uses WinUI-style initialization of `Window`, `Window.Current` will remain `null`, even though Uno currently supports only single-window scenarios. Some internal APIs still rely on `Window.Current`.

## What is the new behavior?

When a `Window` is activated and no "current" window is yet set, this window will become `Current`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
