### PR TITLE
Update UI Test project to net7

### DIFF
--- a/src/SolutionTemplate/UnoUITestTemplate/TestBase.cs
+++ b/src/SolutionTemplate/UnoUITestTemplate/TestBase.cs
@@ -60,10 +60,10 @@ namespace UnoUITestsLibrary
 			var fileInfo = _app.Screenshot(title);
 
 			var fileNameWithoutExt = Path.GetFileNameWithoutExtension(fileInfo.Name);
-			if (fileNameWithoutExt != title)
+			if (fileNameWithoutExt != title && fileInfo.DirectoryName != null)
 			{
 				var destFileName = Path
-					.Combine(Path.GetDirectoryName(fileInfo.FullName), title + Path.GetExtension(fileInfo.Name));
+					.Combine(fileInfo.DirectoryName, title + Path.GetExtension(fileInfo.Name));
 
 				if (File.Exists(destFileName))
 				{

--- a/src/SolutionTemplate/UnoUITestTemplate/UnoUITestsLibrary.csproj
+++ b/src/SolutionTemplate/UnoUITestTemplate/UnoUITestsLibrary.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="Uno.UITest.Helpers" Version="1.1.0-dev.32" />
+    <PackageReference Include="Uno.UITest.Helpers" Version="1.1.0-dev.55" />
     <PackageReference Include="Xamarin.UITest" Version="4.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- unoplatform/uno.templates#28

## PR Type

What kind of change does this PR introduce?

- Refactoring

## What is the current behavior?

UI Test project targets net48

## What is the new behavior?

UI Test project targets net7.0 as is the default for the other templates
