### PR TITLE
fix: Retrieve existing `ResourceLoader` via constructor

### DIFF
--- a/src/Uno.UI.Tests/ResourceLoader/Given_ResourceLoader.cs
+++ b/src/Uno.UI.Tests/ResourceLoader/Given_ResourceLoader.cs
@@ -91,5 +91,14 @@ namespace Uno.UI.Tests.ResourceLoaderTests
 
 			Assert.AreEqual(@"Header in 'en'", SUT.rb.Header);
 		}
+
+		[TestMethod]
+		public void When_Constructor_Used()
+		{
+			_ResourceLoader.DefaultLanguage = "en";
+			var SUT = new _ResourceLoader(UITestResources);
+
+			Assert.AreEqual("App70-en", SUT.GetString("ApplicationName"));
+		}
 	}
 }

--- a/src/Uno.UI.Tests/ResourceLoader/Given_ResourceLoader.cs
+++ b/src/Uno.UI.Tests/ResourceLoader/Given_ResourceLoader.cs
@@ -93,7 +93,7 @@ namespace Uno.UI.Tests.ResourceLoaderTests
 		}
 
 		[TestMethod]
-		public void When_Constructor_Used()
+		public void When_String_Constructor_Used()
 		{
 			_ResourceLoader.DefaultLanguage = "en";
 			var SUT = new _ResourceLoader(UITestResources);

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Xml.Linq;
 using Uno;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
@@ -32,8 +33,17 @@ namespace Windows.ApplicationModel.Resources
 
 		private readonly Dictionary<string, Dictionary<string, string>> _resources = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
 
+		public ResourceLoader() : this(DefaultResourceLoaderName)
+		{
+		}
+
 		public ResourceLoader(string name)
 		{
+			if (_log.IsEnabled(LogLevel.Debug))
+			{
+				_log.LogDebug($"Initializing ResourceLoader {name} (CurrentUICulture: {CultureInfo.CurrentUICulture})");
+			}
+
 			LoaderName = name;
 
 			// If there is already a loader with the same name,
@@ -45,14 +55,6 @@ namespace Windows.ApplicationModel.Resources
 		}
 
 		internal string LoaderName { get; }
-
-		public ResourceLoader()
-		{
-			if (_log.IsEnabled(LogLevel.Debug))
-			{
-				_log.LogDebug($"Initializing ResourceLoader (CurrentUICulture: {CultureInfo.CurrentUICulture})");
-			}
-		}
 
 		public string GetString(string resource)
 		{

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
@@ -35,6 +35,13 @@ namespace Windows.ApplicationModel.Resources
 		public ResourceLoader(string name)
 		{
 			LoaderName = name;
+
+			// If there is already a loader with the same name,
+			// they should share the same resources.
+			if (_loaders.TryGetValue(name, out var existingLoader))
+			{
+				_resources = existingLoader._resources;
+			}
 		}
 
 		internal string LoaderName { get; }

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
@@ -52,6 +52,10 @@ namespace Windows.ApplicationModel.Resources
 			{
 				_resources = existingLoader._resources;
 			}
+			else
+			{
+				_loaders[name] = this;
+			}
 		}
 
 		internal string LoaderName { get; }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5815

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`ResourceLoader` constructor cannot be used to retrieve an existing loader.

## What is the new behavior?

`ResourceLoader` constructor can be used to retrieve an existing loader.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
