### PR TITLE
fix: System.IO.DirectoryNotFoundException looking for /dev/input

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/CoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/CoreWindowExtension.cs
@@ -66,14 +66,17 @@ namespace Uno.UI.Runtime.Skia
 
 			var timeval = stackalloc IntPtr[2];
 
-			foreach (var f in Directory.GetFiles("/dev/input", "event*"))
+			if (Directory.Exists("/dev/input"))
 			{
-				if (this.Log().IsEnabled(LogLevel.Debug))
+				foreach (var f in Directory.GetFiles("/dev/input", "event*"))
 				{
-					this.Log().Debug($"Opening input device {f}");
-				}
+					if (this.Log().IsEnabled(LogLevel.Debug))
+					{
+						this.Log().Debug($"Opening input device {f}");
+					}
 
-				libinput_path_add_device(_libInputContext, f);
+					libinput_path_add_device(_libInputContext, f);
+				}
 			}
 
 			while (!_cts.IsCancellationRequested)


### PR DESCRIPTION
When using it on a device with no input, very common in headless applications, an exception is thrown preventing the program from running. A workround would ask to always have a mouse or keyboard connected, which is not feasible in some use cases. So, let's just check if the directory exists before trying to open it and life goes on.

Signed-off-by: Matheus Castello <matheus.castello@toradex.com>

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`System.IO.DirectoryNotFoundException` looking for `/dev/input`

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
The program runs, even without any input device connected 😌


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
