### PR TITLE
chore: Avoid calling Contains+Add inside BindableTypeProvidersGenerationTask

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -196,7 +196,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 					GenerateTypeTable(writer);
 
 					writer.AppendLineIndented(@"#if DEBUG && !UNO_DISABLE_KNOWN_MISSING_TYPES");
-					writer.AppendLineIndented(@"private global::System.Collections.Generic.List<global::System.Type> _knownMissingTypes = new global::System.Collections.Generic.List<global::System.Type>();");
+					writer.AppendLineIndented(@"private global::System.Collections.Generic.HashSet<global::System.Type> _knownMissingTypes = new global::System.Collections.Generic.HashSet<global::System.Type>();");
 					writer.AppendLineIndented(@"#endif");
 				}
 			}
@@ -605,12 +605,14 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 					writer.AppendLineIndented(@"var bindableType = GetBindableTypeByFullName(type.FullName);");
 
 					writer.AppendLineIndented(@"#if DEBUG && !UNO_DISABLE_KNOWN_MISSING_TYPES");
-					using (writer.BlockInvariant(@"lock(_knownMissingTypes)"))
 					{
-						using (writer.BlockInvariant(@"if(bindableType == null && !_knownMissingTypes.Contains(type) && !type.IsGenericType && !type.IsAbstract)"))
+						using (writer.BlockInvariant(@"if(bindableType == null && !type.IsGenericType && !type.IsAbstract)"))
 						{
-							writer.AppendLineIndented(@"_knownMissingTypes.Add(type);");
-							writer.AppendLineIndented(@"Debug.WriteLine($""The Bindable attribute is missing and the type [{type.FullName}] is not known by the MetadataProvider. Reflection was used instead of the binding engine and generated static metadata. Add the Bindable attribute to prevent this message and performance issues."");");
+							using (writer.BlockInvariant(@"lock(_knownMissingTypes)"))
+							using (writer.BlockInvariant(@"if (_knownMissingTypes.Add(type))"))
+							{
+								writer.AppendLineIndented(@"Debug.WriteLine($""The Bindable attribute is missing and the type [{type.FullName}] is not known by the MetadataProvider. Reflection was used instead of the binding engine and generated static metadata. Add the Bindable attribute to prevent this message and performance issues."");");
+							}
 						}
 					}
 					writer.AppendLineIndented(@"#endif");

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -605,14 +605,12 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 					writer.AppendLineIndented(@"var bindableType = GetBindableTypeByFullName(type.FullName);");
 
 					writer.AppendLineIndented(@"#if DEBUG && !UNO_DISABLE_KNOWN_MISSING_TYPES");
+					using (writer.BlockInvariant(@"if(bindableType == null && !type.IsGenericType && !type.IsAbstract)"))
 					{
-						using (writer.BlockInvariant(@"if(bindableType == null && !type.IsGenericType && !type.IsAbstract)"))
+						using (writer.BlockInvariant(@"lock(_knownMissingTypes)"))
+						using (writer.BlockInvariant(@"if (_knownMissingTypes.Add(type))"))
 						{
-							using (writer.BlockInvariant(@"lock(_knownMissingTypes)"))
-							using (writer.BlockInvariant(@"if (_knownMissingTypes.Add(type))"))
-							{
-								writer.AppendLineIndented(@"Debug.WriteLine($""The Bindable attribute is missing and the type [{type.FullName}] is not known by the MetadataProvider. Reflection was used instead of the binding engine and generated static metadata. Add the Bindable attribute to prevent this message and performance issues."");");
-							}
+							writer.AppendLineIndented(@"Debug.WriteLine($""The Bindable attribute is missing and the type [{type.FullName}] is not known by the MetadataProvider. Reflection was used instead of the binding engine and generated static metadata. Add the Bindable attribute to prevent this message and performance issues."");");
 						}
 					}
 					writer.AppendLineIndented(@"#endif");


### PR DESCRIPTION
by using a `HashSet`, where `Add` tells you if the value was present.

The time spent under the lock is smaller, so it should have a positive, if minimal, performance impact (but only in debug builds).

GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Code calls `Contains` and, if negative, calls `Add` on a collection.

## What is the new behavior?

Code calls `Add` on `HashSet` and the results tells us if it was already present (or not). Shorten the time spent under the lock.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
