### PR TITLE
fix Gridview dynamic item width is not respected

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
@@ -15,11 +15,76 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if HAS_UNO
 	[TestClass]
 	[RunsOnUIThread]
-#if !__IOS__
-	[Ignore]
 #endif
 	public class Given_GridView_Items
 	{
+		[TestMethod]
+		public async Task When_GridViewItems_WillRespect_ItemsWidth()
+		{
+			var gridView = new GridView
+			{
+				ItemContainerStyle = TestsResourceHelper.GetResource<Style>("MyGridViewItemStyle")
+			};
+
+			var gvi = new GridViewItem();
+			var gvi2 = new GridViewItem();
+
+			gridView.ItemsSource = new[] { gvi, gvi2 };
+
+			var itemWrap = new ItemsWrapGrid()
+			{
+				MaximumRowsOrColumns = 2,
+				Orientation = Orientation.Horizontal,
+				ItemWidth = 30
+			};
+
+			var itemTemplate = new ItemsPanelTemplate(() => itemWrap);
+
+			gridView.SetValue(ItemsControl.ItemsPanelProperty, itemTemplate);
+
+			WindowHelper.WindowContent = gridView;
+			await WindowHelper.WaitForLoaded(gridView);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(30, gvi2.LayoutSlot.Width);
+		}
+
+		[TestMethod]
+		public async Task When_GridViewItems_ItemsWidthChanges_Refresh_Layout()
+		{
+			var gridView = new GridView
+			{
+				ItemContainerStyle = TestsResourceHelper.GetResource<Style>("MyGridViewItemStyle")
+			};
+
+			var gvi = new GridViewItem();
+			var gvi2 = new GridViewItem();
+
+			gridView.ItemsSource = new[] { gvi, gvi2 };
+
+			var itemWrap = new ItemsWrapGrid()
+			{
+				MaximumRowsOrColumns = 2,
+				Orientation = Orientation.Horizontal,
+				ItemWidth = 30
+			};
+
+			var itemTemplate = new ItemsPanelTemplate(() => itemWrap);
+
+			gridView.SetValue(GridViewVariableSizeBehavior.ShouldResizeProperty, true);
+			gridView.SetValue(ItemsControl.ItemsPanelProperty, itemTemplate);
+
+			WindowHelper.WindowContent = gridView;
+			await WindowHelper.WaitForLoaded(gridView);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(gridView.ActualWidth / 2, gvi2.LayoutSlot.Width, 1);
+		}
+
+
+#if !__IOS__
+		[Ignore]
+#endif
 		[TestMethod]
 		public async Task When_GridViewItems_LayoutSlots()
 		{
@@ -74,5 +139,45 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			gvi2.LayoutSlotWithMarginsAndAlignments);
 		}
 	}
-#endif
+
+	#region Helper Behaviour Class
+	public class GridViewVariableSizeBehavior
+	{
+		public static bool GetShouldResize(DependencyObject obj) => (bool)obj.GetValue(ShouldResizeProperty);
+
+		public static void SetShouldResize(DependencyObject obj, bool value) => obj.SetValue(ShouldResizeProperty, value);
+
+		public static readonly DependencyProperty ShouldResizeProperty =
+			DependencyProperty.RegisterAttached(
+				"ShouldResize",
+				typeof(bool),
+				typeof(GridViewVariableSizeBehavior),
+				new PropertyMetadata(false, OnShouldResizeChanged));
+
+		private static void OnShouldResizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			if (d is GridView gridView)
+			{
+				if (e.NewValue is bool shouldResize && shouldResize)
+				{
+					gridView.SizeChanged += GridView_SizeChanged;
+				}
+				else
+				{
+					gridView.SizeChanged -= GridView_SizeChanged;
+				}
+			}
+		}
+
+		private static void GridView_SizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			if (sender is GridView gridView && gridView?.ItemsPanelRoot is ItemsWrapGrid wrapGrid)
+			{
+				var width = (e.NewSize.Width - gridView.Padding.Left - gridView.Padding.Right) / Math.Max(wrapGrid.MaximumRowsOrColumns, 1);
+				wrapGrid.ItemWidth = width;
+			}
+		}
+	}
+	#endregion
+
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
@@ -84,7 +84,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 #if !__IOS__
-	[Ignore]
+		[Ignore]
 #endif
 		[TestMethod]
 		public async Task When_GridViewItems_LayoutSlots()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
@@ -15,6 +15,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if HAS_UNO
 	[TestClass]
 	[RunsOnUIThread]
+#if !__IOS__ && !__ANDROID__
+	[Ignore]
 #endif
 	public class Given_GridView_Items
 	{
@@ -81,9 +83,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(gridView.ActualWidth / 2, gvi2.LayoutSlot.Width, 1);
 		}
 
-
 #if !__IOS__
-		[Ignore]
+	[Ignore]
 #endif
 		[TestMethod]
 		public async Task When_GridViewItems_LayoutSlots()
@@ -139,7 +140,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			gvi2.LayoutSlotWithMarginsAndAlignments);
 		}
 	}
-
 	#region Helper Behaviour Class
 	public class GridViewVariableSizeBehavior
 	{
@@ -179,5 +179,5 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 	}
 	#endregion
-
+#endif
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_GridView_Items.cs
@@ -20,6 +20,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 	public class Given_GridView_Items
 	{
+#if !__ANDROID__
+		[Ignore]
+#endif
 		[TestMethod]
 		public async Task When_GridViewItems_WillRespect_ItemsWidth()
 		{
@@ -51,6 +54,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(30, gvi2.LayoutSlot.Width);
 		}
 
+#if !__ANDROID__
+		[Ignore]
+#endif
 		[TestMethod]
 		public async Task When_GridViewItems_ItemsWidthChanges_Refresh_Layout()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGrid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGrid.cs
@@ -17,7 +17,6 @@ namespace Windows.UI.Xaml.Controls
 #if XAMARIN_ANDROID
 		public int FirstCacheIndex => _layout.XamlParent.NativePanel.ViewCache.FirstCacheIndex;
 		public int LastCacheIndex => _layout.XamlParent.NativePanel.ViewCache.LastCacheIndex;
-#endif
 
 		partial void OnItemWidthChangedPartial(double oldItemWidth, double newItemWidth)
 		{
@@ -28,7 +27,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			_layout?.Refresh();
 		}
-
+#endif
 		public ItemsWrapGrid()
 		{
 			if (FeatureConfiguration.ListViewBase.DefaultCacheLength.HasValue)

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGrid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGrid.cs
@@ -19,6 +19,16 @@ namespace Windows.UI.Xaml.Controls
 		public int LastCacheIndex => _layout.XamlParent.NativePanel.ViewCache.LastCacheIndex;
 #endif
 
+		partial void OnItemWidthChangedPartial(double oldItemWidth, double newItemWidth)
+		{
+			_layout?.Refresh();
+		}
+
+		partial void OnItemHeightChangedPartial(double oldItemHeight, double newItemHeight)
+		{
+			_layout?.Refresh();
+		}
+
 		public ItemsWrapGrid()
 		{
 			if (FeatureConfiguration.ListViewBase.DefaultCacheLength.HasValue)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11055

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
Setting the ItemWidth for the GridViewItem is not respecting the size

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
