### PR TITLE
fix: `ContentDialog` does not receive focus

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/TextBox_Focus_Leak.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/TextBox_Focus_Leak.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.TextBox_Focus_Leak"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<TextBox x:Name="TestTextBox" Text="Focus me" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/TextBox_Focus_Leak.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/TextBox_Focus_Leak.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class TextBox_Focus_Leak : UserControl
+	{
+		public TextBox_Focus_Leak()
+		{
+			this.InitializeComponent();
+
+			Loaded += TextBox_Focus_Leak_Loaded;
+		}
+
+		private void TextBox_Focus_Leak_Loaded(object sender, RoutedEventArgs e)
+		{
+			TestTextBox.Focus(FocusState.Programmatic);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -79,7 +79,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #if !__WASM__ && !__IOS__ // Disabled - https://github.com/unoplatform/uno/issues/7860
 		[DataRow("Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.ContentDialog_Leak", 15)]
 #endif
+#if !__IOS__ // Disabled - #10344
 		[DataRow(typeof(TextBox_Focus_Leak), 15)]
+#endif
 		public async Task When_Add_Remove(object controlTypeRaw, int count)
 		{
 #if TRACK_REFS

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -79,6 +79,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #if !__WASM__ && !__IOS__ // Disabled - https://github.com/unoplatform/uno/issues/7860
 		[DataRow("Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.ContentDialog_Leak", 15)]
 #endif
+		[DataRow(typeof(TextBox_Focus_Leak), 15)]
 		public async Task When_Add_Remove(object controlTypeRaw, int count)
 		{
 #if TRACK_REFS

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -12,6 +12,7 @@ using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Tests.Enterprise;
 using static Private.Infrastructure.TestServices;
@@ -147,6 +148,93 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				var fg = SUT.PrimaryButton.Foreground as SolidColorBrush;
 				Assert.IsNotNull(fg);
 				Assert.AreEqual(Colors.White, fg.Color);
+			}
+			finally
+			{
+				SUT.Hide();
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_Initial_Focus_With_Focusable_Content()
+		{
+			Button button = new Button() { Content = "Target" };
+			var SUT = new MyContentDialog
+			{
+				Title = "Dialog title",
+				Content = button,
+				PrimaryButtonText = "Target",
+				SecondaryButtonText = "Secondary"
+			};
+
+			SUT.DefaultButton = ContentDialogButton.None;
+
+			try
+			{
+				await ShowDialog(SUT);
+
+				var focused = FocusManager.GetFocusedElement(SUT.XamlRoot);
+
+				Assert.AreEqual(button, focused);
+			}
+			finally
+			{
+				SUT.Hide();
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_Initial_Focus_With_DefaultButton_Not_Set()
+		{
+			var SUT = new MyContentDialog
+			{
+				Title = "Dialog title",
+				Content = "Dialog content",
+				PrimaryButtonText = "Target",
+				SecondaryButtonText = "Secondary"
+			};
+
+			SUT.DefaultButton = ContentDialogButton.None;
+
+			try
+			{
+				await ShowDialog(SUT);
+
+				var focused = FocusManager.GetFocusedElement(SUT.XamlRoot);
+
+				Assert.IsInstanceOfType(focused, typeof(Button));
+				Assert.AreEqual("Target", ((Button)focused).Content);
+			}
+			finally
+			{
+				SUT.Hide();
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_Initial_Focus_With_DefaultButton_Set()
+		{
+			var SUT = new MyContentDialog
+			{
+				Title = "Dialog title",
+				Content = "Dialog content",
+				PrimaryButtonText = "Accept",
+				SecondaryButtonText = "Target"
+			};
+
+			SUT.DefaultButton = ContentDialogButton.Secondary;
+
+			try
+			{
+				await ShowDialog(SUT);
+
+				var focused = FocusManager.GetFocusedElement(SUT.XamlRoot);
+
+				Assert.IsInstanceOfType(focused, typeof(Button));
+				Assert.AreEqual("Target", ((Button)focused).Content);
 			}
 			finally
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -157,6 +157,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RequiresFullWindow]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 		public async Task When_Initial_Focus_With_Focusable_Content()
 		{
 			Button button = new Button() { Content = "Target" };
@@ -186,6 +189,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RequiresFullWindow]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 		public async Task When_Initial_Focus_With_DefaultButton_Not_Set()
 		{
 			var SUT = new MyContentDialog
@@ -215,6 +221,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RequiresFullWindow]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 		public async Task When_Initial_Focus_With_DefaultButton_Set()
 		{
 			var SUT = new MyContentDialog

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -407,16 +407,19 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 
-			d.Add(_popup.PopupPanel.RegisterDisposablePropertyChangedCallback(Popup.VisibilityProperty, (s, e) =>
-			{
-				if (_popup.PopupPanel.Visibility == Visibility.Visible)
-				{
-					this.SetDialogFocus();
-				}
-			}));
+			d.Add(_popup.PopupPanel.RegisterDisposablePropertyChangedCallback(VisibilityProperty, OnPopupPanelVisibilityChanged));
 
 			_subscriptions.Disposable = d;
 		}
+
+		private void OnPopupPanelVisibilityChanged(object sender, DependencyPropertyChangedEventArgs e)
+		{
+			if (_popup.PopupPanel.Visibility == Visibility.Visible)
+			{
+				SetDialogFocus();
+			}
+		}
+
 		private void OnBackRequested(object sender, BackRequestedEventArgs e)
 		{
 			// Match Windows behavior:

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -32,7 +32,6 @@ namespace Windows.UI.Xaml.Controls
 		private readonly SerialDisposable _subscriptions = new SerialDisposable();
 		private readonly SerialDisposable _templateSubscriptions = new SerialDisposable();
 
-		private ManagedWeakReference _previouslyFocusedElementWeak;
 		private bool _hiding;
 		private bool _templateApplied;
 
@@ -129,11 +128,6 @@ namespace Windows.UI.Xaml.Controls
 			bool focusSet = false;
 
 			var focusManager = VisualTree.GetFocusManagerForElement(this);
-			var focused = focusManager.FocusedElement;
-			if (focused is UIElement focusedElement)
-			{
-				_previouslyFocusedElementWeak = WeakReferencePool.RentWeakReference(this, focusedElement);
-			}
 
 			if (m_tpContentPart is not null)
 			{
@@ -145,31 +139,16 @@ namespace Windows.UI.Xaml.Controls
 
 			if (!focusSet)
 			{
-				switch (DefaultButton)
+				ButtonBase button = DefaultButton switch				
 				{
-					case ContentDialogButton.Primary:
-						if (m_tpPrimaryButtonPart is not null)
-						{
-							focusSet = m_tpPrimaryButtonPart.Focus(FocusState.Programmatic);
-						}
-						break;
-
-					case ContentDialogButton.Secondary:
-						if (m_tpSecondaryButtonPart is not null)
-						{
-							focusSet = m_tpSecondaryButtonPart.Focus(FocusState.Programmatic);
-						}
-						break;
-					case ContentDialogButton.Close:
-						if (m_tpCloseButtonPart is not null)
-						{
-							focusSet = m_tpCloseButtonPart.Focus(FocusState.Programmatic);
-						}
-						break;
-				}
+					ContentDialogButton.Primary => m_tpPrimaryButtonPart,
+					ContentDialogButton.Secondary => m_tpSecondaryButtonPart,
+					ContentDialogButton.Close => m_tpCloseButtonPart,
+					_ => null,
+				};
+				focusSet = button?.Focus(FocusState.Programmatic) ?? false;
 			}
 
-			// If not set, try to focus the first focusable command button.
 			if (!focusSet && m_tpCommandSpacePart is not null)
 			{
 				if (focusManager.GetFirstFocusableElement(m_tpCommandSpacePart) is UIElement focusableCommandElement)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 
 using Uno.Client;
 using Uno.Disposables;
-using Uno.Extensions;
 using Uno.UI;
 using Windows.Foundation;
 using Windows.UI.Xaml.Input;
@@ -135,7 +134,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_previouslyFocusedElementWeak = WeakReferencePool.RentWeakReference(this, focusedElement);
 			}
-				
+
 			if (m_tpContentPart is not null)
 			{
 				if (focusManager.GetFirstFocusableElement(m_tpContentPart) is UIElement focusableElement)
@@ -427,6 +426,15 @@ namespace Windows.UI.Xaml.Controls
 					navManager.BackRequested -= OnBackRequested;
 				});
 			}
+
+
+			d.Add(_popup.PopupPanel.RegisterDisposablePropertyChangedCallback(Popup.VisibilityProperty, (s, e) =>
+			{
+				if (_popup.PopupPanel.Visibility == Visibility.Visible)
+				{
+					this.SetDialogFocus();
+				}
+			}));
 
 			_subscriptions.Disposable = d;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10135, closes #8980, closes #10342

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`ContentDialog` does not get focused


## What is the new behavior?

It does!


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
