### PR TITLE
fix: ignore case when comparing environment variable

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -35,7 +35,7 @@ namespace Uno.UI.RemoteControl.HotReload
 	{	
 		private void ReloadFile(FileReload fileReload)
 		{
-			if (Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES") == "debug")
+			if (Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES").Equals("debug", StringComparison.OrdinalIgnoreCase))
 			{
 				if (this.Log().IsEnabled(LogLevel.Debug))
 				{


### PR DESCRIPTION
We have no control over how this variable is set outside of Uno E.g. https://github.com/xamarin/xamarin-android/pull/6027/files

GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Only `debug` (all lowercase) is accepted. E.g. `Debug` as used by `net6.0-android` would be `false`.

## What is the new behavior?

Any case insensitive variation of `debug` is accepted. E.g. `Debug` as used by `net6.0-android` would be `true` instead of `false`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
