### PR TITLE
fix(ListView): ios lv snap rubber-banding

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1558,6 +1558,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Snap_Rubberband.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PasswordBoxTests\PasswordBox_AutoFill.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5531,6 +5535,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Source_Nullify.xaml.cs">
       <DependentUpon>Image_Source_Nullify.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Snap_Rubberband.xaml.cs">
+      <DependentUpon>ListView_Snap_Rubberband.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PlaceholderForeground.xaml.cs">
       <DependentUpon>TextBox_PlaceholderForeground.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Snap_Rubberband.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Snap_Rubberband.xaml
@@ -1,0 +1,98 @@
+﻿<UserControl x:Class="SamplesApp.Windows_UI_Xaml_Controls.ListView.ListView_Snap_Rubberband"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:xamarin="http://uno.ui/xamarin"
+	  mc:Ignorable="d xamarin"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<UserControl.Resources>
+		<Style x:Key="TestHorizontalLVStyle" TargetType="ListView">
+			<Setter Property="IsTabStop" Value="False" />
+			<Setter Property="TabNavigation" Value="Once" />
+			<Setter Property="IsSwipeEnabled" Value="True" />
+			<Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Visible" />
+			<Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+			<Setter Property="ScrollViewer.HorizontalScrollMode" Value="Enabled" />
+			<Setter Property="ScrollViewer.VerticalScrollMode" Value="Disabled" />
+			<Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="True" />
+			<Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
+			<Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+			<Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
+			<Setter Property="ItemContainerTransitions">
+				<Setter.Value>
+					<TransitionCollection>
+						<AddDeleteThemeTransition />
+						<ContentThemeTransition />
+						<ReorderThemeTransition />
+						<EntranceThemeTransition IsStaggeringEnabled="False" />
+					</TransitionCollection>
+				</Setter.Value>
+			</Setter>
+
+			<Setter Property="ItemsPanel">
+				<Setter.Value>
+					<ItemsPanelTemplate>
+						<ItemsStackPanel Orientation="Horizontal" />
+					</ItemsPanelTemplate>
+				</Setter.Value>
+			</Setter>
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ListView">
+						<ScrollViewer x:Name="ScrollViewer"
+										xamarin:Style="{StaticResource ListViewBaseScrollViewerStyle}"
+										HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+										HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+										VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+										VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+										IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}"
+										IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+										IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}"
+										IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+										IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+										BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+										AutomationProperties.AccessibilityView="Raw"
+										HorizontalSnapPointsType="MandatorySingle"
+										HorizontalSnapPointsAlignment="Center">
+							<ItemsPresenter Header="{TemplateBinding Header}"
+											HeaderTemplate="{TemplateBinding HeaderTemplate}"
+											HeaderTransitions="{TemplateBinding HeaderTransitions}"
+											Footer="{TemplateBinding Footer}"
+											FooterTemplate="{TemplateBinding FooterTemplate}"
+											FooterTransitions="{TemplateBinding FooterTransitions}"
+											Padding="{TemplateBinding Padding}" />
+						</ScrollViewer>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+		<Style x:Key="TestLVIStyle" TargetType="ListViewItem">
+			<Setter Property="Padding" Value="0" />
+			<Setter Property="MinWidth" Value="0" />
+			<Setter Property="MinHeight" Value="1" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="ListViewItem">
+						<ContentPresenter Content="{TemplateBinding Content}"
+										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  xamarin:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<Grid Width="100" Height="100">
+		<ListView ItemsSource="{Binding}" ItemContainerStyle="{StaticResource TestLVIStyle}" Style="{StaticResource TestHorizontalLVStyle}">
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<Border Padding="5" Width="90" Height="90" Background="Pink">
+						<TextBlock Text="{Binding}" HorizontalAlignment="Center" />
+					</Border>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+		</ListView>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Snap_Rubberband.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Snap_Rubberband.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Tests;
+using Uno.UI.Samples.UITests.Helpers;
+
+namespace SamplesApp.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo("AAAListView", nameof(ListView_Snap_Rubberband), IsManualTest = true, Description = SampleDescription)]
+	public sealed partial class ListView_Snap_Rubberband : UserControl
+	{
+		private const string SampleDescription =
+			"[ManualTest]: While the LV is snapped to the 1st item, wait at least 1second. " +
+			"Using flipping gesture, over-scroll to left, and then quickly (within 250ms) scroll to the right. " +
+			"The LV should snap to the 2nd item, and not rubber banding back to the first.";
+
+		public ListView_Snap_Rubberband()
+		{
+			this.InitializeComponent();
+			this.DataContext = new[] { 0, 1, 2 };
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1280,6 +1280,7 @@ namespace Windows.UI.Xaml.Controls
 			if (isIntermediate && UpdatesMode != Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous)
 			{
 				RequestUpdate();
+				_snapPointsTimer?.Stop();
 			}
 			else
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10892

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On iOS, while flipping/scrolling in a ListView, it would sometimes randomly fail to snap to the item in the direction of scroll and rubber-band back to the starting place.

## What is the new behavior?
The rubber-banding snap should not happen anymore.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
The bug occurs when the user rapidly scrolls twice within the `_snapPointsTimer.Interval`(250ms). The 2nd scrolling should begin before that 250ms interval, but not complete until `_snapPointsTimer` has proc'd. When these specific conditions are met, uno would attempt to snap towards the target location of the 1st snap. (_There will be a 2nd snap due to the 1st, but it will be canceled as the target location is a snap point._)
