### PR TITLE
fix(ItemsControl): ContentControl at the DataTemplate root should keep bindings

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsControl.cs
@@ -480,6 +480,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsNotNull(third.ContentTemplateSelector);
 		}
 
+#if HAS_UNO
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_ContentPresenter_ContainerRecycled_And_ContentControl_Template()
@@ -559,6 +560,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.IsNotNull(secondInnerContent.GetBindingExpression(ContentControl.ContentProperty));
 			}
 		}
+#endif
 
 		[TestMethod]
 		[RunsOnUIThread]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsControl.cs
@@ -482,6 +482,86 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		public async Task When_ContentPresenter_ContainerRecycled_And_ContentControl_Template()
+		{
+			var dataTemplate = (DataTemplate)XamlReader.Load(
+				"""
+				<DataTemplate xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
+					<ContentControl Content="{Binding}"/>
+				</DataTemplate>
+				""");
+
+			var selector = new TestTemplateSelector();
+
+			var source = new[]
+			{
+				"First",
+				"Second",
+			};
+
+			var SUT = new ItemsControl()
+			{
+				ItemsSource = source,
+				ItemTemplate = dataTemplate
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+
+			{
+				ContentPresenter first = null;
+				await WindowHelper.WaitFor(() => (first = SUT.ContainerFromItem(source[0]) as ContentPresenter) != null);
+
+				ContentPresenter second = null;
+				await WindowHelper.WaitFor(() => (second = SUT.ContainerFromItem(source[1]) as ContentPresenter) != null);
+
+				Assert.IsNotNull(first);
+				Assert.IsNotNull(second);
+
+				Assert.IsNotNull(first.Content);
+				Assert.IsNotNull(second.Content);
+
+				var firstInnerContent = first.ContentTemplateRoot as ContentControl;
+				Assert.AreEqual(source[0], firstInnerContent?.Content);
+				Assert.IsNotNull(firstInnerContent.GetBindingExpression(ContentControl.ContentProperty));
+
+				var secondInnerContent = second.ContentTemplateRoot as ContentControl;
+				Assert.AreEqual(source[1], secondInnerContent.Content);
+				Assert.IsNotNull(secondInnerContent.GetBindingExpression(ContentControl.ContentProperty));
+			}
+
+			SUT.ItemsSource = null;
+			await WindowHelper.WaitForIdle();
+
+			SUT.ItemsSource = source;
+			await WindowHelper.WaitForIdle();
+
+			{
+				ContentPresenter first = null;
+				await WindowHelper.WaitFor(() => (first = SUT.ContainerFromItem(source[0]) as ContentPresenter) != null);
+
+				ContentPresenter second = null;
+				await WindowHelper.WaitFor(() => (second = SUT.ContainerFromItem(source[1]) as ContentPresenter) != null);
+
+				Assert.IsNotNull(first);
+				Assert.IsNotNull(second);
+
+				Assert.IsNotNull(first.Content);
+				Assert.IsNotNull(second.Content);
+
+				var firstInnerContent = first.ContentTemplateRoot as ContentControl;
+				Assert.AreEqual(source[0], firstInnerContent?.Content);
+				Assert.IsNotNull(firstInnerContent.GetBindingExpression(ContentControl.ContentProperty));
+
+				var secondInnerContent = second.ContentTemplateRoot as ContentControl;
+				Assert.AreEqual(source[1], secondInnerContent.Content);
+				Assert.IsNotNull(secondInnerContent.GetBindingExpression(ContentControl.ContentProperty));
+			}
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -18,6 +18,9 @@ using System.Collections.Generic;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 
+#if __MACOS__
+[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 [TestClass]
 [RunsOnUIThread]
 public class Given_TreeView

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -22,7 +22,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 [RunsOnUIThread]
 public class Given_TreeView
 {
-	// Test method that create a tree of three nested items from a itemssource and that will open and close a single treeview item twice and validate that the container is still containing the same property values
+	// Test method that creates a tree of three nested items from an itemssource and that will open and close a single treeview item twice and validate that the container is still containing the same property values
 	[TestMethod]
 	public async Task When_Open_Close_Twice()
 	{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -40,11 +40,11 @@ public class Given_TreeView
 		SUT.myTree.ItemsSource = new[] { root };
 		await TestServices.WindowHelper.WaitForIdle();
 
-		var rootNode = (TreeViewItem)SUT.FindName("root");
+		var rootNode = (TreeViewItem)SUT.myTree.ContainerFromItem(root);
 		rootNode.IsExpanded = true;
 		await TestServices.WindowHelper.WaitForIdle();
 
-		var child1Node = (TreeViewItem)SUT.FindName("Child 1");
+		var child1Node = (TreeViewItem)SUT.myTree.ContainerFromItem(child1);
 		Assert.IsNotNull(child1Node);
 		Assert.AreEqual("Child 1", child1Node.Content);
 
@@ -54,12 +54,12 @@ public class Given_TreeView
 		rootNode.IsExpanded = true;
 		await TestServices.WindowHelper.WaitForIdle();
 
-		var child1NodeAfter = (TreeViewItem)SUT.FindName("Child 1");
+		var child1NodeAfter = (TreeViewItem)SUT.myTree.ContainerFromItem(child1);
 		Assert.IsNotNull(child1NodeAfter);
 
 		Assert.AreEqual("Child 1", child1NodeAfter.Content);
 
-		var child2NodeAfter = (TreeViewItem)SUT.FindName("Child 2");
+		var child2NodeAfter = (TreeViewItem)SUT.myTree.ContainerFromItem(child2);
 		Assert.IsNotNull(child2NodeAfter);
 
 		Assert.AreEqual("Child 2", child2NodeAfter.Content);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Linq;
+using Windows.UI;
+using System.Threading.Tasks;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TreeView = Microsoft.UI.Xaml.Controls.TreeView;
+using TreeViewItem = Microsoft.UI.Xaml.Controls.TreeViewItem;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests;
+using System.Collections.Generic;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_TreeView
+{
+	// Test method that create a tree of three nested items from a itemssource and that will open and close a single treeview item twice and validate that the container is still containing the same property values
+	[TestMethod]
+	public async Task When_Open_Close_Twice()
+	{
+		var SUT = new When_Open_Close_Twice();
+		TestServices.WindowHelper.WindowContent = SUT;
+
+		var root = new MyNode();
+		root.Name = "root";
+		root.Children = new List<MyNode>();
+		var child1 = new MyNode { Name = "Child 1" };
+		var child2 = new MyNode { Name = "Child 2" };
+		root.Children.Add(child1);
+		root.Children.Add(child2);
+
+		SUT.myTree.ItemsSource = new[] { root };
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var rootNode = (TreeViewItem)SUT.FindName("root");
+		rootNode.IsExpanded = true;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var child1Node = (TreeViewItem)SUT.FindName("Child 1");
+		Assert.IsNotNull(child1Node);
+		Assert.AreEqual("Child 1", child1Node.Content);
+
+		rootNode.IsExpanded = false;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		rootNode.IsExpanded = true;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var child1NodeAfter = (TreeViewItem)SUT.FindName("Child 1");
+		Assert.IsNotNull(child1NodeAfter);
+
+		Assert.AreEqual("Child 1", child1NodeAfter.Content);
+
+		var child2NodeAfter = (TreeViewItem)SUT.FindName("Child 2");
+		Assert.IsNotNull(child2NodeAfter);
+
+		Assert.AreEqual("Child 2", child2NodeAfter.Content);
+	}
+
+	private class MyNode
+	{
+		public string Name { get; set; }
+		public List<MyNode> Children { get; set; }
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -57,12 +57,16 @@ public class Given_TreeView
 		rootNode.IsExpanded = true;
 		await TestServices.WindowHelper.WaitForIdle();
 
-		var child1NodeAfter = (TreeViewItem)SUT.myTree.ContainerFromItem(child1);
+		await TestServices.WindowHelper.WaitFor(() => (SUT.myTree.ContainerFromItem(child1) as TreeViewItem)?.Content?.ToString() == child1.Name);
+		await TestServices.WindowHelper.WaitFor(() => (SUT.myTree.ContainerFromItem(child2) as TreeViewItem)?.Content?.ToString() == child2.Name);
+
+		TreeViewItem child1NodeAfter = (TreeViewItem)SUT.myTree.ContainerFromItem(child1);
 		Assert.IsNotNull(child1NodeAfter);
 
 		Assert.AreEqual("Child 1", child1NodeAfter.Content);
 
 		var child2NodeAfter = (TreeViewItem)SUT.myTree.ContainerFromItem(child2);
+		await TestServices.WindowHelper.WaitForLoaded(child2NodeAfter);
 		Assert.IsNotNull(child2NodeAfter);
 
 		Assert.AreEqual("Child 2", child2NodeAfter.Content);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Open_Close_Twice.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Open_Close_Twice.xaml
@@ -1,0 +1,21 @@
+﻿<Grid x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests.When_Open_Close_Twice"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<muxc:TreeView x:Name="myTree" x:FieldModifier="public" SelectionMode="Multiple"
+				   ItemsSource="{Binding Children}">
+		<muxc:TreeView.ItemTemplate>
+			<DataTemplate>
+				<muxc:TreeViewItem ItemsSource="{Binding Children}"
+								   Content="{Binding Name}"
+								   Name="{Binding Name}" />
+			</DataTemplate>
+		</muxc:TreeView.ItemTemplate>
+	</muxc:TreeView>
+</Grid>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Open_Close_Twice.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Open_Close_Twice.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests;
+
+public sealed partial class When_Open_Close_Twice : Grid
+{
+	public When_Open_Close_Twice()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1157,7 +1157,7 @@ namespace Windows.UI.Xaml.Controls
 						// We must not clear the properties for the container if a binding expession
 						// is defined. This is a use-case present for TreeView, which generally uses TreeViewItem
 						// at the root of hierarchical templates.
-						if (target.GetBindingExpression(property) == null)
+						if (target.GetBindingExpression(property) is null)
 						{
 							target.ClearValue(property);
 						}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1152,16 +1152,27 @@ namespace Windows.UI.Xaml.Controls
 
 				if (!isOwnContainer)
 				{
+					static void ClearPropertyWhenNoExpression(ContentControl target, DependencyProperty property)
+					{
+						// We must not clear the properties for the container if a binding expession
+						// is defined. This is a use-case present for TreeView, which generally uses TreeViewItem
+						// at the root of hierarchical templates.
+						if (target.GetBindingExpression(property) == null)
+						{
+							target.ClearValue(property);
+						}
+					}
+
 					// Clears value set in PrepareContainerForItemOverride
-					element.ClearValue(ContentControl.ContentProperty);
+					ClearPropertyWhenNoExpression(contentControl, ContentControl.ContentProperty);
 
 					if (contentControl.ContentTemplate is { } ct && ct == ItemTemplate)
 					{
-						contentControl.ClearValue(ContentControl.ContentTemplateProperty);
+						ClearPropertyWhenNoExpression(contentControl, ContentControl.ContentTemplateProperty);
 					}
 					else if (contentControl.ContentTemplateSelector is { } cts && cts == ItemTemplateSelector)
 					{
-						contentControl.ClearValue(ContentControl.ContentTemplateSelectorProperty);
+						ClearPropertyWhenNoExpression(contentControl, ContentControl.ContentTemplateSelectorProperty);
 					}
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1154,7 +1154,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					static void ClearPropertyWhenNoExpression(ContentControl target, DependencyProperty property)
 					{
-						// We must not clear the properties for the container if a binding expession
+						// We must not clear the properties of the container if a binding expression
 						// is defined. This is a use-case present for TreeView, which generally uses TreeViewItem
 						// at the root of hierarchical templates.
 						if (target.GetBindingExpression(property) is null)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11587

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Following proper ItemsControl container cleanup, ContentControl at the DataTemplate root should keep bindings.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
