### PR TITLE
fix(logger): Ensure thread safety of `LoggerFactory`

### DIFF
--- a/src/Uno.Foundation.Logging/LoggerFactory.cs
+++ b/src/Uno.Foundation.Logging/LoggerFactory.cs
@@ -7,6 +7,7 @@ namespace Uno.Foundation.Logging
 {
 	internal class LoggerFactory
 	{
+		private static object _gate = new();
 		private Dictionary<string, Logger> _loggers = new Dictionary<string, Logger>();
 		private static Logger _nullLogger = new Logger(null);
 
@@ -26,12 +27,15 @@ namespace Uno.Foundation.Logging
 				return _nullLogger;
 			}
 
-			if (!_loggers.TryGetValue(name, out var logger))
+			lock (_gate)
 			{
-				_loggers[name] = logger = new Logger(ExternalLoggerFactory.CreateLogger(name));
-			}
+				if (!_loggers.TryGetValue(name, out var logger))
+				{
+					_loggers[name] = logger = new Logger(ExternalLoggerFactory.CreateLogger(name));
+				}
 
-			return logger;
+				return logger;
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/nventive-private/issues/415

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The internal `LoggerFactory` is now thread safe.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
