### PR TITLE
fix(dotnetnew): Ensure Wasm and Skia runtime libraries are using the same name

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Skia.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<RootNamespace>UnoCrossRuntimeLib</RootNamespace>
+    <AssemblyName>UnoCrossRuntimeLib</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.Wasm.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<RootNamespace>UnoCrossRuntimeLib</RootNamespace>
+    <AssemblyName>UnoCrossRuntimeLib</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>uap10.0.18362;netstandard2.0;xamarinios10;xamarinmac20;monoandroid12.0</TargetFrameworks>
+    <AssemblyName>UnoCrossRuntimeLib</AssemblyName>
   </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/discussions/10015

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Cross-runtime libraries are now using the right assembly name when packaged.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
