### PR TITLE
feat(droid): Enable Text Selection on ReadOnly TextBox

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -927,7 +927,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.iOS)]
+		[ActivePlatforms(Platform.iOS, Platform.Android)]
 		public void TextBox_Selection_IsReadOnly()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Selection");

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -431,10 +431,10 @@ namespace Windows.UI.Xaml.Controls
 			// not receive any input.
 			var isReadOnly = IsReadOnly || !IsTabStop;
 
-			_textBoxView.Focusable = !isReadOnly;
-			_textBoxView.FocusableInTouchMode = !isReadOnly;
+			_textBoxView.Focusable = IsTabStop;
+			_textBoxView.FocusableInTouchMode = IsTabStop;
 			_textBoxView.Clickable = !isReadOnly;
-			_textBoxView.LongClickable = !isReadOnly;
+			_textBoxView.LongClickable = !IsTabStop;
 			_textBoxView.SetCursorVisible(!isReadOnly);
 
 			if (isReadOnly)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -50,6 +50,11 @@ namespace Windows.UI.Xaml.Controls
 		[Uno.UnoOnly]
 		public bool ShouldForceDisableSpellCheck { get; set; } = true;
 
+		/// <summary>
+		/// Both IsReadOnly = true and IsTabStop = false make the control not receive any input.
+		/// </summary>
+		internal bool IsNativeReadOnly => IsReadOnly || !IsTabStop;
+
 		public bool PreventKeyboardDisplayOnProgrammaticFocus
 		{
 			get
@@ -427,17 +432,13 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			// Both IsReadOnly = true and IsTabStop = false make the control
-			// not receive any input.
-			var isReadOnly = IsReadOnly || !IsTabStop;
-
 			_textBoxView.Focusable = IsTabStop;
 			_textBoxView.FocusableInTouchMode = IsTabStop;
-			_textBoxView.Clickable = !isReadOnly;
+			_textBoxView.Clickable = !IsNativeReadOnly;
 			_textBoxView.LongClickable = !IsTabStop;
-			_textBoxView.SetCursorVisible(!isReadOnly);
+			_textBoxView.SetCursorVisible(!IsNativeReadOnly);
 
-			if (isReadOnly)
+			if (IsNativeReadOnly)
 			{
 				_listener = _textBoxView.KeyListener;
 				_textBoxView.KeyListener = null;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Overrides.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Overrides.Android.cs
@@ -45,15 +45,13 @@ namespace Windows.UI.Xaml.Controls
 			private readonly ManagedWeakReference _owner;
 			private TextBox Owner => _owner.Target as TextBox;
 
-			private bool IsReadonly => Owner is not { } owner ? false : owner.IsReadOnly || !owner.IsTabStop;
-
 			public TextBoxStringBuilder(ManagedWeakReference owner, ICharSequence text) : base(text)
 			{
 				_owner = owner;
 			}
 			public override IEditable Replace(int start, int end, ICharSequence tb, int tbstart, int tbend)
 			{
-				if (IsReadonly)
+				if (Owner is { IsNativeReadOnly: true })
 				{
 					return this;
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Overrides.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Overrides.Android.cs
@@ -45,12 +45,19 @@ namespace Windows.UI.Xaml.Controls
 			private readonly ManagedWeakReference _owner;
 			private TextBox Owner => _owner.Target as TextBox;
 
+			private bool IsReadonly => Owner is not { } owner ? false : owner.IsReadOnly || !owner.IsTabStop;
+
 			public TextBoxStringBuilder(ManagedWeakReference owner, ICharSequence text) : base(text)
 			{
 				_owner = owner;
 			}
 			public override IEditable Replace(int start, int end, ICharSequence tb, int tbstart, int tbend)
 			{
+				if (IsReadonly)
+				{
+					return this;
+				}
+
 				// Create a copy of this string builder to preview the change, allowing the TextBox's event handlers to act on the modified text.
 				var copy = new SpannableStringBuilder(this);
 				copy.Replace(start, end, tb, tbstart, tbend);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9908

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
TextBox Readonly will disable the control preventing the users from selecting and copying Text

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
