### PR TITLE
docs: Fix logging indentation for markdown formatting

### DIFF
--- a/doc/articles/logging.md
+++ b/doc/articles/logging.md
@@ -32,7 +32,7 @@ The standard Uno template configures logging in the **Shared** project **App.xam
 
     private static void InitializeLogging()
     {
-#if DEBUG
+    #if DEBUG
 		// Logging is disabled by default for release builds, as it incurs a significant
 		// initialization cost from Microsoft.Extensions.Logging setup. If startup performance
 		// is a concern for your application, keep this disabled. If you're running on web or 
@@ -42,15 +42,15 @@ The standard Uno template configures logging in the **Shared** project **App.xam
 
         var factory = LoggerFactory.Create(builder =>
         {
-#if __WASM__
+    #if __WASM__
             builder.AddProvider(new global::Uno.Extensions.Logging.WebAssembly.WebAssemblyConsoleLoggerProvider());
-#elif __IOS__
+    #elif __IOS__
             builder.AddProvider(new global::Uno.Extensions.Logging.OSLogLoggerProvider());
-#elif NETFX_CORE
+    #elif NETFX_CORE
             builder.AddDebug();
-#else
+    #else
             builder.AddConsole();
-#endif
+    #endif
 
             // Exclude logs below this level
             builder.SetMinimumLevel(LogLevel.Information);
@@ -90,11 +90,11 @@ The standard Uno template configures logging in the **Shared** project **App.xam
 
         global::Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = factory;
 
-#if HAS_UNO
+    #if HAS_UNO
 		global::Uno.UI.Adapter.Microsoft.Extensions.Logging.LoggingAdapter.Initialize();
-#endif
+    #endif
 
-#endif // DEBUG
+    #endif // DEBUG
     }
     ```
 


### PR DESCRIPTION
Fixed #if indentation in md file for a better reading

GitHub Issue (If applicable): closes #10099

## PR Type

Corrected the indentation

## What is the current behavior?

The #if markdows is not correct for displaying


## What is the new behavior?

The #if markdows is now correct


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
