### PR TITLE
Fix: ListView.Header has no DataContext #1598

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
@@ -62,6 +62,11 @@ namespace Windows.UI.Xaml.Controls
 			_callbackSubscriptions.Disposable = disposables;
 		}
 
+		partial void OnDataContextChangedPartial()
+		{
+			NativePanel?.UpdateHeaderAndFooter();
+		}
+
 		partial void CleanUpNativePanel(NativeListViewBase panel)
 		{
 			_callbackSubscriptions.Disposable = null;


### PR DESCRIPTION
Fixes #1598

GitHub Issue (If applicable): closes #1598

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On iOS it's inconsistent. iOS gets `ListView`'s `DataContext` value and puts it on the `Header`/`Footer` and if the `DataContext` is `null` at the time of the call, it will not update later because it doesn't take the binding, but the value.
The workaround is to additionally set `Footer="{Binding}"` or `Header="{Binding}"`.


## What is the new behavior?
iOS ListViewBase.HeaderTemplate and FooterTemplate work without having to set DataContext binding to Footer and Header.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
