### PR TITLE
fix(Binding): Adjust binding to indexer based on expression parameter

### DIFF
--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.Indexer.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.Indexer.cs
@@ -1,0 +1,425 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.Tests.BinderTests
+{
+	public partial class Given_Binder
+	{
+		[TestMethod]
+		public void When_Binding_DataTable_With_Integer_Indexer()
+		{
+			var SUT = new TextBlock();
+			var dt = new System.Data.DataTable();
+			dt.Columns.Add("MyColumn", typeof(int));
+			dt.Rows.Add(42);
+			SUT.DataContext = dt.DefaultView;
+			SUT.SetBinding(TextBlock.TextProperty, new Binding { Path = new PropertyPath("[0][0]") });
+
+			Assert.AreEqual("42", SUT.Text);
+		}
+
+		[TestMethod]
+		public void When_Binding_DataTable_With_Integer_Indexer_And_TwoWay()
+		{
+			var SUT = new TextBlock();
+			var dt = new System.Data.DataTable();
+			dt.Columns.Add("MyColumn", typeof(int));
+			dt.Rows.Add(42);
+			SUT.DataContext = dt.DefaultView;
+			SUT.SetBinding(TextBlock.TextProperty, new Binding { Path = new PropertyPath("[0][0]"), Mode = BindingMode.TwoWay });
+
+			Assert.AreEqual("42", SUT.Text);
+
+			SUT.Text = "43";
+
+			Assert.AreEqual(43, dt.Rows[0].ItemArray[0]);
+		}
+
+		[TestMethod]
+		public void When_Binding_DataTable_With_String_Indexer()
+		{
+			var SUT = new Grid();
+			var dt = new System.Data.DataTable();
+			dt.Columns.Add("MyColumn", typeof(int));
+			dt.Rows.Add(42);
+			SUT.DataContext = dt.DefaultView;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[0][MyColumn]") });
+
+			Assert.AreEqual(42, SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_DataTable_With_String_Indexer_And_TwoWay()
+		{
+			var SUT = new Grid();
+			var dt = new System.Data.DataTable();
+			dt.Columns.Add("MyColumn", typeof(int));
+			dt.Rows.Add(42);
+			SUT.DataContext = dt.DefaultView;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[0][MyColumn]"), Mode = BindingMode.TwoWay });
+
+			Assert.AreEqual(42, SUT.Tag);
+
+			SUT.Tag = 43;
+
+			Assert.AreEqual(43, dt.Rows[0].ItemArray[0]);
+		}
+
+		[TestMethod]
+		public void When_Binding_IntegerOnly_Indexer_Readonly()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestIntegerIndexerReadonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]") });
+
+			Assert.AreEqual(43, SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_IntegerOnly_Indexer_Readonly_And_Invalid()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestIntegerIndexerReadonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]") });
+
+			Assert.IsNull(SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_StringOnly_Indexer_Readonly_And_Integer()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestStringIndexer_Readonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]") });
+
+			Assert.AreEqual("421", SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_StringOnly_Indexer_Readonly_And_String()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestStringIndexer_Readonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]") });
+
+			Assert.AreEqual("toto1", SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestIntString_Indexer_Readonly_And_Integer()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestIntStringIndexer_Readonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]") });
+
+			Assert.AreEqual(43, SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestIntString_Indexer_Readonly_And_String()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestIntStringIndexer_Readonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]") });
+
+			Assert.AreEqual("toto1", SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestObject_Indexer_Readonly_And_Integer()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestObjectIndexer_Readonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]") });
+
+			Assert.AreEqual("421", SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestObject_Indexer_Readonly_And_String()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestObjectIndexer_Readonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]") });
+
+			Assert.AreEqual("toto1", SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestIntObject_Indexer_Readonly_And_Integer()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestIntObjectIndexer_Readonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]") });
+
+			Assert.AreEqual(43, SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestIntObject_Indexer_Readonly_And_String()
+		{
+			var SUT = new Grid();
+			SUT.DataContext = new TestIntObjectIndexer_Readonly();
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]") });
+
+			Assert.AreEqual("toto1", SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Binding_IntegerOnly_Indexer_TwoWay()
+		{
+			var SUT = new Grid();
+			var ctx = new TestIntegerIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]"), Mode = BindingMode.TwoWay });
+
+			Assert.AreEqual(0, SUT.Tag);
+
+			SUT.Tag = 44;
+			Assert.AreEqual(SUT.Tag, ctx[42]);
+		}
+
+		[TestMethod]
+		public void When_Binding_IntegerOnly_Indexer_And_Invalid()
+		{
+			var SUT = new Grid();
+			var ctx = new TestIntegerIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]"), Mode = BindingMode.TwoWay });
+
+			Assert.IsNull(SUT.Tag);
+
+			SUT.Tag = 44;
+			Assert.AreEqual(0, ctx[42]);
+		}
+
+		[TestMethod]
+		public void When_Binding_StringOnly_Indexer_And_Integer()
+		{
+			var SUT = new Grid();
+			var ctx = new TestStringIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]"), Mode = BindingMode.TwoWay });
+
+			Assert.IsNull(SUT.Tag);
+
+			SUT.Tag = "43";
+
+			Assert.AreEqual("4243", ctx["42"]);
+		}
+
+		[TestMethod]
+		public void When_Binding_StringOnly_Indexer_And_String()
+		{
+			var SUT = new Grid();
+			var ctx = new TestStringIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]"), Mode = BindingMode.TwoWay });
+
+			Assert.IsNull(SUT.Tag);
+
+			SUT.Tag = "43";
+
+			Assert.AreEqual("toto43", ctx["toto"]);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestIntString_Indexer_And_Integer()
+		{
+			var SUT = new Grid();
+			var ctx = new TestIntStringIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]"), Mode = BindingMode.TwoWay });
+
+			Assert.AreEqual(0, SUT.Tag);
+
+			SUT.Tag = 43;
+
+			Assert.AreEqual(43, ctx[42]);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestIntString_Indexer_And_String()
+		{
+			var SUT = new Grid();
+			var ctx = new TestIntStringIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]"), Mode = BindingMode.TwoWay });
+
+			Assert.IsNull(SUT.Tag);
+
+			SUT.Tag = "43";
+
+			Assert.AreEqual("toto43", ctx["toto"]);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestObject_Indexer_And_Integer()
+		{
+			var SUT = new Grid();
+			var ctx = new TestObjectIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]"), Mode = BindingMode.TwoWay });
+
+			Assert.IsNull(SUT.Tag);
+
+			SUT.Tag = "43";
+
+			Assert.AreEqual("4342", ctx["42"]);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestObject_Indexer_And_String()
+		{
+			var SUT = new Grid();
+			var ctx = new TestObjectIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]"), Mode = BindingMode.TwoWay });
+
+			Assert.IsNull(SUT.Tag);
+
+			SUT.Tag = "43";
+
+			Assert.AreEqual("43toto", ctx["toto"]);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestIntObject_Indexer_And_Integer()
+		{
+			var SUT = new Grid();
+			var ctx = new TestIntObjectIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[42]"), Mode = BindingMode.TwoWay });
+
+			Assert.AreEqual(0, SUT.Tag);
+
+			SUT.Tag = 43;
+
+			Assert.AreEqual(43, ctx[42]);
+		}
+
+		[TestMethod]
+		public void When_Binding_TestIntObject_Indexer_And_String()
+		{
+			var SUT = new Grid();
+			var ctx = new TestIntObjectIndexer();
+			SUT.DataContext = ctx;
+			SUT.SetBinding(Grid.TagProperty, new Binding { Path = new PropertyPath("[toto]"), Mode = BindingMode.TwoWay });
+
+			Assert.IsNull(SUT.Tag);
+
+			SUT.Tag = "43";
+
+			Assert.AreEqual("43toto", ctx["toto"]);
+		}
+
+
+		public class TestIntegerIndexerReadonly
+		{
+			public int this[int index]
+				=> index + 1;
+		}
+
+		public class TestStringIndexer_Readonly
+		{
+			public string this[string value]
+				=> value + "1";
+		}
+
+		public class TestIntStringIndexer_Readonly
+		{
+			public int this[int index]
+				=> index + 1;
+
+			public string this[string value]
+				=> value + "1";
+		}
+
+		public class TestObjectIndexer_Readonly
+		{
+			public string this[object index]
+				=> index.ToString() + "1";
+		}
+
+		public class TestIntObjectIndexer_Readonly
+		{
+			public int this[int index]
+				=> index + 1;
+
+			public string this[object index]
+				=> index.ToString() + "1";
+		}
+
+		public class TestIntegerIndexer
+		{
+			private int _intValue;
+
+			public int this[int index]
+			{
+				get => _intValue;
+				set => _intValue = value;
+			}
+		}
+
+		public class TestStringIndexer
+		{
+			private string _stringValue;
+
+			public string this[string v]
+			{
+				get => _stringValue;
+				set => _stringValue = v + value;
+			}
+		}
+
+		public class TestIntStringIndexer
+		{
+			private string _stringValue;
+			private int _intValue;
+
+			public int this[int index]
+			{
+				get => _intValue;
+				set => _intValue = value;
+			}
+
+			public string this[string v]
+			{
+				get => _stringValue;
+				set => _stringValue = v + value;
+			}
+		}
+
+		public class TestObjectIndexer
+		{
+			private string _stringValue;
+
+			public string this[object index]
+			{
+				get => _stringValue;
+				set => _stringValue = value + index;
+			}
+		}
+
+		public class TestIntObjectIndexer
+		{
+			private string _stringValue;
+			private int _intValue;
+
+
+			public int this[int index]
+			{
+				get => _intValue;
+				set => _intValue = value;
+			}
+
+			public string this[object index]
+			{
+				get => _stringValue;
+				set => _stringValue = value + index;
+			}
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11446

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that binding to types which contain multiple indexers is using the proper overload, given the expression type.

Fixes binding to a `DataTable`'s `DataRow`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
