### PR TITLE
ci: Adjust t4 installation and WinUI pre-conversion

### DIFF
--- a/build/ci/.azure-devops-winui-convert.yml
+++ b/build/ci/.azure-devops-winui-convert.yml
@@ -51,6 +51,15 @@ jobs:
       logProjectEvents: false
       createLogFile: false
 
+  - powershell: |
+        git config --global user.email "ci@ci.com"
+        git config --global user.name "ci"
+        git add .
+        git commit -m "temporary commit for cleanup"
+        # Remove all non-source files to avoid cross-OS oddities.
+        git clean -fdx
+    displayName: Cleanup sources before publish
+
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: $(build.sourcesdirectory)

--- a/src/Uno.UI/MixinGeneration.targets
+++ b/src/Uno.UI/MixinGeneration.targets
@@ -95,18 +95,28 @@
 	<MixinOutput Include="$(MSBuildThisFileDirectory)Mixins\macOS\FrameworkElementMixins.g.cs" Condition="$(IsXamarinMac)" />	
   </ItemGroup>
 
-  <PropertyGroup>
-	<_UnoDotnetT4ToolBasePath>$(MSBuildThisFileDirectory)..\obj\dotnet-tools</_UnoDotnetT4ToolBasePath>
-  </PropertyGroup>
+	<Target Name="UnoDefineInstallDotnetT4"
+			  BeforeTargets="BeforeBuild;_InnerGenerateMixins">
+		<!--
+		Needs to be defined for _InnerGenerateMixins to work, but also
+		executed late for IntermediateOutputPath to be defined
+		-->
+		<PropertyGroup>
+			<_UnoDotnetT4ToolBasePath>$(MSBuildProjectDirectory)/$(IntermediateOutputPath)dotnet-tools</_UnoDotnetT4ToolBasePath>
+		</PropertyGroup>
+	</Target>
 
-  <Target Name="UnoInstallDotnetT4"
-		  BeforeTargets="BeforeBuild"
-		  Condition="!exists('$(_UnoDotnetT4ToolBasePath)')">
-	<Exec Command="dotnet tool install dotnet-t4 --version 2.3.0-preview-0041-g0bb7f1d477 --tool-path $(_UnoDotnetT4ToolBasePath)" 
-	    WorkingDirectory="$(MSBuildThisFileDirectory)..\" />
-  </Target>
+	<Target Name="UnoInstallDotnetT4"
+			BeforeTargets="BeforeBuild"
+			DependsOnTargets="UnoDefineInstallDotnetT4">
 
-  <!--
+		<Exec Command="dotnet tool install dotnet-t4 --version 2.3.0-preview-0041-g0bb7f1d477 --tool-path $(_UnoDotnetT4ToolBasePath)"
+			  StandardOutputImportance="Low"
+			  WorkingDirectory="$(MSBuildProjectDirectory)/$(IntermediateOutputPath)"
+			  Condition="!exists($(_UnoDotnetT4ToolBasePath))" />
+	</Target>
+
+	<!--
 	DispatchToInnerBuilds is used for direct builds, CoreCompile/_UnoSourceGenerator is for 
 	project dependency induced builds.
 	-->
@@ -114,6 +124,7 @@
         Inputs="@(MixinInput)" 
 		Outputs="@(MixinOutput)" 
 		BeforeTargets="DispatchToInnerBuilds;Build;_UnoSourceGenerator"
+		DependsOnTargets="UnoInstallDotnetT4"
 		Condition="'$(DesignTimeBuild)' != 'true'">
 
 	<ItemGroup>

--- a/src/Uno.UI/MixinGeneration.targets
+++ b/src/Uno.UI/MixinGeneration.targets
@@ -110,6 +110,9 @@
 			BeforeTargets="BeforeBuild"
 			DependsOnTargets="UnoDefineInstallDotnetT4">
 
+		<!-- Avoid dotnet tool to find multiple target projects-->
+		<MakeDir Directories="$(MSBuildProjectDirectory)/$(IntermediateOutputPath)"/>
+
 		<Exec Command="dotnet tool install dotnet-t4 --version 2.3.0-preview-0041-g0bb7f1d477 --tool-path $(_UnoDotnetT4ToolBasePath)"
 			  StandardOutputImportance="Low"
 			  WorkingDirectory="$(MSBuildProjectDirectory)/$(IntermediateOutputPath)"

--- a/src/Uno.UI/MixinGeneration.targets
+++ b/src/Uno.UI/MixinGeneration.targets
@@ -99,7 +99,9 @@
 	<_UnoDotnetT4ToolBasePath>$(MSBuildThisFileDirectory)..\obj\dotnet-tools</_UnoDotnetT4ToolBasePath>
   </PropertyGroup>
 
-  <Target Name="UnoInstallDotnetT4" Condition="!exists('$(_UnoDotnetT4ToolBasePath)')">
+  <Target Name="UnoInstallDotnetT4"
+		  BeforeTargets="BeforeBuild"
+		  Condition="!exists('$(_UnoDotnetT4ToolBasePath)')">
 	<Exec Command="dotnet tool install dotnet-t4 --version 2.3.0-preview-0041-g0bb7f1d477 --tool-path $(_UnoDotnetT4ToolBasePath)" 
 	    WorkingDirectory="$(MSBuildThisFileDirectory)..\" />
   </Target>
@@ -112,7 +114,6 @@
         Inputs="@(MixinInput)" 
 		Outputs="@(MixinOutput)" 
 		BeforeTargets="DispatchToInnerBuilds;Build;_UnoSourceGenerator"
-		DependsOnTargets="UnoInstallDotnetT4"
 		Condition="'$(DesignTimeBuild)' != 'true'">
 
 	<ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- CI

## What is the new behavior?

- Ensures no obj folders are kept in the winui converted artifacts, which avoids cross-OS dotnet-t4 installation issues
- Ensures the dotnet-t4 is installed before the parallelization of cross-targeted build

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
