### PR TITLE
build: Fix race condition when generating mixins

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-t4": {
+      "version": "2.3.0-preview-0041-g0bb7f1d477",
+      "commands": [
+        "t4"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Remove everything beginning with a dot
 .*/
+!.config/
 !.github/
 !.devcontainer/
 

--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -46,7 +46,6 @@
 	<Target Name="PrepareBuildAssets" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)'==''">
 		<Message Text="Building for $(Configuration) and $(Platform) BuildReason:$(BUILD_REASON) Version:$(GitVersion_SemVer) UNO_UWP_BUILD:$(UNO_UWP_BUILD)" />
 
-		<CallTarget Targets="BuildT4Generator" />
 		<CallTarget Targets="UpdateFileVersions;UpdateTasksSHA" Condition="$(_isWindows)" />
 		<CallTarget Targets="PrepareNuGetPackage" />
 	</Target>
@@ -261,7 +260,7 @@
 
 	</Target>
 
-	<Target Name="BuildSyncGenerator" DependsOnTargets="BuildT4Generator">
+	<Target Name="BuildSyncGenerator">
 		<!-- Restore the nuget packages for the whole solution -->
 		<MSBuild Properties="Configuration=Release;InformationalVersion=$(GITVERSION_InformationalVersion);CI_Build=true;_IsCIBuild=true;UnoUIDisableNet7Build=true"
 				 Projects="filters\Uno.UI-packages-no-net6.slnf;filters\Uno.UI-packages-wasm.slnf;filters\Uno.UI-packages-skia.slnf"
@@ -283,10 +282,6 @@
 						 Targets="GenerateMixins"
 						 RebaseOutputs="false"
 						 BuildInParallel="true" />
-	</Target>
-
-	<Target Name="BuildT4Generator">
-		<MSBuild Projects="..\src\Uno.UI\Uno.UI.csproj" Targets="UnoInstallDotnetT4" />
 	</Target>
 
 	<Target Name="GenerateDoc" DependsOnTargets="BuildSyncGenerator">

--- a/src/Uno.UI/MixinGeneration.targets
+++ b/src/Uno.UI/MixinGeneration.targets
@@ -95,28 +95,11 @@
 	<MixinOutput Include="$(MSBuildThisFileDirectory)Mixins\macOS\FrameworkElementMixins.g.cs" Condition="$(IsXamarinMac)" />	
   </ItemGroup>
 
-	<Target Name="UnoDefineInstallDotnetT4"
-			  BeforeTargets="BeforeBuild;_InnerGenerateMixins">
-		<!--
-		Needs to be defined for _InnerGenerateMixins to work, but also
-		executed late for IntermediateOutputPath to be defined
-		-->
-		<PropertyGroup>
-			<_UnoDotnetT4ToolBasePath>$(MSBuildProjectDirectory)/$(IntermediateOutputPath)dotnet-tools</_UnoDotnetT4ToolBasePath>
-		</PropertyGroup>
-	</Target>
-
 	<Target Name="UnoInstallDotnetT4"
-			BeforeTargets="BeforeBuild"
-			DependsOnTargets="UnoDefineInstallDotnetT4">
+			BeforeTargets="BeforeBuild">
 
-		<!-- Avoid dotnet tool to find multiple target projects-->
-		<MakeDir Directories="$(MSBuildProjectDirectory)/$(IntermediateOutputPath)"/>
-
-		<Exec Command="dotnet tool install dotnet-t4 --version 2.3.0-preview-0041-g0bb7f1d477 --tool-path $(_UnoDotnetT4ToolBasePath)"
-			  StandardOutputImportance="Low"
-			  WorkingDirectory="$(MSBuildProjectDirectory)/$(IntermediateOutputPath)"
-			  Condition="!exists($(_UnoDotnetT4ToolBasePath))" />
+		<Exec Command="dotnet tool restore --add-source PackageCache" 
+	    	WorkingDirectory="$(MSBuildThisFileDirectory)..\" />
 	</Target>
 
 	<!--
@@ -130,21 +113,26 @@
 		DependsOnTargets="UnoInstallDotnetT4"
 		Condition="'$(DesignTimeBuild)' != 'true'">
 
+    <PropertyGroup>
+      <FirstTargetFramework Condition=" '$(TargetFrameworks)' == '' ">$(TargetFramework)</FirstTargetFramework>
+      <FirstTargetFramework Condition=" '$(FirstTargetFrameworks)' == '' ">$(TargetFrameworks.Split(';')[0])</FirstTargetFramework>
+    </PropertyGroup>
+
 	<ItemGroup>
 	  <MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsMonoAndroid)">
-		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\Android\BaseActivity.Callbacks.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\Android\BaseActivity.Callbacks.cs;Configuration=$(Configuration);Platform=$(Platform);IntermediateOutputPath=$(IntermediateOutputPath)</Properties>
+		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\Android\BaseActivity.Callbacks.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\Android\BaseActivity.Callbacks.cs;Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(FirstTargetFramework)</Properties>
 	  </MixinDefinition>
 	  <MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsMonoAndroid)">
-		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\Android\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\Android\FrameworkElementMixins.cs;Configuration=$(Configuration);Platform=$(Platform);IntermediateOutputPath=$(IntermediateOutputPath)</Properties>
+		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\Android\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\Android\FrameworkElementMixins.cs;Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(FirstTargetFramework)</Properties>
 	  </MixinDefinition>
 	  <MixinDefinition Include="$(MSBuildThisFileFullPath)">
-		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\DependencyPropertyMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\DependencyPropertyMixins.cs;Configuration=$(Configuration);Platform=$(Platform);IntermediateOutputPath=$(IntermediateOutputPath)</Properties>
+		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\DependencyPropertyMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\DependencyPropertyMixins.cs;Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(FirstTargetFramework)</Properties>
 	  </MixinDefinition>
 	  <MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsXamarinIOS)">
-		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\iOS\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\iOS\FrameworkElementMixins.cs;Configuration=$(Configuration);Platform=$(Platform);IntermediateOutputPath=$(IntermediateOutputPath)</Properties>
+		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\iOS\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\iOS\FrameworkElementMixins.cs;Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(FirstTargetFramework)</Properties>
 	  </MixinDefinition>
 	  <MixinDefinition Include="$(MSBuildThisFileFullPath)" Condition="$(IsXamarinMac)">
-		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\macOS\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\macOS\FrameworkElementMixins.cs;Configuration=$(Configuration);Platform=$(Platform);IntermediateOutputPath=$(IntermediateOutputPath)</Properties>
+		<Properties>InputFile=$(MSBuildThisFileDirectory)Mixins\macOS\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\macOS\FrameworkElementMixins.cs;Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(FirstTargetFramework)</Properties>
 	  </MixinDefinition>
 	</ItemGroup>
 
@@ -169,6 +157,6 @@
   </Target>
 
   <Target Name="_InnerGenerateMixins">
-	  <Exec Command="$(_UnoDotnetT4ToolBasePath)\t4 $(InputFile) -o $(OutputPath)" />
+		<Exec Command="dotnet tool run t4 $(InputFile) -o $(OutputPath)" />
   </Target>
 </Project>


### PR DESCRIPTION
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

When building `Uno.UI.Skia` for net7.0 and netstandard2.0 in parallel, `_InnerGenerateMixins` runs twice in parallel, and can cause the following failure:

```
Could not write output file 'D:\a\1\s\src\Uno.UI\Mixins\DependencyPropertyMixins.g.cs':
System.IO.IOException: The process cannot access the file 'D:\a\1\s\src\Uno.UI\Mixins\DependencyPropertyMixins.g.cs' because it is being used by another process.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.FileStreamHelpers.ChooseStrategy(FileStream fileStream, String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
   at System.IO.StreamWriter.ValidateArgsAndOpenPath(String path, Boolean append, Encoding encoding, Int32 bufferSize)
   at System.IO.File.WriteAllText(String path, String contents, Encoding encoding)
   at Mono.TextTemplating.TextTransform.MainInternal(String[] args) in /_/dotnet-t4/TextTransform.cs:line 234
```

![image](https://user-images.githubusercontent.com/31348972/197331739-4a07c2ca-aa83-40d4-80f5-200fa35c4a60.png)


## What is the new behavior?

![image](https://user-images.githubusercontent.com/31348972/197341156-34d00276-b8c1-4965-848b-34587ba1aac1.png)

`_InnerGenerateMixins` is now run once only.

This is because next runs of `GenerateMixins` are skipped:

![image](https://user-images.githubusercontent.com/31348972/197341228-04a3773b-5b5f-4253-839a-6e31b1814fce.png)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
