### PR TITLE
fix(android_scaling): Fixed the calculation of the pixel density on Android

### DIFF
--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
@@ -65,8 +65,7 @@ namespace Windows.Graphics.Display
 		public uint ScreenWidthInRawPixels
 			=> (uint)_cachedDisplayMetrics.WidthPixels;
 
-		public double RawPixelsPerViewPixel
-			=> 1.0f * (int)_cachedDisplayMetrics.DensityDpi / (int)DisplayMetricsDensity.Default;
+		public double RawPixelsPerViewPixel => _cachedDisplayMetrics.Density;
 
 		public float LogicalDpi
 			// DisplayMetrics of 1.0 matches 100%, or UWP's default 96.0 DPI.
@@ -281,7 +280,7 @@ namespace Windows.Graphics.Display
 				{
 					Xdpi = configuration.DensityDpi;
 					Ydpi = configuration.DensityDpi;
-					Density = configuration.DensityDpi / 160;
+					Density = configuration.DensityDpi / (float)DisplayMetricsDensity.Default;
 					ScaledDensity = Density;
 					DensityDpi = ConvertIntToDensityEnum(configuration.DensityDpi);
 				}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11944

# Bugfix
On Android api >= 30, the calculation for the Density were done using an integer result instead of a float, leading to a wrong result (density=2 instead of 2.625, for example).


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
