### PR TITLE
fix(droid): BringIntoView blocked behind keyboard

### DIFF
--- a/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.Android.cs
+++ b/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.Android.cs
@@ -44,10 +44,17 @@ namespace Windows.UI.ViewManagement
 
 			if (Visible && FocusManager.GetFocusedElement() is UIElement focusedElement)
 			{
-				var scrollContentViewer = focusedElement.FindFirstParent<ScrollContentPresenter>();
-				if (scrollContentViewer != null)
+				if (focusedElement.FindFirstParent<ScrollContentPresenter>() is { } scp)
 				{
-					_padScrollContentPresenter = scrollContentViewer.Pad(OccludedRect);
+					// ScrollViewer can be nested, but the outer-most SV isn't necessarily the one to handle this "padded" scroll.
+					// Only the first SV that is constrained would be the one, as unconstrained SV can just expand freely.
+					while (double.IsPositiveInfinity(scp.LastAvailableSize.Height)
+						&& scp.FindFirstParent<ScrollContentPresenter>(includeCurrent: false) is { } outerScv)
+					{
+						scp = outerScv;
+					}
+
+					_padScrollContentPresenter = scp.Pad(OccludedRect);
 				}
 				focusedElement.StartBringIntoView();
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.mux.cs
@@ -41,6 +41,10 @@ public partial class ScrollContentPresenter
 		var viewportHeight = ViewportHeight;
 		var zoomFactor = Scroller.ZoomFactor;
 
+#if __ANDROID__ // Adjust for region blocked by keyboard.
+		viewportHeight -= _occludedRectPadding.Bottom;
+#endif
+
 		// Compute the target offsets based on the provided BringIntoViewRequestedEventArgs.
 		ComputeBringIntoViewTargetOffsets(
 			content,
@@ -129,6 +133,11 @@ public partial class ScrollContentPresenter
 		var viewportWidth = ViewportWidth;
 		var viewportHeight = ViewportHeight;
 		var zoomFactor = Scroller.ZoomFactor;
+
+#if __ANDROID__ // Adjust for region blocked by keyboard.
+		viewportHeight -= _occludedRectPadding.Bottom;
+#endif
+
 		if (!double.IsNaN(requestEventArgs.HorizontalAlignmentRatio))
 		{
 			// Account for the horizontal alignment ratio
@@ -166,6 +175,10 @@ public partial class ScrollContentPresenter
 
 		double scrollableWidth = Scroller.ScrollableWidth;
 		double scrollableHeight = Scroller.ScrollableHeight;
+
+#if __ANDROID__ // Adjust for region blocked by keyboard.
+		scrollableHeight += _occludedRectPadding.Bottom;
+#endif
 
 		targetZoomedHorizontalOffsetTmp = targetZoomedHorizontalOffsetTmp.Clamp(0.0, scrollableWidth);
 		targetZoomedVerticalOffsetTmp = targetZoomedVerticalOffsetTmp.Clamp(0.0, scrollableHeight);


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/nventive-private#190

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
With `SoftInput.AdjustNothing`, when focused, TextBox or PasswordBox inside a ScrollViewer would be brought into view, but behind the keyboard.

## What is the new behavior?
^ should not happen.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->