### PR TITLE
fix(ContentDialog): Handle back button being pressed

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -270,10 +270,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
+#if HAS_UNO
 		[DataTestMethod]
 		[DataRow(true)]
 		[DataRow(false)]
-		public async Task When_BackButton_Pressed_With_CloseButton(bool isCloseButtonEnabled)
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task When_BackButton_Pressed(bool isCloseButtonEnabled)
 		{
 			var closeButtonClickEvent = new Event();
 			var closedEvent = new Event();
@@ -323,6 +327,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				SUT.Hide();
 			}
 		}
+#endif
 
 #if __ANDROID__
 		// Fails because keyboard does not appear when TextBox is programmatically focussed, or appearance is not correctly registered - https://github.com/unoplatform/uno/issues/7995

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -6,11 +6,14 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
 using Windows.UI;
+using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Tests.Enterprise;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -264,6 +267,60 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				{
 					SUT.Hide();
 				}
+			}
+		}
+
+		[DataTestMethod]
+		[DataRow(true)]
+		[DataRow(false)]
+		public async Task When_BackButton_Pressed_With_CloseButton(bool isCloseButtonEnabled)
+		{
+			var closeButtonClickEvent = new Event();
+			var closedEvent = new Event();
+			var openedEvent = new Event();
+			var closeButtonClickRegistration = new SafeEventRegistration<ContentDialog, TypedEventHandler<ContentDialog, ContentDialogButtonClickEventArgs>>("CloseButtonClick");
+			var closedRegistration = new SafeEventRegistration<ContentDialog, TypedEventHandler<ContentDialog, ContentDialogClosedEventArgs>>("Closed");
+			var openedRegistration = new SafeEventRegistration<ContentDialog, TypedEventHandler<ContentDialog, ContentDialogOpenedEventArgs>>("Opened");
+
+			var SUT = new MyContentDialog
+			{
+				Title = "Dialog title",
+				Content = "Dialog content",
+				CloseButtonText = "Close",
+			};
+
+			if (!isCloseButtonEnabled)
+			{
+				var disabledStyle = new Style(typeof(Button));
+				disabledStyle.Setters.Add(new Setter(FrameworkElement.IsEnabledProperty, false));
+
+				SUT.CloseButtonStyle = disabledStyle;
+			}
+
+
+			closeButtonClickRegistration.Attach(SUT, (s, e) => closeButtonClickEvent.Set());
+			closedRegistration.Attach(SUT, (s, e) => closedEvent.Set());
+			openedRegistration.Attach(SUT, (s, e) => openedEvent.Set());
+
+			try
+			{
+				await ShowDialog(SUT);
+
+				await openedEvent.WaitForDefault();
+				VERIFY_IS_TRUE(SUT._popup.IsOpen);
+
+				SystemNavigationManager.GetForCurrentView().RequestBack();
+
+				await closeButtonClickEvent.WaitForDefault();
+				await closedEvent.WaitForDefault();
+
+				Assert.AreEqual(isCloseButtonEnabled, closeButtonClickEvent.HasFired());
+				VERIFY_IS_TRUE(closedEvent.HasFired());
+				VERIFY_IS_FALSE(SUT._popup.IsOpen);
+			}
+			finally
+			{
+				SUT.Hide();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -14,6 +14,7 @@ using Windows.System;
 using Uno.UI.DataBinding;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.ViewManagement;
+using Windows.UI.Core;
 
 #if HAS_UNO_WINUI
 using WindowSizeChangedEventArgs = Microsoft.UI.Xaml.WindowSizeChangedEventArgs;
@@ -345,7 +346,36 @@ namespace Windows.UI.Xaml.Controls
 				window.SizeChanged -= WindowSizeChanged;
 			});
 
+			// Here we are relying on the BackRequested event to be able to close the ContentDialog on back button pressed.
+			// This diverges from Windows behaviour as they do not allow BackRequested to be raised if the back button was pressed
+			// while a ContentDialog was open.
+			if (SystemNavigationManager.GetForCurrentView() is { } navManager)
+			{
+				navManager.BackRequested += OnBackRequested;
+
+				d.Add(() =>
+				{
+					navManager.BackRequested -= OnBackRequested;
+				});
+			}
+
 			_subscriptions.Disposable = d;
+		}
+		private void OnBackRequested(object sender, BackRequestedEventArgs e)
+		{
+			// Match Windows behavior:
+			// If we have a clickable close button, then invoke it, otherwise just
+			// return a result of None.
+			if (m_tpCloseButtonPart is { IsEnabled: true } closeButton)
+			{
+				closeButton.RaiseClick();
+			}
+			else
+			{
+				Hide();
+			}
+
+			e.Handled = true;
 		}
 
 		private void OnCloseButtonClicked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/768

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

A back navigation or app closure will occur when tapping the back button while a contentdialog is being displayed

## What is the new behavior?

while dialog is open, back should just close the dialog and do nothing else
