### PR TITLE
fix(dragdrop): [WASM] Fix support of D&D multiple files.

### DIFF
--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions/StreamExtensions.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions/StreamExtensions.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Uno.Extensions
@@ -113,14 +114,9 @@ namespace Uno.Extensions
 		/// <remarks>The stream will be disposed when calling this method.</remarks>
 		public static string ReadToEnd(this Stream stream)
 		{
-			string value;
-			using (var reader = new StreamReader(stream))
-			{
-				value = reader.ReadToEnd();
-			}
-			return value;
+			using var reader = new StreamReader(stream);
+			return reader.ReadToEnd();
 		}
-
 
 		/// <summary>
 		/// Reads the text container into the specified stream.
@@ -130,12 +126,32 @@ namespace Uno.Extensions
 		/// <remarks>The stream will be disposed when calling this method.</remarks>
 		public static string ReadToEnd(this Stream stream, Encoding encoding)
 		{
-			string value;
-			using (var reader = new StreamReader(stream, encoding))
-			{
-				value = reader.ReadToEnd();
-			}
-			return value;
+			using var reader = new StreamReader(stream, encoding);
+			return reader.ReadToEnd();
+		}
+
+		/// <summary>
+		/// Reads the text container into the specified stream.
+		/// </summary>
+		/// <param name="stream"></param>
+		/// <returns>The string using the default encoding.</returns>
+		/// <remarks>The stream will be disposed when calling this method.</remarks>
+		public static async Task<string> ReadToEndAsync(this Stream stream, CancellationToken ct)
+		{
+			using var reader = new StreamReader(stream);
+			return await reader.ReadToEndAsync();
+		}
+
+		/// <summary>
+		/// Reads the text container into the specified stream.
+		/// </summary>
+		/// <param name="stream"></param>
+		/// <returns>The string using the default encoding.</returns>
+		/// <remarks>The stream will be disposed when calling this method.</remarks>
+		public static async Task<string> ReadToEndAsync(this Stream stream, Encoding encoding, CancellationToken ct)
+		{
+			using var reader = new StreamReader(stream, encoding);
+			return await reader.ReadToEndAsync();
 		}
 
 		/// <summary>


### PR DESCRIPTION
fixes https://github.com/unoplatform/kahua-private/issues/40

## Bugfix
[WASM] Fix support of D&D multiple files.

## What is the current behavior?
When dropping multiple files in the browser only the first one is accessible.

This is due to an invalid marshaling (method was invoked with only the first item id) + the data package from the browser is being cleared as soon as the event has being dispatched. As file loading is made async, sequentially, only the first item was valid.

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
