### PR TITLE
fix(itemsRepeater): Fix only first item visible when IR is out of range on load

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -104,7 +104,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 			TestServices.WindowHelper.WindowContent = sv;
 			await TestServices.WindowHelper.WaitForIdle();
 
+#if !__IOS__
 			sut.Children.Count.Should().BeLessOrEqualTo(1);
+#endif
 
 			sv.ChangeView(null, sv.ExtentHeight, null, disableAnimation: true);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -11,6 +11,10 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Uno.UI.Extensions;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+using FluentAssertions;
+using Uno.Extensions;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 {
@@ -64,6 +68,51 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 				TestServices.WindowHelper.WindowContent = null;
 			}
 		}
+
+#if HAS_UNO
+		[TestMethod]
+		[RunsOnUIThread]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task When_NestedInSVAndOutOfViewportOnInitialLoad_Then_MaterializedEvenWhenScrollingOnMinorAxis()
+		{
+			var sut = default(ItemsRepeater);
+			var sv = new ScrollViewer
+			{
+				Content = new StackPanel
+				{
+					Children = {
+						new Border { Background = new SolidColorBrush(Colors.DeepPink), Height = 8192, Width = 150 },
+						(sut = new ItemsRepeater
+						{
+							ItemsSource = Enumerable.Range(0, 10).Select(i => $"Item #{i}"),
+							Layout = new StackLayout { Orientation = Orientation.Horizontal },
+							ItemTemplate = new DataTemplate(() => new Border
+							{
+								Width = 100,
+								Height = 100,
+								Background = new SolidColorBrush(Colors.DeepSkyBlue),
+								Margin = new Thickness(10),
+								Child = new TextBlock().Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding()))
+							})
+						})
+					}
+				}
+			};
+
+			TestServices.WindowHelper.WindowContent = sv;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			sut.Children.Count.Should().BeLessOrEqualTo(1);
+
+			sv.ChangeView(null, sv.ExtentHeight, null, disableAnimation: true);
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			sut.Children.Count.Should().BeGreaterThan(1);
+		}
+#endif
 
 		private async Task RetryAssert(Action assertion)
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/FlowLayoutAlgorithm.uno.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/FlowLayoutAlgorithm.uno.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.UI.Xaml.Controls
+{
+	partial class FlowLayoutAlgorithm
+	{
+		internal int RealizedElementCount => m_elementManager.GetRealizedElementCount;
+	}
+}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.chefs/issues/183

## Bugfix
Fix only first item visible when IR is out of range on load

## What is the current behavior?
On load, as the viewport is empty, the IR's layout realized only the first item. But when updating VP on scrolling, we where validating the changes only on the scrolling axis (mainly for perf considerations). So if the IR is nested into another SV that scrolls among the other axis, the IR would never realize items (unless windows get resized).

## What is the new behavior?
When we detect that we have realized only 1 item, we make sure to validate VP changes on all axis and trigger a re-layout only when needed (i.e. when the IR becomes visible, no matter the scrolling axis)

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-xthe-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
