### PR TITLE
fix(Skia): Initialize `DisplayBlock` text in `TextBoxView`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -10,6 +10,7 @@ using static Private.Infrastructure.TestServices;
 using Windows.UI.Xaml;
 using Windows.UI;
 using FluentAssertions;
+using MUXControlsTestApp.Utilities;
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -473,5 +474,25 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(0, textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 		}
+
+#if __SKIA__
+		[TestMethod]
+		public async Task When_Text_Set_On_Initial_Load()
+		{
+			var initialText = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+			var textBox = new TextBox
+			{
+				Text = initialText
+			};
+
+			WindowHelper.WindowContent = textBox;
+			await WindowHelper.WaitForLoaded(textBox);
+
+			var contentControl = VisualTreeUtils.FindVisualChildByType<ContentControl>(textBox);
+			// This will no longer be true when we support non-native text box input - test will have to be updated for this option
+			Assert.IsInstanceOfType(contentControl.Content, typeof(TextBlock));
+			Assert.AreEqual(initialText, ((TextBlock)contentControl.Content).Text);
+		}
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -22,6 +22,7 @@ namespace Windows.UI.Xaml.Controls
 			if (ContentElement != null && ContentElement.Content != TextBoxView.DisplayBlock)
 			{
 				ContentElement.Content = TextBoxView.DisplayBlock;
+				TextBoxView.SetTextNative(Text);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10621

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`TextBox` appears empty on first load even though there is content

## What is the new behavior?

Content loaded correctly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
