### PR TITLE
fix(winappsdk): Ensure that only the ui.toolkit assemby is referenced

### DIFF
--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -366,6 +366,11 @@
 		<reference file="Uno.UI.Toolkit.dll" />
 	  </group>
 
+	  <!--
+	  This group must not be present for nuget to fallback on net7.0 target when running on Skia+Wpf.
+	  The references list is adjusted only when WinAppSDK is detected.
+	  <group targetFramework="net5.0-windows10.0.18362.0">
+	  </group>-->
 	</references>
   </metadata>
   <files>

--- a/build/uno.winui.winappsdk.targets
+++ b/build/uno.winui.winappsdk.targets
@@ -1,4 +1,37 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	
+	<PropertyGroup>
+		<_UnoRemoveReferences_BeforeTargets>
+			$(_UnoRemoveReferences_BeforeTargets);
+			FindReferenceAssembliesForReferences;
+			MarkupCompilePass1;
+		</_UnoRemoveReferences_BeforeTargets>
+	</PropertyGroup>
 
+	<Target Name="_UnoRemoveReferences"
+			BeforeTargets="$(_UnoRemoveReferences_BeforeTargets)">
+		<ItemGroup>
+			<_UnoReferencePathToRemove
+				Include="@(ReferencePath)"
+				Condition="'%(ReferencePath.NuGetPackageId)'=='Uno.UI' or '%(ReferencePath.NuGetPackageId)'=='Uno.WinUI'" />
+
+			<!-- Remove all uno references -->
+			<ReferencePath Remove="@(_UnoReferencePathToRemove)" />
+
+			<!-- Clear items -->
+			<_UnoReferencePathToRemove Remove="@(_UnoReferencePathToRemove)" />
+		</ItemGroup>
+
+		<ItemGroup Condition="'$(PkgUno_WinUI)'!=''">
+			<!-- This must be aligned with $winuisourcepath$ in the nuspec -->
+			<ReferencePath Include="$(PkgUno_WinUI)/lib/net5.0-windows10.0.18362.0/*.dll" />
+		</ItemGroup>
+
+		<ItemGroup Condition="'$(PkgUno_UI)'!=''">
+			<!-- This must be aligned with $winuisourcepath$ in the nuspec -->
+			<ReferencePath Include="$(PkgUno_UI)/lib/net5.0-windows10.0.18362.0/*.dll" />
+		</ItemGroup>
+	</Target>
+	
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10463

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes the referenced assemblies when building with WinAppSDK. Uno.UI.Toolkit.dll is the only reference needed in this case.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
