### PR TITLE
fix: `Image.Source` nullify

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -413,7 +413,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 		[AutoRetry]
 		public void Image_Source_Nullify()
 		{
-			Run("Uno.UI.Samples.UITests.ImageTests.Image_Source_Nullify");
+			Run("UITests.Windows_UI_Xaml_Controls.ImageTests.Image_Source_Nullify");
 
 			var panel = _app.Marked("CompareGrid");
 			var loadButton = _app.Marked("LoadButton");

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ImageTests/UnoSamples_Tests.Image.cs
@@ -408,6 +408,34 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ImageTests
 			ImageAssert.AreEqual(afterHide, beforeHide, originalRect, tolerance: PixelTolerance.Exclusive(1));
 		}
 
+		// Can be removed when #10340 is done (in favor of When_Image_Source_Nullify runtime test).
+		[Test]
+		[AutoRetry]
+		public void Image_Source_Nullify()
+		{
+			Run("Uno.UI.Samples.UITests.ImageTests.Image_Source_Nullify");
+
+			var panel = _app.Marked("CompareGrid");
+			var loadButton = _app.Marked("LoadButton");
+			var clearButton = _app.Marked("ClearButton");
+
+			var physicalRect = _app.GetPhysicalRect(panel);
+
+			using var beforeLoad = TakeScreenshot("image_source_nullify_empty");
+
+			loadButton.FastTap();
+
+			using var afterLoad = TakeScreenshot("image_source_nullify_loaded");
+
+			ImageAssert.AreNotEqual(beforeLoad, afterLoad, physicalRect);
+
+			clearButton.FastTap();
+			
+			using var afterClear = TakeScreenshot("image_source_nullify_cleared");
+
+			ImageAssert.AreEqual(beforeLoad, afterClear, physicalRect, tolerance: PixelTolerance.Exclusive(1));
+		}
+
 		private void WaitForBitmapOrSvgLoaded()
 		{
 			var isLoaded = _app.Marked("isLoaded");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1545,6 +1545,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Source_Nullify.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PasswordBoxTests\PasswordBox_AutoFill.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5496,6 +5500,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping652.xaml.cs">
       <DependentUpon>Clipping652.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Source_Nullify.xaml.cs">
+      <DependentUpon>Image_Source_Nullify.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PlaceholderForeground.xaml.cs">
       <DependentUpon>TextBox_PlaceholderForeground.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Source_Nullify.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Source_Nullify.xaml
@@ -1,0 +1,26 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.ImageTests.Image_Source_Nullify"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ImageTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<Button
+            Grid.Row="0"
+            HorizontalAlignment="Left"
+            Command="{x:Bind ViewModel.ClearImageCommand, Mode=OneWay}"
+            Content="Clear Image" />
+		<Button
+            Grid.Row="1"
+            HorizontalAlignment="Left"
+            Command="{x:Bind ViewModel.LoadImageCommand, Mode=OneWay}"
+            Content="Load Image" />
+		<Image 
+            Grid.Row="2"
+            Source="{x:Bind ViewModel.TestImageSource, Mode=OneWay}" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Source_Nullify.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Source_Nullify.xaml
@@ -8,19 +8,26 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid>
+    <Grid RowSpacing="8" Padding="8">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
 		<Button
+			x:Name="ClearButton"
             Grid.Row="0"
             HorizontalAlignment="Left"
             Command="{x:Bind ViewModel.ClearImageCommand, Mode=OneWay}"
             Content="Clear Image" />
 		<Button
+			x:Name="LoadButton"
             Grid.Row="1"
             HorizontalAlignment="Left"
             Command="{x:Bind ViewModel.LoadImageCommand, Mode=OneWay}"
             Content="Load Image" />
-		<Image 
-            Grid.Row="2"
-            Source="{x:Bind ViewModel.TestImageSource, Mode=OneWay}" />
+		<Grid Grid.Row="2" Background="White" x:Name="CompareGrid" Width="100" Height="100" Padding="8">
+			<Image Stretch="Fill" Source="{x:Bind ViewModel.TestImageSource, Mode=OneWay}" />
+		</Grid>
 	</Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Source_Nullify.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Source_Nullify.xaml.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+using System.Windows.Input;
+using Uno.UI.Samples.UITests.Helpers;
+
+namespace UITests.Windows_UI_Xaml_Controls.ImageTests;
+
+[Sample("Image", ViewModelType = typeof(ImageSourceNullifyViewModel))]
+public sealed partial class Image_Source_Nullify : Page
+{
+	public Image_Source_Nullify()
+	{
+		this.InitializeComponent();
+	}
+}
+
+public class ImageSourceNullifyViewModel : ViewModelBase
+{
+	private ICommand clearImageCommand;
+
+	private ICommand loadImageCommand;
+
+	private ImageSource testImageSource;
+
+	public ImageSourceNullifyViewModel(Dispatcher )
+	{
+		this.LoadImageCommand = new RelayCommand(async () =>
+		{
+			this.TestImageSource = new BitmapImage(new Uri("ms-appx:///Assets/ingredient1.png"));
+		});
+
+		this.ClearImageCommand = new DelegateCommand(() =>
+		{
+			this.TestImageSource = null;
+		});
+	}
+
+	/// <summary> Gets or sets the clear image command. </summary>
+	/// <value> The clear image command. </value>
+	public ICommand ClearImageCommand
+	{
+		get => this.clearImageCommand;
+		private set => this.SetProperty(ref this.clearImageCommand, value);
+	}
+
+	/// <summary> Gets or sets the load image command. </summary>
+	/// <value> The load image command. </value>
+	public ICommand LoadImageCommand
+	{
+		get => this.loadImageCommand;
+		private set => this.SetProperty(ref this.loadImageCommand, value);
+	}
+
+	/// <summary> Gets or sets the test image source. </summary>
+	/// <value> The test image source. </value>
+	public ImageSource TestImageSource
+	{
+		get => this.testImageSource;
+		private set => this.SetProperty(ref this.testImageSource, value);
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Source_Nullify.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Image_Source_Nullify.xaml.cs
@@ -14,7 +14,10 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using Uno.UI.Samples.Controls;
 using System.Windows.Input;
+using Uno.UI.Common;
+using Windows.UI.Core;
 using Uno.UI.Samples.UITests.Helpers;
+using Windows.UI.Xaml.Media.Imaging;
 
 namespace UITests.Windows_UI_Xaml_Controls.ImageTests;
 
@@ -24,51 +27,51 @@ public sealed partial class Image_Source_Nullify : Page
 	public Image_Source_Nullify()
 	{
 		this.InitializeComponent();
+		DataContextChanged += Image_Source_Nullify_DataContextChanged;
 	}
+
+	private void Image_Source_Nullify_DataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+	{
+		ViewModel = (ImageSourceNullifyViewModel)args.NewValue;
+	}
+
+	internal ImageSourceNullifyViewModel ViewModel { get; set; }
 }
 
-public class ImageSourceNullifyViewModel : ViewModelBase
+internal class ImageSourceNullifyViewModel : ViewModelBase
 {
-	private ICommand clearImageCommand;
+	private ImageSource _testImageSource;
 
-	private ICommand loadImageCommand;
-
-	private ImageSource testImageSource;
-
-	public ImageSourceNullifyViewModel(Dispatcher )
+	public ImageSourceNullifyViewModel(CoreDispatcher dispatcher) : base(dispatcher)
 	{
-		this.LoadImageCommand = new RelayCommand(async () =>
+		LoadImageCommand = new DelegateCommand(() =>
 		{
-			this.TestImageSource = new BitmapImage(new Uri("ms-appx:///Assets/ingredient1.png"));
+			TestImageSource = new BitmapImage(new Uri("ms-appx:///Assets/square100.png"));
 		});
 
-		this.ClearImageCommand = new DelegateCommand(() =>
+		ClearImageCommand = new DelegateCommand(() =>
 		{
-			this.TestImageSource = null;
+			TestImageSource = null;
 		});
 	}
 
 	/// <summary> Gets or sets the clear image command. </summary>
 	/// <value> The clear image command. </value>
-	public ICommand ClearImageCommand
-	{
-		get => this.clearImageCommand;
-		private set => this.SetProperty(ref this.clearImageCommand, value);
-	}
+	public ICommand ClearImageCommand { get; }
 
 	/// <summary> Gets or sets the load image command. </summary>
 	/// <value> The load image command. </value>
-	public ICommand LoadImageCommand
-	{
-		get => this.loadImageCommand;
-		private set => this.SetProperty(ref this.loadImageCommand, value);
-	}
+	public ICommand LoadImageCommand { get; }
 
 	/// <summary> Gets or sets the test image source. </summary>
 	/// <value> The test image source. </value>
 	public ImageSource TestImageSource
 	{
-		get => this.testImageSource;
-		private set => this.SetProperty(ref this.testImageSource, value);
+		get => _testImageSource;
+		private set
+		{
+			_testImageSource = value;
+			RaisePropertyChanged();
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -172,6 +172,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282! epic")]
+#endif
 		public async Task When_Image_Source_Nullify()
 		{
 			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -8,12 +8,17 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
+using Windows.Foundation.Metadata;
 using Windows.Graphics.Display;
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -163,6 +168,62 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await TestServices.WindowHelper.WaitFor(() => img.ActualHeight > 0, 3000);
 
 			Assert.IsTrue(img.ActualHeight > 0);			
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Image_Source_Nullify()
+		{
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+
+			var parent = new Border()
+			{
+				Width = 100,
+				Height = 100,
+				Background = new SolidColorBrush(Colors.White)
+			};
+			
+			var SUT = new Image()
+			{
+				Width = 100,
+				Height = 100,
+				Source = new BitmapImage(new Uri("ms-appx:///Assets/square100.png")),
+				Stretch = Stretch.Fill
+			};
+
+			parent.Child = SUT;
+			WindowHelper.WindowContent = parent;
+			await WindowHelper.WaitForLoaded(parent);
+			var result = await TakeScreenshot(parent);
+						
+			var sample = SUT.GetRelativeCoords(parent);
+			var centerX = sample.X + sample.Width / 2;
+			var centerY = sample.Y + sample.Height / 2;
+
+			ImageAssert.HasPixels(
+				result,
+				ExpectedPixels.At(centerX, centerY).Named("center with image").Pixel(Colors.Blue));
+
+			SUT.Source = null;
+			await WindowHelper.WaitForIdle();
+			result = await TakeScreenshot(parent);
+
+			ImageAssert.HasPixels(
+				result,
+				ExpectedPixels.At(centerX, centerY).Named("center without image").Pixel(Colors.White));
+		}
+
+		private async Task<RawBitmap> TakeScreenshot(FrameworkElement SUT)
+		{
+			var renderer = new RenderTargetBitmap();
+			await WindowHelper.WaitForIdle();
+			await renderer.RenderAsync(SUT);
+			var result = await RawBitmap.From(renderer, SUT);
+			await WindowHelper.WaitForIdle();
+			return result;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
@@ -36,6 +36,13 @@ namespace Windows.UI.Xaml.Controls
 			{
 				InitializeImageSource(source);
 			}
+			else
+			{
+				// Null or unsupported source
+				_sourceDisposable.Disposable = null;
+				_imageSprite.Brush = null;
+				InvalidateMeasure();
+			}
 		}
 
 		private void InitializeSvgSource(SvgImageSource source)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10048

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When `Image.Source` is set to `null` on Skia, the image stays displayed.

## What is the new behavior?

Should not be displayed.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.