### PR TITLE
fix(dragdrop): Fix reordering issue on iOS

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,12 +5,6 @@
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CA1416</NoWarn> <!-- Disable warning about cross platform call sites -->
-    <NoWarn>$(NoWarn);MSB4011</NoWarn> <!-- Disable duplicate msbuild files imports message -->
-    <NoWarn>$(NoWarn);NU1505</NoWarn> <!-- Disable: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: Microsoft.NETCore.App.Host.win-x64 [3.1.25], Microsoft.NETCore.App.Host.win-x64 [3.1.25], Microsoft.NETCore.App.Host.win-x64 [3.1.25], Microsoft.NETCore.App.Host.win-x64 [3.1.25]. -->
-
-	<NoWarn Condition="'$(OS)' != 'Windows_NT'">$(NoWarn);IDE0055</NoWarn>
-
     <DebugType>portable</DebugType>
     <DebugSymbols>True</DebugSymbols>
     <RepositoryUrl>$(BUILD_REPOSITORY_URI)</RepositoryUrl>
@@ -229,6 +223,11 @@
     <IsSampleProject>$(MSBuildProjectName.Contains('Sample'))</IsSampleProject>
     <IsSampleProject Condition="'$(IsSampleProject)'=='false'">$(MSBuildProjectName.Contains('UnoIslands'))</IsSampleProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsNotAsErrors Condition="'$(Configuration)' == 'Debug'">$(WarningsNotAsErrors);IDE0051;IDE0055</WarningsNotAsErrors>
+	<NoWarn>$(NoWarn);CA1416</NoWarn> <!-- Disable warning about cross platform call sites -->
+    <NoWarn>$(NoWarn);MSB4011</NoWarn> <!-- Disable duplicate msbuild files imports message -->
+    <NoWarn>$(NoWarn);NU1505</NoWarn> <!-- Disable: Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: Microsoft.NETCore.App.Host.win-x64 [3.1.25], Microsoft.NETCore.App.Host.win-x64 [3.1.25], Microsoft.NETCore.App.Host.win-x64 [3.1.25], Microsoft.NETCore.App.Host.win-x64 [3.1.25]. -->
+	<NoWarn Condition="'$(OS)' != 'Windows_NT'">$(NoWarn);IDE0055</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Uno.UI.Composition/Composition/SkiaCompositionSurface.skia.cs
+++ b/src/Uno.UI.Composition/Composition/SkiaCompositionSurface.skia.cs
@@ -19,6 +19,11 @@ namespace Windows.UI.Composition
 
 		public SKImage? Image { get => _image; }
 
+		internal SkiaCompositionSurface(SKImage image)
+		{
+			_image = image;
+		}
+
 		internal void LoadFromBytes(byte[] image)
 		{
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -7,6 +8,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Imaging;
 using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading;
 using Uno.UI.RuntimeTests.Helpers;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
@@ -106,14 +108,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			await sut.RenderAsync(border);
 
 			var onCanvasReady = new TaskCompletionSource<object>();
+			var onCanvasTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(Debugger.IsAttached ? 300 : 1));
 			var onCanvas = new Image
 			{
-				Source = sut,
 				Width = 10,
 				Height = 10
 			};
+			onCanvasTimeout.Token.Register(() => onCanvasReady.TrySetException(new TimeoutException("Image didn't render")));
 			onCanvas.ImageOpened += (snd, e) => onCanvasReady.TrySetResult(default);
 			onCanvas.ImageFailed += (snd, e) => onCanvasReady.TrySetException(new InvalidOperationException(e.ErrorMessage));
+			onCanvas.Source = sut;
 
 			TestServices.WindowHelper.WindowContent = onCanvas;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
@@ -82,6 +82,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 #if __WASM__
 		[Ignore("Not implemented yet.")]
 #endif
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 		public async Task When_Render_Then_CanRenderOnCanvas()
 		{
 			var border = new Border()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
@@ -83,9 +83,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 		[TestMethod]
 #if __WASM__
 		[Ignore("Not implemented yet.")]
-#endif
-#if __MACOS__
+#elif __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#elif __SKIA__
+		[Ignore("Currently fails on CI for skia GTK (works locally)")]
 #endif
 		public async Task When_Render_Then_CanRenderOnCanvas()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
@@ -7,6 +7,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Imaging;
 using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.RuntimeTests.Helpers;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 {
@@ -75,6 +76,54 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 				var component = i % 4;
 				Assert.AreEqual(rawBorderSnapshot[i], pixelsArray[i], $"The {map[component]} channel of pixel {pixel} is not same. Expected {rawBorderSnapshot[i]:x2} found {pixelsArray[i]:x2}.");
 			}
+		}
+
+		[TestMethod]
+#if __WASM__
+		[Ignore("Not implemented yet.")]
+#endif
+		public async Task When_Render_Then_CanRenderOnCanvas()
+		{
+			var border = new Border()
+			{
+				Name = "TestBorder",
+				Width = 10,
+				Height = 10,
+				BorderThickness = new Thickness(1),
+				Background = Background,
+				BorderBrush = BorderBrush
+			};
+
+			TestServices.WindowHelper.WindowContent = border;
+
+			await TestServices.WindowHelper.WaitForLoaded(border);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var sut = new RenderTargetBitmap();
+			await sut.RenderAsync(border);
+
+			var onCanvasReady = new TaskCompletionSource<object>();
+			var onCanvas = new Image
+			{
+				Source = sut,
+				Width = 10,
+				Height = 10
+			};
+			onCanvas.ImageOpened += (snd, e) => onCanvasReady.TrySetResult(default);
+			onCanvas.ImageFailed += (snd, e) => onCanvasReady.TrySetException(new InvalidOperationException(e.ErrorMessage));
+
+			TestServices.WindowHelper.WindowContent = onCanvas;
+
+			await onCanvasReady.Task;
+			await TestServices.WindowHelper.WaitForLoaded(onCanvas);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// We are also using RenderTargetBitmap to validate the result ... weird but it works :)
+			var resultTarget = new RenderTargetBitmap();
+			await resultTarget.RenderAsync(onCanvas);
+			var result = await RawBitmap.From(resultTarget, onCanvas);
+
+			ImageAssert.HasColorAt(result, 5, 5, Background.Color);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
@@ -7,6 +7,7 @@ using Windows.Foundation;
 using Windows.UI.Composition;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
+using Uno.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -71,6 +72,15 @@ namespace Windows.UI.Xaml.Controls
 				_surfaceBrush = Visual.Compositor.CreateSurfaceBrush(_currentSurface);
 				_imageSprite.Brush = _surfaceBrush;
 				InvalidateMeasure();
+
+				if (img is not { Kind: ImageDataKind.Error })
+				{
+					ImageOpened?.Invoke(this, new RoutedEventArgs(this));
+				}
+				else
+				{
+					ImageFailed?.Invoke(this, new ExceptionRoutedEventArgs(this, img.Error?.Message ?? "Unknown error"));
+				}
 			});
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1597,9 +1597,9 @@ namespace Windows.UI.Xaml.Controls
 			if (items is IList<object> list)
 			{
 				// This is primarily an optimization for ICollectionView, which implements IList<object> but might not implement non-generic IList
-				return list[index];
+				return list.Count > index ? list[index] : default;
 			}
-
+			
 			return items?.ElementAtOrDefault(index);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1599,7 +1599,7 @@ namespace Windows.UI.Xaml.Controls
 				// This is primarily an optimization for ICollectionView, which implements IList<object> but might not implement non-generic IList
 				return list.Count > index ? list[index] : default;
 			}
-			
+
 			return items?.ElementAtOrDefault(index);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -383,10 +383,8 @@ namespace Windows.UI.Xaml.Controls
 
 		#region Helpers
 		private static bool IsObservableCollection(object src)
-		{
-			var srcType = src.GetType();
-			return srcType.IsGenericType && srcType.GetGenericTypeDefinition() == typeof(ObservableCollection<>);
-		}
+			=> src.GetType() is { IsGenericType: true } srcType
+				&& srcType.GetGenericTypeDefinition() == typeof(ObservableCollection<>);
 
 		private static void DoMove(ItemCollection items, int oldIndex, int newIndex)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -573,8 +573,9 @@ namespace Windows.UI.Xaml.Controls
 					}
 
 					SaveContainersBeforeRemoveForIndexRepair(args.OldStartingIndex, args.OldItems.Count);
-					CleanUpContainers(args.OldStartingIndex, args.OldItems.Count);
+					var removedContainers = CaptureContainers(args.OldStartingIndex, args.OldItems.Count);
 					RemoveItems(args.OldStartingIndex, args.OldItems.Count, section);
+					CleanUpContainers(removedContainers);
 					RepairIndices();
 
 					break;
@@ -683,7 +684,10 @@ namespace Windows.UI.Xaml.Controls
 
 		private void CleanUpAllContainers()
 		{
-			if (ShouldItemsControlManageChildren) return;
+			if (ShouldItemsControlManageChildren)
+			{
+				return;
+			}
 
 			foreach (var container in MaterializedContainers)
 			{
@@ -691,17 +695,30 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private void CleanUpContainers(int startingIndex, int length)
+		private ICollection<DependencyObject> CaptureContainers(int startingIndex, int length)
 		{
-			if (ShouldItemsControlManageChildren) return;
+			if (ShouldItemsControlManageChildren)
+			{
+				return Array.Empty<DependencyObject>();
+			}
 
+			var containers = new List<DependencyObject>(length);
 			foreach (var container in MaterializedContainers)
 			{
 				var index = (int)container.GetValue(ItemsControl.IndexForItemContainerProperty);
 				if (startingIndex <= index && index < startingIndex + length)
 				{
-					CleanUpContainer(container);
+					containers.Add(container);
 				}
+			}
+			return containers;
+		}
+
+		private void CleanUpContainers(ICollection<DependencyObject> containersToCleanup)
+		{
+			foreach (var container in containersToCleanup)
+			{
+				CleanUpContainer(container);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
@@ -786,12 +786,12 @@ namespace Windows.UI.Xaml.Controls
 			base.TouchesBegan(touches, evt);
 
 			// We wait for the first touches to get the parent so we don't have to track Loaded/UnLoaded
-			// Like native dispatch on iOS, we do "implicit captures" the target.
+			// Like native dispatch on iOS, we do "implicit captures" of the target.
 			if (this.GetParent() is UIElement parent)
 			{
-				// canBubbleNatively: true => We let native bubbling occur properly as it's never swallowed by system
-				//							  but blocking it would be breaking in lot of aspects
-				//							  (e.g. it would prevent all sub-sequent events for the given pointer).
+				// canBubbleNatively: true => We let native bubbling occur properly as it's never swallowed by the system
+				//							  but blocking it would be breaking in a lot of aspects
+				//							  (e.g. it would prevent all subsequent events for the given pointer).
 
 				_touchTarget = parent;
 				_touchTarget.TouchesBegan(touches, evt, canBubbleNatively: true);
@@ -812,7 +812,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.TouchesEnded(touches, evt);
 
-			// canBubbleNatively: false => system might silently swallow pointer after few moves so we prefer to bubble in managed.
+			// canBubbleNatively: false => system might silently swallow the pointer after a few moves so we prefer to bubble in managed.
 			_touchTarget?.TouchesEnded(touches, evt, canBubbleNatively: false);
 			_touchTarget = null;
 		}
@@ -822,7 +822,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.TouchesCancelled(touches, evt);
 
-			// canBubbleNatively: false => system might silently swallow pointer after few moves so we prefer to bubble in managed.
+			// canBubbleNatively: false => system might silently swallow the pointer after a few moves so we prefer to bubble in managed.
 			_touchTarget?.TouchesCancelled(touches, evt, canBubbleNatively: false);
 			_touchTarget = null;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
@@ -272,7 +272,7 @@ namespace Windows.UI.Xaml.Controls
 					try
 					{
 						base.DeleteItems(indexPaths);
-						}
+					}
 #if NET6_0_OR_GREATER
 					catch (Exception e)
 #else

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
@@ -272,7 +272,7 @@ namespace Windows.UI.Xaml.Controls
 					try
 					{
 						base.DeleteItems(indexPaths);
-					}
+						}
 #if NET6_0_OR_GREATER
 					catch (Exception e)
 #else
@@ -778,6 +778,56 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		#region Touches
+		private UIElement _touchTarget;
+
+		/// <inheritdoc />
+		public override void TouchesBegan(NSSet touches, UIEvent evt)
+		{
+			base.TouchesBegan(touches, evt);
+
+			// We wait for the first touches to get the parent so we don't have to track Loaded/UnLoaded
+			// Like native dispatch on iOS, we do "implicit captures" the target.
+			if (this.GetParent() is UIElement parent)
+			{
+				// canBubbleNatively: true => We let native bubbling occur properly as it's never swallowed by system
+				//							  but blocking it would be breaking in lot of aspects
+				//							  (e.g. it would prevent all sub-sequent events for the given pointer).
+
+				_touchTarget = parent;
+				_touchTarget.TouchesBegan(touches, evt, canBubbleNatively: true);
+			}
+		}
+
+		/// <inheritdoc />
+		public override void TouchesMoved(NSSet touches, UIEvent evt)
+		{
+			base.TouchesMoved(touches, evt);
+
+			// canBubbleNatively: false => The system might silently swallow pointers after a few moves so we prefer to bubble in managed.
+			_touchTarget?.TouchesMoved(touches, evt, canBubbleNatively: false);
+		}
+
+		/// <inheritdoc />
+		public override void TouchesEnded(NSSet touches, UIEvent evt)
+		{
+			base.TouchesEnded(touches, evt);
+
+			// canBubbleNatively: false => system might silently swallow pointer after few moves so we prefer to bubble in managed.
+			_touchTarget?.TouchesEnded(touches, evt, canBubbleNatively: false);
+			_touchTarget = null;
+		}
+
+		/// <inheritdoc />
+		public override void TouchesCancelled(NSSet touches, UIEvent evt)
+		{
+			base.TouchesCancelled(touches, evt);
+
+			// canBubbleNatively: false => system might silently swallow pointer after few moves so we prefer to bubble in managed.
+			_touchTarget?.TouchesCancelled(touches, evt, canBubbleNatively: false);
+			_touchTarget = null;
+		}
+
+
 		private TouchesManager _touchesManager;
 
 		internal TouchesManager TouchesManager => _touchesManager ??= new NativeListViewBaseTouchesManager(this);

--- a/src/Uno.UI/UI/Xaml/Media/ImageDataKind.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageDataKind.cs
@@ -23,15 +23,17 @@ internal enum ImageDataKind
 	/// </summary>
 	ByteArray,
 
-	/// <summary>
-	/// A native image.
-	/// </summary>
-	NativeImage,
-
+#if __SKIA__
 	/// <summary>
 	/// Skia composition surface.
 	/// </summary>
 	CompositionSurface,
+#else
+	/// <summary>
+	/// A native image.
+	/// </summary>
+	NativeImage,
+#endif
 
 	/// <summary>
 	/// The image failed to load (cf. The Error property)

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
@@ -149,7 +149,7 @@ namespace Windows.UI.Xaml.Media
 		/// <returns>True if opening synchronously is possible.</returns>
 		/// <remarks>
 		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
-		/// Depending of stretching, only of each can be provided.
+		/// Depending on stretching, only one of each can be provided.
 		/// </remarks>
 		private protected virtual bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData image)
 		{
@@ -166,7 +166,7 @@ namespace Windows.UI.Xaml.Media
 		/// <returns>True if opening asynchronously is possible.</returns>
 		/// <remarks>
 		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
-		/// Depending of stretching, only of each can be provided.
+		/// Depending on stretching, only one of each can be provided.
 		/// </remarks>
 		private protected virtual bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight, [NotNullWhen(true)] out Task<ImageData> asyncImage)
 		{

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
@@ -140,12 +140,34 @@ namespace Windows.UI.Xaml.Media
 		/// </summary>
 		private protected virtual bool IsSourceReady => false;
 
-		private protected virtual bool TryOpenSourceSync(int? targetWidth, int? targetHeight, [NotNullWhen(true)] out ImageData image)
+		/// <summary>
+		/// Override to provide the capability of concrete ImageSource to open synchronously.
+		/// </summary>
+		/// <param name="targetWidth">The width of the image that will render this ImageSource.</param>
+		/// <param name="targetHeight">The width of the image that will render this ImageSource.</param>
+		/// <param name="image">Returned image data.</param>
+		/// <returns>True if opening synchronously is possible.</returns>
+		/// <remarks>
+		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
+		/// Depending of stretching, only of each can be provided.
+		/// </remarks>
+		private protected virtual bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData image)
 		{
 			image = default;
 			return false;
 		}
 
+		/// <summary>
+		/// Override to provide the capability of concrete ImageSource to open asynchronously.
+		/// </summary>
+		/// <param name="targetWidth">The width of the image that will render this ImageSource.</param>
+		/// <param name="targetHeight">The width of the image that will render this ImageSource.</param>
+		/// <param name="asyncImage">Async task for image data retrieval.</param>
+		/// <returns>True if opening asynchronously is possible.</returns>
+		/// <remarks>
+		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
+		/// Depending of stretching, only of each can be provided.
+		/// </remarks>
 		private protected virtual bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight, [NotNullWhen(true)] out Task<ImageData> asyncImage)
 		{
 			asyncImage = default;

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
@@ -236,7 +236,7 @@ namespace Windows.UI.Xaml.Media
 			}
 			catch (NSErrorException e)
 			{
-				// This can occur for various reasons: download was cancelled, NSAppTransportSecurity blocks download, host couldn't be resolved...
+				// This can occur for various reasons: download was canceled, NSAppTransportSecurity blocks download, the host couldn't be resolved...
 				if (ct.IsCancellationRequested)
 				{
 					if (this.Log().IsEnabled(LogLevel.Debug))

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.iOSmacOS.cs
@@ -127,7 +127,7 @@ public partial class ImageSource
 	/// Override to provide the capability of concrete ImageSource to open synchronously.
 	/// </summary>
 	/// <param name="image">Returned image data.</param>
-	/// <returns>True if opening synchronosly is possible.</returns>
+	/// <returns>True if opening synchronously is possible.</returns>
 	private protected virtual bool TryOpenSourceSync([NotNullWhen(true)] out ImageData image)
 	{
 		image = default;
@@ -138,7 +138,7 @@ public partial class ImageSource
 	/// Override to provide the capability of concrete ImageSource to open asynchronously.
 	/// </summary>
 	/// <param name="image">Async task for image data retrieval.</param>
-	/// <returns>True if opening synchronosly is possible.</returns>
+	/// <returns>True if opening asynchronously is possible.</returns>
 	private protected virtual bool TryOpenSourceAsync(CancellationToken ct, [NotNullWhen(true)] out Task<ImageData> asyncImage)
 	{
 		asyncImage = default;

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.iOSmacOS.cs
@@ -128,7 +128,7 @@ public partial class ImageSource
 	/// </summary>
 	/// <param name="image">Returned image data.</param>
 	/// <returns>True if opening synchronously is possible.</returns>
-	private protected virtual bool TryOpenSourceSync([NotNullWhen(true)] out ImageData image)
+	private protected virtual bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData image)
 	{
 		image = default;
 		return false;
@@ -137,9 +137,15 @@ public partial class ImageSource
 	/// <summary>
 	/// Override to provide the capability of concrete ImageSource to open asynchronously.
 	/// </summary>
-	/// <param name="image">Async task for image data retrieval.</param>
+	/// <param name="targetWidth">The width of the image that will render this ImageSource.</param>
+	/// <param name="targetHeight">The width of the image that will render this ImageSource.</param>
+	/// <param name="asyncImage">Async task for image data retrieval.</param>
 	/// <returns>True if opening asynchronously is possible.</returns>
-	private protected virtual bool TryOpenSourceAsync(CancellationToken ct, [NotNullWhen(true)] out Task<ImageData> asyncImage)
+	/// <remarks>
+	/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
+	/// Depending of stretching, only of each can be provided.
+	/// </remarks>
+	private protected virtual bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight, [NotNullWhen(true)] out Task<ImageData> asyncImage)
 	{
 		asyncImage = default;
 		return false;
@@ -161,7 +167,7 @@ public partial class ImageSource
 			return true;
 		}
 
-		if (IsSourceReady && TryOpenSourceSync(out image))
+		if (IsSourceReady && TryOpenSourceSync(null, null, out image))
 		{
 			return true;
 		}
@@ -185,12 +191,12 @@ public partial class ImageSource
 				return ImageData.Empty;
 			}
 
-			if (IsSourceReady && TryOpenSourceSync(out var img))
+			if (IsSourceReady && TryOpenSourceSync(null, null, out var img))
 			{
 				return _imageData = img;
 			}
 
-			if (IsSourceReady && TryOpenSourceAsync(ct, out var asyncImg))
+			if (IsSourceReady && TryOpenSourceAsync(ct, null, null, out var asyncImg))
 			{
 				return _imageData = await asyncImg;
 			}

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.iOSmacOS.cs
@@ -143,7 +143,7 @@ public partial class ImageSource
 	/// <returns>True if opening asynchronously is possible.</returns>
 	/// <remarks>
 	/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
-	/// Depending of stretching, only of each can be provided.
+	/// Depending on stretching, only one of each can be provided.
 	/// </remarks>
 	private protected virtual bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight, [NotNullWhen(true)] out Task<ImageData> asyncImage)
 	{

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.net.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.net.cs
@@ -44,7 +44,7 @@ namespace Windows.UI.Xaml.Media
 		/// <returns>True if opening synchronously is possible.</returns>
 		/// <remarks>
 		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
-		/// Depending of stretching, only of each can be provided.
+		/// Depending on stretching, only one of each can be provided.
 		/// </remarks>
 		private protected virtual bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData image)
 		{
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml.Media
 		/// <returns>True if opening asynchronously is possible.</returns>
 		/// <remarks>
 		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
-		/// Depending of stretching, only of each can be provided.
+		/// Depending on stretching, only one of each can be provided.
 		/// </remarks>
 		private protected virtual bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight, [NotNullWhen(true)] out Task<ImageData> asyncImage)
 		{

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.net.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.net.cs
@@ -2,6 +2,7 @@
 using Uno.Foundation.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -11,6 +12,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Uno;
 using Uno.Diagnostics.Eventing;
+using Uno.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 
 #if !IS_UNO
@@ -31,5 +33,41 @@ namespace Windows.UI.Xaml.Media
 		{
 			AbsoluteUri = null;
 		}
+
+		#region Implementers API
+		/// <summary>
+		/// Override to provide the capability of concrete ImageSource to open synchronously.
+		/// </summary>
+		/// <param name="targetWidth">The width of the image that will render this ImageSource.</param>
+		/// <param name="targetHeight">The width of the image that will render this ImageSource.</param>
+		/// <param name="image">Returned image data.</param>
+		/// <returns>True if opening synchronously is possible.</returns>
+		/// <remarks>
+		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
+		/// Depending of stretching, only of each can be provided.
+		/// </remarks>
+		private protected virtual bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData image)
+		{
+			image = default;
+			return false;
+		}
+
+		/// <summary>
+		/// Override to provide the capability of concrete ImageSource to open asynchronously.
+		/// </summary>
+		/// <param name="targetWidth">The width of the image that will render this ImageSource.</param>
+		/// <param name="targetHeight">The width of the image that will render this ImageSource.</param>
+		/// <param name="asyncImage">Async task for image data retrieval.</param>
+		/// <returns>True if opening asynchronously is possible.</returns>
+		/// <remarks>
+		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
+		/// Depending of stretching, only of each can be provided.
+		/// </remarks>
+		private protected virtual bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight, [NotNullWhen(true)] out Task<ImageData> asyncImage)
+		{
+			asyncImage = default;
+			return false;
+		}
+		#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.netstd.cs
@@ -74,7 +74,7 @@ namespace Windows.UI.Xaml.Media
 		/// <returns>True if opening synchronously is possible.</returns>
 		/// <remarks>
 		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
-		/// Depending of stretching, only of each can be provided.
+		/// Depending on stretching, only one of each can be provided.
 		/// </remarks>
 		private protected virtual bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData image)
 		{
@@ -91,7 +91,7 @@ namespace Windows.UI.Xaml.Media
 		/// <returns>True if opening asynchronously is possible.</returns>
 		/// <remarks>
 		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
-		/// Depending of stretching, only of each can be provided.
+		/// Depending on stretching, only one of each can be provided.
 		/// </remarks>
 		private protected virtual bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight, [NotNullWhen(true)] out Task<ImageData> asyncImage)
 		{

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.netstd.cs
@@ -2,6 +2,7 @@
 using Uno.Foundation.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -64,14 +65,35 @@ namespace Windows.UI.Xaml.Media
 		internal bool IsOpened => _imageData.HasData;
 
 		#region Implementers API
+		/// <summary>
+		/// Override to provide the capability of concrete ImageSource to open synchronously.
+		/// </summary>
+		/// <param name="targetWidth">The width of the image that will render this ImageSource.</param>
+		/// <param name="targetHeight">The width of the image that will render this ImageSource.</param>
+		/// <param name="image">Returned image data.</param>
+		/// <returns>True if opening synchronously is possible.</returns>
+		/// <remarks>
+		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
+		/// Depending of stretching, only of each can be provided.
+		/// </remarks>
 		private protected virtual bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData image)
 		{
 			image = default;
 			return false;
 		}
 
-		private protected virtual bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight,
-			out Task<ImageData> asyncImage)
+		/// <summary>
+		/// Override to provide the capability of concrete ImageSource to open asynchronously.
+		/// </summary>
+		/// <param name="targetWidth">The width of the image that will render this ImageSource.</param>
+		/// <param name="targetHeight">The width of the image that will render this ImageSource.</param>
+		/// <param name="asyncImage">Async task for image data retrieval.</param>
+		/// <returns>True if opening asynchronously is possible.</returns>
+		/// <remarks>
+		/// <paramref name="targetWidth"/> and <paramref name="targetHeight"/> can be used to improve performance by fetching / decoding only the required size.
+		/// Depending of stretching, only of each can be provided.
+		/// </remarks>
+		private protected virtual bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight, [NotNullWhen(true)] out Task<ImageData> asyncImage)
 		{
 			asyncImage = default;
 			return false;

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.netstd.cs
@@ -144,8 +144,6 @@ namespace Windows.UI.Xaml.Media
 			}
 
 			var listeners = _subscriptions.ToList();
-
-
 			foreach (var listener in listeners)
 			{
 				listener(data);

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.Android.cs
@@ -39,16 +39,9 @@ namespace Windows.UI.Xaml.Media.Imaging
 		/// <inheritdoc />
 		private protected override bool IsSourceReady => _buffer != null;
 
-		/// <inheritdoc />
-		private protected override bool TryOpenSourceSync(int? targetWidth, int? targetHeight, [NotNullWhen(true)] out ImageData image)
+		private static ImageData Open(byte[] buffer, int bufferLength, int width, int height)
 		{
-			image = default;
-			if (_buffer is null)
-			{
-				return false;
-			}
-			image = ImageData.FromBitmap(BitmapFactory.DecodeByteArray(_buffer, 0, _bufferSize));
-			return image.HasData;
+			return ImageData.FromBitmap(BitmapFactory.DecodeByteArray(buffer, 0, bufferLength));
 		}
 
 		private (int ByteCount, int Width, int Height) RenderAsBgra8_Premul(UIElement element, ref byte[]? buffer, Size? scaledSize = null)
@@ -111,8 +104,6 @@ namespace Windows.UI.Xaml.Media.Imaging
 				bitmap?.Dispose();
 				SetSoftwareRendering(element, false);
 			}
-
-
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.cs
@@ -150,6 +150,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 			}
 		}
 
+#if !__IOS__ && !__MACOS__
 		[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
 		private static void SwapRB(ref byte[] buffer, int byteCount)
 		{
@@ -164,6 +165,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 			(a, b) = (b, a);
 		}
 #endif
-		#endregion
+#endif
+#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.cs
@@ -11,6 +11,7 @@ using Windows.Foundation;
 using Windows.Storage.Streams;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
+using Uno.UI.Xaml.Media;
 using Buffer = Windows.Storage.Streams.Buffer;
 using System.Buffers;
 
@@ -19,7 +20,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 #if NOT_IMPLEMENTED
 	[global::Uno.NotImplemented("NET461", "__WASM__", "__NETSTD_REFERENCE__")]
 #endif
-	public partial class RenderTargetBitmap : IDisposable
+	public partial class RenderTargetBitmap : ImageSource, IDisposable
 	{
 #if NOT_IMPLEMENTED
 		internal const bool IsImplemented = false;
@@ -64,6 +65,27 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 		private byte[]? _buffer;
 		private int _bufferSize;
+
+		/// <inheritdoc />
+		private protected override bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData image)
+		{
+			var width = PixelWidth;
+			var height = PixelHeight;
+
+			if (_buffer is null || _bufferSize <= 0 || width <= 0 || height <= 0)
+			{
+				image = default;
+				return false;
+			}
+
+			image = Open(_buffer, _bufferSize, width, height);
+			return image.HasData;
+		}
+
+#if NOT_IMPLEMENTED
+		private static ImageData Open(byte[] buffer, int bufferLength, int width, int height)
+			=> default;
+#endif
 
 #if NOT_IMPLEMENTED
 		[global::Uno.NotImplemented("NET461", "__WASM__", "__NETSTD_REFERENCE__")]
@@ -160,6 +182,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 				Swap(ref buffer![i], ref buffer![i + 2]);
 			}
 		}
+
 		private static void Swap(ref byte a, ref byte b)
 		{
 			(a, b) = (b, a);

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.cs
@@ -166,6 +166,6 @@ namespace Windows.UI.Xaml.Media.Imaging
 		}
 #endif
 #endif
-#endregion
+		#endregion
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.iOS.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using Windows.Foundation;
 using CoreGraphics;
@@ -12,6 +13,10 @@ namespace Windows.UI.Xaml.Media.Imaging
 {
 	partial class RenderTargetBitmap
 	{
+		private const int _bitsPerPixel = 32;
+		private const int _bitsPerComponent = 8;
+		private const int _bytesPerPixel = _bitsPerPixel / _bitsPerComponent;
+
 		/// <inheritdoc />
 		private protected override bool IsSourceReady => _buffer != null;
 
@@ -19,35 +24,31 @@ namespace Windows.UI.Xaml.Media.Imaging
 		private protected override bool TryOpenSourceSync([NotNullWhen(true)] out ImageData image)
 		{
 			image = default;
-			if (_buffer is null)
+
+			var width = PixelWidth;
+			var height = PixelHeight;
+
+			if (_buffer is null || _bufferSize <= 0 || width <= 0 || height <= 0)
 			{
 				return false;
 			}
-			NSData? data;
-			if (_bufferSize == 0)
+
+			using var colorSpace = CGColorSpace.CreateDeviceRGB();
+			using var context = new CGBitmapContext(
+				_buffer,
+				width,
+				height,
+				_bitsPerComponent,
+				width * _bytesPerPixel,
+				colorSpace,
+				CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.PremultipliedFirst);
+
+			using var cgImage = context.ToImage();
+			if (cgImage is not null)
 			{
-				data = NSData.FromBytes(IntPtr.Zero, 0);
-			}
-			else
-			{
-				unsafe
-				{
-					fixed (byte* ptr = &_buffer[0])
-					{
-						data = NSData.FromBytes((IntPtr)ptr, (nuint)_bufferSize);
-					}
-				}
-			}
-			UIImage? nativeImage = null;
-			if (data is { })
-			{
-				nativeImage = UIImage.LoadFromData(data);
+				image = ImageData.FromNative(new UIImage(cgImage));
 			}
 
-			if (nativeImage is not null)
-			{
-				image = ImageData.FromNative(nativeImage);
-			}
 			return image.HasData;
 		}
 
@@ -59,14 +60,15 @@ namespace Windows.UI.Xaml.Media.Imaging
 			{
 				return (0, 0, 0);
 			}
-			UIImage img;
+
+			UIImage uiImage;
 			try
 			{
 				UIGraphics.BeginImageContextWithOptions(size, false, 1f);
 				var ctx = UIGraphics.GetCurrentContext();
 				ctx.SetFillColor(Colors.Transparent); // This is only for pixels not used, but the bitmap as the same size of the element. We keep it only for safety!
 				element.Layer.RenderInContext(ctx);
-				img = UIGraphics.GetImageFromCurrentImageContext();
+				uiImage = UIGraphics.GetImageFromCurrentImageContext();
 			}
 			finally
 			{
@@ -75,40 +77,34 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 			if (scaledSize.HasValue)
 			{
-				using var unscaled = img;
-				img = unscaled.Scale(scaledSize.Value);
+				using var unscaled = uiImage;
+				uiImage = unscaled.Scale(scaledSize.Value);
 			}
 
-			using (img)
+			using (uiImage)
 			{
-				var imageRef = img.CGImage!;
-				var width = imageRef.Width;
-				var height = imageRef.Height;
-				var bitsPerPixel = 32;
-				var bitsPerComponent = 8;
-				var bytesPerPixel = bitsPerPixel / bitsPerComponent;
+				var cgImage = uiImage.CGImage!;
+				var width = cgImage.Width;
+				var height = cgImage.Height;
+				var bytesPerRow = width * _bytesPerPixel;
+				var bufferLength = (int)(bytesPerRow * height);
 
-				var bytesPerRow = width * bytesPerPixel;
-				var bufferLength = bytesPerRow * height;
-				byte[] bitmapData = new byte[bufferLength];
-				var byteCount = (int)bufferLength;
+				EnsureBuffer(ref buffer, bufferLength);
 
 				using var colorSpace = CGColorSpace.CreateDeviceRGB();
-
-				using var context = new CGBitmapContext(bitmapData
-				, width
-				, height
-				, bitsPerComponent
-				, bytesPerRow
-				, colorSpace
-				, CGImageAlphaInfo.PremultipliedLast); // RGBA8
+				using var context = new CGBitmapContext(
+					buffer,
+					width,
+					height,
+					_bitsPerComponent,
+					bytesPerRow,
+					colorSpace,
+					CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.PremultipliedFirst); // BGRA8
 
 				var rect = new CGRect(0, 0, width, height);
-				context.DrawImage(rect, imageRef);
-				EnsureBuffer(ref buffer, byteCount);
-				global::System.Array.Copy(bitmapData, buffer!, bufferLength);
-				SwapRB(ref buffer!, byteCount);
-				return (byteCount, (int)width, (int)height);
+				context.DrawImage(rect, cgImage);
+
+				return (bufferLength, (int)width, (int)height);
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.iOS.cs
@@ -21,21 +21,11 @@ namespace Windows.UI.Xaml.Media.Imaging
 		private protected override bool IsSourceReady => _buffer != null;
 
 		/// <inheritdoc />
-		private protected override bool TryOpenSourceSync([NotNullWhen(true)] out ImageData image)
+		private static ImageData Open(byte[] buffer, int bufferLength, int width, int height)
 		{
-			image = default;
-
-			var width = PixelWidth;
-			var height = PixelHeight;
-
-			if (_buffer is null || _bufferSize <= 0 || width <= 0 || height <= 0)
-			{
-				return false;
-			}
-
 			using var colorSpace = CGColorSpace.CreateDeviceRGB();
 			using var context = new CGBitmapContext(
-				_buffer,
+				buffer,
 				width,
 				height,
 				_bitsPerComponent,
@@ -46,10 +36,10 @@ namespace Windows.UI.Xaml.Media.Imaging
 			using var cgImage = context.ToImage();
 			if (cgImage is not null)
 			{
-				image = ImageData.FromNative(new UIImage(cgImage));
+				return ImageData.FromNative(new UIImage(cgImage));
 			}
 
-			return image.HasData;
+			return default;
 		}
 
 		private static (int ByteCount, int Width, int Height) RenderAsBgra8_Premul(UIElement element, ref byte[]? buffer, Size? scaledSize = null)

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.macOS.cs
@@ -21,22 +21,11 @@ namespace Windows.UI.Xaml.Media.Imaging
 		/// <inheritdoc />
 		private protected override bool IsSourceReady => _buffer != null;
 
-		/// <inheritdoc />
-		private protected override bool TryOpenSourceSync([NotNullWhen(true)] out ImageData image)
+		private static ImageData Open(byte[] buffer, int bufferLength, int width, int height)
 		{
-			image = default;
-
-			var width = PixelWidth;
-			var height = PixelHeight;
-
-			if (_buffer is null || _bufferSize <= 0 || width <= 0 || height <= 0)
-			{
-				return false;
-			}
-
 			using var colorSpace = CGColorSpace.CreateDeviceRGB();
 			using var context = new CGBitmapContext(
-				_buffer,
+				buffer,
 				width,
 				height,
 				_bitsPerComponent,
@@ -47,10 +36,10 @@ namespace Windows.UI.Xaml.Media.Imaging
 			using var cgImage = context.ToImage();
 			if (cgImage is not null)
 			{
-				image = ImageData.FromNative(new NSImage(cgImage, new CGSize(width, height)));
+				return ImageData.FromNative(new NSImage(cgImage, new CGSize(width, height)));
 			}
 
-			return image.HasData;
+			return default;
 		}
 
 		private static (int ByteCount, int Width, int Height) RenderAsBgra8_Premul(UIElement element, ref byte[]? buffer, Size? scaledSize = null)

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.macOS.cs
@@ -47,7 +47,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 			using var cgImage = context.ToImage();
 			if (cgImage is not null)
 			{
-				image = ImageData.FromNative(new UIImage(cgImage));
+				image = ImageData.FromNative(new NSImage(cgImage, new CGSize(width, height)));
 			}
 
 			return image.HasData;

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.skia.cs
@@ -1,15 +1,54 @@
 ﻿#nullable enable
+using System;
 using System.Runtime.InteropServices;
 using Windows.Foundation;
+using Windows.UI.Composition;
+using Uno.UI.Xaml.Media;
+using SkiaSharp;
+
 namespace Windows.UI.Xaml.Media.Imaging
 {
 	partial class RenderTargetBitmap
 	{
+		private const int _bitsPerPixel = 32;
+		private const int _bitsPerComponent = 8;
+		private const int _bytesPerPixel = _bitsPerPixel / _bitsPerComponent;
+
 		delegate void SwapColor(ref byte[] buffer, int byteCount);
 
-		static readonly SwapColor? PlatformSwap = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-			? new SwapColor(SwapRB)
-			: default(SwapColor);
+		private static readonly SwapColor? _platformSwap = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? SwapRB : default;
+
+		private static ImageData Open(byte[] buffer, int bufferLength, int width, int height)
+		{
+			if (_platformSwap is not null)
+			{
+				var swappedBuffer = default(byte[]);
+				EnsureBuffer(ref swappedBuffer, bufferLength);
+				Array.Copy(buffer, swappedBuffer!, bufferLength);
+				_platformSwap(ref swappedBuffer!, bufferLength);
+				buffer = swappedBuffer;
+			}
+
+			var bufferHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+			try
+			{
+				// Note: We use the FromPixelCopy which will create a clone of the buffer, so we are ready to be re-used to render another UIElement.
+				// (It's needed also for if we swapped the buffer since we are not maintaining a ref on the swappedBuffer)
+				var bytesPerRow = width * _bytesPerPixel;
+				var info = new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
+				var image = SKImage.FromPixelCopy(info, bufferHandle.AddrOfPinnedObject(), bytesPerRow);
+
+				return ImageData.FromCompositionSurface(new SkiaCompositionSurface(image));
+			}
+			catch (Exception error)
+			{
+				return ImageData.FromError(error);
+			}
+			finally
+			{
+				bufferHandle.Free();
+			}
+		}
 
 		private static (int ByteCount, int Width, int Height) RenderAsBgra8_Premul(UIElement element, ref byte[]? buffer, Size? scaledSize = null)
 		{
@@ -17,28 +56,28 @@ namespace Windows.UI.Xaml.Media.Imaging
 			var visual = element.Visual;
 
 			if (element.RenderSize is { IsEmpty: true }
-			 || element.RenderSize is { Width: 0, Height: 0 })
+				|| element.RenderSize is { Width: 0, Height: 0 })
 			{
 				return (0, 0, 0);
 			}
-			(int width, int height) = ((int)renderSize.Width, (int)renderSize.Height);
-			var info = new SkiaSharp.
-				SKImageInfo(width, height, SkiaSharp.SKColorType.Bgra8888, SkiaSharp.SKAlphaType.Premul);
-			using SkiaSharp.SKSurface surface = SkiaSharp.SKSurface.Create(info);
+			var (width, height) = ((int)renderSize.Width, (int)renderSize.Height);
+			var info = new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
+			using var surface = SKSurface.Create(info);
 			//Ensure Clear
 			var canvas = surface.Canvas;
-			canvas.Clear(SkiaSharp.SKColors.Transparent);
+			canvas.Clear(SKColors.Transparent);
 			visual.Render(surface);
 
 			var img = surface.Snapshot();
 
-			var bitmap = SkiaSharp.SKBitmap.FromImage(img);
+			var bitmap = SKBitmap.FromImage(img);
 			if (scaledSize.HasValue)
 			{
-				var resize = bitmap.Resize(new SkiaSharp.SKImageInfo((int)scaledSize.Value.Width, (int)scaledSize.Value.Height, SkiaSharp.SKColorType.Bgra8888, SkiaSharp.SKAlphaType.Premul)
-					, SkiaSharp.SKFilterQuality.High);
+				var scaledBitmap = bitmap.Resize(
+					new SKImageInfo((int)scaledSize.Value.Width, (int)scaledSize.Value.Height, SKColorType.Bgra8888, SKAlphaType.Premul),
+					SKFilterQuality.High);
 				bitmap.Dispose();
-				bitmap = resize;
+				bitmap = scaledBitmap;
 				(width, height) = (bitmap.Width, bitmap.Height);
 			}
 
@@ -46,7 +85,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 			EnsureBuffer(ref buffer, byteCount);
 			bitmap.GetPixelSpan().CopyTo(buffer);
 			//On macOS color as stored as rgba
-			PlatformSwap?.Invoke(ref buffer!, byteCount);
+			_platformSwap?.Invoke(ref buffer!, byteCount);
 			bitmap?.Dispose();
 			return (byteCount, width, height);
 		}

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.skia.cs
@@ -33,7 +33,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 			try
 			{
 				// Note: We use the FromPixelCopy which will create a clone of the buffer, so we are ready to be re-used to render another UIElement.
-				// (It's needed also for if we swapped the buffer since we are not maintaining a ref on the swappedBuffer)
+				// (It's needed also if we swapped the buffer since we are not maintaining a ref on the swappedBuffer)
 				var bytesPerRow = width * _bytesPerPixel;
 				var info = new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
 				var image = SKImage.FromPixelCopy(info, bufferHandle.AddrOfPinnedObject(), bytesPerRow);

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.iOSmacOS.cs
@@ -25,7 +25,7 @@ partial class SvgImageSource
 {
 	private protected override bool IsSourceReady => true;
 
-	private protected override bool TryOpenSourceAsync(CancellationToken ct, out Task<ImageData> asyncImage) =>
+	private protected override bool TryOpenSourceAsync(CancellationToken ct, int? targetWidth, int? targetHeight, out Task<ImageData> asyncImage) =>
 		TryOpenSvgImageData(ct, out asyncImage);
 
 	private async Task<ImageData> GetSvgImageDataAsync(CancellationToken ct)

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.iOSmacOS.cs
@@ -15,7 +15,7 @@ partial class WriteableBitmap
 {
 	private protected override bool IsSourceReady => true;
 
-	private protected override bool TryOpenSourceSync(out ImageData imageData)
+	private protected override bool TryOpenSourceSync(int? targetWidth, int? targetHeight, out ImageData imageData)
 	{
 		imageData = default;
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/997

## Bugfix
Fix reordering issue on iOS

## What is the current behavior?
1. Pointer events are not bubbling correctly through `ListView` up to the root
2. `ListView` does not render properly after after the first collection changed
3. `RenderTargetBitmap` cannot be used a `Image.Source` to display it on canvas

## What is the new behavior?
1. `ListView` does the same trick as `UIScrollView` to ensure proper events bubbling
2. We make sure to clean container only **after** it has been removed by the native `UICollectionView`.
3. `RenderTargetBitmap` makes sure to read it buffer as RGBA8

## PR Checklist

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
      ==> Some feature cannot be tested with current tools. Tests will be added as demo of the pointer injection in runtime tests
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
