### PR TITLE
macOS doesn't accept dotnet install but --install, and Broken Link

### DIFF
--- a/doc/articles/get-started-dotnet-new.md
+++ b/doc/articles/get-started-dotnet-new.md
@@ -3,9 +3,18 @@
 The Uno Platform provides a set of command-line templates to create cross-platform applications.
 
 To install the templates, type the following:
+
+# [**.NET 7**](#tab/net7)
+
 ```
 dotnet new install Uno.ProjectTemplates.Dotnet
 ```
+# [**.NET 6**](#tab/net6)
+
+```
+dotnet new -i Uno.ProjectTemplates.Dotnet
+```
+***
 
 If you need to determine the parameters available for a template use `dotnet new [templatename] -h`.
 

--- a/doc/articles/get-started-dotnet-new.md
+++ b/doc/articles/get-started-dotnet-new.md
@@ -4,7 +4,7 @@ The Uno Platform provides a set of command-line templates to create cross-platfo
 
 To install the templates, type the following:
 ```
-dotnet new --install Uno.ProjectTemplates.Dotnet
+dotnet new install Uno.ProjectTemplates.Dotnet
 ```
 
 If you need to determine the parameters available for a template use `dotnet new [templatename] -h`.
@@ -13,6 +13,9 @@ If you need to determine the parameters available for a template use `dotnet new
 > Installing the templates is done per dotnet CLI version. Meaning that the templates are installed for the version shown by `dotnet --version`. If you tried to use the templates with a version different than the one you used for installing, you'll get "No templates found matching: '<template-name>'." error.
 >
 > This is common when using `global.json` that alters the .NET CLI/SDK version. Specifically, it's common for the UI Test template.
+
+> [!NOTE]
+> When using .NET 6, use `dotnet new -i Uno.ProjectTemplates.Dotnet` instead.
 
 [!include[getting-help](use-uno-check-inline.md)]
 

--- a/doc/articles/get-started-dotnet-new.md
+++ b/doc/articles/get-started-dotnet-new.md
@@ -4,7 +4,7 @@ The Uno Platform provides a set of command-line templates to create cross-platfo
 
 To install the templates, type the following:
 ```
-dotnet new install Uno.ProjectTemplates.Dotnet
+dotnet new --install Uno.ProjectTemplates.Dotnet
 ```
 
 If you need to determine the parameters available for a template use `dotnet new [templatename] -h`.
@@ -21,8 +21,6 @@ If you need to determine the parameters available for a template use `dotnet new
 This template can be used to create a blank multi-platform application for iOS, Android, WebAssembly, macOS, Mac Catalyst, Linux, and Win32 Desktop which uses the new WinUI 3 APIs.
 
 This template uses a single project head for iOS, Android, macOS, and Mac Catalyst. It requires Visual Studio 2022.
-
-[**Find detailed instructions here.**](get-started-winui3.md)
 
 A basic example:
 ```


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10352 
 
## PR Type
 
- Documentation content changes 


## What is the current behavior?

On macOS running dotnet new install Uno.ProjectTemplates.Dotnet will fail.
But using dotnet new --install Uno.ProjectTemplates.Dotnet will work.


## What is the new behavior?

Added --install since it works on both windows and macOS.
Also, removed a broken link.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.