### PR TITLE
fix: Remove GuardBand on GTK HW renderers to avoid visual glitches around clipping

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurfaceBase.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurfaceBase.cs
@@ -25,12 +25,6 @@ namespace Uno.UI.Runtime.Skia
 		private const SKColorType colorType = SKColorType.Rgba8888;
 		private const GRSurfaceOrigin surfaceOrigin = GRSurfaceOrigin.BottomLeft;
 
-		/// <summary>
-		/// Include a guard band for the creation of the OpenGL surface to avoid
-		/// incorrect renders when the surface is exactly the size of the GLArea.
-		/// </summary>
-		private const int GuardBand = 32;
-
 		private readonly DisplayInformation _displayInformation;
 		private FocusManager? _focusManager;
 
@@ -93,10 +87,9 @@ namespace Uno.UI.Runtime.Skia
 			}
 
 			var scale = _scale ?? 1f;
-			var scaledGuardBand = (int)(GuardBand * scale);
 
-			var w = (int)Math.Max(0, AllocatedWidth * scale + scaledGuardBand);
-			var h = (int)Math.Max(0, AllocatedHeight * scale + scaledGuardBand);
+			var w = (int)Math.Max(0, AllocatedWidth * scale);
+			var h = (int)Math.Max(0, AllocatedHeight * scale);
 
 			if (_renderTarget == null || _surface == null || _renderTarget.Width != w || _renderTarget.Height != h)
 			{
@@ -137,8 +130,6 @@ namespace Uno.UI.Runtime.Skia
 				{
 					canvas.Scale(scale);
 				}
-
-				canvas.Translate(new SKPoint(0, GuardBand));
 
 				WUX.Window.Current.Compositor.Render(_surface);
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11139, closes #10454, closes #10484

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Clipping is buggy when any corner radius is used

## What is the new behavior?

- No visual glitches


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.