### PR TITLE
[Wasm][Threading] Use proper `CheckThreadAccess`/`HasThreadAccess` behavior, raise DispatcherQueueTimer on proper thread

### DIFF
--- a/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
+++ b/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
@@ -17,6 +17,8 @@
 
 	<PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
 		<TargetFrameworks>$(UnoTargetFrameworkOverride)</TargetFrameworks>
+		<TargetFrameworks Condition="!$(TargetFrameworks.Contains('net461'))">$(UnoTargetFrameworkOverride);net461</TargetFrameworks>
+		<TargetFrameworks Condition="!$(TargetFrameworks.Contains('netstandard2.0'))">$(UnoTargetFrameworkOverride);netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">

--- a/src/Uno.UI.Dispatching/Core/CoreDispatcher.wasm.cs
+++ b/src/Uno.UI.Dispatching/Core/CoreDispatcher.wasm.cs
@@ -13,7 +13,7 @@ namespace Uno.UI.Dispatching
 {
 	internal sealed partial class CoreDispatcher
 	{
-		internal bool IsThreadingSupported { get; }
+		internal static bool IsThreadingSupported { get; }
 			= Environment.GetEnvironmentVariable("UNO_BOOTSTRAP_MONO_RUNTIME_FEATURES")
 				?.Split(',').Any(v => v.Equals("threads", StringComparison.OrdinalIgnoreCase)) ?? false;
 

--- a/src/Uno.UI.RuntimeTests/MUX/Utilities/IdleSynchronizer.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Utilities/IdleSynchronizer.cs
@@ -11,7 +11,7 @@ namespace MUXControlsTestApp.Utilities
 		public static void Wait()
 		{
 #if __WASM__
-			if (!CoreDispatcher.Main.IsThreadingSupported)
+			if (!Uno.UI.Dispatching.CoreDispatcher.IsThreadingSupported)
 			{
 				return;
 			}

--- a/src/Uno.UI.RuntimeTests/MUX/Utilities/RunOnUIThread.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Utilities/RunOnUIThread.cs
@@ -35,7 +35,7 @@ namespace MUXControlsTestApp.Utilities
 			var dispatcher = whichView.Dispatcher;
 			if (dispatcher.HasThreadAccess
 #if __WASM__
-				|| !dispatcher.IsThreadingSupported
+				|| !Uno.UI.Dispatching.CoreDispatcher.IsThreadingSupported
 #endif
 				)
 			{
@@ -124,7 +124,7 @@ namespace MUXControlsTestApp.Utilities
 			var dispatcher = whichView.Dispatcher;
 			if (dispatcher.HasThreadAccess
 #if __WASM__
-				|| !dispatcher.IsThreadingSupported
+				|| !Uno.UI.Dispatching.CoreDispatcher.IsThreadingSupported
 #endif
 				)
 			{

--- a/src/Uno.UI/UI/Xaml/DragDrop/DragDropManager.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragDropManager.cs
@@ -43,7 +43,7 @@ namespace Windows.UI.Xaml
 		{
 			if (
 #if __WASM__
-				_window.Dispatcher.IsThreadingSupported &&
+				Uno.UI.Dispatching.CoreDispatcher.IsThreadingSupported &&
 #endif
 				!_window.Dispatcher.HasThreadAccess)
 			{

--- a/src/Uno.UWP/System/DispatcherQueue.cs
+++ b/src/Uno.UWP/System/DispatcherQueue.cs
@@ -23,13 +23,15 @@ namespace Windows.System
 		{
 			if (_current == null) // Do not even check for thread access if we already have a value!
 			{
-#if !__WASM__
 				// This check is disabled on WASM until threading support is enabled, since HasThreadAccess is currently user-configured (and defaults to false).
-				if (!CoreDispatcher.Main.HasThreadAccess)
+				if (
+#if __WASM__
+					CoreDispatcher.IsThreadingSupported &&
+#endif
+					!CoreDispatcher.Main.HasThreadAccess)
 				{
 					return default;
 				}
-#endif
 
 				_current = new DispatcherQueue();
 			}
@@ -42,13 +44,10 @@ namespace Windows.System
 		/// </summary>
 		internal static void CheckThreadAccess()
 		{
-#if !__WASM__
-			// This check is disabled on WASM until threading support is enabled, since HasThreadAccess is currently user-configured (and defaults to false).
 			if (!CoreDispatcher.Main.HasThreadAccess)
 			{
 				throw new InvalidOperationException("The application called an interface that was marshalled for a different thread.");
 			}
-#endif
 		}
 
 		public bool TryEnqueue(DispatcherQueueHandler callback)
@@ -70,12 +69,6 @@ namespace Windows.System
 		}
 
 		public bool HasThreadAccess
-#if !__WASM__
 			=> CoreDispatcher.Main.HasThreadAccess;
-#else
-			// This check is disabled on WASM until threading support is enabled, since HasThreadAccess is currently user-configured (and defaults to false).
-			=> true;
-#endif
-
 	}
 }

--- a/src/Uno.UWP/System/DispatcherQueueTimer.wasm.cs
+++ b/src/Uno.UWP/System/DispatcherQueueTimer.wasm.cs
@@ -29,10 +29,15 @@ namespace Windows.System
 		{
 			if (_timer == null)
 			{
-				_timer = new Timer(_ => RaiseTick());
+				_timer = new Timer(_ => DispatchRaiseTick());
 			}
 
 			_timer.Change(dueTime, interval);
+		}
+
+		private void DispatchRaiseTick()
+		{
+			_ = Uno.UI.Dispatching.CoreDispatcher.Main.RunAsync(Uno.UI.Dispatching.CoreDispatcherPriority.Normal, () => RaiseTick());
 		}
 
 		private void StopNative()

--- a/src/Uno.UWP/UI/Core/CoreDispatcher.wasm.cs
+++ b/src/Uno.UWP/UI/Core/CoreDispatcher.wasm.cs
@@ -11,8 +11,6 @@ namespace Windows.UI.Core
 {
 	public sealed partial class CoreDispatcher
 	{
-		internal bool IsThreadingSupported { get; } = Environment.GetEnvironmentVariable("UNO_BOOTSTRAP_MONO_RUNTIME_CONFIGURATION").StartsWith("threads", StringComparison.OrdinalIgnoreCase);
-
 		/// <summary>
 		/// Provide a action that will delegate the dispatch of CoreDispatcher work
 		/// </summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10677

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Returns correct values when using `DispatcherQueue.CheckThreadAccess`/`HasThreadAccess`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
