### PR TITLE
test: fix ValidateFractionalWidthDoesNotCrash dragging for 1hr

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ColorPicker/ColorPickerTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ColorPicker/ColorPickerTests.cs
@@ -341,7 +341,10 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 				Content.UpdateLayout();
 			});
 
-			spectrumLoadedEvent.WaitOne();
+			if (!spectrumLoadedEvent.WaitOne(timeout: TimeSpan.FromSeconds(10)))
+			{
+				Assert.Fail("Timeout waiting on SpectrumRectangle.Fill to be set.");
+			}
 		}
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On macOS, ValidateFractionalWidthDoesNotCrash can get randomly stuck and drags the macOS runtime tests task for an hours (vs 10ish min normally):
```
info: Uno.UI.Samples.Tests.UnitTestsControl[0]
      Running test ValidateFractionalWidthDoesNotCrash()
##[error]Bash exited with code '124'.
Finishing: Run macOS Runtime Tests
```

## What is the new behavior?
It will now time out after 10s.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
In this build: https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=75309&view=results
2 out of 4 attempts at macOS runtime tests failed:
- https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=75309&view=logs&j=87167d63-bc8f-50a3-6dc5-c09ef976ffcd&s=b15d9194-8f26-5328-b47f-5968c76b37e7&t=2df18e6c-3297-5bff-bd57-6d1f84483846&l=293
- https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=75309&view=logs&j=8f5c0694-1ae5-53e9-633c-86c204d919dc&s=96ac2280-8cb4-5df5-99de-dd2da759617d&t=913094c0-976c-5930-7915-3731ef66c848&l=237