### PR TITLE
fix(animation): forever animation not repeating from default value

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_DoubleAnimation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_DoubleAnimation.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
 {
@@ -33,6 +37,79 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation
 
 			sb.Begin();
 			sb.SeekAlignedToLastTick(TimeSpan.FromMilliseconds(50));
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if __ANDROID__
+		[Ignore("In this scenario, droid doesnt ReportEachFrame(), so we won't be able to read the animated values to evaluate this test.")]
+#endif
+		public async Task When_RepeatForever_WithoutFrom_Asd()
+		{
+			// droid: The fix is still valid for android, because it will now be reading from non-animated value as well.
+			// However, that doesnt change anything (it worked before), because the animated was never commited into the property details.
+
+			// note: Without an actual rendered target, playing the storyboard will not
+			// affect the actual value effectively voiding this test.
+			var target = new TextBlock() { Text = "asdasd" };
+			WindowHelper.WindowContent = target;
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(target);
+
+			var transform = new TranslateTransform();
+			target.RenderTransform = transform;
+
+			var animation = new DoubleAnimation()
+			{
+				// From = ..., // left out for this test
+				To = 312,
+				Duration = TimeSpan.FromMilliseconds(500),
+				FillBehavior = FillBehavior.HoldEnd,
+				RepeatBehavior = RepeatBehavior.Forever,
+			};
+			Storyboard.SetTarget(animation, transform);
+			Storyboard.SetTargetProperty(animation, nameof(TranslateTransform.X));
+
+			var storyboard = new Storyboard();
+			storyboard.Children.Add(animation);
+			storyboard.Begin();
+
+			var values = new List<double>();
+			// The delay below are more of a suggestion. We cant realistically expected
+			// to land exactly on the end of loop at 500ms. But the idea here is to measure
+			// that the animated value doesn't freeze/stuck at DoubleAnimation.To of 312
+			// after certain iterations. So the lack of precision is actually desired here.
+			await WaitAndSnapshotValue(100); // 0
+			await WaitAndSnapshotValue(400); // 1 iteration 1 done
+			await WaitAndSnapshotValue(500); // 2 iteration 2 done
+			await WaitAndSnapshotValue(500); // 3 iteration 3 done
+			await WaitAndSnapshotValue(500); // 4 iteration 4 done
+			await WaitAndSnapshotValue(100); // 5
+			await WaitAndSnapshotValue(100); // 6
+			await WaitAndSnapshotValue(100); // 7
+			await WaitAndSnapshotValue(100); // 8
+			await WaitAndSnapshotValue(100); // 9 iteration 5 done
+
+			const double SignificantChangePer100MS = 312 / 5 * 0.5; // 0.5 is margin of error
+			var last5Recorded = values.Skip(values.Count - 5).ToArray();
+			var deltas = last5Recorded.Zip(last5Recorded.Skip(1), (a, b) => Math.Abs(a - b));
+			var closeEnough = Comparer<double>.Create((x, y) => // allows for +-1 to be equal
+				Math.Abs(x - y) < 1 ? 0 : (x > y ? 1: -1)
+			);
+
+			Assert.IsTrue(deltas.Any(x => x > SignificantChangePer100MS), "animated values (last half) should be changing: " + string.Join(", ", last5Recorded));
+			CollectionAssert.AreNotEqual(
+				Enumerable.Repeat(312d, 5).ToArray(),
+				last5Recorded,
+				closeEnough,
+				"animated values should not freeze/stuck at end value (312) or near that value: " + string.Join(", ", values)
+			);
+
+			async Task WaitAndSnapshotValue(int millisecondsDelay)
+			{
+				await Task.Delay(millisecondsDelay);
+				values.Add(transform.X);
+			}
 		}
 	}
 }

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -1019,7 +1019,7 @@ namespace Uno.UI.DataBinding
 
 			if (dp != null)
 			{
-				return (instance) => DependencyObjectExtensions.GetValueUnderPrecedence((DependencyObject)instance, dp, precedence);
+				return (instance) => DependencyObjectExtensions.GetValueUnderPrecedence((DependencyObject)instance, dp, precedence).value;
 			}
 
 			{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
@@ -74,6 +74,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			private void SetValue(object value) => _owner?.SetValue(value);
 			private bool NeedsRepeat(Stopwatch activeDuration, int replayCount) => _owner?.NeedsRepeat(activeDuration, replayCount) ?? false;
 			private object GetValue() => _owner?.GetValue();
+			private object GetNonAnimatedValue() => _owner?.GetNonAnimatedValue();
 
 			public void Begin()
 			{
@@ -431,7 +432,7 @@ namespace Windows.UI.Xaml.Media.Animation
 				}
 				else
 				{
-					var value = GetValue();
+					var value = GetNonAnimatedValue();
 
 					if (value != null)
 					{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2498

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Animation on repeat=forever would be stuck animating between end-value to end-value after 2 iterations.

## What is the new behavior?
Animation will repeat with non-animated value as starting value.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.