### PR TITLE
fix(ios): animation stopped when app resumes from background

### DIFF
--- a/src/Uno.UI.Composition/Composition/CoreAnimation.iOSmacOS.cs
+++ b/src/Uno.UI.Composition/Composition/CoreAnimation.iOSmacOS.cs
@@ -52,7 +52,7 @@ namespace Windows.UI.Composition
 			/// <summary>
 			/// The animation stopped successfully
 			/// </summary>
-			Sucesss = 0,
+			Success = 0,
 
 			/// <summary>
 			/// The animation got stopped (e.g. the animated layer is not in the visual tree)
@@ -186,7 +186,7 @@ namespace Windows.UI.Composition
 			animation.FillMode = CAFillMode.Forwards;
 			// Let the 'OnAnimationStop' forcefully apply the final value before removing the animation.
 			// That's required for Storyboards that animating multiple properties of the same object at once.
-			animation.RemovedOnCompletion = false; 
+			animation.RemovedOnCompletion = false;
 			animation.AnimationStarted += OnAnimationStarted(animation);
 			animation.AnimationStopped += OnAnimationStopped(animation);
 
@@ -329,8 +329,7 @@ namespace Windows.UI.Composition
 					// We have to remove the animation only in case of 'StopReason.Completed',
 					// for other cases it's what we actually did to request the stop.
 					layer?.RemoveAnimation(_key);
-
-					_onCompleted(args.Finished ? CompletedInfo.Sucesss : CompletedInfo.Error);
+					_onCompleted(args.Finished ? CompletedInfo.Success : CompletedInfo.Error);
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/GPUFloatValueAnimator.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/GPUFloatValueAnimator.iOSmacOS.cs
@@ -4,7 +4,17 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using Windows.Foundation;
+using Windows.UI.Composition;
+using Windows.UI.Core;
+using CoreAnimation;
+using CoreGraphics;
+using Foundation;
+using Uno.Extensions;
+using Uno.Foundation.Logging;
+using Uno.UI;
 using Uno.UI.DataBinding;
+using Uno.UI.Extensions;
+
 #if __IOS__
 using UIKit;
 using _View = UIKit.UIView;
@@ -12,14 +22,6 @@ using _View = UIKit.UIView;
 using AppKit;
 using _View = AppKit.NSView;
 #endif
-using CoreGraphics;
-using Foundation;
-using CoreAnimation;
-using Uno.Extensions;
-using Uno.Foundation.Logging;
-using Windows.UI.Composition;
-using Uno.UI;
-using Uno.UI.Extensions;
 
 namespace Windows.UI.Xaml.Media.Animation
 {
@@ -29,6 +31,8 @@ namespace Windows.UI.Xaml.Media.Animation
 	internal class GPUFloatValueAnimator : IValueAnimator
 	{
 		private static readonly string __notSupportedProperty = "This transform is not supported by GPU enabled animations.";
+		private static readonly List<ManagedWeakReference> _weakActiveInstanceCache = new();
+		private static bool _subscribedToVisibilityChanged;
 
 		private float _to;
 		private float _from;
@@ -38,6 +42,8 @@ namespace Windows.UI.Xaml.Media.Animation
 		private UnoCoreAnimation _coreAnimation;
 		private IEasingFunction _easingFunction;
 		private bool _isDisposed;
+		private bool _isPausedInBackground; // flag the animation to be resumed once foregrounded
+		private bool _coreStoppedNotFinished; // the animation came to an abrupt end; used by OnCoreWindowVisibilityChanged to confirm paused by backgrounding
 
 #region PropertyNameConstants
 		private const string TranslateTransformX = "TranslateTransform.X";
@@ -72,7 +78,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		private const string CompositeTransformSkewXWithNamespace = "Windows.UI.Xaml.Media:CompositeTransform.SkewX";
 		private const string CompositeTransformSkewY = "CompositeTransform.SkewY";
 		private const string CompositeTransformSkewYWithNamespace = "Windows.UI.Xaml.Media:CompositeTransform.SkewY";
-#endregion
+		#endregion
 
 		internal static Point GetAnchorForAnimation(Transform transform, Point relativeOrigin, Size viewSize)
 		{
@@ -126,14 +132,45 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 
 			InitializeCoreAnimation();
+			TrackCurrentInstance();
 
 			if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 			{
 				this.Log().DebugFormat("Starting GPU Float value animator on property {0}.", _bindingPath.LastOrDefault().PropertyName);
 			}
 
+			ResetBackgroundPauseTrackingStates();
 			_valueAnimator?.Start();
 			_coreAnimation?.Start();
+		}
+
+		public void Pause()
+		{
+			var pausedTime = _valueAnimator?.CurrentPlayTime;
+			var pausedValue = (float?)_valueAnimator?.AnimatedValue;
+
+			_valueAnimator?.Pause();
+			_coreAnimation?.Pause(pausedTime, pausedValue);
+
+			AnimationPause?.Invoke(this, EventArgs.Empty);
+		}
+
+		public void Resume()
+		{
+			ResetBackgroundPauseTrackingStates();
+			_valueAnimator?.Resume();
+			_coreAnimation?.Resume();
+		}
+
+		public void Cancel()
+		{
+			ResetBackgroundPauseTrackingStates();
+			_valueAnimator?.Cancel();
+			_coreAnimation?.Cancel();
+			AnimationCancel?.Invoke(this, EventArgs.Empty);
+
+			ReleaseCoreAnimation();
+			UntrackCurrentInstance();
 		}
 
 		private void InitializeCoreAnimation()
@@ -167,7 +204,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 				// case TransformGroup group:
 				//  ==> No needs to validate the TransformGroup: there is no animatable property on it.
-				//		If a anmiation is declared on it (e.g. "(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)"),
+				//		If a animation is declared on it (e.g. "(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)"),
 				//		the _bindingPath should resolve the target child Transform, and animatedItem.DataContext should be the ScaleTransform.
 
 
@@ -176,30 +213,34 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 		}
 
-		public void Pause()
+		private void TrackCurrentInstance()
 		{
-			var pausedTime = _valueAnimator?.CurrentPlayTime;
-			var pausedValue = (float?)_valueAnimator?.AnimatedValue;
-
-			_valueAnimator?.Pause();
-			_coreAnimation?.Pause(pausedTime, pausedValue);
-
-			AnimationPause?.Invoke(this, EventArgs.Empty);
+			lock(_weakActiveInstanceCache)
+			{
+				_weakActiveInstanceCache.Add(WeakReferencePool.RentWeakReference(this, this));
+			}
+			if (!_subscribedToVisibilityChanged &&
+				CoreWindow.GetForCurrentThread() is { } coreWindow)
+			{
+				coreWindow.VisibilityChanged += OnCoreWindowVisibilityChanged;
+				_subscribedToVisibilityChanged = true;
+			}
 		}
 
-		public void Resume()
+		private void UntrackCurrentInstance()
 		{
-			_valueAnimator?.Resume();
-			_coreAnimation?.Resume();
-		}
-
-		public void Cancel()
-		{
-			_valueAnimator?.Cancel();
-			_coreAnimation?.Cancel();
-			AnimationCancel?.Invoke(this, EventArgs.Empty);
-
-			ReleaseCoreAnimation();
+			lock(_weakActiveInstanceCache)
+			{
+				for (int i = _weakActiveInstanceCache.Count - 1; i >= 0; i--)
+				{
+					if (_weakActiveInstanceCache[i] is var pInstance &&
+						pInstance.Target == this)
+					{
+						_weakActiveInstanceCache.RemoveAt(i);
+						WeakReferencePool.ReturnWeakReference(this, pInstance);
+					}
+				}
+			}
 		}
 
 		public bool IsRunning => _valueAnimator?.IsRunning ?? false;
@@ -378,7 +419,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			string property,
 			Func<float, NSValue> nsValueConversion)
 			=> CreateCoreAnimation(transform.View, property, nsValueConversion, transform.StartAnimation, transform.EndAnimation);
-		
+
 		private UnoCoreAnimation CreateCoreAnimation(
 			_View view,
 			string property,
@@ -395,7 +436,6 @@ namespace Windows.UI.Xaml.Media.Animation
 			return prepareAnimation == null || endAnimation == null
 				? new UnoCoreAnimation(view.Layer, property, _from, _to, StartDelay, _duration, timingFunction, nsValueConversion, FinalizeAnimation, isDiscrete)
 				: new UnoCoreAnimation(view.Layer, property, _from, _to, StartDelay, _duration, timingFunction, nsValueConversion, FinalizeAnimation, isDiscrete, prepareAnimation, endAnimation);
-
 		}
 
 		private NSValue ToCASkewTransform(float angleX, float angleY)
@@ -417,6 +457,55 @@ namespace Windows.UI.Xaml.Media.Animation
 			return NSValue.FromCATransform3D(CATransform3D.MakeFromAffine(matrix));
 		}
 
+		private static void OnCoreWindowVisibilityChanged(CoreWindow sender, VisibilityChangedEventArgs args)
+		{
+			lock(_weakActiveInstanceCache)
+			{
+				for (int i = _weakActiveInstanceCache.Count - 1; i >= 0; i--)
+				{
+					if (_weakActiveInstanceCache[i] is var pInstance &&
+						pInstance.IsAlive &&
+						pInstance.Target is GPUFloatValueAnimator instance)
+					{
+						instance.OnCoreWindowVisibilityChangedImpl(args);
+					}
+					else // purge collected instance
+					{
+						_weakActiveInstanceCache.RemoveAt(i);
+						WeakReferencePool.ReturnWeakReference(pInstance.Owner, pInstance);
+					}
+				}
+			}
+		}
+
+		private void OnCoreWindowVisibilityChangedImpl(VisibilityChangedEventArgs args)
+		{
+			// note: There is no guarantee on which is called first between this (didEnterBackgroundNotification)
+			// and FinalizeAnimation (animationDidStop).
+			if (!args.Visible)
+			{
+				if (IsRunning || _coreStoppedNotFinished)
+				{
+					Pause();
+					_isPausedInBackground = true;
+				}
+			}
+			else
+			{
+				if (_isPausedInBackground)
+				{
+					if (_coreAnimation is { })
+					{
+						Resume();
+					}
+					else
+					{
+						Start();
+					}
+				}
+			}
+		}
+
 		private void FinalizeAnimation(UnoCoreAnimation.CompletedInfo completedInfo)
 		{
 			if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
@@ -424,25 +513,48 @@ namespace Windows.UI.Xaml.Media.Animation
 				this.Log().DebugFormat("Finalizing animation for GPU Float value animator on property {0}.", _bindingPath.LastOrDefault().PropertyName);
 			}
 
-			if (_valueAnimator?.IsRunning ?? false)
+			var wasRunning = _valueAnimator?.IsRunning ?? false;
+			if (wasRunning)
 			{
 				_valueAnimator.Cancel();
 			}
 
 			switch(completedInfo)
 			{
-				case UnoCoreAnimation.CompletedInfo.Sucesss: AnimationEnd?.Invoke(this, EventArgs.Empty); break;
-				case UnoCoreAnimation.CompletedInfo.Error: AnimationFailed?.Invoke(this, EventArgs.Empty); break;
+				case UnoCoreAnimation.CompletedInfo.Success:
+					AnimationEnd?.Invoke(this, EventArgs.Empty);
+					break;
+
+				case UnoCoreAnimation.CompletedInfo.Error:
+					// ref: https://developer.apple.com/documentation/quartzcore/caanimationdelegate/2097259-animationdidstop
+					// This callback from animationDidStop:finished with the finished=false (which is translated to Error here)
+					// means that the animation have ended because "it has been removed from the layer it is attached to."
+					// It could mean it was explicitly CoreAnimation::StopAnimation'd by us, or killed by the os as the app is background'd.
+					// Since we don't know which case it is, we are just setting another flag to be later confirmed in OnCoreWindowVisibilityChanged.
+					AnimationFailed?.Invoke(this, EventArgs.Empty);
+					if (wasRunning)
+					{
+						_coreStoppedNotFinished = true;
+					}
+					break;
+
 				default: throw new NotSupportedException($"{completedInfo} is not supported");
 			};
 
 			ReleaseCoreAnimation();
+			UntrackCurrentInstance();
 		}
 
 		private void ReleaseCoreAnimation()
 		{
 			_coreAnimation?.Dispose();
 			_coreAnimation = null;
+		}
+
+		private void ResetBackgroundPauseTrackingStates()
+		{
+			_coreStoppedNotFinished = false;
+			_isPausedInBackground = false;
 		}
 
 		public void Dispose()

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -257,7 +257,7 @@ namespace Windows.UI.Xaml
 
 				Visible = newVisibility;
 
-				var args = new VisibilityChangedEventArgs();
+				var args = new VisibilityChangedEventArgs() { Visible = newVisibility };
 				CoreWindow.OnVisibilityChanged(args);
 				VisibilityChanged?.Invoke(this, args);
 			}

--- a/src/Uno.UWP/UI/Core/VisibilityChangedEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/VisibilityChangedEventArgs.cs
@@ -13,6 +13,6 @@ namespace Windows.UI.Core
 		/// <summary>
 		/// Gets whether the window is visible or not.
 		/// </summary>
-		public bool Visible { get; }
+		public bool Visible { get; internal init; }
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10627

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On-going animation bricks after alt-tabbing out and back.

## What is the new behavior?
The animation now continues to play.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
ninja-fix: CoreWindow.VisibilityChanged's event-args always passing `Visible` as false.