### PR TITLE
fix: `VisualCollection` changes should influence `IsChildrenRenderOrderDirty`

### DIFF
--- a/src/Uno.UI.Composition/Composition/ContainerVisual.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.cs
@@ -11,8 +11,12 @@ namespace Windows.UI.Composition
 		internal ContainerVisual(Compositor compositor) : base(compositor)
 		{
 			Children = new VisualCollection(compositor, this);
+			Children.CollectionChanged += Children_CollectionChanged;
 		}
 
 		public VisualCollection Children { get; }
+
+		private void Children_CollectionChanged(object? sender, EventArgs e) =>
+			IsChildrenRenderOrderDirty = true;
 	}
 }

--- a/src/Uno.UI.Composition/Composition/ContainerVisual.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.cs
@@ -2,21 +2,19 @@
 
 using System;
 
-namespace Windows.UI.Composition
+namespace Windows.UI.Composition;
+
+public partial class ContainerVisual : Visual
 {
-	public partial class ContainerVisual : Visual
+	internal ContainerVisual() : base(null!) => throw new NotSupportedException("Use the ctor with Compositor");
+
+	internal ContainerVisual(Compositor compositor) : base(compositor)
 	{
-		internal ContainerVisual() : base(null!) => throw new NotSupportedException("Use the ctor with Compositor");
-
-		internal ContainerVisual(Compositor compositor) : base(compositor)
-		{
-			Children = new VisualCollection(compositor, this);
-			Children.CollectionChanged += Children_CollectionChanged;
-		}
-
-		public VisualCollection Children { get; }
-
-		private void Children_CollectionChanged(object? sender, EventArgs e) =>
-			IsChildrenRenderOrderDirty = true;
+		Children = new VisualCollection(compositor, this);
+		InitializePartial();
 	}
+
+	partial void InitializePartial();
+
+	public VisualCollection Children { get; }
 }

--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -12,6 +12,11 @@ public partial class ContainerVisual : Visual
 
 	internal bool IsChildrenRenderOrderDirty { get; set; }
 
+	partial void InitializePartial()
+	{
+		Children.CollectionChanged += (s, e) => IsChildrenRenderOrderDirty = true;
+	}
+
 	internal IList<Visual> GetChildrenInRenderOrder()
 	{
 		if (IsChildrenRenderOrderDirty)

--- a/src/Uno.UI.Composition/Composition/VisualCollection.cs
+++ b/src/Uno.UI.Composition/Composition/VisualCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -19,6 +20,8 @@ namespace Windows.UI.Composition
 			_owner = owner;
 		}
 
+		internal event EventHandler CollectionChanged;
+
 		public int Count => _visuals.Count;
 
 		internal IList<Visual> InnerList => _visuals;
@@ -29,13 +32,18 @@ namespace Windows.UI.Composition
 			_visuals.Insert(index, newChild);
 
 			InsertAbovePartial(newChild, sibling);
+
+			CollectionChanged?.Invoke(this, EventArgs.Empty);
 		}
+
 		partial void InsertAbovePartial(Visual newChild, Visual sibling);
 
 		public void InsertAtBottom(Visual newChild)
 		{
 			_visuals.Insert(0, newChild);
 			InsertAtBottomPartial(newChild);
+
+			CollectionChanged?.Invoke(this, EventArgs.Empty);
 		}
 		partial void InsertAtBottomPartial(Visual newChild);
 
@@ -43,6 +51,8 @@ namespace Windows.UI.Composition
 		{
 			_visuals.Insert(_visuals.Count, newChild);
 			InsertAtTopPartial(newChild);
+
+			CollectionChanged?.Invoke(this, EventArgs.Empty);
 		}
 		partial void InsertAtTopPartial(Visual newChild);
 
@@ -51,6 +61,8 @@ namespace Windows.UI.Composition
 			var index = _visuals.IndexOf(sibling);
 			_visuals.Insert(index - 1, newChild);
 			InsertBelowPartial(newChild, sibling);
+
+			CollectionChanged?.Invoke(this, EventArgs.Empty);
 		}
 		partial void InsertBelowPartial(Visual newChild, Visual sibling);
 
@@ -58,6 +70,8 @@ namespace Windows.UI.Composition
 		{
 			_visuals.Remove(child);
 			RemovePartial(child);
+
+			CollectionChanged?.Invoke(this, EventArgs.Empty);
 		}
 		partial void RemovePartial(Visual child);
 
@@ -65,6 +79,8 @@ namespace Windows.UI.Composition
 		{
 			_visuals.Clear();
 			RemoveAllPartial();
+
+			CollectionChanged?.Invoke(this, EventArgs.Empty);
 		}
 		partial void RemoveAllPartial();
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ContainerVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ContainerVisual.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Private.Infrastructure;
+using Windows.UI.Composition;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
+
+[TestClass]
+public class Given_ContainerVisual
+{
+#if __SKIA__
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_Children_Change()
+	{
+		var compositor = Windows.UI.Xaml.Window.Current.Compositor;
+		var containerVisual = compositor.CreateContainerVisual();
+		Assert.IsFalse(containerVisual.IsChildrenRenderOrderDirty);
+
+		var shape = compositor.CreateShapeVisual();
+		containerVisual.Children.InsertAtTop(shape);
+		Assert.IsTrue(containerVisual.IsChildrenRenderOrderDirty);
+		var children = containerVisual.GetChildrenInRenderOrder();
+		Assert.IsFalse(containerVisual.IsChildrenRenderOrderDirty);
+		Assert.AreEqual(1, children.Count);
+
+		containerVisual.Children.InsertAtTop(compositor.CreateShapeVisual());
+		Assert.IsTrue(containerVisual.IsChildrenRenderOrderDirty);
+		children = containerVisual.GetChildrenInRenderOrder();
+		Assert.IsFalse(containerVisual.IsChildrenRenderOrderDirty);
+		Assert.AreEqual(2, children.Count);
+
+		containerVisual.Children.Remove(shape);
+		Assert.IsTrue(containerVisual.IsChildrenRenderOrderDirty);
+		children = containerVisual.GetChildrenInRenderOrder();
+		Assert.IsFalse(containerVisual.IsChildrenRenderOrderDirty);
+		Assert.AreEqual(1, children.Count);
+	}
+#endif
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -130,7 +130,6 @@ namespace Windows.UI.Xaml
 			}
 
 			OnChildAdded(child);
-			Visual.IsChildrenRenderOrderDirty = true;
 
 			// Reset to original (invalidated) state
 			child.ResetLayoutFlags();
@@ -209,7 +208,6 @@ namespace Windows.UI.Xaml
 			if (Visual != null)
 			{
 				Visual.Children.Remove(child.Visual);
-				Visual.IsChildrenRenderOrderDirty = true;
 			}
 			OnChildRemoved(child);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11851

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
