### PR TITLE
fix(reg): don't dispose AssemblyDefinition on mono

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -772,7 +772,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private void BuildResourceLoaderFromFilePath(IndentedStringBuilder writer, string? referenceFilePath)
 		{
 			using var stream = File.OpenRead(referenceFilePath);
-			using var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly(stream);
+
+#if NETSTANDARD2_0
+			// Using is conditional to netstandard2 when running under netcore
+			// disposing the assembly crashes the mono runtime under macos.
+			using
+#endif
+				var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly(stream);
 
 			if (asm.MainModule.HasResources && asm.MainModule.Resources.Any(r => r.Name.EndsWith("upri", StringComparison.Ordinal)))
 			{


### PR DESCRIPTION
The generation tooling may crash with:

```
   at <unknown> <0xffffffff>
   at Uno.UI.SourceGenerators.XamlGenerator.XamlFileGenerator:BuildResourceLoaderFromFilePath <0x007ca>
   at Uno.UI.SourceGenerators.XamlGenerator.XamlFileGenerator:GenerateResourceLoader <0x001e2>
   at Uno.UI.SourceGenerators.XamlGenerator.XamlFileGenerator:BuildApplicationInitializerBody <0x0014a>
   at Uno.UI.SourceGenerators.XamlGenerator.XamlFileGenerator:BuildInitializeComponent <0x00432>
   at Uno.UI.SourceGenerators.XamlGenerator.XamlFileGenerator:InnerGenerateFile <0x009da>
   at Uno.UI.SourceGenerators.XamlGenerator.XamlFileGenerator:GenerateFile <0x003aa>
   at <>c__DisplayClass42_0:<Generate>b__2 <0x0037a>
   at System.Func`2:invoke_TResult_T <0x000ad>
   at SelectQueryOperatorResults:GetElement <0x00070>
   at System.Linq.Parallel.QueryResults`1:get_Item <0x00051>
   at ListContiguousIndexRangeEnumerator:MoveNext <0x000fa>
   at System.Linq.Parallel.StopAndGoSpoolingTask`2:SpoolingWork <0x001b0>
   at System.Linq.Parallel.SpoolingTaskBase:Work <0x00058>
   at System.Linq.Parallel.QueryTask:BaseWork <0x0006f>
   at <>c:<.cctor>b__10_0 <0x0006a>
   at System.Threading.Tasks.Task:InnerInvoke <0x0008f>
   at System.Threading.Tasks.Task:Execute <0x00037>
   at System.Threading.Tasks.Task:ExecutionContextCallback <0x0005b>
   at System.Threading.ExecutionContext:RunInternal <0x001a9>
   at System.Threading.ExecutionContext:Run <0x00042>
   at System.Threading.Tasks.Task:ExecuteWithThreadLocal <0x000f6>
   at System.Threading.Tasks.Task:ExecuteEntry <0x000e8>
   at System.Threading.Tasks.Task:System.Threading.IThreadPoolWorkItem.ExecuteWorkItem <0x00026>
   at System.Threading.ThreadPoolWorkQueue:Dispatch <0x00279>
   at System.Threading._ThreadPoolWaitCallback:PerformWaitCallback <0x0001c>
   at <Module>:runtime_invoke_bool <0x000a5>
```
