### PR TITLE
fix(xamlreader): Ensure adding properties on an explicit property reports an error

### DIFF
--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlXmlReader.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlXmlReader.cs
@@ -745,15 +745,24 @@ namespace Uno.Xaml
 			}
 			else
 			{
-
-				if (r.Name.Contains(".") && r.IsEmptyElement && !r.HasAttributes)
+				if (r.Name.Contains(".") && r.IsEmptyElement)
 				{
-					// This case is present to handle self closing attached property nodes.
+					if (!r.HasAttributes)
+					{
+						// This case is present to handle self closing attached property nodes.
 
-					yield return Node(XamlNodeType.StartMember, xm);
-					yield return Node(XamlNodeType.EndMember, xm);
-					r.Read();
-					yield break;
+						yield return Node(XamlNodeType.StartMember, xm);
+						yield return Node(XamlNodeType.EndMember, xm);
+						r.Read();
+						yield break;
+					}
+					else
+					{
+						throw new XamlParseException(
+							string.Format(
+								CultureInfo.InvariantCulture,
+								"Member '{0}' cannot have properties", xm.Name)) { LineNumber = this.LineNumber, LinePosition = this.LinePosition };
+					}
 				}
 				else
 				{ 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/Windows_UI_Xaml_Controls/ParserTests/Controls/When_Invalid_Element_Property.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/Windows_UI_Xaml_Controls/ParserTests/Controls/When_Invalid_Element_Property.xaml
@@ -1,0 +1,23 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml_Controls.ParserTests.Controls.When_Invalid_Element_Property"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_XAML_Controls.GridTests.Controls"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		
+		<NavigationView IsBackButtonVisible="Collapsed"
+						IsPaneToggleButtonVisible="False"
+						IsSettingsVisible="False"
+						PaneDisplayMode="Left">
+
+			<NavigationView.PaneTitle FontSize="16"
+									  FontWeight="Bold"
+									  Text="PaneTitle" />
+
+		</NavigationView>
+		
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/Windows_UI_Xaml_Controls/ParserTests/Controls/When_Invalid_Element_Property.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/Windows_UI_Xaml_Controls/ParserTests/Controls/When_Invalid_Element_Property.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.ParserTests.Controls
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class When_Invalid_Element_Property : Page
+	{
+		public When_Invalid_Element_Property()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/Windows_UI_Xaml_Controls/ParserTests/Given_Parser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.netcore.Tests/Windows_UI_Xaml_Controls/ParserTests/Given_Parser.cs
@@ -1,0 +1,78 @@
+﻿using System.Text;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+using Uno.UI.SourceGenerators.Tests.Verifiers;
+
+namespace Uno.UI.SourceGenerators.Tests.Windows_UI_Xaml_Controls.ParserTests;
+
+using Verify = XamlSourceGeneratorVerifier;
+
+[TestClass]
+public class Given_Parser
+{
+	[TestMethod]
+	public async Task When_Invalid_Element_Property()
+	{
+		var xamlFiles = new[]
+		{
+			new XamlFile(
+				"MainPage.xaml",
+				"""
+				<Page x:Class="TestRepro.MainPage"
+					  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+
+					<Grid>
+
+						<NavigationView IsBackButtonVisible="Collapsed"
+										IsPaneToggleButtonVisible="False"
+										IsSettingsVisible="False"
+										PaneDisplayMode="Left">
+
+							<NavigationView.PaneTitle FontSize="16"
+													  FontWeight="Bold"
+													  Text="PaneTitle" />
+
+						</NavigationView>
+
+					</Grid>
+				</Page>
+				"""),
+		};
+
+		var test = new Verify.Test(xamlFiles)
+		{
+			TestState =
+			{
+				Sources =
+				{
+					"""
+					using Windows.UI.Xaml.Controls;
+
+					namespace TestRepro
+					{
+						public sealed partial class MainPage : Page
+						{
+							public MainPage()
+							{
+								this.InitializeComponent();
+							}
+						}
+					}
+					"""
+				}
+			}
+		};
+
+		test.ExpectedDiagnostics.AddRange(
+			new[] {
+				// /0/MainPage.xaml(13,5): error UXAML0001: Member 'PaneTitle' cannot have properties at line 13, position 5
+				DiagnosticResult.CompilerError("UXAML0001").WithSpan("/0/MainPage.xaml", 13, 5, 13, 5).WithArguments("Member 'PaneTitle' cannot have properties at line 13, position 5"),
+				// /0/Test0.cs(9,9): error CS1061: 'MainPage' does not contain a definition for 'InitializeComponent' and no accessible extension method 'InitializeComponent' accepting a first argument of type 'MainPage' could be found (are you missing a using directive or an assembly reference?)
+				DiagnosticResult.CompilerError("CS1061").WithSpan(9, 9, 9, 28).WithArguments("TestRepro.MainPage", "InitializeComponent")
+			}
+		);
+		await test.RunAsync();
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/discussions/11619

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that parsing invalid XAML does not fall into an infinite loop.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
