### PR TITLE
perf: Remove dependency to DataContractSerializers

### DIFF
--- a/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragDropExtension.wasm.cs
@@ -493,17 +493,16 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 			}
 		}
 
-		[DataContract]
 		private struct DataEntry
 		{
 #pragma warning disable CS0649 // error CS0649: Field 'DragDropExtension.DataEntry.kind' is never assigned to, and will always have its default value null
-			[DataMember]
+			[global::System.Text.Json.Serialization.JsonIncludeAttribute]
 			public int id;
 
-			[DataMember]
+			[global::System.Text.Json.Serialization.JsonIncludeAttribute]
 			public string kind;
 
-			[DataMember]
+			[global::System.Text.Json.Serialization.JsonIncludeAttribute]
 			public string type;
 #pragma warning restore CS0649 // error CS0649: Field 'DragDropExtension.DataEntry.kind' is never assigned to, and will always have its default value null
 

--- a/src/Uno.UI/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI/Uno.UI.Wasm.csproj
@@ -77,6 +77,7 @@
 		<PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
 		<PackageReference Include="Uno.SourceGenerationTasks" />
 		<PackageReference Include="System.Memory" Version="4.5.2" />
+		<PackageReference Include="System.Text.Json" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UWP/ApplicationModel/Contacts/Internal/WasmContact.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/Contacts/Internal/WasmContact.wasm.cs
@@ -4,22 +4,21 @@ using System.Runtime.Serialization;
 
 namespace Uno.ApplicationModel.Contacts.Internal
 {
-	[DataContract]
 	internal class WasmContact
 	{
-		[DataMember(Name = "id")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("id")]
 		public string? Id { get; set; }
 
-		[DataMember(Name = "email")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("email")]
 		public string[]? Email { get; set; }
 
-		[DataMember(Name = "name")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("name")]
 		public string[]? Name { get; set; }
 
-		[DataMember(Name = "tel")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("tel")]
 		public string[]? Tel { get; set; }
 
-		[DataMember(Name = "address")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("address")]
 		public WasmContactAddress[]? Address { get; set; }
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/Contacts/Internal/WasmContactAddress.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/Contacts/Internal/WasmContactAddress.wasm.cs
@@ -4,37 +4,36 @@ using System.Runtime.Serialization;
 
 namespace Uno.ApplicationModel.Contacts.Internal
 {
-	[DataContract]
 	internal class WasmContactAddress
 	{
-		[DataMember(Name = "city")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("city")]
 		public string? City { get; set; }
 
-		[DataMember(Name = "country")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("country")]
 		public string? Country { get; set; }
 
-		[DataMember(Name = "dependentLocality")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("dependentLocality")]
 		public string? DependentLocality { get; set; }
 
-		[DataMember(Name = "organization")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("organization")]
 		public string? Organization { get; set; }
 
-		[DataMember(Name = "phone")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("phone")]
 		public string? Phone { get; set; }
 
-		[DataMember(Name = "postalCode")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("postalCode")]
 		public string? PostalCode { get; set; }
 
-		[DataMember(Name = "recipient")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("recipient")]
 		public string? Recipient { get; set; }
 
-		[DataMember(Name = "region")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("region")]
 		public string? Region { get; set; }
 
-		[DataMember(Name = "sortingCode")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("sortingCode")]
 		public string? SortingCode { get; set; }
 
-		[DataMember(Name = "addressLine")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("addressLine")]
 		public string?[]? AddressLine { get; set; }
 	}
 }

--- a/src/Uno.UWP/Helpers/Serialization/JsonHelper.wasm.cs
+++ b/src/Uno.UWP/Helpers/Serialization/JsonHelper.wasm.cs
@@ -14,11 +14,7 @@ namespace Uno.Helpers.Serialization
 				throw new ArgumentNullException(nameof(json));
 			}
 
-			using (var stream = new MemoryStream(Encoding.Default.GetBytes(json)))
-			{
-				var serializer = new DataContractJsonSerializer(typeof(T));
-				return (T)serializer.ReadObject(stream);
-			}
+			return System.Text.Json.JsonSerializer.Deserialize<T>(json);
 		}
 
 		public static bool TryDeserialize<T>(string json, out T value)
@@ -37,12 +33,7 @@ namespace Uno.Helpers.Serialization
 
 		public static string Serialize<T>(T value)
 		{
-			using var stream = new MemoryStream();
-			var serializer = new DataContractJsonSerializer(typeof(T));
-			serializer.WriteObject(stream, value);
-			stream.Position = 0;
-			using StreamReader reader = new StreamReader(stream);
-			return reader.ReadToEnd();
+			return System.Text.Json.JsonSerializer.Serialize(value);
 		}
 	}
 }

--- a/src/Uno.UWP/Storage/Internal/NativeStorageItemInfo.wasm.cs
+++ b/src/Uno.UWP/Storage/Internal/NativeStorageItemInfo.wasm.cs
@@ -5,16 +5,15 @@ using System.Runtime.Serialization;
 
 namespace Uno.Storage.Internal
 {
-	[DataContract]
 	internal class NativeStorageItemInfo
 	{
-		[DataMember(Name = "id")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("id")]
 		public Guid Id { get; set; }
 
-		[DataMember(Name = "name")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("name")]
 		public string Name { get; set; } = null!;
 
-		[DataMember(Name = "isFile")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("isFile")]
 		public bool IsFile { get; set; }
 	}
 }

--- a/src/Uno.UWP/Storage/Pickers/Internal/NativeFilePickerAcceptType.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/Internal/NativeFilePickerAcceptType.wasm.cs
@@ -2,13 +2,12 @@
 
 namespace Uno.Storage.Pickers.Internal
 {
-	[DataContract]
 	internal class NativeFilePickerAcceptType
 	{
-		[DataMember(Name = "description")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("description")]
 		public string Description { get; set; }
 
-		[DataMember(Name = "accept")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("accept")]
 		public NativeFilePickerAcceptTypeItem[] Accept { get; set; }
 	}
 }

--- a/src/Uno.UWP/Storage/Pickers/Internal/NativeFilePickerAcceptTypeItem.wasm.cs
+++ b/src/Uno.UWP/Storage/Pickers/Internal/NativeFilePickerAcceptTypeItem.wasm.cs
@@ -2,13 +2,12 @@
 
 namespace Uno.Storage.Pickers.Internal
 {
-	[DataContract]
 	internal class NativeFilePickerAcceptTypeItem
 	{
-		[DataMember(Name = "mimeType")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("mimeType")]
 		public string MimeType { get; set; }
 
-		[DataMember(Name = "extensions")]
+		[global::System.Text.Json.Serialization.JsonPropertyName("extensions")]
 		public string[] Extensions { get; set; }
 	}
 }

--- a/src/Uno.UWP/Uno.Wasm.csproj
+++ b/src/Uno.UWP/Uno.Wasm.csproj
@@ -34,6 +34,7 @@
 	
 	<ItemGroup>
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+		<PackageReference Include="System.Text.Json" Version="5.0.0" />
 		<PackageReference Include="Uno.SourceGenerationTasks" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Perf
Remove dependency to DataContractSerializers

## What is the current behavior?
Use DataContract serializer for internal complex object marshaling. This has the incinvenient to bring lot of dependencies like `System.Xml` and reduces linker efficiency.

## What is the new behavior?
Use `System.Text.Json`.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
