### PR TITLE
fix(XamlReader): parsing of Rect type property

### DIFF
--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -278,6 +278,11 @@ namespace Uno.UI.DataBinding
 				return true;
 			}
 
+			if (FastStringToRect(outputType, input, ref output))
+			{
+				return true;
+			}
+
 			if (FastStringToMatrix(outputType, input, ref output))
 			{
 				return true;
@@ -585,6 +590,22 @@ namespace Uno.UI.DataBinding
 				if (fields.Count == 1)
 				{
 					output = new Windows.Foundation.Point(fields[0], fields[0]);
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private static bool FastStringToRect(Type outputType, string input, ref object output)
+		{
+			if (outputType == typeof(Windows.Foundation.Rect))
+			{
+				var fields = GetDoubleValues(input);
+
+				if (fields.Count == 4)
+				{
+					output = new Windows.Foundation.Rect(fields[0], fields[1], fields[2], fields[3]);
 					return true;
 				}
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
XamlReader.LoadXaml throws exception when attempting to parse property of type Rect:
System.ArgumentOutOfRangeException: No strategy registration for conversion 'String' to 'Rect' Arg_ParamName_Name, extensionPoint

## Other information
ninja-fix: LoadXaml<T> would throw on self-closing root element, since it would inject xmlns between the `/` and `>`.