### PR TITLE
fix(tooltip): Adjust initial propagation of the DataContext

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
@@ -5,6 +5,9 @@ using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -42,6 +45,165 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 				Assert.AreEqual("DataContext2", textBlock.DataContext);
 				Assert.AreEqual("DataContext2", SUT.DataContext);
+			}
+			finally
+			{
+#if HAS_UNO
+				Windows.UI.Xaml.Media.VisualTreeHelper.CloseAllPopups();
+#endif
+			}
+		}
+
+		[TestMethod]
+		public async Task When_ToggleButton_DataContext_Set_On_ToolTip_Owner_After()
+		{
+			try
+			{
+				var toggleButton = new ToggleButton();
+
+				var textBlock = new TextBlock();
+				textBlock.SetBinding(TextBlock.TextProperty, new Binding { Path = new(".") });
+
+				var SUT = new ToolTip() { Content = textBlock };
+				ToolTipService.SetToolTip(toggleButton, SUT);
+
+				var stackPanel = new StackPanel
+				{
+					Children =
+					{
+						toggleButton,
+					}
+				};
+
+				TestServices.WindowHelper.WindowContent = stackPanel;
+				await TestServices.WindowHelper.WaitForIdle();
+
+				stackPanel.DataContext = "DataContext1";
+
+				Assert.AreEqual("DataContext1", toggleButton.DataContext);
+				Assert.AreEqual("DataContext1", SUT.DataContext);
+
+				SUT.IsOpen = true;
+
+				stackPanel.DataContext = "DataContext2";
+
+				Assert.AreEqual("DataContext2", toggleButton.DataContext);
+				Assert.AreEqual("DataContext2", SUT.DataContext);
+				Assert.AreEqual("DataContext2", textBlock.DataContext);
+			}
+			finally
+			{
+#if HAS_UNO
+				Windows.UI.Xaml.Media.VisualTreeHelper.CloseAllPopups();
+#endif
+			}
+		}
+
+		[TestMethod]
+		public async Task When_ToggleButton_DataContext_Set_On_ToolTip_Owner_Before()
+		{
+			try
+			{
+				var toggleButton = new ToggleButton();
+
+				var textBlock = new TextBlock();
+				textBlock.SetBinding(TextBlock.TextProperty, new Binding { Path = new(".") });
+
+				var SUT = new ToolTip() { Content = textBlock };
+				ToolTipService.SetToolTip(toggleButton, SUT);
+
+				var stackPanel = new StackPanel
+				{
+					Children =
+					{
+						toggleButton,
+					}
+				};
+
+				TestServices.WindowHelper.WindowContent = stackPanel;
+				await TestServices.WindowHelper.WaitForIdle();
+
+				stackPanel.DataContext = "DataContext1";
+
+				Assert.AreEqual("DataContext1", toggleButton.DataContext);
+				Assert.AreEqual("DataContext1", SUT.DataContext);
+
+				// Set the datacontext before opening
+				stackPanel.DataContext = "DataContext2";
+
+				SUT.IsOpen = true;
+
+				Assert.AreEqual("DataContext2", toggleButton.DataContext);
+				Assert.AreEqual("DataContext2", SUT.DataContext);
+				Assert.AreEqual("DataContext2", textBlock.DataContext);
+
+				stackPanel.DataContext = "DataContext3";
+
+				Assert.AreEqual("DataContext3", toggleButton.DataContext);
+				Assert.AreEqual("DataContext3", SUT.DataContext);
+				Assert.AreEqual("DataContext3", textBlock.DataContext);
+
+				SUT.IsOpen = false;
+
+				stackPanel.DataContext = "DataContext4";
+
+				SUT.IsOpen = true;
+
+				Assert.AreEqual("DataContext4", toggleButton.DataContext);
+				Assert.AreEqual("DataContext4", SUT.DataContext);
+				Assert.AreEqual("DataContext4", textBlock.DataContext);
+			}
+			finally
+			{
+#if HAS_UNO
+				Windows.UI.Xaml.Media.VisualTreeHelper.CloseAllPopups();
+#endif
+			}
+		}
+
+		[TestMethod]
+		public async Task When_ToggleButton_DataContext_Set_On_ToolTip_Owner_Nested()
+		{
+			try
+			{
+				var toggleButton = new ToggleButton();
+
+				var textBlock = new TextBlock();
+				textBlock.SetBinding(TextBlock.TextProperty, new Binding { Path = new(".") });
+
+				var innerStackPanel = new StackPanel();
+				innerStackPanel.Children.Add(textBlock);
+
+				var SUT = new ToolTip() { Content = innerStackPanel };
+				ToolTipService.SetToolTip(toggleButton, SUT);
+
+				var stackPanel = new StackPanel
+				{
+					Children =
+					{
+						toggleButton,
+					}
+				};
+
+				TestServices.WindowHelper.WindowContent = stackPanel;
+				await TestServices.WindowHelper.WaitForIdle();
+
+				SUT.DataContextChanged += (s, e) =>
+				{
+				};
+
+				stackPanel.DataContext = "DataContext1";
+
+				Assert.AreEqual("DataContext1", toggleButton.DataContext);
+				Assert.AreEqual("DataContext1", SUT.DataContext);
+
+				SUT.IsOpen = true;
+
+				stackPanel.DataContext = "DataContext2";
+
+				Assert.AreEqual("DataContext2", toggleButton.DataContext);
+				Assert.AreEqual("DataContext2", SUT.DataContext);
+				Assert.AreEqual("DataContext2", textBlock.DataContext);
 			}
 			finally
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
@@ -57,10 +57,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_ToggleButton_DataContext_Set_On_ToolTip_Owner_After()
 		{
-			if(!FeatureConfiguration.ToolTip.UseToolTips)
+#if HAS_UNO
+			if (!FeatureConfiguration.ToolTip.UseToolTips)
 			{
 				Assert.Inconclusive();
 			}
+#endif
 
 			try
 			{
@@ -107,11 +109,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_ToggleButton_DataContext_Set_On_ToolTip_Owner_Before()
 		{
+#if HAS_UNO
 			if (!FeatureConfiguration.ToolTip.UseToolTips)
 			{
 				Assert.Inconclusive();
 			}
-			
+#endif
+
 			try
 			{
 				var toggleButton = new ToggleButton();
@@ -174,10 +178,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_ToggleButton_DataContext_Set_On_ToolTip_Owner_Nested()
 		{
+#if HAS_UNO
 			if (!FeatureConfiguration.ToolTip.UseToolTips)
 			{
 				Assert.Inconclusive();
 			}
+#endif
 
 			try
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
@@ -57,6 +57,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_ToggleButton_DataContext_Set_On_ToolTip_Owner_After()
 		{
+			if(!FeatureConfiguration.ToolTip.UseToolTips)
+			{
+				Assert.Inconclusive();
+			}
+
 			try
 			{
 				var toggleButton = new ToggleButton();
@@ -102,6 +107,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_ToggleButton_DataContext_Set_On_ToolTip_Owner_Before()
 		{
+			if (!FeatureConfiguration.ToolTip.UseToolTips)
+			{
+				Assert.Inconclusive();
+			}
+			
 			try
 			{
 				var toggleButton = new ToggleButton();
@@ -164,6 +174,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_ToggleButton_DataContext_Set_On_ToolTip_Owner_Nested()
 		{
+			if (!FeatureConfiguration.ToolTip.UseToolTips)
+			{
+				Assert.Inconclusive();
+			}
+
 			try
 			{
 				var toggleButton = new ToggleButton();

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -134,6 +134,13 @@ namespace Windows.UI.Xaml.Controls
 
 				Opened?.Invoke(this, new RoutedEventArgs(this));
 				GoToElementState("Opened", useTransitions: true);
+
+				if (_owner is FrameworkElement fe)
+				{
+					// Propagate the DC once, the inheritance
+					// will update the rest on DC changes.
+					this.SetValue(DataContextProperty, fe.DataContext, DependencyPropertyValuePrecedences.Inheritance);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11526

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures initial propagation of the DataContext on tooltip opening.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
