### PR TITLE
fix(droid): LV oscillating snapping

### DIFF
--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -354,6 +354,11 @@ namespace Uno.UI
 			/// Forcing a recycling pass with ItemAnimator is known to cause a flicker of the whole list.
 			/// </remarks>
 			public static bool ForceRecycleOnDrop;
+
+			/// <summary>
+			/// Sets a value indicating whether the item snapping will be implemented by the native <see cref="AndroidX.RecyclerView.Widget.SnapHelper"/> or by Uno.
+			/// </summary>
+			public static bool UseNativeSnapHelper = true;
 		}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
@@ -65,7 +65,10 @@ namespace Windows.UI.Xaml.Controls
 			ViewCache = new BufferViewCache(this);
 			SetViewCacheExtension(ViewCache);
 
-			InitializeSnapHelper();
+			if (FeatureConfiguration.NativeListViewBase.UseNativeSnapHelper)
+			{
+				InitializeSnapHelper();
+			}
 
 			_shouldRecalibrateFlingVelocity = (int)Android.OS.Build.VERSION.SdkInt >= 28; // Android.OS.BuildVersionCodes.P
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.SnapPoints.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.SnapPoints.Android.cs
@@ -19,6 +19,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var helper = new SnapPointsSnapHelper(this);
 			helper.AttachToRecyclerView(this);
+
+			UseNativeSnapping = true;
 		}
 
 		private class SnapPointsSnapHelper : SnapHelper

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.cs
@@ -13,6 +13,8 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class NativeListViewBase : IFrameworkElement, DependencyObject, IScrollSnapPointsInfo
 	{
+		internal bool UseNativeSnapping { get; private set; }
+
 		public bool AreHorizontalSnapPointsRegular => ((IScrollSnapPointsInfo)NativeLayout).AreHorizontalSnapPointsRegular;
 
 		public bool AreVerticalSnapPointsRegular => ((IScrollSnapPointsInfo)NativeLayout).AreVerticalSnapPointsRegular;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -2079,17 +2079,16 @@ namespace Windows.UI.Xaml.Controls
 
 		private float GetSnapPoint(View view, SnapPointsAlignment alignment)
 		{
-			switch (alignment)
+			var snapPointInPhysical = alignment switch
 			{
-				case SnapPointsAlignment.Near:
-					return ContentOffset + GetChildStartWithMargin(view);
-				case SnapPointsAlignment.Center:
-					return ContentOffset + (GetChildStartWithMargin(view) + GetChildEndWithMargin(view)) / 2f;
-				case SnapPointsAlignment.Far:
-					return ContentOffset + GetChildEndWithMargin(view);
-				default:
-					throw new ArgumentOutOfRangeException(nameof(alignment));
-			}
+				SnapPointsAlignment.Near => ContentOffset + GetChildStartWithMargin(view),
+				SnapPointsAlignment.Center => ContentOffset + (GetChildStartWithMargin(view) + GetChildEndWithMargin(view)) / 2f,
+				SnapPointsAlignment.Far => ContentOffset + GetChildEndWithMargin(view),
+
+				_ => throw new ArgumentOutOfRangeException(nameof(alignment)),
+			};
+
+			return (float)ViewHelper.PhysicalToLogicalPixels(snapPointInPhysical);
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.SnapPoints.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.SnapPoints.cs
@@ -385,32 +385,22 @@ namespace Windows.UI.Xaml.Controls
 						// it doesn't matter so do it for consistency.
 						snapPoint *= zoomFactor;
 
-						var alignedSnapPoint = alignment switch
+						// Adjust snap point to relative(near/center/far) viewport offset, and then
+						// clamp it within valid scroll range.
+						var adjustedOffset = alignment switch
 						{
 							SnapPointsAlignment.Near => snapPoint,
 							SnapPointsAlignment.Center => (float)(snapPoint - viewportDimension / 2),
 							SnapPointsAlignment.Far => (float)(snapPoint - viewportDimension),
 							_ => throw new IndexOutOfRangeException("alignment")
 						};
+						var clampedOffset = (float)Math.Max(0, Math.Min(adjustedOffset, ScrollableWidth));
 
-						var distanceFromFarEdge = (float)(extentDimension - viewportDimension - alignedSnapPoint);
-
-						// With certain scale factors and resolutions the snap points sometimes get pushed out of bounds
-						// by rounding errors, in these cases we need to intervene and return them to the boundary.
-						if (distanceFromFarEdge < 0 &&
-						    distanceFromFarEdge >= (-1.0 * (ScrollViewerSnapPointLocationTolerance * Math.Max(1.0f, zoomFactor))))
+						if (staticZoomFactor == 1.0f)
 						{
-							alignedSnapPoint = (float)(extentDimension - viewportDimension);
-							distanceFromFarEdge = 0;
+							clampedOffset /= zoomFactor;
 						}
-						if (alignedSnapPoint >= 0 && distanceFromFarEdge >= 0)
-						{
-							if (staticZoomFactor == 1.0f)
-							{
-								alignedSnapPoint /= zoomFactor;
-							}
-							result.Add(alignedSnapPoint);
-						}
+						result.Add(clampedOffset);
 					}
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1285,7 +1285,11 @@ namespace Windows.UI.Xaml.Controls
 			{
 				Update(isIntermediate);
 
-				if (!isIntermediate)
+				if (!isIntermediate
+#if __IOS__ || __ANDROID__
+					&& (_presenter as ListViewBaseScrollContentPresenter)?.NativePanel?.UseNativeSnapping != true
+#endif
+				)
 				{
 					if (HorizontalSnapPointsType != SnapPointsType.None
 						|| VerticalSnapPointsType != SnapPointsType.None)


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/nventive-private#421

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On Android when scrolled, ListView with snapping will oscillate forever between the different snap-points resulted from uno and native implementations.

## What is the new behavior?
Add a `FeatureConfiguration` to toggle the implementation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
unoplatform/nventive-private#42