### PR TITLE
Avoid changing native view in `TextChanged`, trigger `TextChanging` more reliably

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -510,11 +510,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
 
+			int textChangedInvokeCount = 0;
+			int textChangingInvokeCount = 0;
+
 			bool failedCheck = false;
 			bool finished = false;
 
 			void OnTextChanged(object sender, TextChangedEventArgs e)
 			{
+				textChangedInvokeCount++;
 				if (GetCurrentText() != textBox.Text)
 				{
 					failedCheck = true;
@@ -530,7 +534,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				}
 			}
 
+			void OnTextChanging(object sender, TextBoxTextChangingEventArgs e) =>
+				textChangingInvokeCount++;
+
 			textBox.TextChanged += OnTextChanged;
+			textBox.TextChanging += OnTextChanging;
 
 			textBox.Text = GetNewText();
 
@@ -541,6 +549,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.Fail("Text changed to incorrect value. Expected: " + GetCurrentText() + ", Actual: " + textBox.Text);
 			}
 
+			Assert.AreEqual(5, textChangedInvokeCount);
+			Assert.AreEqual(5, textChangingInvokeCount);
 			Assert.AreEqual(initialText + "5", textBox.Text);
 		}
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -11,6 +11,7 @@ using Windows.UI.Xaml;
 using Windows.UI;
 using FluentAssertions;
 using MUXControlsTestApp.Utilities;
+using System.Runtime.InteropServices;
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -492,5 +493,55 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(initialText, ((TextBlock)contentControl.Content).Text);
 		}
 #endif
+
+		[TestMethod]
+		public async Task When_Changes_In_TextChanged()
+		{
+			int update = 0;
+			var initialText = "Text";
+			string GetCurrentText() => initialText + update;
+			string GetNewText() => initialText + ++update;
+
+			var textBox = new TextBox
+			{
+				Text = "Waiting"
+			};
+
+			WindowHelper.WindowContent = textBox;
+			await WindowHelper.WaitForLoaded(textBox);
+
+			bool failedCheck = false;
+			bool finished = false;
+
+			void OnTextChanged(object sender, TextChangedEventArgs e)
+			{
+				if (GetCurrentText() != textBox.Text)
+				{
+					failedCheck = true;
+					finished = true;
+				}
+				else if (update <= 4)
+				{
+					textBox.Text = GetNewText();
+				}
+				else
+				{
+					finished = true;
+				}
+			}
+
+			textBox.TextChanged += OnTextChanged;
+
+			textBox.Text = GetNewText();
+
+			await WindowHelper.WaitFor(() => finished);
+
+			if (failedCheck)
+			{
+				Assert.Fail("Text changed to incorrect value. Expected: " + GetCurrentText() + ", Actual: " + textBox.Text);
+			}
+
+			Assert.AreEqual(initialText + "5", textBox.Text);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -66,6 +66,10 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		private bool _isInvokingTextChanged;
 		/// <summary>
+		/// Set when <see cref="TextChanging"/> event is being raised, to ensure modifications by handlers don't trigger an infinite loop.
+		/// </summary>
+		private bool _isInvokingTextChanging;
+		/// <summary>
 		/// Set when the <see cref="Text"/> property is being modified by user input.
 		/// </summary>
 		private bool _isInputModifyingText;
@@ -239,22 +243,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			_hasTextChangedThisFocusSession = true;
 
-			if (!_isInvokingTextChanged)
-			{
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
-				try
-#endif
-				{
-					_isInvokingTextChanged = true;
-					TextChanging?.Invoke(this, new TextBoxTextChangingEventArgs());
-				}
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
-				finally
-#endif
-				{
-					_isInvokingTextChanged = false;
-				}
-			}
+			RaiseTextChanging();
 
 			if (!_isInputModifyingText)
 			{
@@ -269,6 +258,26 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_isTextChangedPending = true;
 				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, RaiseTextChanged);
+			}
+		}
+
+		private void RaiseTextChanging()
+		{
+			if (!_isInvokingTextChanging)
+			{
+#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
+				try
+#endif
+				{
+					_isInvokingTextChanging = true;
+					TextChanging?.Invoke(this, new TextBoxTextChangingEventArgs());
+				}
+#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
+				finally
+#endif
+				{
+					_isInvokingTextChanging = false;
+				}
 			}
 		}
 
@@ -290,6 +299,7 @@ namespace Windows.UI.Xaml.Controls
 #endif
 			{
 				_isInvokingTextChanged = true;
+				_isTextChangedPending = false;
 				TextChanged?.Invoke(this, new TextChangedEventArgs(this));
 			}
 #if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
@@ -297,7 +307,6 @@ namespace Windows.UI.Xaml.Controls
 #endif
 			{
 				_isInvokingTextChanged = false;
-				_isTextChangedPending = false;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -272,30 +272,34 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		/// <summary>
+		/// This is called asynchronously after the UI changes in line with WinUI.
+		/// Note that no further native text box view text modification should
+		/// be performed in this method to avoid potential race conditions
+		/// (see #)
+		/// </summary>
 		private void RaiseTextChanged()
 		{
-			if (!_isInvokingTextChanged)
+			if (_isInvokingTextChanged)
 			{
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
-				try
-#endif
-				{
-					_isInvokingTextChanged = true;
-					TextChanged?.Invoke(this, new TextChangedEventArgs(this));
-				}
-#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
-				finally
-#endif
-				{
-					_isInvokingTextChanged = false;
-					_isTextChangedPending = false;
-				}
+				return;
 			}
 
-			_textBoxView?.SetTextNative(Text);
-
+#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
+			try
+#endif
+			{
+				_isInvokingTextChanged = true;
+				TextChanged?.Invoke(this, new TextChangedEventArgs(this));
+			}
+#if !HAS_EXPENSIVE_TRYFINALLY // Try/finally incurs a very large performance hit in mono-wasm - https://github.com/dotnet/runtime/issues/50783
+			finally
+#endif
+			{
+				_isInvokingTextChanged = false;
+				_isTextChangedPending = false;
+			}
 		}
-
 
 		private void UpdatePlaceholderVisibility()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -276,7 +276,7 @@ namespace Windows.UI.Xaml.Controls
 		/// This is called asynchronously after the UI changes in line with WinUI.
 		/// Note that no further native text box view text modification should
 		/// be performed in this method to avoid potential race conditions
-		/// (see #)
+		/// (see #6289)
 		/// </summary>
 		private void RaiseTextChanged()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -122,6 +122,7 @@ namespace Windows.UI.Xaml.Controls
 			if (textBox != null)
 			{
 				var text = textBox.ProcessTextInput(newText);
+				DisplayBlock.Text = text;
 				if (text != newText)
 				{
 					SetTextNative(text);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6289

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
