### PR TITLE
fix(reg): Don't use C# 8.0 lambda parameter shadowing for xamarin projects

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -31,7 +31,11 @@
 								  and (
 									'$(MSBuildVersion)' &lt; '17.0'
 									or (
-										'$(LangVersion)'!=''
+										'$(MSBuildVersion)' &gt;= '17.0'
+										and '$(LangVersion)' != ''
+										and '$(LangVersion)' != 'latest'
+										and '$(LangVersion)' != 'latestMajor'
+										and '$(LangVersion)' != 'default'
 										and '$(LangVersion)' &lt; '8.0'
 									)
 								  )">false</UnoForceHotReloadCodeGen>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -24,8 +24,17 @@
 		<!--
 		MSBuild below 17.0 implies C# 7.3 or below, which does not support lambda parameters shadowing (https://github.com/dotnet/csharplang/blob/main/meetings/2019/LDM-2019-01-16.md).
 		In this mode, we disable all hot reload specific code generation.
+		Additionally, if LangVersion is explicitly set to 7.3 or below, we also disable hot reload (Xamarin.iOS/Android/Mac projects set this explicitly)
 		-->
-		<UnoForceHotReloadCodeGen Condition="'$(UnoForceHotReloadCodeGen)'=='' and '$(MSBuildVersion)' &lt; '17.0'">false</UnoForceHotReloadCodeGen>
+		<UnoForceHotReloadCodeGen Condition="
+								  '$(UnoForceHotReloadCodeGen)'==''
+								  and (
+									'$(MSBuildVersion)' &lt; '17.0'
+									or (
+										'$(LangVersion)'!=''
+										and '$(LangVersion)' &lt; '8.0'
+									)
+								  )">false</UnoForceHotReloadCodeGen>
 
 		<XamarinProjectType Condition="
 							'$(ProjectTypeGuids)'=='{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}'


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10547

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Xamarin projects explicit set LangVersion to 7.3, regardless of the VS version, causing lambda parameters shadowing to fail, this change restores the original behavior.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
