### PR TITLE
fix(embeddedresources): Restore proper AssignTargetPaths/AssignLinkMetadata for EmbeddedResource LogicalName metadata

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/Embedded/SubFolder1/SubFolder2/SharedProjectEmbeddedFile.txt
+++ b/src/SamplesApp/SamplesApp.Shared/Embedded/SubFolder1/SubFolder2/SharedProjectEmbeddedFile.txt
@@ -1,0 +1,1 @@
+﻿Hello Uno!

--- a/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
@@ -58,6 +58,7 @@
     <Content Include="$(MSBuildThisFileDirectory)Assets\nodpi-validationresource.jpeg" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\BackArrow.scale-300.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\Asset With Spaces.svg" />
+    <Content Include="$(MSBuildThisFileDirectory)Embedded\SubFolder1\SubFolder2\SharedProjectEmbeddedFile.txt" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-US\Resources.resw" />
@@ -74,5 +75,8 @@
     <Compile Update="$(MSBuildThisFileDirectory)Samples\UnitTests\HttpUnitTests.xaml.cs">
       <DependentUpon>HttpUnitTests.xaml</DependentUpon>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Embedded\SubFolder1\SubFolder2\" />
   </ItemGroup>
 </Project>

--- a/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
@@ -58,7 +58,7 @@
     <Content Include="$(MSBuildThisFileDirectory)Assets\nodpi-validationresource.jpeg" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\BackArrow.scale-300.png" />
     <Content Include="$(MSBuildThisFileDirectory)Assets\Asset With Spaces.svg" />
-    <Content Include="$(MSBuildThisFileDirectory)Embedded\SubFolder1\SubFolder2\SharedProjectEmbeddedFile.txt" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Embedded\SubFolder1\SubFolder2\SharedProjectEmbeddedFile.txt" />
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-US\Resources.resw" />

--- a/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
+++ b/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
@@ -202,4 +202,16 @@
 			<ReferencePath Remove="@(_ReferencePathToRemove)" />
 		</ItemGroup>
 	</Target>
+  
+	<Target Name="_PrepareUnoResourcesGeneration" BeforeTargets="BeforeBuild" Condition="'$(TargetFrameworkIdentifier)'=='Xamarin.Mac' and '$(_IsUnoUISolution)'=='true'">
+		
+		<PropertyGroup>
+			<!--
+			AssignTargetPathsDependsOn is reset forcibly by a targets file included after this current file.
+			This does not happen when running through a nuget package.
+			-->
+			<AssignTargetPathsDependsOn>$(AssignTargetPathsDependsOn);AssignLinkMetadata</AssignTargetPathsDependsOn>
+		</PropertyGroup>
+		
+	</Target>
 </Project>

--- a/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
+++ b/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
@@ -203,7 +203,7 @@
 		</ItemGroup>
 	</Target>
   
-	<Target Name="_PrepareUnoResourcesGeneration" BeforeTargets="BeforeBuild" Condition="'$(TargetFrameworkIdentifier)'=='Xamarin.Mac' and '$(_IsUnoUISolution)'=='true'">
+	<Target Name="_PrepareUnoResourcesGeneration" BeforeTargets="BeforeBuild">
 		
 		<PropertyGroup>
 			<!--

--- a/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
+++ b/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
@@ -202,16 +202,13 @@
 			<ReferencePath Remove="@(_ReferencePathToRemove)" />
 		</ItemGroup>
 	</Target>
-  
-	<Target Name="_PrepareUnoResourcesGeneration" BeforeTargets="BeforeBuild">
-		
-		<PropertyGroup>
-			<!--
-			AssignTargetPathsDependsOn is reset forcibly by a targets file included after this current file.
-			This does not happen when running through a nuget package.
-			-->
-			<AssignTargetPathsDependsOn>$(AssignTargetPathsDependsOn);AssignLinkMetadata</AssignTargetPathsDependsOn>
-		</PropertyGroup>
-		
-	</Target>
+ 		
+  <PropertyGroup>
+		<!--
+		AssignTargetPathsDependsOn is reset forcibly by a targets file included after this current file.
+		This does not happen when running through a nuget package.
+		-->
+    <AssignTargetPathsDependsOn>$(AssignTargetPathsDependsOn);AssignLinkMetadata</AssignTargetPathsDependsOn>
+  </PropertyGroup>
+
 </Project>

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -36,18 +36,6 @@
 		<AssignTargetPathsDependsOn>$(AssignTargetPathsDependsOn);AssignLinkMetadata</AssignTargetPathsDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_PrepareUnoResourcesGeneration" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)'=='xamarinmac20' and '$(_IsUnoUISolution)'=='true'">
-		
-		<PropertyGroup>
-			<!--
-			AssignTargetPathsDependsOn is reset forcibly by a targets file included after this current file.
-			This does not happen when running through a nuget package.
-			-->
-			<AssignTargetPathsDependsOn>$(AssignTargetPathsDependsOn);AssignLinkMetadata</AssignTargetPathsDependsOn>
-		</PropertyGroup>
-		
-	</Target>
-
 	<!--
 	  This task transforms all the Content files and PRIResources into resources files compatible for each platform.
 

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -30,7 +30,7 @@
 		<!--
 		Ensures that AssignLinkMetadata runs before AssignTargetPaths.
 		Otherwise, AssignTargetPath will generate a rooted path and will break embedded sources
-		LogicalPath metadata's behavior.
+		LogicalName metadata's behavior.
 		-->
 		<AssignTargetPathsDependsOn>$(AssignTargetPathsDependsOn);AssignLinkMetadata</AssignTargetPathsDependsOn>
 	</PropertyGroup>

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -26,6 +26,7 @@
 			<DefaultLanguage Condition="'$(DefaultLanguage)'==''">en</DefaultLanguage>
 		</PropertyGroup>
 	</Target>
+
 	<PropertyGroup>
 		<!--
 		Ensures that AssignLinkMetadata runs before AssignTargetPaths.
@@ -34,6 +35,18 @@
 		-->
 		<AssignTargetPathsDependsOn>$(AssignTargetPathsDependsOn);AssignLinkMetadata</AssignTargetPathsDependsOn>
 	</PropertyGroup>
+
+	<Target Name="_PrepareUnoResourcesGeneration" BeforeTargets="BeforeBuild" Condition="'$(TargetFramework)'=='xamarinmac20' and '$(_IsUnoUISolution)'=='true'">
+		
+		<PropertyGroup>
+			<!--
+			AssignTargetPathsDependsOn is reset forcibly by a targets file included after this current file.
+			This does not happen when running through a nuget package.
+			-->
+			<AssignTargetPathsDependsOn>$(AssignTargetPathsDependsOn);AssignLinkMetadata</AssignTargetPathsDependsOn>
+		</PropertyGroup>
+		
+	</Target>
 
 	<!--
 	  This task transforms all the Content files and PRIResources into resources files compatible for each platform.

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -26,6 +26,15 @@
 			<DefaultLanguage Condition="'$(DefaultLanguage)'==''">en</DefaultLanguage>
 		</PropertyGroup>
 	</Target>
+	<PropertyGroup>
+		<!--
+		Ensures that AssignLinkMetadata runs before AssignTargetPaths.
+		Otherwise, AssignTargetPath will generate a rooted path and will break embedded sources
+		LogicalPath metadata's behavior.
+		-->
+		<AssignTargetPathsDependsOn>$(AssignTargetPathsDependsOn);AssignLinkMetadata</AssignTargetPathsDependsOn>
+	</PropertyGroup>
+
 	<!--
 	  This task transforms all the Content files and PRIResources into resources files compatible for each platform.
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel_Resources/Given_EmbeddedResources.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_ApplicationModel_Resources/Given_EmbeddedResources.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Linq;
+using Windows.ApplicationModel.Resources;
+using Windows.ApplicationModel.Resources.Core;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.RuntimeTests.Tests
+{
+	[TestClass]
+	public class Given_EmbeddedResources
+	{
+		[TestMethod]
+		public void When_EmbeddedResource()
+		{
+			var assembly = Application.Current.GetType().Assembly;
+
+			var resourceName = assembly.GetManifestResourceNames().FirstOrDefault(f => f.EndsWith("SubFolder1.SubFolder2.SharedProjectEmbeddedFile.txt"));
+			Assert.IsNotNull(resourceName);
+
+			using var s = assembly.GetManifestResourceStream(resourceName);
+
+			Assert.AreNotEqual(0, s.Length);
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10696
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores proper EmbeddedResource LogicalName metadat for Android targets.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
