### PR TITLE
ci: Split net6mobile and net7mobile

### DIFF
--- a/build/ci/.azure-devops-android-tests.yml
+++ b/build/ci/.azure-devops-android-tests.yml
@@ -35,7 +35,7 @@ jobs:
   - checkout: self
     clean: true
 
-  - template: templates/dotnet6-install-mac.yml
+  - template: templates/dotnet7-mobile-install-mac.yml
 
   - template: templates/nuget-cache.yml
     parameters:

--- a/build/ci/.azure-devops-package-net6-win.yml
+++ b/build/ci/.azure-devops-package-net6-win.yml
@@ -12,13 +12,29 @@ jobs:
 
   strategy:
     matrix:
-      UWP:
+      UWP_NET6:
         UNO_UWP_BUILD: true
-        XAML_FLAVOR_BUILD: UWP 
+        XAML_FLAVOR_BUILD: UWP
+        UnoDisableNet7Mobile: true
+        ZipFileTargetFramework: net6
 
-      WinUI:
+      WinUI_NET6:
         UNO_UWP_BUILD: false
         XAML_FLAVOR_BUILD: WinUI 
+        UnoDisableNet7Mobile: true
+        ZipFileTargetFramework: net6
+
+      UWP_NET7:
+        UNO_UWP_BUILD: true
+        XAML_FLAVOR_BUILD: UWP
+        UnoDisableNet6Mobile: true
+        ZipFileTargetFramework: net7
+
+      WinUI_NET7:
+        UNO_UWP_BUILD: false
+        XAML_FLAVOR_BUILD: WinUI 
+        UnoDisableNet6Mobile: true
+        ZipFileTargetFramework: net7
 
   variables:
     CombinedConfiguration: Release|Any CPU
@@ -48,7 +64,10 @@ jobs:
   - template: templates/download-winui-converted-tree.yml
 
   - template: templates/gitversion.yml
-  - template: templates/dotnet6-install-windows.yml
+
+  - template: templates/dotnet6-mobile-install-windows.yml
+  - template: templates/dotnet7-mobile-install-windows.yml
+
   - template: templates/install-windows-sdk.yml
 
   - powershell: |
@@ -60,12 +79,12 @@ jobs:
   - task: DotNetCoreCLI@2
     inputs:
       workingDirectory: Build
-      arguments: Uno.UI.Build.csproj /nr:false /r /m /t:PrepareBuildAssets "/p:CombinedConfiguration=$(CombinedConfiguration)" /detailedsummary /bl:$(build.artifactstagingdirectory)\build-$(GitVersion.FullSemVer)-netcoremobile-prepare-$(UNO_UWP_BUILD).binlog
+      arguments: Uno.UI.Build.csproj /nr:false /r /m /t:PrepareBuildAssets "/p:CombinedConfiguration=$(CombinedConfiguration)" /detailedsummary /bl:$(build.artifactstagingdirectory)\build-$(GitVersion.FullSemVer)-netcoremobile-$(ZipFileTargetFramework)-prepare-$(UNO_UWP_BUILD).binlog
 
   - task: DotNetCoreCLI@2
     inputs:
       workingDirectory: Build
-      arguments: Uno.UI.Build.csproj /r /m /t:BuildCINet6 "/p:CombinedConfiguration=$(CombinedConfiguration)" /detailedsummary /bl:$(build.artifactstagingdirectory)\build-$(GitVersion.FullSemVer)-netcoremobile-$(UNO_UWP_BUILD).binlog
+      arguments: Uno.UI.Build.csproj /r /m /t:BuildCINet6 "/p:CombinedConfiguration=$(CombinedConfiguration)" /detailedsummary /bl:$(build.artifactstagingdirectory)\build-$(GitVersion.FullSemVer)-netcoremobile-$(ZipFileTargetFramework)-$(UNO_UWP_BUILD).binlog
 
   - template: templates/copy-package-assets.yml
 
@@ -74,7 +93,7 @@ jobs:
       rootFolderOrFile: $(build.sourcesdirectory)\build-artifacts\bin-$(XAML_FLAVOR_BUILD)
       includeRootFolder: false
       archiveType: 'zip'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/windows-netcoremobile-bin-$(XAML_FLAVOR_BUILD).zip'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/windows-netcoremobile-$(ZipFileTargetFramework)-bin-$(XAML_FLAVOR_BUILD).zip'
 
   - task: PublishBuildArtifacts@1
     condition: always()

--- a/build/ci/.azure-devops-project-template-tests.yml
+++ b/build/ci/.azure-devops-project-template-tests.yml
@@ -56,7 +56,7 @@ jobs:
   # msbuild (and not `dotnet`), and VS 17.3 only supports building for .NET 6.
   - template: templates/dotnet-install.yml
 
-  - template: templates/dotnet6-install-windows.yml
+  - template: templates/dotnet7-mobile-install-windows.yml
   - template: templates/update-vs-components.yml
 
   - template: templates/install-windows-sdk.yml

--- a/build/ci/.azure-devops-winui-convert.yml
+++ b/build/ci/.azure-devops-winui-convert.yml
@@ -27,7 +27,7 @@ jobs:
     parameters:
       nugetPackages: $(NUGET_PACKAGES)
 
-  - template: templates/dotnet6-install-windows.yml
+  - template: templates/dotnet7-mobile-install-windows.yml
   - template: templates/dotnet-install.yml
   - template: templates/install-windows-sdk.yml
 

--- a/build/ci/templates/dotnet6-mobile-install-mac.yml
+++ b/build/ci/templates/dotnet6-mobile-install-mac.yml
@@ -1,0 +1,50 @@
+parameters:
+  DotNetVersion: '6.0.401'
+  UnoCheck_Version: '1.5.4'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/34b1a60f5c1c51604b47362781969dde46979fd5/manifests/uno.ui.manifest.json'
+  Dotnet_Root: '/usr/local/share/dotnet/'
+  Dotnet_Tools: '~/.dotnet/tools'
+
+steps:
+  - task: UseDotNet@2
+    displayName: install .NET 5
+    retryCountOnTaskFailure: 3
+    inputs:
+      version: 5.x
+      installationPath: ${{ parameters.Dotnet_Root }}
+
+  - task: UseDotNet@2
+    displayName: install .NET 3.1
+    retryCountOnTaskFailure: 3
+    inputs:
+      version: 3.1.x
+      installationPath: ${{ parameters.Dotnet_Root }}
+
+  # Required until .NET 6 installs properly using UseDotnet
+  # using preview builds
+  #- bash: |
+  #    export PATH="${{ parameters.Dotnet_Root }}:${{ parameters.Dotnet_Tools }}:$PATH"
+  #    curl -L https://raw.githubusercontent.com/dotnet/install-scripts/11b4eebe23d871c074364940d301c3eb53e7c7ec/src/dotnet-install.sh > dotnet-install.sh
+  #    sh dotnet-install.sh --version ${{ parameters.DotNetVersion }} --install-dir $DOTNET_ROOT --verbose
+  #    dotnet --list-sdks
+  #    echo "##vso[task.setvariable variable=PATH]$PATH"
+  #  displayName: install .NET ${{ parameters.DotNetVersion }}
+  #  retryCountOnTaskFailure: 3
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK ${{ parameters.DotNetVersion }}'
+    retryCountOnTaskFailure: 3
+    condition: and(succeeded(), ne(variables.UnoDisableNet6Mobile, 'true'))
+    inputs:
+      packageType: sdk
+      version: ${{ parameters.DotNetVersion }}
+      includePreviewVersions: true
+
+  - template: jdk-setup.yml
+
+  - bash: |
+      dotnet tool update --global uno.check --version ${{ parameters.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json
+      uno-check --ci --non-interactive --fix --skip androidsdk --skip gtk3 --skip xcode --skip vswin --skip vsmac --manifest ${{ parameters.UnoCheck_Manifest }}
+    displayName: Install .NET Workloads
+    condition: and(succeeded(), ne(variables.UnoDisableNet6Mobile, 'true'))
+    retryCountOnTaskFailure: 3

--- a/build/ci/templates/dotnet6-mobile-install-windows.yml
+++ b/build/ci/templates/dotnet6-mobile-install-windows.yml
@@ -1,0 +1,36 @@
+parameters:
+  DotNetVersion: '6.0.401'
+  UnoCheck_Version: '1.5.4'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/34b1a60f5c1c51604b47362781969dde46979fd5/manifests/uno.ui.manifest.json'
+
+steps:
+
+  # Required until .NET 6 installs properly on Windows using UseDotnet
+  # using preview builds
+  #- powershell: |
+  #    $ProgressPreference = 'SilentlyContinue'
+  #    Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+  #    & .\dotnet-install.ps1 -Version ${{ parameters.DotNetVersion }} -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
+  #    & dotnet --list-sdks
+  #  displayName: Install .NET ${{ parameters.DotNetVersion }}
+  #  errorActionPreference: stop
+  #  retryCountOnTaskFailure: 3
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK ${{ parameters.DotNetVersion }}'
+    condition: and(succeeded(), ne(variables.UnoDisableNet6Mobile, 'true'))
+    retryCountOnTaskFailure: 3
+    inputs:
+      packageType: sdk
+      version: ${{ parameters.DotNetVersion }}
+      includePreviewVersions: true
+
+  - template: jdk-setup.yml
+    
+  - powershell: |
+      & dotnet tool update --global uno.check --version ${{ parameters.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json
+      & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --manifest ${{ parameters.UnoCheck_Manifest }}
+    displayName: Install .NET Workloads
+    errorActionPreference: continue
+    condition: and(succeeded(), ne(variables.UnoDisableNet6Mobile, 'true'))
+    ignoreLASTEXITCODE: true
+    retryCountOnTaskFailure: 3

--- a/build/ci/templates/dotnet7-mobile-install-mac.yml
+++ b/build/ci/templates/dotnet7-mobile-install-mac.yml
@@ -34,6 +34,7 @@ steps:
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK ${{ parameters.DotNetVersion }}'
     retryCountOnTaskFailure: 3
+    condition: and(succeeded(), ne(variables.UnoDisableNet7Mobile, 'true'))
     inputs:
       packageType: sdk
       version: ${{ parameters.DotNetVersion }}
@@ -45,4 +46,5 @@ steps:
       dotnet tool update --global uno.check --version ${{ parameters.UnoCheck_Version }} --add-source https://api.nuget.org/v3/index.json
       uno-check --ci --non-interactive --fix --skip androidsdk --skip gtk3 --skip xcode --skip vswin --skip vsmac --manifest ${{ parameters.UnoCheck_Manifest }}
     displayName: Install .NET Workloads
+    condition: and(succeeded(), ne(variables.UnoDisableNet7Mobile, 'true'))
     retryCountOnTaskFailure: 3

--- a/build/ci/templates/dotnet7-mobile-install-windows.yml
+++ b/build/ci/templates/dotnet7-mobile-install-windows.yml
@@ -17,6 +17,7 @@ steps:
   #  retryCountOnTaskFailure: 3
   - task: UseDotNet@2
     displayName: 'Use .NET Core SDK ${{ parameters.DotNetVersion }}'
+    condition: and(succeeded(), ne(variables.UnoDisableNet7Mobile, 'true'))
     retryCountOnTaskFailure: 3
     inputs:
       packageType: sdk
@@ -30,5 +31,6 @@ steps:
       & uno-check -v --ci --non-interactive --fix --skip xcode --skip gtk3 --skip vswin --skip vsmac --manifest ${{ parameters.UnoCheck_Manifest }}
     displayName: Install .NET Workloads
     errorActionPreference: continue
+    condition: and(succeeded(), ne(variables.UnoDisableNet7Mobile, 'true'))
     ignoreLASTEXITCODE: true
     retryCountOnTaskFailure: 3

--- a/src/Uno.CrossTargetting.props
+++ b/src/Uno.CrossTargetting.props
@@ -23,7 +23,9 @@
 	<NoWarn>$(NoWarn);0105</NoWarn>
   </PropertyGroup>
 
-  <!--
+	<Import Project="uno.mobile-cross-targeting-disable.props" />
+	
+	<!--
   List of known constants:
   - __SKIA__: Used when building for the Skia backend
   - __WASM__: Used when building for the WebAssembly backend

--- a/src/netcore-build.props
+++ b/src/netcore-build.props
@@ -1,8 +1,9 @@
 <Project ToolsVersion="15.0">
 
-  <PropertyGroup Condition="'$(UnoUIDisableNet7Build)'=='' and '$(MSBuildRuntimeType)'=='Core'">
-	<TargetFrameworks>$(TargetFrameworks);net7.0</TargetFrameworks>
-	<TargetFrameworksCI>$(TargetFrameworks);net7.0</TargetFrameworksCI>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(UnoUIDisableNet7Build)'=='' and '$(MSBuildRuntimeType)'=='Core'">
+		<TargetFrameworks>$(TargetFrameworks);net7.0</TargetFrameworks>
+		<TargetFrameworksCI>$(TargetFrameworks);net7.0</TargetFrameworksCI>
+	</PropertyGroup>
 
+	<Import Project="uno.mobile-cross-targeting-disable.props" />
 </Project>

--- a/src/uno.mobile-cross-targeting-disable.props
+++ b/src/uno.mobile-cross-targeting-disable.props
@@ -1,0 +1,24 @@
+<Project ToolsVersion="15.0">
+
+	<!-- CI helper to split net6 and net7 builds and actually build on net6 the net6.0-* targets -->
+	<PropertyGroup Condition="'$(UnoDisableNet6Mobile)'=='true'">
+		<_UnoFilteredTargetFrameworks>$(TargetFrameworks.Replace('net6.0-ios','').Replace('net6.0-android','').Replace('net6.0-maccatalyst','').Replace('net6.0-macos','').Trim(';'))</_UnoFilteredTargetFrameworks>
+
+		<!--
+		Results from property functions are escaped, causing itemgroup inclusion to be
+		done as a single string. Unescape restores `;` as a proper separator.
+		-->
+		<TargetFrameworks>$([MSBuild]::Unescape($(_UnoFilteredTargetFrameworks)))</TargetFrameworks>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(UnoDisableNet7Mobile)'=='true'">
+		<_UnoFilteredTargetFrameworks>$(TargetFrameworks.Replace('net7.0-ios','').Replace('net7.0-android','').Replace('net7.0-maccatalyst','').Replace('net7.0-macos','').Trim(';'))</_UnoFilteredTargetFrameworks>
+
+		<!--
+		Results from property functions are escaped, causing itemgroup inclusion to be
+		done as a single string. Unescape restores `;` as a proper separator.
+		-->
+		<TargetFrameworks>$([MSBuild]::Unescape($(_UnoFilteredTargetFrameworks)))</TargetFrameworks>
+	</PropertyGroup>
+	
+</Project>


### PR DESCRIPTION
Avoids the following message:

```
CSC : error CS1705: Assembly 'Uno.UI' with identity 'Uno.UI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null' uses 'Microsoft.iOS, Version=16.0.0.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065' which has a higher version than referenced assembly 'Microsoft.iOS' with identity 'Microsoft.iOS, Version=15.4.300.0, Culture=neutral, PublicKeyToken=84e04ff9cfb79065' [/Users/runner/work/1/s/src/Calculator.Mobile/Calculator.Mobile.csproj]
```
