### PR TITLE
fix(CameraCaptureUI): Fix crash on net6.0+

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
+++ b/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
@@ -7,6 +7,9 @@
 	<uses-permission android:name="android.permission.READ_CONTACTS" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.BLUETOOTH" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+	<uses-permission android:name="android.permission.CAMERA"/>
+
 	<!-- NOTE: Uncomment the following to test the use of custom tabs for the WebAuthenticationBroker -->
 	<!--<queries>
 		<intent>

--- a/src/SamplesApp/SamplesApp.Droid/Properties/AssemblyInfo.cs
+++ b/src/SamplesApp/SamplesApp.Droid/Properties/AssemblyInfo.cs
@@ -40,3 +40,5 @@ using Android.App;
 [assembly: UsesPermission("android.permission.MANAGE_EXTERNAL_STORAGE")]
 [assembly: UsesPermission("android.permission.MANAGE_MEDIA")]
 [assembly: UsesPermission("android.permission.USE_FULL_SCREEN_INTENT")]
+[assembly: UsesPermission("android.permission.WRITE_EXTERNAL_STORAGE")]
+[assembly: UsesPermission("android.permission.CAMERA")]

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -550,6 +550,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_Media\CameraCaptureUISample.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_Media\MediaPlayerTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5335,6 +5339,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Graphics_Display\DisplayInformationTests.xaml.cs">
       <DependentUpon>DisplayInformationTests.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_Media\CameraCaptureUISample.xaml.cs">
+      <DependentUpon>CameraCaptureUISample.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Media\MediaPlayerTests.xaml.cs">
       <DependentUpon>MediaPlayerTests.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_Media/CameraCaptureUISample.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Media/CameraCaptureUISample.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+    x:Class="UITests.Windows_Media.CameraCaptureUISample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_Media"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:android="http://platform.uno/android"
+	xmlns:ios="http://platform.uno/android"
+    mc:Ignorable="d android ios"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+		<android:Button Content="Capture Image" Click="CaptureButton_Click" />
+		<ios:Button Content="Capture Image" Click="CaptureButton_Click" />
+		<Image x:Name="ImageControl" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_Media/CameraCaptureUISample.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Media/CameraCaptureUISample.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Uno.UI.Samples.Controls;
+using Windows.Media.Capture;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace UITests.Windows_Media;
+
+[Sample("CameraCapture", IsManualTest = true)]
+public sealed partial class CameraCaptureUISample : Page
+{
+	public CameraCaptureUISample()
+	{
+		this.InitializeComponent();
+	}
+
+#if __ANDROID__ || __IOS__
+	private async void CaptureButton_Click(object sender, RoutedEventArgs e)
+	{
+		try
+		{
+			var captureUI = new CameraCaptureUI();
+
+			var file = await captureUI.CaptureFileAsync(CameraCaptureUIMode.Photo);
+
+			if (file != null)
+			{
+				using var stream = await file.OpenReadAsync();
+				var bitmapImage = new BitmapImage();
+				await bitmapImage.SetSourceAsync(stream);
+				ImageControl.Source = bitmapImage;
+			}
+			else
+			{
+				ImageControl.Source = null;
+			}
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Debug.WriteLine(ex);
+		}
+	}
+#endif
+}

--- a/src/Uno.UWP/Media/Capture/CameraCaptureUI.Android.cs
+++ b/src/Uno.UWP/Media/Capture/CameraCaptureUI.Android.cs
@@ -24,7 +24,6 @@ namespace Windows.Media.Capture
 	{
 		private const int CameraRequestCode = 2;
 
-
 		private async Task<StorageFile> CaptureFile(CancellationToken ct, CameraCaptureUIMode mode)
 		{
 			await ValidateRequiredPermissions(ct);
@@ -54,7 +53,7 @@ namespace Windows.Media.Capture
 
 			return await CreateTempImage(
 				ContextHelper.Current.ContentResolver.OpenInputStream(photoUri),
-				Path.GetExtension(new Uri(photoUri.Path, UriKind.RelativeOrAbsolute).LocalPath)
+				Path.GetExtension(photoUri.Path)
 			);
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9397

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

CameraCaptureUI crashes on Android when using net6.0+

## What is the new behavior?

Works properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

`photoUri.Path` looks similar to this `"/external/images/media/50"`

On MonoAndroid, `new Uri(photoUri.Path, UriKind.RelativeOrAbsolute)` will create an absolute uri prefixed with `file:///`. This is not the case for net6.0+

Then, `LocalPath` will fail on net6.0+ because it works only for absolute paths, and throws for relative paths.

The behavior on MonoAndroid ends up that `new Uri(photoUri.Path, UriKind.RelativeOrAbsolute).LocalPath` is just the same as `photoUri.Path`, so I used that directly.

Either way, this path doesn't have any extension and the `Path.GetExtension(...)` call is always empty string. I could go ahead and use empty string directly, but I preferred to keep the existing `GetExtension` call.