### PR TITLE
feat: Bump UWPSyncGenerator version

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -82,6 +82,7 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <!-- When updating this in the future, please also update CSharpLangVersion constant in src\Uno.UWPSyncGenerator\Generator.cs -->
     <LangVersion>11.0</LangVersion>
 
     <!-- Roslyn generation is enabled by default for all uno projects (inside uno.ui only) -->

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -14,7 +14,7 @@ namespace Uno.UWPSyncGenerator
 	abstract class Generator
 	{
 		private const string CSharpLangVersion = "11.0";
-		
+
 		private const string net461Define = "NET461";
 		private const string AndroidDefine = "__ANDROID__";
 		private const string iOSDefine = "__IOS__";

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -13,6 +13,8 @@ namespace Uno.UWPSyncGenerator
 {
 	abstract class Generator
 	{
+		private const string CSharpLangVersion = "11.0";
+		
 		private const string net461Define = "NET461";
 		private const string AndroidDefine = "__ANDROID__";
 		private const string iOSDefine = "__IOS__";
@@ -1755,7 +1757,7 @@ namespace Uno.UWPSyncGenerator
 								//{ "BuildingInsideVisualStudio", "true" },
 								{ "SkipUnoResourceGeneration", "true" }, // Required to avoid loading a non-existent task
 								{ "DocsGeneration", "true" }, // Detect that source generation is running
-								{ "LangVersion", "8.0" },
+								{ "LangVersion", CSharpLangVersion },
 								//{ "DesignTimeBuild", "true" },
 								//{ "UseHostCompilerIfAvailable", "false" },
 								//{ "UseSharedCompilation", "false" },


### PR DESCRIPTION
**Thanks @Youssef1313 for finding this!**

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

Currently Sync generator does not take into account global usings. which can cause trouble.

## What is the new behavior?

Bumped C# version to 11.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
