### PR TITLE
fix: Remove bootstrapper splash override, apply same styling

### DIFF
--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -222,31 +222,19 @@ embed.uno-frameworkelement.uno-unarranged {
     overflow-y: scroll;
   }
 
+/* Splash image styling */
 .uno-splash {
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  max-width: 620px;
-  width: calc(100vw - 10px);
+  max-width: min(90%, 620px);
+  max-height: min(90%, 300px);
+  width: auto;
   height: auto;
   background-repeat: no-repeat;
   background-position: center;
   background-size: 620px 300px;
-}
-
-/* Bootstrapper logo override */
-.uno-loader .logo {
-  position: fixed !important;
-  top: 50% !important;
-  left: 50% !important;
-  transform: translate(-50%, -50%) !important;
-  max-width: 620px !important;
-  width: calc(100vw - 10px) !important;
-  height: auto !important;
-  background-repeat: no-repeat !important;
-  background-position: center !important;
-  background-size: 620px 300px !important;
 }
 
 textarea {


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/Uno.Wasm.Bootstrap/pull/707

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The splash screen image would not stretch correctly, especially on small screens. 

## What is the new behavior?

This removes the unnecessary override to bootstrapper splash styling and applies the exact same style to the "application-level" splash


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
