### PR TITLE
fix(reg): Native `DatePicker` flyout positioning regression

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -847,6 +847,44 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
+#if __IOS__
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_Native_DatePickerFlyout_Placement()
+		{
+			var flyout = new NativeDatePickerFlyout();
+			try
+			{
+				var grid = new Grid();
+				var host = new Button() { Content = "Asd", Margin = new Thickness(30, 0) };
+				grid.Children.Add(host);
+				flyout.Content = new Button() { Content = "Test" };
+				FlyoutBase.SetAttachedFlyout(host, flyout);
+
+				TestServices.WindowHelper.WindowContent = grid;
+				await TestServices.WindowHelper.WaitForIdle();
+				await TestServices.WindowHelper.WaitForLoaded(grid);
+
+				FlyoutBase.ShowAttachedFlyout(host);
+
+				await TestServices.WindowHelper.WaitForIdle();
+				await TestServices.WindowHelper.WaitForIdle();
+
+				var popups = VisualTreeHelper.GetOpenPopupsForXamlRoot(host.XamlRoot);				
+				var popupPanel = popups[0].PopupPanel;
+				var child = popupPanel.Children[0];
+				var transform = child.TransformToVisual(grid);
+				var topLeft = transform.TransformPoint(default);
+				Assert.AreEqual(0, topLeft.X); // Positioned on the left edge of the screen
+				Assert.IsTrue(topLeft.Y > 100); // Positioned lower on the screen
+			}
+			finally
+			{
+				flyout.Hide();
+			}
+		}
+#endif
+
 		private static void VerifyRelativeContentPosition(HorizontalPosition horizontalPosition, VerticalPosition verticalPosition, FrameworkElement content, double minimumTargetOffset, FrameworkElement target)
 		{
 			var contentScreenBounds = content.GetOnScreenBounds();

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -125,9 +125,13 @@ internal partial class PopupPanel : Panel
 		}
 		else if (Popup.CustomLayouter == null)
 		{
-			// TODO: For now, the layouting logic for DatePickerFlyout does not correctly work
+			// TODO: For now, the layouting logic for managed DatePickerFlyout does not correctly work
 			// against the placement target approach.
-			if (Popup.AssociatedFlyout is not DatePickerFlyout &&
+			var isFlyoutManagedDatePicker =
+				Popup.AssociatedFlyout is DatePickerFlyout &&
+				Popup.AssociatedFlyout is not NativeDatePickerFlyout;
+
+			if (!isFlyoutManagedDatePicker &&
 				Popup.PlacementTarget is not null
 #if __ANDROID__ || __IOS__
 				|| NativeAnchor is not null

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -128,8 +128,12 @@ internal partial class PopupPanel : Panel
 			// TODO: For now, the layouting logic for managed DatePickerFlyout does not correctly work
 			// against the placement target approach.
 			var isFlyoutManagedDatePicker =
-				Popup.AssociatedFlyout is DatePickerFlyout &&
-				Popup.AssociatedFlyout is not NativeDatePickerFlyout;
+				Popup.AssociatedFlyout is DatePickerFlyout 
+#if __ANDROID__ || __IOS__
+				&& Popup.AssociatedFlyout is not NativeDatePickerFlyout
+#endif
+				;
+				
 
 			if (!isFlyoutManagedDatePicker &&
 				Popup.PlacementTarget is not null


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10959

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Native `DatePicker` is showing up in wrong position

## What is the new behavior?

- Showing up correctly at the bottom


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
