### PR TITLE
fix(animation): not defaulting starting value from animated value

### DIFF
--- a/src/Uno.UI.RuntimeTests/Extensions/StoryboardExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Extensions/StoryboardExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media.Animation;
+
+namespace Uno.UI.RuntimeTests.Extensions;
+
+internal static class StoryboardExtensions
+{
+	public static void Begin(this Timeline timeline)
+	{
+		var storyboard = new Storyboard { Children = { timeline } };
+
+		storyboard.Begin();
+	}
+
+	public static async Task RunAsync(this Timeline timeline, TimeSpan? timeout, bool throwsException = false)
+	{
+		var storyboard = new Storyboard { Children = { timeline } };
+
+		await storyboard.RunAsync(timeout, throwsException);
+	}
+
+	public static async Task RunAsync(this Storyboard storyboard, TimeSpan? timeout = null, bool throwsException = false)
+	{
+		var tcs = new TaskCompletionSource<bool>();
+		void OnCompleted(object sender, object e)
+		{
+			tcs.SetResult(true);
+			storyboard.Completed -= OnCompleted;
+		}
+
+		storyboard.Completed += OnCompleted;
+		storyboard.Begin();
+
+		if (timeout is { })
+		{
+			if (await Task.WhenAny(tcs.Task, Task.Delay(timeout.Value)) != tcs.Task)
+			{
+				if (throwsException)
+				{
+					throw new TimeoutException($"Timeout waiting for the storyboard to complete: {timeout}ms");
+				}
+			}
+		}
+		else
+		{
+			await tcs.Task;
+		}
+	}
+
+	public static TTimeline BindTo<TTimeline>(this TTimeline timeline, DependencyObject target, string property)
+		where TTimeline : Timeline
+	{
+		Storyboard.SetTarget(timeline, target);
+		Storyboard.SetTargetProperty(timeline, property);
+
+		return timeline;
+	}
+}

--- a/src/Uno.UI/DataBinding/BindingPath.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.cs
@@ -121,6 +121,16 @@ namespace Uno.UI.DataBinding
 			return _chain?.Flatten(i => i.Next!) ?? Array.Empty<BindingItem>();
 		}
 
+		public (object DataContext, string PropertyName) GetTargetContextAndPropertyName()
+		{
+			var info = GetPathItems().Last();
+			var propertyName = info.PropertyName
+				.Split(new[] { '.' }).Last()
+				.Replace("(", "").Replace(")", "");
+
+			return (info.DataContext, propertyName);
+		}
+
 		/// <summary>
 		/// Checks the property path for members which may be shared resources (<see cref="Brush"/>es and <see cref="Transform"/>s) and creates a
 		/// copy of them if need be (ie if not already copied). Intended to be used prior to animating the targeted property.

--- a/src/Uno.UI/Extensions/TimelineExtensions.iOSmacOS.cs
+++ b/src/Uno.UI/Extensions/TimelineExtensions.iOSmacOS.cs
@@ -16,20 +16,12 @@ namespace Windows.UI.Xaml.Media.Animation
 				timeline.Log().DebugFormat("Setting [{0}] to [{1} / {2}] and bypassing native propagation", value, Storyboard.GetTargetName(timeline), Storyboard.GetTargetProperty(timeline));
 			}
 
-			var animatedItem = timeline.PropertyInfo.GetPathItems().Last();
-
-			// Get the property name from the last part of the
-			// specified name (for dotted paths, if they exist)
-			var propertyName = animatedItem.PropertyName.Split(new[] { '.' }).Last().Replace("(", "").Replace(")", "");
-
-			var dc = animatedItem.DataContext;
-			using (dc != null ?
-				DependencyObjectStore.BypassPropagation(
+			var (dc, propertyName) = timeline.PropertyInfo.GetTargetContextAndPropertyName();
+			using (dc != null
+				? DependencyObjectStore.BypassPropagation(
 					(DependencyObject)dc,
-					DependencyProperty.GetProperty(dc.GetType(), propertyName)
-				) :
-				// DC may have been collected since it's weakly held
-				null
+					DependencyProperty.GetProperty(dc.GetType(), propertyName))
+				: null // DC may have been collected since it's weakly held
 			)
 			{
 				timeline.PropertyInfo.Value = value;

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -771,5 +771,14 @@ namespace Uno.UI
 			public static bool UseHandForInteraction { get; set; } = true;
 #endif
 		}
+
+		public static class Timeline
+		{
+			/// <summary>
+			/// Determines if the default animation starting value
+			/// will be from the animated value or local value, when the From property is omitted.
+			/// </summary>
+			public static bool DefaultsStartingValueFromAnimatedValue { get; } = true;
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
@@ -47,10 +47,9 @@ namespace Windows.UI.Xaml.Media.Animation
 			// Performance : http://developer.android.com/guide/topics/graphics/hardware-accel.html#layers-anims
 			// Properties  : http://developer.android.com/guide/topics/graphics/prop-animation.html#views
 
-			var info = timeline.PropertyInfo.GetPathItems().Last();
-			var target = info.DataContext;
-			var property = info.PropertyName.Split(new[] { '.' }).Last().Replace("(", "").Replace(")", "");
+			var (target, property) = timeline.PropertyInfo.GetTargetContextAndPropertyName();
 
+			// note: implementation below should be mirrored in TryGetNativeAnimatedValue
 			if (target is View view)
 			{
 				switch (property)
@@ -332,10 +331,60 @@ namespace Windows.UI.Xaml.Media.Animation
 		}
 
 		/// <summary>
-		/// Ensures that scale value is without the android accepted values
+		/// Ensures that scale value is within the android accepted values
 		/// </summary>
 		private static double ToNativeScale(double value)
 			=> double.IsNaN(value) ? 1 : value;
 
+		/// <summary>
+		/// Get the underlying native property value which the target dependency property is associated with when animating.
+		/// </summary>
+		/// <param name="timeline"></param>
+		/// <param name="value">The associated native animated value <b>in logical unit</b>.</param>
+		/// <returns>Whether a native animation value is present and active.</returns>
+		/// <remarks>The <paramref name="value"/> will be <b>in logical unit</b>, as the consumer of this method will have no idea which property are scaled or not.</remarks>
+		internal static bool TryGetNativeAnimatedValue(Timeline timeline, out object value)
+		{
+			value = null;
+
+			if (timeline.GetIsDependantAnimation() || timeline.GetIsDurationZero())
+			{
+				return false;
+			}
+
+			var (target, property) = timeline.PropertyInfo.GetTargetContextAndPropertyName();
+			if (target is Transform { IsAnimating: false })
+			{
+				// While not animating, these native properties will be reset.
+				// In that case, the dp actual value should be read instead (by returning false here).
+				return false;
+			}
+
+			value = property switch
+			{
+				// note: Implementation here should be mirrored in GetGPUAnimator
+				nameof(FrameworkElement.Opacity) when target is View view => (double)view.Alpha,
+
+				nameof(TranslateTransform.X) when target is TranslateTransform translate => ViewHelper.PhysicalToLogicalPixels(translate.View.TranslationX),
+				nameof(TranslateTransform.Y) when target is TranslateTransform translate => ViewHelper.PhysicalToLogicalPixels(translate.View.TranslationY),
+				nameof(RotateTransform.Angle) when target is RotateTransform rotate => (double)rotate.View.Rotation,
+				nameof(ScaleTransform.ScaleX) when target is ScaleTransform scale => (double)scale.View.ScaleX,
+				nameof(ScaleTransform.ScaleY) when target is ScaleTransform scale => (double)scale.View.ScaleY,
+				//nameof(SkewTransform.AngleX) when target is SkewTransform skew => ViewHelper.PhysicalToLogicalPixels(skew.View.ScaleX), // copied as is from GetGPUAnimator
+				//nameof(SkewTransform.AngleY) when target is SkewTransform skew => ViewHelper.PhysicalToLogicalPixels(skew.View.ScaleY),
+
+				nameof(CompositeTransform.TranslateX) when target is CompositeTransform composite => ViewHelper.PhysicalToLogicalPixels(composite.View.TranslationX),
+				nameof(CompositeTransform.TranslateY) when target is CompositeTransform composite => ViewHelper.PhysicalToLogicalPixels(composite.View.TranslationY),
+				nameof(CompositeTransform.Rotation) when target is CompositeTransform composite => (double)composite.View.Rotation,
+				nameof(CompositeTransform.ScaleX) when target is CompositeTransform composite => (double)composite.View.ScaleX,
+				nameof(CompositeTransform.ScaleY) when target is CompositeTransform composite => (double)composite.View.ScaleY,
+				//nameof(CompositeTransform.SkewX) when target is CompositeTransform composite => ViewHelper.PhysicalToLogicalPixels(composite.View.ScaleX), // copied as is from GetGPUAnimator
+				//nameof(CompositeTransform.SkewY) when target is CompositeTransform composite => ViewHelper.PhysicalToLogicalPixels(composite.View.ScaleY),
+
+				_ => null,
+			};
+
+			return value != null;
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): 
- closes unoplatform/nventive-private#464, 
- closes unoplatform/nventive-private#452
- closes #11896

## PR Type
- Bugfix

## What is the current behavior?
Currently animations with omitted `From` infers their starting value from the non-animated value.
On windows, you are allow to starting a new animation from the animated value, be mid animation or the `HoldEnd` value of a completed animation.

## What is the new behavior?
Aligned behavior with windows:
![animation start from animated value](https://user-images.githubusercontent.com/2359550/228901442-a115e7e7-c324-4bd6-8670-4f258d79def8.gif)

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.