### PR TITLE
fix(MenuFlyoutItem): synchronize can execute on loaded

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -20,6 +20,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 using static Private.Infrastructure.TestServices;
+using Uno.UI.Common;
 #if NETFX_CORE
 // Use the MUX MenuBar on Window for consistency, since Uno is using the MUX styles. (However Uno.UI only defines WUXC.MenuBar, not MUXC.MenuBar)
 using MenuBar = Microsoft.UI.Xaml.Controls.MenuBar;
@@ -246,5 +247,44 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await Verify_MenuBarItem_Bounds();
 		}
 #endif
+
+		[TestMethod]
+		public async Task When_MenuFlyoutItem_CommandChanging()
+		{
+			var SUT = new MenuBar();
+			var item = new MenuBarItem() { Title = "test item" };
+			DelegateCommand command1 = null;
+			command1 = new DelegateCommand(() => command1.CanExecuteEnabled = !command1.CanExecuteEnabled);
+			var flyoutItem = new MenuFlyoutItem
+			{
+				Command = command1,
+				Text="test flyout"
+			};
+
+			SUT.Items.Add(item);
+			item.Items.Add(flyoutItem);
+
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+
+			item.Invoke();
+			Assert.IsTrue(flyoutItem.IsEnabled);
+
+			await WindowHelper.WaitForLoaded(flyoutItem);
+
+			flyoutItem.InvokeClick();
+
+			// Force close the flyout as InvokeClick does not do so.
+			item.CloseMenuFlyout();
+
+			await WindowHelper.WaitForIdle();
+
+			item.Invoke();
+
+			Assert.IsFalse(flyoutItem.IsEnabled);
+
+			flyoutItem.InvokeClick();
+			item.CloseMenuFlyout();
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -247,13 +247,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+#if HAS_UNO
 		[TestMethod]
 		public async Task When_MenuFlyoutItem_CommandChanging()
 		{
 			var SUT = new MenuBar();
 			var item = new MenuBarItem() { Title = "test item" };
-			DelegateCommand command1 = null;
-			command1 = new DelegateCommand(() => command1.CanExecuteEnabled = !command1.CanExecuteEnabled);
+			Common.DelegateCommand command1 = null;
+			command1 = new(() => command1.CanExecuteEnabled = !command1.CanExecuteEnabled);
 			var flyoutItem = new MenuFlyoutItem
 			{
 				Command = command1,
@@ -285,5 +286,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			flyoutItem.InvokeClick();
 			item.CloseMenuFlyout();
 		}
+#endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -20,7 +20,6 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 using static Private.Infrastructure.TestServices;
-using Uno.UI.Common;
 #if NETFX_CORE
 // Use the MUX MenuBar on Window for consistency, since Uno is using the MUX styles. (However Uno.UI only defines WUXC.MenuBar, not MUXC.MenuBar)
 using MenuBar = Microsoft.UI.Xaml.Controls.MenuBar;

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -521,10 +521,11 @@ namespace Windows.UI.Xaml.Controls
 
 					m_epCanExecuteChangedHandler = Disposable.Create(() => spCommand.CanExecuteChanged -= OnCanExecuteChanged);
 				}
-				// In case we missed an update to CanExecute while the CanExecuteChanged handler was unhooked,
-				// we need to update our value now.
-				UpdateCanExecute();
 			}
+
+			// In case we missed an update to CanExecute while the CanExecuteChanged handler was unhooked,
+			// we need to update our value now.
+			UpdateCanExecute();
 		}
 
 		private protected override void OnUnloaded()


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10479

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes CanExecute refresh on flyout loaded.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
