### PR TITLE
fix(remotecontrol): Ensure generators run after a referenced project file update

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Given_HotReloadService.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Given_HotReloadService.cs
@@ -21,11 +21,11 @@ public class Given_HotReloadService
 {
 	[DataTestMethod]
 	[DynamicData(nameof(GetScenarios), DynamicDataSourceType.Method)]
-	public async Task HR(string name, Scenario? scenario)
+	public async Task HR(string name, Scenario? scenario, Project[]? projects)
 	{
 		if (scenario != null)
 		{
-			var results = await ApplyScenario(scenario.IsDebug, scenario.IsMono, name);
+			var results = await ApplyScenario(projects, scenario.IsDebug, scenario.IsMono, name);
 
 			for (int i = 0; i < scenario.PassResults.Length; i++)
 			{
@@ -40,11 +40,18 @@ public class Given_HotReloadService
 		}
 	}
 
+	public record ScenariosDescriptor(
+		Project[] Projects,
+		Scenario[] Scenarios);
+
+	public record Project(string Name, ProjectReference[]? ProjectReferences);
+	public record ProjectReference(string Name);
 	public record Scenario(bool IsDebug, bool IsMono, params PassResult[] PassResults)
 	{
 		public override string ToString()
 			=> $"{(IsDebug ? "Debug" : "Release")},{(IsMono ? "MonoVM" : "NetCore")}";
 	}
+
 	public record PassResult(int MetadataUpdates, params DiagnosticsResult[] Diagnostics);
 	public record DiagnosticsResult(string Id);
 
@@ -55,22 +62,23 @@ public class Given_HotReloadService
 			var scenarioName = Path.GetFileName(scenarioFolder);
 			var path = Path.Combine(scenarioFolder, "Scenario.json");
 
-			//if (scenarioName != "When_Simple_Xaml_ResourceDictionary_Change_One")
+			//if (scenarioName != "When_Two_Projects_Single_Code_File_With_Code_Update")
 			//{
 			//	continue;
 			//}
 
 			if (File.Exists(path))
 			{
-				var scenarios = ReadScenarioConfig(path);
+				var scenariosDescriptor = ReadScenarioConfig(path);
 
-				if (scenarios != null)
+				if (scenariosDescriptor is not null)
 				{
-					foreach (var scenario in scenarios)
+					foreach (var scenario in scenariosDescriptor.Scenarios)
 					{
 						yield return new object?[] {
 							scenarioName,
-							scenario
+							scenario,
+							scenariosDescriptor.Projects
 						};
 					}
 				}
@@ -81,20 +89,20 @@ public class Given_HotReloadService
 			}
 		}
 
-		static Scenario[]? ReadScenarioConfig(string path)
+		static ScenariosDescriptor? ReadScenarioConfig(string path)
 		{
 			try
 			{
 				var detailsContent = File.ReadAllText(path);
 
-				var scenarios = System.Text.Json.JsonSerializer.Deserialize<Scenario[]>(
+				var scenarioDescriptor = System.Text.Json.JsonSerializer.Deserialize<ScenariosDescriptor>(
 					detailsContent,
 					new System.Text.Json.JsonSerializerOptions()
 					{
 						ReadCommentHandling = System.Text.Json.JsonCommentHandling.Skip,
 						AllowTrailingCommas = true
 					});
-				return scenarios;
+				return scenarioDescriptor;
 			}
 			catch (Exception e)
 			{
@@ -109,7 +117,11 @@ public class Given_HotReloadService
 			"MetadataUpdateTests",
 			"Scenarios");
 
-	private async Task<HotReloadWorkspace.UpdateResult[]> ApplyScenario(bool isDebugCompilation, bool isMono, [CallerMemberName] string? name = null)
+	private async Task<HotReloadWorkspace.UpdateResult[]> ApplyScenario(
+		Project[]? projects
+		, bool isDebugCompilation
+		, bool isMono
+		, [CallerMemberName] string? name = null)
 	{
 		if(name is null)
 		{
@@ -120,6 +132,16 @@ public class Given_HotReloadService
 		
 		HotReloadWorkspace SUT = new(isDebugCompilation, isMono);
 		List<HotReloadWorkspace.UpdateResult> results = new();
+
+		if (projects is not null)
+		{
+			foreach (var project in projects)
+			{
+				SUT.AddProject(
+					project.Name
+					, (project.ProjectReferences ?? Array.Empty<ProjectReference>()).Select(r => r.Name).ToArray());
+			}
+		}
 
 		var steps = Directory
 			.GetFiles(scenarioFolder, "*.*", SearchOption.AllDirectories)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Empty/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Empty/Scenario.json
@@ -1,17 +1,19 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{ "MetadataUpdates": 0 }
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{ "MetadataUpdates": 0 }
-		]
-	}
-]
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{ "MetadataUpdates": 0 }
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{ "MetadataUpdates": 0 }
+			]
+		}
+	]
+}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Function_Property_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Function_Property_Add/Scenario.json
@@ -1,26 +1,27 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					{ "Id": "ENC0100" },
-					{ "Id": "ENC0100" }
-				]
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						{ "Id": "ENC0100" },
+						{ "Id": "ENC0100" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Function_Property_Update/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Function_Property_Update/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Function_Property_Update_Two_Params/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Function_Property_Update_Two_Params/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Simple_Property/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Simple_Property/Scenario.json
@@ -1,26 +1,27 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			},
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					{ "Id": "ENC0100" },
-					{ "Id": "ENC0100" }
-				]
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						{ "Id": "ENC0100" },
+						{ "Id": "ENC0100" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Simple_Property_Update/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xBind_Simple_Property_Update/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xLoad/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Add_xLoad/Scenario.json
@@ -1,26 +1,27 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(68,83): error ENC0049: Ceasing to capture variable '__that' requires restarting the application.
-					{ "Id": "ENC0049" }
-				]
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(68,83): error ENC0049: Ceasing to capture variable '__that' requires restarting the application.
+						{ "Id": "ENC0049" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_ElementName_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_ElementName_Add/Scenario.json
@@ -1,27 +1,28 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// error ENC0100: Adding field requires restarting the application.
-					{ "Id": "ENC0100" },
-					{ "Id": "ENC0100" }
-				]
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// error ENC0100: Adding field requires restarting the application.
+						{ "Id": "ENC0100" },
+						{ "Id": "ENC0100" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Event_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Event_Add/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_ResourceDictionary_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_ResourceDictionary_Add/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_ResourceDictionary_Change_One/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_ResourceDictionary_Change_One/Scenario.json
@@ -1,26 +1,28 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": [
-				]
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					{ "Id": "ENC0100" },
-					{ "Id": "ENC0100" }
-				]
-			}
-		]
-	}
-]
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": [
+					]
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						{ "Id": "ENC0100" },
+						{ "Id": "ENC0100" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_ResourceDictionary_Remove/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_ResourceDictionary_Remove/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Single_Text_Change/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Single_Text_Change/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Single_xName_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Single_xName_Add/Scenario.json
@@ -1,25 +1,26 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					{ "Id": "ENC0100" }
-				]
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						{ "Id": "ENC0100" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Single_xName_Add_Twice/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Single_xName_Add_Twice/Scenario.json
@@ -1,85 +1,86 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			},
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// error ENC0100: Adding field requires restarting the application.
-					{ "Id": "ENC0100" }
-				]
-			},
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(102,59): error ENC0100: Adding field requires restarting the application.
-					{ "Id": "ENC0100" },
-					{ "Id": "ENC0100" }
-				]
-			}
-		]
-	},
-	{
-		"IsDebug": false,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			},
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(68,83): error ENC0049: Ceasing to capture variable '__that' requires restarting the application.
-					{ "Id": "ENC0049" },
-					{ "Id": "ENC0049" },
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// error ENC0100: Adding field requires restarting the application.
+						{ "Id": "ENC0100" }
+					]
+				},
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(102,59): error ENC0100: Adding field requires restarting the application.
+						{ "Id": "ENC0100" },
+						{ "Id": "ENC0100" }
+					]
+				}
+			]
+		},
+		{
+			"IsDebug": false,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(68,83): error ENC0049: Ceasing to capture variable '__that' requires restarting the application.
+						{ "Id": "ENC0049" },
+						{ "Id": "ENC0049" },
 
-					// error ENC0009: Updating the type of method requires restarting the application.
-					{ "Id": "ENC0009" },
-					{ "Id": "ENC0009" }
-				]
-			}
-		]
-	},
-	{
-		"IsDebug": false,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// error ENC0100: Adding field requires restarting the application.
-					{ "Id": "ENC0100" }
-				]
-			},
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(68,83): error ENC0049: Ceasing to capture variable '__that' requires restarting the application.
-					{ "Id": "ENC0049" },
-					{ "Id": "ENC0049" },
+						// error ENC0009: Updating the type of method requires restarting the application.
+						{ "Id": "ENC0009" },
+						{ "Id": "ENC0009" }
+					]
+				}
+			]
+		},
+		{
+			"IsDebug": false,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// error ENC0100: Adding field requires restarting the application.
+						{ "Id": "ENC0100" }
+					]
+				},
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(68,83): error ENC0049: Ceasing to capture variable '__that' requires restarting the application.
+						{ "Id": "ENC0049" },
+						{ "Id": "ENC0049" },
 
-					// error ENC0009: Updating the type of method requires restarting the application.
-					{ "Id": "ENC0009" },
-					{ "Id": "ENC0009" }
-				]
-			}
-		]
-	}
-]
-
+						// error ENC0009: Updating the type of method requires restarting the application.
+						{ "Id": "ENC0009" },
+						{ "Id": "ENC0009" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Single_xName_Change/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Single_xName_Change/Scenario.json
@@ -1,29 +1,30 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// error ENC0009: Updating the type of method requires restarting the application.
-					{ "Id": "ENC0009" }
-				]
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// error ENC0009: Updating the type of method requires restarting the application.
-					{ "Id": "ENC0009" }
-				]
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// error ENC0009: Updating the type of method requires restarting the application.
+						{ "Id": "ENC0009" }
+					]
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// error ENC0009: Updating the type of method requires restarting the application.
+						{ "Id": "ENC0009" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_With_ThemeResource_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_With_ThemeResource_Add/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xBind_Event_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xBind_Event_Add/Scenario.json
@@ -1,28 +1,29 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": [
-					// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(132,3): error ENC0100: Adding auto-property requires restarting the application.
-					{ "Id": "ENC0100" },
-					{ "Id": "ENC0100" },
-					{ "Id": "ENC0100" }
-				]
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// MainPage_c2bc688a73eab5431d787dcd21fe32b9.cs(132,3): error ENC0100: Adding auto-property requires restarting the application.
+						{ "Id": "ENC0100" },
+						{ "Id": "ENC0100" },
+						{ "Id": "ENC0100" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Single_Code_File_With_Code_Update/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Single_Code_File_With_Code_Update/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 1,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Single_Code_File_With_No_Update/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Single_Code_File_With_No_Update/Scenario.json
@@ -1,23 +1,24 @@
-[
-	{
-		"IsDebug": true,
-		"IsMono": false,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": []
-			}
-		]
-	},
-	{
-		"IsDebug": true,
-		"IsMono": true,
-		"PassResults": [
-			{
-				"MetadataUpdates": 0,
-				"Diagnostics": []
-			}
-		]
-	}
-]
-
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/0/p1/File1.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/0/p1/File1.cs
@@ -1,0 +1,6 @@
+﻿public static class Program
+{
+	public static void Main()
+	{
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/0/p2/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/0/p2/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:CSHRTest01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/0/p2/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/0/p2/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/0/p2/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/0/p2/MainPage.xaml.cs
@@ -5,13 +5,13 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
 
 namespace Test01;
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/1/p1/File1.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/1/p1/File1.cs
@@ -1,0 +1,6 @@
+﻿public static class Program
+{
+	public static void Main()
+	{
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/1/p2/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/1/p2/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:CSHRTest01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock x:Name="test" Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/1/p2/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/1/p2/MainPage.xaml.cs
@@ -5,13 +5,13 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
 
 namespace Test01;
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/1/p2/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/1/p2/MainPage.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+
+		test.Text = "42";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Simple_Xaml_Single_xName_Add/Scenario.json
@@ -1,11 +1,24 @@
 {
+	"Projects": [
+		{
+			"Name": "p1",
+			"ProjectReferences": [
+				{
+					"Name": "p2"
+				}
+			]
+		},
+		{
+			"Name": "p2"
+		}
+	],
 	"Scenarios": [
 		{
 			"IsDebug": true,
 			"IsMono": false,
 			"PassResults": [
 				{
-					"MetadataUpdates": 0,
+					"MetadataUpdates": 1,
 					"Diagnostics": []
 				}
 			]
@@ -16,7 +29,9 @@
 			"PassResults": [
 				{
 					"MetadataUpdates": 0,
-					"Diagnostics": []
+					"Diagnostics": [
+						{ "Id": "ENC0100" }
+					]
 				}
 			]
 		}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/0/p1/File1.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/0/p1/File1.cs
@@ -1,0 +1,6 @@
+﻿public static class Program
+{
+	public static void Main()
+	{
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/0/p2/File1.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/0/p2/File1.cs
@@ -1,0 +1,6 @@
+﻿public static class Class1
+{
+	public static void Method1()
+	{
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/1/p1/File1.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/1/p1/File1.cs
@@ -1,0 +1,7 @@
+﻿public static class Program
+{
+	public static void Main()
+	{
+		System.Console.WriteLine();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/1/p2/File1.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/1/p2/File1.cs
@@ -1,0 +1,7 @@
+﻿public static class Class1
+{
+	public static void Method1()
+	{
+		System.Console.WriteLine();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdateTests/Scenarios/When_Two_Projects_Single_Code_File_With_Code_Update/Scenario.json
@@ -1,11 +1,24 @@
 {
+	"Projects": [
+		{
+			"Name": "p1",
+			"ProjectReferences": [
+				{
+					"Name": "p2"
+				}
+			]
+		},
+		{
+			"Name": "p2"
+		}
+	],
 	"Scenarios": [
 		{
 			"IsDebug": true,
 			"IsMono": false,
 			"PassResults": [
 				{
-					"MetadataUpdates": 0,
+					"MetadataUpdates": 2,
 					"Diagnostics": []
 				}
 			]
@@ -15,7 +28,7 @@
 			"IsMono": true,
 			"PassResults": [
 				{
-					"MetadataUpdates": 0,
+					"MetadataUpdates": 2,
 					"Diagnostics": []
 				}
 			]

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdates/HotReloadWorkspaceProvider.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/MetadataUpdates/HotReloadWorkspaceProvider.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Text;
 using Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates;
 using Uno.UI.SourceGenerators.Tests.Verifiers;
@@ -26,6 +27,7 @@ internal class HotReloadWorkspace
 	private readonly string _baseWorkFolder;
 	private readonly bool _isDebugCompilation;
 	private readonly bool _isMono;
+	private Dictionary<string, string[]> _projects = new();
 	private Dictionary<string, Dictionary<string, string>> _sourceFiles = new();
 	private Dictionary<string, Dictionary<string, string>> _additionalFiles = new();
 	private Solution? _currentSolution;
@@ -39,6 +41,22 @@ internal class HotReloadWorkspace
 		Directory.CreateDirectory(_baseWorkFolder);
 
 		Environment.SetEnvironmentVariable("Microsoft_CodeAnalysis_EditAndContinue_LogDir", _baseWorkFolder);
+	}
+
+	internal void AddProject(string name, string[] references)
+	{
+		var exists = _projects.TryGetValue(name, out var existingReferences);
+		if (exists
+			&& existingReferences is not null
+			&& !references.SequenceEqual(existingReferences))
+		{
+			throw new InvalidOperationException($"Project {name} already exists with a different set of project references");
+		}
+
+		if (!exists)
+		{
+			_projects.Add(name, references);
+		}
 	}
 
 	public void SetSourceFile(string project, string fileName, string content)
@@ -124,11 +142,13 @@ internal class HotReloadWorkspace
 		var currentSolution = workspace.CurrentSolution;
 		var frameworkReferences = BuildFrameworkReferences();
 		var references = BuildUnoReferences().Concat(frameworkReferences);
-		
+
 		var generatorReference = new MyGeneratorReference(
 			ImmutableArray.Create<ISourceGenerator>(new XamlGenerator.XamlCodeGenerator()));
 
-		foreach (var projectName in _additionalFiles.Keys.Concat(_sourceFiles.Keys).Distinct())
+		FillProjectsFromFiles();
+
+		foreach (var projectName in EnumerateProjects())
 		{
 			var projectInfo = ProjectInfo.Create(
 							ProjectId.CreateNewId(),
@@ -149,9 +169,20 @@ internal class HotReloadWorkspace
 
 			projectInfo = projectInfo
 				.WithCompilationOutputInfo(
-					projectInfo.CompilationOutputInfo.WithAssemblyPath(Path.Combine(_baseWorkFolder, projectName + Guid.NewGuid() + ".exe")));
+					projectInfo.CompilationOutputInfo.WithAssemblyPath(Path.Combine(_baseWorkFolder, projectName + Guid.NewGuid() + ".dll")));
 
-			var project = workspace.AddProject(projectInfo);
+			if(!_projects.TryGetValue(projectName, out var projectReferences))
+			{
+				throw new InvalidOperationException($"Project {projectName} is not defined in the project list.");
+			}
+
+			var project = workspace
+				.AddProject(projectInfo)
+				.AddProjectReferences(currentSolution
+					.Projects
+					.Where(p => projectReferences.Contains(p.Name))
+					.Select(p => new ProjectReference(p.Id)));
+
 			currentSolution = project.Solution;
 
 			if (_sourceFiles.TryGetValue(projectName, out var sourceFiles))
@@ -199,7 +230,7 @@ internal class HotReloadWorkspace
 					foreach (var (fileName, content) in additionalFiles.Where(k => k.Key.EndsWith(".xaml")))
 					{
 						globalConfigBuilder.Append($"""
-							[{Path.Combine(_baseWorkFolder, project.Name, fileName).Replace("\\","/")}]
+							[{Path.Combine(_baseWorkFolder, project.Name, fileName).Replace("\\", "/")}]
 							build_metadata.AdditionalFiles.SourceItemGroup = Page
 							""");
 					}
@@ -209,11 +240,13 @@ internal class HotReloadWorkspace
 						name: ".globalconfig",
 						filePath: "/.globalconfig",
 						text: SourceText.From(globalConfigBuilder.ToString())
-					); ;	
+					); ;
 				}
 			}
+
+			workspace.TryApplyChanges(currentSolution);
 		}
-	
+
 
 		// Materialize the first build
 		foreach (var p in currentSolution.Projects)
@@ -231,7 +264,7 @@ internal class HotReloadWorkspace
 
 				throw new InvalidOperationException($"Compilation errors: {string.Join("\n", errors)}");
 			}
-			
+
 			var emitResult = c.Emit(
 				p.CompilationOutputInfo.AssemblyPath!,
 				pdbPath: Path.ChangeExtension(p.CompilationOutputInfo.AssemblyPath, ".pdb"));
@@ -248,6 +281,61 @@ internal class HotReloadWorkspace
 
 		_currentSolution = currentSolution;
 		_hotReloadService = hotReloadService;
+	}
+
+	private IEnumerable<string> EnumerateProjects()
+	{
+		Stack<string> currentProjects = new();
+		HashSet<string> processed = new();
+
+		foreach(var project in InnerEnumerate(_projects.Keys))
+		{
+			yield return project;
+		}
+
+		IEnumerable<string> InnerEnumerate(IEnumerable<string> projects)
+		{
+			foreach(var project in projects)
+			{
+				if (currentProjects.Contains(project))
+				{
+					throw new InvalidOperationException($"Circular dependency detected: { string.Join(" -> ", currentProjects) } -> {project}");
+				}
+
+				currentProjects.Push(project);
+				
+				if (_projects.TryGetValue(project, out var children))
+				{
+					foreach(var child in InnerEnumerate(children))
+					{
+						yield return child;
+					}
+				}
+				
+				if (!processed.Contains(project))
+				{
+					yield return project;
+
+					processed.Add(project);
+				}
+
+				currentProjects.Pop();
+			}
+		}
+	}
+
+	private void FillProjectsFromFiles()
+	{
+		var projects = _additionalFiles
+			.Keys
+			.Concat(_sourceFiles.Keys)
+			.Distinct()
+			.Except(_projects.Keys);
+		
+		foreach (var project in projects)
+		{
+			AddProject(project, Array.Empty<string>());
+		}
 	}
 
 	public async Task<UpdateResult> Update()

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -72,7 +72,12 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 		{
 			var observedPaths =
 				solution.Projects
-					.SelectMany(p => p.Documents.Select(d => Path.GetDirectoryName(d.FilePath)))
+					.SelectMany(p => p
+						.Documents
+						.Select(d => d.FilePath)
+						.Concat(p.AdditionalDocuments
+							.Select(d => d.FilePath)))
+					.Select(p => Path.GetDirectoryName(p))
 					.Distinct()
 					.ToArray();
 
@@ -170,6 +175,16 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				var sourceText = await GetSourceTextAsync(file);
 				updatedSolution = _currentSolution.WithAdditionalDocumentText(additionalDocument.Id, sourceText, PreservationMode.PreserveValue);
 				updatedProjectId = additionalDocument.Project.Id;
+
+				// Generate an empty document to force the generators to run
+				// in a separate project of the same solution. This is not needed
+				// for the head project, but it's no causing issues either.
+				var docName = Guid.NewGuid().ToString();
+				updatedSolution = updatedSolution.AddAdditionalDocument(
+					DocumentId.CreateNewId(updatedProjectId),
+					docName,
+					SourceText.From("")
+				);
 			}
 			else
 			{
@@ -178,9 +193,10 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				return false;
 			}
 
+
 			var (updates, hotReloadDiagnostics) = await _hotReloadService.EmitSolutionUpdateAsync(updatedSolution, cancellationToken);
 
-			Console.WriteLine($"Got results after {sw.Elapsed}");
+			_reporter.Output($"Found {updates.Length} metadata updates after {sw.Elapsed}");
 
 			if (hotReloadDiagnostics.IsDefaultOrEmpty && updates.IsDefaultOrEmpty)
 			{
@@ -225,6 +241,10 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 			async Task UpdateMetadata(string file, ImmutableArray<WatchHotReloadService.Update> updates)
 			{
+#if DEBUG
+				_reporter.Output($"Sending {updates.Length} metadata updates for {file}");
+#endif
+
 				for (int i = 0; i < updates.Length; i++)
 				{
 					var updateTypesWriterStream = new MemoryStream();


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/10244

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Separate projects reload files properly if only additional files change.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
