### PR TITLE
fix(NativeFramePresenter): Create Page instances at time of insertion into the Frame.BackStack

### DIFF
--- a/doc/articles/features/native-frame-nav.md
+++ b/doc/articles/features/native-frame-nav.md
@@ -42,8 +42,9 @@ There is a `FrameNavigationHelper` that is in place to expose useful properties 
 
 Method|Return Type|Description
 -|-|-
-`GetCurrentEntry(Frame)`|`PageStackEntry`|Returns the PageStackEntry for the currently displayed Page within the given `frame`.
-`GetInstance(PageStackEntry)`|`Page`|Returns the actual Page instance of the given `entry`.
+`GetCurrentEntry(Frame)`|`PageStackEntry`|Returns the PageStackEntry for the currently displayed Page within the given `frame`
+`GetInstance(PageStackEntry)`|`Page`|Returns the actual Page instance of the given `entry`
+`EnsurePageInitialized(Frame, PageStackEntry)`|`Page`|Retrieves the current `Page` instance of the given `PageStackEntry`. If no instance exists, the `Page` will be created and properly initialized to the provided `Frame`
 `CreateNavigationEventArgs(...)`|`NavigationEventArgs`|Creates a new instance of `NavigationEventArgs`/>
 
 ## Platform Specifics

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NativeFrame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NativeFrame.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__
+﻿#if __ANDROID__ || __IOS__
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,12 +13,18 @@ using Windows.UI.Xaml;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using Uno.UI.RuntimeTests.Extensions;
+using SamplesApp.UITests.TestFramework;
+using Windows.UI.Xaml.Navigation;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Markup;
+using Uno.UI.Controls;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
 	[TestClass]
 	public class Given_NativeFrame
 	{
+#if __ANDROID__
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
@@ -86,8 +92,93 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await SUT.WaitForPages(1);
 		}
+#endif
+#if __IOS__
+		[TestMethod]
+		[RunsOnUIThread]
+		[RequiresFullWindow]
+		public async Task When_Altering_BackStack()
+		{
+			var style = (Style)XamlReader.Load(@"
+				<Style xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+						xmlns:uc=""using:Uno.UI.Controls""
+						xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+						TargetType=""Frame"">
+				<Setter Property=""Template"">
+					<Setter.Value>
+						<ControlTemplate TargetType=""Frame"">
+							<uc:NativeFramePresenter x:Name=""NativePresenter"" Background=""{TemplateBinding Background}"" />
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>");
+
+			var SUT = new Frame()
+			{
+				Style = style
+			};
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var presenter = SUT.FindName("NativePresenter") as NativeFramePresenter;
+
+			SUT.Navigate(typeof(MyPage));
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			//Simulate a deep-link navigation. Nav directly to MyThirdPage and add the logical previous pages into the BackStack manually
+			SUT.Navigate(typeof(MyThirdPage));
+            SUT.BackStack.Clear();
+            SUT.BackStack.Add(new PageStackEntry(typeof(MyFirstPage), null, null));
+            SUT.BackStack.Add(new PageStackEntry(typeof(MySecondPage), null, null));
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			await Task.Delay(1000);
+
+			Assert.AreEqual(SUT.CurrentEntry.Instance, presenter.NavigationController.TopViewController.View as Page);
+			Assert.AreEqual(typeof(MyThirdPage), SUT.CurrentSourcePageType);
+			AssertBackStackMatchesNavigationControllerStack();
+
+			SUT.GoBack();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			await Task.Delay(1000);
+
+			Assert.AreEqual(SUT.CurrentEntry.Instance, presenter.NavigationController.TopViewController.View as Page);
+			Assert.AreEqual(typeof(MySecondPage), SUT.CurrentSourcePageType);
+			AssertBackStackMatchesNavigationControllerStack();
+
+
+			SUT.GoBack();
+			await TestServices.WindowHelper.WaitForIdle();
+
+			await Task.Delay(1000);
+
+			Assert.AreEqual(SUT.CurrentEntry.Instance, presenter.NavigationController.TopViewController.View as Page);
+			Assert.AreEqual(typeof(MyFirstPage), SUT.CurrentSourcePageType);
+			AssertBackStackMatchesNavigationControllerStack();
+
+			void AssertBackStackMatchesNavigationControllerStack()
+			{
+				CollectionAssert.AreEqual(
+					SUT.BackStack.Select(x => x.Instance).ToArray(),
+					presenter.NavigationController.ViewControllers.SkipLast(1).Select(x => x.View).ToArray());
+			}
+		}
+#endif
 	}
 	partial class MyPage : Page
+	{
+	}
+	partial class MyFirstPage : Page
+	{
+	}
+	partial class MySecondPage : Page
+	{
+	}
+	partial class MyThirdPage : Page
 	{
 	}
 }

--- a/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
@@ -366,7 +366,7 @@ namespace Uno.UI.Controls
 				.Where(entry => entry != null)
 				.Distinct()
 				.OfType<PageStackEntry>()
-				.Select(entry => entry.Instance.FindViewController() ?? new PageViewController(entry.Instance))
+				.Select(FindOrCreateViewController)
 				.ToArray();
 
 			if (!viewControllers.SequenceEqual(NavigationController.ViewControllers))
@@ -387,8 +387,18 @@ namespace Uno.UI.Controls
 				{
 					NavigationController.SetViewControllers(viewControllers, animated: true);
 				}
-				
 			}
+		}
+
+		private UIViewController FindOrCreateViewController(PageStackEntry entry)
+		{
+			if (entry.Instance is { } pageInstance)
+			{
+				return pageInstance.FindViewController() ?? new PageViewController(pageInstance);
+			}
+
+			var page = _frame.EnsurePageInitialized(entry);
+			return new PageViewController(page);
 		}
 
 		private bool GetIsAnimated(NavigationTransitionInfo transitionInfo)

--- a/src/Uno.UI/Helpers/FrameNavigationHelper.cs
+++ b/src/Uno.UI/Helpers/FrameNavigationHelper.cs
@@ -28,6 +28,13 @@ namespace Uno.UI.Helpers
 		public static Page? GetInstance(PageStackEntry? entry) => entry?.Instance;
 
 		/// <summary>
+		/// Retrieves the current <see cref="Page"/> instance of the given <paramref name="entry"/>. If no instance exists, the <see cref="Page"/> will be created and properly initialized to the provided <paramref name="frame"/>.
+		/// </summary>
+		/// <param name="entry">The PageStackEntry from the Frame's BackStack.</param>
+		/// <returns><see cref="Page"/></returns>
+		public static Page? EnsurePageInitialized(Frame? frame, PageStackEntry? entry) => frame?.EnsurePageInitialized(entry);
+
+		/// <summary>
 		/// Creates a new instance of <see cref="NavigationEventArgs"/>
 		/// </summary>
 		/// <param name="content"></param>

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -347,13 +347,11 @@ namespace Windows.UI.Xaml.Controls
 
 			if (CurrentEntry.Instance == null)
 			{
-				var page = CreatePageInstanceCached(entry.SourcePageType);
-				if (page == null)
+				if (EnsurePageInitialized(entry) is not { } page)
 				{
 					return false;
 				}
 
-				page.Frame = this;
 				CurrentEntry.Instance = page;
 			}
 
@@ -431,6 +429,17 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public void SetNavigationState(string navigationState) => _navigationState = navigationState;
+
+		internal Page EnsurePageInitialized(PageStackEntry entry)
+		{
+			if (entry is { Instance: null } && CreatePageInstanceCached(entry.SourcePageType) is { } page)
+			{
+				page.Frame = this;
+				entry.Instance = page;
+			}
+
+			return entry?.Instance;
+		}
 
 		private static Page CreatePageInstanceCached(Type sourcePageType) => _pool.DequeuePage(sourcePageType);
 


### PR DESCRIPTION
Relates to https://github.com/unoplatform/uno.toolkit.ui/issues/346

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Manually editing the Frame.BackStack while use the NativeFramePresenter on iOS leads to navigation problems. ViewControllers in the NavigationController stack will not contain references to the proper Page instances. This is causing the Frame BackStack and the NavigationController's ViewControllers to become out of sync with one another

## What is the new behavior?

Upon any change to the Frame's BackStack, the iOS NativeFramePresenter will attempt to instantiate Pages that have been added to the BackStack through an insertion of a new `PageStackEntry`.

We are also introducing a new Helper method for the `FrameNavigationHelper` that will allow the NativeFramePresenter within Toolkit, or any other Frame-reliant navigation mechanism, to achieve the same logic.

