### PR TITLE
fix(reg): Remove invalid removal of uno.ui files when building with WinAppSDK

### DIFF
--- a/build/uno.winui.winappsdk.targets
+++ b/build/uno.winui.winappsdk.targets
@@ -1,23 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<PropertyGroup>
-		<_UnoRemoveReferences_BeforeTargets>
-			$(_UnoRemoveReferences_BeforeTargets);
-			FindReferenceAssembliesForReferences;
-			MarkupCompilePass1;
-		</_UnoRemoveReferences_BeforeTargets>
-	</PropertyGroup>
-
-	<Target Name="_UnoRemoveReferences"
-			BeforeTargets="$(_UnoRemoveReferences_BeforeTargets)">
-		<ItemGroup>
-			<_UnoReferencePathToRemove Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)'=='Uno.UI' or '%(ReferencePath.NuGetPackageId)'=='Uno.WinUI'" />
-			<ReferencePath Remove="@(_UnoReferencePathToRemove)" />
-
-			<!-- Clear items -->
-			<_UnoReferencePathToRemove Remove="@(_UnoReferencePathToRemove)" />
-		</ItemGroup>
-	</Target>
-
 </Project>


### PR DESCRIPTION
The current change removes all binaries from the net5.0-windows target, which is incorrect as it also removes uno.toolkit.ui (as it includes ElevatedView and VisibleBoundsPadding).

The proper fix is to specifically modify Uno.WindowsCommunityToolkit, which does not include a Windows target. This causes netstandard2.0 binaries to incorrectly show up in the build.

Related to https://github.com/unoplatform/uno/issues/10182 and https://github.com/unoplatform/uno/pull/10193