### PR TITLE
feat(Clipboard): WASM rich clipboard support

### DIFF
--- a/src/Uno.UI/ts/Clipboard.ts
+++ b/src/Uno.UI/ts/Clipboard.ts
@@ -125,6 +125,14 @@ namespace Uno.Utils {
 			return null;
 		}
 
+		public static async getDataAsJson(mime: string): Promise<string> {
+			var result = await Clipboard.getData(mime);
+			if (!result) {
+				return null;
+			}
+			return JSON.stringify(result);
+		}
+
 		private static onClipboardChanged() {
 			if (!Clipboard.dispatchContentChanged) {
 				Clipboard.dispatchContentChanged =

--- a/src/Uno.UI/ts/Clipboard.ts
+++ b/src/Uno.UI/ts/Clipboard.ts
@@ -1,8 +1,20 @@
 ﻿// Type declarations for Clipboard API
 // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
+interface ClipboardItem {
+	readonly types: ReadonlyArray<string>;
+	getType(type: string): Promise<Blob>;
+}
+
+declare var ClipboardItem: {
+	prototype: ClipboardItem;
+	new(items: Record<string, string | Blob | PromiseLike<string | Blob>>, options?: any): ClipboardItem;
+};
+
 interface Clipboard {
-	writeText(newClipText: string): Promise<void>;
+	read(): Promise<ClipboardItem[]>;
 	readText(): Promise<string>;
+	write(data: ClipboardItem[]): Promise<void>;
+	writeText(newClipText: string): Promise<void>;
 }
 
 interface NavigatorClipboard {
@@ -13,6 +25,15 @@ interface NavigatorClipboard {
 interface Navigator extends NavigatorClipboard { }
 
 namespace Uno.Utils {
+	interface MarshalledData {
+		ptr: number;
+		len: number;
+	}
+
+	interface MarshalledDataWithMime extends MarshalledData {
+		mime: string;
+	}
+
 	export class Clipboard {
 		private static dispatchContentChanged: () => number;
 		private static dispatchGetContent: (requestId : string, content : string) => number;
@@ -50,17 +71,63 @@ namespace Uno.Utils {
 			return "ok";
 		}
 
-		public static getText(): Promise<string> {			
+		public static getText(): Promise<string> {
 			const nav = navigator as NavigatorClipboard;
 			if (nav.clipboard) {
-				return nav.clipboard.readText();				
+				return nav.clipboard.readText();
 			}
 			return Promise.resolve(null)
 		}
 
+		public static setData(data: MarshalledDataWithMime[]): string {
+			const nav = navigator as NavigatorClipboard;
+			if (nav.clipboard) {
+				nav.clipboard.write(
+					[
+						new ClipboardItem(Object.assign({}, ...data.map(d =>
+							({[d.mime]: new Blob([Module.HEAPU8.subarray(d.ptr, d.ptr + d.len)], { type: d.mime })})
+						)))
+					]
+				);
+				Clipboard.onClipboardChanged();
+				return "ok";
+			}
+			return null;
+		}
+
+		public static async getDataMimes(): Promise<string[]> {
+			const nav = navigator as NavigatorClipboard;
+			if (nav.clipboard) {
+				const clipboardContents = await nav.clipboard.read();
+				const mimes = [];
+				for (const content of clipboardContents) {
+					mimes.push(...content.types);
+				}
+				return mimes;
+			}
+			return [];
+		}
+
+		public static async getData(mime: string): Promise<MarshalledData> {
+			const nav = navigator as NavigatorClipboard;
+			if (nav.clipboard) {
+				const clipboardContents = await nav.clipboard.read();
+				for (const content of clipboardContents) {
+					if (content.types.includes(mime)) {
+						const blob = await content.getType(mime);
+						const buffer = await blob.arrayBuffer();
+						const ptr = Module._malloc(buffer.byteLength);
+						Module.HEAPU8.set(new Uint8Array(buffer), ptr);
+						return {ptr: ptr, len: buffer.byteLength};
+					}
+				}
+			}
+			return null;
+		}
+
 		private static onClipboardChanged() {
 			if (!Clipboard.dispatchContentChanged) {
-				Clipboard.dispatchContentChanged = 
+				Clipboard.dispatchContentChanged =
 					(<any>Module).mono_bind_static_method(
 						"[Uno] Windows.ApplicationModel.DataTransfer.Clipboard:DispatchContentChanged");
 			}

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.MarshalledData.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.MarshalledData.wasm.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading;
+
+namespace Windows.ApplicationModel.DataTransfer
+{
+	public static partial class Clipboard
+	{
+		[DataContract]
+		private class MarshalledData: IDisposable
+		{
+			private bool _disposed;
+			private IntPtr _ptr;
+
+			[DataMember(Name = "ptr")]
+			private long _longPtr
+			{
+				get => (long)_ptr;
+				set => _ptr = (IntPtr)value;
+			}
+
+			[DataMember(Name = "len")]
+			private int _len;
+
+			public MarshalledData()
+			{
+			}
+
+			public MarshalledData(byte[] arr)
+			{
+				_ptr = Marshal.AllocHGlobal(arr.Length);
+				_len = arr.Length;
+				Marshal.Copy(arr, 0, _ptr, _len);
+			}
+
+			public MarshalledData(string str)
+				: this(Encoding.UTF8.GetBytes(str))
+			{
+			}
+
+			public unsafe override string ToString()
+			{
+				return Encoding.UTF8.GetString((byte*)_ptr, _len);
+			}
+
+			public byte[] ToArray()
+			{
+				var arr = new byte[_len];
+				Marshal.Copy(_ptr, arr, 0, _len);
+				return arr;
+			}
+
+			protected virtual void Dispose(bool disposing)
+			{
+				if (!_disposed)
+				{
+					var toFree = Interlocked.Exchange(ref _ptr, IntPtr.Zero);
+					Marshal.FreeHGlobal(toFree);
+					_disposed = true;
+				}
+			}
+
+			~MarshalledData()
+			{
+				Dispose(disposing: false);
+			}
+
+			public void Dispose()
+			{
+				Dispose(disposing: true);
+				GC.SuppressFinalize(this);
+			}
+		}
+
+		[DataContract]
+		private class MarshalledDataWithMime: MarshalledData
+		{
+			[DataMember(Name = "mime")]
+			private string _mime;
+
+			public MarshalledDataWithMime(byte[] arr, string mime)
+				: base(arr)
+			{
+				_mime = mime;
+			}
+
+			public MarshalledDataWithMime(string str, string mime)
+				: base(str)
+			{
+				_mime = mime;
+			}
+		}
+    }
+}

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
@@ -3,9 +3,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Uno.Disposables;
@@ -18,91 +15,6 @@ namespace Windows.ApplicationModel.DataTransfer
 	public static partial class Clipboard
 	{
 		private const string JsType = "Uno.Utils.Clipboard";
-
-		[DataContract]
-		private class MarshalledData: IDisposable
-		{
-			private bool _disposed;
-			private IntPtr _ptr;
-
-			[DataMember(Name = "ptr")]
-			private long _longPtr
-			{
-				get => (long)_ptr;
-				set => _ptr = (IntPtr)value;
-			}
-
-			[DataMember(Name = "len")]
-			private int _len;
-
-			public MarshalledData()
-			{
-			}
-
-			public MarshalledData(byte[] arr)
-			{
-				_ptr = Marshal.AllocHGlobal(arr.Length);
-				_len = arr.Length;
-				Marshal.Copy(arr, 0, _ptr, _len);
-			}
-
-			public MarshalledData(string str)
-				: this(Encoding.UTF8.GetBytes(str))
-			{
-			}
-
-			public unsafe override string ToString()
-			{
-				return Encoding.UTF8.GetString((byte*)_ptr, _len);
-			}
-
-			public byte[] ToArray()
-			{
-				var arr = new byte[_len];
-				Marshal.Copy(_ptr, arr, 0, _len);
-				return arr;
-			}
-
-			protected virtual void Dispose(bool disposing)
-			{
-				if (!_disposed)
-				{
-					var toFree = Interlocked.Exchange(ref _ptr, IntPtr.Zero);
-					Marshal.FreeHGlobal(toFree);
-					_disposed = true;
-				}
-			}
-
-			~MarshalledData()
-			{
-				Dispose(disposing: false);
-			}
-
-			public void Dispose()
-			{
-				Dispose(disposing: true);
-				GC.SuppressFinalize(this);
-			}
-		}
-
-		[DataContract]
-		private class MarshalledDataWithMime: MarshalledData
-		{
-			[DataMember(Name = "mime")]
-			private string _mime;
-
-			public MarshalledDataWithMime(byte[] arr, string mime)
-				: base(arr)
-			{
-				_mime = mime;
-			}
-
-			public MarshalledDataWithMime(string str, string mime)
-				: base(str)
-			{
-				_mime = mime;
-			}
-		}
 
 		public static void Clear() => SetClipboardText(string.Empty);
 
@@ -249,15 +161,7 @@ namespace Windows.ApplicationModel.DataTransfer
 		private static async Task<MarshalledData> GetClipboardData(string mime, CancellationToken ct)
 		{
 			var escapedMime = WebAssemblyRuntime.EscapeJs(mime);
-			var command = $@"
-				(async () => {{
-					var result = await {JsType}.getData(""{escapedMime}"");
-					if (!result) return null;
-					return JSON.stringify(result);
-				}})()
-				";
-
-			var json = await WebAssemblyRuntime.InvokeAsync(command, ct);
+			var json = await WebAssemblyRuntime.InvokeAsync($"{JsType}.getDataAsJson(\"{escapedMime}\")", ct);
 
 			if (json == null)
 			{

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
@@ -1,12 +1,17 @@
 ﻿#nullable disable // Not supported by WinUI yet
 
 using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Windows.UI.Core;
-using Uno.Extensions.Specialized;
-using Uno.Foundation;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
+using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
+using Uno.Disposables;
+using Uno.Foundation;
+using Uno.Helpers.Serialization;
+using Windows.Storage.Streams;
 
 namespace Windows.ApplicationModel.DataTransfer
 {
@@ -14,7 +19,140 @@ namespace Windows.ApplicationModel.DataTransfer
 	{
 		private const string JsType = "Uno.Utils.Clipboard";
 
+		[DataContract]
+		private class MarshalledData: IDisposable
+		{
+			private bool _disposed;
+			private IntPtr _ptr;
+
+			[DataMember(Name = "ptr")]
+			private long _longPtr
+			{
+				get => (long)_ptr;
+				set => _ptr = (IntPtr)value;
+			}
+
+			[DataMember(Name = "len")]
+			private int _len;
+
+			public MarshalledData()
+			{
+			}
+
+			public MarshalledData(byte[] arr)
+			{
+				_ptr = Marshal.AllocHGlobal(arr.Length);
+				_len = arr.Length;
+				Marshal.Copy(arr, 0, _ptr, _len);
+			}
+
+			public MarshalledData(string str)
+				: this(Encoding.UTF8.GetBytes(str))
+			{
+			}
+
+			public unsafe override string ToString()
+			{
+				return Encoding.UTF8.GetString((byte*)_ptr, _len);
+			}
+
+			public byte[] ToArray()
+			{
+				var arr = new byte[_len];
+				Marshal.Copy(_ptr, arr, 0, _len);
+				return arr;
+			}
+
+			protected virtual void Dispose(bool disposing)
+			{
+				if (!_disposed)
+				{
+					var toFree = Interlocked.Exchange(ref _ptr, IntPtr.Zero);
+					Marshal.FreeHGlobal(toFree);
+					_disposed = true;
+				}
+			}
+
+			~MarshalledData()
+			{
+				Dispose(disposing: false);
+			}
+
+			public void Dispose()
+			{
+				Dispose(disposing: true);
+				GC.SuppressFinalize(this);
+			}
+		}
+
+		[DataContract]
+		private class MarshalledDataWithMime: MarshalledData
+		{
+			[DataMember(Name = "mime")]
+			private string _mime;
+
+			public MarshalledDataWithMime(byte[] arr, string mime)
+				: base(arr)
+			{
+				_mime = mime;
+			}
+
+			public MarshalledDataWithMime(string str, string mime)
+				: base(str)
+			{
+				_mime = mime;
+			}
+		}
+
 		public static void Clear() => SetClipboardText(string.Empty);
+
+		public static DataPackageView GetContent()
+		{
+			var dataPackage = new DataPackage();
+
+			// Implementation notes:
+			//
+			// In Javascript, the only clipboard API available is `read`, which is asynchronous.
+			// There is no other way for the application to enumerate available data types.
+			//
+			// We therefore set a data provider for every supported type and then run
+			// `InitializeFromNativeClipboardAsync` as soon as possible. This functions
+			// asynchronously reads the browser's clipboard and check which data types are available
+			// and removes the data providers for unavailable types.
+			//
+			// Before the `DataPackage` is completely initialized, C# code might wrongly think
+			// that the `DataPackage` actually contains data (text, rich text, bitmaps,...) while in
+			// reality there isn't. In such case, reading clipboard data from the `DataPackageView` will
+			// return empty values (string.Empty, or an empty stream for bitmaps).
+			//
+			// As calls to `InitializeFromNativeClipboardAsync` are included in each data provider,
+			// to avoid false positives, the C# code can simply call any asynchrnous `DataPackageView` function
+			// to ensure initialization of the WASM `DataPackage`:
+			//
+			// var dataPackageView = Clipboard.GetContent();
+			// _ = await dataPackageView.GetTextAsync();
+			// if (dataPackageView.Contains("The desired data format"))
+			// { // Do work here.
+
+			dataPackage.SetDataProvider(StandardDataFormats.Text, async (ct) =>
+				{ await dataPackage.InitializeFromNativeClipboardAsync(ct); return await GetClipboardText(ct); });
+
+			dataPackage.SetDataProvider(StandardDataFormats.Rtf, async (ct) =>
+				{ await dataPackage.InitializeFromNativeClipboardAsync(ct); return await GetClipboardRichText("text/rtf", ct); });
+
+			dataPackage.SetDataProvider(StandardDataFormats.Html, async (ct) =>
+				{ await dataPackage.InitializeFromNativeClipboardAsync(ct); return await GetClipboardRichText("text/html", ct); });
+
+			// Currently, on most browsers the only supported bitmap type on Clipboard is "image/png".
+			dataPackage.SetDataProvider(StandardDataFormats.Bitmap, async (ct) =>
+				{ await dataPackage.InitializeFromNativeClipboardAsync(ct); return await GetClipboardBitmap("image/png", ct); });
+
+			_ = Uno.UI.Dispatching.CoreDispatcher.Main.RunAsync(
+				Uno.UI.Dispatching.CoreDispatcherPriority.High,
+				() => dataPackage.InitializeFromNativeClipboardAsync());
+
+			return dataPackage.GetView();
+		}
 
 		public static void SetContent(DataPackage/* ? */ content)
 		{
@@ -26,20 +164,48 @@ namespace Windows.ApplicationModel.DataTransfer
 		internal static async Task SetContentAsync(DataPackage/* ? */ content)
 		{
 			var data = content?.GetView(); // Freezes the DataPackage
-			if (data?.Contains(StandardDataFormats.Text) ?? false)
+			using (var marshalledDataList = new CompositeDisposable())
 			{
-				var text = await data.GetTextAsync();
-				SetClipboardText(text);
+				if (data?.Contains(StandardDataFormats.Text) ?? false)
+				{
+					var text = await data.GetTextAsync();
+					// Special case for text: `SetClipboardText` calls `writeText` which
+					// is more widely supported. Furthermore, it has a workaround using the
+					// `copy` event for non-HTTPS pages.
+					// If the code below succeeds, the data would be overwritten anyway.
+					SetClipboardText(text);
+
+					marshalledDataList.Add(new MarshalledDataWithMime(text, "text/plain"));
+				}
+				// Most browsers don't support MIME types other than plain, html and png.
+				// if (data?.Contains(StandardDataFormats.Rtf) ?? false)
+				// {
+				//	var text = await data.GetRtfAsync();
+				//	marshalledDataList.Add(new MarshalledDataWithMime(text, "text/rtf"));
+				// }
+				if (data?.Contains(StandardDataFormats.Html) ?? false)
+				{
+					var text = await data.GetHtmlFormatAsync();
+					marshalledDataList.Add(new MarshalledDataWithMime(text, "text/html"));
+				}
+				if (data?.Contains(StandardDataFormats.Bitmap) ?? false)
+				{
+					var streamReference = await data.GetBitmapAsync();
+					var randomAccessStream = await streamReference.OpenReadAsync();
+					var sourceStream = randomAccessStream.AsStreamForRead();
+					var memoryStream = new MemoryStream();
+
+					await sourceStream.CopyToAsync(memoryStream);
+
+					marshalledDataList.Add(new MarshalledDataWithMime(memoryStream.ToArray(), "image/png"));
+				}
+				// This JSON serializer does not recognize MarshalledDataWithMime in the IDisposable collection.
+				// We therefore have to explicitly cast it to a list.
+				// This should not be expensive as the list is really small.
+				var json = JsonHelper.Serialize(marshalledDataList.Cast<MarshalledDataWithMime>().ToList());
+				var command = $"{JsType}.setData({json});";
+				await WebAssemblyRuntime.InvokeAsync(command);
 			}
-		}
-
-		public static DataPackageView GetContent()
-		{
-			var dataPackage = new DataPackage();
-
-			dataPackage.SetDataProvider(StandardDataFormats.Text, async ct => await GetClipboardText(ct));
-			
-			return dataPackage.GetView();
 		}
 
 		private static async Task<string> GetClipboardText(CancellationToken ct)
@@ -55,6 +221,50 @@ namespace Windows.ApplicationModel.DataTransfer
 			var escapedText = WebAssemblyRuntime.EscapeJs(text);
 			var command = $"{JsType}.setText(\"{escapedText}\");";
 			WebAssemblyRuntime.InvokeJS(command);
+		}
+
+		private static async Task<string> GetClipboardRichText(string mime, CancellationToken ct)
+		{
+			using (var data = await GetClipboardData(mime, ct))
+			{
+				return data?.ToString() ?? string.Empty;
+			}
+		}
+
+		private static Task<RandomAccessStreamReference> GetClipboardBitmap(string mime, CancellationToken ct)
+		{
+			return Task.FromResult(new RandomAccessStreamReference(async (ct) =>
+			{
+				MemoryStream memoryStream;
+
+				using (var data = await GetClipboardData(mime, ct))
+				{
+					memoryStream = new MemoryStream(data?.ToArray() ?? Array.Empty<byte>());
+				}
+
+				return new RandomAccessStreamOverStream(memoryStream).TrySetContentType();
+			}));
+		}
+
+		private static async Task<MarshalledData> GetClipboardData(string mime, CancellationToken ct)
+		{
+			var escapedMime = WebAssemblyRuntime.EscapeJs(mime);
+			var command = $@"
+				(async () => {{
+					var result = await {JsType}.getData(""{escapedMime}"");
+					if (!result) return null;
+					return JSON.stringify(result);
+				}})()
+				";
+
+			var json = await WebAssemblyRuntime.InvokeAsync(command, ct);
+
+			if (json == null)
+			{
+				return null;
+			}
+
+			return JsonHelper.Deserialize<MarshalledData>(json);
 		}
 
 		private static void StartContentChanged()

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.wasm.cs
@@ -1,0 +1,84 @@
+﻿#if __WASM__
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Foundation;
+using Uno.Helpers.Serialization;
+
+namespace Windows.ApplicationModel.DataTransfer
+{
+	public partial class DataPackage
+	{
+		private const string ClipboardJsType = "Uno.Utils.Clipboard";
+		private Task? _initializeFromClipboardTask;
+		private object _initializeFromClipboardTaskLock = new object();
+
+		internal Task InitializeFromNativeClipboardAsync(CancellationToken? cancellationToken = null)
+		{
+			lock (_initializeFromClipboardTaskLock)
+			{
+				_initializeFromClipboardTask = _initializeFromClipboardTask ?? InitializeFromNativeClipboardCoreAsync();
+				return _initializeFromClipboardTask;
+			}
+
+			async Task InitializeFromNativeClipboardCoreAsync()
+			{
+				var mimesJson = await WebAssemblyRuntime.InvokeAsync(
+					$"(async () => JSON.stringify(await {ClipboardJsType}.getDataMimes()))()",
+					cancellationToken ?? CancellationToken.None);
+
+				var hasPlain = false;
+				var hasHtml = false;
+				var hasRtf = false;
+				var hasPng = false;
+
+				if (mimesJson != null)
+				{
+					var mimes = JsonHelper.Deserialize<string[]>(mimesJson);
+					foreach (var mime in mimes)
+					{
+						switch (mime)
+						{
+							case "text/plain":
+								hasPlain = true;
+								break;
+							case "text/html":
+								hasHtml = true;
+								break;
+							case "text/rtf":
+								hasRtf = true;
+								break;
+							case "image/png":
+								hasPng = true;
+								break;
+						}
+					}
+				}
+
+				if (!hasPlain)
+				{
+					ImmutableInterlocked.TryRemove(ref _data, StandardDataFormats.Text, out _);
+				}
+				if (!hasHtml)
+				{
+					ImmutableInterlocked.TryRemove(ref _data, StandardDataFormats.Html, out _);
+				}
+				if (!hasRtf)
+				{
+					ImmutableInterlocked.TryRemove(ref _data, StandardDataFormats.Rtf, out _);
+				}
+				if (!hasPng)
+				{
+					ImmutableInterlocked.TryRemove(ref _data, StandardDataFormats.Bitmap, out _);
+				}
+			}
+		}
+	}
+}
+
+#endif


### PR DESCRIPTION
Added support for content other than plain text on WASM, using the JavaScript raw `Clipboard.read()` and `Clipboard.write()` APIs.

The clipboard can now read/write HTML text and PNG images, but is subject to a few restrictions of the underlying APIs.

GitHub Issue (If applicable): closes #10032

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

WASM `Clipboard` API can only read plain text content.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

WASM `Clipboard` API can now read HTML and PNG content.
Other content (RTF rich text, other image formats,...) cannot be read because [major browsers don't seem to support content other than plain, html and png](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/clipboard/clipboard_writer.cc;drc=e882b8e4a8272f65cb14c608d3d2bc4f0512aa20;l=304).

A screenshot of the Uno Gallery sample app at https://github.com/unoplatform/Uno.Gallery/pull/467 combined with code from this pull request:

![image](https://user-images.githubusercontent.com/57174311/193467676-7371ccc2-0346-4739-b01b-a299e1bd9a4f.png)

<!-- Please describe the new behavior after your modifications. -->

Unlike on UWP and Skia.WPF/GTK, the content types of the clipboard is not known after `Clipboard.GetContent` is called, but rather resolved asynchronously. Therefore, there can be false positives, such as `dataPackageView.Contains(StandardDataFormats.Text)` returning `true` despite the Clipboard containing only a single image. In such cases, an empty string, or stream in case of a bitmap, is returned.

To resolve this problem, call any of the `Get...` methods of the `DataPackageView` _before_ checking for `Contains`:

```csharp
	private async void PasteText_Click(object sender, RoutedEventArgs args)
	{
		var package = Clipboard.GetContent();
                _ = await package.GetTextAsync();
                // Now things should be valid.
		if (package.Contains(StandardDataFormats.Bitmap))
		{
			var streamRef = await package.GetBitmapAsync();
		}
	}
```

This should _not_ be a breaking change, as `package.Contains(StandardDataFormats.Text)` in the official Uno packages currently always returns `true` regardless of whether text is available on the clipboard or not.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
