### PR TITLE
perf: Optimize LOH string allocations in Xaml generator

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/StringBuilderBasedSourceText.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Utils/StringBuilderBasedSourceText.cs
@@ -1,0 +1,34 @@
+﻿using System.Text;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Uno.UI.SourceGenerators.XamlGenerator.Utils;
+
+/// <summary>
+/// A SourceText implementation that is more performant for cases when we already have a StringBuilder.
+/// In Xaml generator, sometimes our output code gets very large and calling builder.ToString() allocates in Large Object Heap (LOH).
+/// LOH allocations are costly and we want to avoid them, so we implement our own SourceText instead of using `SourceText.From(builder.ToString())`
+/// </summary>
+/// <remarks>
+/// Once this SourceText is created, the builder should NOT be altered in anyway.
+/// </remarks>
+internal sealed class StringBuilderBasedSourceText : SourceText
+{
+	private readonly StringBuilder _builder;
+
+	public StringBuilderBasedSourceText(StringBuilder builder)
+	{
+		_builder = builder;
+	}
+
+	public override char this[int position] => _builder[position];
+
+	public override Encoding Encoding => Encoding.UTF8;
+
+	public override int Length => _builder.Length;
+
+	public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
+		=> _builder.CopyTo(sourceIndex, destination, destinationIndex, count);
+
+	public override string ToString(TextSpan span)
+		=> _builder.ToString(span.Start, span.Length);
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -960,7 +960,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 			}
 
-			Debugger.Launch();
 			return new StringBuilderBasedSourceText(writer.Builder);
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using Uno.UI.SourceGenerators.Helpers;
+using Uno.UI.SourceGenerators.XamlGenerator.Utils;
 
 #if NETFRAMEWORK
 using Microsoft.Build.Execution;
@@ -343,7 +344,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return link;
 		}
 
-		public List<KeyValuePair<string, string>> Generate(GenerationRunInfo generationRunInfo)
+		public List<KeyValuePair<string, SourceText>> Generate(GenerationRunInfo generationRunInfo)
 		{
 			var stopwatch = Stopwatch.StartNew();
 
@@ -405,7 +406,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						.WithDegreeOfParallelism(1);
 				}
 
-				var outputFiles = filesToProcess.Select(file => new KeyValuePair<string, string>(
+				var outputFiles = filesToProcess.Select(file => new KeyValuePair<string, SourceText>(
 					file.UniqueID,
 					new XamlFileGenerator(
 						this,
@@ -441,7 +442,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					).GenerateFile()
 				)).ToList();
 
-				outputFiles.Add(new KeyValuePair<string, string>("GlobalStaticResources", GenerateGlobalResources(files, globalStaticResourcesMap)));
+				outputFiles.Add(new KeyValuePair<string, SourceText>("GlobalStaticResources", GenerateGlobalResources(files, globalStaticResourcesMap)));
 
 				TrackGenerationDone(stopwatch.Elapsed);
 
@@ -481,7 +482,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		}
 
 #if !NETFRAMEWORK
-		private List<KeyValuePair<string, string>> ProcessParsingException(Exception e)
+		private List<KeyValuePair<string, SourceText>> ProcessParsingException(Exception e)
 		{
 			IEnumerable<Exception> Flatten(Exception ex)
 			{
@@ -519,7 +520,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				_generatorContext.ReportDiagnostic(diagnostic);
 			}
 
-			return new List<KeyValuePair<string, string>>();
+			return new List<KeyValuePair<string, SourceText>>();
 		}
 
 		private Location? GetExceptionFileLocation(Exception exception)
@@ -772,7 +773,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				.Max();
 		}
 
-		private string GenerateGlobalResources(IEnumerable<XamlFileDefinition> files, XamlGlobalStaticResourcesMap map)
+		private SourceText GenerateGlobalResources(IEnumerable<XamlFileDefinition> files, XamlGlobalStaticResourcesMap map)
 		{
 			var writer = new IndentedStringBuilder();
 
@@ -959,7 +960,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 			}
 
-			return writer.ToString();
+			Debugger.Launch();
+			return new StringBuilderBasedSourceText(writer.Builder);
 		}
 
 		private static bool IsResourceDictionary(XamlFileDefinition fileDefinition) => fileDefinition.Objects.FirstOrDefault()?.Type.Name == "ResourceDictionary";

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGenerator.Tracing.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGenerator.Tracing.cs
@@ -9,13 +9,14 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 using Uno.Roslyn;
 
 namespace Uno.UI.SourceGenerators.XamlGenerator
 {
 	public partial class XamlCodeGenerator : ISourceGenerator
 	{
-		private void DumpXamlSourceGeneratorState(GeneratorExecutionContext context, List<KeyValuePair<string, string>> generatedSources)
+		private void DumpXamlSourceGeneratorState(GeneratorExecutionContext context, List<KeyValuePair<string, SourceText>> generatedSources)
 		{
 			var tracingFolder = context.GetMSBuildPropertyValue("XamlSourceGeneratorTracingFolder");
 
@@ -81,11 +82,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			File.WriteAllLines(Path.Combine(basePath, "MSBuildItems.txt"), items);
 		}
 
-		private void DumpGeneratedSourceFiles(string sourcesPath, List<KeyValuePair<string, string>> generatedSources)
+		private void DumpGeneratedSourceFiles(string sourcesPath, List<KeyValuePair<string, SourceText>> generatedSources)
 		{
 			foreach (var sourceFile in generatedSources)
 			{
-				File.WriteAllText(Path.Combine(sourcesPath, $"{sourceFile.Key}.cs"), sourceFile.Value);
+				File.WriteAllText(Path.Combine(sourcesPath, $"{sourceFile.Key}.cs"), sourceFile.Value.ToString());
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -24,6 +24,7 @@ using Uno.UI.SourceGenerators.Helpers;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Text;
+using Microsoft.CodeAnalysis.Text;
 
 
 #if NETFRAMEWORK
@@ -279,7 +280,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// <remarks>Initial behavior is to write // Warning, hence the default value to false, but we suggest setting this to true.</remarks>
 		public bool ShouldWriteErrorOnInvalidXaml { get; }
 
-		public string GenerateFile()
+		public SourceText GenerateFile()
 		{
 #if DEBUG
 			Console.WriteLine("Processing file {0}".InvariantCultureFormat(_fileDefinition.FilePath));
@@ -310,7 +311,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 #if DEBUG
 					Console.WriteLine("Skipping unmodified file {0}".InvariantCultureFormat(_fileDefinition.FilePath));
 #endif
-					return File.ReadAllText(outputFile);
+					return SourceText.From(File.ReadAllText(outputFile), Encoding.UTF8);
 				}
 			}
 
@@ -353,7 +354,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 		}
 
-		private string InnerGenerateFile()
+		private SourceText InnerGenerateFile()
 		{
 			var writer = new IndentedStringBuilder();
 
@@ -516,7 +517,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			BuildXamlApplyBlocks(writer);
 
 			// var formattedCode = ReformatCode(writer.ToString());
-			return writer.ToString();
+			return new StringBuilderBasedSourceText(writer.Builder);
 		}
 
 		/// <summary>

--- a/src/Uno.Foundation.Runtime.WebAssembly/Helpers/IndentedStringBuilderExtensions.cs
+++ b/src/Uno.Foundation.Runtime.WebAssembly/Helpers/IndentedStringBuilderExtensions.cs
@@ -23,11 +23,6 @@ namespace Uno.Foundation.Runtime.WebAssembly.Helpers
 {
 	internal static class IndentedStringBuilderExtensions
 	{
-		public static IndentedStringBuilder AsIndented(this StringBuilder builder)
-		{
-			return new IndentedStringBuilder(builder);
-		}
-
 		public static void AppendLine(this IndentedStringBuilder builder, IFormatProvider formatProvider, string pattern, params object[] replacements)
 		{
 			builder.AppendFormat(formatProvider, pattern, replacements);

--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Extensions/IndentedStringBuilder.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Extensions/IndentedStringBuilder.cs
@@ -25,18 +25,12 @@ namespace Uno.Extensions
 	/// </summary>
 	internal sealed class IndentedStringBuilder : IIndentedStringBuilder
 	{
-		private readonly StringBuilder _stringBuilder;
+		public StringBuilder Builder { get; } = new();
 
 		public int CurrentLevel { get; private set; }
 
 		public IndentedStringBuilder()
-			: this(new StringBuilder())
 		{
-		}
-
-		public IndentedStringBuilder(StringBuilder stringBuilder)
-		{
-			_stringBuilder = stringBuilder;
 		}
 
 		public IDisposable Indent(int count = 1)
@@ -71,37 +65,37 @@ namespace Uno.Extensions
 
 		public void Append(string text)
 		{
-			_stringBuilder.Append(text);
+			Builder.Append(text);
 		}
 
 		public void AppendIndented(string text)
 		{
-			_stringBuilder.Append('\t', CurrentLevel);
-			_stringBuilder.Append(text);
+			Builder.Append('\t', CurrentLevel);
+			Builder.Append(text);
 		}
 
 		public void AppendIndented(ReadOnlySpan<char> text)
 		{
-			_stringBuilder.Append('\t', CurrentLevel);
+			Builder.Append('\t', CurrentLevel);
 			unsafe
 			{
 				fixed (char* ptr = &MemoryMarshal.GetReference(text))
 				{
-					_stringBuilder.Append(ptr, text.Length);
+					Builder.Append(ptr, text.Length);
 				}
 			}
 		}
 
 		private void AppendIndented(char c, int indentCount)
 		{
-			_stringBuilder.Append('\t', indentCount);
-			_stringBuilder.Append(c);
+			Builder.Append('\t', indentCount);
+			Builder.Append(c);
 		}
 
 		public void AppendFormatIndented(IFormatProvider formatProvider, string text, params object[] replacements)
 		{
-			_stringBuilder.Append('\t', CurrentLevel);
-			_stringBuilder.AppendFormat(formatProvider, text, replacements);
+			Builder.Append('\t', CurrentLevel);
+			Builder.AppendFormat(formatProvider, text, replacements);
 		}
 
 		/// <summary>
@@ -109,7 +103,7 @@ namespace Uno.Extensions
 		/// </summary>
 		public void AppendLine()
 		{
-			_stringBuilder.AppendLine();
+			Builder.AppendLine();
 		}
 
 		/// <summary>
@@ -127,7 +121,7 @@ namespace Uno.Extensions
 
 		public override string ToString()
 		{
-			return _stringBuilder.ToString();
+			return Builder.ToString();
 		}
 	}
 


### PR DESCRIPTION
Found LOH string allocations in a trace:

![image](https://user-images.githubusercontent.com/31348972/221874923-d1b162bf-2310-4ff6-a51f-b7ca0a141f72.png)

So now, we are not allocating these large strings and letting Roslyn do the right thing with `CopyTo` and `ToString(TextSpan)` overrides.

closes #11515

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
