### PR TITLE
Fixed the #10710 LightSensor documentation bug

### DIFF
--- a/doc/articles/features/lightsensor.md
+++ b/doc/articles/features/lightsensor.md
@@ -23,8 +23,8 @@
 ### Capturing sensor readings
 
 ```csharp
-var LightSensor = LightSensor.GetDefault();
-LightSensor.ReadingChanged += LightSensor_ReadingChanged;
+var lightSensor = LightSensor.GetDefault();
+lightSensor.ReadingChanged += LightSensor_ReadingChanged;
 
 private async void LightSensor_ReadingChanged(LightSensor sender, LightSensorReadingChangedEventArgs args)
 {
@@ -42,5 +42,5 @@ private async void LightSensor_ReadingChanged(LightSensor sender, LightSensorRea
 ### Unsubscribing from the readings
 
 ```csharp
-LightSensor.ReadingChanged -= LightSensor_ReadingChanged;
+lightSensor.ReadingChanged -= LightSensor_ReadingChanged;
 ```


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10710

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Examples code throws `Cannot use local variable 'LightSensor' before it is declared.`

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

Used camelCase formatting on the `var LightSensor`, so the code doesn't throw the error.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.