### PR TITLE
fix!: Remove `[Get|Set][Left|Top|ZIndex]` methods that take DependencyObject from `Canvas`

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -9484,6 +9484,12 @@
 			<Member fullName="System.Void Windows.UI.Xaml.Controls.WebView.NavigateWithHttpRequestMessage(System.Net.Http.HttpRequestMessage requestMessage)" reason="Api alignments" />
 			<Member fullName="System.Boolean Uno.Devices.Sensors.INativeDualScreenProvider.get_IsDualScreen()" reason="Api alignments" />
 			<Member fullName="System.Boolean Windows.UI.Xaml.Controls.WebView.MustUseWebKitWebView()" reason="Api alignments" />
+			<Member fullName="System.Double Windows.UI.Xaml.Controls.Canvas.GetLeft(Windows.UI.Xaml.DependencyObject obj)" reason="Api alignments" />
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Canvas.SetLeft(Windows.UI.Xaml.DependencyObject obj, System.Double value)" reason="Api alignments" />
+			<Member fullName="System.Double Windows.UI.Xaml.Controls.Canvas.GetTop(Windows.UI.Xaml.DependencyObject obj)" reason="Api alignments" />
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Canvas.SetTop(Windows.UI.Xaml.DependencyObject obj, System.Double value)" reason="Api alignments" />
+			<Member fullName="System.Double Windows.UI.Xaml.Controls.Canvas.GetZIndex(Windows.UI.Xaml.DependencyObject obj)" reason="Api alignments" />
+			<Member fullName="System.Void Windows.UI.Xaml.Controls.Canvas.SetZIndex(Windows.UI.Xaml.DependencyObject obj, System.Double value)" reason="Api alignments" />
 		</Methods>
 	</IgnoreSet>
 

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/CanvasTests/Given_Canvas.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/CanvasTests/Given_Canvas.cs
@@ -84,7 +84,7 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.CanvasTests
 			Assert.AreEqual(42d, SUT.GetValue(Canvas.TopProperty));
 
 			SUT.SetValue(Canvas.ZIndexProperty, "42");
-			Assert.AreEqual(42d, SUT.GetValue(Canvas.ZIndexProperty));
+			Assert.AreEqual(42, SUT.GetValue(Canvas.ZIndexProperty));
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.Android.cs
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Controls
 
 				var sorted = Children
 					.Select((view, childrenIndex) => (view, childrenIndex))
-					.OrderBy(tpl => tpl.view is DependencyObject obj ? Canvas.GetZIndex(obj) : 0); // Note: this has to be a stable sort
+					.OrderBy(tpl => tpl.view is UIElement obj ? Canvas.GetZIndex(obj) : 0); // Note: this has to be a stable sort
 
 				var drawOrder = 0;
 				foreach (var tpl in sorted)

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.Layout.cs
@@ -45,19 +45,19 @@ namespace Windows.UI.Xaml.Controls
 			{
 				if (child is _View childView)
 				{
-					var childAsDO = child as DependencyObject;
+					var childAsUIElement = child as UIElement;
 					var desiredSize = GetElementDesiredSize(childView);
 
 					var childRect = new Rect
 					{
-						X = GetLeft(childAsDO),
-						Y = GetTop(childAsDO),
+						X = GetLeft(childAsUIElement),
+						Y = GetTop(childAsUIElement),
 						Width = desiredSize.Width,
 						Height = desiredSize.Height,
 					};
 
 #if __IOS__
-					child.Layer.ZPosition = (nfloat)GetZIndex(childAsDO);
+					child.Layer.ZPosition = (nfloat)GetZIndex(childAsUIElement);
 #endif
 
 					ArrangeElement(child, childRect);

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
@@ -66,7 +66,7 @@ namespace Windows.UI.Xaml.Controls
 
 		#region ZIndex
 
-		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true, Options = FrameworkPropertyMetadataOptions.AutoConvert)]
+		[GeneratedDependencyProperty(DefaultValue = 0, AttachedBackingFieldOwner = typeof(UIElement), Attached = true, Options = FrameworkPropertyMetadataOptions.AutoConvert)]
 		public static DependencyProperty ZIndexProperty { get; } = CreateZIndexProperty();
 
 		private static void OnZIndexChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Canvas/Canvas.cs
@@ -22,13 +22,6 @@ namespace Windows.UI.Xaml.Controls
 	{
 		#region Left
 
-		public static double GetLeft(DependencyObject obj)
-			=> GetLeftValue(obj);
-
-		public static void SetLeft(DependencyObject obj, double value)
-			=> SetLeftValue(obj, value);
-
-
 		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true, Options = FrameworkPropertyMetadataOptions.AutoConvert | FrameworkPropertyMetadataOptions.AffectsArrange)]
 		public static DependencyProperty LeftProperty { get; } = CreateLeftProperty();
 
@@ -51,12 +44,6 @@ namespace Windows.UI.Xaml.Controls
 
 		#region Top
 
-		public static double GetTop(DependencyObject obj)
-			=> GetTopValue(obj);
-
-		public static void SetTop(DependencyObject obj, double value)
-			=> SetTopValue(obj, value);
-
 		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true, Options = FrameworkPropertyMetadataOptions.AutoConvert | FrameworkPropertyMetadataOptions.AffectsArrange)]
 		public static DependencyProperty TopProperty { get; } = CreateTopProperty();
 
@@ -78,12 +65,6 @@ namespace Windows.UI.Xaml.Controls
 		#endregion
 
 		#region ZIndex
-
-		public static double GetZIndex(DependencyObject obj)
-			=> GetZIndexValue(obj);
-
-		public static void SetZIndex(DependencyObject obj, double value)
-			=> SetZIndexValue(obj, value);
 
 		[GeneratedDependencyProperty(DefaultValue = 0.0d, AttachedBackingFieldOwner = typeof(UIElement), Attached = true, Options = FrameworkPropertyMetadataOptions.AutoConvert)]
 		public static DependencyProperty ZIndexProperty { get; } = CreateZIndexProperty();
@@ -111,16 +92,16 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void InitializePartial();
 
-		public static double GetLeft(global::Windows.UI.Xaml.UIElement element) => GetLeft((DependencyObject)element);
+		public static double GetLeft(global::Windows.UI.Xaml.UIElement element) => GetLeftValue(element);
 
-		public static void SetLeft(global::Windows.UI.Xaml.UIElement element, double length) => SetLeft((DependencyObject)element, length);
+		public static void SetLeft(global::Windows.UI.Xaml.UIElement element, double length) => SetLeftValue(element, length);
 
-		public static double GetTop(global::Windows.UI.Xaml.UIElement element) => GetTop((DependencyObject)element);
+		public static double GetTop(global::Windows.UI.Xaml.UIElement element) => GetTopValue(element);
 
-		public static void SetTop(global::Windows.UI.Xaml.UIElement element, double length) => SetTop((DependencyObject)element, length);
+		public static void SetTop(global::Windows.UI.Xaml.UIElement element, double length) => SetTopValue(element, length);
 
-		public static int GetZIndex(global::Windows.UI.Xaml.UIElement element) => (int)GetZIndex((DependencyObject)element);
+		public static int GetZIndex(global::Windows.UI.Xaml.UIElement element) => GetZIndexValue(element);
 
-		public static void SetZIndex(global::Windows.UI.Xaml.UIElement element, int value) => SetZIndex((DependencyObject)element, value);
+		public static void SetZIndex(global::Windows.UI.Xaml.UIElement element, int value) => SetZIndexValue(element, value);
 	}
 }


### PR DESCRIPTION
BREAKING CHANGE: `GetLeft`, `GetTop`, `SetLeft`, `SetTop`, `GetZIndex`, and `SetZIndex` overloads that take DependencyObject are now removed. The UIElement overloads should be used instead.

GitHub Issue (If applicable): #8339

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
