### PR TITLE
perf(do): Reduce CallbackManager allocations when no callbacks are registered

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -779,13 +779,13 @@ namespace Windows.UI.Xaml
 
 			if (ReferenceEquals(callback.Target, ActualInstance))
 			{
-				return propertyDetails.CallbackManager.RegisterCallback(callback);
+				return propertyDetails.RegisterCallback(callback);
 			}
 			else
 			{
 				CreateWeakDelegate(callback, out var weakCallback, out var weakDelegateRelease);
 
-				var cookie = propertyDetails.CallbackManager.RegisterCallback(weakCallback);
+				var cookie = propertyDetails.RegisterCallback(weakCallback);
 
 				return new RegisterPropertyChangedCallbackForPropertyConditionalDisposable(
 					callback,
@@ -1905,7 +1905,7 @@ namespace Windows.UI.Xaml
 			}
 
 			// Raise the changes for the callbacks register through RegisterPropertyChangedCallback.
-			propertyDetails.CallbackManager.RaisePropertyChanged(actualInstanceAlias, eventArgs);
+			propertyDetails.RaisePropertyChanged(actualInstanceAlias, eventArgs);
 
 			// Raise the property change for generic handlers
 			for (var callbackIndex = 0; callbackIndex < _genericCallbacks.Data.Length; callbackIndex++)

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -52,8 +52,6 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		public DependencyPropertyCallbackManager CallbackManager => _callbackManager ??= new DependencyPropertyCallbackManager();
-
 		public DependencyProperty Property { get; }
 
 		public PropertyMetadata Metadata => _metadata ??= Property.GetMetadata(_dependencyObjectType);
@@ -371,6 +369,12 @@ namespace Windows.UI.Xaml
 		{
 			return $"DependencyPropertyDetails({Property.Name})";
 		}
+
+		internal IDisposable RegisterCallback(PropertyChangedCallback callback)
+			=> (_callbackManager ??= new DependencyPropertyCallbackManager()).RegisterCallback(callback);
+
+		internal void RaisePropertyChanged(DependencyObject actualInstanceAlias, DependencyPropertyChangedEventArgs eventArgs)
+			=> _callbackManager?.RaisePropertyChanged(actualInstanceAlias, eventArgs);
 
 		[Flags]
 		enum Flags


### PR DESCRIPTION
GitHub Issue (If applicable): #8597

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Avoid the creation of a callback manager on event raising, when no callbacks are registered.

Credit to @ebariche for finding it :)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
