### PR TITLE
fix(xBind): Adjust FallbackValue behavior to explicitly support setting null to the target

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_ValueType.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_ValueType.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls.xBind_ValueType"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls"
+	xmlns:xc="using:Windows.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<TextBlock x:Name="tb1"
+				   x:FieldModifier="public"
+				   Tag="{x:Bind VM.Model2.MyDateTime, Mode=OneWay, FallbackValue={x:Null}}" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_ValueType.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/xBind_ValueType.xaml.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls
+{
+	public sealed partial class xBind_ValueType : UserControl
+	{
+		public xBind_ValueType()
+		{
+			this.InitializeComponent();
+		}
+
+		public xBind_ValueType_MyModel1 VM { get; } = new();
+	}
+
+	public class xBind_ValueType_MyModel1 : System.ComponentModel.INotifyPropertyChanged
+	{
+		private xBind_ValueType_MyModel2 model2;
+
+		public xBind_ValueType_MyModel2 Model2
+		{
+			get => model2;
+			set
+			{
+				model2 = value;
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(Model2)));
+			}
+		}
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+	}
+
+	public class xBind_ValueType_MyModel2 : System.ComponentModel.INotifyPropertyChanged
+	{
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		private DateTime myDateTime;
+
+		public DateTime MyDateTime
+		{
+			get => myDateTime;
+			set
+			{
+				myDateTime = value;
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(MyDateTime)));
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -1299,6 +1299,23 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 			Assert.AreEqual(42, SUT.tb1.Tag);
 		}
 
+		[TestMethod]
+		public async Task When_ValueType()
+		{
+			var SUT = new xBind_ValueType();
+			var date1 = new DateTime(2022, 10, 01);
+
+			SUT.VM.Model2 = new() { MyDateTime = date1 };
+
+			SUT.ForceLoaded();
+
+			Assert.AreEqual(date1, SUT.tb1.Tag);
+
+			SUT.VM.Model2 = null;
+
+			Assert.IsNull(SUT.tb1.Tag);
+		}
+
 		private async Task AssertIsNullAsync<T>(Func<T> getter, TimeSpan? timeout = null) where T:class
 		{
 			timeout ??= TimeSpan.FromSeconds(1);

--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -335,7 +335,8 @@ namespace Windows.UI.Xaml.Data
 
 		private void ApplyFallbackValue(bool useTypeDefaultValue = true)
 		{
-			if (ParentBinding.FallbackValue != null)
+			if (ParentBinding.FallbackValue != null
+				|| (ParentBinding.CompiledSource != null && ParentBinding.IsFallbackValueSet))
 			{
 				SetTargetValue(ConvertToBoundPropertyType(ParentBinding.FallbackValue));
 			}

--- a/src/Uno.UI/UI/Xaml/Data/Binding.cs
+++ b/src/Uno.UI/UI/Xaml/Data/Binding.cs
@@ -40,6 +40,16 @@ namespace Windows.UI.Xaml.Data
 		/// </summary>
 		private object _source;
 
+		/// <summary>
+		/// Storage for the FallbackValue property
+		/// </summary>
+		private object _fallbackValue;
+
+		/// <summary>
+		/// A set of flags for this instance
+		/// </summary>
+		private BindingFlags _flags;
+
 		public Binding()
 		{
 
@@ -61,9 +71,9 @@ namespace Windows.UI.Xaml.Data
 			Mode = BindingMode.OneWay;
 		}
 
-		public static implicit operator Binding (string path)
+		public static implicit operator Binding(string path)
 		{
-			return new Binding (path);
+			return new Binding(path);
 		}
 
 		/// <summary>
@@ -100,7 +110,18 @@ namespace Windows.UI.Xaml.Data
 		/// Gets or sets the value to use when the binding is unable to return a value.
 		/// </summary>
 		/// <value>The fallback value.</value>
-		public object FallbackValue { get; set; }
+		public object FallbackValue
+		{
+			get => _fallbackValue;
+			set
+			{
+				_fallbackValue = value;
+
+				// Mark the value as set, regardless of the value itself
+				// so x:Bind can set that value to the target.
+				_flags |= BindingFlags.FallbackValueSet;
+			}
+		}
 
 		/// <summary>
 		/// Gets or sets a value that indicates the direction of the data flow in the binding.
@@ -202,6 +223,24 @@ namespace Windows.UI.Xaml.Data
 			XBindSelector = xBindSelector;
 			XBindPropertyPaths = propertyPaths;
 			XBindBack = xBindBack;
+		}
+
+		/// <summary>
+		/// Determines if the FallbackValue has been set
+		/// </summary>
+		/// <remarks>To be used for x:Bind only</remarks>
+		internal bool IsFallbackValueSet
+			=> _flags.HasFlag(BindingFlags.FallbackValueSet);
+
+		[Flags]
+		private enum BindingFlags
+		{
+			None = 0,
+
+			/// <summary>
+			/// Determines if the FallbackValue has been set.
+			/// </summary>
+			FallbackValueSet = 1,
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9918

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

An x:Bind expression with `FallbackValue={x:Null}` now sets the target to null explicitly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
