### PR TITLE
fix(ContentPresenter): Reset DataContext override on null Content

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -617,11 +617,16 @@ namespace Windows.UI.Xaml.Controls
 				ContentTemplateRoot = null;
 			}
 
-			if (newValue != null)
+			if (newValue is not null)
 			{
 				TrySetDataContextFromContent(newValue);
 
 				SetUpdateTemplate();
+			}
+			else
+			{
+				// Restore the inherited data context as it may have been overriden by TrySetDataContextFromContent
+				this.ClearValue(DataContextProperty, DependencyPropertyValuePrecedences.Local);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/10248

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures DataContext is reset properly on Content set to null, to avoid reference leaks.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
