### PR TITLE
fix(animation): setting Local value should clear Animation value in filling state

### DIFF
--- a/src/Uno.UI.RuntimeTests/Extensions/TimelineExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Extensions/TimelineExtensions.cs
@@ -8,20 +8,11 @@ using Windows.UI.Xaml.Media.Animation;
 
 namespace Uno.UI.RuntimeTests.Extensions;
 
-internal static class StoryboardExtensions
+internal static class TimelineExtensions
 {
-	public static void Begin(this Timeline timeline)
+	public static Storyboard ToStoryboard(this Timeline timeline)
 	{
-		var storyboard = new Storyboard { Children = { timeline } };
-
-		storyboard.Begin();
-	}
-
-	public static async Task RunAsync(this Timeline timeline, TimeSpan? timeout, bool throwsException = false)
-	{
-		var storyboard = new Storyboard { Children = { timeline } };
-
-		await storyboard.RunAsync(timeout, throwsException);
+		return new Storyboard { Children = { timeline } };
 	}
 
 	public static async Task RunAsync(this Storyboard storyboard, TimeSpan? timeout = null, bool throwsException = false)

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -49,7 +49,7 @@ namespace Uno.UI.DataBinding
 		//          those. If this situation changes, we could remove the associated code and 
 		//          revert to memoized Funcs.
 		//
-		private static Dictionary<CachedTuple<Type, String, DependencyPropertyValuePrecedences?, bool>, ValueGetterHandler> _getValueGetter = new Dictionary<CachedTuple<Type, string, DependencyPropertyValuePrecedences?, bool>, ValueGetterHandler>(CachedTuple<Type, String, DependencyPropertyValuePrecedences?, bool>.Comparer);
+		private static Dictionary<CachedTuple<Type, string, DependencyPropertyValuePrecedences?, bool>, ValueGetterHandler> _getValueGetter = new Dictionary<CachedTuple<Type, string, DependencyPropertyValuePrecedences?, bool>, ValueGetterHandler>(CachedTuple<Type, String, DependencyPropertyValuePrecedences?, bool>.Comparer);
 		private static Dictionary<CachedTuple<Type, string, bool, DependencyPropertyValuePrecedences>, ValueSetterHandler> _getValueSetter = new Dictionary<CachedTuple<Type, string, bool, DependencyPropertyValuePrecedences>, ValueSetterHandler>(CachedTuple<Type, string, bool, DependencyPropertyValuePrecedences>.Comparer);
 		private static Dictionary<CachedTuple<Type, string, DependencyPropertyValuePrecedences>, ValueGetterHandler> _getPrecedenceSpecificValueGetter = new Dictionary<CachedTuple<Type, string, DependencyPropertyValuePrecedences>, ValueGetterHandler>(CachedTuple<Type, string, DependencyPropertyValuePrecedences>.Comparer);
 		private static Dictionary<CachedTuple<Type, string, DependencyPropertyValuePrecedences>, ValueGetterHandler> _getSubstituteValueGetter = new Dictionary<CachedTuple<Type, string, DependencyPropertyValuePrecedences>, ValueGetterHandler>(CachedTuple<Type, string, DependencyPropertyValuePrecedences>.Comparer);
@@ -1132,7 +1132,7 @@ namespace Uno.UI.DataBinding
 		{
 			if (type == typeof(UnsetValue))
 			{
-				return _ => { };
+				return UnsetValueUnsetter;
 			}
 
 			property = SanitizePropertyName(type, property);
@@ -1249,6 +1249,8 @@ namespace Uno.UI.DataBinding
 			=> DependencyProperty.UnsetValue;
 
 		private static void UnsetValueSetter(object unused, object? unused2) { }
+
+		private static void UnsetValueUnsetter(object unused) { }
 
 		/// <summary>
 		/// Determines if the type can be provided by the MetadataProvider

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -130,8 +130,33 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
-			// If we were unsetting the current highest precedence value, we need to find the next highest
-			if (valueIsUnsetValue && precedence == _highestPrecedence)
+			// On Windows, explicitly calling SetValue(dp, DP.UnsetValue) or ClearValue(dp) doesnt clear the animation value.
+			// (note: Both the methods target local value)
+			// This means that we should not be handling those special case in here. Instead,
+			// when Timeline clears the animation value, it should also clears the filling animation value at the same time.
+			// ---
+			// Clear the animated value, when we are setting a local value to a property
+			// with an animated value from the filling part of an HoldEnd animation.
+			// note: There is no equivalent block in SetValueFast, as its condition would never be satisfied:
+			// _stack would've been materialized if the property had been animated.
+			bool forceUpdatePrecedence = false;
+			if (!valueIsUnsetValue &&
+				_highestPrecedence == DependencyPropertyValuePrecedences.FillingAnimations &&
+				(precedence is DependencyPropertyValuePrecedences.Local or DependencyPropertyValuePrecedences.Animations))
+			{
+				stackAlias[(int)DependencyPropertyValuePrecedences.FillingAnimations] = UnsetValue.Instance;
+				if (precedence is DependencyPropertyValuePrecedences.Local)
+				{
+					stackAlias[(int)DependencyPropertyValuePrecedences.Animations] = UnsetValue.Instance;
+				}
+
+				forceUpdatePrecedence = true;
+			}
+
+			// Update highest precedence, when the current highest value was unset or
+			// when animation value was overridden by local value.
+			if ((valueIsUnsetValue && precedence == _highestPrecedence) ||
+				forceUpdatePrecedence)
 			{
 				// Start from current precedence and find next highest
 				for (int i = (int)precedence; i < (int)DependencyPropertyValuePrecedences.DefaultValue; i++)

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyValuePrecedences.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyValuePrecedences.cs
@@ -12,6 +12,12 @@ namespace Windows.UI.Xaml
 		Coercion = 0,
 
 		/// <summary>
+		/// Defined when filling from a HoldEnd animation
+		/// </summary>
+		/// <remarks>Set the animation or local value will clear this value.</remarks>
+		FillingAnimations,
+
+		/// <summary>
 		/// Defined by animation storyboards
 		/// </summary>
 		Animations,

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -297,6 +297,11 @@ namespace Windows.UI.Xaml.Media.Animation
 			PropertyInfo.Value = value;
 		}
 
+		internal void SetAnimationFillingValue(object value)
+		{
+			PropertyInfo.SetAnimationFillingValue(value);
+		}
+
 		/// <summary>
 		/// Clears the animated value of the dependency property value precedence system
 		/// </summary>
@@ -308,6 +313,11 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 
 			PropertyInfo.ClearValue();
+		}
+
+		internal void ClearAnimationFillingValue()
+		{
+			PropertyInfo.ClearAnimationFillingValue();
 		}
 
 		void ITimeline.Begin()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #631

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->