### PR TITLE
fix: make the SpeechRecognizer ask before recognition

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/Properties/AssemblyInfo.cs
+++ b/src/SamplesApp/SamplesApp.Droid/Properties/AssemblyInfo.cs
@@ -42,3 +42,4 @@ using Android.App;
 [assembly: UsesPermission("android.permission.USE_FULL_SCREEN_INTENT")]
 [assembly: UsesPermission("android.permission.WRITE_EXTERNAL_STORAGE")]
 [assembly: UsesPermission("android.permission.CAMERA")]
+[assembly: UsesPermission("android.permission.RECORD_AUDIO")]

--- a/src/SamplesApp/SamplesApp.netcoremobile/Android/AssemblyInfo.Android.cs
+++ b/src/SamplesApp/SamplesApp.netcoremobile/Android/AssemblyInfo.Android.cs
@@ -10,3 +10,4 @@ using Android.App;
 [assembly: UsesPermission("android.permission.ACCESS_NETWORK_STATE")]
 [assembly: UsesPermission("android.permission.SET_WALLPAPER")]
 [assembly: UsesPermission("android.permission.READ_CONTACTS")]
+[assembly: UsesPermission("android.permission.RECORD_AUDIO")]

--- a/src/Uno.UWP/Media/SpeechRecognition/SpeechRecognizer.Android.cs
+++ b/src/Uno.UWP/Media/SpeechRecognition/SpeechRecognizer.Android.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Android.Content;
 using Android.Speech;
 using Windows.Foundation;
+using Windows.Extensions;
 
 namespace Windows.Media.SpeechRecognition
 {
@@ -15,8 +17,15 @@ namespace Windows.Media.SpeechRecognition
 			_speechRecognizer = Android.Speech.SpeechRecognizer.CreateSpeechRecognizer(Android.App.Application.Context);
 		}
 
-		public IAsyncOperation<SpeechRecognitionResult> RecognizeAsync()
+		private async Task<SpeechRecognitionResult> RecognizeTaskAsync(CancellationToken ct)
 		{
+			var isPermissionGranted = await PermissionsHelper.TryGetPermission(ct, Android.Manifest.Permission.RecordAudio);
+
+			if (!isPermissionGranted)
+			{
+				throw new Exception("The RECORD_AUDIO permission is either not present in your Manifest or was not accepted prior to attempting a speech recognition.");
+			}
+
 			var tcs = new TaskCompletionSource<SpeechRecognitionResult>();
 
 			var listener = new SpeechRecognitionListener
@@ -50,8 +59,11 @@ namespace Windows.Media.SpeechRecognition
 
 			OnStateChanged(SpeechRecognizerState.Capturing);
 
-			return tcs.Task.AsAsyncOperation();
+			return await tcs.Task;
+
 		}
+
+		public IAsyncOperation<SpeechRecognitionResult> RecognizeAsync() => AsyncOperation.FromTask(RecognizeTaskAsync);
 
 		protected virtual Intent CreateSpeechIntent()
 		{

--- a/src/Uno.UWP/Media/SpeechRecognition/SpeechRecognizer.Android.cs
+++ b/src/Uno.UWP/Media/SpeechRecognition/SpeechRecognizer.Android.cs
@@ -23,7 +23,7 @@ namespace Windows.Media.SpeechRecognition
 
 			if (!isPermissionGranted)
 			{
-				throw new Exception("The RECORD_AUDIO permission is either not present in your Manifest or was not accepted prior to attempting a speech recognition.");
+				throw new UnauthorizedAccessException("The RECORD_AUDIO permission is either not present in your Manifest or was not accepted prior to attempting a speech recognition.");
 			}
 
 			var tcs = new TaskCompletionSource<SpeechRecognitionResult>();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11819

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR
-->
- Bugfix
<!--
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
Currently, the SpeechRecognizer does not ask for permission before trying to recognize speech and throws the same error as if the permission has been denied.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
The SpeechRecognizer now verifies if the RECORD_AUDIO permission has been granted. If it has not been granted, the SpeechRecognizer displays an appropriate dialog to request permission.
If the user declines to grant permission, an error with proper message is thrown.

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
I couldn't try if the same issue is present on iOS also. 
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
