### PR TITLE
fix: [iOS] Possible layout cycle when a sub-child invalidate its layout while being arranged

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -210,6 +210,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(2, count);
 		}
 
+#if !WINDOWS_UWP
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
@@ -248,7 +249,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 							}),
 							Layout = new Microsoft.UI.Xaml.Controls.StackLayout{Orientation = Orientation.Horizontal}
 						}
-						.GridRow(1)
+						.Apply(ir => Grid.SetRow(ir, 1))
 				}
 			};
 
@@ -259,6 +260,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			TestServices.WindowHelper.WindowContent = null;
 		}
+#endif
 
 		[TestMethod]
 		public Task MeasureWithNan() =>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -18,6 +18,7 @@ using FluentAssertions.Execution;
 using Private.Infrastructure;
 using MUXControlsTestApp.Utilities;
 using Windows.UI.Xaml.Automation;
+using Uno.Extensions;
 #if __IOS__
 using UIKit;
 #endif
@@ -207,6 +208,56 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await TestServices.WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(2, count);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[RequiresFullWindow]
+		public async Task When_InvalidateDuringArrange_Then_DoesNotInvalidateParents()
+		{
+			var sut = new Grid
+			{
+				Margin = new Thickness(0, 100, 0, 0),
+				BorderBrush = new SolidColorBrush(Windows.UI.Colors.DeepPink),
+				BorderThickness = new Thickness(5),
+				MinWidth = 100,
+				MinHeight = 100,
+				RowDefinitions =
+				{
+					new RowDefinition{Height = 75},
+					new RowDefinition(),
+					//new RowDefinition{Height = 75}, // Not working on iOS when the line below is commented
+				},
+				Children =
+				{
+					new TextBlock{Text = "Hello world"},
+					new Microsoft.UI.Xaml.Controls.ItemsRepeater
+						{
+							ItemsSource="0123456789",
+							ItemTemplate = new DataTemplate(() => new Border
+							{
+								BorderBrush= new SolidColorBrush(Windows.UI.Colors.Red),
+								Margin= new Thickness(5),
+								BorderThickness=new Thickness(5),
+								Width=300,
+								Child = new TextBlock
+								{
+									TextWrapping= TextWrapping.Wrap,
+									Foreground = new SolidColorBrush(Windows.UI.Colors.Chartreuse)
+								}.Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding()))
+							}),
+							Layout = new Microsoft.UI.Xaml.Controls.StackLayout{Orientation = Orientation.Horizontal}
+						}
+						.GridRow(1)
+				}
+			};
+
+			TestServices.WindowHelper.WindowContent = sut;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			sut.IsArrangeDirty.Should().BeFalse();
+
+			TestServices.WindowHelper.WindowContent = null;
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -236,9 +236,9 @@ namespace Uno.UI
 
 #if __IOS__
 			/// <summary>
-			/// When true, propagate the NeedsLayout on superview even if element is in its LayoutSubViews() (i.e. Arrange()).
-			/// This is known to cause layout cycle when a child invalidates itself during arrange (e.g. ItemsRepeater).
-			/// Default value is false, set it to true will restore behavior of uno v4.7 and earlier.
+			/// When true, propagate the NeedsLayout on superview even if the element is in its LayoutSubViews() (i.e. Arrange()).
+			/// This is known to cause a layout cycle when a child invalidates itself during arrange (e.g. ItemsRepeater).
+			/// Default value is false, setting it to true will restore the behavior of uno v4.7 and earlier.
 			/// </summary>
 			public static bool IOsAllowSuperviewNeedsLayoutWhileInLayoutSubViews { get; set; }
 #endif

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -233,6 +233,15 @@ namespace Uno.UI
 			/// will not, which is how WinUI behaves. Set to true if you have code written for earlier versions of Uno that relies upon the old behavior.
 			/// </summary>
 			public static bool UseLegacyHitTest { get; set; }
+
+#if __IOS__
+			/// <summary>
+			/// When true, propagate the NeedsLayout on superview even if element is in its LayoutSubViews() (i.e. Arrange()).
+			/// This is known to cause layout cycle when a child invalidates itself during arrange (e.g. ItemsRepeater).
+			/// Default value is false, set it to true will restore behavior of uno v4.7 and earlier.
+			/// </summary>
+			public static bool IOsAllowSuperviewNeedsLayoutWhileInLayoutSubViews { get; set; }
+#endif
 		}
 
 		public static class FrameworkTemplate

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -36,7 +36,10 @@ namespace Windows.UI.Xaml
 
 			SetLayoutFlags(LayoutFlag.MeasureDirty | LayoutFlag.ArrangeDirty);
 
-			SetSuperviewNeedsLayout();
+			if (!_inLayoutSubviews)
+			{
+				SetSuperviewNeedsLayout();
+			}
 		}
 
 		public override void LayoutSubviews()

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -36,7 +36,7 @@ namespace Windows.UI.Xaml
 
 			SetLayoutFlags(LayoutFlag.MeasureDirty | LayoutFlag.ArrangeDirty);
 
-			if (!_inLayoutSubviews)
+			if (FeatureConfiguration.FrameworkElement.IOsAllowSuperviewNeedsLayoutWhileInLayoutSubViews || !_inLayoutSubviews)
 			{
 				SetSuperviewNeedsLayout();
 			}


### PR DESCRIPTION
linked https://github.com/unoplatform/uno.chefs/issues/99

## Bugfix
Possible layout cycle when a sub-child invalidate its layout while being arranged

## What is the current behavior?
On iOS when an element invalidate its layout while being arranged, it will also invalidate all its parents, driving to a possible layout cycle.

## What is the new behavior?
Invalidation stops on the first layer that is currently being arranged.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
