### PR TITLE
ci: Disable macOS dotnet new template validation

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -83,7 +83,7 @@ jobs:
 
 - template: build/ci/.azure-devops-project-template-tests.yml
   parameters:
-    vmImageWindows: '$(windows2022HostedVMImage)'
+    poolName: '$(windowsScaledPool)'
     vmImageLinux: '$(linuxVMImage)'
 
 - template: build/ci/.azure-devops-uap.yml

--- a/build/ci/.azure-devops-project-template-tests.yml
+++ b/build/ci/.azure-devops-project-template-tests.yml
@@ -42,8 +42,7 @@ jobs:
 - job: Dotnet_Template_Tests_Net6
   displayName: 'dotnet new net6 Templates Tests'
 
-  pool:
-    vmImage: ${{ parameters.vmImageWindows }}
+  pool: ${{ parameters.poolName }}
 
   dependsOn: Generate_Packages
 

--- a/build/ci/.azure-devops-project-template-tests.yml
+++ b/build/ci/.azure-devops-project-template-tests.yml
@@ -6,8 +6,7 @@ jobs:
 - job: Dotnet_Template_Tests
   displayName: 'dotnet new Templates Tests'
 
-  pool:
-    vmImage: ${{ parameters.vmImageWindows }}
+  pool: ${{ parameters.poolName }}
 
   dependsOn: Generate_Packages
 

--- a/build/test-scripts/run-template-tests.ps1
+++ b/build/test-scripts/run-template-tests.ps1
@@ -57,12 +57,7 @@ $templateConfigurations =
     (Get-TemplateConfiguration),
     (Get-TemplateConfiguration -android 1),
     (Get-TemplateConfiguration -iOS 1),
-
-    # disabled because of https://developercommunity.visualstudio.com/t/XamarinMac-binaries-are-missing-in-173/10164443
-    # Replaced by a double test of iOS
-    # (Get-TemplateConfiguration -macOS 1),
-    (Get-TemplateConfiguration -iOS 1),
-
+    (Get-TemplateConfiguration -macOS 1),
     (Get-TemplateConfiguration -wasm 1),
     (Get-TemplateConfiguration -skiaGtk 1),
     (Get-TemplateConfiguration -skiaWpf 1),

--- a/build/test-scripts/run-template-tests.ps1
+++ b/build/test-scripts/run-template-tests.ps1
@@ -57,7 +57,12 @@ $templateConfigurations =
     (Get-TemplateConfiguration),
     (Get-TemplateConfiguration -android 1),
     (Get-TemplateConfiguration -iOS 1),
-    (Get-TemplateConfiguration -macOS 1),
+
+    # disabled because of https://developercommunity.visualstudio.com/t/XamarinMac-binaries-are-missing-in-173/10164443
+    # Replaced by a double test of iOS
+    # (Get-TemplateConfiguration -macOS 1),
+    (Get-TemplateConfiguration -iOS 1),
+
     (Get-TemplateConfiguration -wasm 1),
     (Get-TemplateConfiguration -skiaGtk 1),
     (Get-TemplateConfiguration -skiaWpf 1),


### PR DESCRIPTION
GitHub Issue (If applicable): https://developercommunity.visualstudio.com/t/XamarinMac-binaries-are-missing-in-173/10164443

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Disables `dotnet new` xamarin.mac validations.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
