### PR TITLE
perf: Remove string allocations from method Colors.FromArbg

### DIFF
--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -71,45 +71,62 @@ namespace Windows.UI
 		public static Color FromARGB(string colorCode)
 		{
 			byte a, r, b, g;
+			int offset;
+			int len;
 
-			colorCode = colorCode.TrimStart(new char[] { '#' });
+			if (colorCode is null)
+			{
+				len = 0;
+				offset = 0;
+			}
+			else
+			{
+				len = colorCode.Length;
+				// skip a starting `#` if present 
+				offset = (len > 0 && colorCode[0] == '#' ? 1 : 0);
+				len -= offset;
+			}
 
-			if (colorCode.Length == 3)
+			// deal with optional alpha value
+			if (len == 4)
 			{
-				a = 0xFF;
-				r = Convert.ToByte(new String(colorCode[0], 2), 16);
-				g = Convert.ToByte(new String(colorCode[1], 2), 16);
-				b = Convert.ToByte(new String(colorCode[2], 2), 16);
+				a = Convert.ToByte(colorCode[offset++]);
+				a = (byte)(a << 4 + a);
+				len = 3;
 			}
-			else if (colorCode.Length == 4)
+			else if (len == 8)
 			{
-				a = Convert.ToByte(new String(colorCode[0], 2), 16);
-				r = Convert.ToByte(new String(colorCode[1], 2), 16);
-				g = Convert.ToByte(new String(colorCode[2], 2), 16);
-				b = Convert.ToByte(new String(colorCode[3], 2), 16);
-			}
-			else if (colorCode.Length == 6)
-			{
-				a = 0xFF;
-				r = Convert.ToByte(colorCode.Substring(0, 2), 16);
-				g = Convert.ToByte(colorCode.Substring(2, 2), 16);
-				b = Convert.ToByte(colorCode.Substring(4, 2), 16);
-			}
-			else if (colorCode.Length == 8)
-			{
-				a = Convert.ToByte(colorCode.Substring(0, 2), 16);
-				r = Convert.ToByte(colorCode.Substring(2, 2), 16);
-				g = Convert.ToByte(colorCode.Substring(4, 2), 16);
-				b = Convert.ToByte(colorCode.Substring(6, 2), 16);
+				a = (byte)(Convert.ToByte(colorCode[offset++]) << 8 + Convert.ToByte(colorCode[offset++]));
+				len = 6;
 			}
 			else
 			{
 				a = 0xFF;
+			}
+
+			// the process the required R G and B values
+			if (len == 3)
+			{
+				r = Convert.ToByte(colorCode[offset++]);
+				r = (byte)(r << 4 + r);
+				g = Convert.ToByte(colorCode[offset++]);
+				g = (byte)(g << 4 + g);
+				b = Convert.ToByte(colorCode[offset++]);
+				b = (byte)(b << 4 + b);
+			}
+			else if (len == 6)
+			{
+				r = (byte)(Convert.ToByte(colorCode[offset++]) << 8 + Convert.ToByte(colorCode[offset++]));
+				g = (byte)(Convert.ToByte(colorCode[offset++]) << 8 + Convert.ToByte(colorCode[offset++]));
+				b = (byte)(Convert.ToByte(colorCode[offset++]) << 8 + Convert.ToByte(colorCode[offset++]));
+			}
+			else
+			{
 				r = 0xFF;
 				g = 0x0;
 				b = 0x0;
 			}
-			return Color.FromArgb(a, r, g, b);
+			return new Color(a, r, g, b);
 		}
 
 		private static Color? _transparent;

--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -129,7 +129,7 @@ namespace Windows.UI
 			return new Color(a, r, g, b);
 		}
 
-		static private byte ToByte(char c)
+		private static byte ToByte(char c)
 		{
 			if (c >= '0' && c <= '9')
 			{

--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -104,7 +104,7 @@ namespace Windows.UI
 				a = 0xFF;
 			}
 
-			// the process the required R G and B values
+			// then process the required R G and B values
 			if (len == 3)
 			{
 				r = ToByte(colorCode[offset++]);

--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -90,13 +90,13 @@ namespace Windows.UI
 			// deal with optional alpha value
 			if (len == 4)
 			{
-				a = Convert.ToByte(colorCode[offset++]);
+				a = ToByte(colorCode[offset++]);
 				a = (byte)(a << 4 + a);
 				len = 3;
 			}
 			else if (len == 8)
 			{
-				a = (byte)(Convert.ToByte(colorCode[offset++]) << 8 + Convert.ToByte(colorCode[offset++]));
+				a = (byte)((ToByte(colorCode[offset++]) << 4) + ToByte(colorCode[offset++]));
 				len = 6;
 			}
 			else
@@ -107,18 +107,18 @@ namespace Windows.UI
 			// the process the required R G and B values
 			if (len == 3)
 			{
-				r = Convert.ToByte(colorCode[offset++]);
+				r = ToByte(colorCode[offset++]);
 				r = (byte)(r << 4 + r);
-				g = Convert.ToByte(colorCode[offset++]);
+				g = ToByte(colorCode[offset++]);
 				g = (byte)(g << 4 + g);
-				b = Convert.ToByte(colorCode[offset++]);
+				b = ToByte(colorCode[offset++]);
 				b = (byte)(b << 4 + b);
 			}
 			else if (len == 6)
 			{
-				r = (byte)(Convert.ToByte(colorCode[offset++]) << 8 + Convert.ToByte(colorCode[offset++]));
-				g = (byte)(Convert.ToByte(colorCode[offset++]) << 8 + Convert.ToByte(colorCode[offset++]));
-				b = (byte)(Convert.ToByte(colorCode[offset++]) << 8 + Convert.ToByte(colorCode[offset++]));
+				r = (byte)((ToByte(colorCode[offset++]) << 4) + ToByte(colorCode[offset++]));
+				g = (byte)((ToByte(colorCode[offset++]) << 4) + ToByte(colorCode[offset++]));
+				b = (byte)((ToByte(colorCode[offset++]) << 4) + ToByte(colorCode[offset++]));
 			}
 			else
 			{
@@ -127,6 +127,26 @@ namespace Windows.UI
 				b = 0x0;
 			}
 			return new Color(a, r, g, b);
+		}
+
+		static private byte ToByte(char c)
+		{
+			if (c >= '0' && c <= '9')
+			{
+				return (byte)(c - '0');
+			}
+			else if (c >= 'a' && c <= 'f')
+			{
+				return (byte)(c - 'a' + 10);
+			}
+			else if (c >= 'A' && c <= 'F')
+			{
+				return (byte)(c - 'A' + 10);
+			}
+			else
+			{
+				throw new FormatException();
+			}
 		}
 
 		private static Color? _transparent;

--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -145,7 +145,7 @@ namespace Windows.UI
 			}
 			else
 			{
-				throw new FormatException();
+				throw new FormatException($"The character {c} is not valid for a Color string");
 			}
 		}
 

--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -87,7 +87,7 @@ namespace Windows.UI
 				len -= offset;
 			}
 
-			// deal with optional alpha value
+			// deal with an optional alpha value
 			if (len == 4)
 			{
 				a = ToByte(colorCode[offset++]);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

`Colors.FromArgb` is allocating several strings while parsing.

```
BenchmarkDotNet=v0.13.4, OS=macOS 13.0.1 (22A400) [Darwin 22.1.0]
Apple M1, 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 7.0.0 (7.0.22.51805), Arm64 RyuJIT AdvSIMD

|   Method |    Mean |    Error |   StdDev |
|--------- |--------:|---------:|---------:|
| FromARGB | 5.724 s | 0.0118 s | 0.0110 s |
```

## What is the new behavior?

`Colors.FromArgb` does not allocate any temporary string while parsing.

```
BenchmarkDotNet=v0.13.4, OS=macOS 13.0.1 (22A400) [Darwin 22.1.0]
Apple M1, 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 7.0.0 (7.0.22.51805), Arm64 RyuJIT AdvSIMD

|   Method |     Mean |   Error |  StdDev |
|--------- |---------:|--------:|--------:|
| FromARGB | 506.2 ms | 0.15 ms | 0.13 ms |
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Benchmark code:
https://github.com/spouliot/benchmarks/tree/main/Colors_FromARGB

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
