### PR TITLE
feat(mediaplayer): Enable for WinUI, update to WinAppSDK 1.2

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_3gp_Extension.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_3gp_Extension.xaml
@@ -1,11 +1,10 @@
 ﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_3gp_Extension"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="">
 
-	<not_mux:MediaPlayerElement Source="http://mirrors.standaloneinstaller.com/video-sample/jellyfish-25-mbps-hd-hevc.3gp"
+	<MediaPlayerElement Source="http://mirrors.standaloneinstaller.com/video-sample/jellyfish-25-mbps-hd-hevc.3gp"
 						AreTransportControlsEnabled="True"
 						AutoPlay="True" />
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Avi_Extension.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Avi_Extension.xaml
@@ -1,11 +1,10 @@
 ﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Avi_Extension"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 mc:Ignorable="">
 
-	<not_mux:MediaPlayerElement Source="http://mirrors.standaloneinstaller.com/video-sample/Panasonic_HDC_TM_700_P_50i.avi"
+	<MediaPlayerElement Source="http://mirrors.standaloneinstaller.com/video-sample/Panasonic_HDC_TM_700_P_50i.avi"
 						AreTransportControlsEnabled="True"
 						AutoPlay="True" />
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Flv_Extension.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Flv_Extension.xaml
@@ -1,11 +1,10 @@
 ﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Flv_Extension"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="">
 
-	<not_mux:MediaPlayerElement Source="https://sample-videos.com/video123/flv/360/big_buck_bunny_360p_5mb.flv"
+	<MediaPlayerElement Source="https://sample-videos.com/video123/flv/360/big_buck_bunny_360p_5mb.flv"
 						AreTransportControlsEnabled="True"
 						AutoPlay="True" />
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Full.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Full.xaml
@@ -1,6 +1,5 @@
 ﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Full"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
- 			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Grid>
@@ -9,7 +8,7 @@
 			<RowDefinition Height="2*" />
 		</Grid.RowDefinitions>
 
-		<not_mux:MediaPlayerElement x:Name="Mpe"
+		<MediaPlayerElement x:Name="Mpe"
 							Source="https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
 							PosterSource="https://bitmovin-a.akamaihd.net/content/sintel/poster.png"
 							AreTransportControlsEnabled="{Binding IsChecked, ElementName=AreTransportControlsEnabled}"
@@ -42,7 +41,7 @@
 										IsZoomButtonVisible="{Binding IsChecked, ElementName=IsZoomButtonVisible}"
 										IsZoomEnabled="{Binding IsChecked, ElementName=IsZoomEnabled}" />
 			</MediaPlayerElement.TransportControls>
-		</not_mux:MediaPlayerElement>
+		</MediaPlayerElement>
 
 		<ScrollViewer Grid.Row="1"
 					  Margin="10,20">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Minimal.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Minimal.xaml
@@ -1,11 +1,10 @@
 ﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Minimal"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
 	<UserControl.Resources>
 
-		<not_mux:Style TargetType="MediaTransportControls"
+		<Style TargetType="MediaTransportControls"
 			   x:Key="MediaTransportControlsMinimalStyle">
 			<Setter Property="IsTabStop"
 					Value="False" />
@@ -126,17 +125,17 @@
 					</ControlTemplate>
 				</Setter.Value>
 			</Setter>
-		</not_mux:Style>
+		</Style>
 		
 	</UserControl.Resources>
 
-	<not_mux:MediaPlayerElement Source="https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
+	<MediaPlayerElement Source="https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
 						PosterSource="https://bitmovin-a.akamaihd.net/content/sintel/poster.png"
 						AreTransportControlsEnabled="True"
 						AutoPlay="True">
 		<MediaPlayerElement.TransportControls>
 			<MediaTransportControls Style="{StaticResource MediaTransportControlsMinimalStyle}" />
 		</MediaPlayerElement.TransportControls>
-	</not_mux:MediaPlayerElement>
+	</MediaPlayerElement>
 	
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Mkv_Extension.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Mkv_Extension.xaml
@@ -1,11 +1,10 @@
 ﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Mkv_Extension"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="">
 
-	<not_mux:MediaPlayerElement Source="https://sample-videos.com/video123/mkv/720/big_buck_bunny_720p_5mb.mkv"
+	<MediaPlayerElement Source="https://sample-videos.com/video123/mkv/720/big_buck_bunny_720p_5mb.mkv"
 						AreTransportControlsEnabled="True"
 						AutoPlay="True" />
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Mov_Extension.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Mov_Extension.xaml
@@ -1,11 +1,10 @@
 ﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Mov_Extension"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="">
 
-	<not_mux:MediaPlayerElement Source="http://file-examples.com/wp-content/uploads/2018/04/file_example_MOV_1280_1_4MB.mov"
+	<MediaPlayerElement Source="http://file-examples.com/wp-content/uploads/2018/04/file_example_MOV_1280_1_4MB.mov"
 						AreTransportControlsEnabled="True"
 						AutoPlay="True" />
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Ogg_Extension.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Ogg_Extension.xaml
@@ -1,11 +1,10 @@
 ﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Ogg_Extension"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="">
 
-	<not_mux:MediaPlayerElement Source="http://file-examples.com/wp-content/uploads/2018/04/file_example_OGG_640_2_7mg.ogg"
+	<MediaPlayerElement Source="http://file-examples.com/wp-content/uploads/2018/04/file_example_OGG_640_2_7mg.ogg"
 						AreTransportControlsEnabled="True"
 						AutoPlay="True" />
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Original.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Original.xaml
@@ -1,11 +1,10 @@
 ﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Original"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="">
 
-	<not_mux:MediaPlayerElement Source="http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4"
+	<MediaPlayerElement Source="http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4"
 						AreTransportControlsEnabled="True"
 						AutoPlay="True" />
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Sources.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Sources.xaml
@@ -2,7 +2,6 @@
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.MediaPlayerElement"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 mc:Ignorable="d"
@@ -23,7 +22,7 @@
 				<ColumnDefinition Width="Auto" />
 			</Grid.ColumnDefinitions>
 
-			<not_mux:MediaPlayerElement x:Name="Mpe"
+			<MediaPlayerElement x:Name="Mpe"
 								AreTransportControlsEnabled="True"
 								AutoPlay="True"
 								Grid.ColumnSpan="2" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Stretch_Fill.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Stretch_Fill.xaml
@@ -2,10 +2,9 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-			 xmlns:not_mux="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              mc:Ignorable="">
 
-	<not_mux:MediaPlayerElement Source="http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4"
+	<MediaPlayerElement Source="http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4"
 						Stretch="Fill"
 						AreTransportControlsEnabled="True"
 						AutoPlay="True" />

--- a/src/Uno.UI/Microsoft/UI/Input/IPointerPointTransform.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/IPointerPointTransform.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.UI.Input
 {
-	public interface IPointerPointTransform
+	public partial interface IPointerPointTransform
 	{
 		IPointerPointTransform Inverse
 		{

--- a/src/Uno.UI/Microsoft/UI/Input/InputCursor.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/InputCursor.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.UI.Input
 {
-	public class InputCursor
+	public partial class InputCursor
 	{
 		protected InputCursor()
 		{

--- a/src/Uno.UI/Microsoft/UI/Input/InputDesktopResourceCursor.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/InputDesktopResourceCursor.cs
@@ -3,7 +3,7 @@ using Uno;
 
 namespace Microsoft.UI.Input
 {
-	public sealed class InputDesktopResourceCursor : InputCursor
+	public sealed partial class InputDesktopResourceCursor : InputCursor
 	{
 		private InputDesktopResourceCursor(string moduleName, uint resourceId)
 		{

--- a/src/Uno.UI/Microsoft/UI/Input/InputKeyboardSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/InputKeyboardSource.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.UI.Input
 {
-	public static class InputKeyboardSource
+	public partial class InputKeyboardSource
 	{
 		public static Windows.UI.Core.CoreVirtualKeyStates GetKeyStateForCurrentThread(Windows.System.VirtualKey virtualKey)
 			=> Xaml.Window.Current.CoreWindow.GetKeyState(virtualKey);

--- a/src/Uno.UI/Microsoft/UI/Input/InputLightDismissAction.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/InputLightDismissAction.cs
@@ -4,7 +4,7 @@ using Uno;
 
 namespace Microsoft.UI.Input
 {
-	public sealed class InputLightDismissAction : InputObject
+	public sealed partial class InputLightDismissAction : InputObject
 	{
 #pragma warning disable 67
 		public event Windows.Foundation.TypedEventHandler<InputLightDismissAction, InputLightDismissEventArgs> Dismissed;

--- a/src/Uno.UI/Microsoft/UI/Input/InputLightDismissEventArgs.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/InputLightDismissEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.UI.Input
 {
-	public sealed class InputLightDismissEventArgs
+	public sealed partial class InputLightDismissEventArgs
 	{
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Input/InputObject.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/InputObject.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.UI.Input
 {
-	public class InputObject
+	public partial class InputObject
 	{
 		public Microsoft.UI.Dispatching.DispatcherQueue DispatcherQueue
 			=> Xaml.Window.Current.DispatcherQueue;

--- a/src/Uno.UI/Microsoft/UI/Input/InputPointerSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/InputPointerSource.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.UI.Input
 {
-	public sealed class InputPointerSource : InputObject
+	public sealed partial class InputPointerSource : InputObject
 	{
 		public InputCursor Cursor { get; set; }
 

--- a/src/Uno.UI/Microsoft/UI/Input/InputSystemCursor.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/InputSystemCursor.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.UI.Input
 {
-	public sealed class InputSystemCursor : InputCursor
+	public sealed partial class InputSystemCursor : InputCursor
 	{
 		private InputSystemCursor(InputSystemCursorShape type)
 		{

--- a/src/Uno.UI/Microsoft/UI/Input/PointerEventArgs.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/PointerEventArgs.cs
@@ -4,7 +4,7 @@ using Uno;
 
 namespace Microsoft.UI.Input
 {
-	public sealed class PointerEventArgs
+	public sealed partial class PointerEventArgs
 	{
 		internal PointerEventArgs(PointerPoint currentPoint)
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedAcceptVisualSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedAcceptVisualSource.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Controls;
 namespace Microsoft.UI.Xaml.Controls.AnimatedVisuals
 {
 	// TODO Uno: This is currently a stub, as animated visuals are not properly supported
-	public class AnimatedAcceptVisualSource : IAnimatedVisualSource2
+	public partial class AnimatedAcceptVisualSource : IAnimatedVisualSource2
 	{
 		public IReadOnlyDictionary<string, double> Markers => new Dictionary<string, double>();
 		public void Load() { }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedBackVisualSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedBackVisualSource.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Controls;
 namespace Microsoft.UI.Xaml.Controls.AnimatedVisuals
 {
 	// TODO Uno: This is currently a stub, as animated visuals are not properly supported
-	public class AnimatedBackVisualSource : IAnimatedVisualSource2
+	public partial class AnimatedBackVisualSource : IAnimatedVisualSource2
 	{
 		public IReadOnlyDictionary<string, double> Markers => new Dictionary<string, double>();
 		public void Load() { }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedChevronDownSmallVisualSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedChevronDownSmallVisualSource.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Controls;
 namespace Microsoft.UI.Xaml.Controls.AnimatedVisuals
 {
 	// TODO Uno: This is currently a stub, as animated visuals are not properly supported
-	public class AnimatedChevronDownSmallVisualSource : IAnimatedVisualSource2
+	public partial class AnimatedChevronDownSmallVisualSource : IAnimatedVisualSource2
 	{
 		public IReadOnlyDictionary<string, double> Markers => new Dictionary<string, double>();
 		public void Load() { }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedChevronRightDownSmallVisualSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedChevronRightDownSmallVisualSource.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Controls;
 namespace Microsoft.UI.Xaml.Controls.AnimatedVisuals
 {
 	// TODO Uno: This is currently a stub, as animated visuals are not properly supported
-	public class AnimatedChevronRightDownSmallVisualSource : IAnimatedVisualSource2
+	public partial class AnimatedChevronRightDownSmallVisualSource : IAnimatedVisualSource2
 	{
 		public IReadOnlyDictionary<string, double> Markers => new Dictionary<string, double>();
 		public void Load() { }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedChevronUpDownSmallVisualSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedChevronUpDownSmallVisualSource.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Controls;
 namespace Microsoft.UI.Xaml.Controls.AnimatedVisuals
 {
 	// TODO Uno: This is currently a stub, as animated visuals are not properly supported
-	public class AnimatedChevronUpDownSmallVisualSource : IAnimatedVisualSource2
+	public partial class AnimatedChevronUpDownSmallVisualSource : IAnimatedVisualSource2
 	{
 		public IReadOnlyDictionary<string, double> Markers => new Dictionary<string, double>();
 		public void Load() { }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedFindVisualSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedFindVisualSource.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Controls;
 namespace Microsoft.UI.Xaml.Controls.AnimatedVisuals
 {
 	// TODO Uno: This is currently a stub, as animated visuals are not properly supported
-	public class AnimatedFindVisualSource : IAnimatedVisualSource2
+	public partial class AnimatedFindVisualSource : IAnimatedVisualSource2
 	{
 		public IReadOnlyDictionary<string, double> Markers => new Dictionary<string, double>();
 		public void Load() { }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedGlobalNavigationButtonVisualSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedGlobalNavigationButtonVisualSource.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Controls;
 namespace Microsoft.UI.Xaml.Controls.AnimatedVisuals
 {
 	// TODO Uno: This is currently a stub, as animated visuals are not properly supported
-	public class AnimatedGlobalNavigationButtonVisualSource : IAnimatedVisualSource2
+	public partial class AnimatedGlobalNavigationButtonVisualSource : IAnimatedVisualSource2
 	{
 		public IReadOnlyDictionary<string, double> Markers => new Dictionary<string, double>();
 		public void Load() { }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedSettingsVisualSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedVisuals/AnimatedSettingsVisualSource.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Controls;
 namespace Microsoft.UI.Xaml.Controls.AnimatedVisuals
 {
 	// TODO Uno: This is currently a stub, as animated visuals are not properly supported
-	public class AnimatedSettingsVisualSource : IAnimatedVisualSource2
+	public partial class AnimatedSettingsVisualSource : IAnimatedVisualSource2
 	{
 		public IReadOnlyDictionary<string, double> Markers => new Dictionary<string, double>();
 		public void Load() { }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/IconSource/AnimatedIconSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/IconSource/AnimatedIconSource.cs
@@ -7,7 +7,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	public class AnimatedIconSource : IconSource
+	public partial class AnimatedIconSource : IconSource
 	{
 		public IconSource FallbackIconSource
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/IconSource/ImageIconSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/IconSource/ImageIconSource.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Media;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	public class ImageIconSource : IconSource
+	public partial class ImageIconSource : IconSource
 	{
 		public ImageSource ImageSource
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/AnimatedVisualPlayer/IAnimatedVisualSource2.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AnimatedVisualPlayer/IAnimatedVisualSource2.cs
@@ -4,8 +4,8 @@ using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml.Controls
 {
-	public interface IAnimatedVisualSource2 : IAnimatedVisualSource
-	{
+	public partial interface IAnimatedVisualSource2 : IAnimatedVisualSource
+    {
 		public IReadOnlyDictionary<string, double> Markers { get; }
 
 		void SetColorProperty(string propertyName, Color value);

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerElement.cs
@@ -1,4 +1,4 @@
-#if !HAS_UNO_WINUI && (__IOS__ || __ANDROID__ || __MACOS__)
+#if __IOS__ || __ANDROID__ || __MACOS__
 using System;
 using Uno.Extensions;
 using Windows.Media.Playback;

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.Android.cs
@@ -1,4 +1,3 @@
-#if !HAS_UNO_WINUI
 using System;
 using Android.Views;
 using Uno.Media.Playback;
@@ -50,4 +49,3 @@ namespace Windows.UI.Xaml.Controls
 		}
 	}
 }
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.cs
@@ -1,4 +1,4 @@
-#if !HAS_UNO_WINUI && (__ANDROID__ || __IOS__ || __MACOS__)
+#if __ANDROID__ || __IOS__ || __MACOS__
 using System;
 using Windows.Foundation;
 using Windows.Media.Playback;

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.iOSmacOS.cs
@@ -1,4 +1,3 @@
-#if !HAS_UNO_WINUI
 using System;
 using AVFoundation;
 using Uno.Extensions;
@@ -53,4 +52,3 @@ namespace Windows.UI.Xaml.Controls
 		}
 	}
 }
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.MediaPlayer.cs
@@ -1,4 +1,4 @@
-#if !HAS_UNO_WINUI && (__ANDROID__ || __IOS__ || NET461 || __MACOS__)
+#if __ANDROID__ || __IOS__ || NET461 || __MACOS__
 
 using System;
 using System.Timers;

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.Properties.cs
@@ -1,4 +1,4 @@
-#if !HAS_UNO_WINUI && (__ANDROID__ || __IOS__ || __MACOS__)
+#if __ANDROID__ || __IOS__ || __MACOS__
 
 using System;
 using Windows.Media.Playback;

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.cs
@@ -1,4 +1,4 @@
-#if !HAS_UNO_WINUI && (__ANDROID__ || __IOS__ || NET461 || __MACOS__)
+#if __ANDROID__ || __IOS__ || NET461 || __MACOS__
 using System;
 using System.Timers;
 using Uno.UI.Converters;

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControlsHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControlsHelper.cs
@@ -1,5 +1,5 @@
 #if __ANDROID__ || __IOS__ || __MACOS__
-namespace Microsoft.UI.Xaml.Controls
+namespace Windows.UI.Xaml.Controls
 {
 	public partial class MediaTransportControlsHelper
 	{

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControlsHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControlsHelper.cs
@@ -1,5 +1,5 @@
-#if !HAS_UNO_WINUI && (__ANDROID__ || __IOS__ || __MACOS__)
-namespace Windows.UI.Xaml.Controls
+#if __ANDROID__ || __IOS__ || __MACOS__
+namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class MediaTransportControlsHelper
 	{

--- a/src/Uno.UWPSyncGenerator.Reference/Uno.UWPSyncGenerator.Reference.csproj
+++ b/src/Uno.UWPSyncGenerator.Reference/Uno.UWPSyncGenerator.Reference.csproj
@@ -121,16 +121,7 @@
 		<When Condition="'$(UNO_UWP_BUILD)'=='false'">
 			<ItemGroup>
 				<PackageReference Include="Microsoft.WindowsAppSDK">
-					<Version>1.1.3</Version>
-				</PackageReference>
-				<PackageReference Include="Microsoft.WindowsAppSDK.WinUI">
-					<Version>1.0.0-experimental1</Version>
-				</PackageReference>
-				<PackageReference Include="Microsoft.WindowsAppSDK.Foundation">
-					<Version>1.0.0-experimental1</Version>
-				</PackageReference>
-				<PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences">
-					<Version>1.0.0-experimental1</Version>
+					<Version>1.2.221209.1</Version>
 				</PackageReference>
 			</ItemGroup>
 		</When>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10938

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Restores MediaPlayer, introduced by WinAppSDK 1.2

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
