### PR TITLE
feat(WASM): Support setting the screen orientation

### DIFF
--- a/src/Uno.UI/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI/WasmScripts/Uno.UI.d.ts
@@ -864,19 +864,30 @@ declare namespace Windows.Gaming.Input {
     }
 }
 declare namespace Windows.Graphics.Display {
-    class DisplayInformation {
+    enum DisplayOrientations {
+        None = 0,
+        Landscape = 1,
+        Portrait = 2,
+        LandscapeFlipped = 4,
+        PortraitFlipped = 8
+    }
+    export class DisplayInformation {
         private static readonly DpiCheckInterval;
         private static lastDpi;
         private static dpiWatcher;
         private static dispatchOrientationChanged;
         private static dispatchDpiChanged;
+        private static lockingSupported;
         static startOrientationChanged(): void;
         static stopOrientationChanged(): void;
         static startDpiChanged(): void;
         static stopDpiChanged(): void;
+        static setOrientationAsync(uwpOrientations: DisplayOrientations): Promise<void>;
+        private static parseUwpOrientation;
         private static updateDpi;
         private static onOrientationChange;
     }
+    export {};
 }
 interface Window {
     SpeechRecognition: any;

--- a/src/Uno.UI/ts/Windows/Graphics/Display/DisplayInformation.ts
+++ b/src/Uno.UI/ts/Windows/Graphics/Display/DisplayInformation.ts
@@ -1,4 +1,11 @@
 ﻿namespace Windows.Graphics.Display {
+	enum DisplayOrientations {
+		None = 0,
+		Landscape = 1,
+		Portrait = 2,
+		LandscapeFlipped = 4,
+		PortraitFlipped = 8
+	}
 
 	export class DisplayInformation {
 		private static readonly DpiCheckInterval = 1000;
@@ -8,6 +15,8 @@
 
 		private static dispatchOrientationChanged: (type: string) => number;
 		private static dispatchDpiChanged: (dpi: number) => number;
+
+		private static lockingSupported: boolean | null;
 
 		public static startOrientationChanged() {
 			window.screen.orientation.addEventListener("change", DisplayInformation.onOrientationChange);
@@ -25,7 +34,7 @@
 
 			// start polling the devicePixel
 			DisplayInformation.dpiWatcher = window.setInterval(
-				DisplayInformation.updateDpi, 
+				DisplayInformation.updateDpi,
 				DisplayInformation.DpiCheckInterval);
 		}
 
@@ -33,9 +42,85 @@
 			window.clearInterval(DisplayInformation.dpiWatcher);
 		}
 
+		public static async setOrientationAsync(uwpOrientations: DisplayOrientations): Promise<void> {
+			let oldOrientation = screen.orientation.type;
+			let orientations = DisplayInformation.parseUwpOrientation(uwpOrientations);
+
+			if (orientations.includes(oldOrientation)) {
+				return;
+			}
+
+			// Setting the orientation requires briefly changing the device to fullscreen.
+			// This causes a glitch, which is unnecessary for devices which does not support
+			// setting the orientation, such as most desktop browsers.
+			// We therefore attempt to check for support, and do nothing if the feature is
+			// unavailable.
+			if (this.lockingSupported == null) {
+				try {
+					await screen.orientation.lock(oldOrientation);
+					this.lockingSupported = true;
+				} catch (e) {
+					if (e instanceof DOMException && e.name === "NotSupportedError") {
+						this.lockingSupported = false;
+						console.log("This browser does not support setting the orientation.")
+					} else {
+						// On most mobile devices we should reach this line.
+						this.lockingSupported = true;
+					}
+				}
+			}
+
+			if (!this.lockingSupported) {
+				return;
+			}
+
+			let wasFullscreen = document.fullscreenElement != null;
+
+			if (!wasFullscreen) {
+				await document.body.requestFullscreen();
+			}
+
+			for (let orientation of orientations) {
+				try {
+					// On success, screen.orientation should fire the 'change' event.
+					await screen.orientation.lock(orientation);
+					break;
+				} catch (e) {
+					// Absorb all errors to ensure that the exitFullscreen block below is called.
+					console.log(`Failed to set the screen orientation to '${orientation}': ${e}`);
+				}
+			}
+
+			if (!wasFullscreen) {
+				await document.exitFullscreen();
+			}
+		}
+
+		private static parseUwpOrientation(uwpOrientations: DisplayOrientations): OrientationLockType[] {
+			let orientations: OrientationLockType[] = [];
+
+			if (uwpOrientations & DisplayOrientations.Landscape) {
+				orientations.push("landscape-primary");
+			}
+
+			if (uwpOrientations & DisplayOrientations.Portrait) {
+				orientations.push("portrait-primary");
+			}
+
+			if (uwpOrientations & DisplayOrientations.LandscapeFlipped) {
+				orientations.push("landscape-secondary");
+			}
+
+			if (uwpOrientations & DisplayOrientations.PortraitFlipped) {
+				orientations.push("portrait-secondary");
+			}
+
+			return orientations;
+		}
+
 		private static updateDpi() {
 			const currentDpi = window.devicePixelRatio;
-			if (Math.abs(DisplayInformation.lastDpi - currentDpi) > 0.001) {				
+			if (Math.abs(DisplayInformation.lastDpi - currentDpi) > 0.001) {
 				if (DisplayInformation.dispatchDpiChanged == null) {
 					DisplayInformation.dispatchDpiChanged =
 						(<any>Module).mono_bind_static_method(

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
@@ -1,8 +1,10 @@
 ﻿#if __WASM__
-using Uno;
-using Uno.Foundation;
 using System;
 using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno;
+using Uno.Foundation;
 
 namespace Windows.Graphics.Display
 {
@@ -134,6 +136,13 @@ namespace Windows.Graphics.Display
 			WebAssemblyRuntime.InvokeJS(command);
 		}
 
+		static partial void SetOrientationPartial(DisplayOrientations orientations)
+		{
+			Uno.UI.Dispatching.CoreDispatcher.Main.RunAsync(
+				Uno.UI.Dispatching.CoreDispatcherPriority.High,
+				(ct) => SetOrientationAsync(orientations, ct));
+		}
+
 		private static bool TryReadJsFloat(string property, out float value) =>
 			float.TryParse(WebAssemblyRuntime.InvokeJS(property), NumberStyles.Any, CultureInfo.InvariantCulture, out value);
 
@@ -151,6 +160,11 @@ namespace Windows.Graphics.Display
 				"landscape-secondary" => DisplayOrientations.LandscapeFlipped,
 				_ => DisplayOrientations.None,
 			};
+		}
+
+		private static Task SetOrientationAsync(DisplayOrientations orientations, CancellationToken ct)
+		{
+			return WebAssemblyRuntime.InvokeAsync($"{JsType}.setOrientationAsync({(int)orientations})", ct);
 		}
 	}
 }


### PR DESCRIPTION
Supports setting the screen orientation through the `DisplayInformation.AutoRotationPreferences` on supported browsers.

Internally the implementation calls the JavaScript `screen.orientation.lock` API.

GitHub Issue (If applicable): closes #3177

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Uno WASM applications ignore the `DisplayInformation.AutoRotationPreferences` property.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Uno WASM applications attempts to use the `screen.orientation.lock` JavaScript API to set the screen orientation on supported devices.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
