### PR TITLE
chore: reorder Colors.Parse code to avoid dupe null checks

### DIFF
--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -14,7 +14,7 @@ namespace Windows.UI
 #endif
 	static partial class Colors
 	{
-		private static Dictionary<string, Color> _colorMap = new Dictionary<string, Color>(StringComparer.OrdinalIgnoreCase);
+		private static readonly Dictionary<string, Color?> _colorMap = new(StringComparer.OrdinalIgnoreCase);
 
 		public static Color FromARGB(byte a, byte r, byte g, byte b) => new(a, r, g, b);
 
@@ -25,25 +25,23 @@ namespace Windows.UI
 		/// </summary>
 		/// <param name="colorCode"></param>
 		/// <returns></returns>
-		public static Color Parse(string colorCode)
+		public static Color? Parse(string colorCode)
 		{
-			if (colorCode?.StartsWith("#", StringComparison.Ordinal) ?? false)
+			if (!string.IsNullOrWhiteSpace(colorCode))
 			{
-				return FromARGB(colorCode);
-			}
-			else
-			{
-				if (!string.IsNullOrWhiteSpace(colorCode))
+				if (colorCode[0] == '#')
 				{
-					Color color;
-
-					if (!_colorMap.TryGetValue(colorCode, out color))
+					return FromARGB(colorCode);
+				}
+				else
+				{
+					if (!_colorMap.TryGetValue(colorCode, out var color))
 					{
 						var property = typeof(Colors).GetProperty(colorCode);
 
 						if (property != null)
 						{
-							_colorMap[colorCode] = color = (Color)property.GetValue(null);
+							_colorMap[colorCode] = color = (Color?)property.GetValue(null);
 						}
 						else
 						{
@@ -53,10 +51,10 @@ namespace Windows.UI
 
 					return color;
 				}
-				else
-				{
-					throw new InvalidOperationException($"Cannot parse an empty color string");
-				}
+			}
+			else
+			{
+				throw new InvalidOperationException($"Cannot parse an empty color string");
 			}
 		}
 

--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -27,7 +27,7 @@ namespace Windows.UI
 		/// <returns></returns>
 		public static Color Parse(string colorCode)
 		{
-			if (!string.IsNullOrWhiteSpace(colorCode))
+			if (!string.IsNullOrEmpty(colorCode))
 			{
 				if (colorCode[0] == '#')
 				{

--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -14,7 +14,7 @@ namespace Windows.UI
 #endif
 	static partial class Colors
 	{
-		private static readonly Dictionary<string, Color?> _colorMap = new(StringComparer.OrdinalIgnoreCase);
+		private static readonly Dictionary<string, Color> _colorMap = new(StringComparer.OrdinalIgnoreCase);
 
 		public static Color FromARGB(byte a, byte r, byte g, byte b) => new(a, r, g, b);
 
@@ -25,7 +25,7 @@ namespace Windows.UI
 		/// </summary>
 		/// <param name="colorCode"></param>
 		/// <returns></returns>
-		public static Color? Parse(string colorCode)
+		public static Color Parse(string colorCode)
 		{
 			if (!string.IsNullOrWhiteSpace(colorCode))
 			{
@@ -41,7 +41,7 @@ namespace Windows.UI
 
 						if (property != null)
 						{
-							_colorMap[colorCode] = color = (Color?)property.GetValue(null);
+							_colorMap[colorCode] = color = (Color)property.GetValue(null)!;
 						}
 						else
 						{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)


## What is the current behavior?

Input string is checked twice for null.

There was also a nullability warning in the method.

> /xxxsrc/Uno.UWP/UI/Colors.cs(57,39): warning CS8605: Unboxing a possibly null value. [/xxx/benchmarks/Colors_FromInteger/Colors_FromInteger.csproj]


## What is the new behavior?

Single null check.
Fixed warning.

Performance change is unmeasurable, but it’s less code :-)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
