### PR TITLE
`XamlReader` should apply `StaticResources` before `ElementName` gets evaluated

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -1,26 +1,19 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno;
-using Uno.Extensions;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Uno.Disposables;
-using System.Text;
-using System.Threading.Tasks;
-using View = Windows.UI.Xaml.FrameworkElement;
-using Windows.UI.Xaml.Media;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Documents;
-using FluentAssertions;
-using Windows.UI.Xaml.Controls.Primitives;
-using Microsoft.Extensions.Logging;
-using Microsoft.UI;
-using Windows.UI;
-using System.Text.RegularExpressions;
-using FluentAssertions.Execution;
-using System.Globalization;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Media;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 {
@@ -1582,6 +1575,27 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 			Assert.AreEqual("\n   You can construct URLs and access their parts. For URLs that represent local files, you can also manipulate properties of those files directly.\n", ((Run)SUT.Inlines[2]).Text);
 			Assert.IsInstanceOfType(SUT.Inlines[3], typeof(LineBreak));
 			Assert.AreEqual("\n   AfterLineBreak \n", ((Run)SUT.Inlines[4]).Text);
+		}
+
+		[TestMethod]
+		public void When_Binding_Converter_StaticResource()
+		{
+			var root = (StackPanel)XamlReader.Load(
+				@"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' 
+                        xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                        xmlns:primitives='using:Microsoft.UI.Xaml.Controls.Primitives'> 
+                    <StackPanel.Resources>
+                        <primitives:CornerRadiusFilterConverter x:Key='RightCornerRadiusFilterConverter' Filter='Right'/>
+                    </StackPanel.Resources>
+					<Grid x:Name='SourceGrid' CornerRadius='6,6,6,6' />
+                    <Grid x:Name='RightRadiusGrid'
+                        CornerRadius='{Binding ElementName=SourceGrid, Path=CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}'>
+                    </Grid>
+                </StackPanel>");
+
+			var rightRadiusGrid = (Grid)root.FindName("RightRadiusGrid");
+
+			Assert.AreEqual(new CornerRadius(0, 6, 6, 0), rightRadiusGrid.CornerRadius);
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -1251,14 +1251,14 @@ namespace Windows.UI.Xaml.Markup.Reader
 
 		private void ApplyPostActions(object? instance)
 		{
-			if (instance is FrameworkElement fe)
-			{
-				ResolveElementNames(fe);
-			}
-
 			while (_postActions.Count != 0)
 			{
 				_postActions.Dequeue()();
+			}
+
+			if (instance is FrameworkElement fe)
+			{
+				ResolveElementNames(fe);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11502

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Applied too late.

## What is the new behavior?

Applied before `ElementName` gets evaluated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
