### PR TITLE
fix(framebuffer): Restore 32 bits color format

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FrameBufferDevice.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FrameBufferDevice.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using SkiaSharp;
+using Uno.Foundation.Logging;
 using Uno.UI.Runtime.Skia.Native;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
@@ -42,12 +43,56 @@ namespace Uno.UI.Runtime.Skia
 		public SKColorType PixelFormat =>
 			_screenInfo.bits_per_pixel switch
 			{
-				32 => _screenInfo.blue.offset == 16
-					? SKColorType.Bgra8888
-					: SKColorType.Rgba8888,
+				// 32 bits
+				//
+				// Sample: (RPi 4b 64bits w/ disabled 3d acceleration)
+				//		red
+				//		  red.offset = 16
+				//		  red.length = 8
+				//		  red.msb_right = 0
+				//		green
+				//		  green.offset = 8
+				//		  green.length = 8
+				//		  green.msb_right = 0
+				//		blue
+				//		  blue.offset = 0
+				//		  blue.length = 8
+				//		  blue.msb_right = 0
+				//		transp
+				//		  transp.offset = 24
+				//		  transp.length = 8
+				//		  transp.msb_right = 0
+				32 => _screenInfo.blue.offset switch
+				{
+					0 => SKColorType.Bgra8888,
+					16 => SKColorType.Rgba8888,
+					_ => throw new NotSupportedException($"Framebuffer configuration with blue offset of {_screenInfo.blue.offset} is not yet supported")
+				},
+
+				// 16 bits
+				//
+				//  Sample: (RPi 4b 64bits w/ 3d acceleration)
+				//  red
+				//	  red.offset = 11
+				//	  red.length = 5
+				//	  red.msb_right = 0
+				//	green
+				//	  green.offset = 5
+				//	  green.length = 6
+				//	  green.msb_right = 0
+				//	blue
+				//	  blue.offset = 0
+				//	  blue.length = 5
+				//	  blue.msb_right = 0
+				//	transp
+				//	  transp.offset = 0
+				//	  transp.length = 0
+				//	  transp.msb_right = 0
+
 				16 => _screenInfo.red.offset == 11
 					? SKColorType.Rgb565
 					: throw new NotSupportedException($"RGB555 is not supported by Uno Platform"),
+
 				_ => throw new NotSupportedException($"{_screenInfo.bits_per_pixel} bpp framebuffer is not supported"),
 			};
 
@@ -99,7 +144,7 @@ namespace Uno.UI.Runtime.Skia
 
 				if (_screenInfo.bits_per_pixel != 32)
 				{
-					if(_screenInfo.bits_per_pixel != 16)
+					if (_screenInfo.bits_per_pixel != 16)
 					{
 						throw new InvalidOperationException($"Failed to set 32 bits display mode (Found {_screenInfo.bits_per_pixel})");
 					}
@@ -129,6 +174,8 @@ namespace Uno.UI.Runtime.Skia
 			{
 				throw new InvalidOperationException($"Failed to map {_mappedLength} bytes ({Marshal.GetLastWin32Error()})");
 			}
+
+			LogFramebufferInformation();
 		}
 
 		void Set32BitsPixelFormat()
@@ -193,6 +240,55 @@ namespace Uno.UI.Runtime.Skia
 		~FrameBufferDevice()
 		{
 			Dispose(false);
+		}
+
+		private void LogFramebufferInformation()
+		{
+			if (this.Log().IsEnabled(LogLevel.Trace))
+			{
+				this.Log().Trace(
+					$"""
+					Framebuffer information:
+						xres = {_screenInfo.xres}
+						yres = {_screenInfo.yres}
+						xres_virtual = {_screenInfo.xres_virtual}
+						yres_virtual = {_screenInfo.yres_virtual}
+						xoffset = {_screenInfo.xoffset}
+						yoffset = {_screenInfo.yoffset}
+						bits_per_pixel = {_screenInfo.bits_per_pixel}
+						grayscale = {_screenInfo.grayscale}
+						red
+						  red.offset = {_screenInfo.red.offset}
+						  red.length = {_screenInfo.red.length}
+						  red.msb_right = {_screenInfo.red.msb_right}
+						green
+						  green.offset = {_screenInfo.green.offset}
+						  green.length = {_screenInfo.green.length}
+						  green.msb_right = {_screenInfo.green.msb_right}
+						blue
+						  blue.offset = {_screenInfo.blue.offset}
+						  blue.length = {_screenInfo.blue.length}
+						  blue.msb_right = {_screenInfo.blue.msb_right}
+						transp
+						  transp.offset = {_screenInfo.transp.offset}
+						  transp.length = {_screenInfo.transp.length}
+						  transp.msb_right = {_screenInfo.transp.msb_right}
+						nonstd = {_screenInfo.nonstd}
+						activate = {_screenInfo.activate}
+						height = {_screenInfo.height}
+						width = {_screenInfo.width}
+						accel_flags = {_screenInfo.accel_flags}
+						pixclock = {_screenInfo.pixclock}
+						left_margin = {_screenInfo.left_margin}
+						right_margin = {_screenInfo.right_margin}
+						upper_margin = {_screenInfo.upper_margin}
+						lower_margin = {_screenInfo.lower_margin}
+						hsync_len = {_screenInfo.hsync_len}
+						vsync_len = {_screenInfo.vsync_len}
+						sync = {_screenInfo.sync}
+						vmode = {_screenInfo.vmode}
+					""");
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10474

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores correct pixel format for 32 bits framebuffer mode.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
