### PR TITLE
chore(test): Move some media tests to runtime

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/GradientBrushTests/LinearGradientBrush_Tests.cs
@@ -39,6 +39,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.GradientBrushTests
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]//Will be moved to runtime when it will have the equivalent of screenshot
 		public void When_Opacity_Is_Specified()
 		{
 			Run("UITests.Windows_UI_Xaml_Media.GradientBrushTests.LinearGradientBrush_Opacity");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_WriteableBitmap.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media/ImageBrushTests/ImageBrush_WriteableBitmap.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers.Queries;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml_Media.ImageBrushTests
 {
@@ -14,6 +15,9 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media.ImageBrushTests
 	{
 		[Test]
 		[AutoRetry]
+		// Other tests are in runtime
+		// Cannot be totaly moved since there are no equivalent of TakeScreenshot for Wasm
+		[ActivePlatforms(Platform.Browser)] 
 		public void When_UseWriteablBitmapAsImageBrushSource()
 		{
 			Run("UITests.Windows_UI_Xaml_Media.ImageBrushTests.ImageBrush_WriteableBitmap");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Geometry/Path_EllipseGeometry.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Geometry/Path_EllipseGeometry.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.Path_Ellipse_Geometry"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="400">
+
+    <Grid>
+        <Border Background="Yellow"
+                x:Name="HostBorder"
+                x:FieldModifier="Public"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Width="160"
+                Height="80"
+                Margin="5">
+            <Path Fill="Red">
+                <Path.Data>
+                    <EllipseGeometry Center="80,40"
+                                     RadiusX="80"
+                                     RadiusY="40" />
+                </Path.Data>
+            </Path>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Geometry/Path_EllipseGeometry.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Geometry/Path_EllipseGeometry.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	public sealed partial class Path_Ellipse_Geometry : UserControl
+	{
+		public Path_Ellipse_Geometry()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Geometry/Path_LineGeometry.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Geometry/Path_LineGeometry.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.Path_LineGeometry"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="400">
+
+    <Grid>
+        <Border Background="Yellow"
+                x:Name="HostBorder"
+                x:FieldModifier="Public"
+                Height="20"
+                Width="60"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Margin="5">
+            <Path Stroke="Green"
+                  StrokeThickness="20">
+                <Path.Data>
+                    <LineGeometry StartPoint="10,10"
+                                  EndPoint="50,10" />
+                </Path.Data>
+            </Path>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Geometry/Path_LineGeometry.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Geometry/Path_LineGeometry.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	public sealed partial class Path_LineGeometry : UserControl
+	{
+		public Path_LineGeometry()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_BasicAutomatedTransformation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_BasicAutomatedTransformation.cs
@@ -200,7 +200,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 			await WindowHelper.WaitForIdle();
 			return result;
 		}
-
 		private void Assert(FrameworkElement SUT, RawBitmap result, float x, float y, string color)
 		{
 			float border = 3; 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_Geometry.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_Geometry.cs
@@ -4,7 +4,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.Foundation;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+using Uno.UI.RuntimeTests.Helpers;
 using static Private.Infrastructure.TestServices;
+using System.Threading.Tasks;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Extensions;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 {
@@ -31,7 +38,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 			var geometry = new RectangleGeometry
 			{
 				Rect = new Rect(0, 0, 100, 100),
-				Transform = new TranslateTransform { X=20, Y=40 }
+				Transform = new TranslateTransform { X = 20, Y = 40 }
 			};
 
 			geometry.Bounds.Should().Be(new Rect(20, 40, 100, 100));
@@ -106,7 +113,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 			var geometry2 = new RectangleGeometry
 			{
 				Rect = new Rect(200, 200, 100, 100),
-				Transform = new CompositeTransform { CenterX = 350, CenterY = 350, ScaleX=2, ScaleY = 0.5 }
+				Transform = new CompositeTransform { CenterX = 350, CenterY = 350, ScaleX = 2, ScaleY = 0.5 }
 			};
 
 			var geometry = new GeometryGroup();
@@ -131,6 +138,59 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 		public void EmptyGeometry_CheckBounds()
 		{
 			Console.WriteLine(Geometry.Empty.Bounds);
+		}
+
+		[TestMethod]
+		public async Task When_EllipseGeometry()
+		{
+#if __MACOS__
+			Assert.Inconclusive(); // MACOS interpret colors differently
+#endif
+#if __IOS__
+			Assert.Inconclusive(); // Test is inconsistent on IOS
+#endif
+
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+
+			const string Red = "#FFFF0000";
+			var SUT = new Path_Ellipse_Geometry();
+
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			var scrn = await TakeScreenshot(SUT);
+			var border = SUT.HostBorder;
+			await WindowHelper.WaitForIdle();
+			ImageAssert.HasColorAtChild(scrn, border, border.Width / 2, border.Height / 2, Red, tolerance: 10);
+		}
+
+		[TestMethod]
+		public async Task When_LineGeometry()
+		{
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+			const string Green = "#FF008000";
+			var SUT = new Path_LineGeometry();
+			var scrn = await TakeScreenshot(SUT);
+
+			var rect = SUT.GetRelativeCoords(SUT.HostBorder);
+			ImageAssert.HasColorAt(scrn, rect.CenterX, rect.CenterY, Green, tolerance: 10);
+		}
+
+		private async Task<RawBitmap> TakeScreenshot(FrameworkElement SUT)
+		{
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			var renderer = new RenderTargetBitmap();
+			await WindowHelper.WaitForIdle();
+			await renderer.RenderAsync(SUT);
+			var result = await RawBitmap.From(renderer, SUT);
+			await WindowHelper.WaitForIdle();
+			return result;
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrushWriteableBitmap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrushWriteableBitmap.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UI.RuntimeTests.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media.Imaging;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public partial class ImageBrush_WriteableBitmap
+	{
+		[TestMethod]
+		public async Task When_UseWriteableBitmapAsImageBrushSource()
+		{
+#if !__MACOS__  //That test cause a Runtime error with MACOS
+
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+
+			const string BlueViolet = "#FF8A2BE2";
+			var imageBrush = new ImageBrush_WriteableBitmap();
+			WindowHelper.WindowContent = imageBrush;
+			await WindowHelper.WaitForLoaded(imageBrush);
+			var result = await TakeScreenshot(imageBrush);
+			var sut = imageBrush.GetRelativeCoords(imageBrush.SUT);
+			
+			ImageAssert.HasColorAt(result, sut.CenterX, sut.CenterY, BlueViolet);
+#endif
+		}
+		private async Task<RawBitmap> TakeScreenshot(FrameworkElement SUT)
+		{
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			var renderer = new RenderTargetBitmap();
+			await WindowHelper.WaitForIdle();
+			await renderer.RenderAsync(SUT);
+			var result = await RawBitmap.From(renderer, SUT);
+			await WindowHelper.WaitForIdle();
+			return result;
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrushWriteableBitmap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrushWriteableBitmap.cs
@@ -37,6 +37,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 			var sut = imageBrush.GetRelativeCoords(imageBrush.SUT);
 			
 			ImageAssert.HasColorAt(result, sut.CenterX, sut.CenterY, BlueViolet);
+#else
+			await Task.Yield();
 #endif
 		}
 		private async Task<RawBitmap> TakeScreenshot(FrameworkElement SUT)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_LinearGradientBrush.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_LinearGradientBrush.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UI.RuntimeTests.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Imaging;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class LinearGradientBrush_Tests
+	{
+		[TestMethod]
+		public async Task When_Opacity_Is_Specified()
+		{
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+			const string Coral = "#FFFF8080";
+			var SUT = new LinearGradientBrush_Opacity();
+			var result = await TakeScreenshot(SUT);
+			var grid = SUT.GetRelativeCoords(SUT.TestGrid);
+
+			ImageAssert.HasColorAt(result, grid.CenterX, grid.CenterY, Coral, tolerance: 20);
+		}
+		private async Task<RawBitmap> TakeScreenshot(FrameworkElement SUT)
+		{
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			var renderer = new RenderTargetBitmap();
+			await WindowHelper.WaitForIdle();
+			await renderer.RenderAsync(SUT);
+			var result = await RawBitmap.From(renderer, SUT);
+			await WindowHelper.WaitForIdle();
+			return result;
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_SolidColorBrush.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_SolidColorBrush.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UI.RuntimeTests.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation.Metadata;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Imaging;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public class SolidColorBrush_Tests
+	{
+		[TestMethod]
+		public async Task When_SolidColorBrush_Color_Changed()
+		{
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+
+			const string Green = "#FF008000";
+			const string Chestnut = "#FFCD5C5C";
+			const string Violet = "#FFEE82EE";
+			const string Gold = "#FFB8860B";
+			const string Blue = "#FF0000FF";
+#if Android
+			const int offset = 0;
+#else 
+			const int offset = 2;
+#endif
+			var SUT = new SolidColorBrush_ColorChanged();
+			WindowHelper.WindowContent = SUT;
+			var initial = await TakeScreenshot(SUT);
+
+			var border = SUT.GetRelativeCoords(SUT.ToggleableBorder);
+			var grid = SUT.GetRelativeCoords(SUT.ToggleableGrid);
+			var ellipse = SUT.GetRelativeCoords(SUT.ToggleableEllipse);
+			var fillEllipse = SUT.GetRelativeCoords(SUT.ToggleableFillEllipse);
+
+			var data = new (RelativeCoords view, string InitialColor)[]
+			{
+				(border, Green),
+				(grid, Chestnut),
+				(ellipse, Violet),
+			};
+
+			await WindowHelper.WaitForIdle();
+
+			foreach (var (view, initialColor) in data)
+			{
+				ImageAssert.HasColorAt(initial, view.CenterX, view.Y + offset, initialColor);
+			}
+			
+			ImageAssert.HasColorAt(initial, fillEllipse.CenterX, fillEllipse.CenterY, Gold);
+
+			WindowHelper.WindowContent = SUT;
+			SUT.PaintItBlue();
+			await WindowHelper.WaitForIdle();
+
+			var borderChanged = await TakeScreenshot(SUT);
+
+			foreach (var (view, _) in data)
+			{
+				ImageAssert.HasColorAt(borderChanged, view.CenterX, view.Y + 2, Blue);
+			}
+
+			await WindowHelper.WaitForIdle();
+			ImageAssert.HasColorAt(borderChanged, fillEllipse.CenterX, fillEllipse.CenterY, Blue);
+		}
+		private async Task<RawBitmap> TakeScreenshot(FrameworkElement SUT)
+		{
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+			var renderer = new RenderTargetBitmap();
+			await WindowHelper.WaitForIdle();
+			await renderer.RenderAsync(SUT);
+			var result = await RawBitmap.From(renderer, SUT);
+			await WindowHelper.WaitForIdle();
+			return result;
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Gradient_Brush/LinearGradientBrush_Opacity.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Gradient_Brush/LinearGradientBrush_Opacity.xaml
@@ -1,0 +1,23 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.LinearGradientBrush_Opacity"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid x:Name="TestGrid"
+          x:FieldModifier="Public"
+          Width="200"
+          Height="200">
+        <Grid.Background>
+            <LinearGradientBrush StartPoint="0,0" EndPoint="1,1" Opacity="0.5">
+                <!-- Making it single color to easily test the opacity property -->
+                <GradientStop Color="Red" Offset="0.0" />
+                <GradientStop Color="Red" Offset="1.0" />
+            </LinearGradientBrush>
+        </Grid.Background>
+
+        <TextBlock FontSize="20" />
+    </Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Gradient_Brush/LinearGradientBrush_Opacity.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Gradient_Brush/LinearGradientBrush_Opacity.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+    public sealed partial class LinearGradientBrush_Opacity : Page
+	{
+		public LinearGradientBrush_Opacity()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Image_Brush/ImageBrush_WriteableBitmap.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Image_Brush/ImageBrush_WriteableBitmap.xaml
@@ -1,0 +1,15 @@
+﻿<Page
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.ImageBrush_WriteableBitmap"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+        <TextBlock Text="You should see 2 identical blue violet squares." />
+        <Border Background="BlueViolet" Width="20" Height="20" Margin="10" />
+        <Border x:Name="SUT" x:FieldModifier="Public" Width="20" Height="20" />
+    </StackPanel>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Image_Brush/ImageBrush_WriteableBitmap.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Image_Brush/ImageBrush_WriteableBitmap.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI.Samples;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	public sealed partial class ImageBrush_WriteableBitmap : Page
+	{
+		public ImageBrush_WriteableBitmap()
+		{
+			this.InitializeComponent();
+
+			Loaded += OnSampleLoaded;
+		}
+
+		private void OnSampleLoaded(object sender, RoutedEventArgs e)
+		{
+			const int w = 10, h = 10;
+
+			var pixel = new[] { Colors.BlueViolet.B, Colors.BlueViolet.G, Colors.BlueViolet.R, Colors.BlueViolet.A };
+			var bitmap = new WriteableBitmap(w, h);
+
+			using (var pixels = bitmap.PixelBuffer.AsStream())
+			{
+				for (var i = 0; i < bitmap.PixelBuffer.Length; i += pixel.Length)
+				{
+					pixels.Write(pixel, 0, pixel.Length);
+				}
+			}
+
+			var brush = new ImageBrush
+			{
+				ImageSource = bitmap,
+				Stretch = Stretch.Fill
+			};
+			SUT.Background = brush;
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Reveal_Brush/RevealBrush_Fallback.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Reveal_Brush/RevealBrush_Fallback.xaml
@@ -1,0 +1,52 @@
+﻿<UserControl x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.RevealBrush_Fallback"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+	<UserControl.Resources>
+		<RevealBackgroundBrush x:Name="OrangeCrush"
+							   Color="Orange"
+							   FallbackColor="Orange" />
+	</UserControl.Resources>
+
+	<StackPanel>
+		<TextBlock x:Name="StatusTextBlock"
+				   Text="Initial" />
+
+		<Grid Background="{StaticResource OrangeCrush}"
+			  x:Name="RevealGrid"
+			  x:FieldModifier="Public"
+			  Margin="10"
+			  Width="120"
+			  Height="55">
+		</Grid>
+		<Grid CornerRadius="10"
+			  Background="{StaticResource OrangeCrush}"
+			  x:Name="RevealGridCR"
+			  x:FieldModifier="Public"
+			  Margin="10"
+			  Width="120"
+			  Height="55">
+		</Grid>
+
+		<Border Background="{StaticResource OrangeCrush}"
+				x:Name="RevealBorder"
+				x:FieldModifier="Public"
+				Margin="10"
+				Width="120"
+				Height="55">
+		</Border>
+		<Border CornerRadius="10"
+				Background="{StaticResource OrangeCrush}"
+				x:Name="RevealBorderCR"
+				x:FieldModifier="Public"
+				Margin="10"
+				Width="120"
+				Height="55">
+		</Border>
+
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Reveal_Brush/RevealBrush_Fallback.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Reveal_Brush/RevealBrush_Fallback.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+	public sealed partial class RevealBrush_Fallback : UserControl
+	{
+		public RevealBrush_Fallback()
+		{
+			this.InitializeComponent();
+		}
+
+		public void MakeItGreen()
+		{
+			OrangeCrush.Color = Colors.ForestGreen;
+			OrangeCrush.FallbackColor = Colors.ForestGreen;
+			StatusTextBlock.Text = "Color changed";
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Solid_Color/SolidColorBrush_Color_Changed.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Solid_Color/SolidColorBrush_Color_Changed.xaml
@@ -1,0 +1,95 @@
+﻿<UserControl x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media.SolidColorBrush_ColorChanged"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="400">
+
+    <StackPanel Margin="0,50,0,0"
+                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <TextBlock x:Name="StatusTextBlock"
+                   Text="Unset"
+                   Margin="3" />
+        <Grid HorizontalAlignment="Left"
+              VerticalAlignment="Center">
+            <Border Width="190"
+                    Height="70"
+                    x:Name="ToggleableBorder"
+                    x:FieldModifier="Public"
+                    Margin="3"
+                    CornerRadius="5"
+                    BorderThickness="15">
+                <Border.BorderBrush>
+                    <SolidColorBrush Color="Green" />
+                </Border.BorderBrush>
+            </Border>
+            <Rectangle x:Name="ToggleableBorderViewfinder"
+                       Width="15"
+                       Margin="3"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Stretch"
+                       Fill="Transparent" />
+        </Grid>
+        <Grid HorizontalAlignment="Left"
+              VerticalAlignment="Center">
+            <Grid Width="190"
+                  Height="70"
+                  x:Name="ToggleableGrid"
+                  x:FieldModifier="Public"
+                  Margin="3"
+                  CornerRadius="5"
+                  BorderThickness="15">
+                <Grid.BorderBrush>
+                    <SolidColorBrush Color="IndianRed" />
+                </Grid.BorderBrush>
+            </Grid>
+            <Rectangle x:Name="ToggleableGridViewfinder"
+                       Width="15"
+                       Margin="3"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Stretch"
+                       Fill="Transparent" />
+        </Grid>
+        <Grid HorizontalAlignment="Left"
+              VerticalAlignment="Center">
+            <Ellipse Width="190"
+                     Height="70"
+                     x:Name="ToggleableEllipse"
+                     x:FieldModifier="Public"
+                     StrokeThickness="15"
+                     Margin="3">
+                <Ellipse.Stroke>
+                    <SolidColorBrush Color="Violet" />
+                </Ellipse.Stroke>
+            </Ellipse>
+            <Rectangle x:Name="ToggleableEllipseViewfinder"
+                       Width="15"
+                       Margin="3"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Stretch"
+                       Fill="Transparent" />
+        </Grid>
+        <Grid HorizontalAlignment="Left"
+              VerticalAlignment="Center">
+            <Ellipse Width="190"
+                     Height="70"
+                     x:Name="ToggleableFillEllipse"
+                     x:FieldModifier="Public"
+                     StrokeThickness="15"
+                     Stroke="Transparent"
+                     Margin="3">
+                <Ellipse.Fill>
+                    <SolidColorBrush Color="DarkGoldenrod" />
+                </Ellipse.Fill>
+            </Ellipse>
+            <Rectangle x:Name="ToggleableFillEllipseViewfinder"
+                       Width="15"
+                       Margin="3"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Stretch"
+                       Fill="Transparent" />
+        </Grid>
+    </StackPanel>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Solid_Color/SolidColorBrush_Color_Changed.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Solid_Color/SolidColorBrush_Color_Changed.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
+{
+		public sealed partial class SolidColorBrush_ColorChanged : UserControl
+	{
+		public SolidColorBrush_ColorChanged()
+		{
+			this.InitializeComponent();
+		}
+
+		public void PaintItBlue()
+		{
+			(ToggleableBorder.BorderBrush as SolidColorBrush).Color = Colors.Blue;
+			(ToggleableGrid.BorderBrush as SolidColorBrush).Color = Colors.Blue;
+			(ToggleableEllipse.Stroke as SolidColorBrush).Color = Colors.Blue;
+			(ToggleableFillEllipse.Fill as SolidColorBrush).Color = Colors.Blue;
+			StatusTextBlock.Text = "Set";
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #9811

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- When_EllipseGeometry() and  When_LineGeometry() were only implemented for Browser Platform. 


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
- When_EllipseGeometry() and  When_LineGeometry() are now implemented for other platform in Runtime.
- When_Opacity_Is_Specified() and When_UseWriteablBitmapAsImageBrushSource() have been moved for every platform beside Browser.
- When_FallbackColor_Set()  and When_SolidColorBrush_Color_Changed() have a variant implemented in runtime but the original Sample test have been left since it implies some light user interaction.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
<!-- Please provide any additional information if necessary -->