### PR TITLE
chore: Avoid using UWP naming while retargeting assets

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.cs
@@ -11,7 +11,7 @@ using Windows.ApplicationModel.Resources.Core;
 namespace Uno.UI.Tasks.Assets
 {
 	/// <summary>
-	/// Retargets UWP assets to Android and iOS.
+	/// Retargets assets to Android and iOS.
 	/// </summary>
 	/// <remarks>
 	/// Currently supports .png, .jpg, .jpeg and .gif.
@@ -42,7 +42,7 @@ namespace Uno.UI.Tasks.Assets
 
 		public override bool Execute()
 		{
-			Log.LogMessage($"Retargeting UWP assets to {TargetPlatform}.");
+			Log.LogMessage($"Retargeting assets to {TargetPlatform}.");
 
 			Func<ResourceCandidate, string> resourceToTargetPath;
 			Func<string, string> pathEncoder;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Currently build logs for Uno apps output "Retargeting UWP assets to Android", etc.

## What is the new behavior?

Build logs output "Retargeting assets to Android", etc., as technically the assets are in shared project anyway, so they are not "UWP" nor "WinAppSDK" specific, the task is just adjusting them for the target platform.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
