### PR TITLE
fix: List .NET 7 mobile targets in crosstargeting sample

### DIFF
--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -26,9 +26,9 @@
         │ MonoAndroid13.0                           │ Android 13.0            │ Uno.UI-Android-only.slnf                                                           │
         │ netstandard2.0 or net7.0                  │ WebAssembly, Skia       │ Uno.UI-Wasm-only.slnf, Uno.UI-Skia-only.slnf                                       │
         │ net6.0-ios or net7.0-ios                  │ .NET 6/7 iOS            │ Uno.UI-netcore-mobile-only.slnf                                                    │
-        │ net6.0-android or net6.0-android          │ .NET 6/7 Android        │ Uno.UI-netcore-mobile-only.slnf                                                    │
-        │ net6.0-maccatalyst or net6.0-maccatalyst  │ .NET 6/7 macOS Catalyst │ Uno.UI-netcore-mobile-only.slnf                                                    │
-        │ net6.0-macos or net6.0-macos              │ .NET 6/7 macOS AppKit   │ Uno.UI-netcore-mobile-only.slnf                                                    │
+        │ net6.0-android or net7.0-android          │ .NET 6/7 Android        │ Uno.UI-netcore-mobile-only.slnf                                                    │
+        │ net6.0-maccatalyst or net7.0-maccatalyst  │ .NET 6/7 macOS Catalyst │ Uno.UI-netcore-mobile-only.slnf                                                    │
+        │ net6.0-macos or net7.0-macos              │ .NET 6/7 macOS AppKit   │ Uno.UI-netcore-mobile-only.slnf                                                    │
         │ xamarinmac20                              │ macOS                   │ Uno.UI-macOS-only.slnf (VS for Windows), Uno.UI-vs4mac-macOS-only.sln (VS for Mac) │
         │ netstandard2.0 or net7.0                  │ Wasm+Skia Reference API │ Uno.UI-Reference-only.slnf                                                         │
         │ net461                                    │ Uno.UI.Tests            │ Uno.UI-UnitTests-only.slnf                                                         │


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

.NET 7 mobile targets are not listed correctly in crosstargeting sample file


## What is the new behavior?

Listed


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
