### PR TITLE
Misc trimming, conditionally exclude ExpandoObject binding

### DIFF
--- a/doc/articles/uno-development/Uno-UI-XAML-ResourceTrimming.md
+++ b/doc/articles/uno-development/Uno-UI-XAML-ResourceTrimming.md
@@ -32,17 +32,19 @@ As of Uno 3.9, the Uno.UI WebAssembly assembly is 7.5MB, trimmed down to 3.1MB f
 In some scenarios (e.g. ExpandoObject), it may be needed to generate linker hints for non-DependencyObject types.
 
 To get a `__LinkerHints` property for an additional type, add the following in AssemblyInfo.cs:
+
 ```csharp
 [assembly: AdditionalLinkerHint("System.Dynamic.ExpandoObject")]
 ```
 
 Then make the code using `ExpandoObject` conditional:
+
 ```csharp
-if(__LinkerHints.Is_System_Dynamic_ExpandoObject_Available
+if (__LinkerHints.Is_System_Dynamic_ExpandoObject_Available
 	&& type == typeof(System.Dynamic.ExpandoObject))
-    {
-        ...
-    }
+{
+    ...
+}
 ```
 
 The linker will automatically remove the rest of the conditional block if the linker hint is considered false, based on the use of `ExpandoObject` in the rest of the app (except the current assembly).

--- a/doc/articles/uno-development/Uno-UI-XAML-ResourceTrimming.md
+++ b/doc/articles/uno-development/Uno-UI-XAML-ResourceTrimming.md
@@ -12,17 +12,37 @@ In order to determine what is actually used by the application, the Uno Platform
 
 In order to prepare the linking pass:
 - The tooling determines the presence of the `UnoXamlResourcesTrimming` msbuild property
-- During the source generation, the tooling generates a `LinkerHints` class, which contains a set of properties for all `DependencyObject` inheriting classes.
+- During the source generation, the tooling generates a `__LinkerHints` class, which contains a set of properties for all `DependencyObject` inheriting classes.
 - The source generation creates XAML Resources and Bindable Metadata code that conditionally uses those classes behind `LinkerHints` properties.
 - The tooling also embeds an ILLinker substitution file allowing the linker to unconditionally remove the code that conditionally references those properties. For instance, for `LinkerHints.Is_Windows_UI_Xaml_Controls_Border_Available`, any block of `if (LinkerHints.Is_Windows_UI_Xaml_Controls_Border_Available)` will be removed when the `--feature Is_Windows_UI_Xaml_Controls_Border_Available false` parameter is provided to the linker.
 
 Then the multiple passes of IL Linker are done:
-- The first pass runs the IL Linker with all XAML resources and Binding Metadata disabled by setting all `LinkerHints` properties to false. This removes all code directly associated to those Bindable Metadata and XAML Resources. This has the effect of only keeping framework code which is directly referenced from user code.
+- The first pass runs the IL Linker with all XAML resources and Binding Metadata disabled by setting all `__LinkerHints` properties to false. This removes all code directly associated to those Bindable Metadata and XAML Resources. This has the effect of only keeping framework code which is directly referenced from user code.
 - The tooling then reads the result of the linker to determine which types in the `LinkerHints` are still available in the assemblies.
-- The subsequent passes run the IL Linker with `LinkerHints` enabled only for types detected to be used during the first pass. This will enable types indirectly referenced by XAML Resources (e.g. a ScrollBar inside a ScrollViewer style) to be kept by the linker.
-- The tooling then reads again the result of the linker to determine which types in the `LinkerHints` are still available in the assemblies.
+- The subsequent passes run the IL Linker with `__LinkerHints` enabled only for types detected to be used during the first pass. This will enable types indirectly referenced by XAML Resources (e.g. a ScrollBar inside a ScrollViewer style) to be kept by the linker.
+- The tooling then reads again the result of the linker to determine which types in the `__LinkerHints` are still available in the assemblies.
 - The tooling re-runs this last pass until the available types list stops changing.
 
-The resulting `LinkerHints` types are now passed as features to the final linker pass (the one bundled with the .NET tooling) to generate the final binary, containing only the used types.
+The resulting `__LinkerHints` types are now passed as features to the final linker pass (the one bundled with the .NET tooling) to generate the final binary, containing only the used types.
 
 As of Uno 3.9, the Uno.UI WebAssembly assembly is 7.5MB, trimmed down to 3.1MB for a `dotnet new unoapp` template.
+
+## Using the `AdditionalLinkerHintAttribute` attribute
+
+In some scenarios (e.g. ExpandoObject), it may be needed to generate linker hints for non-DependencyObject types.
+
+To get a `__LinkerHints` property for an additional type, add the following in AssemblyInfo.cs:
+```csharp
+[assembly: AdditionalLinkerHint("System.Dynamic.ExpandoObject")]
+```
+
+Then make the code using `ExpandoObject` conditional:
+```csharp
+if(__LinkerHints.Is_System_Dynamic_ExpandoObject_Available
+	&& type == typeof(System.Dynamic.ExpandoObject))
+    {
+        ...
+    }
+```
+
+The linker will automatically remove the rest of the conditional block if the linker hint is considered false, based on the use of `ExpandoObject` in the rest of the app (except the current assembly).

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/DependencyObjectAvailabilityGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/DependencyObjectAvailabilityGenerator.cs
@@ -83,7 +83,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 						_dependencyObjectSymbol = context.Compilation.GetTypeByMetadataName("Windows.UI.Xaml.DependencyObject");
 						_additionalLinkerHintAttributeSymbol = context.Compilation.GetTypeByMetadataName("Uno.Foundation.Diagnostics.CodeAnalysis.AdditionalLinkerHintAttribute");
 
-						var additionalLinkerHintSymbols = FindAdditionalLinkerHints(_additionalLinkerHintAttributeSymbol, context);
+						var additionalLinkerHintSymbols = FindAdditionalLinkerHints(context);
 
 						var modules = from ext in context.Compilation.ExternalReferences
 									  let sym = context.Compilation.GetAssemblyOrModuleSymbol(ext) as IAssemblySymbol
@@ -148,17 +148,17 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 				}
 			}
 
-			private HashSet<INamedTypeSymbol> FindAdditionalLinkerHints(INamedTypeSymbol? additionalLinkerHintAttributeSymbol, GeneratorExecutionContext context)
+			private HashSet<INamedTypeSymbol> FindAdditionalLinkerHints(GeneratorExecutionContext context)
 			{
 				HashSet<INamedTypeSymbol> types = new(SymbolEqualityComparer.Default);
 
-				if (additionalLinkerHintAttributeSymbol != null)
+				if (_additionalLinkerHintAttributeSymbol != null)
 				{
 					var attributes = context
 						.Compilation
 						.Assembly
 						.GetAttributes()
-						.Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, additionalLinkerHintAttributeSymbol));
+						.Where(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, _additionalLinkerHintAttributeSymbol));
 
 					foreach (var attribute in attributes)
 					{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/DependencyObjectAvailabilityGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/DependencyObjectAvailabilityGenerator.cs
@@ -150,7 +150,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 
 			private HashSet<INamedTypeSymbol> FindAdditionalLinkerHints(INamedTypeSymbol? additionalLinkerHintAttributeSymbol, GeneratorExecutionContext context)
 			{
-				HashSet<INamedTypeSymbol> types = new();
+				HashSet<INamedTypeSymbol> types = new(SymbolEqualityComparer.Default);
 
 				if (additionalLinkerHintAttributeSymbol != null)
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/DependencyObjectAvailabilityGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/DependencyObjectAvailabilityGenerator.cs
@@ -139,11 +139,11 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 					var diagnostic = Diagnostic.Create(
 						XamlCodeGenerationDiagnostics.GenericXamlErrorRule,
 						null,
-						$"Failed to generate dependency objects. ({e.Message})");
+						$"Failed to generate linker hints. ({e.Message})");
 
 					context.ReportDiagnostic(diagnostic);
 #else
-					Console.WriteLine("Failed to generate type providers.", new Exception("Failed to generate type providers." + message, e));
+					Console.WriteLine("Failed to generate linker hints", new Exception("Failed to generate linker hints" + message, e));
 #endif
 				}
 			}

--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
@@ -148,7 +148,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				$"--feature UnoBindableMetadata false",
 				$"--verbose",
 				$"--deterministic",
-				$"--used-attrs-only true",
+				// $"--used-attrs-only true", // not used to keep additional linker hints
 				$"--skip-unresolved true",
 				$"-b true",
 				$"-a {AssemblyPath}",
@@ -185,10 +185,11 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 
 			var features = new Dictionary<string, string>();
 
-			var availableLinkerHints = FindAvailableLinkerHints(assemblies);
+			var originalLinkerHints = FindAvailableLinkerHints(BuildOriginalResourceSearchList());
+
 			var availableTypes = BuildAvailableTypes(assemblies);
 
-			foreach(var hint in availableLinkerHints)
+			foreach(var hint in originalLinkerHints)
 			{
 				features[hint] = "false";
 			}
@@ -256,7 +257,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 
 		private string BuildLinkerFeaturesList()
 		{
-			var assemblySearchList = BuildResourceSearchList();
+			var assemblySearchList = BuildOriginalResourceSearchList();
 
 			var hints = FindAvailableLinkerHints(assemblySearchList);
 
@@ -305,7 +306,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			return map;
 		}
 
-		private List<AssemblyDefinition> BuildResourceSearchList()
+		private List<AssemblyDefinition> BuildOriginalResourceSearchList()
 		{
 			var sourceList = new List<string>();
 

--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
@@ -293,7 +293,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 			{
 				foreach(var type in asm.MainModule.Types)
 				{
-					if(!map.TryGetValue(type.FullName, out var list))
+					if (!map.TryGetValue(type.FullName, out var list))
 					{
 						list = new();
 					}

--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
@@ -295,7 +295,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				{
 					if (!map.TryGetValue(type.FullName, out var list))
 					{
-						list = new();
+						map[type.FullName] = list = new();
 					}
 
 					list.Add(type);

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -56,8 +56,10 @@
 		<PropertyGroup>
 			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
 			<_baseNugetPath Condition="'$(USERPROFILE)'!=''">$(USERPROFILE)</_baseNugetPath>
-      <_baseNugetPath Condition="'$(HOME)'!=''">$(HOME)</_baseNugetPath>
-			<_TargetNugetFolder>$(_baseNugetPath)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\buildTransitive\Uno.UI.Tasks</_TargetNugetFolder>
+			<_baseNugetPath Condition="'$(HOME)'!=''">$(HOME)</_baseNugetPath>
+			<_PackageId>Uno.UI</_PackageId>
+			<_PackageId Condition="'$(UNO_UWP_BUILD)'=='false'">Uno.WinUI</_PackageId>
+			<_TargetNugetFolder>$(_baseNugetPath)\.nuget\packages\$(_PackageId)\$(UnoNugetOverrideVersion)\buildTransitive\Uno.UI.Tasks</_TargetNugetFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<_OutputFiles Include="$(TargetDir)**" />

--- a/src/Uno.Foundation/Diagnostics/CodeAnalysis/AdditionalLinkerHintAttribute.cs
+++ b/src/Uno.Foundation/Diagnostics/CodeAnalysis/AdditionalLinkerHintAttribute.cs
@@ -10,7 +10,7 @@ namespace Uno.Foundation.Diagnostics.CodeAnalysis
 	/// Provide the ability to include an additional type to the linker hints generator.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-	internal class AdditionalLinkerHintAttribute : Attribute
+	internal sealed class AdditionalLinkerHintAttribute : Attribute
 	{
 		/// <summary>
 		/// Builds a new linker hint

--- a/src/Uno.Foundation/Diagnostics/CodeAnalysis/AdditionalLinkerHintAttribute.cs
+++ b/src/Uno.Foundation/Diagnostics/CodeAnalysis/AdditionalLinkerHintAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Uno.Foundation.Diagnostics.CodeAnalysis
+{
+	/// <summary>
+	/// Provide the ability to include an additional type to the linker hints generator.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+	internal class AdditionalLinkerHintAttribute : Attribute
+	{
+		/// <summary>
+		/// Builds a new linker hint
+		/// </summary>
+		/// <param name="fullTypeName">The full type name, using Cecil's formatting</param>
+		public AdditionalLinkerHintAttribute(string fullTypeName)
+		{
+			FullTypeName = fullTypeName;
+		}
+
+		/// <summary>
+		/// The linker hint target type
+		/// </summary>
+		public string FullTypeName { get; }
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1510,6 +1510,37 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.AreEqual(FillRule.EvenOdd, geometry.FillRule);
     }
 
+		[TestMethod]
+		public void MyTestMethod()
+		{
+			var height = 0.0f;
+			var leftCorner = 0.0f;
+			var rightCorner = 0.0f;
+			var scaleFactor = 1.0f;
+			var actualHeight = 0.0f;
+			var data = "<Geometry xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>F1 M0,{0}  a 4,4 0 0 0 4,-4  L 4,{1}  a {2},{3} 0 0 1 {4},-{5}  l {6},0  a {7},{8} 0 0 1 {9},{10}  l 0,{11}  a 4,4 0 0 0 4,4 Z</Geometry>";
+
+			var strOut = string.Format(
+				CultureInfo.InvariantCulture,
+				data,
+				height - 1.0f,
+				leftCorner,
+				leftCorner,
+				leftCorner,
+				leftCorner,
+				leftCorner,
+				actualHeight - (leftCorner + rightCorner + 1.0f / scaleFactor),
+				rightCorner,
+				rightCorner,
+				rightCorner,
+				rightCorner,
+				height - (5 + rightCorner));
+
+			var geometry = Windows.UI.Xaml.Markup.XamlReader.Load(strOut) as Uno.Media.StreamGeometry;
+			Assert.IsNotNull(geometry);
+			Assert.AreEqual(FillRule.Nonzero, geometry.FillRule);
+		}
+
 		/// <summary>
 		/// XamlReader.Load the xaml and type-check result.
 		/// </summary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -554,7 +554,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			var link = tb1.Inlines.OfType<Hyperlink>().Single();
 			link.NavigateUri.ToString().Should().Be("http://www.site.com/");
 			link.Inlines.Single().Should().BeOfType<Run>();
-			((Run) link.Inlines.Single()).Text.Should().Be("Nav");
+			((Run)link.Inlines.Single()).Text.Should().Be("Nav");
 
 			var tb2 = r.FindName("tb02") as TextBlock;
 
@@ -728,7 +728,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.IsTrue((bool)tb1.IsChecked);
 			Assert.IsTrue((bool)tb2.IsChecked);
 		}
-		
+
 		[TestMethod]
 		public void When_GridRowDefinitions()
 		{
@@ -835,12 +835,13 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		[TestMethod]
 		public void When_ImplicitStyle_WithoutKey()
 		{
-			Assert.ThrowsException<InvalidOperationException>(() => {
+			Assert.ThrowsException<InvalidOperationException>(() =>
+			{
 				var s = GetContent(nameof(When_ImplicitStyle_WithoutKey));
 				var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
 			});
 		}
-		
+
 		[TestMethod]
 		public void When_NonDependencyPropertyAssignable()
 		{
@@ -854,7 +855,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.AreEqual("42", inner.Tag);
 			Assert.AreEqual(43, inner.MyProperty);
 		}
-		
+
 		[TestMethod]
 		public void When_NonDependencyProperty_Binding()
 		{
@@ -1144,7 +1145,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 				Assert.AreEqual(24, owner.Test.Value);
 			}
 		}
-		
+
 		[TestMethod]
 		public void When_xName_Reload()
 		{
@@ -1500,45 +1501,14 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.AreEqual(Windows.UI.Colors.Blue, (border2.Background as SolidColorBrush)?.Color);
 			Assert.AreEqual(Windows.UI.Colors.Yellow, (border2.BorderBrush as SolidColorBrush)?.Color);
 		}
-    
+
 		[TestMethod]
-    public void When_Geometry()
+		public void When_Geometry()
 		{
 			var path = "<Geometry xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z</Geometry>";
 			var geometry = Windows.UI.Xaml.Markup.XamlReader.Load(path) as Uno.Media.StreamGeometry;
 			Assert.IsNotNull(geometry);
 			Assert.AreEqual(FillRule.EvenOdd, geometry.FillRule);
-    }
-
-		[TestMethod]
-		public void MyTestMethod()
-		{
-			var height = 0.0f;
-			var leftCorner = 0.0f;
-			var rightCorner = 0.0f;
-			var scaleFactor = 1.0f;
-			var actualHeight = 0.0f;
-			var data = "<Geometry xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>F1 M0,{0}  a 4,4 0 0 0 4,-4  L 4,{1}  a {2},{3} 0 0 1 {4},-{5}  l {6},0  a {7},{8} 0 0 1 {9},{10}  l 0,{11}  a 4,4 0 0 0 4,4 Z</Geometry>";
-
-			var strOut = string.Format(
-				CultureInfo.InvariantCulture,
-				data,
-				height - 1.0f,
-				leftCorner,
-				leftCorner,
-				leftCorner,
-				leftCorner,
-				leftCorner,
-				actualHeight - (leftCorner + rightCorner + 1.0f / scaleFactor),
-				rightCorner,
-				rightCorner,
-				rightCorner,
-				rightCorner,
-				height - (5 + rightCorner));
-
-			var geometry = Windows.UI.Xaml.Markup.XamlReader.Load(strOut) as Uno.Media.StreamGeometry;
-			Assert.IsNotNull(geometry);
-			Assert.AreEqual(FillRule.Nonzero, geometry.FillRule);
 		}
 
 		/// <summary>
@@ -1547,7 +1517,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		/// <param name="sanitizedXaml">Xaml with single or double quots</param>
 		/// <param name="defaultXmlns">The default xmlns to inject; use null to not inject one.</param>
 		private T LoadXaml<T>(string sanitizedXaml, string defaultXmlns = "http://schemas.microsoft.com/winfx/2006/xaml/presentation") where T : class =>
-			LoadXaml<T>(sanitizedXaml, new Dictionary<string, string>{ [string.Empty] = defaultXmlns });
+			LoadXaml<T>(sanitizedXaml, new Dictionary<string, string> { [string.Empty] = defaultXmlns });
 
 		/// <summary>
 		/// XamlReader.Load the xaml and type-check result.

--- a/src/Uno.UI/AssemblyInfo.cs
+++ b/src/Uno.UI/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Uno.Foundation.Diagnostics.CodeAnalysis;
 
 [assembly: InternalsVisibleTo("Uno.UI.Foldable")]
 [assembly: InternalsVisibleTo("Uno.UI.Tests")]
@@ -27,3 +28,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyMetadata("IsTrimmable", "True")]
 
 [assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(Uno.UI.RuntimeTypeMetadataUpdateHandler))]
+
+[assembly: AdditionalLinkerHint("System.Dynamic.ExpandoObject")]
+[assembly: AdditionalLinkerHint("System.Dynamic.DynamicObject")]

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.MemberBinder.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.MemberBinder.cs
@@ -7,6 +7,7 @@ namespace Uno.UI.DataBinding
 
 	internal static partial class BindingPropertyHelper
 	{
+		[Preserve]
 		private class UnoGetMemberBinder : GetMemberBinder
 		{
 			public UnoGetMemberBinder(string name, bool ignoreCase) : base(name, ignoreCase) { }
@@ -15,6 +16,7 @@ namespace Uno.UI.DataBinding
 				=> throw new NotSupportedException();
 		}
 
+		[Preserve]
 		private class UnoSetMemberBinder : SetMemberBinder
 		{
 			public UnoSetMemberBinder(string name, bool ignoreCase) : base(name, ignoreCase) { }

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -691,7 +691,7 @@ namespace Uno.UI.DataBinding
 					return instance => attachedPropertyGetter.Invoke(null, new[] { instance });
 				}
 
-				if(__LinkerHints.Is_System_Dynamic_ExpandoObject_Available
+				if (__LinkerHints.Is_System_Dynamic_ExpandoObject_Available
 					&& type == typeof(System.Dynamic.ExpandoObject))
 				{
 					return instance =>
@@ -708,7 +708,7 @@ namespace Uno.UI.DataBinding
 					};
 				}
 
-				if(__LinkerHints.Is_System_Dynamic_DynamicObject_Available
+				if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
 					&& type.Is(typeof(System.Dynamic.DynamicObject)))
 				{
 					return instance =>

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -691,7 +691,8 @@ namespace Uno.UI.DataBinding
 					return instance => attachedPropertyGetter.Invoke(null, new[] { instance });
 				}
 
-				if(type == typeof(System.Dynamic.ExpandoObject))
+				if(__LinkerHints.Is_System_Dynamic_ExpandoObject_Available
+					&& type == typeof(System.Dynamic.ExpandoObject))
 				{
 					return instance =>
 					{
@@ -707,7 +708,8 @@ namespace Uno.UI.DataBinding
 					};
 				}
 
-				if(type.Is(typeof(System.Dynamic.DynamicObject)))
+				if(__LinkerHints.Is_System_Dynamic_DynamicObject_Available
+					&& type.Is(typeof(System.Dynamic.DynamicObject)))
 				{
 					return instance =>
 					{
@@ -905,7 +907,8 @@ namespace Uno.UI.DataBinding
 					}
 				}
 
-				if (type == typeof(System.Dynamic.ExpandoObject))
+				if (__LinkerHints.Is_System_Dynamic_ExpandoObject_Available
+					&& type == typeof(System.Dynamic.ExpandoObject))
 				{
 					return (instance, value) =>
 					{
@@ -917,7 +920,8 @@ namespace Uno.UI.DataBinding
 				}
 
 
-				if (type.Is(typeof(System.Dynamic.DynamicObject)))
+				if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
+					&& type.Is(typeof(System.Dynamic.DynamicObject)))
 				{
 					return (instance, value) =>
 					{

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -19,6 +19,7 @@ using Uno.Conversion;
 using Windows.UI.Xaml.Data;
 using System.Dynamic;
 using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Uno.UI.DataBinding
 {
@@ -55,6 +56,8 @@ namespace Uno.UI.DataBinding
 		private static Dictionary<CachedTuple<Type, string, DependencyPropertyValuePrecedences>, ValueUnsetterHandler> _getValueUnsetter = new Dictionary<CachedTuple<Type, string, DependencyPropertyValuePrecedences>, ValueUnsetterHandler>(CachedTuple<Type, string, DependencyPropertyValuePrecedences>.Comparer);
 		private static Dictionary<CachedTuple<Type, string>, bool> _isEvent = new Dictionary<CachedTuple<Type, string>, bool>(CachedTuple<Type, string>.Comparer);
 		private static Dictionary<CachedTuple<Type, string, bool>, Type?> _getPropertyType = new Dictionary<CachedTuple<Type, string, bool>, Type?>(CachedTuple<Type, string, bool>.Comparer);
+		private static Type? _unoGetMemberBindingType;
+		private static Type? _unoSetMemberBindingType;
 
 		static BindingPropertyHelper()
 		{
@@ -711,14 +714,31 @@ namespace Uno.UI.DataBinding
 				if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
 					&& type.Is(typeof(System.Dynamic.DynamicObject)))
 				{
-					return instance =>
+					return [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(UnoGetMemberBinder))] (instance) =>
 					{
 						if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
-							&& instance is System.Dynamic.DynamicObject dynamicObject
-							&& dynamicObject.TryGetMember(new UnoGetMemberBinder(property, true), out var binderValue)
-						)
+							&& instance is System.Dynamic.DynamicObject dynamicObject)
 						{
-							return binderValue;
+							// Referencing UnoGetMemberBinder using a typeof or a generic type is enough to pull
+							// the System.Dynamic containing assembly. We're using reflection to create the binder
+							// given that the full type has been kept through `DynamicDependency` provided above.
+							_unoGetMemberBindingType ??=
+								Type.GetType("Uno.UI.DataBinding.UnoGetMemberBinder, Uno.UI")
+								?? throw new InvalidOperationException();
+
+							var binder = (GetMemberBinder?)Activator.CreateInstance(_unoGetMemberBindingType, property, true);
+
+							if(binder is not null)
+							{
+								if (dynamicObject.TryGetMember(binder, out var binderValue))
+								{
+									return binderValue;
+								}
+							}
+							else
+							{
+								_log.ErrorFormat("The type UnoGetMemberBinder is not available, likely caused by an incorrect Linker configuration.", property, type);
+							}
 						}
 
 						return null;
@@ -923,12 +943,29 @@ namespace Uno.UI.DataBinding
 				if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
 					&& type.Is(typeof(System.Dynamic.DynamicObject)))
 				{
-					return (instance, value) =>
+					return [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(UnoSetMemberBinder))] (instance, value) =>
 					{
 						if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
 							&& instance is System.Dynamic.DynamicObject dynamicObject)
 						{
-							dynamicObject.TrySetMember(new UnoSetMemberBinder(property, true), value);
+							// Referencing UnoGetMemberBinder using a typeof or a generic type is enough to pull
+							// the System.Dynamic containing assembly. We're using reflection to create the binder
+							// given that the full type has been kept through `DynamicDependency` provided above.
+							_unoSetMemberBindingType ??=
+								Type.GetType("Uno.UI.DataBinding.UnoSetMemberBinder, Uno.UI")
+								?? throw new InvalidOperationException();
+
+							var binder = (SetMemberBinder?)Activator.CreateInstance(_unoSetMemberBindingType, property, true);
+
+							if (binder is not null)
+							{
+								dynamicObject.TrySetMember(binder, value);
+							}
+							else
+							{
+								_log.ErrorFormat("The type UnoSetMemberBinder is not available, likely caused by an incorrect Linker configuration.", property, type);
+							}
+
 						}
 					};
 				}

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -737,7 +737,7 @@ namespace Uno.UI.DataBinding
 							}
 							else
 							{
-								_log.ErrorFormat("The type UnoGetMemberBinder is not available, likely caused by an incorrect Linker configuration.", property, type);
+								_log.ErrorFormat("The type UnoGetMemberBinder is not available, likely caused by an incorrect Linker configuration.");
 							}
 						}
 
@@ -948,7 +948,7 @@ namespace Uno.UI.DataBinding
 						if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
 							&& instance is System.Dynamic.DynamicObject dynamicObject)
 						{
-							// Referencing UnoGetMemberBinder using a typeof or a generic type is enough to pull
+							// Referencing UnoSetMemberBinder using a typeof or a generic type is enough to pull
 							// the System.Dynamic containing assembly. We're using reflection to create the binder
 							// given that the full type has been kept through `DynamicDependency` provided above.
 							_unoSetMemberBindingType ??=
@@ -963,7 +963,7 @@ namespace Uno.UI.DataBinding
 							}
 							else
 							{
-								_log.ErrorFormat("The type UnoSetMemberBinder is not available, likely caused by an incorrect Linker configuration.", property, type);
+								_log.ErrorFormat("The type UnoSetMemberBinder is not available, likely caused by an incorrect Linker configuration.");
 							}
 
 						}

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -723,7 +723,7 @@ namespace Uno.UI.DataBinding
 							// the System.Dynamic containing assembly. We're using reflection to create the binder
 							// given that the full type has been kept through `DynamicDependency` provided above.
 							_unoGetMemberBindingType ??=
-								Type.GetType("Uno.UI.DataBinding.UnoGetMemberBinder, Uno.UI")
+								Type.GetType("Uno.UI.DataBinding.BindingPropertyHelper+UnoGetMemberBinder, " + typeof(BindingPropertyHelper).Assembly.FullName)
 								?? throw new InvalidOperationException();
 
 							var binder = (GetMemberBinder?)Activator.CreateInstance(_unoGetMemberBindingType, property, true);
@@ -952,7 +952,7 @@ namespace Uno.UI.DataBinding
 							// the System.Dynamic containing assembly. We're using reflection to create the binder
 							// given that the full type has been kept through `DynamicDependency` provided above.
 							_unoSetMemberBindingType ??=
-								Type.GetType("Uno.UI.DataBinding.UnoSetMemberBinder, Uno.UI")
+								Type.GetType("Uno.UI.DataBinding.BindingPropertyHelper+UnoSetMemberBinder, " + typeof(BindingPropertyHelper).Assembly.FullName)
 								?? throw new InvalidOperationException();
 
 							var binder = (SetMemberBinder?)Activator.CreateInstance(_unoSetMemberBindingType, property, true);

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -713,8 +713,8 @@ namespace Uno.UI.DataBinding
 				{
 					return instance =>
 					{
-						if (
-							instance is System.Dynamic.DynamicObject dynamicObject
+						if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
+							&& instance is System.Dynamic.DynamicObject dynamicObject
 							&& dynamicObject.TryGetMember(new UnoGetMemberBinder(property, true), out var binderValue)
 						)
 						{
@@ -925,7 +925,8 @@ namespace Uno.UI.DataBinding
 				{
 					return (instance, value) =>
 					{
-						if (instance is System.Dynamic.DynamicObject dynamicObject)
+						if (__LinkerHints.Is_System_Dynamic_DynamicObject_Available
+							&& instance is System.Dynamic.DynamicObject dynamicObject)
 						{
 							dynamicObject.TrySetMember(new UnoSetMemberBinder(property, true), value);
 						}

--- a/src/Uno.UI/UI/Xaml/Controls/RichEditBox/RichEditBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/RichEditBox/RichEditBox.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class RichEditBox : Control
+	{
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.mux.cs
@@ -20,6 +20,7 @@ using Uno.UI.Xaml.Core.Rendering;
 using static Microsoft.UI.Xaml.Controls._Tracing;
 using Windows.UI.Core;
 using Uno.Foundation.Logging;
+using Uno.UI;
 
 //TODO:MZ: Handle parameters in/out
 
@@ -1724,7 +1725,7 @@ namespace Windows.UI.Xaml.Input
 
 			lastInputDeviceType = _contentRoot.InputManager.LastInputDeviceType;
 
-			if (lastInputDeviceType == InputDeviceType.GamepadOrRemote)
+			if (lastInputDeviceType == InputDeviceType.GamepadOrRemote && __LinkerHints.Is_Windows_UI_Xaml_Controls_TextBox_Available)
 			{
 				var pElementAsTextBox = newFocusTarget as TextBox;
 				if (pElementAsTextBox != null)
@@ -2598,9 +2599,7 @@ namespace Windows.UI.Xaml.Input
 		private void OnAccessKeyDisplayModeChanged()
 		{
 			// We should update the caret to visible/collapsed depending on if AK mode is active
-			var pTextBox = _focusedElement as TextBox;
-
-			if (pTextBox != null)
+			if (__LinkerHints.Is_Windows_UI_Xaml_Controls_TextBox_Available && _focusedElement is TextBox pTextBox)
 			{
 				//TODO Uno: We don't support caret show/hide in TextBoxView yet
 				//pTextBox.GetView().ShowOrHideCaret();

--- a/src/Uno.UI/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI/Uno.UI.Wasm.csproj
@@ -170,7 +170,7 @@
 
 		<PropertyGroup>
 			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
-			<_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\$(PackageId)\$(UnoNugetOverrideVersion)\uno-runtime\$(UnoRuntimeIdentifier.ToLowerInvariant())</_TargetNugetFolder>
+			<_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\$(PackageId)\$(UnoNugetOverrideVersion)\uno-runtime\$(TargetFramework)\$(UnoRuntimeIdentifier.ToLowerInvariant())</_TargetNugetFolder>
 		</PropertyGroup>
 		<ItemGroup>
 			<_OutputFiles Include="$(TargetDir)**" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

- Adjust RichTextBox, MenuFlyout and TextBox trimming
- Add support for `AdditionalLinkerHint` to remove some create weak unconditional uses of `ExpandoObject`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
