### PR TITLE
fix(ItemsControl): Don't clear content on IsContainerFromTemplateRoot

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -15,7 +15,6 @@ using TreeView = Microsoft.UI.Xaml.Controls.TreeView;
 using TreeViewItem = Microsoft.UI.Xaml.Controls.TreeViewItem;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests;
 using System.Collections.Generic;
-using Uno.Foundation.Logging;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -15,6 +15,7 @@ using TreeView = Microsoft.UI.Xaml.Controls.TreeView;
 using TreeViewItem = Microsoft.UI.Xaml.Controls.TreeViewItem;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests;
 using System.Collections.Generic;
+using Uno.Foundation.Logging;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 
@@ -25,7 +26,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 [RunsOnUIThread]
 public class Given_TreeView
 {
-	// Test method that creates a tree of three nested items from an itemssource and that will open and close a single treeview item twice and validate that the container is still containing the same property values
 	[TestMethod]
 	public async Task When_Open_Close_Twice()
 	{
@@ -72,9 +72,75 @@ public class Given_TreeView
 		Assert.AreEqual("Child 2", child2NodeAfter.Content);
 	}
 
-	private class MyNode
+	[TestMethod]
+	public async Task When_Open_Close_Twice_Grid()
 	{
-		public string Name { get; set; }
-		public List<MyNode> Children { get; set; }
+		var SUT = new When_Open_Close_Twice_Grid();
+		TestServices.WindowHelper.WindowContent = SUT;
+
+		var root = new MyNode();
+		root.Name = "root 4";
+		root.IsDirectory = true;
+		root.Children = new List<MyNode>();
+		var child1 = new MyNode { Name = "Child 1" };
+		var child2 = new MyNode { Name = "Child 2" };
+		root.Children.Add(child1);
+		root.Children.Add(child2);
+
+		SUT.myTree.ItemsSource = new[] { root };
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var rootNode = (TreeViewItem)SUT.myTree.ContainerFromItem(root);
+		rootNode.IsExpanded = true;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var child1Node = (TreeViewItem)SUT.myTree.ContainerFromItem(child1);
+		Assert.IsNotNull(child1Node);
+		Assert.AreEqual(child1, child1Node.DataContext);
+
+		rootNode.IsExpanded = false;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		rootNode.IsExpanded = true;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		await TestServices.WindowHelper.WaitFor(() => (SUT.myTree.ContainerFromItem(child1) as TreeViewItem)?.DataContext == child1);
+		await TestServices.WindowHelper.WaitFor(() => (SUT.myTree.ContainerFromItem(child2) as TreeViewItem)?.DataContext == child2);
+
+		await TestServices.WindowHelper.WaitFor(() => (SUT.myTree.ContainerFromItem(child1) as TreeViewItem)?.Content is Grid);
+		await TestServices.WindowHelper.WaitFor(() => (SUT.myTree.ContainerFromItem(child2) as TreeViewItem)?.Content is Grid);
+
+		var child1NodeAfter = (TreeViewItem)SUT.myTree.ContainerFromItem(child1);
+		Assert.IsNotNull(child1NodeAfter);
+
+		Assert.AreEqual(child1, child1NodeAfter.DataContext);
+
+		var child2NodeAfter = (TreeViewItem)SUT.myTree.ContainerFromItem(child2);
+		await TestServices.WindowHelper.WaitForLoaded(child2NodeAfter);
+		Assert.IsNotNull(child2NodeAfter);
+
+		Assert.AreEqual(child2, child2NodeAfter.DataContext);
 	}
+}
+
+public class MyNode
+{
+	public string Name { get; set; }
+
+	public bool IsDirectory { get; set; }
+
+	public List<MyNode> Children { get; set; }
+}
+
+public class FSObjectTemplateSelector : DataTemplateSelector
+{
+	public DataTemplate FileTemplate { get; set; }
+	public DataTemplate DirectoryTemplate { get; set; }
+
+	protected override DataTemplate SelectTemplateCore(object item, DependencyObject container) => SelectTemplateCore(item);
+
+	protected override DataTemplate SelectTemplateCore(object item)
+		=> item is MyNode node && node.IsDirectory
+			? DirectoryTemplate
+			: FileTemplate;
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Open_Close_Twice_Grid.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Open_Close_Twice_Grid.xaml
@@ -1,0 +1,137 @@
+﻿<Grid x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests.When_Open_Close_Twice_Grid"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests"
+	  xmlns:local2="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid.Resources>
+
+		<DataTemplate x:Key="DirectoryTemplate">
+			<muxc:TreeViewItem ItemsSource="{Binding Children}">
+				<Grid>
+					<TextBlock Foreground="Blue" Text="{Binding Name}" />
+				</Grid>
+			</muxc:TreeViewItem>
+		</DataTemplate>
+		<DataTemplate x:Key="FileTemplate">
+			<muxc:TreeViewItem>
+				<Grid>
+					<TextBlock Foreground="Green" Text="{Binding Name}" />
+				</Grid>
+			</muxc:TreeViewItem>
+		</DataTemplate>
+
+		<local2:FSObjectTemplateSelector x:Key="FSObjectTemplateSelector"
+										 FileTemplate="{StaticResource FileTemplate}"
+										 DirectoryTemplate="{StaticResource DirectoryTemplate}" />
+	
+		<Style x:Key="FileExplorerTreeViewItemStyle"
+			   TargetType="muxc:TreeViewItem">
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="muxc:TreeViewItem">
+						<Grid x:Name="ContentPresenterGrid"
+							  Margin="0,0,0,0"
+							  Background="Red"
+							  BorderBrush="{TemplateBinding BorderBrush}"
+							  CornerRadius="{TemplateBinding CornerRadius}">
+
+							<Grid x:Name="MultiSelectGrid"
+								  Padding="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.Indentation}">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition />
+								</Grid.ColumnDefinitions>
+
+								<Grid Grid.Column="0">
+									<CheckBox x:Name="MultiSelectCheckBox"
+											  Width="32"
+											  MinWidth="32"
+											  Margin="12,0,0,0"
+											  VerticalAlignment="Center"
+											  Visibility="Collapsed"
+											  IsTabStop="False"
+											  AutomationProperties.AccessibilityView="Raw" />
+									<Border x:Name="MultiArrangeOverlayTextBorder"
+											Visibility="Collapsed"
+											IsHitTestVisible="False"
+											MinWidth="20"
+											Height="20"
+											VerticalAlignment="Center"
+											HorizontalAlignment="Center"
+											Background="{ThemeResource SystemControlBackgroundAccentBrush}"
+											BorderThickness="1"
+											BorderBrush="{ThemeResource SystemControlBackgroundChromeWhiteBrush}"
+											CornerRadius="{ThemeResource ControlCornerRadius}">
+										<TextBlock x:Name="MultiArrangeOverlayText"
+												   Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.DragItemsCount}"
+												   Style="{ThemeResource CaptionTextBlockStyle}"
+												   Foreground="{ThemeResource SystemControlForegroundChromeWhiteBrush}"
+												   IsHitTestVisible="False"
+												   VerticalAlignment="Center"
+												   HorizontalAlignment="Center"
+												   AutomationProperties.AccessibilityView="Raw" />
+									</Border>
+								</Grid>
+
+								<Grid x:Name="ExpandCollapseChevron"
+									  Grid.Column="1"
+									  Padding="12,0,12,0"
+									  Width="Auto"
+									  Opacity="{TemplateBinding GlyphOpacity}"
+									  Background="Transparent">
+									<TextBlock Foreground="{TemplateBinding GlyphBrush}"
+											   Width="12"
+											   Height="12"
+											   Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.CollapsedGlyphVisibility}"
+											   FontSize="{TemplateBinding GlyphSize}"
+											   Text="{TemplateBinding CollapsedGlyph}"
+											   FontFamily="{StaticResource SymbolThemeFontFamily}"
+											   VerticalAlignment="Center"
+											   AutomationProperties.AccessibilityView="Raw"
+											   IsTextScaleFactorEnabled="False"
+											   IsHitTestVisible="False" />
+									<TextBlock Foreground="{TemplateBinding GlyphBrush}"
+											   Width="12"
+											   Height="12"
+											   Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TreeViewItemTemplateSettings.ExpandedGlyphVisibility}"
+											   FontSize="{TemplateBinding GlyphSize}"
+											   Text="{TemplateBinding ExpandedGlyph}"
+											   FontFamily="{StaticResource SymbolThemeFontFamily}"
+											   VerticalAlignment="Center"
+											   AutomationProperties.AccessibilityView="Raw"
+											   IsTextScaleFactorEnabled="False"
+											   IsHitTestVisible="False" />
+								</Grid>
+
+								<ContentPresenter x:Name="ContentPresenter"
+												  Grid.Column="2"
+												  ContentTransitions="{TemplateBinding ContentTransitions}"
+												  ContentTemplate="{TemplateBinding ContentTemplate}"
+												  Content="{TemplateBinding Content}"
+												  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+												  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+												  Margin="{TemplateBinding Padding}" />
+							</Grid>
+
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</Grid.Resources>
+
+	<muxc:TreeView x:Name="myTree"
+				   x:FieldModifier="public"
+				   SelectionMode="Multiple"
+				   ItemTemplateSelector="{StaticResource FSObjectTemplateSelector}"
+				   ItemContainerStyle="{StaticResource FileExplorerTreeViewItemStyle}"
+				   ItemsSource="{Binding Children}">
+	</muxc:TreeView>
+</Grid>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Open_Close_Twice_Grid.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Open_Close_Twice_Grid.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests;
+
+public sealed partial class When_Open_Close_Twice_Grid : Grid
+{
+	public When_Open_Close_Twice_Grid()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1163,8 +1163,11 @@ namespace Windows.UI.Xaml.Controls
 						}
 					}
 
-					// Clears value set in PrepareContainerForItemOverride
-					ClearPropertyWhenNoExpression(contentControl, ContentControl.ContentProperty);
+					if (!contentControl.IsContainerFromTemplateRoot)
+					{
+						// Clears value set in PrepareContainerForItemOverride
+						ClearPropertyWhenNoExpression(contentControl, ContentControl.ContentProperty);
+					}
 
 					if (contentControl.ContentTemplate is { } ct && ct == ItemTemplate)
 					{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes invalid Content property reset on non-ContentPresenter template root (found in TreeViewItem).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
