### PR TITLE
fix(lottie): Lottie animation using ms-appx source fails to manually start

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSource.iOSmacOS.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSource.iOSmacOS.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 					_lastSource = sourceUri;
 					if ((await TryLoadDownloadJson(sourceUri, ct)) is { } jsonStream)
 					{
+						var tcs = new TaskCompletionSource<bool>();
+
 						var cacheKey = sourceUri.OriginalString;
 						_animationDataSubscription.Disposable = null;
 						_animationDataSubscription.Disposable =
@@ -56,12 +58,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 							var animation = LOTAnimationView.AnimationFromJSON(jsonData);
 							SetAnimation(animation);
 
-							if (_playState != null)
-							{
-								var (fromProgress, toProgress, looped) = _playState.Value;
-								Play(fromProgress, toProgress, looped);
-							}
+							tcs.TrySetResult(true);
 						}
+
+						await tcs.Task;
 					}
 					else
 					{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10312

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Enhanced support for ms-appx broke non-automatic playback. This PR restores this feature.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
