### PR TITLE
fix: Fix CameraCaptureUI on Android 11 and later

### DIFF
--- a/src/SamplesApp/SamplesApp.netcoremobile/Android/AssemblyInfo.Android.cs
+++ b/src/SamplesApp/SamplesApp.netcoremobile/Android/AssemblyInfo.Android.cs
@@ -10,3 +10,5 @@ using Android.App;
 [assembly: UsesPermission("android.permission.ACCESS_NETWORK_STATE")]
 [assembly: UsesPermission("android.permission.SET_WALLPAPER")]
 [assembly: UsesPermission("android.permission.READ_CONTACTS")]
+[assembly: UsesPermission("android.permission.CAMERA")]
+[assembly: UsesPermission("android.permission.WRITE_EXTERNAL_STORAGE")]

--- a/src/Uno.UWP/Media/Capture/CameraCaptureUI.cs
+++ b/src/Uno.UWP/Media/Capture/CameraCaptureUI.cs
@@ -31,7 +31,7 @@ namespace Windows.Media.Capture
 #if __ANDROID__ || __IOS__
 		private static async Task<StorageFile> CreateTempImage(Stream source, string extension)
 		{
-			var filePath = Path.Combine(Windows.Storage.ApplicationData.Current.TemporaryFolder.Path, Guid.NewGuid() + extension);
+			var filePath = Path.Combine(ApplicationData.Current.TemporaryFolder.Path, Guid.NewGuid() + extension);
 
 			using (var file = File.OpenWrite(filePath))
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11787

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

We ask for `WRITE_EXTERNAL_STORAGE` permission, which has no effect on Android 11 and later, hence, we throw exception because the permission is not granted (this is a breaking change from Android).

## What is the new behavior?

`WRITE_EXTERNAL_STORAGE` is only needed on Android 9 and lower. See https://developer.android.com/training/data-storage/shared/media#request-permissions

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
