### PR TITLE
fix(skia): support inline rendering for constrained measure size

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -65,5 +65,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = SUT;
 			SUT.Measure(new Size(1000, 1000));
 		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Check_Single_Character_Run_With_Wrapping_Constrained()
+		{
+			var SUT = new TextBlock
+			{
+				Inlines = {
+					new Run { Text = "", FontSize = 16, CharacterSpacing = 18 }
+				},
+				TextWrapping = TextWrapping.Wrap,
+				FontSize = 16,
+				CharacterSpacing = 18
+			};
+
+			WindowHelper.WindowContent = new Border { Width = 10, Height = 10, Child = SUT };
+
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreNotEqual(0, SUT.DesiredSize.Width);
+			Assert.AreNotEqual(0, SUT.DesiredSize.Height);
+
+			Assert.AreNotEqual(0, SUT.ActualWidth);
+			Assert.AreNotEqual(0, SUT.ActualHeight);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -180,8 +180,9 @@ namespace Windows.UI.Xaml.Documents
 							length = 1;
 							width = GetGlyphWidthWithSpacing(segment.Glyphs[start], characterSpacing);
 
-							while ((width + GetGlyphWidthWithSpacing(segment.Glyphs[start + length], characterSpacing)) is var newWidth &&
-								   newWidth < remainingWidth)
+							while ( start + length < segment.Glyphs.Count
+								&& (width + GetGlyphWidthWithSpacing(segment.Glyphs[start + length], characterSpacing)) is var newWidth
+								&& newWidth < remainingWidth)
 							{
 								width = newWidth;
 								length++;


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10494

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Prevents invalid operation when measuring a wrapped TextBlockwithout sufficient measure space.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
