### PR TITLE
fix(AdaptiveTrigger): AdaptiveTriggers precedence

### DIFF
--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
@@ -35,20 +35,7 @@ namespace Windows.UI.Xaml
 
 			var isActive = w >= mw && h >= mh;
 
-			if (isActive && mw >= 0)
-			{
-				// If we have 'mw' and 'mh' we activate using the 'MinWidthTrigger' as it's higher ranked by 'ViusalStateGroup.GetActiveTrigger()'
-				SetActivePrecedence(StateTriggerPrecedence.MinWidthTrigger);
-			}
-			else if (isActive)
-			{
-				// We don't validate that 'mh > 0' so we are able to activate trigger with 'MinWindowWidth = 0' and 'MinWindowHeight = 0'
-				SetActivePrecedence(StateTriggerPrecedence.MinHeightTrigger);
-			}
-			else
-			{
-				SetActivePrecedence(StateTriggerPrecedence.Inactive);
-			}
+			SetActivePrecedence(isActive ? StateTriggerPrecedence.AdaptiveTrigger : StateTriggerPrecedence.Inactive);
 		}
 
 		#region MinWindowHeight DependencyProperty

--- a/src/Uno.UI/UI/Xaml/StateTriggerPrecedence.cs
+++ b/src/Uno.UI/UI/Xaml/StateTriggerPrecedence.cs
@@ -7,7 +7,6 @@ namespace Windows.UI.Xaml
 	{
 		Inactive = 0,
 		CustomTrigger = 1,
-		MinWidthTrigger = 2,
-		MinHeightTrigger = 3
+		AdaptiveTrigger = 2,
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #2662

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The first AdaptiveTrigger satisfying MinWindowWidth (if none then MinWindowHeight) is active.

## What is the new behavior?
This behavior is now aligned with windows. The first satisfying AdaptiveTrigger ranked by MinWindowWidth, then by MinWindowHeight, and finally by declaration order is active.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
n/a