### PR TITLE
fix: don't reset runinfos on full builds as generations are no longer ignored

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -428,8 +428,6 @@
 		<Message Importance="low"
 			   Condition="'$(UnoUIUseRoslynSourceGenerators)'==''"
 			   Text="Uno.UI is using Uno.SourceGenerators" />
-
-		<WriteLinesToFile File="$(IntermediateOutputPath)\build-time-generator.touch" />
 	</Target>
 
 	<Target Name="_RemoveRoslynUnoSourceGeneration" BeforeTargets="CoreCompile" Condition="'$(UnoUIUseRoslynSourceGenerators)'=='false' or '$(WindowsAppSDKWinUI)'=='true'">

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/GenerationInfoManager.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/GenerationInfoManager.cs
@@ -17,7 +17,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 	internal class GenerationRunInfoManager
 	{
 		private List<GenerationRunInfo> _runs = new List<GenerationRunInfo>();
-		private DateTime _previousWriteTime;
 
 		internal GenerationRunInfoManager()
 		{
@@ -35,51 +34,5 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return runInfo;
 		}
 
-		internal void Update(GeneratorExecutionContext context)
-		{
-			var intermediateOutputPath = context.GetMSBuildPropertyValue("IntermediateOutputPath");
-
-			if (intermediateOutputPath != null)
-			{
-				var runFilePath = Path.Combine(intermediateOutputPath, "build-time-generator.touch");
-
-				if (File.Exists(runFilePath))
-				{
-					var lastWriteTime = new FileInfo(runFilePath).LastWriteTime;
-
-					if(lastWriteTime > _previousWriteTime)
-					{
-						_previousWriteTime = lastWriteTime;
-
-						// Clear the existing runs if a full build has been started
-						_runs.Clear();
-					}
-				}
-			}
-
-			if(GetIsDesignTimeBuild(context)
-				&& !GetIsHotReloadHost(context)
-				&& !Process.GetCurrentProcess().ProcessName.Equals("devenv", StringComparison.InvariantCultureIgnoreCase))
-			{
-				// Design-time builds need to clear runs for the x:Name values to be regenerated, in the context of OmniSharp.
-				// In the context of HotReload, we need to skip this, as the HotReload service sets DesignTimeBuild to build
-				// to true, preventing existing runs to be kept active.
-				//
-				// Devenv is also added to the conditions as there's no explicit way
-				// for knowing that we're in a hot-reload session.
-				//
-				_runs.Clear();
-			}
-		}
-
-		private bool GetIsDesignTimeBuild(GeneratorExecutionContext context)
-		{
-			return bool.TryParse(context.GetMSBuildPropertyValue("DesignTimeBuild"), out var value) && value;
-		}
-
-		private bool GetIsHotReloadHost(GeneratorExecutionContext context)
-		{
-			return bool.TryParse(context.GetMSBuildPropertyValue("IsHotReloadHost"), out var value) && value;
-		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGenerator.cs
@@ -47,8 +47,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				if (PlatformHelper.IsValidPlatform(context))
 				{
-					_generationRunInfoManager.Update(context);
-
 					var gen = new XamlCodeGeneration(context);
 					var generatedTrees = gen.Generate(_generationRunInfoManager.CreateRun());
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that metadata update use the latest generation regardless of separate processes building the source.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
