### PR TITLE
fix(reg): Metadata update is optional below net6 for skia targets

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/MetadataUpdaterAgent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/MetadataUpdaterAgent.cs
@@ -55,12 +55,12 @@ internal sealed class HotReloadAgent : IDisposable
 				}
 				else
 				{
-					throw new NotSupportedException($"Unable to find System.Reflection.Metadata.MetadataUpdater.ApplyUpdate(...)");
+					_log($"Metadata updates are not supported with this runtime (Unable to find System.Reflection.Metadata.MetadataUpdater.ApplyUpdate(...))");
 				}
 			}
 			else
 			{
-				throw new NotSupportedException($"Unable to find System.Reflection.Metadata.MetadataUpdater");
+				_log($"Metadata updates are not supported with this runtime (Unable to find System.Reflection.Metadata.MetadataUpdater)");
 			}
 		}
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10581

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Avoid app startup failure when running below net6.0 for Skia targets.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
