### PR TITLE
fix: avoid NRE when DOTNET_MODIFIABLE_ASSEMBLIES is not set

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -35,7 +35,7 @@ namespace Uno.UI.RemoteControl.HotReload
 	{	
 		private void ReloadFile(FileReload fileReload)
 		{
-			if (Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES").Equals("debug", StringComparison.OrdinalIgnoreCase))
+			if (String.Equals(Environment.GetEnvironmentVariable("DOTNET_MODIFIABLE_ASSEMBLIES"), "debug", StringComparison.OrdinalIgnoreCase))
 			{
 				if (this.Log().IsEnabled(LogLevel.Debug))
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

RemoteControl fails with a `NullReferenceException` when `DOTNET_MODIFIABLE_ASSEMBLIES` is not set.

## What is the new behavior?

No exception.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Issue introduced with my previous commit 607da54f69f3886d3aa25ba19dffcea262f7b188

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
