### PR TITLE
perf: avoid intermediate calls for Colors.FromInteger

### DIFF
--- a/src/Uno.UWP/UI/Color.cs
+++ b/src/Uno.UWP/UI/Color.cs
@@ -37,13 +37,23 @@ namespace Windows.UI
 
 		public static Color FromArgb(byte a, byte r, byte g, byte b) => new Color(a, r, g, b);
 
-		private Color(byte a, byte r, byte g, byte b)
+		internal Color(byte a, byte r, byte g, byte b)
 		{
 			_color = 0; // Required for field initialization rules in C#
 			_b = b;
 			_g = g;
 			_r = r;
 			_a = a;
+		}
+
+		internal Color(uint color)
+		{
+			// Required for field initialization rules in C#
+			_b = 0;
+			_g = 0;
+			_r = 0;
+			_a = 0;
+			_color = color;
 		}
 
 		public override bool Equals(object o) => o is Color color && Equals(color);

--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -16,20 +16,9 @@ namespace Windows.UI
 	{
 		private static Dictionary<string, Color> _colorMap = new Dictionary<string, Color>(StringComparer.OrdinalIgnoreCase);
 
-		public static Color FromARGB(byte a, byte r, byte g, byte b)
-		{
-			return Color.FromArgb(a, r, g, b);
-		}
+		public static Color FromARGB(byte a, byte r, byte g, byte b) => new(a, r, g, b);
 
-		public static Color FromInteger(int color)
-		{
-			return FromARGB(
-				(byte)((color & 0xFF000000) >> 24),
-				(byte)((color & 0x00FF0000) >> 16),
-				(byte)((color & 0x0000FF00) >> 8),
-				(byte)((color & 0x000000FF))
-			);
-		}
+		public static Color FromInteger(int color) => new((uint)color);
 
 		/// <summary>
 		/// Parses a string representing a color


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

```
Colors.FromInteger(int) ->
	Colors.FromARGB(byte, byte, byte, byte) ->
		Color.FromArgb(byte, byte, byte, byte) ->
			new Color(uint)
```

```
BenchmarkDotNet=v0.13.4, OS=macOS 13.0.1 (22A400) [Darwin 22.1.0]
Apple M1, 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 7.0.0 (7.0.22.51805), Arm64 RyuJIT AdvSIMD

|      Method |     Mean |   Error |  StdDev |
|------------ |---------:|--------:|--------:|
| FromInteger | 327.9 us | 0.80 us | 0.71 us |
```

## What is the new behavior?

```
FromInteger(int) -> new Color(uint)
```

```
BenchmarkDotNet=v0.13.4, OS=macOS 13.0.1 (22A400) [Darwin 22.1.0]
Apple M1, 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 7.0.0 (7.0.22.51805), Arm64 RyuJIT AdvSIMD

|      Method |     Mean |   Error |  StdDev |
|------------ |---------:|--------:|--------:|
| FromInteger | 327.6 us | 0.21 us | 0.17 us |
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

The net7 JIT compiler will inline them… but not the interpreter [1].

Still at least the metadata will be present as the linker won’t be able to remove the extra methods. It's also easier to step in while debugging the code.


[1] https://github.com/spouliot/benchmarks/tree/main/Colors_FromInteger

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
