### PR TITLE
Fix multiple Flyout DataContext propagation issues

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -452,7 +452,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
-#if IS_UNO
+#if HAS_UNO
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task Test_Flyout_Binding()
@@ -480,6 +480,80 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Test_Flyout_Binding_In_MenuFlyoutItem()
+		{
+			var menuBar = new MenuBar();
+			var menuBarItem = new MenuBarItem();
+			var menuFlyoutItem = new MenuFlyoutItem();
+
+			menuFlyoutItem.SetBinding(MenuFlyoutItem.TextProperty, new Binding { Path = "." });
+
+			menuBar.Items.Add(menuBarItem);
+			menuBarItem.Items.Add(menuFlyoutItem);
+
+			menuBar.DataContext = "42";
+
+			TestServices.WindowHelper.WindowContent = menuBar;
+
+			await TestServices.WindowHelper.WaitForLoaded(menuBar);
+
+			menuBarItem.Invoke();
+
+			await TestServices.WindowHelper.WaitForLoaded(menuFlyoutItem);
+
+			Assert.AreEqual("42", menuFlyoutItem.Text);
+
+			menuBarItem.CloseMenuFlyout();
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Test_Flyout_Binding_With_SetAttachedFlyout()
+		{
+			Border b1 = new()
+			{
+				DataContext = "41",
+				Width = 10,
+				Height = 10,
+			};
+			Border b2 = new()
+			{
+				DataContext = "42",
+				Width = 10,
+				Height = 10,
+			};
+
+			var stackPanel = new StackPanel()
+			{
+				Children = { b1, b2 }
+			};
+
+			TestServices.WindowHelper.WindowContent = stackPanel;
+			await TestServices.WindowHelper.WaitForLoaded(stackPanel);
+
+			var tb = new TextBlock();
+			tb.SetBinding(TextBlock.TextProperty, new Binding { Path = "." });
+			var SUT = new Flyout
+			{
+				Content = tb
+			};
+
+			FlyoutBase.SetAttachedFlyout(b1, SUT);
+			FlyoutBase.SetAttachedFlyout(b2, SUT);
+
+			FlyoutBase.ShowAttachedFlyout(b1);
+			await TestServices.WindowHelper.WaitForLoaded(tb);
+			Assert.AreEqual("41", tb.Text);
+			SUT.Close();
+
+			FlyoutBase.ShowAttachedFlyout(b2);
+			await TestServices.WindowHelper.WaitForLoaded(tb);
+			Assert.AreEqual("42", tb.Text);
+			SUT.Close();
+		}
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_Flyout_Content_Takes_Focus()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -452,7 +452,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
-#if HAS_UNO
+#if HAS_UNO && !__MACOS__ // For macOS, see https://github.com/unoplatform/uno/issues/626 
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task Test_Flyout_Binding()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -478,8 +478,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var stackPanel = content as StackPanel;
 			Assert.AreEqual("My Data Context", (stackPanel.Children[0] as TextBlock).Text);
 		}
-#endif
-
 
 		[TestMethod]
 		[RunsOnUIThread]
@@ -554,6 +552,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual("42", tb.Text);
 			SUT.Close();
 		}
+#endif
+
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_Flyout_Content_Takes_Focus()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -70,6 +70,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task Check_Single_Character_Run_With_Wrapping_Constrained()
 		{
+#if __MACOS__
+			Assert.Inconclusive("https://github.com/unoplatform/uno/issues/626");
+#endif
+
 			var SUT = new TextBlock
 			{
 				Inlines = {

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/ScrollViewerIRefreshInfoProviderAdapter.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PullToRefresh/ScrollViewerIRefreshInfoProviderAdapter/ScrollViewerIRefreshInfoProviderAdapter.cs
@@ -10,12 +10,15 @@ using Windows.Foundation;
 using Windows.UI.Composition;
 using Windows.UI.Composition.Interactions;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using static Microsoft.UI.Xaml.Controls._Tracing;
 using RefreshPullDirection = Microsoft.UI.Xaml.Controls.RefreshPullDirection;
+
+#pragma warning disable CS0105 // Ignore duplicate namespace for WinUI build
+using Windows.UI.Xaml.Controls;
+#pragma warning restore CS0105
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
@@ -129,6 +129,16 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		protected internal override void OnDataContextChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnDataContextChanged(e);
+
+			if (Content is IDependencyObjectStoreProvider binder)
+			{
+				binder.Store.SetValue(binder.Store.DataContextProperty, DataContext, DependencyPropertyValuePrecedences.Local);
+			}
+		}
+
 		protected override Control CreatePresenter()
 		{
 			_presenter = new FlyoutPresenter();

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -458,6 +458,13 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		public static void ShowAttachedFlyout(FrameworkElement flyoutOwner)
 		{
 			var flyout = GetAttachedFlyout(flyoutOwner);
+
+			flyout?.SetValue(
+				FlyoutBase.DataContextProperty,
+				flyoutOwner.DataContext,
+				precedence: DependencyPropertyValuePrecedences.Inheritance
+			);
+
 			flyout?.ShowAt(flyoutOwner);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/MenuBar/MenuBarItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuBar/MenuBarItem.cs
@@ -64,6 +64,23 @@ namespace Windows.UI.Xaml.Controls
 		private void SynchronizeMenuBar()
 			=> m_menuBar = SharedHelpers.GetAncestorOfType<MenuBar>(VisualTreeHelper.GetParent(this));
 
+		internal protected override void OnDataContextChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnDataContextChanged(e);
+
+			SetFlyoutDataContext();
+		}
+
+		private void SetFlyoutDataContext()
+		{
+			// This is present to force the dataContext to be passed to the popup of the flyout since it is not directly a child in the visual tree of the flyout. 
+			m_flyout?.SetValue(
+				MenuFlyout.DataContextProperty,
+				this.DataContext,
+				precedence: DependencyPropertyValuePrecedences.Inheritance
+			);
+		}
+
 		private void PopulateContent()
 		{
 			// Create flyout
@@ -88,6 +105,8 @@ namespace Windows.UI.Xaml.Controls
 				m_button.IsAccessKeyScope = true;
 				m_button.ContextFlyout = flyout;
 			}
+
+			SetFlyoutDataContext();
 		}
 
 		private void AttachEventHandlers()


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10400

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Fix propagation during `ShowAttachedFlyout`
- Fix propagation when used in `MenuBarItem`
- Adjusts WinUI duplicate namespace when using auto-generated WinUI branch

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
