### PR TITLE
ci: Remove MidiDeviceEnumerationTests from snapshot tests

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_Devices/Midi/MidiDeviceEnumeration.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/Midi/MidiDeviceEnumeration.xaml.cs
@@ -14,7 +14,7 @@ using Windows.UI.Xaml.Controls;
 namespace UITests.Shared.Windows_Devices.Midi
 {
 	// Based on https://github.com/microsoft/Windows-universal-samples/blob/master/Samples/MIDI/cs/Scenario1_MIDIDeviceEnumeration.xaml.cs
-	[SampleControlInfo("Windows.Devices", "Midi_DeviceEnumeration", description: "Sample for enumeration of MIDI devices")]
+	[SampleControlInfo("Windows.Devices", "Midi_DeviceEnumeration", description: "Sample for enumeration of MIDI devices", ignoreInSnapshotTests: true)]
 	public sealed partial class MidiDeviceEnumerationTests : UserControl
 	{
 		/// <summary>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Removes MidiDeviceEnumerationTests from snapshots tests temporarily to troubleshoot potential stack overflow with Android 28 in `resetResolvedLayoutDirection`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
