### PR TITLE
fix: Ensure ShowAsync returns if popup is forcibly closed

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -70,6 +70,15 @@ namespace Windows.UI.Xaml.Controls
 					that.UpdateVisualState();
 				}
 			};
+
+			_popup.Closed += (s, e) =>
+			{
+				if (thisRef.Target is ContentDialog that)
+				{
+					that.Hide();
+				}
+			};
+
 			this.KeyDown += OnPopupKeyDown;
 			var inputPane = InputPane.GetForCurrentView();
 			inputPane.Showing += (o, e) =>


### PR DESCRIPTION
closes #10038


## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

The ContentDialog's popup may be forcibly closed by things such as the app moving to the background, when this happens, the ShowAsync method never returns