### PR TITLE
perf(dp): Reduce property search allocations

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -31,6 +31,12 @@ namespace Windows.UI.Xaml
 		private readonly static TypeToPropertiesDictionary _getPropertiesForType = new TypeToPropertiesDictionary();
 		private readonly static NameToPropertyDictionary _getPropertyCache = new NameToPropertyDictionary();
 
+		/// <summary>
+		/// A static <see cref="PropertyCacheEntry"/> used for lookups and avoid creating new instances. This assumes that uses are non-reentrant.
+		/// </summary>
+		private readonly static PropertyCacheEntry _searchPropertyCacheEntry = new();
+
+
 		private readonly static FrameworkPropertiesForTypeDictionary _getFrameworkPropertiesForType = new FrameworkPropertiesForTypeDictionary();
 
 		private readonly PropertyMetadata _ownerTypeMetadata; // For perf consideration, we keep direct ref the metadata for the owner type
@@ -317,12 +323,11 @@ namespace Windows.UI.Xaml
 		/// <returns>A <see cref="DependencyProperty"/> instance, otherwise null it not found.</returns>
 		internal static DependencyProperty GetProperty(Type type, string name)
 		{
-			DependencyProperty result = null;
-			var key = new PropertyCacheEntry(type, name);
+			_searchPropertyCacheEntry.Update(type, name);
 
-			if (!_getPropertyCache.TryGetValue(key, out result))
+			if (!_getPropertyCache.TryGetValue(_searchPropertyCacheEntry, out var result))
 			{
-				_getPropertyCache.Add(key, result = InternalGetProperty(type, name));
+				_getPropertyCache.Add(_searchPropertyCacheEntry.Clone(), result = InternalGetProperty(type, name));
 			}
 
 			return result;
@@ -332,7 +337,9 @@ namespace Windows.UI.Xaml
 		{
 			if (_getPropertyCache.Count != 0)
 			{
-				_getPropertyCache.Remove(new PropertyCacheEntry(ownerType, name));
+				_searchPropertyCacheEntry.Update(ownerType, name);
+
+				_getPropertyCache.Remove(_searchPropertyCacheEntry);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyCacheEntry.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyCacheEntry.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Uno.Core.Comparison;
 
@@ -12,11 +13,28 @@ namespace Windows.UI.Xaml
 	/// </summary>
 	internal class PropertyCacheEntry
 	{
-		private readonly Type Type;
-		private readonly string Name;
-		private readonly int CachedHashCode;
+		private Type Type;
+		private string Name;
+		private int CachedHashCode;
 
-		public PropertyCacheEntry(Type type, string name)
+		public PropertyCacheEntry()
+			=> Update(typeof(object), "");
+
+		private PropertyCacheEntry(PropertyCacheEntry other)
+		{
+			CachedHashCode = other.CachedHashCode;
+			Name = other.Name;
+			Type = other.Type;
+		}
+
+		public PropertyCacheEntry Clone()
+			=> new(this);
+
+		/// <summary>
+		/// Mutates the fields from this instance
+		/// </summary>
+		[MemberNotNull(nameof(Type), nameof(Name))]
+		public void Update(Type type, string name)
 		{
 			this.Type = type;
 			this.Name = name;


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/8597

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Reduce DependencyProperty search allocations with non-reentrant `PropertyCacheEntry` mutations.

Credit to @ebariche for finding it!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
