### PR TITLE
ci: Split build artifacts into smaller pieces

### DIFF
--- a/build/ci/.azure-devops-package-generic.yml
+++ b/build/ci/.azure-devops-package-generic.yml
@@ -100,7 +100,7 @@ jobs:
     condition: always()
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)
-      ArtifactName: NugetPackages-Artifacts
+      ArtifactName: NugetPackages-Artifacts-generic
       ArtifactType: Container
   
   # - task: PublishBuildArtifacts@1

--- a/build/ci/.azure-devops-package-net6-win.yml
+++ b/build/ci/.azure-devops-package-net6-win.yml
@@ -73,5 +73,5 @@ jobs:
     condition: always()
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)
-      ArtifactName: NugetPackages-Artifacts
+      ArtifactName: NugetPackages-Artifacts-net6
       ArtifactType: Container

--- a/build/ci/.azure-devops-package-reference.yml
+++ b/build/ci/.azure-devops-package-reference.yml
@@ -57,5 +57,5 @@ jobs:
     condition: always()
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)
-      ArtifactName: NugetPackages-Artifacts
+      ArtifactName: NugetPackages-Artifacts-reference
       ArtifactType: Container

--- a/build/ci/.azure-devops-package-skia.yml
+++ b/build/ci/.azure-devops-package-skia.yml
@@ -61,5 +61,5 @@ jobs:
     condition: always()
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)
-      ArtifactName: NugetPackages-Artifacts
+      ArtifactName: NugetPackages-Artifacts-skia
       ArtifactType: Container

--- a/build/ci/.azure-devops-package-wasm.yml
+++ b/build/ci/.azure-devops-package-wasm.yml
@@ -62,5 +62,5 @@ jobs:
     condition: always()
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)
-      ArtifactName: NugetPackages-Artifacts
+      ArtifactName: NugetPackages-Artifacts-wasm
       ArtifactType: Container

--- a/build/ci/.azure-devops-package.yml
+++ b/build/ci/.azure-devops-package.yml
@@ -58,6 +58,7 @@ jobs:
 
   - ${{ each artifact in parameters.artifactsToDownload }}:
       - task: DownloadBuildArtifacts@0
+        displayName: Download build artifact ${{ artifact }}
         inputs:
           artifactName: ${{ artifact }}
           downloadPath: '$(Agent.WorkFolder)' 
@@ -104,7 +105,7 @@ jobs:
       TargetFolder: $(build.artifactstagingdirectory)\vslatest
       CleanTargetFolder: false
       OverWrite: false
-      flattenFolders: false
+      flattenFolders: true
 
   - task: PowerShell@2
     displayName: Authenticode Sign Packages

--- a/build/ci/.azure-devops-package.yml
+++ b/build/ci/.azure-devops-package.yml
@@ -1,6 +1,12 @@
 parameters:
   poolName: ''
-
+  artifactsToDownload:
+    - "NugetPackages-Artifacts-generic"
+    - "NugetPackages-Artifacts-net6"
+    - "NugetPackages-Artifacts-reference"
+    - "NugetPackages-Artifacts-skia"
+    - "NugetPackages-Artifacts-wasm"
+    
 jobs:
 - job: Generate_Packages
   displayName: 'Pack NuGet'
@@ -50,15 +56,16 @@ jobs:
 
   - template: templates/install-windows-sdk.yml
 
-  - task: DownloadBuildArtifacts@0
-    inputs:
-      artifactName: NugetPackages-Artifacts
-      downloadPath: '$(Agent.WorkFolder)' 
+  - ${{ each artifact in parameters.artifactsToDownload }}:
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          artifactName: ${{ artifact }}
+          downloadPath: '$(Agent.WorkFolder)' 
 
   - task: ExtractFiles@1
     displayName: Restore binaries structure
     inputs:
-      archiveFilePatterns: '$(Agent.WorkFolder)/NugetPackages-Artifacts/*-bin-$(XAML_FLAVOR_BUILD).zip' 
+      archiveFilePatterns: '$(Agent.WorkFolder)/NugetPackages-Artifacts*/*-bin-$(XAML_FLAVOR_BUILD).zip' 
       destinationFolder: $(build.sourcesdirectory)
       cleanDestinationFolder: false
       overwriteExistingFiles: true
@@ -90,36 +97,10 @@ jobs:
     displayName: Copy generic build packages
     condition: always()
     inputs:
-      SourceFolder: $(Agent.WorkFolder)/NugetPackages-Artifacts/vslatest-generic
+      SourceFolder: $(Agent.WorkFolder)/
       Contents: |
-        *.nupkg
-        *.vsix
-      TargetFolder: $(build.artifactstagingdirectory)\vslatest
-      CleanTargetFolder: false
-      OverWrite: false
-      flattenFolders: false
-
-  - task: CopyFiles@2
-    displayName: Copy Skia build packages
-    condition: always()
-    inputs:
-      SourceFolder: $(Agent.WorkFolder)/NugetPackages-Artifacts/vslatest-skia
-      Contents: |
-        *.nupkg
-        *.vsix
-      TargetFolder: $(build.artifactstagingdirectory)\vslatest
-      CleanTargetFolder: false
-      OverWrite: false
-      flattenFolders: false
-
-  - task: CopyFiles@2
-    displayName: Copy Wasm build packages
-    condition: always()
-    inputs:
-      SourceFolder: $(Agent.WorkFolder)/NugetPackages-Artifacts/vslatest-wasm
-      Contents: |
-        *.nupkg
-        *.vsix
+        NugetPackages-Artifacts*/vslatest*/*.nupkg
+        NugetPackages-Artifacts*/vslatest*/*.vsix
       TargetFolder: $(build.artifactstagingdirectory)\vslatest
       CleanTargetFolder: false
       OverWrite: false


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?

Artifacts download fail with:
`Possibly unsupported ZIP platform type, 251`

## What is the new behavior?

Avoids having a single download to go over 4.5GB.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
