### PR TITLE
fix: Switch template to default to net7.0

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.template.config/template.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.template.config/template.json
@@ -210,7 +210,7 @@
 		}
 	  ],
 	  "replaces": "net6.0",
-	  "defaultValue": "net6.0"
+	  "defaultValue": "net7.0"
 	}
   },
   "primaryOutputs": [


### PR DESCRIPTION
GitHub Issue (If applicable): closes #Version 17.4.0

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

unoapp template defaults to net6.0

## What is the new behavior?

unoapp template defaults to net7.0, so should be able to be built and run using standard install of VS 17.4.0

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
