### PR TITLE
fix: adding WinUI dependencies for windows target

### DIFF
--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="5.0">
 	<id>Uno.UI</id>
@@ -15,6 +15,13 @@
 	<repository type="git" url="https://github.com/unoplatform/uno.git" branch="$branch$" commit="$commitid$" />
 
 	<dependencies>
+
+	  <!-- net5.0-windows10.0.18362.0 -->
+	  <group targetFramework="$winuitargetpath$">
+		<!-- References from Uno.UI.Toolkit -->
+		<dependency id="Microsoft.WindowsAppSDK" version="1.0.0" />
+		<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.22000.196" />
+	  </group>
 
 	  <!-- net7.0-android30.0 -->
 	  <group targetFramework="net7.0-android30.0">

--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -18,7 +18,7 @@
 
 	  <!-- References from Uno.UI.Toolkit -->
 	  <!-- BEGIN WinUI-specific
-	  <group targetFramework=""net5.0-windows10.0.18362.0"">
+	  <group targetFramework="net5.0-windows10.0.18362.0">
 		<dependency id="Microsoft.WindowsAppSDK" version="1.0.0" />
 		<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.22000.196" />
 	  </group>

--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -17,10 +17,12 @@
 	<dependencies>
 
 	  <!-- References from Uno.UI.Toolkit -->
-	  <!-- <group targetFramework="net5.0-windows10.0.18362.0">
+	  <!-- BEGIN WinUI-specific
+	  <group targetFramework=""net5.0-windows10.0.18362.0"">
 		<dependency id="Microsoft.WindowsAppSDK" version="1.0.0" />
 		<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.22000.196" />
-	  </group> -->
+	  </group>
+	  END WinUI-specific -->
 
 	  <!-- net7.0-android30.0 -->
 	  <group targetFramework="net7.0-android30.0">

--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -16,12 +16,11 @@
 
 	<dependencies>
 
-	  <!-- net5.0-windows10.0.18362.0 -->
-	  <group targetFramework="$winuitargetpath$">
-		<!-- References from Uno.UI.Toolkit -->
+	  <!-- References from Uno.UI.Toolkit -->
+	  <!-- <group targetFramework="net5.0-windows10.0.18362.0">
 		<dependency id="Microsoft.WindowsAppSDK" version="1.0.0" />
 		<dependency id="Microsoft.Windows.SDK.BuildTools" version="10.0.22000.196" />
-	  </group>
+	  </group> -->
 
 	  <!-- net7.0-android30.0 -->
 	  <group targetFramework="net7.0-android30.0">

--- a/build/Uno.WinUI.nuspec
+++ b/build/Uno.WinUI.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata minClientVersion="5.0">
 	<id>Uno.UI</id>
@@ -199,7 +199,7 @@
 		<reference file="Uno.UI.FluentTheme.v1.dll" />
 		<reference file="Uno.UI.FluentTheme.v2.dll" />
 	  </group>
-		
+
 	  <!-- .NET 7.0 Reference -->
 	  <group targetFramework="net7.0">
 		<reference file="Uno.Xaml.dll" />
@@ -306,7 +306,7 @@
 		<reference file="Uno.UI.FluentTheme.v1.dll" />
 		<reference file="Uno.UI.FluentTheme.v2.dll" />
 	  </group>
-		
+
 	  <!-- net6.0-android30.0 -->
 	  <group targetFramework="net6.0-android30.0">
 		<reference file="Uno.UI.BindingHelper.Android.dll" />
@@ -367,7 +367,7 @@
 		<reference file="Uno.UI.FluentTheme.v1.dll" />
 		<reference file="Uno.UI.FluentTheme.v2.dll" />
 	  </group>
-		
+
 	  <!-- net7.0-android30.0 -->
 	  <group targetFramework="net7.0-android30.0">
 		<reference file="Uno.UI.BindingHelper.Android.dll" />
@@ -585,7 +585,7 @@
 	<file src="..\src\Uno.UI.FluentTheme\bin\Uno.UI.FluentTheme.netcoremobile\Release\net6.0-android\Uno.UI.FluentTheme.v2.pdb" target="lib\net6.0-android30.0" />
 	<file src="..\src\Uno.UI.Toolkit\bin\Uno.UI.Toolkit.netcoremobile\Release\net6.0-android\Uno.UI.Toolkit.dll" target="lib\net6.0-android30.0" />
 	<file src="..\src\Uno.UI.Toolkit\bin\Uno.UI.Toolkit.netcoremobile\Release\net6.0-android\Uno.UI.Toolkit.pdb" target="lib\net6.0-android30.0" />
-	  
+
 	<!-- net7.0-ios -->
 	<file src="..\src\Uno.UI\Bin\Uno.UI.netcoremobile\Release\net7.0-ios\Uno.dll" target="lib\net7.0-ios" />
 	<file src="..\src\Uno.UI\Bin\Uno.UI.netcoremobile\Release\net7.0-ios\Uno.pdb" target="lib\net7.0-ios" />
@@ -688,7 +688,7 @@
 	<file src="..\src\Uno.UI.FluentTheme\bin\Uno.UI.FluentTheme.netcoremobile\Release\net7.0-android\Uno.UI.FluentTheme.v2.pdb" target="lib\net7.0-android30.0" />
 	<file src="..\src\Uno.UI.Toolkit\bin\Uno.UI.Toolkit.netcoremobile\Release\net7.0-android\Uno.UI.Toolkit.dll" target="lib\net7.0-android30.0" />
 	<file src="..\src\Uno.UI.Toolkit\bin\Uno.UI.Toolkit.netcoremobile\Release\net7.0-android\Uno.UI.Toolkit.pdb" target="lib\net7.0-android30.0" />
-	  
+
 	<!-- macOS -->
 	<file src="..\src\Uno.UI\Bin\Release\xamarinmac20\Uno.dll" target="lib\xamarinmac20" />
 	<file src="..\src\Uno.UI\Bin\Release\xamarinmac20\Uno.pdb" target="lib\xamarinmac20" />

--- a/src/Uno.WinUIRevert/Program.cs
+++ b/src/Uno.WinUIRevert/Program.cs
@@ -139,6 +139,8 @@ namespace UnoWinUIRevert
 			//ReplaceInFile(Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Media\RadialGradientBrush.cs"), "namespace Windows.UI.Xaml.Controls", "namespace Windows.UI.Xaml.Controls");
 			//ReplaceInFile(Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Media\RadialGradientBrush.iOSmacOS.cs"), "namespace Windows.UI.Xaml.Controls", "namespace Windows.UI.Xaml.Controls");
 			//ReplaceInFile(Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Media\RadialGradientBrush.wasm.cs"), "namespace Windows.UI.Xaml.Controls", "namespace Windows.UI.Xaml.Controls");
+
+			AddWindowsDependencyGroup(Path.Combine(basePath, "build", "Uno.WinUI.nuspec"));
 		}
 
 		static string[] _exclusions = new string[] {
@@ -215,6 +217,14 @@ namespace UnoWinUIRevert
 					File.Delete(filePath);
 				}
 			}
+		}
+
+		private static void AddWindowsDependencyGroup(string nuspecPath)
+		{
+			var contents = File.ReadAllText(nuspecPath);
+			contents = Regex.Replace(contents, @"<!-- <group targetFramework=""net5.0-windows10.0.18362.0"">", @"<group targetFramework=""net5.0-windows10.0.18362.0"">");
+			contents = Regex.Replace(contents, @"</group> -->", @"</group>");
+			File.WriteAllText(nuspecPath, contents);
 		}
 	}
 }

--- a/src/Uno.WinUIRevert/Program.cs
+++ b/src/Uno.WinUIRevert/Program.cs
@@ -140,7 +140,7 @@ namespace UnoWinUIRevert
 			//ReplaceInFile(Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Media\RadialGradientBrush.iOSmacOS.cs"), "namespace Windows.UI.Xaml.Controls", "namespace Windows.UI.Xaml.Controls");
 			//ReplaceInFile(Path.Combine(basePath, @"src\Uno.UI\UI\Xaml\Media\RadialGradientBrush.wasm.cs"), "namespace Windows.UI.Xaml.Controls", "namespace Windows.UI.Xaml.Controls");
 
-			AddWindowsDependencyGroup(Path.Combine(basePath, "build", "Uno.WinUI.nuspec"));
+			UncommentWinUISpecificBlock(Path.Combine(basePath, "build", "Uno.WinUI.nuspec"));
 		}
 
 		static string[] _exclusions = new string[] {
@@ -219,12 +219,10 @@ namespace UnoWinUIRevert
 			}
 		}
 
-		private static void AddWindowsDependencyGroup(string nuspecPath)
+		private static void UncommentWinUISpecificBlock(string nuspecPath)
 		{
-			var contents = File.ReadAllText(nuspecPath);
-			contents = Regex.Replace(contents, @"<!-- <group targetFramework=""net5.0-windows10.0.18362.0"">", @"<group targetFramework=""net5.0-windows10.0.18362.0"">");
-			contents = Regex.Replace(contents, @"</group> -->", @"</group>");
-			File.WriteAllText(nuspecPath, contents);
+			ReplaceInFile(nuspecPath, @"<!-- BEGIN WinUI-specific", string.Empty);
+			ReplaceInFile(nuspecPath, @"END WinUI-specific -->", string.Empty);
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #11399

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Generated Uno.WinUI nuget does not specify any dependencies for the windows target

## What is the new behavior?

Generated Uno.WinUI nuget will specify the version of `Microsoft.WindowsAppSDK` & `Microsoft.Windows.SDK.BuildTools` that is used by Uno.UI.Toolkit

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
