### PR TITLE
fix(reg): Adjust UnoHasLocalizationResources metadata

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -382,10 +382,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private void TryGenerateUnoResourcesKeyAttribute(ImmutableHashSet<string> resourceKeys)
 		{
-			if (!resourceKeys.IsEmpty)
-			{
-				_generatorContext.AddSource("LocalizationResources", "[assembly: global::System.Reflection.AssemblyMetadata(\"UnoHasLocalizationResources\", \"True\")]");
-			}
+			var hasResources = !resourceKeys.IsEmpty;
+			
+			_generatorContext.AddSource(
+				"LocalizationResources",
+				$"[assembly: global::System.Reflection.AssemblyMetadata(" +
+				$"\"UnoHasLocalizationResources\", " +
+				$"\"{hasResources.ToString(CultureInfo.InvariantCulture)}\")]");
 		}
 
 #if !NETFRAMEWORK


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10990

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The change ensure that backward compatibility code path is not used when UnoHasLocalizationResources has been added to the assembly. This reverts the behavior where all assemblies containing a `GlobalStaticResources` type were considered candidates for resources lookups.

This change is validated using canaries.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
