### PR TITLE
feat(xbind): Add pathless casting support

### DIFF
--- a/doc/articles/features/windows-ui-xaml-xbind.md
+++ b/doc/articles/features/windows-ui-xaml-xbind.md
@@ -87,6 +87,28 @@ Uno supports the [`x:Bind`](https://docs.microsoft.com/en-us/windows/uwp/xaml-pl
   <TextBox FontFamily="{x:Bind (FontFamily)MyComboBox.SelectedValue}" />
   ```
 
+- [Pathless casting](https://learn.microsoft.com/en-us/windows/uwp/xaml-platform/x-bind-markup-extension#pathless-casting)
+  ```xml
+  <Page
+    x:Class="AppSample.MainPage"
+    ...
+    xmlns:local="using:AppSample">
+
+    <Grid>
+        <ListView ItemsSource="{x:Bind Songs}">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="local:SongItem">
+                    <TextBlock
+                        Margin="12"
+                        FontSize="40"
+                        Text="{x:Bind local:MainPage.GenerateSongTitle((local:SongItem))}" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </Grid>
+  </Page>
+  ```
+
 - `x:Load` binding
   ```xml
   <TextBox x:Load="{x:Bind IsMyControlVisible}" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests.Shared/Given_XBindRewriter.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests.Shared/Given_XBindRewriter.cs
@@ -30,6 +30,11 @@ namespace Uno.UI.SourceGenerators.Tests
 		[DataRow("ctx", "(FontFamily)a.Value", "(FontFamily)ctx.a.Value")]
 		[DataRow("ctx", "(global::System.Int32)a.Value", "(global::System.Int32)ctx.a.Value")]
 
+		// Pathless casting https://learn.microsoft.com/en-us/windows/uwp/xaml-platform/x-bind-markup-extension#pathless-casting
+		[DataRow("ctx", "MyFunction((global::System.String))", "ctx.MyFunction(((global::System.String)ctx))")]
+		[DataRow("ctx", "MyFunction2((global::System.String),(global::System.String))", "ctx.MyFunction2(((global::System.String)ctx),((global::System.String)ctx))")]
+		[DataRow("ctx", "(global::System.String)", "((global::System.String)ctx)")]
+
 		// Not supported https://github.com/unoplatform/uno/issues/5061
 		// [DataRow("ctx", "MyFunction((global::System.Int32)MyProperty)", "ctx.MyFunction((global::System.Int32)ctx.MyProperty)")]
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_PathLessCasting.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_PathLessCasting.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.xBind_PathLessCasting"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	xmlns:xc="using:Windows.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<TextBlock x:Name="tb1"
+				   x:FieldModifier="public"
+				   Tag="{x:Bind (xc:UserControl)}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_PathLessCasting.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_PathLessCasting.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	public sealed partial class xBind_PathLessCasting : UserControl
+	{
+		public xBind_PathLessCasting()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_PathLessCasting_Template.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_PathLessCasting_Template.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.xBind_PathLessCasting_Template"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+
+	<Grid>
+		<ContentControl x:Name="root"
+						x:FieldModifier="public">
+			<ContentControl.ContentTemplate>
+				<DataTemplate x:DataType="local:xBind_PathLessCasting_Template_Model">
+					<Grid>
+						<TextBlock x:Name="tb1"
+								   x:FieldModifier="public"
+								   Tag="{x:Bind (local:xBind_PathLessCasting_Template_Model)}" />
+					</Grid>
+				</DataTemplate>
+			</ContentControl.ContentTemplate>
+		</ContentControl>
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_PathLessCasting_Template.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_PathLessCasting_Template.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	public sealed partial class xBind_PathLessCasting_Template : UserControl
+	{
+		public xBind_PathLessCasting_Template()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public class xBind_PathLessCasting_Template_Model
+	{
+
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -1264,6 +1264,31 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			Assert.AreEqual("42", SUT.tb1.Text);
 		}
 
+		[TestMethod]
+		public async Task When_PathLessCasting()
+		{
+			var SUT = new xBind_PathLessCasting();
+
+			SUT.ForceLoaded();
+
+			Assert.AreEqual(SUT, SUT.tb1.Tag);
+		}
+
+		[TestMethod]
+		public async Task When_PathLessCasting_Template()
+		{
+			var SUT = new xBind_PathLessCasting_Template();
+
+			SUT.ForceLoaded();
+
+			var rootData = new xBind_PathLessCasting_Template_Model();
+			SUT.root.Content = rootData;
+
+			var myObject = SUT.FindName("tb1") as TextBlock;
+
+			Assert.AreEqual(rootData, myObject.Tag);
+		}
+
 		private async Task AssertIsNullAsync<T>(Func<T> getter, TimeSpan? timeout = null) where T:class
 		{
 			timeout ??= TimeSpan.FromSeconds(1);


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/7893

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Adds support for https://docs.microsoft.com/en-us/windows/uwp/xaml-platform/x-bind-markup-extension#pathless-casting

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
