### PR TITLE
chore(ScrollViewer): customizable snapping delay

### DIFF
--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -539,6 +539,11 @@ namespace Uno.UI
 			/// </summary>
 			public static TimeSpan? AndroidScrollbarFadeDelay { get; set; }
 #endif
+
+			/// <summary>
+			/// Defines the delay of after which the ScrollViewer starts to move to snap points. The default value is 250ms.
+			/// </summary>
+			public static TimeSpan SnapDelay { get; set; } = TimeSpan.FromMilliseconds(250);
 		}
 
 		public static class ThemeAnimation

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1301,7 +1301,7 @@ namespace Windows.UI.Xaml.Controls
 						{
 							_snapPointsTimer = Windows.System.DispatcherQueue.GetForCurrentThread().CreateTimer();
 							_snapPointsTimer.IsRepeating = false;
-							_snapPointsTimer.Interval = FeatureConfiguration.ScrollViewer.UnoSnapDelay;
+							_snapPointsTimer.Interval = FeatureConfiguration.ScrollViewer.SnapDelay;
 							_snapPointsTimer.Tick += (snd, evt) => DelayedMoveToSnapPoint();
 						}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1301,7 +1301,7 @@ namespace Windows.UI.Xaml.Controls
 						{
 							_snapPointsTimer = Windows.System.DispatcherQueue.GetForCurrentThread().CreateTimer();
 							_snapPointsTimer.IsRepeating = false;
-							_snapPointsTimer.Interval = TimeSpan.FromMilliseconds(250);
+							_snapPointsTimer.Interval = FeatureConfiguration.ScrollViewer.UnoSnapDelay;
 							_snapPointsTimer.Tick += (snd, evt) => DelayedMoveToSnapPoint();
 						}
 


### PR DESCRIPTION
GitHub Issue (If applicable): re: #10891

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
Uno ScrollViewer snapping trigger delay can now be customized via FeatureConfiguration.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
n/a