### PR TITLE
fix(xamlreader): Process members on top-level resource dictionaries

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1511,6 +1511,27 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.AreEqual(FillRule.EvenOdd, geometry.FillRule);
 		}
 
+		[TestMethod]
+		public void When_ThemeResource_With_StaticResource()
+		{
+			var s = GetContent(nameof(When_ThemeResource_With_StaticResource));
+			var SUT = Windows.UI.Xaml.Markup.XamlReader.Load(s) as Page;
+
+			Assert.IsNotNull(SUT.Resources["Color1"]);
+			Assert.IsNotNull(SUT.Resources["Color2"]);
+		}
+
+		[TestMethod]
+		public void When_ResourceDictionary_With_Theme_And_Static()
+		{
+			var s = GetContent(nameof(When_ResourceDictionary_With_Theme_And_Static));
+			var SUT = Windows.UI.Xaml.Markup.XamlReader.Load(s) as ResourceDictionary;
+
+			Assert.AreEqual(2, SUT.ThemeDictionaries.Count);
+			Assert.IsNotNull(SUT["CustomSecondBrush"]);
+			Assert.IsNotNull(SUT["MyCustomFirstBrush"]);
+		}
+
 		/// <summary>
 		/// XamlReader.Load the xaml and type-check result.
 		/// </summary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1532,6 +1532,16 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.IsNotNull(SUT["MyCustomFirstBrush"]);
 		}
 
+		[TestMethod]
+		public void When_ResourceDictionary_With_Theme_And_No_Static()
+		{
+			var s = GetContent(nameof(When_ResourceDictionary_With_Theme_And_No_Static));
+			var SUT = Windows.UI.Xaml.Markup.XamlReader.Load(s) as ResourceDictionary;
+
+			Assert.AreEqual(2, SUT.ThemeDictionaries.Count);
+			Assert.IsNotNull(SUT["PrimaryColor"]);
+		}
+
 		/// <summary>
 		/// XamlReader.Load the xaml and type-check result.
 		/// </summary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ResourceDictionary_With_Theme_And_No_Static.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ResourceDictionary_With_Theme_And_No_Static.xamltest
@@ -1,0 +1,12 @@
+﻿<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<!--Colors-->
+	<!--Themed colors-->
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Light">
+			<Color x:Key="PrimaryColor">#FFFFFF</Color>
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Dark">
+			<Color x:Key="PrimaryColor">#544794</Color>
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ResourceDictionary_With_Theme_And_Static.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ResourceDictionary_With_Theme_And_Static.xamltest
@@ -1,0 +1,17 @@
+﻿<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<!--Colors-->
+	<!--Themed colors-->
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Light">
+			<Color x:Key="OnPrimaryColor">#FFFFFF</Color>
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Dark">
+			<Color x:Key="PrimaryColor">#544794</Color>
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+	<!--Unthemed colors-->
+	<Color x:Key="MyCustomFirstColor">#B910A8</Color>
+	<!--Custom colors brushes-->
+	<SolidColorBrush x:Key="CustomSecondBrush" Color="{ThemeResource CustomSecondColor}" />
+	<SolidColorBrush x:Key="MyCustomFirstBrush" Color="{ThemeResource MyCustomFirstColor}" />
+</ResourceDictionary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ThemeResource_With_StaticResource.xamltest
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/When_ThemeResource_With_StaticResource.xamltest
@@ -1,0 +1,28 @@
+﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+			Name="rootPage"
+      mc:Ignorable="d">
+
+	<Page.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.ThemeDictionaries>
+				<ResourceDictionary x:Key="Light">
+					<Color x:Key="Color1">#FFFFFF</Color>
+				</ResourceDictionary>
+				<ResourceDictionary x:Key="Dark">
+					<Color x:Key="Color1">#000000</Color>
+				</ResourceDictionary>
+			</ResourceDictionary.ThemeDictionaries>
+
+			<Color x:Key="Color2">#B910A8</Color>
+		</ResourceDictionary>
+	</Page.Resources>
+
+	<StackPanel>
+		<Border Background="{StaticResource Color1}" />
+		<Border Background="{StaticResource Color2}" />
+	</StackPanel>
+</Page>

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -133,6 +133,16 @@ namespace Windows.UI.Xaml.Markup.Reader
 						}
 					}
 
+					if (rootInstance is null)
+					{
+						// This is a top level dictionary, where explicit members need to
+						// be process explicitly (other types are processed below).
+						foreach (var member in control.Members.Where(m => m != unknownContent))
+						{
+							ProcessNamedMember(control, rd, member, rd);
+						}
+					}
+
 					return rd;
 				}
 				else
@@ -582,7 +592,15 @@ namespace Windows.UI.Xaml.Markup.Reader
 		{
 			if (TypeResolver.IsCollectionOrListType(propertyInfo.PropertyType))
 			{
-				if (propertyInfo.PropertyType == typeof(ResourceDictionary))
+				if (propertyInfo.PropertyType == typeof(ResourceDictionary)
+					|| (
+						propertyInfo.DeclaringType == typeof(ResourceDictionary)
+						&& (
+							propertyInfo.Name == nameof(ResourceDictionary.ThemeDictionaries)
+							|| propertyInfo.Name == nameof(ResourceDictionary.MergedDictionaries)
+						)
+					)
+				)
 				{
 					var methods = propertyInfo.PropertyType.GetMethods();
 					var addMethod = propertyInfo.PropertyType.GetMethod("Add", new[] { typeof(object), typeof(object) })


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10800

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that XamlReader can load top-level ResourceDictionary instances with Theme and Merged dictionaries.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
