### PR TITLE
fix: EffectiveViewport does not goes through native only elements

### DIFF
--- a/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
@@ -198,7 +198,7 @@ public static partial class ViewExtensions
 	// note: methods for retrieving children/ancestors exist with varying signatures.
 	// re-implementing them with unified & more inclusive signature for convenience.
 #if __IOS__ || __MACOS__
-	private static IEnumerable<_View> EnumerateAncestors(this _View? o)
+	internal static IEnumerable<_View> EnumerateAncestors(this _View? o)
 	{
 		if (o is null) yield break;
 		while (o.Superview is _View parent)

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.Interface.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.Interface.cs
@@ -11,7 +11,7 @@ namespace Windows.UI.Xaml
 	internal interface IFrameworkElement_EffectiveViewport
 	{
 		void InitializeEffectiveViewport();
-		IDisposable RequestViewportUpdates(bool isInternal, IFrameworkElement_EffectiveViewport? child = null);
+		IDisposable RequestViewportUpdates(bool isInternal, IFrameworkElement_EffectiveViewport child);
 		void OnParentViewportChanged(bool isInitial, bool isInternal, IFrameworkElement_EffectiveViewport parent, ViewportInfo viewport);
 		void OnLayoutUpdated();
 	}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
@@ -22,10 +22,17 @@ using Uno.UI;
 using Uno.UI.Extensions;
 using Windows.UI.Xaml;
 using _This = Windows.UI.Xaml.FrameworkElement;
+
 #if __IOS__
 using UIKit;
+using _View = UIKit.UIView;
 #elif __MACOS__
 using AppKit;
+using _View = AppKit.NSView;
+#elif __ANDROID__
+using _View = Android.Views.View;
+#else
+using _View = Windows.UI.Xaml.DependencyObject;
 #endif
 
 namespace Windows.UI.Xaml
@@ -35,7 +42,7 @@ namespace Windows.UI.Xaml
 		private static readonly RoutedEventHandler ReconfigureViewportPropagationOnLoad = (snd, e) => ((_This)snd).ReconfigureViewportPropagation();
 		private event TypedEventHandler<_This, EffectiveViewportChangedEventArgs>? _effectiveViewportChanged;
 		private bool _hasNewHandler;
-		private int _childrenInterestedInViewportUpdates;
+		private List<IFrameworkElement_EffectiveViewport>? _childrenInterestedInViewportUpdates;
 		private IDisposable? _parentViewportUpdatesSubscription;
 		private ViewportInfo _parentViewport = ViewportInfo.Empty; // WARNING: Stored in parent's coordinates space, use GetParentViewport()
 		private ViewportInfo _lastEffectiveViewport;
@@ -68,7 +75,7 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// Indicates if the effective viewport should/will be propagated to/by this element
 		/// </summary>
-		private bool IsEffectiveViewportEnabled => _childrenInterestedInViewportUpdates > 0 || _effectiveViewportChanged != null;
+		private bool IsEffectiveViewportEnabled => _childrenInterestedInViewportUpdates is { Count: > 0 } || _effectiveViewportChanged != null;
 
 		/// <summary>
 		/// Make sure to request or disable effective viewport changes from the parent
@@ -88,18 +95,18 @@ namespace Windows.UI.Xaml
 				{
 					TRACE_EFFECTIVE_VIEWPORT("Enabling effective viewport propagation.");
 
-					var parent = this.GetVisualTreeParent();
-					if (parent is IFrameworkElement_EffectiveViewport parentFwElt)
-					{
-						_parentViewportUpdatesSubscription = parentFwElt.RequestViewportUpdates(isInternal, this);
-					}
-					else
+					var parent = this.FindFirstAncestor<IFrameworkElement_EffectiveViewport>();
+					if (parent is null)
 					{
 						global::System.Diagnostics.Debug.Assert(IsVisualTreeRoot);
 
 						// We are the root of the visual tree, we update the effective viewport
 						// in order to initialize the _parentViewport of children.
 						PropagateEffectiveViewportChange(isInitial: true, isInternal: isInternal);
+					}
+					else
+					{
+						_parentViewportUpdatesSubscription = parent.RequestViewportUpdates(isInternal, this);
 					}
 				}
 				else if (child != null)
@@ -140,16 +147,18 @@ namespace Windows.UI.Xaml
 		/// Used by a child of this element, in order to subscribe to viewport updates
 		/// (so the OnParentViewportChanged will be invoked on this given child)
 		/// </summary>
-		IDisposable IFrameworkElement_EffectiveViewport.RequestViewportUpdates(bool isInternalUpdate, IFrameworkElement_EffectiveViewport? child)
+		IDisposable IFrameworkElement_EffectiveViewport.RequestViewportUpdates(bool isInternalUpdate, IFrameworkElement_EffectiveViewport child)
 		{
-			global::System.Diagnostics.Debug.Assert(Uno.UI.Extensions.DependencyObjectExtensions.GetChildren(this).OfType<IFrameworkElement_EffectiveViewport>().Contains(child));
+			global::System.Diagnostics.Debug.Assert(
+				Uno.UI.Extensions.DependencyObjectExtensions.GetChildren(this).OfType<IFrameworkElement_EffectiveViewport>().Contains(child)
+				|| (child as _View)?.FindFirstAncestor<IFrameworkElement_EffectiveViewport>() == this);
 
-			_childrenInterestedInViewportUpdates++;
+			(_childrenInterestedInViewportUpdates ??= new()).Add(child);
 			ReconfigureViewportPropagation(isInternalUpdate, child);
 
 			return Disposable.Create(() =>
 			{
-				_childrenInterestedInViewportUpdates--;
+				_childrenInterestedInViewportUpdates!.Remove(child);
 				ReconfigureViewportPropagation();
 			});
 		}
@@ -324,7 +333,7 @@ namespace Windows.UI.Xaml
 				+ $"| parent: {parentViewport} "
 				+ $"| scroll: {(IsScrollPort ? $"{ScrollOffsets.ToDebugString()}" : "--none--")} "
 				+ $"| reason: {caller} "
-				+ $"| children: {_childrenInterestedInViewportUpdates}");
+				+ $"| children: {_childrenInterestedInViewportUpdates?.Count ?? 0}");
 
 			if (viewportUpdated
 				&& (
@@ -339,15 +348,11 @@ namespace Windows.UI.Xaml
 				_effectiveViewportChanged?.Invoke(this, new EffectiveViewportChangedEventArgs(parentViewport.Effective));
 			}
 
-			if (_childrenInterestedInViewportUpdates > 0 && (isInitial || viewportUpdated))
+			if (_childrenInterestedInViewportUpdates is { Count: > 0 } && (isInitial || viewportUpdated))
 			{
-				var children = Uno.UI.Extensions.DependencyObjectExtensions.GetChildren(this);
-				foreach (var child in children)
+				foreach (var child in _childrenInterestedInViewportUpdates)
 				{
-					if (child is IFrameworkElement_EffectiveViewport childFwElt)
-					{
-						childFwElt.OnParentViewportChanged(isInitial, isInternal, this, viewport);
-					}
+					child.OnParentViewportChanged(isInitial, isInternal, this, viewport);
 				}
 			}
 		}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.chefs/issues/99

## Bugfix
fix: EffectiveViewport does not goes through native only elements

## What is the current behavior?
EVP propagation was not going through native only elements driving sub-elements to not receive their valid viewport

## What is the new behavior?
EVP propagation assumes that native elements are stretching their element and propagate the viewport of native elements only directly to their children.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Anything else we need to know?
This also workaround the issue https://github.com/unoplatform/uno.toolkit.ui/issues/449