### PR TITLE
fix(templates): Only build net6.0-windows10.0.18362 on Windows

### DIFF
--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.netcore/Views/UnoQuickStart.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.netcore/Views/UnoQuickStart.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>$libarybasetargetframework$</TargetFrameworks>
-		$if$($UseWinUI$ == True)<TargetFrameworks>$(TargetFrameworks);$basetargetframework$-windows10.0.18362</TargetFrameworks>$endif$
+		$if$($UseWinUI$ == True)<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);$basetargetframework$-windows10.0.18362</TargetFrameworks>$endif$
 		$if$($UseAndroid$ == True)<TargetFrameworks>$(TargetFrameworks);$basetargetframework$-android</TargetFrameworks>$endif$
 		$if$($UseIOS$ == True)<TargetFrameworks>$(TargetFrameworks);$basetargetframework$-ios</TargetFrameworks>$endif$
 		$if$($UseCatalyst$ == True)<TargetFrameworks>$(TargetFrameworks);$basetargetframework$-maccatalyst</TargetFrameworks>$endif$

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.netcore/Views/UnoQuickStart.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.netcore/Views/UnoQuickStart.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>$libarybasetargetframework$</TargetFrameworks>
-		$if$($UseWinUI$ == True)<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);$basetargetframework$-windows10.0.18362</TargetFrameworks>$endif$
+		$if$($UseWinUI$ == True)<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$basetargetframework$-windows10.0.18362</TargetFrameworks>$endif$
 		$if$($UseAndroid$ == True)<TargetFrameworks>$(TargetFrameworks);$basetargetframework$-android</TargetFrameworks>$endif$
 		$if$($UseIOS$ == True)<TargetFrameworks>$(TargetFrameworks);$basetargetframework$-ios</TargetFrameworks>$endif$
 		$if$($UseCatalyst$ == True)<TargetFrameworks>$(TargetFrameworks);$basetargetframework$-maccatalyst</TargetFrameworks>$endif$


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10888

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Project created from new template does not restore on macOS

## What is the new behavior?

Project can be restored on macOS


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
