### PR TITLE
fix(iOS): Multiline TextBox with external keyboard

### DIFF
--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -366,6 +366,12 @@ namespace Uno.UI.Controls
 
 			var keyboardTop = (nfloat)_inputPane.OccludedRect.Top;
 
+			//if Keyboard.Top is not greater than zero, then this means there is not visible keyboard on the screen
+			if (keyboardTop <= 0)
+			{
+				return;
+			}
+
 			var keyboardOverlap = scrollViewRectInWindow.Bottom - keyboardTop;
 			if (keyboardOverlap > 0)
 			{
@@ -393,7 +399,7 @@ namespace Uno.UI.Controls
 			}
 			else
 			{
-				if (!(view is TextBox))
+				if (view is not TextBox)
 				{
 					//We want to scroll to the textbox and not the inner textview.
 					view = view.FindFirstParent<TextBox>() ?? view;

--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -366,7 +366,8 @@ namespace Uno.UI.Controls
 
 			var keyboardTop = (nfloat)_inputPane.OccludedRect.Top;
 
-			//if Keyboard.Top is not greater than zero, then this means there is not visible keyboard on the screen
+			// if Keyboard.Top is not greater than zero, then this means there is not visible keyboard on the screen]
+			// Doing so will avoid the scrollviewer to animate on platforms allowing hardware keyboard input (Simulator, iPad, Catalyst).
 			if (keyboardTop <= 0)
 			{
 				return;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3460 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
When using a MultiLine TextBox on iOS and an External Keyboard, the TextBox presents a weird scroll behaviour.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
