### PR TITLE
perf(memory): Fix datacontext propagation on precedence level change

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
@@ -475,6 +475,104 @@ namespace Uno.UI.Tests.BinderTests.Propagation
 
 			Assert.IsNotNull(anim);
 		}
+
+		[TestMethod]
+		public async Task When_PrecedenceChanged_Then_Released()
+		{
+			var SUT = new ContentControl();
+
+			WeakReference Build()
+			{
+				var dc = new object();
+				SUT.DataContext = dc;
+				SUT.SetValue(ContentControl.ForegroundProperty, new SolidColorBrush(Windows.UI.Colors.Red));
+
+				SUT.DataContext = null;
+
+				return new(dc);
+			}
+
+			await AssertCollectedReference(Build());
+		}
+
+
+		[TestMethod]
+		public async Task When_PrecedenceChanged_And_Back_Then_Restored()
+		{
+			var SUT = new ContentControl();
+
+			WeakReference Build()
+			{
+				var dc = new object();
+				SUT.DataContext = dc;
+
+				var originalBrush = SUT.Foreground as Brush;
+				var newBrush = new SolidColorBrush(Windows.UI.Colors.Red);
+
+				SUT.SetValue(ContentControl.ForegroundProperty, newBrush);
+
+				Assert.IsNull(originalBrush.DataContext);
+				Assert.IsNotNull(newBrush.DataContext);
+
+				SUT.ClearValue(ContentControl.ForegroundProperty);
+
+				Assert.AreEqual(dc, originalBrush.DataContext);
+				Assert.IsNull(newBrush.DataContext);
+
+				SUT.DataContext = null;
+
+				return new(dc);
+			}
+
+			await AssertCollectedReference(Build());
+		}
+
+		[TestMethod]
+		public async Task When_PrecedenceChanged_To_Null_And_Back_Then_Restored()
+		{
+			var SUT = new ContentControl();
+
+			WeakReference Build()
+			{
+				var dc = new object();
+				SUT.DataContext = dc;
+
+				var originalBrush = SUT.Foreground as Brush;
+
+				SUT.SetValue(ContentControl.ForegroundProperty, null);
+
+				Assert.IsNull(originalBrush.DataContext);
+
+				SUT.ClearValue(ContentControl.ForegroundProperty);
+
+				Assert.AreEqual(dc, originalBrush.DataContext);
+
+				SUT.DataContext = null;
+
+				return new(dc);
+			}
+
+			await AssertCollectedReference(Build());
+		}
+
+		private async Task AssertCollectedReference(WeakReference reference)
+		{
+			var sw = Stopwatch.StartNew();
+			while (sw.Elapsed < TimeSpan.FromSeconds(2))
+			{
+				GC.Collect(2);
+				GC.WaitForPendingFinalizers();
+
+				if (!reference.IsAlive)
+				{
+					return;
+				}
+
+				await Task.Delay(100);
+			}
+
+			Assert.IsFalse(reference.IsAlive);
+		}
 	}
 
 	public partial class MyObject : DependencyObject

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
@@ -20,6 +20,8 @@ using Uno.UI.Converters;
 using Microsoft.Extensions.Logging;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
+using Windows.UI.Xaml.Media;
+using System.Diagnostics;
 
 namespace Uno.UI.Tests.BinderTests.Propagation
 {

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -36,14 +36,11 @@ namespace Windows.UI.Xaml
 		private readonly PropertyMetadata _ownerTypeMetadata; // For perf consideration, we keep direct ref the metadata for the owner type
 		private readonly PropertyMetadataDictionary _metadata = new PropertyMetadataDictionary();
 
+		private readonly Flags _flags;
 		private string _name;
 		private Type _propertyType;
 		private Type _ownerType;
-		private readonly bool _isAttached;
-		private readonly bool _isTypeNullable;
 		private readonly int _uniqueId;
-		private readonly bool _isDependencyObjectCollection;
-		private readonly bool _hasWeakStorage;
 		private object _fallbackDefaultValue;
 
 		private static int _globalId;
@@ -53,11 +50,14 @@ namespace Windows.UI.Xaml
 			_name = name;
 			_propertyType = propertyType;
 			_ownerType = ownerType;
-			_isAttached = attached;
-			_isDependencyObjectCollection = typeof(DependencyObjectCollection).IsAssignableFrom(propertyType);
-			_isTypeNullable = GetIsTypeNullable(propertyType);
+
+			_flags |= attached ? Flags.IsAttached : Flags.None;
+			_flags |= typeof(DependencyObjectCollection).IsAssignableFrom(propertyType) ? Flags.IsDependencyObjectCollection : Flags.None;
+			_flags |= GetIsTypeNullable(propertyType) ? Flags.IsTypeNullable : Flags.None;
+			_flags |= (defaultMetadata as FrameworkPropertyMetadata)?.Options.HasWeakStorage() is true ? Flags.HasWeakStorage : Flags.None;
+			_flags |= ownerType.Assembly.Equals(typeof(DependencyProperty).Assembly) ? Flags.IsUnoType : Flags.None;
+
 			_uniqueId = Interlocked.Increment(ref _globalId);
-			_hasWeakStorage = (defaultMetadata as FrameworkPropertyMetadata)?.Options.HasWeakStorage() ?? false;
 
 			_ownerTypeMetadata = defaultMetadata ?? new FrameworkPropertyMetadata(null);
 			_metadata.Add(_ownerType, _ownerTypeMetadata);
@@ -74,12 +74,14 @@ namespace Windows.UI.Xaml
 		/// <summary>
 		/// Determines if the property storage should be backed by a <see cref="Uno.UI.DataBinding.ManagedWeakReference"/>
 		/// </summary>
-		internal bool HasWeakStorage => _hasWeakStorage;
+		internal bool HasWeakStorage
+			=> (_flags & Flags.HasWeakStorage) != 0;
 
 		/// <summary>
 		/// Determines if the property type inherits from <see cref="DependencyObjectCollection"/>
 		/// </summary>
-		internal bool IsDependencyObjectCollection => _isDependencyObjectCollection;
+		internal bool IsDependencyObjectCollection
+			=> (_flags & Flags.IsDependencyObjectCollection) != 0;
 
 		/// <summary>
 		/// Registers a dependency property on the specified <paramref name="ownerType"/>.
@@ -285,9 +287,7 @@ namespace Windows.UI.Xaml
 		/// Determines if the Type of the property is a ValueType
 		/// </summary>
 		internal bool IsTypeNullable
-		{
-			get { return _isTypeNullable; }
-		}
+			=> (_flags & Flags.IsTypeNullable) != 0;
 
 		internal object GetFallbackDefaultValue()
 			=> _fallbackDefaultValue != null ? _fallbackDefaultValue : _fallbackDefaultValue = Activator.CreateInstance(Type);
@@ -297,7 +297,17 @@ namespace Windows.UI.Xaml
 			get { return _name; }
 		}
 
-		internal bool IsAttached { get { return _isAttached; } }
+		/// <summary>
+		/// Determines if the property is an attached property
+		/// </summary>
+		internal bool IsAttached
+			=> (_flags & Flags.IsAttached) != 0;
+
+		/// <summary>
+		/// Determines if the owner type is declared by Uno.UI
+		/// </summary>
+		internal bool IsUnoType
+			=> (_flags & Flags.IsUnoType) != 0;
 
 		/// <summary>
 		/// Get the specified dependency property on the specified owner type.
@@ -500,6 +510,41 @@ namespace Windows.UI.Xaml
 		internal static DependencyProperty Register(string v, Type type1, Type type2, PropertyMetadata propertyMetadata, object updateSourceOnChanged)
 		{
 			throw new NotImplementedException();
+		}
+
+
+		[Flags]
+		private enum Flags
+		{
+			/// <summary>
+			/// No flag
+			/// </summary>
+			None = 0,
+
+			/// <summary>
+			/// Set when the property is an attached property
+			/// </summary>
+			IsAttached = (1 << 0),
+
+			/// <summary>
+			/// Set when the <see cref="_propertyType"/> is nullable
+			/// </summary>
+			IsTypeNullable = (1 << 1),
+
+			/// <summary>
+			/// Set when the <see cref="_propertyType"/> is a <see cref="DependencyObjectCollection"/> 
+			/// </summary>
+			IsDependencyObjectCollection = (1 << 2),
+
+			/// <summary>
+			/// Set when the internal storage for the property is using weak references
+			/// </summary>
+			HasWeakStorage = (1 << 3),
+
+			/// <summary>
+			/// Set when the property type is declared in Uno.UI
+			/// </summary>
+			IsUnoType = (1 << 4),
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -62,15 +62,15 @@ namespace Windows.UI.Xaml
 		/// Constructor
 		/// </summary>
 		/// <param name="defaultValue">The default value of the Dependency Property</param>
-		internal DependencyPropertyDetails(DependencyProperty property, Type dependencyObjectType)
+		internal DependencyPropertyDetails(DependencyProperty property, Type dependencyObjectType, bool hasInherits, bool hasValueInherits, bool hasValueDoesNotInherits)
 		{
 			Property = property;
 			_dependencyObjectType = dependencyObjectType;
 
-			if (property.HasWeakStorage)
-			{
-				_flags |= Flags.WeakStorage;
-			}
+			_flags |= property.HasWeakStorage ? Flags.WeakStorage : Flags.None;
+			_flags |= hasValueInherits ? Flags.ValueInherits : Flags.None;
+			_flags |= hasValueDoesNotInherits ? Flags.ValueDoesNotInherit : Flags.None;
+			_flags |= hasInherits ? Flags.Inherits : Flags.None;
 		}
 
 		private object? GetDefaultValue()
@@ -318,6 +318,15 @@ namespace Windows.UI.Xaml
 		private bool HasDefaultValueSet
 			=> (_flags & Flags.DefaultValueSet) != 0;
 
+		internal bool HasValueInherits
+			=> (_flags & Flags.ValueInherits) != 0;
+
+		internal bool HasValueDoesNotInherit
+			=> (_flags & Flags.ValueDoesNotInherit) != 0;
+
+		internal bool HasInherits
+			=> (_flags & Flags.Inherits) != 0;
+
 		private object?[] Stack
 		{
 			get
@@ -367,6 +376,11 @@ namespace Windows.UI.Xaml
 		enum Flags
 		{
 			/// <summary>
+			/// No flag is being set
+			/// </summary>
+			None = 0,
+
+			/// <summary>
 			/// This dependency property uses weak storage for its values
 			/// </summary>
 			WeakStorage = 1 << 0,
@@ -375,6 +389,21 @@ namespace Windows.UI.Xaml
 			/// Determines if the default value has been populated
 			/// </summary>
 			DefaultValueSet = 1 << 1,
+
+			/// <summary>
+			/// Determines if the property inherits DataContext from its parent
+			/// </summary>
+			ValueInherits = 1 << 2,
+
+			/// <summary>
+			/// Determines if the property must not inherit DataContext from its parent
+			/// </summary>
+			ValueDoesNotInherit = 1 << 3,
+
+			/// <summary>
+			/// Determines if the property inherits Value from its parent
+			/// </summary>
+			Inherits = 1 << 4,
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -131,13 +131,20 @@ namespace Windows.UI.Xaml
 			// https://stackoverflow.com/a/17095534/26346
 			var isInRange = (uint)entryIndex <= (_maxId - _minId);
 
+			GetPropertyInheritanceConfiguration(
+				property: property,
+				hasInherits: out var hasInherits,
+				hasValueInherits: out var hasValueInherits,
+				hasValueDoesNotInherit: out var hasValueDoesNotInherits
+			);
+
 			if (isInRange)
 			{
 				ref var propertyEntry = ref Entries![entryIndex];
 
 				if (forceCreate && propertyEntry == null)
 				{
-					propertyEntry = new DependencyPropertyDetails(property, _ownerType);
+					propertyEntry = new DependencyPropertyDetails(property, _ownerType, hasInherits, hasValueInherits, hasValueDoesNotInherits);
 
 					if (TryResolveDefaultValueFromProviders(property, out var value))
 					{
@@ -175,7 +182,7 @@ namespace Windows.UI.Xaml
 					}
 
 					ref var propertyEntry = ref Entries![property.UniqueId - _minId];
-					propertyEntry = new DependencyPropertyDetails(property, _ownerType);
+					propertyEntry = new DependencyPropertyDetails(property, _ownerType, hasInherits, hasValueInherits, hasValueDoesNotInherits);
 					if (TryResolveDefaultValueFromProviders(property, out var value))
 					{
 						propertyEntry.SetValue(value, DependencyPropertyValuePrecedences.DefaultValue);
@@ -188,6 +195,35 @@ namespace Windows.UI.Xaml
 					return null;
 				}
 			}
+		}
+
+		private void GetPropertyInheritanceConfiguration(
+			DependencyProperty property,
+			out bool hasInherits,
+			out bool hasValueInherits,
+			out bool hasValueDoesNotInherit)
+		{
+			if (property == _templatedParentProperty
+				|| property == _dataContextProperty)
+			{
+				// TemplatedParent is a DependencyObject but does not propagate datacontext
+				hasValueInherits = false;
+				hasValueDoesNotInherit = true;
+				hasInherits = true;
+				return;
+			}
+
+			if (property.GetMetadata(_ownerType) is FrameworkPropertyMetadata propertyMetadata)
+			{
+				hasValueInherits = propertyMetadata.Options.HasValueInheritsDataContext();
+				hasValueDoesNotInherit = propertyMetadata.Options.HasValueDoesNotInheritDataContext();
+				hasInherits = propertyMetadata.Options.HasInherits();
+				return;
+			}
+
+			hasValueInherits = false;
+			hasValueDoesNotInherit = false;
+			hasInherits = false;
 		}
 
 		private bool TryResolveDefaultValueFromProviders(DependencyProperty property, out object? value)


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/10248

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change ensures that the DependencyProperty value precedence changes do not keep references to instances into inaccessible precedence levels.

This change also introduces more flags to get states of `DependencyProperty` and avoid type casts.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
