### PR TITLE
Support for custom markup extensions in `Setter`

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -5931,6 +5931,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 											applyWriter.AppendLineIndented($";");
 										}
 									}
+									else if (HasCustomMarkupExtension(valueNode))
+									{
+										var propertyValue = GetCustomMarkupExtensionValue(valueNode);
+										writer.AppendLineIndented($"{propertyValue})");
+									}
 									else
 									{
 										BuildChild(writer, valueNode, valueNode.Objects.First(), outerClosure: null);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1846,6 +1846,32 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						);
 					}
 				}
+				else if (HasCustomMarkupExtension(valueNode))
+				{
+					var propertyValue = GetCustomMarkupExtensionValue(valueNode);
+					if (isDependencyProperty)
+					{
+						TryAnnotateWithGeneratorSource(writer, suffix: "CustomMarkupExtensionValueDP");
+						writer.AppendLineInvariantIndented(
+							"new global::Windows.UI.Xaml.Setter({0}.{1}Property, ({2}){3})" + lineEnding,
+							GetGlobalizedTypeName(fullTargetType),
+							property,
+							propertyType,
+							propertyValue
+						);
+					}
+					else
+					{
+						TryAnnotateWithGeneratorSource(writer, suffix: "CustomMarkupExtensionValuePOCO");
+						writer.AppendLineInvariantIndented(
+							"new global::Windows.UI.Xaml.Setter<{0}>(\"{1}\", o => {3}.{1} = {2})" + lineEnding,
+							GetGlobalizedTypeName(fullTargetType),
+							property,
+							propertyValue,
+							targetInstance
+						);
+					}
+				}
 				else if (isDependencyProperty && HasResourceMarkupExtension(valueNode))
 				{
 					TryAnnotateWithGeneratorSource(writer, suffix: "IsResourceMarkupValueDP");

--- a/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
@@ -12,6 +12,9 @@
 		<x:String x:Key="ResourceString">From a Resource String</x:String>
 		<x:String x:Key="ResourceStringFull">From a Resource String FullName</x:String>
 		<ex:TestEntityObject x:Key="TestEntity" />
+		<Style TargetType="TextBlock" x:Key="MarkupExtensionStyle">
+			<Setter Property="Text" Value="{ex:StyleSetterExtension Wrapped=Test}" />
+		</Style>
 	</UserControl.Resources>
 
 	<StackPanel>
@@ -76,6 +79,9 @@
 				<TextBlock Text="This should compile and not be confused with TextBlockExtension" />
 			</Border.Child>
 		</Border>
+
+		<TextBlock x:Name="StyleSetterTextBlock1" x:FieldModifier="public" Style="{StaticResource MarkupExtensionStyle}" />
+		<TextBlock x:Name="StyleSetterTextBlock2" x:FieldModifier="public" Style="{StaticResource MarkupExtensionStyle}" />
 	</StackPanel>
 
 </UserControl>

--- a/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
+++ b/src/Uno.UI.Tests/App/Xaml/Test_MarkupExtension.xaml
@@ -18,6 +18,18 @@
 	</UserControl.Resources>
 
 	<StackPanel>
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup>
+				<VisualState>
+					<VisualState.StateTriggers>
+						<AdaptiveTrigger MinWindowWidth="0" />
+					</VisualState.StateTriggers>
+					<VisualState.Setters>
+						<Setter Target="VisualStateTextBlock.Text" Value="{ex:VisualStateSetterExtension Wrapped=Test}" />
+					</VisualState.Setters>
+				</VisualState>
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
 		<TextBlock x:Name="Text1"
 				   Text="{ex:SimpleMarkupExt TextValue='Just a simple ...'}" />
 
@@ -82,6 +94,7 @@
 
 		<TextBlock x:Name="StyleSetterTextBlock1" x:FieldModifier="public" Style="{StaticResource MarkupExtensionStyle}" />
 		<TextBlock x:Name="StyleSetterTextBlock2" x:FieldModifier="public" Style="{StaticResource MarkupExtensionStyle}" />
+		<TextBlock x:Name="VisualStateTextBlock" x:FieldModifier="public" />
 	</StackPanel>
 
 </UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
@@ -93,6 +93,26 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests
 		}
 
 		[TestMethod]
+		public void When_Extension_In_VisualState_Setter()
+		{
+			var currentCulture = Thread.CurrentThread.CurrentCulture;
+			try
+			{				
+				Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+				var app = UnitTestsApp.App.EnsureApplication();
+
+				var control = new Test_MarkupExtension();
+				app.HostView.Children.Add(control);
+
+				Assert.AreEqual("**Test**", control.VisualStateTextBlock.Text);
+			}
+			finally
+			{
+				Thread.CurrentThread.CurrentCulture = currentCulture;
+			}
+		}
+
+		[TestMethod]
 		public void When_Shortened_Name_Overlaps_Type()
 		{
 			var currentCulture = Thread.CurrentThread.CurrentCulture;
@@ -197,6 +217,16 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests
 		protected override object ProvideValue()
 		{
 			Calls++;
+			return $"**{Wrapped}**";
+		}
+	}
+
+	public class VisualStateSetterExtension : MarkupExtension
+	{
+		public object Wrapped { get; set; }
+
+		protected override object ProvideValue()
+		{
 			return $"**{Wrapped}**";
 		}
 	}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/MarkupExtensionTests/Given_MarkupExtension.cs
@@ -70,6 +70,29 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests
 		}
 
 		[TestMethod]
+		public void When_Extension_In_Style_Setter()
+		{
+			var currentCulture = Thread.CurrentThread.CurrentCulture;
+			try
+			{
+				StyleSetterExtension.Calls = 0;
+				Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+				var app = UnitTestsApp.App.EnsureApplication();
+
+				var control = new Test_MarkupExtension();
+				app.HostView.Children.Add(control);
+
+				Assert.AreEqual("**Test**", control.StyleSetterTextBlock1.Text);
+				Assert.AreEqual("**Test**", control.StyleSetterTextBlock2.Text);
+				Assert.AreEqual(1, StyleSetterExtension.Calls);
+			}
+			finally
+			{
+				Thread.CurrentThread.CurrentCulture = currentCulture;
+			}
+		}
+
+		[TestMethod]
 		public void When_Shortened_Name_Overlaps_Type()
 		{
 			var currentCulture = Thread.CurrentThread.CurrentCulture;
@@ -163,6 +186,19 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.MarkupExtensionTests
 		public object Wrapped { get; set; }
 
 		protected override object ProvideValue() => $"**{Wrapped}**";
+	}
+
+	public class StyleSetterExtension : MarkupExtension
+	{
+		public static int Calls { get; set; }
+
+		public object Wrapped { get; set; }
+
+		protected override object ProvideValue()
+		{
+			Calls++;
+			return $"**{Wrapped}**";
+		}
 	}
 
 	// This should not be mistaken for a TextBlock


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10962

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Not supported


## What is the new behavior?

Supported


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.