### PR TITLE
fix(ListView): fe item removal cleanup

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1141,6 +1141,15 @@ namespace Windows.UI.Xaml.Controls
 			else if (element is ContentControl contentControl)
 			{
 				contentControl.ClearValue(DataContextProperty);
+
+				if (contentControl.ContentTemplate is { } ct && ct == ItemTemplate)
+				{
+					contentControl.ClearValue(ContentControl.ContentTemplateProperty);
+				}
+				else if (contentControl.ContentTemplateSelector is { } cts && cts == ItemTemplateSelector)
+				{
+					contentControl.ClearValue(ContentControl.ContentTemplateSelectorProperty);
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -573,6 +573,7 @@ namespace Windows.UI.Xaml.Controls
 					}
 
 					SaveContainersBeforeRemoveForIndexRepair(args.OldStartingIndex, args.OldItems.Count);
+					CleanUpContainers(args.OldStartingIndex, args.OldItems.Count);
 					RemoveItems(args.OldStartingIndex, args.OldItems.Count, section);
 					RepairIndices();
 
@@ -677,6 +678,20 @@ namespace Windows.UI.Xaml.Controls
 				containerPair.Key.SetValue(ItemsControl.IndexForItemContainerProperty, containerPair.Value);
 			}
 			_containersForIndexRepair.Clear();
+		}
+
+		private void CleanUpContainers(int startingIndex, int length)
+		{
+			if (ShouldItemsControlManageChildren) return;
+			
+			foreach (var container in MaterializedContainers)
+			{
+				var index = (int)container.GetValue(ItemsControl.IndexForItemContainerProperty);
+				if (startingIndex <= index && index < startingIndex + length)
+				{
+					CleanUpContainer(container);
+				}
+			}
 		}
 
 		internal override void OnItemsSourceGroupsChanged(object sender, NotifyCollectionChangedEventArgs args)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9620

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When an item of type `FrameworkElement` is removed from `ListView.Items`, it is not being properly removed and remains in the visual tree.

## What is the new behavior?
When removed, the item is detached from the visual tree.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.