### PR TITLE
perf: Faster symbol lookup

### DIFF
--- a/src/SourceGenerators/SourceGeneratorHelpers/Helpers/RoslynMetadataHelper.cs
+++ b/src/SourceGenerators/SourceGeneratorHelpers/Helpers/RoslynMetadataHelper.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿#nullable enable
+
+using System;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Uno.Extensions;
 
 #if NETFRAMEWORK
@@ -15,28 +14,28 @@ namespace Uno.Roslyn
 	internal class RoslynMetadataHelper
 	{
 		private readonly INamedTypeSymbol _nullableSymbol;
-		private readonly Func<string, ITypeSymbol> _findTypeByFullName;
+		private readonly Func<string, ITypeSymbol?> _findTypeByFullName;
 		private readonly Func<INamedTypeSymbol, INamedTypeSymbol[]> _getAllTypesAttributedWith;
 
 		public Compilation Compilation { get; }
 
-		public string AssemblyName => Compilation.AssemblyName;
+		public string AssemblyName => Compilation.AssemblyName!;
 
 		public RoslynMetadataHelper(GeneratorExecutionContext context)
 		{
 			Compilation = context.Compilation;
 
-			_findTypeByFullName = Funcs.Create<string, ITypeSymbol>(SourceFindTypeByFullName).AsLockedMemoized();
+			_findTypeByFullName = Funcs.Create<string, ITypeSymbol?>(SourceFindTypeByFullName).AsLockedMemoized();
 			_getAllTypesAttributedWith = Funcs.Create<INamedTypeSymbol, INamedTypeSymbol[]>(SourceGetAllTypesAttributedWith).AsLockedMemoized();
 			_nullableSymbol = Compilation.GetSpecialType(SpecialType.System_Nullable_T);
 		}
 
-		public ITypeSymbol FindTypeByFullName(string fullName)
+		public ITypeSymbol? FindTypeByFullName(string fullName)
 		{
 			return _findTypeByFullName(fullName);
 		}
 
-		private ITypeSymbol SourceFindTypeByFullName(string fullName)
+		private ITypeSymbol? SourceFindTypeByFullName(string fullName)
 		{
 			var symbol = Compilation.GetTypeByMetadataName(fullName);
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -97,6 +97,34 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private const string WinUIThemeResourcePathSuffixFormatString = "themeresources_v{0}.xaml";
 		private static string WinUICompactPathSuffix = Path.Combine("DensityStyles", "Compact.xaml");
 
+		internal Lazy<INamedTypeSymbol?> AssemblyMetadataSymbol { get; }
+		internal Lazy<INamedTypeSymbol> ElementStubSymbol { get; }
+		internal Lazy<INamedTypeSymbol> ContentPresenterSymbol { get; }
+		internal Lazy<INamedTypeSymbol> StringSymbol { get; }
+		internal Lazy<INamedTypeSymbol> ObjectSymbol { get; }
+		internal Lazy<INamedTypeSymbol> FrameworkElementSymbol { get; }
+		internal Lazy<INamedTypeSymbol> UIElementSymbol { get; }
+		internal Lazy<INamedTypeSymbol> DependencyObjectSymbol { get; }
+		internal Lazy<INamedTypeSymbol> MarkupExtensionSymbol { get; }
+		internal Lazy<INamedTypeSymbol> BrushSymbol { get; }
+		internal Lazy<INamedTypeSymbol> ImageSourceSymbol { get; }
+		internal Lazy<INamedTypeSymbol> ImageSymbol { get; }
+		internal Lazy<INamedTypeSymbol> DependencyObjectParseSymbol { get; }
+		internal Lazy<INamedTypeSymbol?> AndroidContentContextSymbol { get; }
+		internal Lazy<INamedTypeSymbol?> AndroidViewSymbol { get; }
+		internal Lazy<INamedTypeSymbol?> IOSViewSymbol { get; }
+		internal Lazy<INamedTypeSymbol?> AppKitViewSymbol { get; }
+		internal Lazy<INamedTypeSymbol> ICollectionSymbol { get; }
+		internal Lazy<INamedTypeSymbol> ICollectionOfTSymbol { get; }
+		internal Lazy<INamedTypeSymbol> IConvertibleSymbol { get; }
+		internal Lazy<INamedTypeSymbol> IListSymbol { get; }
+		internal Lazy<INamedTypeSymbol> IListOfTSymbol { get; }
+		internal Lazy<INamedTypeSymbol> IDictionaryOfTKeySymbol { get; }
+		internal Lazy<INamedTypeSymbol> DataBindingSymbol { get; }
+		internal Lazy<INamedTypeSymbol> StyleSymbol { get; }
+		internal Lazy<INamedTypeSymbol> SetterSymbol { get; }
+		internal Lazy<INamedTypeSymbol> ColorSymbol { get; }
+
 		public XamlCodeGeneration(GeneratorExecutionContext context)
 		{
 			// To easily debug XAML code generation:
@@ -225,6 +253,43 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			_isWasm = context.GetMSBuildPropertyValue("DefineConstantsProperty")?.Contains("__WASM__") ?? false;
 			_isDesignTimeBuild = Helpers.DesignTimeHelper.IsDesignTime(context);
+
+			StringSymbol = GetSpecialTypeSymbolAsLazy(SpecialType.System_String);
+			ObjectSymbol = GetSpecialTypeSymbolAsLazy(SpecialType.System_Object);
+			AssemblyMetadataSymbol = GetOptionalSymbolAsLazy("System.Reflection.AssemblyMetadataAttribute");
+			ElementStubSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.ElementStub);
+			SetterSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.Setter);
+			ContentPresenterSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.ContentPresenter);
+			FrameworkElementSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.FrameworkElement);
+			UIElementSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.UIElement);
+			ImageSourceSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.ImageSource);
+			ImageSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.Image);
+			DependencyObjectSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.DependencyObject);
+			MarkupExtensionSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.MarkupExtension);
+			BrushSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.Brush);
+			DependencyObjectParseSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.IDependencyObjectParse);
+			ICollectionSymbol = GetMandatorySymbolAsLazy("System.Collections.ICollection");
+			ICollectionOfTSymbol = GetSpecialTypeSymbolAsLazy(SpecialType.System_Collections_Generic_ICollection_T);
+			IConvertibleSymbol = GetMandatorySymbolAsLazy("System.IConvertible");
+			IListSymbol = GetMandatorySymbolAsLazy("System.Collections.IList");
+			IListOfTSymbol = GetSpecialTypeSymbolAsLazy(SpecialType.System_Collections_Generic_IList_T);
+			IDictionaryOfTKeySymbol = GetMandatorySymbolAsLazy("System.Collections.Generic.IDictionary`2");
+			DataBindingSymbol = GetMandatorySymbolAsLazy("Windows.UI.Xaml.Data.Binding");
+			StyleSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.Style);
+			ColorSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.Color);
+			AndroidContentContextSymbol = GetOptionalSymbolAsLazy("Android.Content.Context");
+			AndroidViewSymbol = GetOptionalSymbolAsLazy("Android.Views.View");
+			IOSViewSymbol = GetOptionalSymbolAsLazy("UIKit.UIView");
+			AppKitViewSymbol = GetOptionalSymbolAsLazy("AppKit.NSView");
+
+			Lazy<INamedTypeSymbol> GetMandatorySymbolAsLazy(string fullyQualifiedName)
+				=> new(() => context.Compilation.GetTypeByMetadataName(fullyQualifiedName) ?? throw new InvalidOperationException($"Unable to find type {fullyQualifiedName}"));
+
+			Lazy<INamedTypeSymbol?> GetOptionalSymbolAsLazy(string fullyQualifiedName)
+				=> new(() => context.Compilation.GetTypeByMetadataName(fullyQualifiedName));
+
+			Lazy<INamedTypeSymbol> GetSpecialTypeSymbolAsLazy(SpecialType specialType)
+				=> new(() => context.Compilation.GetSpecialType(specialType));
 		}
 
 		private static bool IsWinUIItem(Uno.Roslyn.MSBuildItem item)
@@ -341,44 +406,40 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 
 				var outputFiles = filesToProcess.Select(file => new KeyValuePair<string, string>(
-
-							file.UniqueID,
-							new XamlFileGenerator(
-									file: file,
-									targetPath: _targetPath,
-									defaultNamespace: _defaultNamespace,
-									metadataHelper: _metadataHelper,
-									fileUniqueId: file.UniqueID,
-									lastReferenceUpdateTime: lastBinaryUpdateTime,
-									analyzerSuppressions: _analyzerSuppressions,
-									globalStaticResourcesMap: globalStaticResourcesMap,
-									resourceDetailsCollection: resourceDetailsCollection,
-									isUiAutomationMappingEnabled: _isUiAutomationMappingEnabled,
-									uiAutomationMappings: _uiAutomationMappings,
-									defaultLanguage: _defaultLanguage,
-									shouldWriteErrorOnInvalidXaml: _shouldWriteErrorOnInvalidXaml,
-									isWasm: _isWasm,
-									isDebug: _isDebug,
-									isHotReloadEnabled: _isHotReloadEnabled,
-									isInsideMainAssembly: isInsideMainAssembly,
-									useXamlReaderHotReload: _useXamlReaderHotReload,
-									isDesignTimeBuild: _isDesignTimeBuild,
-									skipUserControlsInVisualTree: _skipUserControlsInVisualTree,
-									shouldAnnotateGeneratedXaml: _shouldAnnotateGeneratedXaml,
-									isUnoAssembly: IsUnoAssembly,
-									isUnoFluentAssembly: IsUnoFluentAssembly,
-									isLazyVisualStateManagerEnabled: _isLazyVisualStateManagerEnabled,
-									enableFuzzyMatching: _enableFuzzyMatching,
-									generatorContext: _generatorContext,
-									xamlResourcesTrimming: _xamlResourcesTrimming,
-									generationRunFileInfo: generationRunInfo.GetRunFileInfo(file.UniqueID),
-									xamlTypeToXamlTypeBaseMap: xamlTypeToXamlTypeBaseMap
-								)
-								.GenerateFile()
-						)
-					)
-					.ToList();
-
+					file.UniqueID,
+					new XamlFileGenerator(
+						this,
+						file: file,
+						targetPath: _targetPath,
+						defaultNamespace: _defaultNamespace,
+						metadataHelper: _metadataHelper,
+						fileUniqueId: file.UniqueID,
+						lastReferenceUpdateTime: lastBinaryUpdateTime,
+						analyzerSuppressions: _analyzerSuppressions,
+						globalStaticResourcesMap: globalStaticResourcesMap,
+						resourceDetailsCollection: resourceDetailsCollection,
+						isUiAutomationMappingEnabled: _isUiAutomationMappingEnabled,
+						uiAutomationMappings: _uiAutomationMappings,
+						defaultLanguage: _defaultLanguage,
+						shouldWriteErrorOnInvalidXaml: _shouldWriteErrorOnInvalidXaml,
+						isWasm: _isWasm,
+						isDebug: _isDebug,
+						isHotReloadEnabled: _isHotReloadEnabled,
+						isInsideMainAssembly: isInsideMainAssembly,
+						useXamlReaderHotReload: _useXamlReaderHotReload,
+						isDesignTimeBuild: _isDesignTimeBuild,
+						skipUserControlsInVisualTree: _skipUserControlsInVisualTree,
+						shouldAnnotateGeneratedXaml: _shouldAnnotateGeneratedXaml,
+						isUnoAssembly: IsUnoAssembly,
+						isUnoFluentAssembly: IsUnoFluentAssembly,
+						isLazyVisualStateManagerEnabled: _isLazyVisualStateManagerEnabled,
+						enableFuzzyMatching: _enableFuzzyMatching,
+						generatorContext: _generatorContext,
+						xamlResourcesTrimming: _xamlResourcesTrimming,
+						generationRunFileInfo: generationRunInfo.GetRunFileInfo(file.UniqueID),
+						xamlTypeToXamlTypeBaseMap: xamlTypeToXamlTypeBaseMap
+					).GenerateFile()
+				)).ToList();
 
 				outputFiles.Add(new KeyValuePair<string, string>("GlobalStaticResources", GenerateGlobalResources(files, globalStaticResourcesMap)));
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -752,7 +752,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					&& type.Name == "Bind"
 				   )
 				{
-					return _metadataHelper.FindTypeByFullName(XamlConstants.Namespaces.Data + ".Binding") as INamedTypeSymbol;
+					return Generation.DataBindingSymbol.Value;
 				}
 
 				var isKnownNamespace = ns?.Prefix is { Length: > 0 };

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -241,29 +241,29 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private bool IsFrameworkElement(XamlType xamlType)
 		{
-			return IsType(xamlType, _frameworkElementSymbol);
+			return IsType(xamlType, Generation.FrameworkElementSymbol.Value);
 		}
 
 		private bool IsAndroidView(XamlType xamlType)
 		{
-			return IsType(xamlType, _androidViewSymbol);
+			return IsType(xamlType, Generation.AndroidViewSymbol.Value);
 		}
 
 		private bool IsIOSUIView(XamlType xamlType)
 		{
-			return IsType(xamlType, _iOSViewSymbol);
+			return IsType(xamlType, Generation.IOSViewSymbol.Value);
 		}
 
 		private bool IsMacOSNSView(XamlType xamlType)
 		{
-			return IsType(xamlType, _appKitViewSymbol);
+			return IsType(xamlType, Generation.AppKitViewSymbol.Value);
 		}
 
 		private bool IsDependencyObject(XamlObjectDefinition component)
-			=> GetType(component.Type).GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol));
+			=> GetType(component.Type).GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, Generation.DependencyObjectSymbol.Value));
 
 		private bool IsUIElement(XamlObjectDefinition component)
-			=> IsType(component.Type, _uiElementSymbol);
+			=> IsType(component.Type, Generation.UIElementSymbol.Value);
 
 		/// <summary>
 		/// Is the type derived from the native view type on a Xamarin platform?
@@ -274,7 +274,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// Is the type one of the base view types in WinUI? (UIElement is most commonly used to mean 'any WinUI view type,' but
 		/// FrameworkElement is valid too)
 		/// </summary>
-		private bool IsManagedViewBaseType(INamedTypeSymbol? targetType) => SymbolEqualityComparer.Default.Equals(targetType, _uiElementSymbol) || SymbolEqualityComparer.Default.Equals(targetType, _frameworkElementSymbol);
+		private bool IsManagedViewBaseType(INamedTypeSymbol? targetType) => SymbolEqualityComparer.Default.Equals(targetType, Generation.UIElementSymbol.Value) || SymbolEqualityComparer.Default.Equals(targetType, Generation.FrameworkElementSymbol.Value);
 
 		private bool IsDependencyProperty(XamlMember member)
 		{
@@ -301,12 +301,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private bool HasIsParsing(XamlType xamlType)
 		{
-			return IsImplementingInterface(FindType(xamlType), _dependencyObjectParseSymbol);
+			return IsImplementingInterface(FindType(xamlType), Generation.DependencyObjectParseSymbol.Value);
 		}
 
 		private bool HasIsParsing(INamedTypeSymbol? type)
 		{
-			return IsImplementingInterface(type, _dependencyObjectParseSymbol);
+			return IsImplementingInterface(type, Generation.DependencyObjectParseSymbol.Value);
 		}
 
 		private Accessibility FindObjectFieldAccessibility(XamlObjectDefinition objectDefinition)
@@ -614,25 +614,25 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// Returns true if the type implements either ICollection, IList or one of their generics
 		/// </summary>
 		private bool IsCollectionOrListType(INamedTypeSymbol? propertyType)
-			=> IsImplementingInterface(propertyType, _iCollectionSymbol)
-			|| IsImplementingInterface(propertyType, _iCollectionOfTSymbol)
-			|| IsImplementingInterface(propertyType, _iListSymbol)
-			|| IsImplementingInterface(propertyType, _iListOfTSymbol);
+			=> IsImplementingInterface(propertyType, Generation.ICollectionSymbol.Value)
+			|| IsImplementingInterface(propertyType, Generation.ICollectionOfTSymbol.Value)
+			|| IsImplementingInterface(propertyType, Generation.IListSymbol.Value)
+			|| IsImplementingInterface(propertyType, Generation.IListOfTSymbol.Value);
 
 		/// <summary>
 		/// Returns true if the type implements <see cref="IDictionary{TKey, TValue}"/>
 		/// </summary>
 		private bool IsDictionary(INamedTypeSymbol? propertyType)
-			=> IsImplementingInterface(propertyType, _iDictionaryOfTKeySymbol);
+			=> IsImplementingInterface(propertyType, Generation.IDictionaryOfTKeySymbol.Value);
 
 		/// <summary>
 		/// Returns true if the type exactly implements either ICollection, IList or one of their generics
 		/// </summary>
 		private bool IsExactlyCollectionOrListType(INamedTypeSymbol type)
 		{
-			return SymbolEqualityComparer.Default.Equals(type, _iCollectionSymbol)
+			return SymbolEqualityComparer.Default.Equals(type, Generation.ICollectionSymbol.Value)
 				|| type.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_ICollection_T
-				|| SymbolEqualityComparer.Default.Equals(type, _iListSymbol)
+				|| SymbolEqualityComparer.Default.Equals(type, Generation.IListSymbol.Value)
 				|| type.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IList_T;
 		}
 
@@ -652,8 +652,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				return false;
 			}
 
-			return IsImplementingInterface(type, _iCollectionSymbol)
-				|| IsImplementingInterface(type, _iCollectionOfTSymbol);
+			return IsImplementingInterface(type, Generation.ICollectionSymbol.Value)
+				|| IsImplementingInterface(type, Generation.ICollectionOfTSymbol.Value);
 		}
 
 		/// <summary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -147,36 +147,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// </summary>
 		private readonly Dictionary<INamedTypeSymbol, int> _xamlAppliedTypes = new Dictionary<INamedTypeSymbol, int>();
 
-		private readonly INamedTypeSymbol _assemblyMetadataSymbol;
-
-		private readonly INamedTypeSymbol _elementStubSymbol;
-		private readonly INamedTypeSymbol _contentPresenterSymbol;
-		private readonly INamedTypeSymbol _stringSymbol;
-		private readonly INamedTypeSymbol _objectSymbol;
-		private readonly INamedTypeSymbol _frameworkElementSymbol;
-		private readonly INamedTypeSymbol _uiElementSymbol;
-		private readonly INamedTypeSymbol _dependencyObjectSymbol;
-		private readonly INamedTypeSymbol _markupExtensionSymbol;
-		private readonly INamedTypeSymbol _brushSymbol;
-		private readonly INamedTypeSymbol _imageSourceSymbol;
-		private readonly INamedTypeSymbol _imageSymbol;
-		private readonly INamedTypeSymbol _dependencyObjectParseSymbol;
-		private readonly INamedTypeSymbol? _androidContentContextSymbol; // Android.Content.Context
-		private readonly INamedTypeSymbol? _androidViewSymbol; // Android.Views.View
-		private readonly INamedTypeSymbol? _iOSViewSymbol; // UIKit.UIView
-		private readonly INamedTypeSymbol? _appKitViewSymbol; // AppKit.NSView
-
-		private readonly INamedTypeSymbol _iCollectionSymbol;
-		private readonly INamedTypeSymbol _iCollectionOfTSymbol;
-		private readonly INamedTypeSymbol _iConvertibleSymbol;
-		private readonly INamedTypeSymbol _iListSymbol;
-		private readonly INamedTypeSymbol _iListOfTSymbol;
-		private readonly INamedTypeSymbol _iDictionaryOfTKeySymbol;
-		private readonly INamedTypeSymbol _dataBindingSymbol;
-		private readonly INamedTypeSymbol _styleSymbol;
-		private readonly INamedTypeSymbol _setterSymbol;
-		private readonly INamedTypeSymbol _colorSymbol;
-
 		private readonly List<INamedTypeSymbol> _xamlConversionTypes;
 
 		private readonly bool _isWasm;
@@ -219,6 +189,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private const string DictionaryProviderInterfaceName = "global::Uno.UI.IXamlResourceDictionaryProvider";
 
+		public XamlCodeGeneration Generation { get; }
+
 		static XamlFileGenerator()
 		{
 			_findContentProperty = Funcs.Create<INamedTypeSymbol, IPropertySymbol?>(SourceFindContentProperty).AsLockedMemoized();
@@ -228,6 +200,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		}
 
 		public XamlFileGenerator(
+			XamlCodeGeneration generation,
 			XamlFileDefinition file,
 			string targetPath,
 			string defaultNamespace,
@@ -258,6 +231,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			GenerationRunFileInfo generationRunFileInfo,
 			IDictionary<INamedTypeSymbol, XamlType> xamlTypeToXamlTypeBaseMap)
 		{
+			Generation = generation;
 			_fileDefinition = file;
 			_targetPath = targetPath;
 			_defaultNamespace = defaultNamespace;
@@ -287,33 +261,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			InitCaches();
 
 			_relativePath = PathHelper.GetRelativePath(_targetPath, _fileDefinition.FilePath);
-			_stringSymbol = _metadataHelper.Compilation.GetSpecialType(SpecialType.System_String);
-			_objectSymbol = _metadataHelper.Compilation.GetSpecialType(SpecialType.System_Object);
-			_assemblyMetadataSymbol = (INamedTypeSymbol)_metadataHelper.FindTypeByFullName("System.Reflection.AssemblyMetadataAttribute");
-			_elementStubSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.ElementStub);
-			_setterSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.Setter);
-			_contentPresenterSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.ContentPresenter);
-			_frameworkElementSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.FrameworkElement);
-			_uiElementSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.UIElement);
-			_imageSourceSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.ImageSource);
-			_imageSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.Image);
-			_dependencyObjectSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.DependencyObject);
-			_markupExtensionSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.MarkupExtension);
-			_brushSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.Brush);
-			_dependencyObjectParseSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.IDependencyObjectParse);
-			_iCollectionSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName("System.Collections.ICollection");
-			_iCollectionOfTSymbol = _metadataHelper.Compilation.GetSpecialType(SpecialType.System_Collections_Generic_ICollection_T);
-			_iConvertibleSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName("System.IConvertible");
-			_iListSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName("System.Collections.IList");
-			_iListOfTSymbol = _metadataHelper.Compilation.GetSpecialType(SpecialType.System_Collections_Generic_IList_T);
-			_iDictionaryOfTKeySymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName("System.Collections.Generic.IDictionary`2");
-			_dataBindingSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName("Windows.UI.Xaml.Data.Binding");
-			_styleSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.Style);
-			_colorSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.Color);
-			_androidContentContextSymbol = _metadataHelper.FindTypeByFullName("Android.Content.Context") as INamedTypeSymbol;
-			_androidViewSymbol = _metadataHelper.FindTypeByFullName("Android.Views.View") as INamedTypeSymbol;
-			_iOSViewSymbol = _metadataHelper.FindTypeByFullName("UIKit.UIView") as INamedTypeSymbol;
-			_appKitViewSymbol = _metadataHelper.FindTypeByFullName("AppKit.NSView") as INamedTypeSymbol;
+
 			_xamlConversionTypes = _metadataHelper.GetAllTypesAttributedWith((INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.CreateFromStringAttribute)).ToList();
 			ShouldWriteErrorOnInvalidXaml = shouldWriteErrorOnInvalidXaml;
 
@@ -774,7 +722,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					using (writer.BlockInvariant("switch (imageName)"))
 					{
-						var drawables = _metadataHelper.FindTypeByFullName($"{_defaultNamespace}.Resource").GetTypeMembers("Drawable").Single().GetFields();
+						var drawables = _metadataHelper.GetTypeByFullName($"{_defaultNamespace}.Resource").GetTypeMembers("Drawable").Single().GetFields();
 
 						foreach (var drawable in drawables)
 						{
@@ -852,7 +800,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private void BuildResourceLoaderFromAssembly(IndentedStringBuilder writer, IAssemblySymbol assembly)
 		{
 			var unoHasLocalizationResourcesAttribute = assembly.GetAttributes().FirstOrDefault(a =>
-				SymbolEqualityComparer.Default.Equals(a.AttributeClass, _assemblyMetadataSymbol)
+				SymbolEqualityComparer.Default.Equals(a.AttributeClass, Generation.AssemblyMetadataSymbol.Value)
 				&& a.ConstructorArguments.Length == 2
 				&& a.ConstructorArguments[0].Value is "UnoHasLocalizationResources");
 			var unoHasLocalizationResourcesAttributeDefined = unoHasLocalizationResourcesAttribute is not null;
@@ -1132,9 +1080,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			var hasXBindExpressions = CurrentScope.XBindExpressions.Count != 0;
 			var hasResourceExtensions = CurrentScope.Components.Any(c => HasMarkupExtensionNeedingComponent(c.XamlObject));
+			var frameworkElementSymbol = Generation.FrameworkElementSymbol.Value;
 			var isFrameworkElement =
-				IsType(_xClassName.Symbol, _frameworkElementSymbol)              // The current type may not have a base type as it is defined in XAML,
-				|| IsType(controlBaseType, _frameworkElementSymbol);    // so look at the control base type extracted from the XAML.
+				IsType(_xClassName.Symbol, frameworkElementSymbol)              // The current type may not have a base type as it is defined in XAML,
+				|| IsType(controlBaseType, frameworkElementSymbol);    // so look at the control base type extracted from the XAML.
 
 			if (hasXBindExpressions || hasResourceExtensions)
 			{
@@ -1801,12 +1750,12 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				// Styles are handled differently for now, and there's no variable generated
 				// for those entries. Skip the ApplyCompiledBindings for those. See
 				// ImportResourceDictionary handling of x:Name for more details.
-				if (SymbolEqualityComparer.Default.Equals(type, _styleSymbol))
+				if (SymbolEqualityComparer.Default.Equals(type, Generation.StyleSymbol.Value))
 				{
 					return false;
 				}
 
-				if (type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol)))
+				if (type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, Generation.DependencyObjectSymbol.Value)))
 				{
 					return true;
 				}
@@ -1852,7 +1801,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				if (basedOnNode != null)
 				{
-					writer.AppendLineInvariantIndented("BasedOn = (global::Windows.UI.Xaml.Style){0},", BuildBindingOption(basedOnNode, _styleSymbol));
+					writer.AppendLineInvariantIndented("BasedOn = (global::Windows.UI.Xaml.Style){0},", BuildBindingOption(basedOnNode, Generation.StyleSymbol.Value));
 				}
 
 				using (writer.BlockInvariant("Setters = ", fullTargetType))
@@ -2268,7 +2217,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				return null;
 			}
 
-			if (findType?.Is(_markupExtensionSymbol) ?? false)
+			if (findType?.Is(Generation.MarkupExtensionSymbol.Value) ?? false)
 			{
 				return findType;
 			}
@@ -2517,7 +2466,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 								writer.AppendLineInvariantIndented("{0}Child = ", setterPrefix);
 
 								var implicitContent = implicitContentChild.Objects.First();
-								using (TryAdaptNative(writer, implicitContent, _uiElementSymbol))
+								using (TryAdaptNative(writer, implicitContent, Generation.UIElementSymbol.Value))
 								{
 									BuildChild(writer, implicitContentChild, implicitContent);
 								}
@@ -3010,7 +2959,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					var symbol = GetType(styleTargetType);
 
-					if (symbol.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol)))
+					if (symbol.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, Generation.DependencyObjectSymbol.Value)))
 					{
 						var safeTypeName = LinkerHintsHelpers.GetPropertyAvailableName(symbol.GetFullMetadataName());
 						var linkerHintClass = LinkerHintsHelpers.GetLinkerHintsClassName(_defaultNamespace);
@@ -3058,7 +3007,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				typeName == "Style"
 				|| typeName == "ControlTemplate"
 				|| typeName == "DataTemplate"
-				|| symbol.Is(_brushSymbol)
+				|| symbol.Is(Generation.BrushSymbol.Value)
 			)
 			{
 				// Always lazily initialize these types, since they may be large or many being unused (e.g. brushes)
@@ -3306,7 +3255,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var extendedProperties = GetExtendedProperties(objectDefinition);
 			bool hasChildrenWithPhase = HasChildrenWithPhase(objectDefinition);
 			var objectDefinitionType = FindType(objectDefinition.Type);
-			var isFrameworkElement = IsType(objectDefinitionType, _frameworkElementSymbol);
+			var isFrameworkElement = IsType(objectDefinitionType, Generation.FrameworkElementSymbol.Value);
 			var hasIsParsing = HasIsParsing(objectDefinitionType);
 
 			if (extendedProperties.Any() || hasChildrenWithPhase || isFrameworkElement || hasIsParsing || !objectUid.IsNullOrEmpty())
@@ -4075,7 +4024,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			TryAnnotateWithGeneratorSource(writer);
 			if (
-				SymbolEqualityComparer.Default.Equals(FindType(objectDefinition.Type), _contentPresenterSymbol)
+				SymbolEqualityComparer.Default.Equals(FindType(objectDefinition.Type), Generation.ContentPresenterSymbol.Value)
 				&& member.Member.Name == "Content"
 			)
 			{
@@ -4257,11 +4206,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					TryAnnotateWithGeneratorSource(writer, suffix: "HasBindingOptions");
 					var isAttachedProperty = IsDependencyProperty(member.Member);
-					var isBindingType = SymbolEqualityComparer.Default.Equals(FindPropertyType(member.Member), _dataBindingSymbol);
+					var isBindingType = SymbolEqualityComparer.Default.Equals(FindPropertyType(member.Member), Generation.DataBindingSymbol.Value);
 					var isOwnerDependencyObject = member.Owner != null && GetType(member.Owner.Type) is { } ownerType &&
 						(
-							(_xamlTypeToXamlTypeBaseMap.TryGetValue(ownerType, out var baseTypeSymbol) && FindType(baseTypeSymbol)?.GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol)) == true) ||
-							ownerType.GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, _dependencyObjectSymbol))
+							(_xamlTypeToXamlTypeBaseMap.TryGetValue(ownerType, out var baseTypeSymbol) && FindType(baseTypeSymbol)?.GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, Generation.DependencyObjectSymbol.Value)) == true) ||
+							ownerType.GetAllInterfaces().Any(i => SymbolEqualityComparer.Default.Equals(i, Generation.DependencyObjectSymbol.Value))
 						);
 
 					if (isAttachedProperty)
@@ -4737,7 +4686,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			if (FindPropertyType(member.Member) is INamedTypeSymbol propertyType)
 			{
 				var cast = default(string);
-				if (IsImplementingInterface(propertyType, _iConvertibleSymbol))
+				if (IsImplementingInterface(propertyType, Generation.IConvertibleSymbol.Value))
 				{
 					// The target property implements IConvertible, therefore
 					// cast ProvideValue() using Convert.ChangeType
@@ -4849,7 +4798,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				if (IsXamlTypeConverter(targetPropertyType))
 				{
 					// We expect the resource to be a string if we're applying the CreateFromStringAttribute
-					var memberValue = GetSimpleStaticResourceRetrieval(targetPropertyType: _stringSymbol, resourcePath);
+					var memberValue = GetSimpleStaticResourceRetrieval(targetPropertyType: Generation.StringSymbol.Value, resourcePath);
 
 					// We must build the member value as a call to a "conversion" function
 					var converterValue = BuildXamlTypeConverterLiteralValue(targetPropertyType, memberValue, includeQuotations: false);
@@ -4868,7 +4817,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// </summary>
 		private string GetSimpleStaticResourceRetrieval(INamedTypeSymbol? targetPropertyType, string? keyStr)
 		{
-			targetPropertyType = targetPropertyType ?? _objectSymbol;
+			targetPropertyType = targetPropertyType ?? Generation.ObjectSymbol.Value;
 
 			var targetPropertyFQT = targetPropertyType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
@@ -5131,8 +5080,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						var declaringType = FindFirstConcreteAncestorType(owner?.Owner);
 
 						if (
-							declaringType.Is(_imageSourceSymbol)
-							|| declaringType.Is(_imageSymbol)
+							declaringType.Is(Generation.ImageSourceSymbol.Value)
+							|| declaringType.Is(Generation.ImageSymbol.Value)
 						)
 						{
 							var uriBase = rawValue.StartsWith("/", StringComparison.Ordinal)
@@ -5391,7 +5340,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var colorsSymbol = (INamedTypeSymbol)_metadataHelper.GetTypeByFullName(XamlConstants.Types.Colors);
 
 			if (colorsSymbol.GetProperties().FirstOrDefault(p =>
-				SymbolEqualityComparer.Default.Equals(p.Type, _colorSymbol) &&
+				SymbolEqualityComparer.Default.Equals(p.Type, Generation.ColorSymbol.Value) &&
 					p.Name.Equals(memberValue, StringComparison.OrdinalIgnoreCase)) is IPropertySymbol property)
 			{
 				return $"{GlobalPrefix}{XamlConstants.Types.Colors}.{property.Name}";
@@ -5484,7 +5433,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			if (memberName == "Path")
 			{
-				var value = BuildLiteralValue(m, GetPropertyTypeByOwnerSymbol(_dataBindingSymbol, memberName));
+				var value = BuildLiteralValue(m, GetPropertyTypeByOwnerSymbol(Generation.DataBindingSymbol.Value, memberName));
 				value = RewriteAttachedPropertyPath(value);
 
 				return value;
@@ -5516,7 +5465,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						m.Owner.Members.None(otherMember => otherMember.Member.Name == "Converter"));
 				propertyType = shouldMatchPropertyType
 					? propertyType
-					: GetPropertyTypeByOwnerSymbol(_dataBindingSymbol, memberName);
+					: GetPropertyTypeByOwnerSymbol(Generation.DataBindingSymbol.Value, memberName);
 				var targetValueType = propertyType;
 
 				// If value is typed and the property is not, the value type should be preserved.
@@ -6082,7 +6031,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 									{
 										writer.AppendLineIndented($"null)");
 
-										using (var applyWriter = CreateApplyBlock(writer, _setterSymbol, out var setterClosure))
+										using (var applyWriter = CreateApplyBlock(writer, Generation.SetterSymbol.Value, out var setterClosure))
 										{
 											applyWriter.AppendLineIndented($"{setterClosure}.");
 											BuildChild(applyWriter, valueNode, valueNode.Objects.First(), outerClosure: setterClosure);
@@ -6231,7 +6180,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					var type = GetType(owner.Type);
 
-					if (type.Is(_uiElementSymbol))
+					if (type.Is(Generation.UIElementSymbol.Value))
 					{
 						return owner;
 					}
@@ -6357,9 +6306,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				var dataContextMember = FindMember(definition, "DataContext");
 				var nameMember = FindMember(definition, "Name");
 
-				if (!(targetType?.Is(_elementStubSymbol.BaseType) ?? false))
+				var elementStubBaseType = Generation.ElementStubSymbol.Value.BaseType;
+				if (!(targetType?.Is(elementStubBaseType) ?? false))
 				{
-					writer.AppendLineIndented($"/* Lazy DeferLoadStrategy was ignored because the target type is not based on {_elementStubSymbol.BaseType} */");
+					writer.AppendLineIndented($"/* Lazy DeferLoadStrategy was ignored because the target type is not based on {elementStubBaseType} */");
 					return null;
 				}
 
@@ -6399,7 +6349,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						disposable?.Dispose();
 
 						string closureName;
-						using (var innerWriter = CreateApplyBlock(writer, _elementStubSymbol, out closureName))
+						using (var innerWriter = CreateApplyBlock(writer, Generation.ElementStubSymbol.Value, out closureName))
 						{
 							var elementStubType = new XamlType("", "ElementStub", new List<XamlType>(), new XamlSchemaContext());
 
@@ -6633,7 +6583,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private string GenerateConstructorParameters(XamlType xamlType)
 		{
-			if (IsType(xamlType, _androidViewSymbol))
+			if (IsType(xamlType, Generation.AndroidViewSymbol.Value))
 			{
 				// For android, all native control must take a context as their first parameters
 				// To be able to use this control from the Xaml, we need to generate a constructor
@@ -6645,7 +6595,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					var q = from m in type.Constructors
 							where m.Parameters.Length == 1
-							where SymbolEqualityComparer.Default.Equals(m.Parameters.First().Type, _androidContentContextSymbol)
+							where SymbolEqualityComparer.Default.Equals(m.Parameters.First().Type, Generation.AndroidContentContextSymbol.Value)
 							select m;
 
 					var hasContextConstructor = q.Any();
@@ -6905,7 +6855,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			=> CurrentResourceOwner?.Name ?? "this";
 
 		public bool HasImplicitViewPinning
-			=> _iOSViewSymbol != null || _appKitViewSymbol != null;
+			=> Generation.IOSViewSymbol.Value is not null || Generation.AppKitViewSymbol.Value is not null;
 
 		/// <summary>
 		/// Pushes a ResourceOwner variable name onto the stack


### PR DESCRIPTION
Two changes made:

1. Move getting symbols to XamlCodeGeneration instead of XamlFileGenerator. So we now have less calls.
2. Using `Lazy<T>` instead of `AsLockedMemoized`. Here is a benchmark for `AsLockedMemoized` vs `Lazy<T>`

```csharp
using System;
using System.Collections.Concurrent;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using Microsoft.CodeAnalysis;
using Microsoft.CodeAnalysis.CSharp;

public class Program
{
    public static void Main(string[] args)
    {
        _ = BenchmarkRunner.Run(typeof(Program).Assembly);
    }
}

public static class Funcs
{
    public static Func<TParam, TResult> Create<TParam, TResult>(Func<TParam, TResult> function) {
        return function;
    }
}

[MemoryDiagnoser]
public class Benchs
{
    private Func<string, ITypeSymbol> _findTypeByFullName;
    private Compilation _compilation;
    private Lazy<INamedTypeSymbol> _lazy;


    private ITypeSymbol SourceFindTypeByFullName(string fullName)
    {
        var symbol = _compilation.GetTypeByMetadataName(fullName);

        return symbol;
    }

    [GlobalSetup]
    public void Setup()
    {
        _compilation = CSharpCompilation.Create(null, new[] { SyntaxFactory.ParseSyntaxTree("namespace A.B.C { public class D { } }") });
        _findTypeByFullName = Funcs.Create<string, ITypeSymbol>(SourceFindTypeByFullName).AsLockedMemoized();
        _lazy = new Lazy<INamedTypeSymbol>(() => _compilation.GetTypeByMetadataName("A.B.C.D"));
    }

    [Benchmark(Baseline = true)]
    public void Baseline()
    {
        _findTypeByFullName("A.B.C.D");
    }

    [Benchmark]
    public void UsingLazy()
    {
        _ = _lazy.Value;
    }
}

public static class Ext
{
    public static Func<TKey, TResult> AsLockedMemoized<TKey, TResult>(this Func<TKey, TResult> func)
    {
        var values = new ConcurrentDictionary<TKey, TResult>();

        return (key) => values.GetOrAdd(key, func);
    }
}

```

Result on my machine:

|    Method |      Mean |     Error |    StdDev | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |----------:|----------:|----------:|------:|------:|------:|------:|----------:|
|  Baseline | 23.743 ns | 0.0698 ns | 0.0583 ns |  1.00 |     - |     - |     - |         - |
| UsingLazy |  3.529 ns | 0.0187 ns | 0.0156 ns |  0.15 |     - |     - |     - |         - |

![image](https://user-images.githubusercontent.com/31348972/221410676-97ca0114-0ae3-40d9-a258-9ca834bc5f8c.png)
