### PR TITLE
fix: `AnimatedIcon` leaks

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -45,6 +45,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(XamlEvent_Leak_UserControl_xBind), 15)]
 		[DataRow(typeof(XamlEvent_Leak_UserControl_xBind_Event), 15)]
 		[DataRow(typeof(XamlEvent_Leak_TextBox), 15)]
+		[DataRow(typeof(Microsoft.UI.Xaml.Controls.AnimatedIcon), 15)]
 		[DataRow(typeof(Animation_Leak), 15)]
 		[DataRow(typeof(TextBox), 15)]
 		[DataRow(typeof(Button), 15)]

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.Uno.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.Uno.cs
@@ -1,4 +1,5 @@
 ﻿using Windows.Foundation;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml.Controls
@@ -18,6 +19,11 @@ namespace Microsoft.UI.Xaml.Controls
 				OnApplyTemplate();
 				_applyTemplateCalled = true;
 			}
+
+			if (m_foregroundColorPropertyChangedRevoker.Disposable is null)
+			{
+				OnForegroundPropertyChanged(this, null);
+			}
 		}
 
 		private void InitializeVisualTree()
@@ -28,6 +34,11 @@ namespace Microsoft.UI.Xaml.Controls
 				AddIconElementView(new Grid());
 				_initialized = true;
 			}
+		}
+
+		private void OnIconUnloaded(object sender, RoutedEventArgs args)
+		{
+			m_foregroundColorPropertyChangedRevoker.Disposable = null;
 		}
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.cs
@@ -35,6 +35,7 @@ namespace Microsoft.UI.Xaml.Controls
 			m_progressPropertySet = new CompositionPropertySet(null);
 #endif
 			Loaded += OnLoaded;
+			Unloaded += OnIconUnloaded;
 
 			this.RegisterPropertyChangedCallback(ForegroundProperty, OnForegroundPropertyChanged);
 			this.RegisterPropertyChangedCallback(FlowDirectionProperty, OnFlowDirectionPropertyChanged);
@@ -77,7 +78,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private void OnLoaded(object sender, RoutedEventArgs args)
 		{
 #if HAS_UNO
-			// Uno specific: Called to ensure OnApplyTemplate runs
+			// Uno specific: Called to ensure OnApplyTemplate runs and Foreground is subscribed
 			EnsureInitialized();
 #endif
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10309 


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`AnimatedIcon` always subscribed to its `Foreground` brush changes, but did not unsubscribe.


## What is the new behavior?

Unsubscribing on `Unload` correctly.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
