### PR TITLE
fix(ios): LVI is sometimes clipped

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.Measure.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.Measure.cs
@@ -8,6 +8,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Uno.UI.RuntimeTests.Extensions;
 using System.Collections.ObjectModel;
+using Windows.Foundation;
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -90,7 +91,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			ListViewItem lvi = null;
 
 			const double scrollBy = 300;
-			ScrollBy(SUT, scrollBy);
+			ScrollTo(SUT, scrollBy);
 			var item = 10;
 			await WindowHelper.WaitFor(() => (lvi = SUT.ContainerFromItem(item) as ListViewItem) != null);
 			Assert.AreEqual(minWidth, lvi.ActualWidth);
@@ -228,12 +229,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			async Task ScrollDownAndBackChecked()
 			{
-				await ScrollByInIncrements(SUT, 1000);
+				await ScrollToInIncrements(SUT, 1000);
 				await WindowHelper.WaitForNonNull(() => SUT.ContainerFromIndex(10));
 				VerifyItemHeight(9);
 				VerifyItemHeight(8);
 
-				await ScrollByInIncrements(SUT, -100);
+				await ScrollToInIncrements(SUT, -100);
 				await WindowHelper.WaitForNonNull(() => SUT.ContainerFromIndex(1));
 				await WindowHelper.WaitForNonNull(() => SUT.ContainerFromIndex(0));
 				VerifyItemHeight(0);
@@ -257,6 +258,82 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.AreEqual(ExpectedContainerHeight + TopAndBottomMargin, containerNextRect.Y - containerRect.Y);
 			}
 		}
+
+#if __IOS__
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Item_Recycled_DuringScroll()
+		{
+			var lines = new[]
+			{
+				"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+				"Donec tristique metus vel aliquet malesuada.",
+				"Quisque efficitur diam pulvinar sapien luctus cursus.",
+				"Fusce in tortor vitae risus pretium malesuada quis vitae lacus.",
+				"Quisque vitae viverra nunc, ut placerat libero.",
+				"Etiam metus ligula, facilisis et odio vitae, placerat ornare nunc.",
+				"Nulla facilisi. Cras id nisi elit.",
+				"Mauris pharetra quam lacinia purus interdum, vitae suscipit lorem lobortis.",
+			};
+			var source = Enumerable.Range(0, 100)
+				.Select(x => string.Join(" ", lines.Take(2 * (2 + x % 3)).Prepend($"#{x}:")))
+				.ToArray();
+
+			var SUT = new ListView
+			{
+				ItemContainerStyle = NoSpaceContainerStyle,
+				ItemTemplate = WrappingTextBlockItemTemplate,
+				ItemsSource = source,
+				Height = 500,
+				Width = 350,
+			};
+
+			SUT.ContainerContentChanging += (s, e) =>
+			{
+				Console.WriteLine($"@xy ContainerContentChanging: #{e.ItemIndex}, InRecycleQueue={e.InRecycleQueue}");
+			};
+
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForNonNull(() => SUT.FindFirstChild<ItemsPresenter>());
+			await WindowHelper.WaitForIdle();
+
+			var sv = SUT.FindFirstChild<ScrollViewer>();
+			var itemHeights = Enumerable.Range(0, 3)
+				.Select(x => (ListViewItem)SUT.ContainerFromIndex(x))
+				.Select(x => x.LayoutSlot.Height)
+				.ToArray();
+
+			Assert.IsTrue(itemHeights[0] < itemHeights[1] && itemHeights[1] < itemHeights[2], "Set of item heights should be in ascending order: " + string.Join(" < ", itemHeights));
+
+			var snapshots = new List<(int Index, Rect? ClippedFrame)>();
+			(int Index, ListViewItem Container)? previousContainer = null;
+			SUT.ContainerContentChanging += (s, e) =>
+			{
+				// The clean up occurs after this event, so we have to check the previous one when the next is being prepared.
+				if (previousContainer is { } previous)
+				{
+					// We should not throw/assert here, as this event is coming straight from native without any exception-guard.
+					// Throwing in this context will cause the app to crash directly.
+					snapshots.Add((previous.Index, previous.Container.ClippedFrame));
+				}
+
+				previousContainer = (e.ItemIndex, (ListViewItem)e.ItemContainer);
+			};
+
+			await ScrollToAndWait(SUT, sv.ExtentHeight);
+			await ScrollToAndWait(SUT, 0);
+
+			string FormatRect(Rect? rect) => rect is { } x ? $"[{x.Width:0.#}x{x.Height:0.#}@{x.Left:0.#},{x.Top:0.#}]" : "null";
+
+			foreach (var (index, frame) in snapshots)
+			{
+				var variantIndex = index % 3;
+				var expectedHeight = itemHeights[variantIndex];
+
+				Assert.IsTrue(frame is not { } cf || cf.Height == expectedHeight, $"Item's ClippedFrame shouldve been cleared, or be of expected height: Row={index} ('{variantIndex}), ClippedFrame={FormatRect(frame)}, ExpectedHeight={expectedHeight}");
+			}
+		}
+#endif
 
 		[TestMethod]
 		[RunsOnUIThread]
@@ -290,12 +367,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await Task.Delay(2000);
 			var sv = SUT.FindFirstChild<ScrollViewer>();
-			ScrollBy(SUT, 40);
+			ScrollTo(SUT, 40);
 			double InitialScroll()
 			{
 #if NETFX_CORE
 				// For some reason on UWP the initial ChangeView may not work
-				ScrollBy(SUT, 40);
+				ScrollTo(SUT, 40);
 #endif
 				return sv.VerticalOffset;
 			}
@@ -305,7 +382,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var rectScrolledPartial = container.GetRelativeBounds(SUT);
 			Assert.AreEqual(HeightOfTwoItems - 40, rectScrolledPartial.Y, 1, "HeightOfTwoItems - 40");
 
-			await ScrollByInIncrements(SUT, 200);
+			await ScrollToInIncrements(SUT, 200);
 			const double MaxPossibleScroll = 310 - 250;
 			await WindowHelper.WaitForEqual(MaxPossibleScroll, () => sv.VerticalOffset);
 
@@ -356,19 +433,46 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		// Works around ScrollIntoView() not implemented for all platforms
-		private static void ScrollBy(ListViewBase listViewBase, double scrollBy)
+		private static void ScrollTo(ListViewBase listViewBase, double vOffset)
 		{
 			var sv = listViewBase.FindFirstChild<ScrollViewer>();
 			Assert.IsNotNull(sv);
-			sv.ChangeView(null, scrollBy, null);
+			sv.ChangeView(null, vOffset, null);
 		}
 
-		private static async Task ScrollByInIncrements(ListViewBase listViewBase, double scrollBy)
+		/// <summary>
+		/// Scroll and wait until at least 1s has elapsed since ScrollViewer.ViewChange or timed out after a given time.
+		/// </summary>
+		/// <param name="listViewBase"></param>
+		/// <param name="vOffset"></param>
+		/// <param name="timeoutInMs"></param>
+		/// <returns></returns>
+		private static async Task ScrollToAndWait(ListViewBase listViewBase, double vOffset, int timeoutInMs = 10000)
+		{
+			var sv = listViewBase.FindFirstChild<ScrollViewer>();
+
+			var lastScrolled = DateTime.Now;
+			sv.ViewChanged += (s, e) => lastScrolled = DateTime.Now;
+
+			sv.ChangeView(null, vOffset, null);
+
+			var timeout = DateTime.Now.AddMilliseconds(timeoutInMs);
+			while (DateTime.Now < timeout)
+			{
+				await WindowHelper.WaitForIdle();
+				if (lastScrolled.AddSeconds(1) < DateTime.Now)
+				{
+					return;
+				}
+			}
+		}
+
+		private static async Task ScrollToInIncrements(ListViewBase listViewBase, double vOffset)
 		{
 			var sv = listViewBase.FindFirstChild<ScrollViewer>();
 			Assert.IsNotNull(sv);
 			var current = sv.VerticalOffset;
-			if (current == scrollBy)
+			if (current == vOffset)
 			{
 				return;
 			}
@@ -377,9 +481,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			{
 				Assert.Fail("ScrollViewer must have non-zero height");
 			}
-			if (scrollBy > current)
+			if (vOffset > current)
 			{
-				for (double d = current + increment; d < scrollBy; d += increment)
+				for (double d = current + increment; d < vOffset; d += increment)
 				{
 					sv.ChangeView(null, d, null);
 					await Task.Delay(10);
@@ -387,14 +491,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 			else
 			{
-				for (double d = current - increment; d > scrollBy; d -= increment)
+				for (double d = current - increment; d > vOffset; d -= increment)
 				{
 					sv.ChangeView(null, d, null);
 					await Task.Delay(10);
 				}
 			}
 
-			sv.ChangeView(null, scrollBy, null);
+			sv.ChangeView(null, vOffset, null);
 		}
 
 		public class When_Item_Changes_Measure_Count_ItemViewModel : System.ComponentModel.INotifyPropertyChanged

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -55,6 +55,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		private DataTemplate TextBlockItemTemplate => _testsResources["TextBlockItemTemplate"] as DataTemplate;
 
+		private DataTemplate WrappingTextBlockItemTemplate => _testsResources["WrappingTextBlockItemTemplate"] as DataTemplate;
+
 		private DataTemplate SelfHostingItemTemplate => _testsResources["SelfHostingItemTemplate"] as DataTemplate;
 
 		/// <summary>
@@ -807,7 +809,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = container;
 			await WindowHelper.WaitForLoaded(list);
 
-			ScrollBy(list, 10000); // Scroll to end
+			ScrollTo(list, 10000); // Scroll to end
 
 			ListViewItem lastItem = null;
 			await WindowHelper.WaitFor(() => (lastItem = list.ContainerFromItem(19) as ListViewItem) != null);
@@ -822,8 +824,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			// Force rebuild the layout so that TranslateTransform picks up
 			// the updated values
-			ScrollBy(list, 0); // Scroll to top
-			ScrollBy(list, 100000); // Scroll to end
+			ScrollTo(list, 0); // Scroll to top
+			ScrollTo(list, 100000); // Scroll to end
 
 			await WindowHelper.WaitForEqual(181, () => GetTop(list.ContainerFromItem(18) as ListViewItem, container), tolerance: 2);
 		}
@@ -866,7 +868,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = container;
 			await WindowHelper.WaitForIdle();
 
-			ScrollBy(list, 1000000); // Scroll to end
+			ScrollTo(list, 1000000); // Scroll to end
 
 			await WindowHelper.WaitForIdle();
 
@@ -910,7 +912,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = container;
 			await WindowHelper.WaitForIdle();
 
-			ScrollBy(list, 1000000); // Scroll to end
+			ScrollTo(list, 1000000); // Scroll to end
 
 			await WindowHelper.WaitForIdle();
 
@@ -963,14 +965,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			dataContextChanged.Should().BeLessThan(5, $"dataContextChanged {dataContextChanged}");
 
-			ScrollBy(list, scroll.ExtentHeight / 2); // Scroll to middle
+			ScrollTo(list, scroll.ExtentHeight / 2); // Scroll to middle
 
 			await WindowHelper.WaitForIdle();
 
 			materialized.Should().BeLessThan(8, $"materialized {materialized}");
 			dataContextChanged.Should().BeLessThan(10, $"dataContextChanged {dataContextChanged}");
 
-			ScrollBy(list, scroll.ExtentHeight / 4); // Scroll to Quarter
+			ScrollTo(list, scroll.ExtentHeight / 4); // Scroll to Quarter
 
 			await WindowHelper.WaitForIdle();
 
@@ -1020,13 +1022,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var scroll = list.FindFirstChild<ScrollViewer>();
 			Assert.IsNotNull(scroll);
 
-			ScrollBy(list, scroll.ExtentHeight / 2); // Scroll to middle
+			ScrollTo(list, scroll.ExtentHeight / 2); // Scroll to middle
 
 			await WindowHelper.WaitForIdle();
 
 			materialized.Should().BeLessThan(10, $"materialized {materialized}");
 
-			ScrollBy(list, scroll.ExtentHeight / 4); // Scroll to Quarter
+			ScrollTo(list, scroll.ExtentHeight / 4); // Scroll to Quarter
 
 			await WindowHelper.WaitForIdle();
 
@@ -1080,28 +1082,28 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsNotNull(scroll);
 			dataContextChanged.Should().BeLessThan(10, $"dataContextChanged {dataContextChanged}");
 
-			ScrollBy(list, ElementHeight);
+			ScrollTo(list, ElementHeight);
 
 			await WindowHelper.WaitForIdle();
 
 			materialized.Should().BeLessThan(12, $"materialized {materialized}");
 			dataContextChanged.Should().BeLessThan(11, $"dataContextChanged {dataContextChanged}");
 
-			ScrollBy(list, ElementHeight * 3);
+			ScrollTo(list, ElementHeight * 3);
 
 			await WindowHelper.WaitForIdle();
 
 			materialized.Should().BeLessThan(14, $"materialized {materialized}");
 			dataContextChanged.Should().BeLessThan(13, $"dataContextChanged {dataContextChanged}");
 
-			ScrollBy(list, scroll.ExtentHeight / 2); // Scroll to middle
+			ScrollTo(list, scroll.ExtentHeight / 2); // Scroll to middle
 
 			await WindowHelper.WaitForIdle();
 
 			materialized.Should().BeLessThan(14, $"materialized {materialized}");
 			dataContextChanged.Should().BeLessThan(25, $"dataContextChanged {dataContextChanged}");
 
-			ScrollBy(list, scroll.ExtentHeight / 4); // Scroll to Quarter
+			ScrollTo(list, scroll.ExtentHeight / 4); // Scroll to Quarter
 
 			await WindowHelper.WaitForIdle();
 
@@ -2552,13 +2554,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var initial = GetCurrenState();
 
 			// scroll to bottom
-			ScrollBy(list, 10000);
+			ScrollTo(list, 10000);
 			await Task.Delay(500);
 			await WindowHelper.WaitForIdle();
 			var firstScroll = GetCurrenState();
 
 			// scroll to bottom
-			ScrollBy(list, 10000);
+			ScrollTo(list, 10000);
 			await Task.Delay(500);
 			await WindowHelper.WaitForIdle();
 			var secondScroll = GetCurrenState();
@@ -2604,7 +2606,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var initial = GetCurrenState();
 
 			// scroll to bottom
-			ScrollBy(list, 10000);
+			ScrollTo(list, 10000);
 			await Task.Delay(500);
 			await WindowHelper.WaitForIdle();
 			var firstScroll = GetCurrenState();
@@ -2613,7 +2615,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			source.HasMoreItems = false;
 
 			// scroll to bottom
-			ScrollBy(list, 10000);
+			ScrollTo(list, 10000);
 			await Task.Delay(500);
 			await WindowHelper.WaitForIdle();
 			var secondScroll = GetCurrenState();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TestsResources.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TestsResources.xaml
@@ -71,6 +71,9 @@
 	<DataTemplate x:Key="TextBlockItemTemplate">
 		<TextBlock Text="{Binding}" />
 	</DataTemplate>
+	<DataTemplate x:Key="WrappingTextBlockItemTemplate">
+		<TextBlock Text="{Binding}" TextWrapping="Wrap" />
+	</DataTemplate>
 	<DataTemplate x:Key="SelfHostingItemTemplate">
 		<ListViewItem Name="SelfHostingListViewItem">
 			<Border x:Name="SelfHostingBorder">

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -252,6 +252,13 @@ namespace Windows.UI.Xaml.Controls
 					// Normally this happens when the SelectorItem.Content is set, but there's an edge case where after a refresh, a
 					// container can be dequeued which happens to have had exactly the same DataContext as the new item.
 					cell.ClearMeasuredSize();
+
+					// Ensure ClippedFrame from a previous recycled item doesn't persist which can happen in some cases,
+					// and cause it to be clipped when either axis was smaller.
+					if (cell.Content is { } contentControl)
+					{
+						contentControl.ClippedFrame = null;
+					}
 				}
 
 				Owner?.XamlParent?.TryLoadMoreItems(index);


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/nventive-private#459

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On iOS while scrolling through a ListView, sometimes LVItems can appear to be clipped at the bottom.

## What is the new behavior?
^ should no longer happen.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This issue happens inside ListView with items of different size, when a LVI is reused for content requiring larger size and its ClippedFrame was somehow not updated during the arrange phase.