### PR TITLE
fix: Don't fail when Uno.UI is included in an WinAppSDK app

### DIFF
--- a/build/Uno.WinUI.MSAL.nuspec
+++ b/build/Uno.WinUI.MSAL.nuspec
@@ -1,97 +1,100 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata minClientVersion="5.0">
-	<id>Uno.WinUI.MSAL</id>
-	<version>0.0.1</version>
-	<authors>nventive</authors>
-	<icon>uno.png</icon>
-	<projectUrl>https://github.com/unoplatform/uno</projectUrl>
-	<license type="expression">Apache-2.0</license>
-	<description>This package provides the extensions to MSAL (Microsoft.Identity.Client) for an Uno Platform application.</description>
-	<copyright>nventive</copyright>
-	<repository type="git" url="https://github.com/unoplatform/uno.git" branch="$branch$" commit="$commitid$" />
-	<dependencies>
-	  <group targetFramework="MonoAndroid12.0">
-		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-	  </group>
-	  <group targetFramework="MonoAndroid13.0">
-		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-	  </group>
-	  <group targetFramework="Xamarin.iOS1.0">
-		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-	  </group>
-	  <group targetFramework="Xamarin.Mac2.0">
-		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-	  </group>
-		<group targetFramework=".NETStandard2.0">
-			<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-			<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-		</group>
-		<group targetFramework="net7.0">
-			<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-			<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-		</group>
-		<group targetFramework="UAP10.0.18362">
-		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-	  </group>
-	  <group targetFramework="net6.0-android30.0">
-		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-	  </group>
-	  <group targetFramework="net6.0-ios13.6">
-		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-	  </group>
-	  <group targetFramework="net6.0-maccatalyst13.5">
-		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-	  </group>
-	  <group targetFramework="net6.0-macos10.15">
-		<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-		<dependency id="Microsoft.Identity.Client" version="4.15.0" />
-	  </group>
-	</dependencies>
-	<frameworkAssemblies>
-	  <frameworkAssembly assemblyName="Java.Interop" targetFramework="MonoAndroid13.0, MonoAndroid12.0" />
-	</frameworkAssemblies>
-  </metadata>
+	<metadata minClientVersion="5.0">
+		<id>Uno.WinUI.MSAL</id>
+		<version>0.0.1</version>
+		<authors>nventive</authors>
+		<icon>uno.png</icon>
+		<projectUrl>https://github.com/unoplatform/uno</projectUrl>
+		<license type="expression">Apache-2.0</license>
+		<description>This package provides the extensions to MSAL (Microsoft.Identity.Client) for an Uno Platform application.</description>
+		<copyright>nventive</copyright>
+		<repository type="git" url="https://github.com/unoplatform/uno.git" branch="$branch$" commit="$commitid$" />
+		<dependencies>
+			<group targetFramework="MonoAndroid12.0">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="MonoAndroid13.0">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="Xamarin.iOS1.0">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="Xamarin.Mac2.0">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework=".NETStandard2.0">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="net6.0-windows">
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="net7.0">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="UAP10.0.18362">
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="net6.0-android30.0">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="net6.0-ios13.6">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="net6.0-maccatalyst13.5">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+			<group targetFramework="net6.0-macos10.15">
+				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
+				<dependency id="Microsoft.Identity.Client" version="4.15.0" />
+			</group>
+		</dependencies>
+		<frameworkAssemblies>
+			<frameworkAssembly assemblyName="Java.Interop" targetFramework="MonoAndroid13.0, MonoAndroid12.0" />
+		</frameworkAssemblies>
+	</metadata>
 
-  <files>
-	<file src="..\src\Common\uno.png" target="/" />
-	
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.Reference\Release\netstandard2.0\Uno.UI.MSAL.*" target="lib\netstandard2.0" />
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.Reference\Release\net7.0\Uno.UI.MSAL.*" target="lib\net7.0" />
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\xamarinios10\Uno.UI.MSAL.*" target="lib\xamarinios10" />
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\xamarinmac20\Uno.UI.MSAL.*" target="lib\xamarinmac20" />
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\MonoAndroid13.0\Uno.UI.MSAL.*" target="lib\MonoAndroid13.0" />
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\MonoAndroid12.0\Uno.UI.MSAL.*" target="lib\MonoAndroid12.0" />
+	<files>
+		<file src="..\src\Common\uno.png" target="/" />
 
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\uap10.0.18362\Uno.UI.MSAL.*" target="lib\uap10.0.18362" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.Reference\Release\netstandard2.0\Uno.UI.MSAL.*" target="lib\netstandard2.0" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.Reference\Release\net7.0\Uno.UI.MSAL.*" target="lib\net7.0" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\xamarinios10\Uno.UI.MSAL.*" target="lib\xamarinios10" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\xamarinmac20\Uno.UI.MSAL.*" target="lib\xamarinmac20" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\MonoAndroid13.0\Uno.UI.MSAL.*" target="lib\MonoAndroid13.0" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\MonoAndroid12.0\Uno.UI.MSAL.*" target="lib\MonoAndroid12.0" />
 
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-android\Uno.UI.MSAL.*" target="lib\net6.0-android" />
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-ios\Uno.UI.MSAL.*" target="lib\net6.0-ios" />
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-maccatalyst\Uno.UI.MSAL.*" target="lib\net6.0-maccatalyst" />
-	<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-macos\Uno.UI.MSAL.*" target="lib\net6.0-macos" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Release\uap10.0.18362\Uno.UI.MSAL.*" target="lib\uap10.0.18362" />
 
-	<!-- Build targets -->
-	<file src="..\src\AddIns\Uno.UI.MSAL\buildTransitive\*" target="buildTransitive" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-android\Uno.UI.MSAL.*" target="lib\net6.0-android" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-ios\Uno.UI.MSAL.*" target="lib\net6.0-ios" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-maccatalyst\Uno.UI.MSAL.*" target="lib\net6.0-maccatalyst" />
+		<file src="..\src\AddIns\Uno.UI.MSAL\bin\Uno.UI.MSAL.net6\Release\net6.0-macos\Uno.UI.MSAL.*" target="lib\net6.0-macos" />
 
-	  <!-- netstandard2.0 WebAssembly -->
-	  <file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Wasm\Release\netstandard2.0\Uno.UI.MSAL.*" target="uno-runtime\netstandard2.0\webassembly" />
+		<!-- Build targets -->
+		<file src="..\src\AddIns\Uno.UI.MSAL\buildTransitive\*" target="buildTransitive" />
 
-	  <!-- netstandard2.0 Skia -->
-	  <file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Skia\Release\netstandard2.0\Uno.UI.MSAL.*" target="uno-runtime\netstandard2.0\skia" />
+		<!-- netstandard2.0 WebAssembly -->
+		<file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Wasm\Release\netstandard2.0\Uno.UI.MSAL.*" target="uno-runtime\netstandard2.0\webassembly" />
 
-	  <!-- net7.0 WebAssembly -->
-	  <file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Wasm\Release\net7.0\Uno.UI.MSAL.*" target="uno-runtime\net7.0\webassembly" />
+		<!-- netstandard2.0 Skia -->
+		<file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Skia\Release\netstandard2.0\Uno.UI.MSAL.*" target="uno-runtime\netstandard2.0\skia" />
 
-	  <!-- net7.0 Skia -->
-	  <file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Skia\Release\net7.0\Uno.UI.MSAL.*" target="uno-runtime\net7.0\skia" />
+		<!-- net7.0 WebAssembly -->
+		<file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Wasm\Release\net7.0\Uno.UI.MSAL.*" target="uno-runtime\net7.0\webassembly" />
 
-  </files>
+		<!-- net7.0 Skia -->
+		<file src="..\src\AddIns\Uno.UI.MSAL\Bin\Uno.UI.MSAL.Skia\Release\net7.0\Uno.UI.MSAL.*" target="uno-runtime\net7.0\skia" />
+
+	</files>
 
 </package>

--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -719,6 +719,17 @@
 	<file src="uno.winui.runtime-replace.targets" target="buildTransitive\net6.0-macos" />
 	<file src="uno.winui.runtime-replace.targets" target="buildTransitive\net5.0-windows" />
 
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\MonoAndroid" />
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\xamarinios10" />
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\xamarinmac20" />
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\netstandard2.0" />
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\net7.0" />
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\net6.0-android30.0" />
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\net6.0-ios" />
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\net6.0-maccatalyst" />
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\net6.0-macos" />
+	<file src="uno.winui.winappsdk.targets" target="buildTransitive\net5.0-windows" />
+
 	<file src="..\src\SourceGenerators\Uno.UI.Tasks\Content\Uno.UI.Tasks*" target="buildTransitive\MonoAndroid" />
 	<file src="..\src\SourceGenerators\Uno.UI.Tasks\Content\Uno.UI.Tasks*" target="buildTransitive\xamarinios10" />
 	<file src="..\src\SourceGenerators\Uno.UI.Tasks\Content\Uno.UI.Tasks*" target="buildTransitive\xamarinmac20" />

--- a/build/uno.winui.targets
+++ b/build/uno.winui.targets
@@ -9,11 +9,5 @@
 	<Import Project="uno.winui.cross-runtime.targets" Condition="'$(WindowsAppSDKWinUI)'!='true'" />
 	<Import Project="uno.winui.single-project.targets" />
 	<Import Project="uno.winui.runtime-replace.targets" Condition="'$(WindowsAppSDKWinUI)'!='true'" />
-
-	<Target Name="_WinAppSDKNotSupported"
-			BeforeTargets="BeforeBuild"
-			Condition="'$(WindowsAppSDKWinUI)'=='True'">
-		<Error Code="UNOB0002"
-			   Text="Using Uno.WinUI in a WinAppSDK head project is not supported. You may be including a package that references Uno.WinUI indirectly and it must be removed. See https://aka.platform.uno/UNOB0002 for more details." />
-	</Target>
+	<Import Project="uno.winui.winappsdk.targets" Condition="'$(WindowsAppSDKWinUI)'=='true'" />
 </Project>

--- a/build/uno.winui.winappsdk.targets
+++ b/build/uno.winui.winappsdk.targets
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<Target Name="_UnoRemoveReferences"
+			BeforeTargets="FindReferenceAssembliesForReferences">
+		<ItemGroup>
+			<_UnoReferencePathToRemove Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)'=='Uno.UI' or %(ReferencePath.NuGetPackageId)'=='Uno.WinUI'" />
+			<ReferencePath Remove="@(_UnoReferencePathToRemove)" />
+
+			<!-- Clear items -->
+			<_UnoReferencePathToRemove Remove="@(_UnoReferencePathToRemove)" />
+		</ItemGroup>
+	</Target>
+
+</Project>

--- a/doc/articles/get-started-wizard.md
+++ b/doc/articles/get-started-wizard.md
@@ -126,6 +126,3 @@ This issue is caused by visual studio enforcing https connections for local cont
 In general, this error happens when the XAML parser detects a syntax error. Fixing the error generally fixes the build.
 
 This error may happen occasionally without any explicit error message, rebuilding the project may fix the issue.
-
-#### Error UNOB0002: Using Uno.WinUI in a WinAppSDK head project is not supported
-This This issue can arise when Uno.WinUI packages are included in a `.Windows` head project, which is not supported. You can fix this by removing the Uno.WinUI or the packages that transitively reference it. For example, including a reference to `Uno.CommunityToolkit.WinUI.*` will transitively include a reference to `Uno.WinUI`, and [the official community toolkit packages](uno-community-toolkit.md) must be used instead.


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Reverts https://github.com/unoplatform/uno/pull/10193 as it's a common case when using Uno UI libraries, to avoid breaking changes. This change removes all Uno.UI/Uno.WinUI references from the compilation to avoid incorrect references.
- Removes Uno.UI.MSAL dependency on Uno.UI for net6.0-windows targets

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
