### PR TITLE
feat(gtk): Add support for .NET Native AOT

### DIFF
--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -78,11 +78,11 @@ To build an app with this feature enabled:
 1. Add the following items in your `.csproj`:
    ```xml
    <ItemGroup>
-		<RdXmlFile Include="rd.xml" />
+		<RdXmlFile Include="MyApp.rd.xml" />
 		<RuntimeHostConfigurationOption Include="Switch.System.Reflection.Assembly.SimulatedCallingAssembly" Value="true" />
    </ItemGroup>
    ```
-1. Create a file name `rd.xml`, and place it next to your csproj:
+1. Create a file name `MyApp.rd.xml`, and place it next to your csproj:
    ```xml
    <Directives>
       <Application>

--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -57,9 +57,50 @@ If you want to upgrade **SkiaSharp** to a later version, you'll need to specify 
 
 ```xml
 <ItemGroup>
-   <PackagReference Include="SkiaSharp" Version="2.88.0" />
-   <PackagReference Include="SkiaSharp.Harfbuzz" Version="2.88.0" />
-   <PackagReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0" />
-   <PackageReference Update="SkiaSharp.NativeAssets.macOS" Version="2.88.0" />
+   <PackagReference Include="SkiaSharp" Version="2.88.3" />
+   <PackagReference Include="SkiaSharp.Harfbuzz" Version="2.88.3" />
+   <PackagReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
+   <PackageReference Update="SkiaSharp.NativeAssets.macOS" Version="2.88.3" />
 </ItemGroup>
 ```
+
+### .NET Native AOT support
+
+Building an Uno Platform Skia+GTK app with .NET (7+) Native AOT requires, GtkSharp 3.24.24.38 (or later), or Uno Platform 4.7 (or later).
+
+To build an app with this feature enabled:
+1. Add the following property in your `.csproj`:
+   ```xml
+   <PropertyGroup>
+   		<PublishAot>true</PublishAot>
+	</PropertyGroup>
+   ```
+1. Add the following items in your `.csproj`:
+   ```xml
+   <ItemGroup>
+		<RdXmlFile Include="rd.xml" />
+		<RuntimeHostConfigurationOption Include="Switch.System.Reflection.Assembly.SimulatedCallingAssembly" Value="true" />
+   </ItemGroup>
+   ```
+1. Create a file name `rd.xml`, and place it next to your csproj:
+   ```xml
+   <Directives>
+      <Application>
+         <Assembly Name="MyApp.Skia.Gtk" Dynamic="Required All" />
+         
+         <Assembly Name="SkiaSharp" Dynamic="Required All" />
+         <Assembly Name="HarfBuzzSharp" Dynamic="Required All"> />
+
+         <Assembly Name="GdkSharp" Dynamic="Required All" />
+         <Assembly Name="GioSharp" Dynamic="Required All" />
+         <Assembly Name="GLibSharp" Dynamic="Required All" />
+         <Assembly Name="GtkSharp" Dynamic="Required All" />
+      </Application>
+   </Directives>
+   ```
+1. Build your app with:
+   ```bash
+   dotnet publish -r win-x64 -c Release
+   ```
+
+See [the runtime documentation](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/reflection-in-aot-mode.md) for more details, and the [.NET Native AOT documentation](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/).

--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -84,7 +84,6 @@ To build an app with this feature enabled:
    <ItemGroup>
       <TrimmerRootAssembly Include="MyApp.Skia.Gtk" />
 		<RdXmlFile Include="MyApp.rd.xml" />
-		<RuntimeHostConfigurationOption Include="Switch.System.Reflection.Assembly.SimulatedCallingAssembly" Value="true" />
    </ItemGroup>
    ```
 1. Create a file name `MyApp.rd.xml`, and place it next to your csproj:

--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -82,6 +82,7 @@ To build an app with this feature enabled:
 1. Add the following items in your `.csproj`:
    ```xml
    <ItemGroup>
+      <TrimmerRootAssembly Include="MyApp.Skia.Gtk" />
 		<RdXmlFile Include="MyApp.rd.xml" />
 		<RuntimeHostConfigurationOption Include="Switch.System.Reflection.Assembly.SimulatedCallingAssembly" Value="true" />
    </ItemGroup>
@@ -89,15 +90,9 @@ To build an app with this feature enabled:
 1. Create a file name `MyApp.rd.xml`, and place it next to your csproj:
    ```xml
    <Directives>
-      <Application>
-         <Assembly Name="MyApp.Skia.Gtk" Dynamic="Required All" />
-         
-         <Assembly Name="GdkSharp" Dynamic="Required All">
-            <Type Name="Gdk.Screen" Dynamic="Required All"/>
-         </Assembly>
-         <Assembly Name="GtkSharp" Dynamic="Required All">
-            <Type Name="Gtk.WindowStateEventArgs" Dynamic="Required All"/>
-         </Assembly>
+      <Application>        
+         <Assembly Name="GdkSharp" />
+         <Assembly Name="GtkSharp" />
       </Application>
    </Directives>
    ```

--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -72,8 +72,8 @@ To build an app with this feature enabled:
 1. Add the following property in your `.csproj`:
    ```xml
    <PropertyGroup>
-   		<PublishAot>true</PublishAot>
-	</PropertyGroup>
+      <PublishAot>true</PublishAot>
+   </PropertyGroup>
    ```
 1. Upgrade your project to net7.0:
    ```xml
@@ -83,17 +83,9 @@ To build an app with this feature enabled:
    ```xml
    <ItemGroup>
       <TrimmerRootAssembly Include="MyApp.Skia.Gtk" />
-		<RdXmlFile Include="MyApp.rd.xml" />
+      <TrimmerRootAssembly Include="GtkSharp" />
+      <TrimmerRootAssembly Include="GdkSharp" />
    </ItemGroup>
-   ```
-1. Create a file name `MyApp.rd.xml`, and place it next to your csproj:
-   ```xml
-   <Directives>
-      <Application>        
-         <Assembly Name="GdkSharp" />
-         <Assembly Name="GtkSharp" />
-      </Application>
-   </Directives>
    ```
 1. Build your app with:
    ```bash

--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -100,7 +100,9 @@ To build an app with this feature enabled:
    ```
 1. Build your app with:
    ```bash
-   dotnet publish -r win-x64 -c Release
+   dotnet publish -c Release
    ```
+   > [!NOTE] 
+   > Cross-compilation support is not supported as of .NET 7. To build a Native AOT app for linux or mac, you'll need to build on corresponding host.
 
 See [the runtime documentation](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/reflection-in-aot-mode.md) for more details, and the [.NET Native AOT documentation](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/).

--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -75,6 +75,10 @@ To build an app with this feature enabled:
    		<PublishAot>true</PublishAot>
 	</PropertyGroup>
    ```
+1. Upgrade your project to net7.0:
+   ```xml
+   <TargetFramework>net7.0</TargetFramework>
+   ```
 1. Add the following items in your `.csproj`:
    ```xml
    <ItemGroup>
@@ -88,13 +92,12 @@ To build an app with this feature enabled:
       <Application>
          <Assembly Name="MyApp.Skia.Gtk" Dynamic="Required All" />
          
-         <Assembly Name="SkiaSharp" Dynamic="Required All" />
-         <Assembly Name="HarfBuzzSharp" Dynamic="Required All"> />
-
-         <Assembly Name="GdkSharp" Dynamic="Required All" />
-         <Assembly Name="GioSharp" Dynamic="Required All" />
-         <Assembly Name="GLibSharp" Dynamic="Required All" />
-         <Assembly Name="GtkSharp" Dynamic="Required All" />
+         <Assembly Name="GdkSharp" Dynamic="Required All">
+            <Type Name="Gdk.Screen" Dynamic="Required All"/>
+         </Assembly>
+         <Assembly Name="GtkSharp" Dynamic="Required All">
+            <Type Name="Gtk.WindowStateEventArgs" Dynamic="Required All"/>
+         </Assembly>
       </Application>
    </Directives>
    ```

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -89,7 +89,7 @@
 	<PackageReference Update="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
 	<PackageReference Update="HarfBuzzSharp.NativeAssets.Tizen" Version="2.8.2.3" />
 	<PackageReference Update="SkiaSharp.HarfBuzz" Version="2.88.3" />
-	<PackageReference Update="GtkSharp" Version="3.24.24.34" />
+	<PackageReference Update="GtkSharp" Version="3.24.24.38" />
 	<PackageReference Update="System.Json" Version="4.7.1" />
 	<PackageReference Update="FluentAssertions" Version="5.10.3" />
 	<PackageReference Update="Microsoft.Extensions.Logging.Console" Version="5.0.0" />

--- a/src/SamplesApp/SamplesApp.Skia.Gtk/SamplesApp.Skia.Gtk.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.Gtk/SamplesApp.Skia.Gtk.csproj
@@ -36,7 +36,7 @@
 	<ItemGroup>
 		<PackageReference Include="SkiaSharp" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" />
-		<PackageReference Include="GtkSharp" Version="3.24.24.4" />
+		<PackageReference Include="GtkSharp" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9269

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

With recent builds of GtkSharp, NativeAOT is now supported. This PR adds some documentation for it and a GtkSharp bump.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
