### PR TITLE
fix(flyout): XamlRoot not implemented

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -715,6 +715,34 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
+		[TestMethod]
+		public async Task When_Opening_XamlRootIsSet()
+		{
+			var flyout = new Flyout();
+			try
+			{
+				var host = new Button() { Content = "Asd" };
+				TestServices.WindowHelper.WindowContent = host;
+				await TestServices.WindowHelper.WaitForIdle();
+				await TestServices.WindowHelper.WaitForLoaded(host);
+
+				var capture = default(XamlRoot);
+
+				flyout.Opening += (s, e) => capture = (s as Flyout).XamlRoot;
+
+				flyout.ShowAt(host);
+				await TestServices.WindowHelper.WaitForIdle();
+				await TestServices.WindowHelper.WaitForIdle();
+				flyout.Hide();
+
+				Assert.AreEqual(host.XamlRoot, capture, "Flyout did not inherit the XamlRoot from its placementTarget.");
+			}
+			finally
+			{
+				flyout.Hide();
+			}
+		}
+
 		private static void VerifyRelativeContentPosition(HorizontalPosition horizontalPosition, VerticalPosition verticalPosition, FrameworkElement content, double minimumTargetOffset, FrameworkElement target)
 		{
 			var contentScreenBounds = content.GetOnScreenBounds();

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
@@ -81,20 +81,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		// Skipping already declared property IsOpen
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::Windows.UI.Xaml.XamlRoot XamlRoot
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member XamlRoot FlyoutBase.XamlRoot is not implemented in Uno.");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.FlyoutBase", "XamlRoot FlyoutBase.XamlRoot");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool ShouldConstrainToRootBounds
 		{
 			get

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -13,6 +13,7 @@ using Uno.UI.Xaml.Input;
 using Windows.Foundation;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 
 #if XAMARIN_IOS
@@ -234,6 +235,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public FrameworkElement Target { get; private set; }
 
+		public XamlRoot XamlRoot { get; set; }
+
 		/// <summary>
 		/// Defines an optional position of the popup in the <see cref="Target"/> element.
 		/// </summary>
@@ -297,6 +300,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			}
 
 			Target = placementTarget;
+			XamlRoot = placementTarget?.XamlRoot;
 			_popup.PlacementTarget = placementTarget;
 
 			if (showOptions != null)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #n/a

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
FlyoutBase::XamlRoot is not implemented.

## What is the new behavior?
^ implemented.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.