### PR TITLE
fix(android): Ensure that DependencyObject.Parent is set when adding a control to its parent

### DIFF
--- a/src/Uno.CrossTargetting.props
+++ b/src/Uno.CrossTargetting.props
@@ -137,6 +137,10 @@
 	<Target Name="CommonOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!='' and '$(UseCommonOverridePackage)'!=''">
 		<PropertyGroup>
 			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
+
+			<!-- Current nuget publishing uses netX.0-android30.0 -->
+			<_OverrideTargetFramework Condition="$(_OverrideTargetFramework.EndsWith('.0-android'))">$(_OverrideTargetFramework)30.0</_OverrideTargetFramework>
+			
 			<_baseNugetPath Condition="'$(USERPROFILE)'!=''">$(USERPROFILE)</_baseNugetPath>
 			<_baseNugetPath Condition="'$(HOME)'!=''">$(HOME)</_baseNugetPath>
 			<CommonOverridePackageId Condition="'$(CommonOverridePackageId)'==''">$(AssemblyName)</CommonOverridePackageId>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/Inner_ThemeResource_Control.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/Inner_ThemeResource_Control.xaml
@@ -4,6 +4,21 @@
 					xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 					xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 					mc:Ignorable="d">
+
+	<ResourceDictionary.ThemeDictionaries>
+
+		<ResourceDictionary x:Key="Light">
+			<SolidColorBrush x:Key="LoadedTestPrimaryBrush"
+							 Color="MediumPurple" />
+		</ResourceDictionary>
+
+		<ResourceDictionary x:Key="Default">
+			<SolidColorBrush x:Key="LoadedTestPrimaryBrush"
+							 Color="Purple" />
+		</ResourceDictionary>
+
+	</ResourceDictionary.ThemeDictionaries>
+
 	<SolidColorBrush x:Key="ResourcesInTemplateTestBrush"
 					 Color="Red" />
 	<Style TargetType="local:Inner_ThemeResource_Control">

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_Parent_Resource_Override_On_Loaded.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_Parent_Resource_Override_On_Loaded.xaml
@@ -1,0 +1,36 @@
+﻿<UserControl x:Class="Uno.UI.RuntimeTests.When_Parent_Resource_Override_On_Loaded"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.ThemeDictionaries>
+				<ResourceDictionary x:Key="Light">
+					<SolidColorBrush x:Key="LoadedTestPrimaryBrush"
+									 Color="Yellow" />
+				</ResourceDictionary>
+				<ResourceDictionary x:Key="Default">
+					<SolidColorBrush x:Key="LoadedTestPrimaryBrush"
+									 Color="Red" />
+				</ResourceDictionary>
+			</ResourceDictionary.ThemeDictionaries>
+		</ResourceDictionary>
+	</UserControl.Resources>
+	
+	<StackPanel HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Spacing="30">
+		<Border Width="100"
+				Height="100"
+				x:Name="innerBorder"
+				x:FieldModifier="public"
+				Background="{ThemeResource LoadedTestPrimaryBrush}" />
+	</StackPanel>
+
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_Parent_Resource_Override_On_Loaded.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_Parent_Resource_Override_On_Loaded.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests;
+
+public sealed partial class When_Parent_Resource_Override_On_Loaded : UserControl
+{
+	public When_Parent_Resource_Override_On_Loaded()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -44,5 +44,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				} 
 			}
 		}
+
+		[TestMethod]
+		public async Task When_Parent_Resource_Override_On_Loaded()
+		{
+			using (StyleHelper.UseAppLevelResources(new App_Level_Resources()))
+			{
+				var userControl = new When_Parent_Resource_Override_On_Loaded();
+
+				WindowHelper.WindowContent = userControl;
+				await WindowHelper.WaitForLoaded(userControl);
+
+				Assert.AreEqual(Colors.Yellow, (userControl.innerBorder.Background as SolidColorBrush).Color);
+			}
+		}
 	}
 }

--- a/src/Uno.UI/Controls/BindableView.Android.cs
+++ b/src/Uno.UI/Controls/BindableView.Android.cs
@@ -112,6 +112,8 @@ namespace Uno.UI.Controls
 		/// observer.</remarks>
 		public new virtual void AddView(View view)
 		{
+			view.TrySetParent(this);
+
 			_childrenShadow.Add(view);
 			base.AddViewFast(view);
 			OnChildViewAdded(view);
@@ -125,6 +127,8 @@ namespace Uno.UI.Controls
 		/// observer.</remarks>
 		public new virtual void AddView(View view, int index)
 		{
+			view.TrySetParent(this);
+
 			_childrenShadow.Insert(index, view);
 			base.AddViewFast(view, index);
 			OnChildViewAdded(view);
@@ -144,6 +148,7 @@ namespace Uno.UI.Controls
 				{
 					fe.IsManagedLoaded = false;
 					fe.PerformOnUnloaded();
+					fe.SetParent(null);
 				}
 			}
 
@@ -169,6 +174,7 @@ namespace Uno.UI.Controls
 				{
 					fe.IsManagedLoaded = false;
 					fe.PerformOnUnloaded();
+					fe.SetParent(null);
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -122,9 +122,32 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// Set the parent of the specified dependency object
 		/// </summary>
+		/// <remarks>
+		/// This method will create a weak attached DependencyObjectStore if the object is
+		/// not an <see cref="IDependencyObjectStoreProvider"/>
+		/// </remarks>
 		internal static void SetParent(this object dependencyObject, object parent)
+			=> GetStore(dependencyObject).Parent = parent;
+
+		/// <summary>
+		/// Set the parent of the specified dependency object
+		/// </summary>
+		internal static void SetParent(this IDependencyObjectStoreProvider storeProvider, object parent)
+			=> storeProvider.Store.Parent = parent;
+
+		/// <summary>
+		/// Tries to set the parent of the specified dependency object
+		/// </summary>
+		/// <returns>true if the parent could be set, otherwise false</returns>
+		internal static bool TrySetParent(this object dependencyObject, object parent)
 		{
-			GetStore(dependencyObject).Parent = parent;
+			if (dependencyObject is IDependencyObjectStoreProvider provider)
+			{
+				SetParent(provider, parent);
+				return true;
+			}
+
+			return false;
 		}
 
 		internal static void SetLogicalParent(this FrameworkElement element, DependencyObject logicalParent)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11084

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change fixes the ancestors traversal when performing resource dictionary lookups on `FrameworkElement.Loading` in XAML generated C#.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
