### PR TITLE
fix(xaml): binding option value type being ignored

### DIFF
--- a/src/SourceGenerators/XamlGenerationTests/LiteralEnumValue.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/LiteralEnumValue.xaml
@@ -1,0 +1,47 @@
+﻿<UserControl x:Class="XamlGenerationTests.Shared.LiteralEnumValue"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:XamlGenerationTests">
+
+	<!--
+		Type of binding option is never inferred from the target dependency-property.
+		In binding-expression markup, literal value (even numerical) are parsed as string:
+			{Binding ConverterParameter=123}, {Binding ConverterParameter='123'}
+				^ both would result in Binding.ConverterParameter being "123"
+				^ same would apply to TargetNullValue or FallbackValue even if they have a numerical target dp
+					Height="{Binding FallbackValue=123}" // would be a "123" string
+		It can however be explicitly provided in the expanded form:
+			<Binding>
+				</Binding.ConverterParameter>
+					<local:SomeEnum>SomeValue</local:SomeEnum>
+		Note that enum type will be casted into its underlying numerical type (default is int).
+		On windows, the parsed binding can be obtained with: TARGET_ELEMENT.GetBindingExpression(DEPENDENCY_PROPERTY).ParentBinding
+	-->
+
+	<!-- expectations:
+		- Content =				=	LiteralEnumValue_Enum.Qwe
+		- HorizontalAlignment	->	... new Binding { ConverterParameter="Center", FallbackValue="Center", TargetNullValue="Center"... }
+		- Visibility			->	... new Binding { ConverterParameter=(int)LiteralEnumValue_Enum.Asd, FallbackValue=(int)LiteralEnumValue_Enum.Asd, TargetNullValue=(int)LiteralEnumValue_Enum.Asd... }
+	-->
+	<ContentControl HorizontalAlignment="{Binding ConverterParameter=Center, FallbackValue=Center, TargetNullValue=Center}">
+		<ContentControl.Content>
+			<!-- OK -->
+			<local:LiteralEnumValue_Enum>Qwe</local:LiteralEnumValue_Enum>
+		</ContentControl.Content>
+		<ContentControl.Visibility>
+			<Binding>
+				<!-- uno#10047 -->
+				<Binding.ConverterParameter>
+					<local:LiteralEnumValue_Enum>Asd</local:LiteralEnumValue_Enum>
+				</Binding.ConverterParameter>
+				<Binding.FallbackValue>
+					<local:LiteralEnumValue_Enum>Asd</local:LiteralEnumValue_Enum>
+				</Binding.FallbackValue>
+				<Binding.TargetNullValue>
+					<local:LiteralEnumValue_Enum>Asd</local:LiteralEnumValue_Enum>
+				</Binding.TargetNullValue>
+			</Binding>
+		</ContentControl.Visibility>
+	</ContentControl>
+
+</UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/LiteralEnumValue.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/LiteralEnumValue.xaml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Markup;
+
+
+namespace XamlGenerationTests.Shared
+{
+	public sealed partial class LiteralEnumValue : UserControl
+	{
+		public LiteralEnumValue()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+	public enum LiteralEnumValue_Enum { Qwe, Asd, Zxc }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10047

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Passing enum value to binding properties like "ConverterParameter,FallbackValue,TargetNullValue" are processed like string by the XamlSourceGenerator:
```
<Binding>
	</Binding.ConverterParameter>
		<local:SomeEnum>SomeValue</local:SomeEnum>
```

## What is the new behavior?
These enum would be properly parsed and then casted to its underlying enum value, like on windows.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->