### PR TITLE
fix(reg): Adjust for XAML Trimming cross-runtime libraries built before Uno 4.6

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
@@ -62,7 +62,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 
 		public override bool Execute()
 		{
-			Debugger.Launch();
+			// Debugger.Launch();
 
 			BuildReferences();
 			OutputPath = AlignPath(OutputPath);

--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
@@ -62,7 +62,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 
 		public override bool Execute()
 		{
-			// Debugger.Launch();
+			Debugger.Launch();
 
 			BuildReferences();
 			OutputPath = AlignPath(OutputPath);
@@ -383,11 +383,29 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 					? "net7.0"
 					: "netstandard2.0";
 
-				return
-					(unoRuntimeIdentifier == "skia" || unoRuntimeIdentifier == "webassembly") &&
-						referencePath.StartsWith(unoUIPackageBasePath, StringComparison.Ordinal) ?
-							referencePath.Replace($"lib{separator}{runtimeTargetFramework}", $"uno-runtime{separator}{runtimeTargetFramework}{separator}{unoRuntimeIdentifier}") :
-								referencePath;
+				var isUnoRuntimeEnabled = (unoRuntimeIdentifier == "skia" || unoRuntimeIdentifier == "webassembly") &&
+						referencePath.StartsWith(unoUIPackageBasePath, StringComparison.Ordinal);
+
+				if (isUnoRuntimeEnabled)
+				{
+					var originalFolderPath = $"lib{separator}{runtimeTargetFramework}";
+					var preUno46FolderPart = $"uno-runtime{separator}{unoRuntimeIdentifier}";
+					var postUno46FolderPathPart = $"uno-runtime{separator}{runtimeTargetFramework}{separator}{unoRuntimeIdentifier}";
+
+					var post46Path = referencePath.Replace(originalFolderPath, postUno46FolderPathPart);
+					var pre46Path = referencePath.Replace(originalFolderPath, preUno46FolderPart);
+
+					if (File.Exists(post46Path))
+					{
+						return post46Path;
+					}
+					else if (File.Exists(pre46Path))
+					{
+						return pre46Path;
+					}
+				}
+
+				return referencePath;
 			}
 		}
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adjusts XAML trimming process to include nuget packages built before uno 4.6 which don't include the target framework in the uno-runtime folder.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
