### PR TITLE
fix: Android `RefreshContainer` horizontal scrollable content

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/RefreshContainerTests/Given_RefreshContainer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/RefreshContainerTests/Given_RefreshContainer.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests
+{
+	public partial class Given_RefreshContainer : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void DoesNotInterfereWithHorizontalDrag()
+		{
+			Run("UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests.RefreshContainerHorizontalScroll");
+
+			var refreshContainerResult = _app.WaitForElement("RefreshContainer");
+			var refreshContainer = _app.Marked("RefreshContainer");
+			var containerRect = ToPhysicalRect(refreshContainerResult[0].Rect).ToRectangle();
+			var containerCenter = new Point(containerRect.Left + containerRect.Width / 2, containerRect.Top + containerRect.Height / 2);
+
+			using var beforeScreenshot = TakeScreenshot("Before horizontal scroll", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+			ImageAssert.HasColorAt(beforeScreenshot, containerCenter.X, containerCenter.Y, Color.Red);
+
+			_app.TapCoordinates(
+				(float)(containerRect.Left + containerRect.Width * 0.9),
+				(float)(containerRect.Top + containerRect.Height / 2));
+			
+			// Imperfect horizontal drag with vertical offset
+			_app.DragCoordinates(
+				(float)(containerRect.Left + containerRect.Width * 0.9),
+				(float)(containerRect.Top + containerRect.Height / 2),
+				(float)(containerRect.Left + containerRect.Width * 0.2),
+				(float)(containerRect.Top + containerRect.Height * 0.8));			
+
+			using var afterScreenshot = TakeScreenshot("After horizontal scroll", new ScreenshotOptions() { IgnoreInSnapshotCompare = true });
+			ImageAssert.DoesNotHaveColorAt(afterScreenshot, containerCenter.X, containerCenter.Y, Color.Red);
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/RefreshContainerTests/Given_RefreshContainer.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/RefreshContainerTests/Given_RefreshContainer.cs
@@ -12,6 +12,7 @@ namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests
 	{
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)]
 		public void DoesNotInterfereWithHorizontalDrag()
 		{
 			Run("UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests.RefreshContainerHorizontalScroll");

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerHorizontalScroll.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerHorizontalScroll.xaml
@@ -18,29 +18,14 @@
 		<StackPanel Orientation="Horizontal" Spacing="8">
 			<Button Click="RequestRefresh_Click">Request refresh</Button>
 		</StackPanel>
-		<mux:RefreshContainer x:Name="RefreshContainer" VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="1">
-			<ListView 
-				SelectionMode="None"
-				IsItemClickEnabled="True"
-				MinHeight="150"
-				MaxHeight="160"
-				Padding="24,0">
-				<ListView.ItemsPanel>
-					<ItemsPanelTemplate>
-						<ItemsStackPanel Orientation="Horizontal" />
-					</ItemsPanelTemplate>
-				</ListView.ItemsPanel>
-				<ListViewItem Content="One" FontSize="50" AutomationProperties.Name="listViewItem1"/>
-				<ListViewItem Content="Two" FontSize="50" AutomationProperties.Name="listViewItem2"/>
-				<ListViewItem Content="Three" FontSize="50" AutomationProperties.Name="listViewItem3"/>
-				<ListViewItem Content="Four" FontSize="50" AutomationProperties.Name="listViewItem4"/>
-				<ListViewItem Content="Five" FontSize="50" AutomationProperties.Name="listViewItem5"/>
-				<ListViewItem Content="Six" FontSize="50" AutomationProperties.Name="listViewItem6"/>
-				<ListViewItem Content="Seven" FontSize="50" AutomationProperties.Name="listViewItem7"/>
-				<ListViewItem Content="Eight" FontSize="50" AutomationProperties.Name="listViewItem8"/>
-				<ListViewItem Content="Nine" FontSize="50" AutomationProperties.Name="listViewItem9"/>
-				<ListViewItem Content="Ten" FontSize="50" AutomationProperties.Name="listViewItem10"/>
-			</ListView>
+		<mux:RefreshContainer x:Name="RefreshContainer" VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="1" Width="300">
+			<ScrollViewer HorizontalScrollMode="Enabled" HorizontalScrollBarVisibility="Auto" VerticalScrollMode="Disabled" Width="250">
+				<StackPanel Orientation="Horizontal">
+					<Rectangle Fill="Red" Width="300" Height="100" />
+					<Rectangle Fill="Orange" Width="100" Height="100" />
+					<Rectangle Fill="Green" Width="100" Height="100" />
+				</StackPanel>
+			</ScrollViewer>
 		</mux:RefreshContainer>
 		<ListView
 			Grid.Row="2"

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerHorizontalScroll.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerHorizontalScroll.xaml
@@ -1,0 +1,69 @@
+﻿<Page
+    x:Class="UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests.RefreshContainerHorizontalScroll"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Padding="20" RowSpacing="8">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="300" />
+			<RowDefinition Height="300" />
+		</Grid.RowDefinitions>
+		<StackPanel Orientation="Horizontal" Spacing="8">
+			<Button Click="RequestRefresh_Click">Request refresh</Button>
+		</StackPanel>
+		<mux:RefreshContainer x:Name="RefreshContainer" VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="1">
+			<ListView 
+				SelectionMode="None"
+				IsItemClickEnabled="True"
+				MinHeight="150"
+				MaxHeight="160"
+				Padding="24,0">
+				<ListView.ItemsPanel>
+					<ItemsPanelTemplate>
+						<ItemsStackPanel Orientation="Horizontal" />
+					</ItemsPanelTemplate>
+				</ListView.ItemsPanel>
+				<ListViewItem Content="One" FontSize="50" AutomationProperties.Name="listViewItem1"/>
+				<ListViewItem Content="Two" FontSize="50" AutomationProperties.Name="listViewItem2"/>
+				<ListViewItem Content="Three" FontSize="50" AutomationProperties.Name="listViewItem3"/>
+				<ListViewItem Content="Four" FontSize="50" AutomationProperties.Name="listViewItem4"/>
+				<ListViewItem Content="Five" FontSize="50" AutomationProperties.Name="listViewItem5"/>
+				<ListViewItem Content="Six" FontSize="50" AutomationProperties.Name="listViewItem6"/>
+				<ListViewItem Content="Seven" FontSize="50" AutomationProperties.Name="listViewItem7"/>
+				<ListViewItem Content="Eight" FontSize="50" AutomationProperties.Name="listViewItem8"/>
+				<ListViewItem Content="Nine" FontSize="50" AutomationProperties.Name="listViewItem9"/>
+				<ListViewItem Content="Ten" FontSize="50" AutomationProperties.Name="listViewItem10"/>
+			</ListView>
+		</mux:RefreshContainer>
+		<ListView
+			Grid.Row="2"
+			SelectionMode="None"
+			IsItemClickEnabled="True"
+			MinHeight="150"
+			MaxHeight="160"
+			Padding="24,0">
+			<ListView.ItemsPanel>
+				<ItemsPanelTemplate>
+					<ItemsStackPanel Orientation="Horizontal" />
+				</ItemsPanelTemplate>
+			</ListView.ItemsPanel>
+			<ListViewItem Content="One" FontSize="50" AutomationProperties.Name="listViewItem1"/>
+			<ListViewItem Content="Two" FontSize="50" AutomationProperties.Name="listViewItem2"/>
+			<ListViewItem Content="Three" FontSize="50" AutomationProperties.Name="listViewItem3"/>
+			<ListViewItem Content="Four" FontSize="50" AutomationProperties.Name="listViewItem4"/>
+			<ListViewItem Content="Five" FontSize="50" AutomationProperties.Name="listViewItem5"/>
+			<ListViewItem Content="Six" FontSize="50" AutomationProperties.Name="listViewItem6"/>
+			<ListViewItem Content="Seven" FontSize="50" AutomationProperties.Name="listViewItem7"/>
+			<ListViewItem Content="Eight" FontSize="50" AutomationProperties.Name="listViewItem8"/>
+			<ListViewItem Content="Nine" FontSize="50" AutomationProperties.Name="listViewItem9"/>
+			<ListViewItem Content="Ten" FontSize="50" AutomationProperties.Name="listViewItem10"/>
+		</ListView>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerHorizontalScroll.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RefreshContainerTests/RefreshContainerHorizontalScroll.xaml.cs
@@ -1,0 +1,40 @@
+using System;
+using Uno.UI.Samples.Controls;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using RefreshVisualizer = Microsoft.UI.Xaml.Controls.RefreshVisualizer;
+using RefreshVisualizerState = Microsoft.UI.Xaml.Controls.RefreshVisualizerState;
+using RefreshRequestedEventArgs = Microsoft.UI.Xaml.Controls.RefreshRequestedEventArgs;
+using RefreshInteractionRatioChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshInteractionRatioChangedEventArgs;
+using RefreshStateChangedEventArgs = Microsoft.UI.Xaml.Controls.RefreshStateChangedEventArgs;
+using RefreshPullDirection = Microsoft.UI.Xaml.Controls.RefreshPullDirection;
+using System.Threading.Tasks;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.RefreshContainerTests
+{
+	[Sample("PullToRefresh")]
+    public sealed partial class RefreshContainerHorizontalScroll : Page
+    {
+		private readonly Random _randomizer = new Random();
+		
+        public RefreshContainerHorizontalScroll()
+        {
+            this.InitializeComponent();
+			this.RefreshContainer.RefreshRequested += RefreshContainer_RefreshRequested;
+		}
+
+		private void RequestRefresh_Click(object sender, RoutedEventArgs args)
+		{
+			this.RefreshContainer.RequestRefresh();
+		}
+
+		private async void RefreshContainer_RefreshRequested(object sender, RefreshRequestedEventArgs e)
+		{
+			var deferral = e.GetDeferral();
+			await Task.Delay(2000);
+			deferral.Complete();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -269,6 +269,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerHorizontalScroll.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerScrollTop.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5066,6 +5070,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerTheming.xaml.cs">
       <DependentUpon>RefreshContainerTheming.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerHorizontalScroll.xaml.cs">
+      <DependentUpon>RefreshContainerHorizontalScroll.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\RefreshContainerTests\RefreshContainerScrollTop.xaml.cs">
       <DependentUpon>RefreshContainerScrollTop.xaml</DependentUpon>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/Native/NativeRefreshControl.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/Native/NativeRefreshControl.Android.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
+using Android.Graphics;
 using Android.Views;
 using Android.Widget;
 using AndroidX.Core.View;
@@ -14,6 +15,7 @@ using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Rect = Windows.Foundation.Rect;
 using ScrollView = Android.Widget.ScrollView;
 using UnoScrollViewer = Windows.UI.Xaml.Controls.ScrollViewer;
 
@@ -24,9 +26,14 @@ public partial class NativeRefreshControl : SwipeRefreshLayout, IShadowChildrenP
 	// Distance in pixels a touch can wander before we think the user is scrolling
 	// https://developer.android.com/reference/android/view/ViewConfiguration.html#getScaledTouchSlop()
 	private static readonly float _touchSlop = ViewConfiguration.Get(ContextHelper.Current).ScaledTouchSlop;
+
+	private PointF _gestureStart;
+	private bool _isSwiping = false;
+	private bool _ignoreGesture = false;
 	private Android.Views.View _content;
 	private ViewGroup _descendantScrollable;
-
+	private bool _baseOnInterceptTouchResult;
+	
 	public NativeRefreshControl() : base(ContextHelper.Current)
 	{
 		_layouter = new NativeRefreshControlLayouter(this);
@@ -68,6 +75,87 @@ public partial class NativeRefreshControl : SwipeRefreshLayout, IShadowChildrenP
 			}
 		}
 		return base.CanChildScrollUp();
+	}
+
+	public override bool OnInterceptTouchEvent(MotionEvent e)
+	{
+		_baseOnInterceptTouchResult = base.OnInterceptTouchEvent(e);
+		switch (e.Action)
+		{
+			case MotionEventActions.Down:
+				_isSwiping = false;
+				_ignoreGesture = false;
+				_gestureStart = new PointF(e.GetX(), e.GetY());
+				break;
+			case MotionEventActions.Move:
+				return ShouldInterceptMove(e);
+			default:
+				_isSwiping = false;
+				_ignoreGesture = false;
+				break;
+		}
+
+		return _baseOnInterceptTouchResult;
+	}
+
+	private bool ShouldInterceptMove(MotionEvent e)
+	{
+		//If the Swipe already started swiping we let it handle the touch until it is completed.
+		if (_isSwiping)
+		{
+			return true;
+		}
+		else
+		{
+			var xDistance = Math.Abs(e.GetX() - _gestureStart.X);
+			var yDistance = Math.Abs(e.GetY() - _gestureStart.Y);
+			var cumulativeDistance = new Vector2(xDistance, yDistance);
+
+			// Here we validate that the touch is not horizontal. 
+			// This is to ensure that it will not override horizontal
+			// touches for children such as flipviews or horizontal listviews.
+			if (_ignoreGesture || cumulativeDistance.X > _touchSlop)
+			{
+				_ignoreGesture = true;
+				return false;
+			}
+
+			if (cumulativeDistance.Y > _touchSlop && // touchSlop is the minimal distance for us to determine it is a scroll
+				cumulativeDistance.Y > cumulativeDistance.X && // Check the scroll is vertical
+				e.GetY() - _gestureStart.Y > 0 && // Check if the scroll is positive so that we don't intercept the scrolling of the AVP/List
+				!CanChildScrollUp()) // Validate if the child can scroll up so that we only allow swipe refresh when the content is scrolled.
+			{
+				_isSwiping = true;
+
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+	}
+
+	public override bool OnTouchEvent(MotionEvent e)
+	{
+		if (e.Action == MotionEventActions.Up && !_baseOnInterceptTouchResult)
+		{
+			// On MotionEventActions.Up, SwipeRefreshLayout.OnTouchEvent checks the current y against mInitialMotionY and sets 
+			// refreshing accordingly. However, if OnInterceptTouchEvent hasn't returned true (because user hasn't dragged far 
+			// enough to trigger a drag) then mInitialMotionY hasn't been set properly, giving rise to false-positive refreshes. 
+			// Hence we don't call base in this case to prevent the false positive.
+			return false;
+		}
+
+		var baseOnTouchResult = base.OnTouchEvent(e);
+		// If we are handling touch and OnInterceptTouchEvent() did not return true, it means there are no touch handlers in the
+		// children. (This can happen if, eg, the content is not scrollable.) Give OnInterceptTouchEvent another chance so that
+		// SwipeRefreshLayout can set its isDragged state correctly, otherwise indicator won't appear.
+		if (baseOnTouchResult && !_baseOnInterceptTouchResult)
+		{
+			OnInterceptTouchEvent(e);
+		}
+		return baseOnTouchResult;
 	}
 
 	private readonly List<View> _emptyList = new();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #https://github.com/unoplatform/uno.extensions/issues/789

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Horizontal scrolling in `RefreshContainer` is not reliable

## What is the new behavior?

- Reliable, fix based on https://github.com/nventive/Nventive.View/blob/master/src/View.Uno/Controls/SwipeRefresh/NativeSwipeRefresh.Android.cs


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.