### PR TITLE
app: Fix ListView missing top elements when flinging #11809

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -917,6 +917,67 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(4, materialized);
 		}
 
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if __IOS__ || __ANDROID__
+		[Ignore("Disabled because of animated scrolling, even when explicitly requested.")]
+#endif
+		public async Task When_Large_List_Scroll_To_End_Then_Back_Up_And_First_Item()
+		{
+			var materialized = 0;
+			var container = new Grid { Height = 500, Width = 100 };
+
+			var list = new ListView
+			{
+				ItemContainerStyle = NoSpaceContainerStyle,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var tb = new TextBlock();
+					tb.SetBinding(TextBlock.TextProperty, new Binding());
+					var border = new Border()
+					{
+						Height = 50,
+						Child = tb
+					};
+
+					materialized++;
+
+					return border;
+				})
+			};
+			container.Children.Add(list);
+
+			var source = new ObservableCollection<int>(Enumerable.Range(0, 50));
+			list.ItemsSource = source;
+
+			WindowHelper.WindowContent = container;
+			await WindowHelper.WaitForIdle();
+
+			for (int i = 0; i < 3; i++)
+			{
+				ScrollTo(list, 1000000); // Scroll to end
+
+				await Task.Delay(200);
+				await WindowHelper.WaitForIdle();
+
+				ScrollTo(list, 5); // Scroll to end
+
+				await Task.Delay(200);
+				await WindowHelper.WaitForIdle();
+
+				var firstContainer = (FrameworkElement)list.ContainerFromIndex(0);
+
+				firstContainer.Should().NotBeNull();
+				LayoutInformation.GetLayoutSlot(firstContainer).Y.Should().BeLessOrEqualTo(0);
+
+				var secondContainer = (FrameworkElement)list.ContainerFromIndex(1);
+
+				secondContainer.Should().NotBeNull();
+				LayoutInformation.GetLayoutSlot(secondContainer).Y.Should().Be(50);
+			}
+		}
+
 		[TestMethod]
 		[RunsOnUIThread]
 #if __IOS__ || __ANDROID__

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -266,7 +266,7 @@ namespace Windows.UI.Xaml.Controls
 				// the line based on the average line height.
 				var index = (int)(ScrollOffset / _averageLineHeight);
 				_dynamicSeedStart = ScrollOffset - _averageLineHeight;
-				_dynamicSeedIndex = Uno.UI.IndexPath.FromRowSection(index - sign, 0);
+				_dynamicSeedIndex = Uno.UI.IndexPath.FromRowSection(index == 0 ? -1 : index - sign, 0);
 			}
 
 			while (unappliedDelta > 0)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11809

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
ListView would miss the top most 1st or 2nd items when scrolling from the bottom to the top quickly (in `VirtualizingPanelLayout`'s term, `isLargeScroll == true`).

## What is the new behavior?
ListView correct layouts the 1st item after scrolling from bottom to top quickly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
I don't mind contributing a UI Test as well if it's not too hard/time-consuming. Having pointers to existing list view tests would be ideal.

Internal Issue (If applicable):
N/A
