### PR TITLE
fix(reg): Include explicitly specified fonts in info.plist for backward compatibilty

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.cs
@@ -31,6 +31,8 @@ namespace Uno.UI.Tasks.Assets
 
 		public string AndroidAssetsPrefix { get; set; }
 
+		public string IosAppManifest { get; set; }
+
 		[Required]
 		public string DefaultLanguage { get; set; }
 
@@ -169,7 +171,7 @@ namespace Uno.UI.Tasks.Assets
 			}
 
 			RetargetedAssets = retargetdAssets.ToArray();
-			PartialAppManifests = GenerateFontPartialManifest(fontAssets);
+			PartialAppManifests = GenerateFontPartialManifest(fontAssets, IosAppManifest);
 		}
 
 

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -128,6 +128,7 @@
 							IntermediateOutputPath="$(IntermediateOutputPath)"
 							ContentItems="@(Content);@(_SourceItemsToCopyToOutputDirectory)"
 							AndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
+							IosAppManifest="$(AppBundleManifest)"
 							Condition="'$(XamarinProjectType)'!=''">
 			<Output TaskParameter="Assets"
 							ItemName="Assets" />

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -121,14 +121,20 @@
 		<!-- Assets -->
 		<PropertyGroup>
 			<UseHighDPIResources Condition="'$(UseHighDPIResources)'==''">True</UseHighDPIResources>
+			
+			<_UnoIosAppManifest>$(AppBundleManifest)</_UnoIosAppManifest>
+
+			<!-- Required for older Xamarin versions -->
+			<_UnoIosAppManifest Condition="'$(_UnoIosAppManifest)'==''">$(_AppManifest)</_UnoIosAppManifest>
 		</PropertyGroup>
+		
 		<RetargetAssets_v0 UseHighDPIResources="$(UseHighDPIResources)"
 							TargetPlatform="$(XamarinProjectType)"
 							DefaultLanguage="$(DefaultLanguage)"
 							IntermediateOutputPath="$(IntermediateOutputPath)"
 							ContentItems="@(Content);@(_SourceItemsToCopyToOutputDirectory)"
 							AndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
-							IosAppManifest="$(AppBundleManifest)"
+							IosAppManifest="$(_UnoIosAppManifest)"
 							Condition="'$(XamarinProjectType)'!=''">
 			<Output TaskParameter="Assets"
 							ItemName="Assets" />

--- a/src/Uno.UI/Controls/UIFontHelper.iOS.cs
+++ b/src/Uno.UI/Controls/UIFontHelper.iOS.cs
@@ -78,6 +78,12 @@ namespace Windows.UI
 
 		private static UIFont? InternalTryGetFont(nfloat size, FontWeight fontWeight, FontStyle fontStyle, FontFamily requestedFamily, nfloat? basePreferredSize)
 		{
+			if (typeof(UIFontHelper).Log().IsEnabled(LogLevel.Trace))
+			{
+				typeof(UIFontHelper).Log().Trace(
+					$"Getting font (size:{size}, weight:{fontWeight}, style:{fontStyle}, family:{requestedFamily}, basePreferredSize:{basePreferredSize})");
+			}
+
 			UIFont? font = null;
 
 			size = GetScaledFontSize(size, basePreferredSize);
@@ -113,6 +119,12 @@ namespace Windows.UI
 #region Load Custom Font
 		private static UIFont? GetCustomFont(nfloat size, string fontPath, FontWeight fontWeight, FontStyle fontStyle)
 		{
+			if (typeof(UIFontHelper).Log().IsEnabled(LogLevel.Trace))
+			{
+				typeof(UIFontHelper).Log().Trace(
+					$"Searching custom font (size:{size}, weight:{fontPath}, style:{fontStyle}, fontWeight:{fontWeight})");
+			}
+
 			UIFont? font;
 			//In Windows we define FontFamily with the path to the font file followed by the font family name, separated by a #
 			if (fontPath.Contains("#"))
@@ -323,8 +335,11 @@ namespace Windows.UI
 				{
 					return updatedFont;
 				}
-
-				font.Log().Warn("Failed to apply Font " + font);
+				
+				if (typeof(UIFontHelper).Log().IsEnabled(LogLevel.Warning))
+				{
+					typeof(UIFontHelper).Log().Warn("Failed to get system font based on " + font);
+				}
 
 				return UIFont.FromName(rootFontFamilyName, size);
 			}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores backwards compatibility for iOS/Catalyst `Info.plist` containing existing font files.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
