### PR TITLE
fix: `BreadcrumbBar` leaks

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -82,6 +82,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(ToggleSwitch), 15)]
 		[DataRow(typeof(SwipeControl), 15)]
 		[DataRow(typeof(SplitView), 15)]
+		[DataRow(typeof(Microsoft.UI.Xaml.Controls.BreadcrumbBar), 15)]
+		[DataRow(typeof(Microsoft.UI.Xaml.Controls.BreadcrumbBarItem), 15)]
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.ColorPicker), 15)]
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.ImageIcon), 15)]
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.InfoBadge), 15)]
@@ -89,7 +91,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.Primitives.MonochromaticOverlayPresenter), 15)]
 #if false // Disabled for #10309
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.AnimatedIcon), 15)]
-		[DataRow(typeof(Microsoft.UI.Xaml.Controls.BreadcrumbBar), 15)]
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.Expander), 15)]
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.NavigationView), 15)]
 #endif

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItem.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItem.cs
@@ -46,17 +46,30 @@ public partial class BreadcrumbBarItem : ContentControl
 
 #if HAS_UNO
 		// Uno specific: We use Unloaded instead of destructor
-		this.Unloaded += BreadcrumbBarItem_Unloaded;
+		Loaded += BreadcrumbBarItem_Loaded;
+		Unloaded += BreadcrumbBarItem_Unloaded;
 #endif
+	}
+
+#if HAS_UNO
+	private void BreadcrumbBarItem_Loaded(object sender, RoutedEventArgs e)
+	{
+		HookListeners(m_isEllipsisDropDownItem);
 	}
 
 	private void BreadcrumbBarItem_Unloaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
 	{
 		RevokeListeners();
+		m_ellipsisRepeaterElementPreparedRevoker.Disposable = null;
+		m_ellipsisRepeaterElementIndexChangedRevoker.Disposable = null;
 	}
+#endif
 
 	private void HookListeners(bool forEllipsisDropDownItem)
 	{
+#if HAS_UNO
+		RevokeListeners();
+#endif
 		if (this is UIElement thisAsUIElement7)
 		{
 			if (m_childPreviewKeyDownToken.Disposable == null)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10309 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`BreadcrumbBar` leaks

## What is the new behavior?

`BreadcrumbBar` does not leak


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.