### PR TITLE
Add Mac Catalyst to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -74,11 +74,12 @@ body:
     attributes:
       label: Affected platforms
       multiple: true
-      options:
-        - iOS
-        - Android
+      options:        
         - WebAssembly
-        - macOS
+        - Android
+        - iOS
+        - macOS (AppKit)
+        - Mac Catalyst
         - Skia (WPF)
         - Skia (GTK on Linux/macOS/Windows)
         - Skia (Linux Framebuffer)

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -21,13 +21,15 @@ labels: kind/consumer-experience, kind/documentation, triage/untriaged, difficul
 
 ## For which Platform:
 
-- [ ] iOS
-- [ ] Android
 - [ ] WebAssembly
-- [ ] macOS
+- [ ] Android
+- [ ] iOS
+- [ ] macOS (AppKit)
+- [ ] Mac Catalyst
 - [ ] Skia
   - [ ] WPF
   - [ ] GTK (Linux)
+  - [ ] Linux Framebuffer
   - [ ] Tizen
 - [ ] Windows
 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -12,10 +12,11 @@ labels: kind/enhancement, triage/untriaged, difficulty/tbd
 
 ## For which Platform:
 
-- [ ] iOS
-- [ ] Android
 - [ ] WebAssembly
-- [ ] macOS
+- [ ] Android
+- [ ] iOS
+- [ ] macOS (AppKit)
+- [ ] Mac Catalyst
 - [ ] Skia
   - [ ] WPF
   - [ ] GTK (Linux)

--- a/.github/ISSUE_TEMPLATE/samples-request.md
+++ b/.github/ISSUE_TEMPLATE/samples-request.md
@@ -12,10 +12,11 @@ labels: kind/contributor-experience, kind/documentation, triage/untriaged, diffi
 
 ## For which Platform:
 
-- [ ] iOS
-- [ ] Android
 - [ ] WebAssembly
-- [ ] macOS
+- [ ] Android
+- [ ] iOS
+- [ ] macOS (AppKit)
+- [ ] Mac Catalyst
 - [ ] Skia
   - [ ] WPF
   - [ ] GTK (Linux)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)
- Build or CI related changes

## What is the current behavior?

- Mac Catalyst was missing in issue templates

## What is the new behavior?

- Mac Catalyst is included
- Reordered targets slightly to put Apple in one spot
- Added Linux Framebuffer to documentation request template

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
