### PR TITLE
fix: Add missing PRIResource in default template

### DIFF
--- a/src/SolutionTemplate/UnoLibraryTemplate.netcore/CrossTargetedLibrary.csproj
+++ b/src/SolutionTemplate/UnoLibraryTemplate.netcore/CrossTargetedLibrary.csproj
@@ -23,6 +23,7 @@
 		<Compile Update="**\*.xaml.cs">
 			<DependentUpon>%(Filename)</DependentUpon>
 		</Compile>
+		<PriResource Include="**\*.resw" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SolutionTemplate/UnoSolutionTemplate.WinUI.netcore/Views/UnoQuickStart.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate.WinUI.netcore/Views/UnoQuickStart.csproj
@@ -43,7 +43,8 @@
 		<ApplicationDefinition Include="App.xaml" Condition="exists('App.xaml')" />
 		<Compile Update="**\*.xaml.cs">
 			<DependentUpon>%(Filename)</DependentUpon>
-		</Compile>
+		</Compile>		
+		<PriResource Include="**\*.resw" />
 	</ItemGroup>
 	<ItemGroup>
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11462

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

New project template does not contain PRIResource itemgroup for localization.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
