### PR TITLE
fix: Generated javascript content is not embedded at the right place

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -61,6 +61,10 @@ jobs:
   parameters:
     vmImage: '$(linuxVMImage)'
 
+- template: build/ci/.azure-devops-winui-convert.yml
+  parameters:
+    vmImage: '$(windows2022HostedVMImage)'
+
 - template: build/ci/.azure-devops-pipeline-validations.yml
   parameters:
     vmImage: '$(linuxVMImage)'

--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -49,8 +49,6 @@
 
 		<CallTarget Targets="UpdateFileVersions;UpdateTasksSHA;PrepareNuGetPackage" Condition="$(_isWindows)" />
 
-		<CallTarget Targets="RunAPISyncTool" Condition="'$(UNO_UWP_BUILD)'=='false'" />
-
 		<CallTarget Targets="BuildCI" Condition="'$(Configuration)'=='Release' and $(_isWindows)" />
 
 		<CallTarget Targets="PublishVSIX2019" Condition="'$(Configuration)'=='Release' and $(_isWindows)" />
@@ -60,8 +58,6 @@
 		<Message Text="Building for $(Configuration) and $(Platform) BuildReason:$(BUILD_REASON) Version:$(GitVersion_SemVer) UNO_UWP_BUILD:$(UNO_UWP_BUILD)" />
 
 		<CallTarget Targets="UpdateFileVersions;UpdateTasksSHA;PrepareNuGetPackage" Condition="$(_isWindows)" />
-
-		<CallTarget Targets="RunAPISyncTool" Condition="'$(UNO_UWP_BUILD)'=='false'" />
 	</Target>
 
 	<Target Name="GeneratePackages" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)'==''">

--- a/build/ci/.azure-devops-package-generic.yml
+++ b/build/ci/.azure-devops-package-generic.yml
@@ -6,7 +6,7 @@ jobs:
   displayName: 'Build Generic Binaries'
   timeoutInMinutes: 90
   
-  dependsOn: Pipeline_Validations
+  dependsOn: winui_convert_tree
 
   pool: ${{ parameters.poolName }}
 
@@ -34,6 +34,8 @@ jobs:
   steps:
   - checkout: self
     clean: true
+
+  - template: templates/download-winui-converted-tree.yml
 
   - template: templates/nuget-cache.yml
     parameters:
@@ -63,13 +65,6 @@ jobs:
 
   - template: templates/install-windows-sdk.yml
   - template: templates/jdk-setup.yml
-
-  - powershell: |
-        cd $(build.sourcesdirectory)\src\Uno.WinUIRevert
-        dotnet run "$(build.sourcesdirectory)"
-
-    condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
-    displayName: Convert source tree to WinUI 3 structure
 
   - task: MSBuild@1
     inputs:

--- a/build/ci/.azure-devops-package-net6-win.yml
+++ b/build/ci/.azure-devops-package-net6-win.yml
@@ -8,7 +8,7 @@ jobs:
 
   pool: ${{ parameters.poolName }}
   
-  dependsOn: Pipeline_Validations
+  dependsOn: winui_convert_tree
 
   strategy:
     matrix:
@@ -45,16 +45,11 @@ jobs:
     parameters:
       nugetPackages: $(NUGET_PACKAGES)
 
+  - template: templates/download-winui-converted-tree.yml
+
   - template: templates/gitversion.yml
   - template: templates/dotnet6-install-windows.yml
   - template: templates/install-windows-sdk.yml
-
-  - powershell: |
-        cd $(build.sourcesdirectory)\src\Uno.WinUIRevert
-        dotnet run "$(build.sourcesdirectory)"
-
-    condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
-    displayName: Convert source tree to WinUI 3 structure
 
   # Required to build on net5 because of uwp compatibility (until 16.10 gets published)
   - task: MSBuild@1

--- a/build/ci/.azure-devops-package.yml
+++ b/build/ci/.azure-devops-package.yml
@@ -9,7 +9,6 @@ jobs:
   dependsOn:
   - generic_win_build
   - net6_win_build
-  # - net6_mac_build
 
   pool: ${{ parameters.poolName }}
 
@@ -42,6 +41,8 @@ jobs:
     parameters:
       nugetPackages: $(NUGET_PACKAGES)
 
+  - template: templates/download-winui-converted-tree.yml
+
   - template: templates/gitversion.yml
    
   - task: NuGetToolInstaller@0
@@ -60,13 +61,6 @@ jobs:
   - task: NodeTool@0
 
   - template: templates/install-windows-sdk.yml
-
-  - powershell: |
-        cd $(build.sourcesdirectory)\src\Uno.WinUIRevert
-        dotnet run "$(build.sourcesdirectory)"
-
-    condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
-    displayName: Convert source tree to WinUI 3 structure
 
   - task: DownloadBuildArtifacts@0
     inputs:

--- a/build/ci/.azure-devops-winui-convert.yml
+++ b/build/ci/.azure-devops-winui-convert.yml
@@ -1,0 +1,64 @@
+parameters:
+  poolName: ''
+
+jobs:
+- job: winui_convert_tree
+  displayName: 'WinUI Converted Tree Generation'
+
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+  
+  dependsOn: Pipeline_Validations
+
+  variables:
+    CombinedConfiguration: Release|Any CPU
+    CI_Build: true
+
+    # This is required to be able to use hard links as much as possible
+    NUGET_PACKAGES: $(Agent.WorkFolder)\.nuget
+
+    UNO_UWP_BUILD: false
+    XAML_FLAVOR_BUILD: WinUI 
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - template: templates/nuget-cache.yml
+    parameters:
+      nugetPackages: $(NUGET_PACKAGES)
+
+  - template: templates/dotnet6-install-windows.yml
+  - template: templates/install-windows-sdk.yml
+
+  - powershell: |
+        cd $(build.sourcesdirectory)\src\Uno.WinUIRevert
+        dotnet run "$(build.sourcesdirectory)"
+
+    condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
+    displayName: Convert source tree to WinUI 3 structure
+
+  # Required to build on net5 because of uwp compatibility (until 16.10 gets published)
+  - task: MSBuild@1
+    inputs:
+      solution: Build/Uno.UI.Build.csproj
+      msbuildLocationMethod: version
+      msbuildVersion: latest
+      msbuildArchitecture: x86
+      msbuildArguments: /r /m /t:RunAPISyncTool "/p:CombinedConfiguration=$(CombinedConfiguration)" /detailedsummary /bl:$(build.artifactstagingdirectory)\build-winui-convert.binlog
+      clean: false
+      restoreNugetPackages: false
+      logProjectEvents: false
+      createLogFile: false
+
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: $(build.sourcesdirectory)
+      artifactName: winui-converted-tree
+
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    inputs:
+      PathtoPublish: $(build.artifactstagingdirectory)
+      ArtifactName: NugetPackages-Artifacts
+      ArtifactType: Container

--- a/build/ci/templates/download-winui-converted-tree.yml
+++ b/build/ci/templates/download-winui-converted-tree.yml
@@ -1,0 +1,7 @@
+steps:
+  - task: DownloadPipelineArtifact@2
+    displayName: Restoring WinUI Converted source tree
+    condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
+    inputs:
+      artifact: winui-converted-tree
+      path: $(Build.SourcesDirectory)

--- a/build/ci/templates/download-winui-converted-tree.yml
+++ b/build/ci/templates/download-winui-converted-tree.yml
@@ -1,6 +1,7 @@
 steps:
   - pwsh: |
-      Get-ChildItem $(Build.SourcesDirectory) -Include *.* -Recurse | ForEach  { $_.Delete()}
+      cd $(Build.SourcesDirectory)
+      rm -r -fo *.*
     condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
     displayName: Pre-cleanup for Restoring WinUI Converted Source Tree
 

--- a/build/ci/templates/download-winui-converted-tree.yml
+++ b/build/ci/templates/download-winui-converted-tree.yml
@@ -1,7 +1,7 @@
 steps:
   - pwsh: |
       cd $(Build.SourcesDirectory)
-      rm -r -fo *.* -Exclude ".git"
+      Get-ChildItem -Exclude ".git" | Remove-Item -Recurse -Force -Exclude
     condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
     displayName: Pre-cleanup for Restoring WinUI Converted Source Tree
 

--- a/build/ci/templates/download-winui-converted-tree.yml
+++ b/build/ci/templates/download-winui-converted-tree.yml
@@ -1,6 +1,6 @@
 steps:
   - pwsh: |
-      Remove-Item –Path $(Build.SourcesDirectory) -include *.* –recurse -exclude ".git"
+      Get-ChildItem $(Build.SourcesDirectory) -Include *.* -Recurse | ForEach  { $_.Delete()}
     condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
     displayName: Pre-cleanup for Restoring WinUI Converted Source Tree
 

--- a/build/ci/templates/download-winui-converted-tree.yml
+++ b/build/ci/templates/download-winui-converted-tree.yml
@@ -1,6 +1,11 @@
 steps:
+  - pwsh: |
+      Remove-Item –Path $(Build.SourcesDirectory) -include *.* –recurse -exclude ".git"
+    condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
+    displayName: Pre-cleanup for Restoring WinUI Converted Source Tree
+
   - task: DownloadPipelineArtifact@2
-    displayName: Restoring WinUI Converted source tree
+    displayName: Restoring WinUI Converted Source Rree
     condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
     inputs:
       artifact: winui-converted-tree

--- a/build/ci/templates/download-winui-converted-tree.yml
+++ b/build/ci/templates/download-winui-converted-tree.yml
@@ -1,7 +1,7 @@
 steps:
   - pwsh: |
       cd $(Build.SourcesDirectory)
-      rm -r -fo *.*
+      rm -r -fo *.* -Exlude ".git"
     condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
     displayName: Pre-cleanup for Restoring WinUI Converted Source Tree
 

--- a/build/ci/templates/download-winui-converted-tree.yml
+++ b/build/ci/templates/download-winui-converted-tree.yml
@@ -1,7 +1,7 @@
 steps:
   - pwsh: |
       cd $(Build.SourcesDirectory)
-      Get-ChildItem -Exclude ".git" | Remove-Item -Recurse -Force -Exclude
+      Get-ChildItem -Exclude ".git" | Remove-Item -Recurse -Force
     condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
     displayName: Pre-cleanup for Restoring WinUI Converted Source Tree
 

--- a/build/ci/templates/download-winui-converted-tree.yml
+++ b/build/ci/templates/download-winui-converted-tree.yml
@@ -1,7 +1,7 @@
 steps:
   - pwsh: |
       cd $(Build.SourcesDirectory)
-      rm -r -fo *.* -Exlude ".git"
+      rm -r -fo *.* -Exclude ".git"
     condition: and(succeeded(), eq(variables['UNO_UWP_BUILD'], 'false'))
     displayName: Pre-cleanup for Restoring WinUI Converted Source Tree
 

--- a/src/SamplesApp/SamplesApp.UWP.Design/SamplesApp.UWP.Design.csproj
+++ b/src/SamplesApp/SamplesApp.UWP.Design/SamplesApp.UWP.Design.csproj
@@ -124,7 +124,7 @@
     <EmbeddedResource Include="Properties\SamplesApp.UWP.Design.rd.xml" />
   </ItemGroup>
   <ItemGroup>
-		<PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
     <PackageReference Include="Microsoft.Identity.Client">
       <Version>4.15.0</Version>
     </PackageReference>

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -116,7 +116,7 @@
 		and '$(BuildingInsideUnoSourceGenerator)' == ''
 		and '$(SkipCompilerExecution)' == ''
 		and ('$(UnoXamlResourcesTrimming)'=='true' or '$(UnoRewriteEmbeddedResources)'=='true')"
-		AfterTargets="CoreCompile;_UnoLinkerHintsSubstitutionsMerge">
+		AfterTargets="CoreCompile;_UnoLinkerHintsSubstitutionsMerge;CompileTypeScriptWithTSConfig">
 
 		<ItemGroup>
 			<!-- Filter ReferenceCopyLocalPaths as it may contain pdbs as well -->


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/9986, closes #9951

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Adjust the generation of javascript helpers for WinUI
- Move WinUI tree generation to a separate step for reuse

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
