### PR TITLE
fix(resources): Use visual parent search for style setters and visual states

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.cs
@@ -87,37 +87,51 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 #if !(__WASM__ || (__ANDROID__ && !NET6_0_OR_GREATER) || (__IOS__ && !NET6_0_OR_GREATER) || (__MACOS__ && !NET6_0_OR_GREATER) || HAS_SKOTTIE)
 		public void Play(double fromProgress, double toProgress, bool looped)
 		{
+#if !NET461
 			throw new NotImplementedException();
+#endif
 		}
 
 		public void Stop()
 		{
+#if !NET461
 			throw new NotImplementedException();
+#endif
 		}
 
 		public void Pause()
 		{
+#if !NET461
 			throw new NotImplementedException();
+#endif
 		}
 
 		public void Resume()
 		{
+#if !NET461
 			throw new NotImplementedException();
+#endif
 		}
 
 		public void SetProgress(double progress)
 		{
+#if !NET461
 			throw new NotImplementedException();
+#endif
 		}
 
 		public void Load()
 		{
+#if !NET461
 			throw new NotImplementedException();
+#endif
 		}
 
 		public void Unload()
 		{
+#if !NET461
 			throw new NotImplementedException();
+#endif
 		}
 
 		public Size Measure(Size availableSize)
@@ -129,9 +143,13 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 		private readonly Size CompositionSize = default;
 #pragma warning restore CA1805 // Do not initialize unnecessarily
 
-		private Task InnerUpdate(CancellationToken ct)
+		private async Task InnerUpdate(CancellationToken ct)
 		{
-			throw new NotSupportedException("Lottie on this platform is not supported yet.");
+#if !NET461
+			throw new NotImplementedException();
+#else
+			await Task.Yield();
+#endif
 		}
 #endif
 

--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.cs
@@ -16,6 +16,7 @@ using Uno.Disposables;
 using Uno.Foundation.Logging;
 using Uno.Extensions;
 using Uno.Helpers;
+using System.Diagnostics;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie
 {
@@ -86,48 +87,27 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
 #if !(__WASM__ || (__ANDROID__ && !NET6_0_OR_GREATER) || (__IOS__ && !NET6_0_OR_GREATER) || (__MACOS__ && !NET6_0_OR_GREATER) || HAS_SKOTTIE)
 		public void Play(double fromProgress, double toProgress, bool looped)
-		{
-#if !NET461
-			throw new NotImplementedException();
-#endif
-		}
+			=> ThrowNotImplementedOnNonTestPlatforms();
 
 		public void Stop()
-		{
-#if !NET461
-			throw new NotImplementedException();
-#endif
-		}
+			=> ThrowNotImplementedOnNonTestPlatforms();
 
 		public void Pause()
-		{
-#if !NET461
-			throw new NotImplementedException();
-#endif
-		}
+			=> ThrowNotImplementedOnNonTestPlatforms();
 
 		public void Resume()
-		{
-#if !NET461
-			throw new NotImplementedException();
-#endif
-		}
+			=> ThrowNotImplementedOnNonTestPlatforms();
 
 		public void SetProgress(double progress)
-		{
-#if !NET461
-			throw new NotImplementedException();
-#endif
-		}
+			=> ThrowNotImplementedOnNonTestPlatforms();
 
 		public void Load()
-		{
-#if !NET461
-			throw new NotImplementedException();
-#endif
-		}
+			=> ThrowNotImplementedOnNonTestPlatforms();
 
 		public void Unload()
+			=> ThrowNotImplementedOnNonTestPlatforms();
+
+		private static void ThrowNotImplementedOnNonTestPlatforms()
 		{
 #if !NET461
 			throw new NotImplementedException();
@@ -143,13 +123,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 		private readonly Size CompositionSize = default;
 #pragma warning restore CA1805 // Do not initialize unnecessarily
 
-		private async Task InnerUpdate(CancellationToken ct)
+		private Task InnerUpdate(CancellationToken ct)
 		{
-#if !NET461
-			throw new NotImplementedException();
-#else
-			await Task.Yield();
-#endif
+			ThrowNotImplementedOnNonTestPlatforms();
+			return Task.CompletedTask;
 		}
 #endif
 

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/RepeaterTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/RepeaterTests.cs
@@ -422,6 +422,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     </ScrollViewer>
                 </controls:ItemsRepeaterScrollHost>");
 
+				Content = anchorProvider;
+
 				rootRepeater = (ItemsRepeater)anchorProvider.FindName("rootRepeater");
 				rootRepeater.SizeChanged += (sender, args) =>
 				{
@@ -450,7 +452,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 				};
 
 				rootRepeater.ItemsSource = itemsSource;
-				Content = anchorProvider;
 			});
 
 			// scroll down several times to cause recycling of elements
@@ -508,6 +509,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     </ScrollViewer>
                 </controls:ItemsRepeaterScrollHost>");
 
+				Content = scrollhost;
+
 				rootRepeater = (ItemsRepeater)scrollhost.FindName("repeater");
 				scrollViewer = (ScrollViewer)scrollhost.FindName("scrollviewer");
 				scrollViewer.ViewChanged += (sender, args) =>
@@ -524,7 +527,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 					items.Add(Enumerable.Range(0, 4).ToList());
 				}
 				rootRepeater.ItemsSource = items;
-				Content = scrollhost;
 			});
 
 			// scroll down several times and validate no crash
@@ -577,6 +579,8 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         </ScrollViewer>
                     </controls:ItemsRepeaterScrollHost>");
 
+				Content = scrollhost;
+
 				rootRepeater = (ItemsRepeater)scrollhost.FindName("rootRepeater");
 
 				List<List<int>> items = new List<List<int>>();
@@ -585,7 +589,6 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 					items.Add(Enumerable.Range(0, 4).ToList());
 				}
 				rootRepeater.ItemsSource = items;
-				Content = scrollhost;
 			});
 
 			IdleSynchronizer.Wait();
@@ -638,14 +641,17 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                         </ScrollViewer>
                     </controls:ItemsRepeaterScrollHost>");
 
-				repeater = (ItemsRepeater)scrollhost.FindName("repeater");
 				Content = scrollhost;
+
+				// Get the control after entering the tree
+				repeater = (ItemsRepeater)scrollhost.FindName("repeater");
 			});
 
 			IdleSynchronizer.Wait();
 
 			RunOnUIThread.Execute(() =>
 			{
+
 				for (int i = 0; i < 10; i++)
 				{
 					var element = repeater.TryGetElement(i) as Button;

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -12,11 +12,11 @@
 	</PropertyGroup>
 	<!--
 	Uncomment to troubleshoot source generation
-	-->
 	<PropertyGroup>
-		<!--<UnoUISourceGeneratorDebuggerBreak>True</UnoUISourceGeneratorDebuggerBreak>-->
+		<UnoUISourceGeneratorDebuggerBreak>True</UnoUISourceGeneratorDebuggerBreak>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 	</PropertyGroup>
+	-->
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>full</DebugType>

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -12,11 +12,11 @@
 	</PropertyGroup>
 	<!--
 	Uncomment to troubleshoot source generation
+	-->
 	<PropertyGroup>
-		<UnoUISourceGeneratorDebuggerBreak>True</UnoUISourceGeneratorDebuggerBreak>
+		<!--<UnoUISourceGeneratorDebuggerBreak>True</UnoUISourceGeneratorDebuggerBreak>-->
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 	</PropertyGroup>
-	-->
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>full</DebugType>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_When_Setter_Override_From_Visual_Parent.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_When_Setter_Override_From_Visual_Parent.xaml
@@ -1,0 +1,63 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.ThemeResource_When_Setter_Override_From_Visual_Parent"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Page.Resources>
+		<Style TargetType="ToggleButton">
+			<Setter Property="Foreground"
+					Value="{ThemeResource ButtonForegroundThemeBrush}" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ToggleButton">
+						<Grid>
+							<!--<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="Pressed" />
+									<VisualState x:Name="PointerOver" />
+									<VisualState x:Name="Checked">
+										<VisualState.Setters>
+											<Setter Target="MarkTextBlock.Foreground"
+													Value="{ThemeResource ButtonForegroundThemeBrush}" />
+										</VisualState.Setters>
+									</VisualState>
+									<VisualState x:Name="CheckedPressed">
+										<VisualState.Setters>
+											<Setter Target="MarkTextBlock.Foreground"
+													Value="{ThemeResource ButtonForegroundThemeBrush}" />
+										</VisualState.Setters>
+									</VisualState>
+									<VisualState x:Name="CheckedPointerOver">
+										<VisualState.Setters>
+											<Setter Target="MarkTextBlock.Foreground"
+													Value="{ThemeResource ButtonForegroundThemeBrush}" />
+										</VisualState.Setters>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>-->
+							<TextBlock x:Name="MarkTextBlock"
+									   Text="42"
+									   Tag="{ThemeResource ButtonForegroundThemeBrush}"
+									   Foreground="{TemplateBinding Foreground}" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+	</Page.Resources>
+
+	<Grid>
+		<Grid.Resources>
+			<SolidColorBrush x:Key="ButtonForegroundThemeBrush" Color="Red" />
+		</Grid.Resources>
+		<ToggleButton x:Name="SubjectToggleButton"
+					  x:FieldModifier="public"
+					  Margin="10"
+					  IsChecked="True" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_When_Setter_Override_From_Visual_Parent.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_When_Setter_Override_From_Visual_Parent.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class ThemeResource_When_Setter_Override_From_Visual_Parent : Page
+	{
+		public ThemeResource_When_Setter_Override_From_Visual_Parent()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_When_Setter_Override_State_From_Visual_Parent.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_When_Setter_Override_State_From_Visual_Parent.xaml
@@ -1,0 +1,47 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.ThemeResource_When_Setter_Override_State_From_Visual_Parent"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Page.Resources>
+		<Style TargetType="ToggleButton">
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ToggleButton">
+						<StackPanel>
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="Pressed" />
+									<VisualState x:Name="PointerOver" />
+									<VisualState x:Name="Checked">
+										<VisualState.Setters>
+											<Setter Target="MarkTextBlock.Foreground"
+													Value="{ThemeResource ButtonForegroundThemeBrush}" />
+										</VisualState.Setters>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+							<TextBlock x:Name="MarkTextBlock"
+									   Text="42"
+									   Foreground="Black" />
+						</StackPanel>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+	</Page.Resources>
+
+	<Grid>
+		<Grid.Resources>
+			<SolidColorBrush x:Key="ButtonForegroundThemeBrush" Color="Orange" />
+		</Grid.Resources>
+		<ToggleButton x:Name="SubjectToggleButton"
+					  x:FieldModifier="public"
+					  Margin="10" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_When_Setter_Override_State_From_Visual_Parent.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_When_Setter_Override_State_From_Visual_Parent.xaml.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class ThemeResource_When_Setter_Override_State_From_Visual_Parent : Page
+	{
+		public ThemeResource_When_Setter_Override_State_From_Visual_Parent()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -563,6 +563,34 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			}
 		}
 
+		[TestMethod]
+		public void ThemeResource_When_Setter_Override_From_Visual_Parent()
+		{
+			var SUT = new ThemeResource_When_Setter_Override_From_Visual_Parent();
+
+			var app = UnitTestsApp.App.EnsureApplication();
+			app.HostView.Children.Add(SUT);
+
+			var tb = (TextBlock)SUT.FindName("MarkTextBlock");
+			Assert.IsNotNull(tb);
+			Assert.AreEqual(Colors.Red, (tb.Foreground as SolidColorBrush)?.Color);
+		}
+
+		[TestMethod]
+		public void ThemeResource_When_Setter_Override_State_From_Visual_Parent()
+		{
+			var SUT = new ThemeResource_When_Setter_Override_State_From_Visual_Parent();
+
+			var app = UnitTestsApp.App.EnsureApplication();
+			app.HostView.Children.Add(SUT);
+
+			VisualStateManager.GoToState(SUT.SubjectToggleButton, "Checked", false);
+
+			var tb = (TextBlock)SUT.FindName("MarkTextBlock");
+			Assert.IsNotNull(tb);
+			Assert.AreEqual(Colors.Orange, (tb.Foreground as SolidColorBrush)?.Color);
+		}
+
 		/// <summary>
 		/// Use Fluent styles for the duration of the test.
 		/// </summary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1463,7 +1463,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 
 			var tb = (TextBlock)SUT.FindName("MarkTextBlock");
 			Assert.IsNotNull(tb);
-			Assert.AreEqual(Colors.Red, (tb.Foreground as SolidColorBrush)?.Color);
+			Assert.AreEqual(Windows.UI.Colors.Red, (tb.Foreground as SolidColorBrush)?.Color);
 		}
 
 		[TestMethod]
@@ -1477,7 +1477,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 
 			var tb = (TextBlock)SUT.FindName("MarkTextBlock");
 			Assert.IsNotNull(tb);
-			Assert.AreEqual(Colors.Orange, (tb.Foreground as SolidColorBrush)?.Color);
+			Assert.AreEqual(Windows.UI.Colors.Orange, (tb.Foreground as SolidColorBrush)?.Color);
 		}
 
 		[TestMethod]
@@ -1494,10 +1494,10 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.IsNotNull(border1);
 			Assert.IsNotNull(border2);
 
-			Assert.AreEqual(Colors.Red, (border1.Background as SolidColorBrush)?.Color);
-			Assert.AreEqual(Colors.Pink, (border1.BorderBrush as SolidColorBrush)?.Color);
-			Assert.AreEqual(Colors.Blue, (border2.Background as SolidColorBrush)?.Color);
-			Assert.AreEqual(Colors.Yellow, (border2.BorderBrush as SolidColorBrush)?.Color);
+			Assert.AreEqual(Windows.UI.Colors.Red, (border1.Background as SolidColorBrush)?.Color);
+			Assert.AreEqual(Windows.UI.Colors.Pink, (border1.BorderBrush as SolidColorBrush)?.Color);
+			Assert.AreEqual(Windows.UI.Colors.Blue, (border2.Background as SolidColorBrush)?.Color);
+			Assert.AreEqual(Windows.UI.Colors.Yellow, (border2.BorderBrush as SolidColorBrush)?.Color);
 		}
 
 		/// <summary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -290,10 +290,6 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			var panel = r.FindName("innerPanel") as StackPanel;
 			Assert.IsNotNull(panel);
 
-			Assert.AreEqual(0, Grid.GetRow(panel));
-			Assert.AreEqual(double.NaN, panel.Width);
-			Assert.AreEqual(double.NaN, panel.Height);
-
 			r.ForceLoaded();
 
 			Assert.AreEqual(42, Grid.GetRow(panel));
@@ -1456,6 +1452,32 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 
 			Assert.AreEqual(t1, Windows.UI.Colors.Red);
 			Assert.AreEqual(t1, b1.Color);
+		}
+
+		[TestMethod]
+		public void When_Setter_Override_From_Visual_Parent()
+		{
+			var s = GetContent(nameof(When_Setter_Override_From_Visual_Parent));
+			var SUT = Windows.UI.Xaml.Markup.XamlReader.Load(s) as Page;
+			SUT.ForceLoaded();
+
+			var tb = (TextBlock)SUT.FindName("MarkTextBlock");
+			Assert.IsNotNull(tb);
+			Assert.AreEqual(Colors.Red, (tb.Foreground as SolidColorBrush)?.Color);
+		}
+
+		[TestMethod]
+		public void When_Setter_Override_State_From_Visual_Parent()
+		{
+			var s = GetContent(nameof(When_Setter_Override_State_From_Visual_Parent));
+			var SUT = Windows.UI.Xaml.Markup.XamlReader.Load(s) as Page;
+			SUT.ForceLoaded();
+
+			VisualStateManager.GoToState((Control)SUT.FindName("SubjectToggleButton"), "Checked", false);
+
+			var tb = (TextBlock)SUT.FindName("MarkTextBlock");
+			Assert.IsNotNull(tb);
+			Assert.AreEqual(Colors.Orange, (tb.Foreground as SolidColorBrush)?.Color);
 		}
 
 		/// <summary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1480,6 +1480,26 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.AreEqual(Colors.Orange, (tb.Foreground as SolidColorBrush)?.Color);
 		}
 
+		[TestMethod]
+		public void When_ThemeResource_Inherited_multiple()
+		{
+			var s = GetContent(nameof(When_ThemeResource_Inherited_multiple));
+			var SUT = Windows.UI.Xaml.Markup.XamlReader.Load(s) as Page;
+			SUT.ForceLoaded();
+
+
+			var border1 = (Border)SUT.FindName("border1");
+			var border2 = (Border)SUT.FindName("border2");
+
+			Assert.IsNotNull(border1);
+			Assert.IsNotNull(border2);
+
+			Assert.AreEqual(Colors.Red, (border1.Background as SolidColorBrush)?.Color);
+			Assert.AreEqual(Colors.Pink, (border1.BorderBrush as SolidColorBrush)?.Color);
+			Assert.AreEqual(Colors.Blue, (border2.Background as SolidColorBrush)?.Color);
+			Assert.AreEqual(Colors.Yellow, (border2.BorderBrush as SolidColorBrush)?.Color);
+		}
+
 		/// <summary>
 		/// XamlReader.Load the xaml and type-check result.
 		/// </summary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_Setter_Override_From_Visual_Parent.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_Setter_Override_From_Visual_Parent.xamltest
@@ -1,0 +1,37 @@
+﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Page.Resources>
+		<Style TargetType="ToggleButton">
+			<Setter Property="Foreground"
+					Value="{ThemeResource ButtonForegroundThemeBrush}" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ToggleButton">
+						<Grid>
+							<TextBlock x:Name="MarkTextBlock"
+									   Text="42"
+									   Tag="{ThemeResource ButtonForegroundThemeBrush}"
+									   Foreground="{TemplateBinding Foreground}" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+	</Page.Resources>
+
+	<Grid>
+		<Grid.Resources>
+			<SolidColorBrush x:Key="ButtonForegroundThemeBrush" Color="Red" />
+		</Grid.Resources>
+		<ToggleButton x:Name="SubjectToggleButton"
+					  x:FieldModifier="public"
+					  Margin="10"
+					  IsChecked="True" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_Setter_Override_State_From_Visual_Parent.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_Setter_Override_State_From_Visual_Parent.xamltest
@@ -1,0 +1,46 @@
+﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Page.Resources>
+		<Style TargetType="ToggleButton">
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ToggleButton">
+						<StackPanel>
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="Pressed" />
+									<VisualState x:Name="PointerOver" />
+									<VisualState x:Name="Checked">
+										<VisualState.Setters>
+											<Setter Target="MarkTextBlock.Foreground"
+													Value="{ThemeResource ButtonForegroundThemeBrush}" />
+										</VisualState.Setters>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+							<TextBlock x:Name="MarkTextBlock"
+									   Text="42"
+									   Foreground="Black" />
+						</StackPanel>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+	</Page.Resources>
+
+	<Grid>
+		<Grid.Resources>
+			<SolidColorBrush x:Key="ButtonForegroundThemeBrush" Color="Orange" />
+		</Grid.Resources>
+		<ToggleButton x:Name="SubjectToggleButton"
+					  x:FieldModifier="public"
+					  Margin="10" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ThemeResource_Inherited_multiple.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ThemeResource_Inherited_multiple.xamltest
@@ -1,0 +1,51 @@
+﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+			Name="rootPage"
+      mc:Ignorable="d">
+
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyBrush">Blue</SolidColorBrush>
+		<SolidColorBrush x:Key="MyBorderBrush">Yellow</SolidColorBrush>
+
+		<Style TargetType="ContentControl" x:Key="MyStyle1">
+			<Setter Property="BorderBrush" Value="{ThemeResource MyBorderBrush}" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ContentControl">
+						<Border x:Name="border1" Background="{ThemeResource MyBrush}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+							<ContentPresenter Content="{TemplateBinding Content}" />
+						</Border>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+		<Style TargetType="ContentControl" x:Key="MyStyle2">
+			<Setter Property="BorderBrush" Value="{StaticResource MyBorderBrush}" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ContentControl">
+						<Border x:Name="border2" Background="{StaticResource MyBrush}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
+							<ContentPresenter Content="{TemplateBinding Content}" />
+						</Border>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</Page.Resources>
+
+	<Border>
+		<Border.Resources>
+			<SolidColorBrush x:Key="MyBrush">Red</SolidColorBrush>
+			<SolidColorBrush x:Key="MyBorderBrush">Pink</SolidColorBrush>
+		</Border.Resources>
+
+		<StackPanel Orientation="Horizontal" Background="Green">
+			<ContentControl Content="A" FontSize="40" Style="{StaticResource MyStyle1}" Width="100" Height="100" BorderThickness="15" />
+			<ContentControl Content="B" FontSize="40" Style="{StaticResource MyStyle2}" Width="100" Height="100" BorderThickness="15" />
+		</StackPanel>
+	</Border>
+</Page>

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -207,6 +207,10 @@ namespace Windows.UI.Xaml.Controls
 			base.OnPostLoading();
 
 			TryCallOnApplyTemplate();
+
+			// Update bindings to ensure resources defined
+			// in visual parents get applied.
+			this.UpdateResourceBindings();
 		}
 
 		private void TryCallOnApplyTemplate()

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.net.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.net.cs
@@ -22,11 +22,11 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void UnregisterSubView()
 		{
-			//var child = this.GetChildren()?.FirstOrDefault();
-			//if (child != null)
-			//{
-			//	RemoveChild(child);
-			//}
+			var child = this.GetChildren()?.FirstOrDefault();
+			if (child != null)
+			{
+				RemoveChild(child);
+			}
 		}
 
 		partial void RegisterSubView(View child)

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1390,7 +1390,7 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// Returns all ResourceDictionaries in scope using the visual tree, from nearest to furthest.
 		/// </summary>
-		private IEnumerable<ResourceDictionary> GetResourceDictionaries(bool includeAppResources, ResourceDictionary? containingDictionary = null)
+		internal IEnumerable<ResourceDictionary> GetResourceDictionaries(bool includeAppResources, ResourceDictionary? containingDictionary = null)
 		{
 			if (containingDictionary != null)
 			{

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -159,6 +159,13 @@ namespace Windows.UI.Xaml.Markup.Reader
 				var instance = component ?? Activator.CreateInstance(type)!;
 				rootInstance ??= instance;
 
+				var instanceAsFrameworkElement = instance as FrameworkElement;
+
+				if (instanceAsFrameworkElement is not null)
+				{
+					instanceAsFrameworkElement.IsParsing = true;
+				}
+
 				IDisposable? TryProcessStyle()
 				{
 					if (instance is Style style)
@@ -196,6 +203,8 @@ namespace Windows.UI.Xaml.Markup.Reader
 						ProcessNamedMember(control, instance, member, rootInstance);
 					}
 				}
+
+				instanceAsFrameworkElement?.CreationComplete();
 
 				return instance;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10551, closes https://github.com/unoplatform/uno/issues/10131

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Ensures that setters applied via ThemeResource get refreshed when entering the visual tree
- Ensures that VisualState.Setters get properly updated when entering the visual tree

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
