### PR TITLE
fix: Ensure imagebrush's source is updated when set

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/ImageAssert.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/ImageAssert.cs
@@ -65,6 +65,25 @@ public static partial class ImageAssert
 		Assert.Fail($"Expected '{ToArgbCode(expectedColor)}' in rectangle '{rect}'.");
 	}
 
+	/// <summary>
+	/// Asserts that a given screenshot does not have a specific color anywhere within a given rectangle.
+	/// </summary>
+	public static void DoesNotHaveColorInRectangle(RawBitmap screenshot, Rectangle rect, Color excludedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
+	{
+		var bitmap = screenshot;
+		for (var x = rect.Left; x < rect.Right; x++)
+		{
+			for (var y = rect.Top; y < rect.Bottom; y++)
+			{
+				var pixel = bitmap.GetPixel(x, y);
+				if (AreSameColor(excludedColor, pixel, tolerance, out _))
+				{
+					Assert.Fail($"Color '{ToArgbCode(excludedColor)}' was found at ({x}, {y}) in rectangle '{rect}'.");
+				}
+			}
+		}
+	}
+
 	private static void HasColorAtImpl(RawBitmap screenshot, int x, int y, Color expectedColor, byte tolerance, int line)
 	{
 		var bitmap = screenshot;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -19,6 +19,7 @@ using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Extensions;
 using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
+using System.Linq;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 {
@@ -165,8 +166,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			await WindowHelper.WaitForIdle();
 			await WindowHelper.WaitForLoaded(rect);
 
-			byte[] bgraPixelData = new byte[wb.PixelBuffer.Length];
-			Array.Fill<byte>(bgraPixelData, 255);
+			var bgraPixelData = Enumerable.Repeat<byte>(255, (int)wb.PixelBuffer.Length).ToArray();
 
 			using (Stream stream = wb.PixelBuffer.AsStream())
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -8,9 +8,17 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media.Imaging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Runtime.InteropServices.WindowsRuntime;
 using Private.Infrastructure;
 using Windows.Storage;
 using static Private.Infrastructure.TestServices;
+using Windows.UI.Xaml.Shapes;
+using Windows.UI.Xaml.Media;
+using Windows.UI;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Extensions;
+using Windows.Foundation.Metadata;
+using Windows.UI.Xaml;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 {
@@ -123,6 +131,65 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			Assert.IsTrue(success);
 		}
 #endif
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_WriteableBitmap_Assigned_With_Data_Present()
+		{
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+
+			var wb = new WriteableBitmap(20, 20);
+
+			var parent = new Border()
+			{
+				Width = 50,
+				Height = 50,
+				Background = new SolidColorBrush(Colors.Blue),
+			};
+
+			var rect = new Rectangle
+			{
+				Width = 20,
+				Height = 20,
+				VerticalAlignment = VerticalAlignment.Center,
+				HorizontalAlignment = HorizontalAlignment.Center,
+			};
+
+			parent.Child = rect;
+
+			WindowHelper.WindowContent = parent;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(rect);
+
+			byte[] bgraPixelData = new byte[wb.PixelBuffer.Length];
+			Array.Fill<byte>(bgraPixelData, 255);
+
+			using (Stream stream = wb.PixelBuffer.AsStream())
+			{
+				stream.Write(bgraPixelData, 0, bgraPixelData.Length);
+			}
+
+			rect.Fill = new ImageBrush
+			{
+				ImageSource = wb
+			};
+
+			await WindowHelper.WaitForIdle();
+
+			var renderer = new RenderTargetBitmap();
+			await WindowHelper.WaitForIdle();
+			await renderer.RenderAsync(parent);
+			var snapshot = await RawBitmap.From(renderer, rect);
+			var coords = parent.GetRelativeCoords(rect);
+			await WindowHelper.WaitForIdle();
+
+			ImageAssert.DoesNotHaveColorInRectangle(
+				snapshot, new System.Drawing.Rectangle((int)coords.X, (int)coords.Y, (int)coords.Width, (int)coords.Height), Colors.Blue);
+		}
 
 		private class Given_BitmapSource_Exception : Exception
 		{

--- a/src/Uno.UI/UI/Xaml/Media/Brush.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.iOSmacOS.cs
@@ -63,6 +63,8 @@ namespace Windows.UI.Xaml.Media
 			else if (b is ImageBrush imageBrush)
 			{
 				var disposables = new CompositeDisposable(5);
+				imageBrushCallback?.Invoke();
+
 				void ImageChanged(_Image _) => colorSetter(SolidColorBrushHelper.Transparent.Color);
 
 				imageBrush.ImageChanged += ImageChanged;


### PR DESCRIPTION
closes #11712

Match the Brush subscription logic from the other platforms and invoke the callback for brush changes when setting an ImageBrush on an element

There are cases, such as when using a WriteableBitmap as the ImageSource, where the image data may have already been loaded prior to the ImageBrush being set on the element (ex: setting Rectangle.Fill to an ImageBrush whose ImageSource is a WriteableBitmap that has already had its data set) 