### PR TITLE
Dismiss splash screen after initial `Window.Activate`, themed `RootVisual` background

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_RootVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_RootVisual.cs
@@ -16,6 +16,7 @@ public class Given_RootVisual
 {
 #if HAS_UNO
 	[TestMethod]
+	[RunsOnUIThread]
 	public async Task When_Theme_Changes()
 	{
 		var rootVisual = Uno.UI.Xaml.Core.CoreServices.Instance.MainRootVisual;

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_RootVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_RootVisual.cs
@@ -7,7 +7,6 @@ using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI;
 using Windows.UI.Xaml.Media;
-using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 
@@ -19,7 +18,7 @@ public class Given_RootVisual
 	[TestMethod]
 	public async Task When_Theme_Changes()
 	{
-		var rootVisual = WinUICoreServices.Instance.MainRootVisual;
+		var rootVisual = Uno.UI.Xaml.Core.CoreServices.Instance.MainRootVisual;
 		if (rootVisual is null)
 		{
 			// Ignore on Uno Islands

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_RootVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_RootVisual.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI;
+using Windows.UI.Xaml.Media;
+using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
+
+[TestClass]
+[RequiresFullWindow]
+public class Given_RootVisual
+{
+#if HAS_UNO
+	[TestMethod]
+	public async Task When_Theme_Changes()
+	{
+		var rootVisual = WinUICoreServices.Instance.MainRootVisual;
+		if (rootVisual is null)
+		{
+			// Ignore on Uno Islands
+			return;
+		}
+
+		Assert.AreEqual(Colors.White, (rootVisual.Background as SolidColorBrush).Color);
+
+		using (ThemeHelper.UseDarkTheme())
+		{
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.AreEqual(Colors.Black, (rootVisual.Background as SolidColorBrush).Color);
+		}
+
+		await TestServices.WindowHelper.WaitForIdle();
+		Assert.AreEqual(Colors.White, (rootVisual.Background as SolidColorBrush).Color);
+	}
+#endif
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_RootVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_RootVisual.cs
@@ -26,16 +26,16 @@ public class Given_RootVisual
 			return;
 		}
 
-		Assert.AreEqual(Colors.White, (rootVisual.Background as SolidColorBrush).Color);
+		Assert.AreEqual(Colors.White, ((SolidColorBrush)rootVisual.Background).Color);
 
 		using (ThemeHelper.UseDarkTheme())
 		{
 			await TestServices.WindowHelper.WaitForIdle();
-			Assert.AreEqual(Colors.Black, (rootVisual.Background as SolidColorBrush).Color);
+			Assert.AreEqual(Colors.Black, ((SolidColorBrush)rootVisual.Background).Color);
 		}
 
 		await TestServices.WindowHelper.WaitForIdle();
-		Assert.AreEqual(Colors.White, (rootVisual.Background as SolidColorBrush).Color);
+		Assert.AreEqual(Colors.White, ((SolidColorBrush)rootVisual.Background).Color);
 	}
 #endif
 }

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -148,6 +148,8 @@ namespace Windows.UI.Xaml
 				_requestedTheme = value;
 				// Sync with core application's theme
 				CoreApplication.RequestedTheme = value == ApplicationTheme.Dark ? SystemTheme.Dark : SystemTheme.Light;
+
+				UpdateRootVisualBackground();
 				UpdateRequestedThemesForResources();
 			}
 		}
@@ -412,6 +414,12 @@ namespace Windows.UI.Xaml
 		internal void UpdateResourceBindingsForHotReload() => OnResourcesChanged(ResourceUpdateReason.HotReload);
 
 		internal void OnRequestedThemeChanged() => OnResourcesChanged(ResourceUpdateReason.ThemeResource);
+
+		private void UpdateRootVisualBackground()
+		{
+			var rootVisual = WinUICoreServices.Instance.MainRootVisual;
+			rootVisual?.SetBackgroundColor(ThemingHelper.GetRootVisualBackground());
+		}
 
 		private void OnResourcesChanged(ResourceUpdateReason updateReason)
 		{

--- a/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
@@ -65,6 +65,7 @@ namespace Windows.UI.Xaml
 		public override void OnAttachedToWindow()
 		{
 			base.OnAttachedToWindow();
+
 			// Cannot call this in ctor: see
 			// https://stackoverflow.com/questions/10593022/monodroid-error-when-calling-constructor-of-custom-view-twodscrollview#10603714
 			RaiseConfigurationChanges();
@@ -202,6 +203,7 @@ namespace Windows.UI.Xaml
 			}
 
 			base.OnCreate(bundle);
+			Windows.UI.Xaml.Window.Current.OnActivityCreated();
 
 			LayoutProvider = new LayoutProvider(this);
 			LayoutProvider.KeyboardChanged += OnKeyboardChanged;

--- a/src/Uno.UI/UI/Xaml/ApplicationTheme.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationTheme.cs
@@ -1,18 +1,17 @@
-namespace Windows.UI.Xaml
+namespace Windows.UI.Xaml;
+
+/// <summary>
+/// Declares the theme preference for an app.
+/// </summary>
+public enum ApplicationTheme
 {
 	/// <summary>
-	/// Declares the theme preference for an app.
+	/// Use the Light default theme.
 	/// </summary>
-	public enum ApplicationTheme
-	{
-		/// <summary>
-		/// Use the Light default theme.
-		/// </summary>
-		Light,
+	Light,
 
-		/// <summary>
-		/// Use the Dark default theme.
-		/// </summary>
-		Dark
-	}
+	/// <summary>
+	/// Use the Dark default theme.
+	/// </summary>
+	Dark
 }

--- a/src/Uno.UI/UI/Xaml/Internal/CoreServices.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/CoreServices.cs
@@ -72,7 +72,7 @@ namespace Uno.UI.Xaml.Core
 
 		private void InitCoreWindowContentRoot()
 		{
-			var contentRoot = ContentRootCoordinator.CreateContentRoot(ContentRootType.CoreWindow, Colors.Transparent, null);
+			var contentRoot = ContentRootCoordinator.CreateContentRoot(ContentRootType.CoreWindow, ThemingHelper.GetRootVisualBackground(), null);
 			_mainVisualTree = contentRoot.VisualTree;
 
 			//TODO Uno: Add input services

--- a/src/Uno.UI/UI/Xaml/NativeApplication.cs
+++ b/src/Uno.UI/UI/Xaml/NativeApplication.cs
@@ -22,7 +22,6 @@ namespace Windows.UI.Xaml
 	{
 		private readonly Application _app;
 		private Intent _lastHandledIntent;
-		private IOnPreDrawListener _activePreDrawListener;
 
 		private bool _isRunning;
 
@@ -71,13 +70,6 @@ namespace Windows.UI.Xaml
 				if (!handled && !_isRunning)
 				{
 					_app.OnLaunched(new LaunchActivatedEventArgs());
-				}
-
-				if (!Window.Current.Visible)
-				{
-					// User did not yet activate the app's window.
-					// Delay the splash screen dismissal.
-					DelayDrawUntilWindowVisible();
 				}
 
 				_isRunning = true;
@@ -129,54 +121,6 @@ namespace Windows.UI.Xaml
 			}
 
 			return handled;
-		}
-
-		private void DelayDrawUntilWindowVisible()
-		{
-			Window.Current.VisibilityChanged += Window_VisibilityChanged;
-			Android.Views.ViewGroup rootVisual = WinUICoreServices.Instance.MainRootVisual;
-			if (_activePreDrawListener != null)
-			{
-				rootVisual.ViewTreeObserver.RemoveOnPreDrawListener(_activePreDrawListener);
-			}
-
-			_activePreDrawListener = new ApplicationPreDrawListener(this);
-			rootVisual.ViewTreeObserver.AddOnPreDrawListener(_activePreDrawListener);
-		}
-
-		private void Window_VisibilityChanged(object sender, VisibilityChangedEventArgs e)
-		{
-			if (e.Visible)
-			{
-				// In case the view render was delayed until Window.Activate(),
-				// we need to invalidate the root visual so PreDraw is called again.
-				Android.Views.ViewGroup rootVisual = WinUICoreServices.Instance.MainRootVisual;
-				rootVisual?.Invalidate();
-
-				Window.Current.VisibilityChanged -= Window_VisibilityChanged;
-			}
-		}
-
-		private class ApplicationPreDrawListener : Java.Lang.Object, IOnPreDrawListener
-		{
-			private readonly NativeApplication _application;
-
-			public ApplicationPreDrawListener(NativeApplication application)
-			{
-				_application = application;
-			}
-
-			public bool OnPreDraw()
-			{
-				if (Window.Current.Visible)
-				{
-					Android.Views.ViewGroup rootVisual = WinUICoreServices.Instance.MainRootVisual;
-					rootVisual.ViewTreeObserver.RemoveOnPreDrawListener(this);
-					_application._activePreDrawListener = null;
-				}
-
-				return Window.Current.Visible;
-			}
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/NativeApplication.cs
+++ b/src/Uno.UI/UI/Xaml/NativeApplication.cs
@@ -12,6 +12,7 @@ using Uno.Extensions;
 using Windows.Foundation.Metadata;
 using System.ComponentModel;
 using Uno.Foundation.Logging;
+using Windows.UI.Core;
 using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
 using IOnPreDrawListener = Android.Views.ViewTreeObserver.IOnPreDrawListener;
 
@@ -143,7 +144,7 @@ namespace Windows.UI.Xaml
 			rootVisual.ViewTreeObserver.AddOnPreDrawListener(_activePreDrawListener);
 		}
 
-		private void Window_VisibilityChanged(object sender, Core.VisibilityChangedEventArgs e)
+		private void Window_VisibilityChanged(object sender, VisibilityChangedEventArgs e)
 		{
 			if (e.Visible)
 			{

--- a/src/Uno.UI/UI/Xaml/ThemingHelper.cs
+++ b/src/Uno.UI/UI/Xaml/ThemingHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace Windows.UI.Xaml;
+﻿using Color = Windows.UI.Color;
+
+namespace Windows.UI.Xaml;
 
 internal static class ThemingHelper
 {

--- a/src/Uno.UI/UI/Xaml/ThemingHelper.cs
+++ b/src/Uno.UI/UI/Xaml/ThemingHelper.cs
@@ -1,0 +1,8 @@
+﻿namespace Windows.UI.Xaml;
+
+internal static class ThemingHelper
+{
+	internal static Color GetRootVisualBackground() =>
+		Application.Current.RequestedTheme == ApplicationTheme.Light ?
+			Colors.White : Colors.Black;
+}

--- a/src/Uno.UI/UI/Xaml/Window.Desktop.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Desktop.cs
@@ -23,7 +23,7 @@ namespace Windows.UI.Xaml
 			CoreWindow = CoreWindow.GetOrCreateForCurrentThread();
 		}
 
-		partial void InternalActivate()
+		partial void ActivatePartial()
 		{
 			_isActive = true;
 			TryLoadRootVisual();

--- a/src/Uno.UI/UI/Xaml/Window.Desktop.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Desktop.cs
@@ -23,7 +23,7 @@ namespace Windows.UI.Xaml
 			CoreWindow = CoreWindow.GetOrCreateForCurrentThread();
 		}
 
-		partial void ActivatePartial()
+		partial void ActivatingPartial()
 		{
 			_isActive = true;
 			TryLoadRootVisual();

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -282,6 +282,11 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
+			if (this.Log().IsEnabled(LogLevel.Trace))
+			{
+				this.Log().LogTrace($"Window visibility changing to {value}");
+			}
+
 			Visible = newVisibility;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -1,17 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Uno.Disposables;
 using System.Runtime.InteropServices;
-using Windows.ApplicationModel.DataTransfer.DragDrop.Core;
+using Uno.Disposables;
 using Uno.Extensions;
+using Uno.Foundation.Logging;
+using Uno.UI.Xaml.Core;
+using Windows.ApplicationModel.DataTransfer.DragDrop.Core;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI.Core;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
-using Uno.Foundation.Logging;
-using Uno.UI.Xaml.Core;
 using Windows.UI.Xaml.Media;
 using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
 

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -218,15 +218,14 @@ namespace Windows.UI.Xaml
 			_current ??= this;
 			_wasEverActivated = true;
 
-			InternalActivate();
-
 			// Initialize visibility on first activation.
 			Visible = true;
-
 			OnActivated(CoreWindowActivationState.CodeActivated);
+
+			ActivatePartial();
 		}
 
-		partial void InternalActivate();
+		partial void ActivatePartial();
 
 		public void Close() { }
 

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -282,11 +282,6 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
-			if (this.Log().IsEnabled(LogLevel.Trace))
-			{
-				this.Log().LogTrace($"Window visibility changing to {value}");
-			}
-
 			Visible = newVisibility;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -29,7 +29,7 @@ namespace Windows.UI.Xaml
 
 		private CoreWindowActivationState? _lastActivationState;
 		private Brush _background;
-		private bool _wasEverActivated;
+		private bool _wasEverCodeActivated;
 
 		private List<WeakEventHelper.GenericEventHandler> _sizeChangedHandlers = new List<WeakEventHelper.GenericEventHandler>();
 		private List<WeakEventHelper.GenericEventHandler> _backgroundChangedHandlers;
@@ -216,16 +216,17 @@ namespace Windows.UI.Xaml
 			// for compatibility with WinUI we set the first activated
 			// as Current #8341
 			_current ??= this;
-			_wasEverActivated = true;
+			_wasEverCodeActivated = true;
 
 			// Initialize visibility on first activation.
 			Visible = true;
-			OnActivated(CoreWindowActivationState.CodeActivated);
 
-			ActivatePartial();
+			ActivatingPartial();
+
+			OnActivated(CoreWindowActivationState.CodeActivated);
 		}
 
-		partial void ActivatePartial();
+		partial void ActivatingPartial();
 
 		public void Close() { }
 
@@ -247,7 +248,7 @@ namespace Windows.UI.Xaml
 
 		internal void OnActivated(CoreWindowActivationState state)
 		{
-			if (!_wasEverActivated)
+			if (!_wasEverCodeActivated)
 			{
 				return;
 			}
@@ -276,7 +277,7 @@ namespace Windows.UI.Xaml
 
 		internal void OnVisibilityChanged(bool newVisibility)
 		{
-			if (!_wasEverActivated)
+			if (!_wasEverCodeActivated)
 			{
 				return;
 			}

--- a/src/Uno.UI/UI/Xaml/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.iOS.cs
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml
 			RaiseNativeSizeChanged(ViewHelper.GetScreenSizeInternal(this));
 		}
 
-		partial void ActivatePartial()
+		partial void ActivatingPartial()
 		{
 			_nativeWindow.RootViewController = _mainController;
 			_nativeWindow.MakeKeyAndVisible();

--- a/src/Uno.UI/UI/Xaml/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.iOS.cs
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml
 			RaiseNativeSizeChanged(ViewHelper.GetScreenSizeInternal(this));
 		}
 
-		partial void InternalActivate()
+		partial void ActivatePartial()
 		{
 			_nativeWindow.RootViewController = _mainController;
 			_nativeWindow.MakeKeyAndVisible();

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -73,7 +73,7 @@ namespace Windows.UI.Xaml
 			RaiseNativeSizeChanged(new CGSize(_window.Frame.Width, _window.Frame.Height));
 		}
 
-		partial void ActivatePartial()
+		partial void ActivatingPartial()
 		{
 			_window.ContentViewController = _mainController;
 			_window.Display();

--- a/src/Uno.UI/UI/Xaml/Window.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.macOS.cs
@@ -73,7 +73,7 @@ namespace Windows.UI.Xaml
 			RaiseNativeSizeChanged(new CGSize(_window.Frame.Width, _window.Frame.Height));
 		}
 
-		partial void InternalActivate()
+		partial void ActivatePartial()
 		{
 			_window.ContentViewController = _mainController;
 			_window.Display();

--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -131,7 +131,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		partial void ActivatePartial()
+		partial void ActivatingPartial()
 		{
 			WindowManagerInterop.WindowActivate();
 		}

--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -131,7 +131,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		partial void InternalActivate()
+		partial void ActivatePartial()
 		{
 			WindowManagerInterop.WindowActivate();
 		}

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -222,6 +222,20 @@ embed.uno-frameworkelement.uno-unarranged {
     overflow-y: scroll;
   }
 
+#uno-loading {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  z-index: 1000;
+  background-color: var(--light-theme-bg-color, #F3F3F3);
+}
+
+@media (prefers-color-scheme: dark) {
+  #uno-loading {
+    background-color: var(--dark-theme-bg-color, #202020);
+  }
+}
+
 /* Splash image styling */
 .uno-splash {
   position: fixed;

--- a/src/Uno.UI/ts/Interop/IAppManifest.ts
+++ b/src/Uno.UI/ts/Interop/IAppManifest.ts
@@ -2,6 +2,8 @@
 	export interface IAppManifest {
 		splashScreenImage: URL;
 		splashScreenColor: string;
+		lightThemeBackgroundColor: string;
+		darkThemeBackgroundColor: string;
 		displayName: string;
 	}
 }

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -144,21 +144,21 @@ namespace Uno.UI {
 
 			if (UnoAppManifest && UnoAppManifest.splashScreenImage) {
 
-				const loading = document.getElementById("loading");
-
-				if (loading) {
-					loading.remove();
-				}
-
 				const unoBody = document.getElementById("uno-body");
 
 				if (unoBody) {
 					const unoLoading = document.createElement("div");
 					unoLoading.id = "uno-loading";
 
-					if (UnoAppManifest.splashScreenColor) {
-						const body = document.getElementsByTagName("body")[0];
-						body.style.backgroundColor = UnoAppManifest.splashScreenColor;
+					if (UnoAppManifest.lightThemeBackgroundColor) {
+						unoLoading.style.setProperty("--light-theme-bg-color", UnoAppManifest.lightThemeBackgroundColor);
+					}
+					if (UnoAppManifest.darkThemeBackgroundColor) {
+						unoLoading.style.setProperty("--dark-theme-bg-color", UnoAppManifest.darkThemeBackgroundColor);
+					}
+
+					if (UnoAppManifest.splashScreenColor && UnoAppManifest.splashScreenColor != 'transparent') {
+						unoLoading.style.backgroundColor = UnoAppManifest.splashScreenColor;
 					}
 
 					splashImage.id = "uno-loading-splash";
@@ -167,6 +167,12 @@ namespace Uno.UI {
 					unoLoading.appendChild(splashImage);
 
 					unoBody.appendChild(unoLoading);
+				}
+
+				const loading = document.getElementById("loading");
+
+				if (loading) {
+					loading.remove();
 				}
 			}
 		}
@@ -1617,10 +1623,6 @@ namespace Uno.UI {
 			if (element) {
 				element.parentElement.removeChild(element);
 			}
-
-			// UWP Window's default background is white.
-			const body = document.getElementsByTagName("body")[0];
-			body.style.backgroundColor = "#fff";
 		}
 
 		private resize() {

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -19,6 +19,8 @@ namespace Uno.UI {
 		private static readonly unoRootClassName = "uno-root-element";
 		private static readonly unoUnarrangedClassName = "uno-unarranged";
 		private static readonly unoCollapsedClassName = "uno-visibility-collapsed";
+		private static readonly unoPersistentLoaderClassName = "uno-persistent-loader";
+		private static readonly unoKeepLoaderClassName = "uno-keep-loader";
 
 		/**
 			* Initialize the WindowManager
@@ -58,10 +60,10 @@ namespace Uno.UI {
 		private static buildSplashScreen(): Promise<boolean> {
 			return new Promise<boolean>(resolve => {
 
-				let bootstrapperLoaders = document.getElementsByClassName("persistent-loader");
+				let bootstrapperLoaders = document.getElementsByClassName(WindowManager.unoPersistentLoaderClassName);
 				if (bootstrapperLoaders.length > 0) {
 					let bootstrapperLoader = bootstrapperLoaders[0] as HTMLElement;
-					bootstrapperLoader.classList.add("keep-loader");
+					bootstrapperLoader.classList.add(WindowManager.unoKeepLoaderClassName);
 
 					// Skip creating local splash screen.
 					return true;
@@ -1626,7 +1628,7 @@ namespace Uno.UI {
 		private removeLoading() {
 			if (!this.loadingElementId) {
 				// No custom loading element, remove the bootstrapper's loader.
-				let bootstrapperLoaders = document.getElementsByClassName("persistent-loader");
+				let bootstrapperLoaders = document.getElementsByClassName(WindowManager.unoPersistentLoaderClassName);
 				if (bootstrapperLoaders.length > 0) {
 					let bootstrapperLoader = bootstrapperLoaders[0] as HTMLElement;
 					bootstrapperLoader.parentElement.removeChild(bootstrapperLoader);

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -57,6 +57,16 @@ namespace Uno.UI {
 		 * */
 		private static buildSplashScreen(): Promise<boolean> {
 			return new Promise<boolean>(resolve => {
+
+				let bootstrapperLoaders = document.getElementsByClassName("persistent-loader");
+				if (bootstrapperLoaders.length > 0) {
+					let bootstrapperLoader = bootstrapperLoaders[0] as HTMLElement;
+					bootstrapperLoader.classList.add("keep-loader");
+
+					// Skip creating local splash screen.
+					return true;
+				}
+
 				const img = new Image();
 				let loaded = false;
 
@@ -1614,14 +1624,18 @@ namespace Uno.UI {
 		}
 
 		private removeLoading() {
-
 			if (!this.loadingElementId) {
-				return;
-			}
-
-			const element = document.getElementById(this.loadingElementId);
-			if (element) {
-				element.parentElement.removeChild(element);
+				// No custom loading element, remove the bootstrapper's loader.
+				let bootstrapperLoaders = document.getElementsByClassName("persistent-loader");
+				if (bootstrapperLoaders.length > 0) {
+					let bootstrapperLoader = bootstrapperLoaders[0] as HTMLElement;
+					bootstrapperLoader.parentElement.removeChild(bootstrapperLoader);
+				}
+			} else {
+				const element = document.getElementById(this.loadingElementId);
+				if (element) {
+					element.parentElement.removeChild(element);
+				}
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): part of #10178, closes #10820, closes #6393


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

White background flickers if Window is activated with a delay.

## What is the new behavior?

In tandem with https://github.com/unoplatform/Uno.Wasm.Bootstrap/pull/699 this should ensure no flickering of white color will show up on Android, iOS, macOS and WASM. This does not help on Skia yet unfortunately, as there is no splash screen yet.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
