### PR TITLE
fix(ios): ListView not resizing as items change

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -57,6 +57,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		private DataTemplate SelfHostingItemTemplate => _testsResources["SelfHostingItemTemplate"] as DataTemplate;
 
+		/// <summary>
+		/// Size = 152w x 29h
+		/// </summary>
 		private DataTemplate FixedSizeItemTemplate => _testsResources["FixedSizeItemTemplate"] as DataTemplate;
 
 		private DataTemplate NV286_Template => _testsResources["NV286_Template"] as DataTemplate;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
@@ -227,6 +227,10 @@ namespace Windows.UI.Xaml.Controls
 					}
 				}
 			}
+			else
+			{
+				NativeLayout?.NeedsRelayout();
+			}
 		}
 
 		public override void InsertSections(NSIndexSet sections)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -1041,6 +1041,10 @@ namespace Windows.UI.Xaml.Controls
 				// If we're adding an item and the previous layout didn't use all available space, we probably need more space.
 				PropagateUnusedSpaceRelayout();
 			}
+			else if (change.Action == NotifyCollectionChangedAction.Remove)
+			{
+				NeedsRelayout();
+			}
 		}
 
 		/// <summary>
@@ -1208,8 +1212,13 @@ namespace Windows.UI.Xaml.Controls
 		private void PropagateUnusedSpaceRelayout()
 		{
 			SetWillConsumeUnusedSpace();
+			NeedsRelayout();
+		}
 
+		internal void NeedsRelayout()
+		{
 			var nativePanel = CollectionView as NativeListViewBase;
+
 			nativePanel.SetNeedsLayout();
 			// NativeListViewBase swallows layout requests by design
 			nativePanel.SetSuperviewNeedsLayout();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7754

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On iOS, ListView fails to re-measure itself when:
1. an item was first added to an empty source; OR
2. an item was removed from the source

## What is the new behavior?
The ListView will always re-measure on these two scenarios.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->