### PR TITLE
fix(gtk): Ensure that harfbuzz is eagerly loaded to avoid system versions interference

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.HarfbuzzPreload.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.HarfbuzzPreload.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.IO;
+using Uno.Foundation.Logging;
+using Windows.UI.Xaml;
+using System.Runtime.InteropServices;
+
+namespace Uno.UI.Runtime.Skia
+{
+	public partial class GtkHost : ISkiaHost
+	{
+		private void PreloadHarfBuzz()
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			{
+				// Here, we preload libHarfBuzzSharp.so using the RTLD_DEEPBIND flag, so that
+				// is loaded with its static dependencies, and not the ones from the system, particularly
+				// libharfbuzz.so.0, which is not compatible with the one used by SkiaSharp.
+				//
+				// We use the runtime's native search directories (https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing#unmanaged-native-library-probing)
+				// to look for the runtime-provided binaries.
+				//
+				// See https://github.com/unoplatform/uno/issues/9793 for research on the topic.
+
+				var search = AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES")?.ToString() ?? "";
+
+				foreach (var path in search.Split(Path.PathSeparator))
+				{
+					var libPath = Path.Combine(path, "libHarfBuzzSharp.so");
+
+					if (File.Exists(libPath))
+					{
+						if (Linux.dlopen(libPath, true) != IntPtr.Zero)
+						{
+							if (this.Log().IsEnabled(LogLevel.Trace))
+							{
+								this.Log().Trace($"Loaded eagerly: {libPath}");
+							}
+							break;
+						}
+					}
+				}
+
+				if (this.Log().IsEnabled(LogLevel.Trace))
+				{
+					this.Log().Trace($"Could not load eagerly: libHarfBuzzSharp");
+				}
+			}
+		}
+
+		// Imported from https://github.com/mono/SkiaSharp/blob/482e6ee2913a08a7cad76520ccf5fbce97c7c23b/binding/Binding.Shared/LibraryLoader.cs
+		private static class Linux
+		{
+			private const string SystemLibrary = "libdl.so";
+			private const string SystemLibrary2 = "libdl.so.2"; // newer Linux distros use this
+
+			private const int RTLD_LAZY = 1;
+			private const int RTLD_NOW = 2;
+			private const int RTLD_DEEPBIND = 8;
+
+			private static bool UseSystemLibrary2 = true;
+
+			public static IntPtr dlopen(string path, bool lazy = true)
+			{
+				try
+				{
+					return dlopen2(path, (lazy ? RTLD_LAZY : RTLD_NOW) | RTLD_DEEPBIND);
+				}
+				catch (DllNotFoundException)
+				{
+					UseSystemLibrary2 = false;
+					return dlopen1(path, (lazy ? RTLD_LAZY : RTLD_NOW) | RTLD_DEEPBIND);
+				}
+			}
+
+			public static IntPtr dlsym(IntPtr handle, string symbol)
+			{
+				return UseSystemLibrary2 ? dlsym2(handle, symbol) : dlsym1(handle, symbol);
+			}
+
+			public static void dlclose(IntPtr handle)
+			{
+				if (UseSystemLibrary2)
+					dlclose2(handle);
+				else
+					dlclose1(handle);
+			}
+
+			[DllImport(SystemLibrary, EntryPoint = "dlopen")]
+			private static extern IntPtr dlopen1(string path, int mode);
+			[DllImport(SystemLibrary, EntryPoint = "dlsym")]
+			private static extern IntPtr dlsym1(IntPtr handle, string symbol);
+			[DllImport(SystemLibrary, EntryPoint = "dlclose")]
+			private static extern void dlclose1(IntPtr handle);
+			[DllImport(SystemLibrary2, EntryPoint = "dlopen")]
+			private static extern IntPtr dlopen2(string path, int mode);
+			[DllImport(SystemLibrary2, EntryPoint = "dlsym")]
+			private static extern IntPtr dlsym2(IntPtr handle, string symbol);
+			[DllImport(SystemLibrary2, EntryPoint = "dlclose")]
+			private static extern void dlclose2(IntPtr handle);
+		}
+
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -33,10 +33,12 @@ using Uno.Disposables;
 using System.Collections.Generic;
 using Uno.Extensions.ApplicationModel.Core;
 using Windows.ApplicationModel;
+using System.Runtime.InteropServices;
+using System.Reflection;
 
 namespace Uno.UI.Runtime.Skia
 {
-	public class GtkHost : ISkiaHost
+	public partial class GtkHost : ISkiaHost
 	{
 		private const int UnoThemePriority = 800;
 
@@ -85,7 +87,7 @@ namespace Uno.UI.Runtime.Skia
 
 		public void Run()
 		{
-			Windows.UI.Xaml.Documents.Inline.ApplyHarfbuzzWorkaround();
+			PreloadHarfBuzz();
 
 			if (!InitializeGtk())
 			{
@@ -140,6 +142,7 @@ namespace Uno.UI.Runtime.Skia
 
 			Gtk.Application.Run();
 		}
+
 
 		private bool InitializeGtk()
 		{

--- a/src/Uno.UI/UI/Xaml/Documents/Inline.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/Inline.skia.cs
@@ -160,23 +160,5 @@ namespace Windows.UI.Xaml.Documents
 
 			return new(skTypeFace, hbFont, hbFace);
 		}
-
-		/// <summary>
-		/// Apply a workaround for https://github.com/mono/SkiaSharp/issues/2113
-		/// </summary>
-		public static void ApplyHarfbuzzWorkaround()
-		{
-			// HarfBuzzSharp.Font.SetFunctionsOpenType() needs to be initialized before GtkSharp is initialized
-			// to avoid libHarfBuzzSharp's own static library to hook onto
-			// the system implementation of libHarfBuzzSharp.
-			var font = GetFont(null, FontWeights.Normal, FontStretch.Normal, FontStyle.Normal);
-
-			using HarfBuzzSharp.Buffer buffer = new();
-			buffer.ContentType = ContentType.Unicode;
-			buffer.GuessSegmentProperties();
-
-			// Force a font loading by shaping a buffer.
-			font.Font.Shape(buffer);
-		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/9793

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Eagerly load libharbuzz.so.0 to avoid incorrect binding with system provided versions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
