### PR TITLE
fix(ItemsControl): Ensure containers are properly cleaned up in ItemsControl

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -684,7 +684,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		private static ContentControl[] GetPanelChildren(ListViewBase list)
 		{
 #if __ANDROID__ || __IOS__
-			return list.GetItemsPanelChildren().OfType<ContentControl>().ToArray();
+			return list
+				.GetItemsPanelChildren()
+				.OfType<ContentControl>()
+				.Where(c => c.Content is not null)
+				.ToArray();
 #else
 			return list.ItemsPanelRoot
 				.Children

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -376,7 +376,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.ItemsSource = source;
 
-			await WindowHelper.WaitFor(() => GetPanelChildren(SUT).Length == 2);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(SUT).Length == 2);
 			var si = SUT.ContainerFromItem(source[0]) as SelectorItem;
 			Assert.AreEqual("item 1", si.Content);
 			Assert.AreSame(si, source[0]);
@@ -609,22 +609,22 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.ItemsSource = source;
 
-			await WindowHelper.WaitFor(() => GetPanelChildren(SUT).Length == 2);
+			await WindowHelper.WaitFor(() => GetAllPanelChildren(SUT).Length == 2);
 
 			var si = SUT.ContainerFromItem(source[0]) as SelectorItem;
 			Assert.AreEqual("item 1", si.Content);
 
 			source.RemoveAt(1);
 
-			await WindowHelper.WaitFor(() => GetPanelChildren(SUT).Length == 1);
+			await WindowHelper.WaitFor(() => GetAllPanelChildren(SUT).Length == 1);
 
 			var newTwo = new ListViewItem { Content = "item 2" };
 			Assert.AreNotEqual(oldTwo, newTwo);
 
 			source.Add(newTwo);
 
-			await WindowHelper.WaitFor(() => GetPanelChildren(SUT).Length == 2);
-			Assert.AreEqual(newTwo, GetPanelChildren(SUT).Last());
+			await WindowHelper.WaitFor(() => GetAllPanelChildren(SUT).Length == 2);
+			Assert.AreEqual(newTwo, GetAllPanelChildren(SUT).Last());
 		}
 
 		[TestMethod]
@@ -681,9 +681,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitFor(() => (lvi = page.SubjectListView.ContainerFromItem("One") as ListViewItem) != null);
 		}
 
-		private static ContentControl[] GetPanelChildren(ListViewBase list)
+		private static ContentControl[] GetPanelVisibleChildren(ListViewBase list)
 		{
 #if __ANDROID__ || __IOS__
+			return list
+				.GetItemsPanelChildren()
+				.OfType<ContentControl>()
+				.ToArray();
+#else
+			return list.ItemsPanelRoot
+				.Children
+				.OfType<ContentControl>()
+				.Where(c => c.Visibility == Visibility.Visible) // Managed ItemsStackPanel currently uses the dirty trick of leaving reyclable items attached to panel and collapsed
+				.ToArray();
+#endif
+		}
+
+		private static ContentControl[] GetAllPanelChildren(ListViewBase list)
+		{
+#if __ANDROID__
+			return list
+				.GetItemsPanelChildren()
+				.OfType<ContentControl>()
+				.ToArray();
+#elif __IOS__
 			return list
 				.GetItemsPanelChildren()
 				.OfType<ContentControl>()
@@ -1110,7 +1131,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			using var _ = new AssertionScope();
 
@@ -1136,7 +1157,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 1);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 1);
 
 			var container = list.ContainerFromItem(item);
 			Assert.AreEqual(list, ItemsControl.ItemsControlFromItemContainer(container));
@@ -1156,7 +1177,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 1);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 1);
 
 			var container = list.ContainerFromIndex(0);
 			Assert.AreEqual(list, ItemsControl.ItemsControlFromItemContainer(container));
@@ -1176,7 +1197,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 1);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 1);
 
 			Assert.AreEqual(list, ItemsControl.ItemsControlFromItemContainer(item));
 		}
@@ -1194,7 +1215,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 1);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 1);
 
 			var container = list.ContainerFromItem(items[0]);
 			Assert.AreEqual(list, ItemsControl.ItemsControlFromItemContainer(container));
@@ -1213,7 +1234,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 1);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 1);
 
 			var container = list.ContainerFromIndex(0);
 			Assert.AreEqual(list, ItemsControl.ItemsControlFromItemContainer(container));
@@ -1236,7 +1257,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			// Item removal
 
@@ -1291,7 +1312,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			// Item removal
 
@@ -1350,7 +1371,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			// Item change
 			var oldItem = items[1];
@@ -1409,7 +1430,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			// Item change
 			var newItems = new ObservableCollection<ListViewItem>()
@@ -1461,7 +1482,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			using var _ = new AssertionScope();
 
@@ -1490,7 +1511,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			// Item removal
 
@@ -1546,7 +1567,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			// Item removal
 
@@ -1609,7 +1630,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			// Item change
 			var oldItem = items[1];
@@ -1679,7 +1700,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			list.ItemsSource = items;
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			// Item change
 			var newItems = new ObservableCollection<int>()
@@ -1852,7 +1873,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForLoaded(list);
-			await WindowHelper.WaitFor(() => GetPanelChildren(list).Length == 4);
+			await WindowHelper.WaitFor(() => GetPanelVisibleChildren(list).Length == 4);
 
 			list.SelectionChanged += (s, e) =>
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1121,6 +1121,9 @@ namespace Windows.UI.Xaml.Controls
 					break;
 
 			}
+
+			var isOwnContainer = ReferenceEquals(element, item);
+
 			ClearContainerForItemOverride(element, item);
 			ContainerClearedForItem(item, element as SelectorItem);
 
@@ -1141,6 +1144,12 @@ namespace Windows.UI.Xaml.Controls
 			else if (element is ContentControl contentControl)
 			{
 				contentControl.ClearValue(DataContextProperty);
+
+				if (!isOwnContainer)
+				{
+					// Clears value set in PrepareContainerForItemOverride
+					element.ClearValue(ContentControl.ContentProperty);
+				}
 
 				if (contentControl.ContentTemplate is { } ct && ct == ItemTemplate)
 				{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -593,6 +593,7 @@ namespace Windows.UI.Xaml.Controls
 					Refresh();
 					break;
 				case NotifyCollectionChangedAction.Reset:
+					CleanUpAllContainers();
 					Refresh();
 					break;
 			}
@@ -678,6 +679,16 @@ namespace Windows.UI.Xaml.Controls
 				containerPair.Key.SetValue(ItemsControl.IndexForItemContainerProperty, containerPair.Value);
 			}
 			_containersForIndexRepair.Clear();
+		}
+
+		private void CleanUpAllContainers()
+		{
+			if (ShouldItemsControlManageChildren) return;
+
+			foreach (var container in MaterializedContainers)
+			{
+				CleanUpContainer(container);
+			}
 		}
 
 		private void CleanUpContainers(int startingIndex, int length)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
@@ -146,9 +146,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (NativePanel != null)
 			{
-				return NativePanel.IndexPathsForVisibleItems
-						.OrderBy(p => p.ToIndexPath())
-						.Select(NativePanel.CellForItem)
+				return NativePanel
+						.Subviews
 						.OfType<ListViewBaseInternalContainer>()
 						.Select(cell => cell.Content)
 						.Trim();

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -260,7 +260,7 @@ namespace Windows.UI.Xaml.Controls
 
 				// We know that the scroll is outside the available
 				// breath, so all lines can be recycled
-				ClearLines();
+				ClearLines(clearContainer: false);
 
 				// Set the seed start to use the approximate position of
 				// the line based on the average line height.
@@ -514,7 +514,7 @@ namespace Windows.UI.Xaml.Controls
 				while (firstMaterializedLine != null && GetMeasuredEnd(firstMaterializedLine.FirstView) < ExtendedViewportStart + extentAdjustment)
 				{
 					// Dematerialize lines that are entirely outside extended viewport
-					RecycleLine(firstMaterializedLine);
+					RecycleLine(firstMaterializedLine, clearContainer: false);
 					_materializedLines.RemoveFromFront();
 					firstMaterializedLine = GetFirstMaterializedLine();
 				}
@@ -526,7 +526,7 @@ namespace Windows.UI.Xaml.Controls
 				while (lastMaterializedLine != null && GetMeasuredStart(lastMaterializedLine.FirstView) > ExtendedViewportEnd + extentAdjustment)
 				{
 					// Dematerialize lines that are entirely outside extended viewport
-					RecycleLine(lastMaterializedLine);
+					RecycleLine(lastMaterializedLine, clearContainer: false);
 					_materializedLines.RemoveFromBack();
 					lastMaterializedLine = GetLastMaterializedLine();
 				}
@@ -536,11 +536,12 @@ namespace Windows.UI.Xaml.Controls
 		/// <summary>
 		/// Recycle all views for a given line.
 		/// </summary>
-		private void RecycleLine(Line line)
+		/// <param name="clearContainer">cleanup the container when an associated item is removed</param>
+		private void RecycleLine(Line line, bool clearContainer)
 		{
 			for (int i = 0; i < line.Items.Length; i++)
 			{
-				Generator.RecycleViewForItem(line.Items[i].container, line.FirstItemFlat + i);
+				Generator.RecycleViewForItem(line.Items[i].container, line.FirstItemFlat + i, clearContainer);
 			}
 		}
 
@@ -798,7 +799,7 @@ namespace Windows.UI.Xaml.Controls
 				this.Log().LogDebug($"{GetMethodTag()}");
 			}
 
-			ClearLines();
+			ClearLines(clearContainer: true);
 
 			UpdateCompleted();
 			Generator.ClearIdCache();
@@ -806,7 +807,7 @@ namespace Windows.UI.Xaml.Controls
 			OwnerPanel?.InvalidateMeasure();
 		}
 
-		private void ClearLines()
+		private void ClearLines(bool clearContainer)
 		{
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
@@ -815,7 +816,7 @@ namespace Windows.UI.Xaml.Controls
 
 			foreach (var line in _materializedLines)
 			{
-				RecycleLine(line);
+				RecycleLine(line, clearContainer);
 			}
 			_materializedLines.Clear();
 		}

--- a/src/Uno.UWP/Devices/Enumeration/Internal/Providers/Midi/MidiDeviceClassProviderBase.Android.cs
+++ b/src/Uno.UWP/Devices/Enumeration/Internal/Providers/Midi/MidiDeviceClassProviderBase.Android.cs
@@ -74,7 +74,6 @@ namespace Uno.Devices.Enumeration.Internal.Providers.Midi
 			_watchMidiManager?.UnregisterDeviceCallback(_deviceCallback);
 			_deviceCallback?.Dispose();
 			_deviceCallback = null;
-			_watchMidiManager?.Dispose();
 			_watchMidiManager = null;
 			WatchStopped?.Invoke(this, null);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/10248

**Note: This PR depends on https://github.com/unoplatform/uno/pull/11237 and https://github.com/unoplatform/uno/pull/11234**

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change ensures that `ItemsControl.CleanUpContainer` mirrors the behavior of `PrepareContainerForItemOverride` to avoid memory leaks.