### PR TITLE
fix(gen): generate less fields BindableMetadataProvider

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -594,38 +594,41 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 			private void GenerateTypeTable(IndentedStringBuilder writer)
 			{
 				var types = _typeMap.Where(k => !k.Key.IsGenericType);
-				writer.AppendLineIndented($"private global::Uno.UI.DataBinding.IBindableType[] _bindableTypes = new global::Uno.UI.DataBinding.IBindableType[{types.Count()}];");
+				writer.AppendLineIndented($"private readonly global::Uno.UI.DataBinding.IBindableType[] _bindableTypes = new global::Uno.UI.DataBinding.IBindableType[{types.Count()}];");
+				writer.AppendLineIndented($"private static global::Uno.UI.DataBinding.IBindableType _null;");
 
 				using (writer.BlockInvariant("public global::Uno.UI.DataBinding.IBindableType GetBindableTypeByFullName(string fullName)"))
 				{
+					writer.AppendLineIndented("ref global::Uno.UI.DataBinding.IBindableType element = ref _null;");
 					using (writer.BlockInvariant(@"switch(fullName)"))
 					{
 						foreach (var type in types)
 						{
 							_cancellationToken.ThrowIfCancellationRequested();
 
-							var typeIndexString = $"{type.Value.Index:000}";
+							var typeIndex = type.Value.Index;
 
-							writer.AppendLineIndented($"case \"{type.Key}\":");
-							using (writer.BlockInvariant($"if(_bindableTypes[{typeIndexString}] == null)"))
+							using (writer.BlockInvariant($"case \"{type.Key}\":"))
 							{
-								if (_xamlResourcesTrimming && type.Key.GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol)))
+								writer.AppendLineIndented($"element = ref _bindableTypes[{typeIndex}];");
+								using (writer.BlockInvariant("if(element == null)"))
 								{
-									var linkerHintsClassName = LinkerHintsHelpers.GetLinkerHintsClassName(_defaultNamespace);
-									var safeTypeName = LinkerHintsHelpers.GetPropertyAvailableName(type.Key.GetFullMetadataName());
+									if (_xamlResourcesTrimming && type.Key.GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol)))
+									{
+										var linkerHintsClassName = LinkerHintsHelpers.GetLinkerHintsClassName(_defaultNamespace);
+										var safeTypeName = LinkerHintsHelpers.GetPropertyAvailableName(type.Key.GetFullMetadataName());
 
-									writer.AppendLineIndented($"if(global::{linkerHintsClassName}.{safeTypeName})");
+										writer.AppendLineIndented($"if(global::{linkerHintsClassName}.{safeTypeName})");
+									}
+
+									writer.AppendLineIndented($"element = MetadataBuilder_{typeIndex:000}.Build();");
 								}
 
-								writer.AppendLineIndented($"_bindableTypes[{typeIndexString}] = MetadataBuilder_{typeIndexString}.Build();");
+								writer.AppendLineIndented("break;");
 							}
-
-							writer.AppendLineIndented($"return _bindableTypes[{typeIndexString}];");
 						}
-
-						writer.AppendLineIndented("default:");
-						writer.AppendLineIndented(@"return null;");
 					}
+					writer.AppendLineIndented("return element;");
 				}
 
 				using (writer.BlockInvariant("public global::Uno.UI.DataBinding.IBindableType GetBindableTypeByType(Type type)"))


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10724

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Crash for some iOS applications (arm64/devices) ~~possibly due to the high number of local variables (more than 2000) inside generated code~~.

Edit: _this reduce the number of fields for the type, the number of locals is still over 2000 due to how the C# compiler optimize the generated `switch`._


## What is the new behavior?

No crash

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
