### PR TITLE
fix: Delayed `MenuFlyout` item with icon

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/SvgImageSource_Icons.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/SvgImageSource_Icons.xaml
@@ -13,6 +13,7 @@
 		<StackPanel Spacing="8" Width="200">
 			<Image Source="ms-appx:///Assets/Formats/couch.svg" Stretch="UniformToFill" Width="40" Height="40" />
 			<Button HorizontalAlignment="Center" Click="OnClick" x:Name="MenuButton">Click me</Button>
+			<Button HorizontalAlignment="Center" Click="OnDelayedClick" x:Name="MenuDelayedButton">Click me (delayed)</Button>
 			<mux:ImageIcon Source="ms-appx:///Assets/Formats/heliocentric.svg" />
 			<BitmapIcon UriSource="ms-appx:///Assets/Formats/bookstack.svg" />
 		</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/SvgImageSource_Icons.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/SvgImageSource_Icons.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml.Controls;
 using Uno.Extensions;
 using Uno.UI.Samples.Controls;
 using Windows.Storage;
@@ -44,5 +45,31 @@ public sealed partial class SvgImageSource_Icons : Page
 			});
 
 		flyout.ShowAt(sender as Button);
+	}
+
+	private async void OnDelayedClick(object sender, RoutedEventArgs args)
+	{
+		using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(
+			(await global::Windows.Storage.FileIO.ReadTextAsync(await StorageFile.GetFileFromApplicationUriAsync(new Uri($"ms-appx:///Assets/Formats/home.svg")))))))
+		{
+			SvgImageSource svgImageSource = new SvgImageSource { RasterizePixelHeight = 48, RasterizePixelWidth = 48 };
+			await svgImageSource.SetSourceAsync(stream.AsRandomAccessStream());
+
+			var menu = new MenuFlyout
+			{
+				Placement = FlyoutPlacementMode.Bottom,
+			};
+
+			menu.Opening += (s2, e2) =>
+			{
+				(s2 as MenuFlyout).Items.Add(new MenuFlyoutItem
+				{
+					Icon = new ImageIcon { Source = svgImageSource },
+					Text = "This menu item should have a HOME icon",
+				});
+			};
+
+			menu.ShowAt(sender as Button);
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/SvgImageSource_Icons.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/SvgImageSource_Icons.xaml.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Microsoft.UI.Xaml.Controls;
 using Uno.Extensions;
 using Uno.UI.Samples.Controls;
 using Windows.Storage;
@@ -64,7 +63,7 @@ public sealed partial class SvgImageSource_Icons : Page
 			{
 				(s2 as MenuFlyout).Items.Add(new MenuFlyoutItem
 				{
-					Icon = new ImageIcon { Source = svgImageSource },
+					Icon = new Microsoft.UI.Xaml.Controls.ImageIcon { Source = svgImageSource },
 					Text = "This menu item should have a HOME icon",
 				});
 			};

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Uno.Extensions;
@@ -18,6 +21,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Shapes;
 using static Private.Infrastructure.TestServices;
 #if NETFX_CORE
@@ -31,13 +35,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
 	[TestClass]
 	[RunsOnUIThread]
+#if __MACOS__
+	[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 	public class Given_MenuFlyout
 	{
 		[TestMethod]
 		[RequiresFullWindow]
-#if __MACOS__
-		[Ignore("Currently fails on macOS, part of #9282 epic")]
-#endif
 		public async Task When_Native_AppBarButton_And_Managed_Popups()
 		{
 			using (StyleHelper.UseNativeFrameNavigation())
@@ -71,9 +75,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RequiresFullWindow]
-#if __MACOS__
-		[Ignore("Currently fails on macOS, part of #9282 epic")]
-#endif
 		public async Task When_Add_MenuFlyoutSeparator_To_MenuBarItem()
 		{
 			using (StyleHelper.UseFluentStyles())
@@ -148,9 +149,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RequiresFullWindow]
-#if __MACOS__
-		[Ignore("Currently fails on macOS, part of #9282 epic")]
-#endif
 		public async Task Verify_MenuBarItem_Bounds()
 		{
 			using (StyleHelper.UseFluentStyles())
@@ -249,9 +247,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 #if HAS_UNO
 		[TestMethod]
-#if __MACOS__
-		[Ignore("Currently fails on macOS, part of #9282 epic")]
-#endif
 		public async Task When_MenuFlyoutItem_CommandChanging()
 		{
 			var SUT = new MenuBar();
@@ -288,6 +283,48 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			flyoutItem.InvokeClick();
 			item.CloseMenuFlyout();
+		}
+
+		[TestMethod]
+		public async Task When_MenuFlyout_Added_In_Opening()
+		{
+			MenuFlyout flyout = null;
+			try
+			{
+				var button = new Button() { Content = "Test" };
+				WindowHelper.WindowContent = button;
+				await WindowHelper.WaitForLoaded(button);
+				var menuItem = new MenuFlyoutItem
+				{
+					Icon = new SymbolIcon(Symbol.Home),
+					Text = "This menu item should have a home icon",
+				};
+
+				flyout = new MenuFlyout
+				{
+					Placement = FlyoutPlacementMode.Bottom,
+				};
+
+				flyout.Opening += (s2, e2) =>
+				{
+					(s2 as MenuFlyout).Items.Add(menuItem);
+				};
+
+				flyout.ShowAt(button);
+
+				await WindowHelper.WaitForLoaded(menuItem);
+
+				var presenter = flyout.GetPresenter() as MenuFlyoutPresenter;
+				Assert.IsNotNull(presenter);
+				Assert.IsTrue(presenter.GetContainsIconItems());
+			}
+			finally
+			{
+				if (flyout?.IsOpen == true)
+				{
+					flyout.Hide();
+				}
+			}
 		}
 #endif
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout_Partial.cs
@@ -25,6 +25,8 @@ namespace Windows.UI.Xaml.Controls
 			base.Placement = FlyoutPlacementMode.Right;
 			base.UsePickerFlyoutTheme = true;
 
+			Opening += OnOpening;
+
 			_asyncOperationManager = new FlyoutAsyncOperationManager<DateTime?>(this, () => default);
 		}
 
@@ -90,8 +92,8 @@ namespace Windows.UI.Xaml.Controls
 			base.ShowAtCore(target, null);
 			return _asyncOperationManager.Start(target);
 		}
-
-		private protected override void OnOpening()
+		
+		private void OnOpening(object sender, object args)
 		{
 			//wrl.ComPtr<xaml_input.IInputManagerStatics> inputManagerStatics;
 			//xaml_input.LastInputDeviceType lastInputDeviceType;

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -340,8 +340,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				}
 			}
 
-			OnOpening();
-			Opening?.Invoke(this, EventArgs.Empty);
+			OnOpening();			
 			Open();
 			SynchronizeContentTemplatedParent();
 			IsOpen = true;
@@ -386,7 +385,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			}
 		}
 
-		private protected virtual void OnOpening() { }
+		private protected virtual void OnOpening()
+		{
+			Opening?.Invoke(this, EventArgs.Empty);
+		}
 
 		internal virtual void OnClosing(ref bool cancel)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
@@ -149,15 +149,18 @@ namespace Windows.UI.Xaml.Controls
 			Control presenter = GetPresenter();
 			MenuFlyoutPresenter menuFlyoutPresenter = presenter as MenuFlyoutPresenter;
 
-			if (menuFlyoutPresenter != null)
+			if (menuFlyoutPresenter is not null)
 			{
 				IMenu parentMenu = (this as IMenu).ParentMenu as IMenu;
 
 				(menuFlyoutPresenter as IMenuPresenter).OwningMenu = parentMenu != null ? parentMenu : this;
 				menuFlyoutPresenter.UpdateTemplateSettings();
+			}
 
-				base.OnOpening();
-				
+			base.OnOpening();
+			
+			if (menuFlyoutPresenter is not null)
+			{
 				// Reset the presenter's ItemsSource.  Since Items is not an IObservableVector, we don't
 				// automatically respond to changes within the vector.  Clearing the property when the presenter
 				// unloads and resetting it before we reopen ensures any changes to Items are reflected

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
@@ -156,6 +156,8 @@ namespace Windows.UI.Xaml.Controls
 				(menuFlyoutPresenter as IMenuPresenter).OwningMenu = parentMenu != null ? parentMenu : this;
 				menuFlyoutPresenter.UpdateTemplateSettings();
 
+				base.OnOpening();
+				
 				// Reset the presenter's ItemsSource.  Since Items is not an IObservableVector, we don't
 				// automatically respond to changes within the vector.  Clearing the property when the presenter
 				// unloads and resetting it before we reopen ensures any changes to Items are reflected


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10554

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Previously items added to `MenuFlyout` during `Opening` event execution were not considered for icon display.

## What is the new behavior?

Works correctly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.