### PR TITLE
fix(animation): droid dependent animation breaks after 1loop

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
@@ -262,7 +262,6 @@ namespace Windows.UI.Xaml.Media.Animation
 				}
 
 				OnEnd();
-				_startingValue = null;
 			}
 
 			private void OnAnimatorAnimationEndFrame(object sender, EventArgs e) => OnFrame();
@@ -328,13 +327,14 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 
 			/// <summary>
-			/// Replays the Animation if required, Sets the final state, Raises the Completed event. 
+			/// Replays the Animation if required, Sets the final state, Raises the Completed event.
 			/// </summary>
 			private void OnEnd()
 			{
 				_animator?.Dispose();
 
 				// If the animation was GPU based, remove the animated value
+
 				if (NeedsRepeat(_activeDuration, _replayCount))
 				{
 					Replay(); // replay the animation
@@ -365,6 +365,7 @@ namespace Windows.UI.Xaml.Media.Animation
 				}
 
 				_owner.OnCompleted();
+				_startingValue = null;
 			}
 
 			/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): re: #182 (addressed only case2 from that issue)

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On android, animation with (EnableDependentAnimation=true) and (RepeatBehavior=Forever) will not be able to updating after 1 loop.

## What is the new behavior?
It should continue working.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
In `AnimationImplementation<T>`, the `_startingValue` is cleared in after `InitializeAnimator()`... And, the `OnFrame()` implementation for android requires having `_startingValue` and `_endValue` to compute the animated value for updates, otherwise it just updates it with null.
