### PR TITLE
Revert "fix: Remove GuardBand on GTK HW renderers to avoid visual glitches around clipping"

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurfaceBase.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GLRenderSurfaceBase.cs
@@ -25,6 +25,12 @@ namespace Uno.UI.Runtime.Skia
 		private const SKColorType colorType = SKColorType.Rgba8888;
 		private const GRSurfaceOrigin surfaceOrigin = GRSurfaceOrigin.BottomLeft;
 
+		/// <summary>
+		/// Include a guard band for the creation of the OpenGL surface to avoid
+		/// incorrect renders when the surface is exactly the size of the GLArea.
+		/// </summary>
+		private const int GuardBand = 32;
+
 		private readonly DisplayInformation _displayInformation;
 		private FocusManager? _focusManager;
 
@@ -87,9 +93,10 @@ namespace Uno.UI.Runtime.Skia
 			}
 
 			var scale = _scale ?? 1f;
+			var scaledGuardBand = (int)(GuardBand * scale);
 
-			var w = (int)Math.Max(0, AllocatedWidth * scale);
-			var h = (int)Math.Max(0, AllocatedHeight * scale);
+			var w = (int)Math.Max(0, AllocatedWidth * scale + scaledGuardBand);
+			var h = (int)Math.Max(0, AllocatedHeight * scale + scaledGuardBand);
 
 			if (_renderTarget == null || _surface == null || _renderTarget.Width != w || _renderTarget.Height != h)
 			{
@@ -130,6 +137,8 @@ namespace Uno.UI.Runtime.Skia
 				{
 					canvas.Scale(scale);
 				}
+
+				canvas.Translate(new SKPoint(0, GuardBand));
 
 				WUX.Window.Current.Compositor.Render(_surface);
 			}


### PR DESCRIPTION
Reverts unoplatform/uno#11497 as it causes visual rendering issues on Windows.

