### PR TITLE
fix(reg): Adjust lookup for symbol resources

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -738,23 +738,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// <param name="writer"></param>
 		private void ApplyFontsOverride(IndentedStringBuilder writer)
 		{
-			var themes = new[] { "Default", "Light", "HighContrast" };
-
 			if (_generatorContext.GetMSBuildPropertyValue("UnoPlatformDefaultSymbolsFontFamily") is { Length: > 0 } fontOverride)
 			{
 				writer.AppendLineInvariantIndented($"global::Uno.UI.FeatureConfiguration.Font.SymbolsFont = \"{fontOverride}\";");
-			}
-
-			writer.AppendLineInvariantIndented("var __symbolsFontFamily = new global::Windows.UI.Xaml.Media.FontFamily(global::Uno.UI.FeatureConfiguration.Font.SymbolsFont);");
-
-			foreach (var theme in themes)
-			{
-				// SymbolThemeFontFamily
-				using var _ = writer.BlockInvariant(
-					$"if (Resources.ThemeDictionaries.TryGetValue(\"{theme}\", out var __{theme}Dictionary) " +
-					$"&& __{theme}Dictionary is global::Windows.UI.Xaml.ResourceDictionary __{theme}ThemeDictionary)");
-				
-				writer.AppendLineInvariantIndented($"__{theme}ThemeDictionary[\"SymbolThemeFontFamily\"] = __symbolsFontFamily;");
 			}
 		}
 

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -113,12 +113,19 @@
 		</ItemGroup>
 	</Target>
 
+	<PropertyGroup>
+		<_UnoFindPackageAssetMarkersDependsOn Condition="'$(ProjectTypeGuids)'!=''">
+			$(_UnoFindPackageAssetMarkersDependsOn);
+			ResolveNuGetPackageAssets
+		</_UnoFindPackageAssetMarkersDependsOn>
+	</PropertyGroup>
+
 	<!--
 	Determines the marker location for project references
 	-->
-	<Target Name="_UnoFindPackageAssetMarkers" 
+	<Target Name="_UnoFindPackageAssetMarkers"
 			Condition="'$(IsUnoHead)'=='true' or '$(AndroidApplication)'=='true' or '$(ProjectTypeGuids)'!=''"
-			DependsOnTargets="ResolveNuGetPackageAssets"
+			DependsOnTargets="$(_UnoFindPackageAssetMarkersDependsOn)"
 			AfterTargets="ResolveAssemblyReferences">
 
 		<ItemGroup Condition="'$(ProjectTypeGuids)'!=''">

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -98,7 +98,7 @@
 	-->
 	<Target Name="_UnoAddLibraryAssets"
 			Condition="'$(IsUnoHead)'=='true' or '$(AndroidApplication)'=='true' or '$(ProjectTypeGuids)'!=''"
-			DependsOnTargets="_UnoFindPackageAssetMarkers"
+			DependsOnTargets="_UnoFindPackageAssetMarkers;ResolveAssemblyReferences"
 			BeforeTargets="GetCopyToOutputDirectoryItems">
 
 		<ExpandPackageAssets_v0 MarkerFiles="@(_UnoPriFiles)">
@@ -118,10 +118,21 @@
 	-->
 	<Target Name="_UnoFindPackageAssetMarkers" 
 			Condition="'$(IsUnoHead)'=='true' or '$(AndroidApplication)'=='true' or '$(ProjectTypeGuids)'!=''"
+			DependsOnTargets="ResolveNuGetPackageAssets"
 			AfterTargets="ResolveAssemblyReferences">
-		<ItemGroup>
+
+		<ItemGroup Condition="'$(ProjectTypeGuids)'!=''">
+			<!-- Xamarin-based targets which don't set RuntimeCopyLocalItems must use  -->
+			<_UnoPriFiles Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).uprimarker')"
+						  Condition="$([System.IO.File]::Exists('%(RootDir)%(Directory)%(Filename).uprimarker'))"/>
+		</ItemGroup>
+
+		<ItemGroup Condition="'$(ProjectTypeGuids)'==''">
 			<_UnoPriFiles Include="@(RuntimeCopyLocalItems->'%(RootDir)%(Directory)%(Filename).uprimarker')"
 						  Condition="$([System.IO.File]::Exists('%(RootDir)%(Directory)%(Filename).uprimarker'))"/>
+		</ItemGroup>
+
+		<ItemGroup>
 			<ReferenceCopyLocalPaths Include="@(_UnoPriFiles)"/>
 		</ItemGroup>
 	</Target>

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -98,7 +98,7 @@
 	-->
 	<Target Name="_UnoAddLibraryAssets"
 			Condition="'$(IsUnoHead)'=='true' or '$(AndroidApplication)'=='true' or '$(ProjectTypeGuids)'!=''"
-			DependsOnTargets="_UnoFindPackageAssetMarkers;ResolveAssemblyReferences"
+			DependsOnTargets="_UnoFindPackageAssetMarkers"
 			BeforeTargets="GetCopyToOutputDirectoryItems">
 
 		<ExpandPackageAssets_v0 MarkerFiles="@(_UnoPriFiles)">
@@ -125,12 +125,11 @@
 	-->
 	<Target Name="_UnoFindPackageAssetMarkers"
 			Condition="'$(IsUnoHead)'=='true' or '$(AndroidApplication)'=='true' or '$(ProjectTypeGuids)'!=''"
-			DependsOnTargets="$(_UnoFindPackageAssetMarkersDependsOn)"
-			AfterTargets="ResolveAssemblyReferences">
+			DependsOnTargets="$(_UnoFindPackageAssetMarkersDependsOn)">
 
 		<ItemGroup Condition="'$(ProjectTypeGuids)'!=''">
 			<!-- Xamarin-based targets which don't set RuntimeCopyLocalItems must use  -->
-			<_UnoPriFiles Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).uprimarker')"
+			<_UnoPriFiles Include="@(Reference->'%(RootDir)%(Directory)%(Filename).uprimarker')"
 						  Condition="$([System.IO.File]::Exists('%(RootDir)%(Directory)%(Filename).uprimarker'))"/>
 		</ItemGroup>
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -5,6 +5,7 @@ using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
+using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -126,8 +127,39 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreNotEqual(0, SUT.DesiredSize.Width);
 			Assert.AreNotEqual(0, SUT.DesiredSize.Height);
 
-			
 			SUT.FontFamily = new Windows.UI.Xaml.Media.FontFamily("ms-appx:///Uno.UI.RuntimeTests/Assets/Fonts/uno-fluentui-assets-runtimetest01.ttf");
+
+			int counter = 3;
+
+			do
+			{
+				await WindowHelper.WaitForIdle();
+				await Task.Delay(100);
+
+				SUT.InvalidateMeasure();
+			}
+			while (SUT.DesiredSize == originalSize && counter-- > 0);
+
+			Assert.AreNotEqual(originalSize, SUT.DesiredSize);
+		}
+
+		[TestMethod]
+		public async Task When_FontFamily_Default()
+		{
+			var SUT = new TextBlock { Text = "\xE102\xE102\xE102\xE102\xE102" };
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForIdle();
+
+			var size = new Size(1000, 1000);
+			SUT.Measure(size);
+
+			var originalSize = SUT.DesiredSize;
+
+			Assert.AreNotEqual(0, SUT.DesiredSize.Width);
+			Assert.AreNotEqual(0, SUT.DesiredSize.Height);
+
+			
+			SUT.FontFamily = Application.Current.Resources["SymbolThemeFontFamily"] as FontFamily;
 
 			int counter = 3;
 
@@ -161,7 +193,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.AreNotEqual(0, SUT.DesiredSize.Width);
 			Assert.AreNotEqual(0, SUT.DesiredSize.Height);
-
 			
 			SUT.FontFamily = new Windows.UI.Xaml.Media.FontFamily("ms-appx:///Assets/Fonts/SymbolsRuntimeTest02.ttf#SymbolsRuntimeTest02");
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -144,6 +144,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[RunsOnUIThread]
 		public async Task When_FontFamily_Default()
 		{
 			var SUT = new TextBlock { Text = "\xE102\xE102\xE102\xE102\xE102" };

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -163,15 +163,25 @@ namespace Uno.UI
 
 		public static class Font
 		{
-			/// <summary>
-			/// Defines the default font to be used when displaying symbols, such as in SymbolIcon.
-			/// </summary>
-			public static string SymbolsFont { get; set; } =
+			private static string _symbolsFont = 
 #if __WASM__ || __MACOS__ || __IOS__
 				"Symbols";
 #else
 				"ms-appx:///Assets/Fonts/uno-fluentui-assets.ttf#Symbols";
 #endif
+
+			/// <summary>
+			/// Defines the default font to be used when displaying symbols, such as in SymbolIcon. Must be invoked after App.InitializeComponent() to have an effect.
+			/// </summary>
+			public static string SymbolsFont
+			{
+				get => _symbolsFont;
+				set
+				{
+					_symbolsFont = value;
+					ResourceResolver.SetSymbolsFontFamily();
+				}
+			}
 
 			/// <summary>
 			/// Ignores text scale factor, resulting in a font size as dictated by the control.

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -130,7 +130,7 @@ namespace Uno.UI
 
 				var themes = new[] { "Default", "Light", "HighContrast" };
 
-				foreach(var theme in themes)
+				foreach (var theme in themes)
 				{
 					if (genericDictionary.ThemeDictionaries.TryGetValue(theme, out var dictionary) && dictionary is ResourceDictionary themeDictionary)
 					{
@@ -155,7 +155,7 @@ namespace Uno.UI
 			{
 				var merged = MasterDictionary.MergedDictionaries[mergedIndex];
 
-				foreach(var theme in merged.ThemeDictionaries)
+				foreach (var theme in merged.ThemeDictionaries)
 				{
 					if (theme.Value is ResourceDictionary themeDictionary && themeDictionary.ContainsKey("SymbolThemeFontFamily"))
 					{

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -12,6 +12,7 @@ using Uno.UI.DataBinding;
 using Uno.UI.Xaml;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Resources;
 
 namespace Uno.UI
@@ -111,6 +112,60 @@ namespace Uno.UI
 		[System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 		public static bool ResolveResourceStatic(object key, out object value, object context = null)
 			=> TryStaticRetrieval(new SpecializedResourceDictionary.ResourceKey(key), context, out value);
+
+		/// <summary>
+		/// Sets the default symbols font, assuming that the GlobalStaticResources have been initialized.
+		/// </summary>
+		/// <remarks>
+		/// This method is needed to search for the resource dictionary containing the appropriate resources
+		/// as the Application.Resources dictionary may change in structure based on how many resource dictionaries
+		/// are included.
+		/// </remarks>
+		internal static void SetSymbolsFontFamily()
+		{
+			// We assume here that we only have one dictionary with theme resources for performance reasons
+			if (FindSymbolFontFamilyDictionary() is { } genericDictionary)
+			{
+				var symbolsFontFamily = new FontFamily(global::Uno.UI.FeatureConfiguration.Font.SymbolsFont);
+
+				var themes = new[] { "Default", "Light", "HighContrast" };
+
+				foreach(var theme in themes)
+				{
+					if (genericDictionary.ThemeDictionaries.TryGetValue(theme, out var dictionary) && dictionary is ResourceDictionary themeDictionary)
+					{
+						themeDictionary["SymbolThemeFontFamily"] = symbolsFontFamily;
+					}
+					else
+					{
+						Debug.Fail($"Unable to find the {theme} theme dictionary to override font asset");
+					}
+				}
+			}
+			else
+			{
+				Debug.Fail("Unable to find theme dictionary to override font asset");
+			}
+		}
+
+		private static ResourceDictionary FindSymbolFontFamilyDictionary()
+		{
+			// For loop to reduce allocations
+			for (var mergedIndex = 0; mergedIndex < MasterDictionary.MergedDictionaries.Count; mergedIndex++)
+			{
+				var merged = MasterDictionary.MergedDictionaries[mergedIndex];
+
+				foreach(var theme in merged.ThemeDictionaries)
+				{
+					if (theme.Value is ResourceDictionary themeDictionary && themeDictionary.ContainsKey("SymbolThemeFontFamily"))
+					{
+						return merged;
+					}
+				}
+			}
+
+			return null;
+		}
 
 #if false
 		// disabled because of https://github.com/mono/mono/issues/20195


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures a stable lookup of the symbol fontfamily resources, as the location may change when merged dictionaries are included in App.Resources.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
