### PR TITLE
fix: Skia.GTK VSCode launch config to use .NET 7 in template

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.vscode/launch.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.vscode/launch.json
@@ -9,7 +9,7 @@
       // Use hover for the description of the existing attributes
       // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
       "name": "Debug (Chrome, WebAssembly)",
-      "type": "pwa-chrome",
+      "type": "chrome",
       "request": "launch",
       "url": "http://localhost:5000",
       "webRoot": "${workspaceFolder}/UnoWinUIQuickStart.Wasm",

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.vscode/launch.json
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unoapp/.vscode/launch.json
@@ -32,7 +32,7 @@
       "request": "launch",
       "preLaunchTask": "build-skia-gtk",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/UnoWinUIQuickStart.Skia.Gtk/bin/Debug/net6.0/UnoWinUIQuickStart.Skia.Gtk.dll",
+      "program": "${workspaceFolder}/UnoWinUIQuickStart.Skia.Gtk/bin/Debug/net7.0/UnoWinUIQuickStart.Skia.Gtk.dll",
       "args": [],
       "env": {
         "DOTNET_MODIFIABLE_ASSEMBLIES": "debug"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Other... Please describe:

Fix to Visual Studio Code launch configuration.

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Following the [Get Started with VSCode](https://github.com/unoplatform/uno/blob/ab2ee2a26e160fb73db358d84ce780a895dae413/doc/articles/get-started-vscode.md) guide, which specifically mentions to install .NET 7, I was unable to run/debug the example using `Skia.GTK (Debug)`, because it was still referencing the .NET 6.0 dll.

While I was looking at the `launch.json`, I saw the message _replace pwa-chrome with chrome_. Seems `pwa_chrome` is no longer necessary https://stackoverflow.com/a/64261636.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

With .NET 7 installed and following the guide, one is now correctly able to debug the example Skia.GTK application.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

There are other `launch.json` files in the templates, which all seems to use `net5.0` for the path to the DLL. I'm not sure how templating in configured so I've left those out, but they might also require amending (all under `src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content`):
- `unoapp-uwp/.vscode/launch.json`
- `unoapp-uwp-net6/.vscode/launch.json`
- `unoapp-winui-xamarin/.vscode/launch.json`

There are various other `launch.json` files in the repo that I haven't looked at.
