### PR TITLE
Update Template WinAppSdk

### DIFF
--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/Directory.Build.props
@@ -8,6 +8,8 @@
 	<BaseOutputPath>bin\$(MSBuildProjectName)</BaseOutputPath>
 	<BaseIntermediateOutputPath>obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
 	<DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**</DefaultItemExcludes>
+	<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
+	<GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
 
 </Project>

--- a/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
+++ b/src/SolutionTemplate/Uno.ProjectTemplates.Dotnet/content/unolib-crossruntime/UnoCrossRuntimeLib/UnoCrossRuntimeLib.csproj
@@ -22,4 +22,41 @@
 		<PackageReference Include="Uno.WinUI" Version="3.0.0-PullRequest-3602-17779-1-3602.956" />
 	</ItemGroup>
 
+	<Choose>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+			<ItemGroup>
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" />
+				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+			</ItemGroup>
+			<ItemGroup>
+				<!--
+				If you encounter this error message:
+
+					error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
+					Please update to a newer .NET SDK in order to reference this assembly.
+
+				This means that the two packages below must be aligned with the "build" version number of
+				the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
+				must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
+				-->
+				<!-- <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
+				<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" /> -->
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<Content Include="Assets\**" />
+				<Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+				<Compile Update="**\*.xaml.cs">
+					<DependentUpon>%(Filename)</DependentUpon>
+				</Compile>
+				<PriResource Include="**\*.resw" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
+
+	<ItemGroup>
+		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+	</ItemGroup>
+
 </Project>

--- a/src/SolutionTemplate/UnoLibraryTemplate.netcore/CrossTargetedLibrary.csproj
+++ b/src/SolutionTemplate/UnoLibraryTemplate.netcore/CrossTargetedLibrary.csproj
@@ -14,7 +14,7 @@
 	<Choose>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
 			<ItemGroup>
-				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230217.4" />
+				<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230313.1" />
 				<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
 			</ItemGroup>
 			<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- unoplatform/uno.extensions/issues/1283

## PR Type

What kind of change does this PR introduce?

- Dependencies

## What is the current behavior?

Cross Runtime does not have the Windows logic or block to handle resources like xaml files

## What is the new behavior?

WinAppSdk updated and Cross Runtime updated to have the WinAppSdk reference with the includes for XAML resources