### PR TITLE
fix(itemsRepeater): IR not visible on intiial load might not materialize enough items

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -400,7 +400,7 @@ dotnet_diagnostic.CA1309.severity = none
 dotnet_diagnostic.CA2101.severity = none
 
 # IDE0055: Fix formatting
-dotnet_diagnostic.IDE0055.severity = warning # Will be promoted as error by TreatWarningsAsErrors but also allows usage of WarningsNotAsErrors in debug
+dotnet_diagnostic.IDE0055.severity = warning # Will be promoted as an error by TreatWarningsAsErrors but also allows usage of WarningsNotAsErrors in debug
 
 # IDE0051: Remove unused private member
 dotnet_diagnostic.IDE0051.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -400,7 +400,7 @@ dotnet_diagnostic.CA1309.severity = none
 dotnet_diagnostic.CA2101.severity = none
 
 # IDE0055: Fix formatting
-dotnet_diagnostic.IDE0055.severity = error
+dotnet_diagnostic.IDE0055.severity = warning # Will be promoted as error by TreatWarningsAsErrors but also allows usage of WarningsNotAsErrors in debug
 
 # IDE0051: Remove unused private member
 dotnet_diagnostic.IDE0051.severity = warning

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayout.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayout.cs
@@ -373,7 +373,7 @@ namespace Microsoft.UI.Xaml.Controls
 			var neededElementsCountToFillNewViewport = Math.Min(_uno_lastKnownItemsCount, MajorSize(newViewport) / _uno_lastKnownAverageElementSize);
 			if (_uno_lastKnownRealizedElementsCount < neededElementsCountToFillNewViewport)
 			{
-				// Only few first items have been measured so far (usually 1 or 2), this might be because the IR is within a SV and not visible yet.
+				// Only a few first items have been measured so far (usually 1 or 2), this might be because the IR is within a SV and not visible yet.
 				// Note: In that case we have to make sure to not only validate the Major axis since the parent SV could be vertical while local layout itself is horizontal.
 				// Note2: Depending of the platform (Android), we might be invoked with empty viewport, make sure to consider out-of-bound in such case.
 				// Test case: When_NestedInSVAndOutOfViewportOnInitialLoad_Then_MaterializedEvenWhenScrollingOnMinorAxis


### PR DESCRIPTION
GitHub Issue (If applicable): closes #https://github.com/unoplatform/uno.chefs/issues/259

## Bugfix
IR not visible on intiial load might not materialize enough items

## What is the current behavior?
On initial load, if IR's viewport is empty it loads only one ** OR TWO** items and won't load more items until a SV is scrolled in the major direction.

## What is the new behavior?
Scrolling on the minor axis also trigger materialization of items if the major axis is not yet full.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
