### PR TITLE
fix(reg): Adjust hot reload generation for C# 7.3

### DIFF
--- a/build/test-scripts/run-template-tests.ps1
+++ b/build/test-scripts/run-template-tests.ps1
@@ -99,6 +99,11 @@ dotnet new unoapp-uwp -n MyApp.Uno
 & $msbuild $debug MyApp.Uno\MyApp.Uno.sln
 Assert-ExitCodeIsZero
 
+# csharp 7.3 test
+dotnet new unoapp-uwp -n CSharp73App
+& $msbuild $debug CSharp73App\CSharp73App.sln /p:LangVersion=7.3 /p:UnoForceHotReloadCodeGen=false
+Assert-ExitCodeIsZero
+
 dotnet new unoapp-uwp -n MyApp.Android (Get-TemplateConfiguration -android 1)
 & $msbuild $debug MyApp.Android\MyApp.Android.sln
 Assert-ExitCodeIsZero

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -367,6 +367,7 @@
 		<UnoSourceGeneratorAdditionalProperty Include="ProjectTypeGuidsProperty" />
 		<UnoSourceGeneratorAdditionalProperty Include="DefineConstantsProperty" />
 		<UnoSourceGeneratorAdditionalProperty Include="IsUiAutomationMappingEnabled" />
+		<UnoSourceGeneratorAdditionalProperty Include="UnoForceHotReloadCodeGen" />
 	</ItemGroup>
 
 	<Target Name="_FillSourceGeneratorItemGroups">

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -21,6 +21,12 @@
 		<UnoUIUseRoslynSourceGenerators Condition="'$(UnoUIUseRoslynSourceGenerators)'=='' and '$(_isRoslynAnalyzerAvailable)' == 'true' and '$(_canUseRoslynAnalyzer)'=='true'">true</UnoUIUseRoslynSourceGenerators>
 		<UnoUIUseRoslynSourceGenerators Condition="'$(UnoUIUseRoslynSourceGenerators)'==''">false</UnoUIUseRoslynSourceGenerators>
 
+		<!--
+		MSBuild below 17.0 implies C# 7.3 or below, which does not support lambda parameters shadowing (https://github.com/dotnet/csharplang/blob/main/meetings/2019/LDM-2019-01-16.md).
+		In this mode, we disable all hot reload specific code generation.
+		-->
+		<UnoForceHotReloadCodeGen Condition="'$(UnoForceHotReloadCodeGen)'=='' and '$(MSBuildVersion)' &lt; '17.0'">false</UnoForceHotReloadCodeGen>
+
 		<XamarinProjectType Condition="
 							'$(ProjectTypeGuids)'=='{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}'
 							or $(TargetFramework.ToLower().StartsWith('xamarinios'))

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4053,7 +4053,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				closureName,
 				appliedType != null && !_isHotReloadEnabled ? _fileUniqueId : null,
 				delegateType,
-				!_isTopLevelDictionary);
+				!_isTopLevelDictionary && _isHotReloadEnabled);
 		}
 
 		private void RegisterPartial(string format, params object[] values)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that C# 7.3 can still be used as a compilation target (for older Xamarin)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
