### PR TITLE
fix: Invalid `Image` should not display

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -386,6 +386,25 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			ImageAssert.AreEqual(screenshotDirect, screenshotStream, rect, tolerance: PixelTolerance.Exclusive(12));
 		}
 
+		[Test]
+		[AutoRetry]
+		public void Image_Invalid()
+		{
+			Run("Uno.UI.Samples.UITests.ImageTests.Image_Invalid");
+
+			var panel = _app.Marked("ComparePanel");
+			var button = _app.Marked("HideButton");
+			var rect = panel.FirstResult().Rect;
+
+			using var beforeHide = TakeScreenshot("BeforeHide", true);
+
+			button.FastTap();
+			
+			using var afterHide = TakeScreenshot("AfterHide", true);
+			
+			ImageAssert.AreEqual(afterHide, beforeHide, rect);
+		}
+
 		private void WaitForBitmapOrSvgLoaded()
 		{
 			var isLoaded = _app.Marked("isLoaded");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -396,13 +396,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			var button = _app.Marked("HideButton");
 			var rect = _app.GetPhysicalRect(panel);
 
-			using var beforeHide = TakeScreenshot("BeforeHide", true);
+			using var beforeHide = TakeScreenshot("image_invalid_before_hide");
 
 			button.FastTap();
 			
-			using var afterHide = TakeScreenshot("AfterHide", true);
-			
-			ImageAssert.AreEqual(afterHide, beforeHide, rect);
+			using var afterHide = TakeScreenshot("image_invalid_after_hide");
+
+			ImageAssert.AreEqual(afterHide, beforeHide, rect, tolerance: PixelTolerance.Exclusive(1));
 		}
 
 		private void WaitForBitmapOrSvgLoaded()

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -394,7 +394,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 			var panel = _app.Marked("ComparePanel");
 			var button = _app.Marked("HideButton");
-			var rect = panel.FirstResult().Rect;
+			var rect = _app.GetPhysicalRect(panel);
 
 			using var beforeHide = TakeScreenshot("BeforeHide", true);
 

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -394,7 +394,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 
 			var panel = _app.Marked("ComparePanel");
 			var button = _app.Marked("HideButton");
-			var rect = _app.GetPhysicalRect(panel);
+			var physicalRect = _app.GetPhysicalRect(panel);
+			
+			// Copy of the rect, as the panel will be hidden, so the the X & Y coords would become negative
+			var originalRect = new AppRect(physicalRect.X, physicalRect.Y, physicalRect.Width, physicalRect.Height);
 
 			using var beforeHide = TakeScreenshot("image_invalid_before_hide");
 
@@ -402,7 +405,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			
 			using var afterHide = TakeScreenshot("image_invalid_after_hide");
 
-			ImageAssert.AreEqual(afterHide, beforeHide, rect, tolerance: PixelTolerance.Exclusive(1));
+			ImageAssert.AreEqual(afterHide, beforeHide, originalRect, tolerance: PixelTolerance.Exclusive(1));
 		}
 
 		private void WaitForBitmapOrSvgLoaded()

--- a/src/SamplesApp/UITests.Shared/Assets/InvalidImage.jpg
+++ b/src/SamplesApp/UITests.Shared/Assets/InvalidImage.jpg
@@ -1,0 +1,1 @@
+The fun thing about this image is how seriously invalid it is. Actually it is not an image at all, it's a text file! Lol!

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1801,6 +1801,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Invalid.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\ImageSourceWriteableBitmapInvalidate.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6145,6 +6149,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_ImageSource_PixelSize.xaml.cs">
       <DependentUpon>Image_ImageSource_PixelSize.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Invalid.xaml.cs">
+      <DependentUpon>Image_Invalid.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Margin.xaml.cs">
       <DependentUpon>Image_Margin.xaml</DependentUpon>
     </Compile>
@@ -8650,6 +8657,7 @@
     <Content Include="$(MSBuildThisFileDirectory)Assets\ingredient6.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\ingredient7.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\ingredient8.png" />
+    <Content Include="$(MSBuildThisFileDirectory)Assets\InvalidImage.jpg" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\LargeWisteria.jpg" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\ListView.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\MakeButton.png" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Invalid.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Invalid.xaml
@@ -13,7 +13,7 @@
 	d:DesignHeight="2000"
 	d:DesignWidth="400">
 
-	<Grid Padding="20" Background="White" RowSpacing="8">
+	<Grid Padding="20" Background="CornflowerBlue" RowSpacing="8">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Invalid.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Invalid.xaml
@@ -16,13 +16,13 @@
 	<Grid Padding="20" Background="CornflowerBlue" RowSpacing="8">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
-			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 		<Button x:Name="HideButton" Click="HideClick">Hide</Button>
-		<StackPanel Spacing="10" x:Name="ComparePanel" Grid.Row="1">
-			<Image Width="100" Height="100" />
-			<Image Source="https://example.com/iamnotreal.jpg" Width="100" Height="100" />
-			<Image Source="ms-appx:///Assets/InvalidImage.jpg" Width="100" Height="100" />
+		<StackPanel Width="50" Height="150" Spacing="10" x:Name="ComparePanel" Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Top">
+			<Image Width="30" Height="30" />
+			<Image Source="https://example.com/iamnotreal.jpg" Width="30" Height="30" />
+			<Image Source="ms-appx:///Assets/InvalidImage.jpg" Width="30" Height="30" />
 		</StackPanel>
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Invalid.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Invalid.xaml
@@ -1,0 +1,28 @@
+<Page
+	x:Class="Uno.UI.Samples.UITests.ImageTests.Image_Invalid"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<Grid Padding="20" Background="White" RowSpacing="8">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Button x:Name="HideButton" Click="HideClick">Hide</Button>
+		<StackPanel Spacing="10" x:Name="ComparePanel" Grid.Row="1">
+			<Image Width="100" Height="100" />
+			<Image Source="https://example.com/iamnotreal.jpg" Width="100" Height="100" />
+			<Image Source="ms-appx:///Assets/InvalidImage.jpg" Width="100" Height="100" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Invalid.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Invalid.xaml.cs
@@ -1,0 +1,20 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.UITests.ImageTests
+{
+	[Sample("Image")]
+	public sealed partial class Image_Invalid : Page
+	{
+		public Image_Invalid()
+		{
+			this.InitializeComponent();
+		}
+
+		private void HideClick(object sender, RoutedEventArgs e)
+		{
+			ComparePanel.Visibility = Visibility.Collapsed;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Image/HtmlImage.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/HtmlImage.wasm.cs
@@ -1,0 +1,12 @@
+﻿#nullable enable
+
+namespace Windows.UI.Xaml.Controls;
+
+public class HtmlImage : UIElement
+{
+	public HtmlImage() : base("img")
+	{
+		// Avoid the "drag effect" which is set by default in browsers
+		SetAttribute("draggable", "false");
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
@@ -14,8 +14,6 @@ using Windows.UI;
 
 namespace Windows.UI.Xaml.Controls
 {
-
-
 	partial class Image : FrameworkElement
 	{
 		private readonly SerialDisposable _sourceDisposable = new SerialDisposable();

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.wasm.cs
@@ -14,12 +14,7 @@ using Windows.UI;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public class HtmlImage : UIElement
-	{
-		public HtmlImage() : base("img")
-		{
-		}
-	}
+
 
 	partial class Image : FrameworkElement
 	{
@@ -35,8 +30,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			_htmlImage = new HtmlImage();
 
-			_htmlImage.SetAttribute("draggable", "false");
-
+			_htmlImage.SetStyle("visibility", "hidden");
+			
 			ImageOpened += OnImageOpened;
 			ImageFailed += OnImageFailed;
 
@@ -68,6 +63,8 @@ namespace Windows.UI.Xaml.Controls
 				this.Log().Debug($"Image failed [{_currentImg.Source}]: {e.ErrorMessage}");
 			}
 
+			_htmlImage.SetStyle("visibility", "hidden");
+
 			_currentImg.Source?.ReportImageFailed(e.ErrorMessage);
 		}
 
@@ -77,6 +74,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				this.Log().Debug($"Image opened [{(Source as BitmapSource)?.AbsoluteUri}]");
 			}
+
+			_htmlImage.SetStyle("visibility", "visible");
 
 			if (_lastMeasuredSize == _zeroSize)
 			{

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -172,6 +172,8 @@ embed.uno-frameworkelement.uno-unarranged {
   -webkit-user-drag: none;
   -webkit-user-select: none;
   -ms-user-select: none;
+  user-drag: none;
+  -webkit-user-drag: none;
 }
 
 .uno-scrollcontentpresenter {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When `Image` source is invalid, it does display "broken image" icon on WASM. If empty, it shows border.

![image](https://user-images.githubusercontent.com/1075116/196048803-fa397865-f75f-404c-b971-aba46c73a8da.png)


## What is the new behavior?

When `Image` source is invalid, it does not display at all.



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
