### PR TITLE
fix(ios): LVI layouting

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
@@ -37,41 +37,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForLoaded(gridView);
 			await WindowHelper.WaitForIdle();
 
-			RectAssert.AreEqual(new Rect
-			{
-				X = 0d,
-				Y = 0d,
-				Width = 104d,
-				Height = 104d,
-			},
-			gvi.LayoutSlot);
-
-			RectAssert.AreEqual(new Rect
-			{
-				X = 0d,
-				Y = 0d,
-				Width = 100d,
-				Height = 100d,
-			},
-			gvi.LayoutSlotWithMarginsAndAlignments);
-
-			RectAssert.AreEqual(new Rect
-			{
-				X = 104d,
-				Y = 0d,
-				Width = 104d,
-				Height = 104d,
-			},
-			gvi2.LayoutSlot);
-
-			RectAssert.AreEqual(new Rect
-			{
-				X = 104d,
-				Y = 0d,
-				Width = 100d,
-				Height = 100d,
-			},
-			gvi2.LayoutSlotWithMarginsAndAlignments);
+			RectAssert.AreEqual(new Rect(0, 0, 100, 100), gvi.LayoutSlot);
+			RectAssert.AreEqual(new Rect(0, 0, 100, 100), gvi.LayoutSlotWithMarginsAndAlignments);
+			RectAssert.AreEqual(new Rect(0, 0, 100, 100), gvi2.LayoutSlot);
+			RectAssert.AreEqual(new Rect(0, 0, 100, 100), gvi2.LayoutSlotWithMarginsAndAlignments);
 		}
 	}
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -743,18 +743,6 @@ namespace Windows.UI.Xaml.Controls
 
 					ContentView.AddSubview(value);
 
-					// Calling these methods: Layouter.ArrangeChild() and UpdateContentLayoutSlots()
-					// everytime we set the Content is required to fix an issue where the
-					// OS is not triggering the Callback LayoutSubViews() at times making the Children to render
-					// with the wrong size.
-					// Layouter.ArrangeChild() will skip if called with the same values.
-					Layouter.ArrangeChild(value, new Rect(0, 0, (float)Frame.Width, (float)Frame.Height));
-
-					// The item has to be arranged relative to this internal container (at 0,0),
-					// but doing this the LayoutSlot[WithMargins] has been updated,
-					// so we fakely re-inject the relative position of the item in its parent.
-					UpdateContentLayoutSlots(Frame);
-
 					ClearMeasuredSize();
 					_contentChangedDisposable.Disposable = value?.RegisterDisposablePropertyChangedCallback(ContentControl.ContentProperty, (_, __) => _measuredContentSize = null);
 				}
@@ -781,8 +769,6 @@ namespace Windows.UI.Xaml.Controls
 				try
 				{
 					base.Frame = value;
-					UpdateContentLayoutSlots(value);
-
 					UpdateContentViewFrame();
 				}
 				catch

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -65,11 +65,7 @@ namespace Windows.UI.Xaml
 
 						Rect finalRect;
 						var parent = Superview;
-						if (parent is UIElement
-							|| parent is ISetLayoutSlots
-							// In the case of ListViewItem inside native list, its parent's parent is ListViewBaseInternalContainer
-							|| parent?.Superview is ISetLayoutSlots
-						   )
+						if (parent is UIElement or ISetLayoutSlots)
 						{
 							finalRect = LayoutSlotWithMarginsAndAlignments;
 						}

--- a/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -184,9 +184,17 @@ namespace Windows.UI.Xaml
 						switch (parent)
 						{
 							case ListViewBaseInternalContainer listViewBaseInternalContainer:
-								// In the case of ListViewBaseInternalContainer, the first managed parent is normally ItemsPresenter. We omit
-								// the offset since it's incorporated separately via the layout slot propagated to ListViewItem + the scroll offset.
+								// In the case of ListViewBaseInternalContainer, the first managed parent is normally ItemsPresenter.
+								// Normally, the offset should be appended in all cases. However with ObservableCollection::Move, it can result in
+								// the offset to be included in LVI.LayoutSlot already. The if-case guards against that case.
 								parentElement = listViewBaseInternalContainer.FindFirstParent<UIElement>();
+								if (listViewBaseInternalContainer.Content is { } container &&
+									container.LayoutSlot.Left == container.Margin.Left &&
+									container.LayoutSlot.Top == container.Margin.Top)
+								{
+									offsetX += parent.Frame.X;
+									offsetY += parent.Frame.Y;
+								}
 								return true;
 
 							case UIElement eltParent:


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10901

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On iOS, scrolling through ListView may show some LVI "rendering" partially.

## What is the new behavior?
It should no longer happens.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
this also reverts #9753