### PR TITLE
chore(test): Move BasicAutomated transformation tests to runtime

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Stretch.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_Stretch.cs
@@ -20,7 +20,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.ImageBrushTests
 		// src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrushStretch.cs
 		// This UI Test can be deleted once we can test Wasm in RuntimeTests.
 		// This is currently blocked due to lack of support for RenderTargetBitmap on Wasm.
-		[ActivePlatforms(Platform.Browser)] 
+		[ActivePlatforms(Platform.Browser)]
 		public void When_Stretch()
 		{
 			Run("UITests.Windows_UI_Xaml_Media.ImageBrushTests.ImageBrush_Stretch");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/Transform_Tests/Basics_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/Transform_Tests/Basics_Automated.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using SamplesApp.UITests._Utils;
 using SamplesApp.UITests.TestFramework;
 using Uno.UITest;
+using Uno.UITest.Helpers.Queries;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Transform_Tests
 {
@@ -18,6 +19,11 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Transform_Tests
 		private IAppRect _sut;
 		private ScreenshotInfo _result;
 
+		// For other platforms than Browser all the tests have been moved in RuntimeTests
+		// in src\Uno.UI.RuntimeTests\Tests\Windows_UI_Xaml_Media\Given_BasicAutomatedTransformation.cs
+		// These UI Test can be deleted once we can test Wasm in RuntimeTests.
+		// This is currently blocked due to lack of support for RenderTargetBitmap on Wasm.
+		[ActivePlatforms(Platform.Browser)]
 		[Test]
 		[AutoRetry]
 		public void When_Rotate()
@@ -54,6 +60,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Transform_Tests
 			Assert(80 + i, 99);
 		}
 
+		[ActivePlatforms(Platform.Browser)]
 		[Test]
 		[AutoRetry]
 		public void When_Translate()
@@ -76,6 +83,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Transform_Tests
 			Assert(99, 15 + i, colored);
 		}
 
+		[ActivePlatforms(Platform.Browser)]
 		[Test]
 		[AutoRetry]
 		public void When_Skew()
@@ -100,6 +108,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Transform_Tests
 			Assert(99, 99, colored);
 		}
 
+		[ActivePlatforms(Platform.Browser)]
 		[Test]
 		[AutoRetry]
 		public void When_Scale()
@@ -126,6 +135,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Transform_Tests
 			Assert(90 + i, 90 + i);
 		}
 
+		[ActivePlatforms(Platform.Browser)]
 		[Test]
 		[AutoRetry]
 		public void When_Composite()
@@ -157,6 +167,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.Transform_Tests
 			Assert(88 + i, 99);
 		}
 
+		[ActivePlatforms(Platform.Browser)]
 		[Test]
 		[AutoRetry]
 		public void When_Group()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_BasicAutomatedTransformation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_BasicAutomatedTransformation.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media.Imaging;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class Basics_AutomatedTransformation
+	{
+
+		//Web Assembly does not have a helper that take screenshots yet
+		//MacOs interprets colors differently
+#if !__WASM__ && !__MACOS__
+
+		private const string White = "#FFFFFF";
+		private const float PixelIncertitude = 2;
+
+		[TestMethod]
+		public async Task When_Rotate()
+		{
+			const string colored = "#FF0000";
+			var grid = new Basics_Automated_Transformation();
+			var SUT = grid.RotateHost;
+			var result = await Arrange(SUT);
+			
+			Assert(SUT, result, 50, 50, colored);
+
+			// Top left
+			Assert(SUT, result, 19 - PixelIncertitude, 0, White);
+			Assert(SUT, result, 21 + PixelIncertitude, 0, colored);
+			Assert(SUT, result, 0, 34 - PixelIncertitude, White);
+			Assert(SUT, result, 0, 38 + PixelIncertitude, colored);
+
+			// Bottom left
+			Assert(SUT, result, 0, 78 - PixelIncertitude, colored);
+			Assert(SUT, result, 0, 80 + PixelIncertitude, White);
+			Assert(SUT, result, 34 - PixelIncertitude, 99, White);
+			Assert(SUT, result, 38 + PixelIncertitude, 99, colored);
+
+			// Top right
+			Assert(SUT, result, 62 - PixelIncertitude, 0, colored);
+			Assert(SUT, result,65 + PixelIncertitude, 0, White);
+			Assert(SUT, result, 99, 19 - PixelIncertitude, White);
+			Assert(SUT, result, 99, 21 + PixelIncertitude, colored);
+
+			// Bottom right
+			Assert(SUT, result, 99, 62 - PixelIncertitude, colored);
+			Assert(SUT, result, 99, 65 + PixelIncertitude, White);
+			Assert(SUT, result, 78 - PixelIncertitude, 99, colored);
+			Assert(SUT, result, 80 + PixelIncertitude, 99, White);
+		}
+
+		[TestMethod]
+		public async Task When_Translate()
+		{
+			const string colored = "#FF8000";
+			
+			var grid = new Basics_Automated_Transformation();
+			var SUT = grid.TranslateHost;
+			var result = await Arrange(SUT);
+
+			// Top left
+			Assert(SUT, result, 14 - PixelIncertitude, 14 - PixelIncertitude, White);
+			Assert(SUT, result, 15 + PixelIncertitude, 14 + PixelIncertitude, colored);
+
+			// Bottom left
+			Assert(SUT, result,14 - PixelIncertitude, 99, White);
+			Assert(SUT, result, 15 + PixelIncertitude, 99, colored);
+
+			// Top right
+			Assert(SUT, result, 99, 14 - PixelIncertitude, White);
+			Assert(SUT, result, 99, 15 + PixelIncertitude, colored);
+		}
+
+		[TestMethod]
+		public async Task When_Skew()
+		{
+			const string colored = "#FFFF00";
+
+			var grid = new Basics_Automated_Transformation();
+			var SUT = grid.SkewHost;
+			var result = await Arrange(SUT);
+
+			// Top left
+			Assert(SUT, result, 0, 0, colored);
+
+			// Bottom left
+			Assert(SUT, result, 28 - PixelIncertitude, 72 + PixelIncertitude, White);
+			Assert(SUT, result, 30 + PixelIncertitude, 70 - PixelIncertitude, colored);
+
+			// Top right
+			Assert(SUT, result, 72 + PixelIncertitude, 28 - PixelIncertitude, White);
+			Assert(SUT, result, 70 - PixelIncertitude, 30 + PixelIncertitude, colored);
+
+			// Bottom right
+			Assert(SUT, result, 99, 99, colored);
+		}
+
+		[TestMethod]
+		public async Task When_Scale()
+		{
+			const string colored = "#008000";
+
+			var grid = new Basics_Automated_Transformation();
+			var SUT = grid.ScaleHost;
+			var result = await Arrange(SUT);
+
+			// Top left
+			Assert(SUT, result, 9 - PixelIncertitude, 9 - PixelIncertitude, White);
+			Assert(SUT, result, 10 + PixelIncertitude, 10 + PixelIncertitude, colored);
+
+			// Bottom left
+			Assert(SUT, result, 9 - PixelIncertitude, 90 + PixelIncertitude, White);
+			Assert(SUT, result, 10 + PixelIncertitude, 89 - PixelIncertitude, colored);
+
+			// Top right
+			Assert(SUT, result, 89 - PixelIncertitude, 10 + PixelIncertitude, colored);
+			Assert(SUT, result, 90 + PixelIncertitude, 9 - PixelIncertitude, White);
+
+			// Bottom right
+			Assert(SUT, result, 89 - PixelIncertitude, 89 - PixelIncertitude, colored);
+			Assert(SUT, result, 90 + PixelIncertitude, 90 + PixelIncertitude, White);
+		}
+
+		[TestMethod]
+		public async Task When_Composite()
+		{
+			const string colored = "#0000FF";
+			
+			var grid = new Basics_Automated_Transformation();
+			var SUT = grid.CompositeHost;
+			var result = await Arrange(SUT);
+
+			// Center
+			Assert(SUT, result, 50, 50, colored);
+
+			// Top left
+			Assert(SUT, result, 41 - PixelIncertitude, 0, White);
+			Assert(SUT, result, 42 + PixelIncertitude, 0, colored);
+
+			// Bottom left
+			Assert(SUT, result, 41 - PixelIncertitude, 70 - PixelIncertitude, White);
+			Assert(SUT, result, 42 + PixelIncertitude, 70 - PixelIncertitude, colored);
+			Assert(SUT, result, 42, 73 + PixelIncertitude, White);
+
+			// Top right
+			Assert(SUT, result, 87, 56 - PixelIncertitude, White);
+			Assert(SUT, result, 87 - PixelIncertitude, 59 + PixelIncertitude, colored);
+			Assert(SUT, result, 88 + PixelIncertitude, 59 + PixelIncertitude, White);
+
+			// Bottom right
+			Assert(SUT, result, 87 - PixelIncertitude, 99, colored);
+			Assert(SUT, result, 88 + PixelIncertitude, 99, White);
+		}
+
+		[Test]
+		public async Task When_Group()
+		{
+			const string colored = "#A000C0";
+			
+			var grid = new Basics_Automated_Transformation();
+			FrameworkElement SUT = grid.GroupHost;
+			var result = await Arrange(SUT);
+
+			// Center
+			Assert(SUT, result, 50, 50, colored);
+
+			// Top left
+			Assert(SUT, result, 41 - PixelIncertitude, 0, White);
+			Assert(SUT, result, 42 + PixelIncertitude, 0, colored);
+
+			// Bottom left
+			Assert(SUT, result, 41 - PixelIncertitude, 70 - PixelIncertitude, White);
+			Assert(SUT, result, 42 + PixelIncertitude, 70 - PixelIncertitude, colored);
+			Assert(SUT, result, 42, 73 + PixelIncertitude, White);
+
+			//Topp right
+			Assert(SUT, result, 87, 56 - PixelIncertitude, White);
+			Assert(SUT, result, 87 - PixelIncertitude, 59 + PixelIncertitude, colored);
+			Assert(SUT, result, 88 + PixelIncertitude, 59 + PixelIncertitude, White);
+
+			// Bottom right
+			Assert(SUT, result, 87 - PixelIncertitude, 99, colored);
+			Assert(SUT, result, 88 + PixelIncertitude, 99, White);
+		}
+
+		private async Task<RawBitmap> Arrange(FrameworkElement SUT)
+		{
+			WindowHelper.WindowContent = SUT;
+			WindowHelper.WaitForLoaded(SUT);
+			var renderer = new RenderTargetBitmap();
+			await WindowHelper.WaitForIdle();
+			await renderer.RenderAsync(SUT);
+			var result = await RawBitmap.From(renderer, SUT);
+			WindowHelper.WaitForIdle();
+			return result;
+		}
+
+		private void Assert(FrameworkElement SUT, RawBitmap result, float x, float y, string color)
+		{
+			float border = 3; 
+			float width = (float)SUT.ActualWidth;
+			float height = (float)SUT.ActualHeight;
+			float dpiScale =  width / (border + 100 + border);
+
+			x *= dpiScale;
+			y *= dpiScale;
+			border *= dpiScale;
+
+			x = x >= 0 ? x + border : width + x - (2 * border);
+			y = y >= 0 ? y + border : height + y - (2 * border);
+
+			ImageAssert.HasColorAt(result, x, y, color, tolerance: 25);
+		}
+#endif
+	}
+}
+

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Transform/Basics_Automated.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Transform/Basics_Automated.xaml
@@ -1,0 +1,224 @@
+﻿<Page
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.Basics_Automated_Transformation"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+<Grid Background="White">
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition />
+			<ColumnDefinition />
+		</Grid.ColumnDefinitions>
+
+		<Grid BorderThickness="5" BorderBrush="#FF0000" Grid.Row="0" Grid.Column="0">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition />
+			</Grid.RowDefinitions>
+
+			<Border Background="#FF0000" Padding="5,5,5,10" HorizontalAlignment="Stretch">
+				<TextBlock Text="Rotate" FontSize="24" Foreground="White" />
+			</Border>
+
+			<Border 
+				Grid.Row="1" 
+				BorderBrush="Black" 
+				Background="White"
+				BorderThickness="3" 
+				HorizontalAlignment="Center"
+				 VerticalAlignment="Center" 
+				 x:Name="RotateHost"
+				x:FieldModifier="Public">
+				<Rectangle Fill="#FF0000" Width="100" Height="100" RenderTransformOrigin="0,0">
+					<Rectangle.RenderTransform>
+						<RotateTransform
+							CenterX="50"
+							CenterY="50"
+							Angle="30" />
+					</Rectangle.RenderTransform>
+				</Rectangle>
+			</Border>
+		</Grid>
+
+		<Grid BorderThickness="5" BorderBrush="#FF8000" Grid.Row="0" Grid.Column="1">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition />
+			</Grid.RowDefinitions>
+
+			<Border Background="#FF8000" Padding="5,5,5,10" HorizontalAlignment="Stretch">
+				<TextBlock Text="Translate" FontSize="24" Foreground="White" />
+			</Border>
+
+			<Border 
+				Grid.RowSpan="3" 
+				Grid.Column="2" 
+				BorderBrush="Black"
+				Background="White" 
+				BorderThickness="3" 
+				HorizontalAlignment="Center" 
+				VerticalAlignment="Center" 
+				x:Name="TranslateHost"
+				x:FieldModifier="Public">
+				<Rectangle Fill="#FF8000" Width="100" Height="100" RenderTransformOrigin="0,0">
+					<Rectangle.RenderTransform>
+						<TranslateTransform
+							X="15"
+							Y="15" />
+					</Rectangle.RenderTransform>
+				</Rectangle>
+			</Border>
+		</Grid>
+
+		<Grid BorderThickness="5" BorderBrush="#FFFF00" Grid.Row="1" Grid.Column="0">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition />
+			</Grid.RowDefinitions>
+
+			<Border Background="#FFFF00" Padding="5,5,5,10" HorizontalAlignment="Stretch">
+				<TextBlock Text="Skew" FontSize="24" Foreground="White" />
+			</Border>
+			
+			<Border 
+				Grid.Row="1"
+			 	BorderBrush="Black"
+				Background="White"
+				BorderThickness="3"
+				HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				x:Name="SkewHost"
+				x:FieldModifier="Public">
+				<Rectangle Fill="#FFFF00" Width="100" Height="100" RenderTransformOrigin="0,0">
+					<Rectangle.RenderTransform>
+						<SkewTransform
+							CenterX="50"
+							CenterY="50"
+							AngleX="30"
+							AngleY="30" />
+					</Rectangle.RenderTransform>
+				</Rectangle>
+			</Border>
+		</Grid>
+
+		<Grid BorderThickness="5" BorderBrush="#008000" Grid.Row="1" Grid.Column="1">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition />
+			</Grid.RowDefinitions>
+
+			<Border Background="#008000" Padding="5,5,5,10" HorizontalAlignment="Stretch">
+				<TextBlock Text="Scale" FontSize="24" Foreground="White" />
+			</Border>
+
+			<Border
+				Grid.Row="1" 
+				BorderBrush="Black" 
+				Background="White"
+				BorderThickness="3" 
+				HorizontalAlignment="Center" 
+				VerticalAlignment="Center"
+				x:Name="ScaleHost"
+				x:FieldModifier="Public">
+				<Rectangle Fill="#008000" Width="100" Height="100" RenderTransformOrigin="0,0">
+					<Rectangle.RenderTransform>
+						<ScaleTransform
+							CenterX="50"
+							CenterY="50"
+							ScaleX=".8"
+							ScaleY=".8" />
+					</Rectangle.RenderTransform>
+				</Rectangle>
+			</Border>
+		</Grid>
+
+		<Grid BorderThickness="5" BorderBrush="#0000FF" Grid.Row="2" Grid.Column="0">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition />
+			</Grid.RowDefinitions>
+
+			<Border Background="#0000FF" Padding="5,5,5,10" HorizontalAlignment="Stretch">
+				<TextBlock Text="Composite" FontSize="24" Foreground="White" />
+			</Border>
+
+			<Border 
+				Grid.Row="1"
+				BorderBrush="Black" 
+				Background="White"
+				BorderThickness="3" 
+				HorizontalAlignment="Center" 
+				VerticalAlignment="Center" 
+				x:Name="CompositeHost"
+				x:FieldModifier="Public">
+				<Rectangle Fill="#0000FF" Width="100" Height="100" RenderTransformOrigin="0,0">
+					<Rectangle.RenderTransform>
+						<CompositeTransform
+							CenterX="50"
+							CenterY="50"
+							ScaleX=".8"
+							ScaleY=".8"
+							SkewX="30"
+							SkewY="30"
+							TranslateX="15"
+							TranslateY="15"
+							Rotation="30" />
+					</Rectangle.RenderTransform>
+				</Rectangle>
+			</Border>
+		</Grid>
+
+		<Grid BorderThickness="5" BorderBrush="#A000C0" Grid.Row="2" Grid.Column="1">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition />
+			</Grid.RowDefinitions>
+
+			<Border Background="#A000C0" Padding="5,5,5,10" HorizontalAlignment="Stretch">
+				<TextBlock Text="Group" FontSize="24" Foreground="White" />
+			</Border>
+
+			<Border 
+				Grid.Row="1" 
+				BorderBrush="Black" 
+				Background="White"
+				BorderThickness="3" 
+				HorizontalAlignment="Center" 
+				VerticalAlignment="Center" 
+				x:Name="GroupHost"
+				x:FieldModifier="Public">
+				<Rectangle Fill="#A000C0" Width="100" Height="100" RenderTransformOrigin=".5,.5">
+					<Rectangle.RenderTransform>
+						<TransformGroup>
+							<ScaleTransform
+									CenterX="0"
+									CenterY="0"
+									ScaleX=".8"
+									ScaleY=".8"/>
+							<SkewTransform
+									CenterX="0"
+									CenterY="0"
+									AngleX="30"
+									AngleY="30"/>
+							<RotateTransform
+									CenterX="0"
+									CenterY="0"
+									Angle="30" />
+							<TranslateTransform
+									X="15"
+									Y="15" />
+						</TransformGroup>
+
+					</Rectangle.RenderTransform>
+				</Rectangle>
+			</Border>
+		</Grid>
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Transform/Basics_Automated.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Transform/Basics_Automated.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples;
+using Uno.UITest;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	public sealed partial class Basics_Automated_Transformation : Page
+	{
+		public Basics_Automated_Transformation()
+		{
+			this.InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #9811

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)
- Project automation

## What is the current behavior?
The Basic automated transformation tests are in the Sample App test for all platforms.

## What is the new behavior?
This test will be on runtime tests for most platform except for Wasm  that does not have the equivalent of `Take Screenshot` and probably MacOs that does not interpret colors the same way.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->