### PR TITLE
fix(ListView): Fix support of items re-ordering support of ICollectionView

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -14,6 +14,7 @@ using Uno.Foundation.Logging;
 using Uno.UI;
 using _DragEventArgs = global::Windows.UI.Xaml.DragEventArgs;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media.Imaging;
 
 namespace Windows.UI.Xaml.Controls
@@ -291,6 +292,13 @@ namespace Windows.UI.Xaml.Controls
 						list.IndexOf,
 						(oldIndex, newIndex) => DoMove(list, oldIndex, newIndex));
 					break;
+
+				case ICollectionView view when !view.IsReadOnly:
+					ProcessMove(
+						view.Count,
+						view.IndexOf,
+						(oldIndex, newIndex) => DoMove(view, oldIndex, newIndex));
+					break;
 			}
 
 			void ProcessMove(
@@ -417,6 +425,20 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		private static void DoMove(IList list, int oldIndex, int newIndex)
+		{
+			var item = list[oldIndex];
+			list.RemoveAt(oldIndex);
+			if (newIndex >= list.Count)
+			{
+				list.Add(item);
+			}
+			else
+			{
+				list.Insert(newIndex, item);
+			}
+		}
+
+		private static void DoMove(ICollectionView list, int oldIndex, int newIndex)
 		{
 			var item = list[oldIndex];
 			list.RemoveAt(oldIndex);


### PR DESCRIPTION
## Bugfix
Fix support of items re-ordering support of ICollectionView

## What is the current behavior?
`ICollectionView` are not being reordered by the `ListView` when used as `ItemsSource`.

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
