### PR TITLE
fix(uap): Fix generators should not run under uap library builds

### DIFF
--- a/src/SourceGenerators/SourceGeneratorHelpers/Helpers/PlatformHelper.cs
+++ b/src/SourceGenerators/SourceGeneratorHelpers/Helpers/PlatformHelper.cs
@@ -21,6 +21,14 @@ namespace Uno.UI.SourceGenerators.Helpers
 
 			var isUAP = evaluatedValue?.Equals("UAP", StringComparison.OrdinalIgnoreCase) ?? false;
 
+			// Validate if we're running in a valid context, where CompileVisibleProperties for
+			// Uno's generators have been included. This may not be the case when building UAP targets
+			// for libraries, during the XamlPreCompile target.
+			var isInvalid =
+				string.IsNullOrEmpty(context.GetMSBuildPropertyValue("Configuration"))
+				&& string.IsNullOrEmpty(context.GetMSBuildPropertyValue("AssemblyName"))
+				&& string.IsNullOrEmpty(context.GetMSBuildPropertyValue("RootNamespace"));
+
 			// Those two checks are now required since VS 16.9 which enables source generators by default
 			// and the uno targets files are not present for uap targets.
 			var isWindowsRuntimeApplicationOutput = context.Compilation.Options.OutputKind == OutputKind.WindowsRuntimeApplication;
@@ -33,7 +41,8 @@ namespace Uno.UI.SourceGenerators.Helpers
 				&& !isWinAppSDK
 				&& !isNetCoreDesktop
 				&& !isWindowsRuntimeMetadataOutput
-				&& !isWindowsRuntimeApplicationOutput;
+				&& !isWindowsRuntimeApplicationOutput
+				&& !isInvalid;
 		}
 
 		public static bool IsAndroid(GeneratorExecutionContext context)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/DependencyObjectGeneratorTests/Given_DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/DependencyObjectGeneratorTests/Given_DependencyObjectGenerator.cs
@@ -18,6 +18,18 @@ public class Given_DependencyObjectGenerator
 	private static readonly ReferenceAssemblies _Net60AndroidWithUno = ReferenceAssemblies.Net.Net60Android.AddPackages(_unoPackage);
 	private static readonly ReferenceAssemblies _Net60WithUno = ReferenceAssemblies.Net.Net60.AddPackages(_unoPackage);
 
+	[TestInitialize]
+	public void Initialize()
+	{
+		DependencyObjectGenerator.IsUnitTest = true;
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		DependencyObjectGenerator.IsUnitTest = false;
+	}
+
 	private async Task TestAndroid(string testCode, params DiagnosticResult[] expectedDiagnostics)
 	{
 		var test = new Verify.Test

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/ImplementedRoutedEventsGeneratorTests/Given_ImplementedRoutedEventsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/ImplementedRoutedEventsGeneratorTests/Given_ImplementedRoutedEventsGenerator.cs
@@ -29,6 +29,18 @@ namespace Uno.UI.SourceGenerators.Tests.ImplementedRoutedEventsGeneratorTests
 			await test.RunAsync();
 		}
 
+		[TestInitialize]
+		public void Initialize()
+		{
+			ImplementedRoutedEventsGenerator.IsUnitTest = true;
+		}
+
+		[TestCleanup]
+		public void Cleanup()
+		{
+			ImplementedRoutedEventsGenerator.IsUnitTest = false;
+		}
+
 		[TestMethod]
 		public async Task Given_NonGeneric_Control_In_Global_Namespace()
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -18,6 +18,8 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 	[Generator]
 	public partial class DependencyObjectGenerator : ISourceGenerator
 	{
+		internal static bool IsUnitTest { get; set; }
+
 		public void Initialize(GeneratorInitializationContext context)
 		{
 			// Debugger.Launch();
@@ -27,7 +29,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 
 		public void Execute(GeneratorExecutionContext context)
 		{
-			if (PlatformHelper.IsValidPlatform(context))
+			if (IsUnitTest || PlatformHelper.IsValidPlatform(context))
 			{
 				var visitor = new SerializationMethodsGenerator(context);
 				visitor.Visit(context.Compilation.SourceModule);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/ImplementedRoutedEvents/ImplementedRoutedEventsGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/ImplementedRoutedEvents/ImplementedRoutedEventsGenerator.cs
@@ -20,6 +20,8 @@ namespace Uno.UI.SourceGenerators.ImplementedRoutedEvents;
 [Generator]
 public class ImplementedRoutedEventsGenerator : ISourceGenerator
 {
+	internal static bool IsUnitTest { get; set; }
+
 	public void Initialize(GeneratorInitializationContext context)
 	{
 		// No initialization required.
@@ -27,7 +29,9 @@ public class ImplementedRoutedEventsGenerator : ISourceGenerator
 
 	public void Execute(GeneratorExecutionContext context)
 	{
-		if (!DesignTimeHelper.IsDesignTime(context) && PlatformHelper.IsValidPlatform(context))
+		if (
+			IsUnitTest
+			|| (!DesignTimeHelper.IsDesignTime(context) && PlatformHelper.IsValidPlatform(context)))
 		{
 			var uiElementSymbol = context.Compilation.GetTypeByMetadataName(XamlConstants.Types.UIElement);
 			if (uiElementSymbol is null)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10556

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Source generators will not run if compiler visible properties are not set properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
