### PR TITLE
Fixed ApplicationLanguages initialization on iOS

### DIFF
--- a/src/Uno.UWP/Globalization/ApplicationLanguages.iOS.cs
+++ b/src/Uno.UWP/Globalization/ApplicationLanguages.iOS.cs
@@ -1,11 +1,21 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Foundation;
 
 namespace Windows.Globalization
 {
 	public static partial class ApplicationLanguages
 	{
-		public static IReadOnlyList<string> ManifestLanguages { get; } = NSBundle.MainBundle.PreferredLocalizations.Concat(NSBundle.MainBundle.Localizations).Distinct().ToArray();
+		public static IReadOnlyList<string> ManifestLanguages { get; } = GetManifestLanguages();
+
+		private static string[] GetManifestLanguages()
+		{
+			var manifestLanguages = global::Foundation.NSLocale.PreferredLanguages
+				.Concat(global::Foundation.NSBundle.MainBundle.PreferredLocalizations)
+				.Concat(global::Foundation.NSBundle.MainBundle.Localizations)
+				.Distinct()
+				.ToArray();
+
+			return manifestLanguages;
+		}
 	}
 }


### PR DESCRIPTION
The Windows.Globalization.ApplicationLanguage were not properly initialized on iOS with languages from the OS.

GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11837

# Bugfix

## What is the current behavior?

The system were using NSBundle.Localizations


## What is the new behavior?

The system is now using NSLocales.PreferredLanguages

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
