### PR TITLE
fix: Attempt to fix possible crash when using CGColor

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -527,7 +527,7 @@ namespace Windows.UI.Xaml.Shapes
 			{
 				Frame = fullArea,
 				Mask = fillMask,
-				BackgroundColor = new CGColor(0, 0, 0, 0),
+				BackgroundColor = _transparent,
 				MasksToBounds = true,
 			};
 
@@ -565,7 +565,7 @@ namespace Windows.UI.Xaml.Shapes
 			{
 				Frame = fullArea,
 				Mask = fillMask,
-				BackgroundColor = new CGColor(0, 0, 0, 0),
+				BackgroundColor = _transparent,
 				MasksToBounds = true,
 			};
 

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -35,6 +35,10 @@ namespace Windows.UI.Xaml.Shapes
 {
 	partial class BorderLayerRenderer
 	{
+		// Creates a unique native CGColor for the transparent color, and make sure to keep a strong ref on it
+		// https://github.com/unoplatform/uno/issues/10283
+		private static readonly CGColor _transparent = Colors.Transparent;
+
 		private LayoutState _previousLayoutState;
 
 		private SerialDisposable _layerDisposable = new SerialDisposable();
@@ -187,7 +191,7 @@ namespace Windows.UI.Xaml.Shapes
 				}
 				else
 				{
-					backgroundLayer.FillColor = Colors.Transparent;
+					backgroundLayer.FillColor = _transparent;
 				}
 
 				outerLayer.Path = path;
@@ -204,6 +208,10 @@ namespace Windows.UI.Xaml.Shapes
 					{
 						outerLayer.StrokeColor = color;
 						outerLayer.FillColor = color;
+
+						// Make sure to hold native object ref until it has been retained by native itself
+						// https://github.com/unoplatform/uno/issues/10283
+						GC.KeepAlive(color);
 					})
 					.DisposeWith(disposables);
 				}
@@ -287,12 +295,13 @@ namespace Windows.UI.Xaml.Shapes
 
 					// This is required because changing the CornerRadius changes the background drawing
 					// implementation and we don't want a rectangular background behind a rounded background.
-					Disposable.Create(() => backgroundLayer.FillColor = null)
+					Disposable
+						.Create(() => backgroundLayer.FillColor = null)
 						.DisposeWith(disposables);
 				}
 				else
 				{
-					backgroundLayer.FillColor = Colors.Transparent;
+					backgroundLayer.FillColor = _transparent;
 				}
 
 				if (borderThickness != Thickness.Empty)

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Shapes
 #endif
 			}
 
-#region Stroke Dependency Property
+		#region Stroke Dependency Property
 		public Brush Stroke
 		{
 			get => (Brush)this.GetValue(StrokeProperty);
@@ -112,9 +112,9 @@ namespace Windows.UI.Xaml.Shapes
 #endif
 			)
 		);
-#endregion
+		#endregion
 
-#region StrokeThickness Dependency Property
+		#region StrokeThickness Dependency Property
 		public double StrokeThickness
 		{
 			get => (double)this.GetValue(StrokeThicknessProperty);
@@ -133,9 +133,9 @@ namespace Windows.UI.Xaml.Shapes
 #endif
 			)
 		);
-#endregion
+		#endregion
 
-#region Stretch Dependency Property
+		#region Stretch Dependency Property
 		public Stretch Stretch
 		{
 			get => (Stretch)this.GetValue(StretchProperty);
@@ -155,9 +155,9 @@ namespace Windows.UI.Xaml.Shapes
 #endif
 			)
 		);
-#endregion
+		#endregion
 
-#region StrokeDashArray Dependency Property
+		#region StrokeDashArray Dependency Property
 		public DoubleCollection StrokeDashArray
 		{
 			get => (DoubleCollection)this.GetValue(StrokeDashArrayProperty);
@@ -177,7 +177,7 @@ namespace Windows.UI.Xaml.Shapes
 #endif
 			)
 		);
-#endregion
+		#endregion
 
 #if LEGACY_SHAPE_MEASURE
 		protected virtual void OnFillChanged(Brush newValue)

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.iOSmacOS.cs
@@ -72,14 +72,15 @@ namespace Windows.UI.Xaml.Shapes
 		{
 			RemoveSublayers();
 
+			CGColor fillColor;
 			switch (Fill)
 			{
 				case SolidColorBrush colorFill:
-					pathLayer.FillColor = colorFill.ColorWithOpacity;
+					fillColor = colorFill.ColorWithOpacity;
 					break;
 
 				case ImageBrush imageFill when TryCreateImageBrushLayers(imageFill, GetFillMask(pathLayer.Path), out var imageLayer):
-					pathLayer.FillColor = Colors.Transparent;
+					fillColor = Colors.Transparent;
 					pathLayer.AddSublayer(imageLayer);
 					break;
 
@@ -89,22 +90,27 @@ namespace Windows.UI.Xaml.Shapes
 					gradientLayer.Mask ??= GetFillMask(pathLayer.Path);
 					gradientLayer.MasksToBounds = true;
 
-					pathLayer.FillColor = Colors.Transparent;
+					fillColor = Colors.Transparent;
 					pathLayer.AddSublayer(gradientLayer);
 					break;
 
 				case null:
-					pathLayer.FillColor = Colors.Transparent;
+					fillColor = Colors.Transparent;
 					break;
 
 				default:
 					Application.Current.RaiseRecoverableUnhandledException(new NotSupportedException($"The brush {Fill} is not supported as Fill for a {this} on this platform."));
-					pathLayer.FillColor = Colors.Transparent;
+					fillColor = Colors.Transparent;
 					break;
 			}
 
 			pathLayer.StrokeColor = Brush.GetColorWithOpacity(Stroke, Colors.Transparent);
 			pathLayer.LineWidth = (nfloat)ActualStrokeThickness;
+			pathLayer.FillColor = fillColor;
+
+			// Make sure to hold native object ref until it has been retained by native itself
+			// https://github.com/unoplatform/uno/issues/10283
+			GC.KeepAlive(fillColor);
 
 			if (StrokeDashArray is { } sda)
 			{


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/10283

## Bugfix
Attempt to fix possible crash when using CGColor

## What is the current behavior?
We get some crash reports when changing the `FillColor` of an `CALayer`.

## What is the new behavior?
We are flaggimg the native `CGColor` instances with `GC.KeepAlive` to make sure the ref remains active long enough.


## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
