### PR TITLE
fix: `AutoSuggestBox` popup positioning improvements

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MUXControlsTestApp.Utilities;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -133,6 +136,75 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				SUT.Focus(FocusState.Programmatic);
 				SUT.Text = "ab";
 				await WindowHelper.WaitForIdle();
+			}
+			finally
+			{
+				button?.Focus(FocusState.Programmatic); // Unfocus the AutoSuggestBox to ensure popup is closed.
+				await WindowHelper.WaitForIdle();
+			}
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_Popup_Above()
+		{
+			await When_Popup_Position(VerticalAlignment.Bottom, (SUT, popup) =>
+			{
+				var popupPoint = popup.Child.TransformToVisual(WindowHelper.WindowContent).TransformPoint(default);
+				var suggestBoxPoint = SUT.TransformToVisual(WindowHelper.WindowContent).TransformPoint(default);
+				Assert.IsTrue(popupPoint.Y + popup.Child.ActualSize.Y <= suggestBoxPoint.Y + 1); // Added 1 to adjust for border on Windows
+			});
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_Popup_Below()
+		{
+			await When_Popup_Position(VerticalAlignment.Top, (SUT, popup) =>
+			{
+				var popupPoint = popup.Child.TransformToVisual(WindowHelper.WindowContent).TransformPoint(default);
+				var suggestBoxPoint = SUT.TransformToVisual(WindowHelper.WindowContent).TransformPoint(default);
+				Assert.IsTrue(popupPoint.Y + 1 >= suggestBoxPoint.Y + SUT.ActualHeight); // Added 1 to adjust for border on Windows
+			});
+		}
+
+		private async Task When_Popup_Position(VerticalAlignment verticalAlignment, Action<AutoSuggestBox, Popup> assert)
+		{
+			var SUT = new AutoSuggestBox();
+
+			Button button = null;
+			try
+			{
+				button = new Button();
+				var rootGrid = new Grid();
+				var stack = new StackPanel()
+				{
+					Children =
+					{
+						button,
+						SUT
+					},
+					VerticalAlignment = verticalAlignment
+				};
+
+				SUT.ItemsSource = Enumerable.Range(0, 10).ToArray();
+				rootGrid.Children.Add(stack);
+				WindowHelper.WindowContent = rootGrid;
+				await WindowHelper.WaitForIdle();
+
+				SUT.Focus(FocusState.Programmatic);
+				SUT.Text = "1";
+				await WindowHelper.WaitForIdle();
+
+				var popups = VisualTreeHelper.GetOpenPopupsForXamlRoot(SUT.XamlRoot);
+				var popup = popups[0];
+
+				Assert.IsNotNull(popup);
+				var child = popup.Child;
+				Assert.IsNotNull(child);
+				await WindowHelper.WaitFor(() => child.ActualSize.Y > 0);
+
+				assert(SUT, popup);
 			}
 			finally
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -144,6 +144,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 		[TestMethod]
 		[RequiresFullWindow]
 		public async Task When_Popup_Above()
@@ -156,6 +159,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			});
 		}
 
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 		[TestMethod]
 		[RequiresFullWindow]
 		public async Task When_Popup_Below()

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -212,8 +212,10 @@ namespace Windows.UI.Xaml.Controls
 				double targetY;
 				double? targetHeight = null;
 
+				var yBelow = containerRect.Top + textBoxHeight;
+
 				// Try to align popup below TextBox
-				var availableHeightBelow = windowRect.Bottom - containerRect.Top + textBoxHeight;
+				var availableHeightBelow = windowRect.Bottom - yBelow;
 				var availableHeightAbove = containerRect.Top - windowRect.Top;
 
 				// Find to position the popup in this order:
@@ -222,7 +224,7 @@ namespace Windows.UI.Xaml.Controls
 				//  3. To the position where is more space available
 				if (availableHeightBelow >= popupChild.DesiredSize.Height)
 				{
-					targetY = containerRect.Top + textBoxHeight;
+					targetY = yBelow;
 				}
 				else if (availableHeightAbove >= popupChild.DesiredSize.Height)
 				{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Does not take SIP overlay into account
- Does not properly size the popup if it does not fit above/below

## What is the new behavior?

- Fixed


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
