### PR TITLE
fix: to not call on disposed object

### DIFF
--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.cs
@@ -166,7 +166,7 @@ namespace Windows.Devices.Geolocation
 
 		private void StartStatusChanged() => _statusChangedSubscriptions.TryAdd(this, 0);
 
-		private void StopStatusChanged() => _statusChangedSubscriptions.TryRemove(this, out var _);
+		private void StopStatusChanged() => _statusChangedSubscriptions?.TryRemove(this, out var _);
 
 		partial void StartPositionChanged();
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
I encounter exception with message that says that disposed object is used. Stack:
 	0x29 in Java.Interop.JniPeerMembers.AssertSelf at /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.cs:153,5	C#
 	0x1 in Java.Interop.JniPeerMembers.JniInstanceMethods.InvokeVirtualInt32Method at /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods_Invoke.cs:502,5	C#
 	0x12 in Java.Lang.Object.GetHashCode at /Users/runner/work/1/s/xamarin-android/src/Mono.Android/obj/Release/monoandroid10/android-31/mcw/Java.Lang.Object.cs:167,5	C#
 	0x12 in System.Collections.Generic.ObjectEqualityComparer<Windows.Devices.Geolocation.Geolocator>.GetHashCode at /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/mcs/class/referencesource/mscorlib/system/collections/generic/equalitycomparer.cs:305,13	C#
 	0x7 in System.Collections.Concurrent.ConcurrentDictionary<Windows.Devices.Geolocation.Geolocator,byte>.TryRemoveInternal at /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/corefx/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs:370,13	C#
 	0x1A in System.Collections.Concurrent.ConcurrentDictionary<Windows.Devices.Geolocation.Geolocator,byte>.TryRemove at /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/corefx/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs:355,13	C#
 	0x8 in Windows.Devices.Geolocation.Geolocator.StopStatusChanged at C:\a\1\s\src\Uno.UWP\Devices\Geolocation\Geolocator.cs:169,39	C#
 	0x1 in Windows.Devices.Geolocation.Geolocator.Finalize at C:\a\1\s\src\Uno.UWP\Devices\Geolocation\Geolocator.cs:52,4	C#



## What is the new behavior?
No crash.
Maybe also some logic change can be done, but adding "?" operator should be enough to fix this exception.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->




