### PR TITLE
docs: Update deprecated 'dotnet new -i' usage

### DIFF
--- a/doc/articles/get-started-dotnet-new.md
+++ b/doc/articles/get-started-dotnet-new.md
@@ -4,7 +4,7 @@ The Uno Platform provides a set of command-line templates to create cross-platfo
 
 To install the templates, type the following:
 ```
-dotnet new -i Uno.ProjectTemplates.Dotnet
+dotnet new install Uno.ProjectTemplates.Dotnet
 ```
 
 If you need to determine the parameters available for a template use `dotnet new [templatename] -h`.


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Documentation content changes

Running `dotnet new -i Uno.ProjectTemplates.Dotnet` now produces a warning:

> Warning: use of 'dotnet new --install' is deprecated. Use 'dotnet new install' instead.
> For more information, run:
>    dotnet new install -h

Switch to  `dotnet new install Uno.ProjectTemplates.Dotnet` in the docs