### PR TITLE
fix: Ensure Xamarin.iOS target is deployable when Mac Host is connected

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate.Wizard.2019/UnoSolutionWizard.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate.Wizard.2019/UnoSolutionWizard.cs
@@ -65,6 +65,7 @@ namespace UnoSolutionTemplate.Wizard
 			OpenWelcomePage();
 			SetStartupProject();
 			SetUWPAnyCPUBuildableAndDeployable();
+			SetiOSDeployable();
 			SetDefaultConfiguration();
 		}
 
@@ -183,17 +184,48 @@ namespace UnoSolutionTemplate.Wizard
 			}
 		}
 
+		private void SetiOSDeployable()
+		{
+			if (_dte?.Solution.SolutionBuild is SolutionBuild val)
+			{
+				try
+				{
+					var iOSConfigs = new[] {
+						GetSolutionConfiguration(val, "Debug", "iPhone"),
+						GetSolutionConfiguration(val, "Debug", "iPhoneSimulator")
+					}.Select(c => c.SolutionContexts);
+
+					foreach (SolutionConfiguration solutionConfiguration2 in val.SolutionConfigurations)
+					{
+						foreach (var iOSSolutionContext in iOSConfigs)
+						{
+							var iOSProject = iOSSolutionContext
+								.Cast<SolutionContext>()
+								.FirstOrDefault(c => c.ProjectName.EndsWith(".iOS.csproj"));
+							if (iOSProject != null)
+							{
+								iOSProject.ShouldDeploy = true;
+							}
+						}
+					}
+				}
+				catch (Exception)
+				{
+				}
+			}
+		}
+
 		private void SetDefaultConfiguration()
 		{
 			try
 			{
 				if (_dte?.Solution.SolutionBuild is SolutionBuild2 val)
 				{
-						var x86Config = val.SolutionConfigurations
-							.Cast<SolutionConfiguration2>()
-							.FirstOrDefault(c => c.Name == "Debug" && c.PlatformName == "x86");
+					var x86Config = val.SolutionConfigurations
+						.Cast<SolutionConfiguration2>()
+						.FirstOrDefault(c => c.Name == "Debug" && c.PlatformName == "x86");
 
-						x86Config?.Activate();
+					x86Config?.Activate();
 				}
 				else
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9572

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When template is created via the wizard, the iOS project is not deployable when targeting iOS devices via MacHost

## What is the new behavior?

Marked deployable by default.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.