### PR TITLE
Support for `DefaultTextForegroundThemeBrush`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Uno.Disposables;
-using Uno.UI.Xaml.Media;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+
+#if HAS_UNO
+using Uno.UI.Xaml.Media;
+#endif
 
 namespace Uno.UI.RuntimeTests.Helpers
 {

--- a/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
@@ -100,6 +100,7 @@ namespace Uno.UI.RuntimeTests.Helpers
 #endif
 		}
 
+#if !NETFX_CORE
 		private static void ResetIslandRootForeground()
 		{
 			if (TestServices.WindowHelper.IsXamlIsland && VisualTreeUtils.FindVisualChildByType<Control>(TestServices.WindowHelper.XamlRoot.Content) is { } control)
@@ -108,5 +109,6 @@ namespace Uno.UI.RuntimeTests.Helpers
 				control.SetValue(Control.ForegroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
 			}
 		}
+#endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
@@ -5,6 +5,8 @@ using System.Text;
 using Uno.Disposables;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Private.Infrastructure;
+using MUXControlsTestApp.Utilities;
 
 #if HAS_UNO
 using Uno.UI.Xaml.Media;
@@ -87,13 +89,24 @@ namespace Uno.UI.RuntimeTests.Helpers
 
 			// Force default brushes to be reloaded
 			DefaultBrushes.ResetDefaultThemeBrushes();
+			ResetIslandRootForeground();
 
 			return new DisposableAction(() =>
 			{
 				resources.MergedDictionaries.Remove(xcr);
 				DefaultBrushes.ResetDefaultThemeBrushes();
+				ResetIslandRootForeground();
 			});
 #endif
+		}
+
+		private static void ResetIslandRootForeground()
+		{
+			if (TestServices.WindowHelper.IsXamlIsland && VisualTreeUtils.FindVisualChildByType<Control>(TestServices.WindowHelper.XamlRoot.Content) is { } control)
+			{
+				// Ensure the root element's Foreground is set correctly
+				control.SetValue(Control.ForegroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
+			}
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Linq;
+using System.Text;
 using Uno.Disposables;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -81,7 +81,14 @@ namespace Uno.UI.RuntimeTests.Helpers
 			var xcr = new Microsoft.UI.Xaml.Controls.XamlControlsResources();
 			resources.MergedDictionaries.Insert(0, xcr);
 
-			return new DisposableAction(() => resources.MergedDictionaries.Remove(xcr));
+			// Force default brushes to be reloaded
+			UIElement.ResetDefaultThemeBrushes();
+
+			return new DisposableAction(() =>
+			{
+				resources.MergedDictionaries.Remove(xcr);
+				UIElement.ResetDefaultThemeBrushes();
+			});
 #endif
 		}
 	}

--- a/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
@@ -7,6 +7,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Private.Infrastructure;
 using MUXControlsTestApp.Utilities;
+using Uno.UI.Dispatching;
 
 #if HAS_UNO
 using Uno.UI.Xaml.Media;
@@ -78,6 +79,9 @@ namespace Uno.UI.RuntimeTests.Helpers
 #if NETFX_CORE // Disabled on UWP for now because 18362 doesn't support WinUI 2.x; Fluent resources are used by default in SamplesApp.UWP
 			return null;
 #else
+
+			CoreDispatcher.CheckThreadAccess();
+
 			var resources = Application.Current.Resources;
 			if (resources is Microsoft.UI.Xaml.Controls.XamlControlsResources || resources.MergedDictionaries.OfType<Microsoft.UI.Xaml.Controls.XamlControlsResources>().Any())
 			{

--- a/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
@@ -7,9 +7,9 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Private.Infrastructure;
 using MUXControlsTestApp.Utilities;
-using Uno.UI.Dispatching;
 
 #if HAS_UNO
+using Uno.UI.Dispatching;
 using Uno.UI.Xaml.Media;
 #endif
 

--- a/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Uno.Disposables;
+using Uno.UI.Xaml.Media;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -82,12 +83,12 @@ namespace Uno.UI.RuntimeTests.Helpers
 			resources.MergedDictionaries.Insert(0, xcr);
 
 			// Force default brushes to be reloaded
-			UIElement.ResetDefaultThemeBrushes();
+			DefaultBrushes.ResetDefaultThemeBrushes();
 
 			return new DisposableAction(() =>
 			{
 				resources.MergedDictionaries.Remove(xcr);
-				UIElement.ResetDefaultThemeBrushes();
+				DefaultBrushes.ResetDefaultThemeBrushes();
 			});
 #endif
 		}

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ProgressRing/ProgressRingTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ProgressRing/ProgressRingTests.cs
@@ -10,6 +10,7 @@ namespace Uno.UI.RuntimeTests.MUX.Microsoft_UI_Xaml_Controls.ProgressRingTests;
 public class ProgressRingTests
 {
 	[TestMethod]
+	[RunsOnUIThread]
 	[DataRow(true)]
 	[DataRow(false)]
 	public async Task ProgressRingDefaultHeightShouldBe32(bool useFluent)

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ToggleSplitButton/ToggleSplitButtonTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ToggleSplitButton/ToggleSplitButtonTests.cs
@@ -5,6 +5,7 @@ using Private.Infrastructure;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Common;
+using Uno.UI.RuntimeTests;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -13,20 +14,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 	{
 		[TestMethod]
 		[Description("Verifies that the TextBlock representing the Chevron glyph uses the correct font")]
+		[RunsOnUIThread]
 		public void VerifyFontFamilyForChevron()
 		{
 			Microsoft.UI.Xaml.Controls.ToggleSplitButton toggleSplitButton = null;
 			using (StyleHelper.UseFluentStyles())
 			{
-				RunOnUIThread.Execute(() =>
-				{
-					toggleSplitButton = new Microsoft.UI.Xaml.Controls.ToggleSplitButton();
-					TestServices.WindowHelper.WindowContent = toggleSplitButton;
+				toggleSplitButton = new Microsoft.UI.Xaml.Controls.ToggleSplitButton();
+				TestServices.WindowHelper.WindowContent = toggleSplitButton;
 
-					var secondayButton = toggleSplitButton.GetTemplateChild("SecondaryButton");
-					var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
-					Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
-				});
+				var secondayButton = toggleSplitButton.GetTemplateChild("SecondaryButton");
+				var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
+				Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
 			}
 		}
 	}

--- a/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/DropDownButtonTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/DropDownButtonTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
+using Uno.UI.RuntimeTests;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
@@ -15,20 +16,18 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests
 		[TestMethod]
 		[Description("Verifies that the TextBlock representing the Chevron glyph uses the correct font")]
 		[Ignore("Fluent styles V2 use AnimatedIcon instead of FontIcon")]
+		[RunsOnUIThread]
 		public void VerifyFontFamilyForChevron()
 		{
 			DropDownButton dropDownButton = null;
 			using (StyleHelper.UseFluentStyles())
 			{
-				RunOnUIThread.Execute(() =>
-				{
-					dropDownButton = new DropDownButton();
-					TestServices.WindowHelper.WindowContent = dropDownButton;
+				dropDownButton = new DropDownButton();
+				TestServices.WindowHelper.WindowContent = dropDownButton;
 
-					var chevronTextBlock = dropDownButton.GetTemplateChild("ChevronTextBlock") as TextBlock;
-					var font = chevronTextBlock.FontFamily;
-					Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
-				});
+				var chevronTextBlock = dropDownButton.GetTemplateChild("ChevronTextBlock") as TextBlock;
+				var font = chevronTextBlock.FontFamily;
+				Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
 			}
 		}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -66,11 +66,17 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #if HAS_UNO // On UWP/WinUI, the Samples app is always in Fluent theme
 		[TestMethod]
 		[RequiresFullWindow]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 		public async Task When_DefaultForeground_Non_Fluent() => await When_DefaultForeground(Colors.Black, Colors.White);
 #endif
 
 		[TestMethod]
 		[RequiresFullWindow]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
 		public async Task When_DefaultForeground_Fluent()
 		{
 			using (StyleHelper.UseFluentStyles())

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
 using Windows.UI;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
 
@@ -56,6 +60,90 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				await WindowHelper.WaitForLoaded(userControl);
 
 				Assert.AreEqual(Colors.Yellow, (userControl.innerBorder.Background as SolidColorBrush).Color);
+			}
+		}
+
+#if HAS_UNO // On UWP/WinUI, the Samples app is always in Fluent theme
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_DefaultForeground_Non_Fluent() => await When_DefaultForeground(Colors.Black, Colors.White);
+#endif
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_DefaultForeground_Fluent()
+		{
+			using (StyleHelper.UseFluentStyles())
+			{
+				await When_DefaultForeground(Color.FromArgb(228, 0, 0, 0), Colors.White);
+			}
+		}
+
+		private async Task When_DefaultForeground(Color lightThemeColor, Color darkThemeColor)
+		{
+			var run = new Run()
+			{
+				Text = "Hello"
+			};
+
+			var textBlock = new TextBlock()
+			{
+				Inlines = {
+					run,
+				}
+			};
+
+			var button = new Button() { Content = "Test" };
+			var bitmapIcon = new BitmapIcon() { UriSource = new Uri("ms-appx:///Assets/Icons/search.png") };
+			var contentPresenter = new ContentPresenter() { Content = "Hi" };
+			var stackPanel = new StackPanel()
+			{
+				Children =
+				{
+					textBlock,
+					button,
+					bitmapIcon,
+					contentPresenter,
+				}
+			};
+
+			WindowHelper.WindowContent = stackPanel;
+			await WindowHelper.WaitForLoaded(stackPanel);
+
+#if !HAS_UNO
+			// Due to a bug in WinUI, RequestedTheme needs to be set explicitly here to force the correct
+			// foreground color - https://github.com/microsoft/microsoft-ui-xaml/issues/8392.
+			stackPanel.RequestedTheme = ElementTheme.Light;
+#endif
+			// Light theme
+			var runForegroundBrush = (SolidColorBrush)run.Foreground;
+			var textBlockForegroundBrush = (SolidColorBrush)textBlock.Foreground;
+			var buttonForegroundBrush = (SolidColorBrush)button.Foreground;
+			var bitmapIconForegroundBrush = (SolidColorBrush)bitmapIcon.Foreground;
+			var contentPresenterForegroundBrush = (SolidColorBrush)contentPresenter.Foreground;
+			Assert.AreEqual(lightThemeColor, runForegroundBrush.Color);
+			Assert.AreEqual(lightThemeColor, textBlockForegroundBrush.Color);
+			Assert.AreEqual(lightThemeColor, buttonForegroundBrush.Color);
+			Assert.AreEqual(lightThemeColor, bitmapIconForegroundBrush.Color);
+			Assert.AreEqual(lightThemeColor, contentPresenterForegroundBrush.Color);
+
+			using (ThemeHelper.UseDarkTheme())
+			{
+#if !HAS_UNO
+				// Due to a bug in WinUI, RequestedTheme needs to be set explicitly here to force the correct
+				// foreground color - https://github.com/microsoft/microsoft-ui-xaml/issues/8392.
+				stackPanel.RequestedTheme = ElementTheme.Dark;
+#endif
+				runForegroundBrush = (SolidColorBrush)run.Foreground;
+				textBlockForegroundBrush = (SolidColorBrush)textBlock.Foreground;
+				buttonForegroundBrush = (SolidColorBrush)button.Foreground;
+				bitmapIconForegroundBrush = (SolidColorBrush)bitmapIcon.Foreground;
+				contentPresenterForegroundBrush = (SolidColorBrush)contentPresenter.Foreground;
+				Assert.AreEqual(darkThemeColor, runForegroundBrush.Color);
+				Assert.AreEqual(darkThemeColor, textBlockForegroundBrush.Color);
+				Assert.AreEqual(darkThemeColor, buttonForegroundBrush.Color);
+				Assert.AreEqual(darkThemeColor, bitmapIconForegroundBrush.Color);
+				Assert.AreEqual(darkThemeColor, contentPresenterForegroundBrush.Color);
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -22,6 +22,7 @@ using Windows.UI.Popups;
 using Uno.UI.WinRT.Extensions.UI.Popups;
 using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
 using Uno.UI.Xaml.Core;
+using Uno.UI.Xaml.Media;
 
 #if HAS_UNO_WINUI
 using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
@@ -46,7 +47,6 @@ using AppKit;
 #else
 using View = Windows.UI.Xaml.UIElement;
 using ViewGroup = Windows.UI.Xaml.UIElement;
-using Uno.UI.Xaml.Media;
 #endif
 
 namespace Windows.UI.Xaml

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -415,6 +415,7 @@ namespace Windows.UI.Xaml
 
 		private void OnResourcesChanged(ResourceUpdateReason updateReason)
 		{
+			UIElement.ResetDefaultThemeBrushes();
 			foreach (var contentRoot in WinUICoreServices.Instance.ContentRootCoordinator.ContentRoots)
 			{
 				if (GetTreeRoot(contentRoot) is { } root)

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -46,6 +46,7 @@ using AppKit;
 #else
 using View = Windows.UI.Xaml.UIElement;
 using ViewGroup = Windows.UI.Xaml.UIElement;
+using Uno.UI.Xaml.Media;
 #endif
 
 namespace Windows.UI.Xaml
@@ -415,7 +416,7 @@ namespace Windows.UI.Xaml
 
 		private void OnResourcesChanged(ResourceUpdateReason updateReason)
 		{
-			UIElement.ResetDefaultThemeBrushes();
+			DefaultBrushes.ResetDefaultThemeBrushes();
 			foreach (var contentRoot in WinUICoreServices.Instance.ContentRootCoordinator.ContentRoots)
 			{
 				if (GetTreeRoot(contentRoot) is { } root)
@@ -449,7 +450,6 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		internal static void PropagateResourcesChanged(object instance, ResourceUpdateReason updateReason)
 		{
-
 			// Update ThemeResource references that have changed
 			if (instance is FrameworkElement fe)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -52,6 +52,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void InitializeContentPresenter()
 		{
+			SetDefaultForeground(ForegroundProperty);
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/BitmapIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/BitmapIcon.cs
@@ -72,7 +72,7 @@ public partial class BitmapIcon : IconElement
 	private void UpdateImageMonochromeColor()
 	{
 #if !NET461
-		if (_image != null)
+		if (_image is not null)
 		{
 			_image.MonochromeColor = ShowAsMonochrome ? (Foreground as SolidColorBrush)?.Color : null;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/BitmapIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/BitmapIcon.cs
@@ -24,7 +24,7 @@ public partial class BitmapIcon : IconElement
 			dependencyProperty: Image.SourceProperty,
 			binding: new Binding { Source = this, Path = nameof(UriSource) }
 		);
-		this.SetValue(ForegroundProperty, SolidColorBrushHelper.Black, DependencyPropertyValuePrecedences.Inheritance);
+
 		UpdateImageMonochromeColor();
 	}
 
@@ -67,8 +67,7 @@ public partial class BitmapIcon : IconElement
 
 	private void OnShowAsMonochromeChanged(bool value) => UpdateImageMonochromeColor();
 
-	private protected override void OnForegroundChanged(DependencyPropertyChangedEventArgs e) =>
-		UpdateImageMonochromeColor();
+	private protected override void OnForegroundChanged(DependencyPropertyChangedEventArgs e) => UpdateImageMonochromeColor();
 
 	private void UpdateImageMonochromeColor()
 	{

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/FontIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/FontIcon.cs
@@ -211,6 +211,13 @@ public partial class FontIcon : IconElement
 		}
 	}
 
-	private protected override void OnForegroundChanged(DependencyPropertyChangedEventArgs e) =>
-		_textBlock.Foreground = (Brush)e.NewValue;
+	private protected override void OnForegroundChanged(DependencyPropertyChangedEventArgs e)
+	{
+		// This may occur while executing the base constructor
+		// so _textBlock may still be null.
+		if (_textBlock is not null)
+		{
+			_textBlock.Foreground = (Brush)e.NewValue;
+		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/IconElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/IconElement.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Uno.UI.Xaml.Media;
 using Windows.Foundation;
+using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls;
@@ -19,6 +21,7 @@ public partial class IconElement : FrameworkElement
 
 	public IconElement()
 	{
+		SetDefaultForeground(ForegroundProperty);
 	}
 
 	/// <summary>
@@ -85,6 +88,13 @@ public partial class IconElement : FrameworkElement
 	}
 
 	private protected virtual void OnForegroundChanged(DependencyPropertyChangedEventArgs e) { }
+
+	internal override void UpdateThemeBindings(ResourceUpdateReason updateReason)
+	{
+		base.UpdateThemeBindings(updateReason);
+
+		SetDefaultForeground(ForegroundProperty);
+	}
 
 	[MemberNotNull(nameof(_rootGrid))]
 	private protected void InitializeRootGrid()

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/PathIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/PathIcon.cs
@@ -51,6 +51,13 @@ public partial class PathIcon : IconElement
 		_path.Data = Data;
 	}
 
-	private protected override void OnForegroundChanged(DependencyPropertyChangedEventArgs e) =>
-		_path.Fill = (Brush)e.NewValue;
+	private protected override void OnForegroundChanged(DependencyPropertyChangedEventArgs e)
+	{
+		// This may occur while executing the base constructor
+		// so _path may still be null.
+		if (_path is not null)
+		{
+			_path.Fill = (Brush)e.NewValue;
+		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/SymbolIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/SymbolIcon.cs
@@ -78,6 +78,13 @@ public sealed partial class SymbolIcon : IconElement
 	private static FontFamily GetSymbolFontFamily() =>
 		 _symbolIconFontFamily ??= new FontFamily(Uno.UI.FeatureConfiguration.Font.SymbolsFont);
 
-	private protected override void OnForegroundChanged(DependencyPropertyChangedEventArgs e) =>
-		_textBlock.Foreground = (Brush)e.NewValue;
+	private protected override void OnForegroundChanged(DependencyPropertyChangedEventArgs e)
+	{
+		// This may occur while executing the base constructor
+		// so _textBlock may still be null.
+		if (_textBlock is not null)
+		{
+			_textBlock.Foreground = (Brush)e.NewValue;
+		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -43,6 +43,8 @@ namespace Windows.UI.Xaml.Controls
 		public TextBlock()
 		{
 			IFrameworkElementHelper.Initialize(this);
+			SetDefaultForeground(ForegroundProperty);
+
 			InitializeProperties();
 
 			InitializePartial();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -25,6 +25,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public TextBlock()
 		{
+			SetDefaultForeground(ForegroundProperty);
 			_textVisual = new TextVisual(Visual.Compositor, this);
 
 			Visual.Children.InsertAtBottom(_textVisual);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -31,6 +31,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public TextBlock() : base("p")
 		{
+			SetDefaultForeground(ForegroundProperty);
+
 			OnFontStyleChangedPartial();
 			OnFontWeightChangedPartial();
 			OnTextChangedPartial();

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
@@ -341,8 +341,8 @@ namespace Windows.UI.Xaml.Documents
 		{
 			this.SetValue(ForegroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
 		}
+#endif
 
 		public void OnThemeChanged() => SetDefaultForeground();
-#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
@@ -17,6 +17,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Text;
 using Uno.UI;
 using Uno.UI.Xaml;
+using Uno.UI.Xaml.Media;
 
 #if XAMARIN_ANDROID
 using View = Android.Views.View;
@@ -35,7 +36,6 @@ using View = Windows.UI.Xaml.UIElement;
 using Color = Windows.UI.Color;
 #else
 using Color = System.Drawing.Color;
-using Uno.UI.Xaml.Media;
 #endif
 
 #if __WASM__

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
@@ -336,13 +336,13 @@ namespace Windows.UI.Xaml.Documents
 			return parent as FrameworkElement;
 		}
 
+		public void OnThemeChanged() => SetDefaultForeground(ForegroundProperty);
+
 #if !__WASM__
-		private void SetDefaultForeground()
+		private void SetDefaultForeground(DependencyProperty foregroundProperty)
 		{
-			this.SetValue(ForegroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
+			this.SetValue(foregroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
 		}
 #endif
-
-		public void OnThemeChanged() => SetDefaultForeground();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
@@ -35,6 +35,7 @@ using View = Windows.UI.Xaml.UIElement;
 using Color = Windows.UI.Color;
 #else
 using Color = System.Drawing.Color;
+using Uno.UI.Xaml.Media;
 #endif
 
 #if __WASM__
@@ -45,11 +46,12 @@ using BaseClass = Windows.UI.Xaml.DependencyObject;
 
 namespace Windows.UI.Xaml.Documents
 {
-	public abstract partial class TextElement : BaseClass
+	public abstract partial class TextElement : BaseClass, IThemeChangeAware
 	{
 #if !__WASM__
 		public TextElement()
 		{
+			SetDefaultForeground();
 			InitializeBinder();
 		}
 #endif
@@ -333,5 +335,14 @@ namespace Windows.UI.Xaml.Documents
 
 			return parent as FrameworkElement;
 		}
+
+#if !__WASM__
+		private void SetDefaultForeground()
+		{
+			this.SetValue(ForegroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
+		}
+
+		public void OnThemeChanged() => SetDefaultForeground();
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Documents
 #if !__WASM__
 		public TextElement()
 		{
-			SetDefaultForeground();
+			SetDefaultForeground(ForegroundProperty);
 			InitializeBinder();
 		}
 #endif

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.wasm.cs
@@ -4,6 +4,7 @@
 	{
 		protected TextElement(string htmlTag = "span") : base(htmlTag)
 		{
+			SetDefaultForeground(ForegroundProperty);
 		}
 
 		partial void OnFontFamilyChangedPartial()

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -964,10 +964,7 @@ namespace Windows.UI.Xaml
 		/// <param name="foregroundProperty">The appropriate property for the calling instance.</param>
 		private protected void SetDefaultForeground(DependencyProperty foregroundProperty)
 		{
-			(this).SetValue(foregroundProperty,
-							Application.Current == null || Application.Current.RequestedTheme == ApplicationTheme.Light
-								? SolidColorBrushHelper.Black
-								: SolidColorBrushHelper.White, DependencyPropertyValuePrecedences.DefaultValue);
+			(this).SetValue(foregroundProperty, UIElement.GetDefaultTextBrush(), DependencyPropertyValuePrecedences.DefaultValue);
 		}
 
 		#region AutomationPeer

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -959,15 +959,6 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		/// <summary>
-		/// Set correct default foreground for the current theme.
-		/// </summary>
-		/// <param name="foregroundProperty">The appropriate property for the calling instance.</param>
-		private protected void SetDefaultForeground(DependencyProperty foregroundProperty)
-		{
-			(this).SetValue(foregroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
-		}
-
 		#region AutomationPeer
 #if !__IOS__ && !__ANDROID__ && !__MACOS__ // This code is generated in FrameworkElementMixins
 		private AutomationPeer _automationPeer;

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -25,6 +25,7 @@ using Uno.UI.Xaml;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Data;
 using Uno.UI.Xaml.Core;
+using Uno.UI.Xaml.Media;
 
 #if XAMARIN_ANDROID
 using View = Android.Views.View;
@@ -964,7 +965,7 @@ namespace Windows.UI.Xaml
 		/// <param name="foregroundProperty">The appropriate property for the calling instance.</param>
 		private protected void SetDefaultForeground(DependencyProperty foregroundProperty)
 		{
-			(this).SetValue(foregroundProperty, UIElement.GetDefaultTextBrush(), DependencyPropertyValuePrecedences.DefaultValue);
+			(this).SetValue(foregroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
 		}
 
 		#region AutomationPeer

--- a/src/Uno.UI/UI/Xaml/Media/DefaultBrushes.cs
+++ b/src/Uno.UI/UI/Xaml/Media/DefaultBrushes.cs
@@ -15,7 +15,7 @@ internal static class DefaultBrushes
 
 	private static Brush? _textForegroundBrush;
 
-	internal static Brush TextForegroundBrush => _textForegroundBrush ??= GetDefaultTextBrush();
+	internal static Brush TextForegroundBrush => GetDefaultTextBrush();
 
 	internal static SolidColorBrush SelectionHighlightColor { get; } = new SolidColorBrush(Color.FromArgb(255, 0, 120, 212));
 

--- a/src/Uno.UI/UI/Xaml/Media/DefaultBrushes.cs
+++ b/src/Uno.UI/UI/Xaml/Media/DefaultBrushes.cs
@@ -1,9 +1,46 @@
-﻿using Windows.UI;
+﻿#nullable enable
+
+using Windows.ApplicationModel.Core;
+using Windows.UI;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
+using Uno.Helpers.Theming;
 
 namespace Uno.UI.Xaml.Media;
 
 internal static class DefaultBrushes
 {
-	public static SolidColorBrush SelectionHighlightColor { get; } = new SolidColorBrush(Color.FromArgb(255, 0, 120, 212));
+	private const string DefaultTextForegroundThemeBrushKey = "DefaultTextForegroundThemeBrush";
+
+	private static Brush? _textForegroundBrush;
+
+	internal static Brush TextForegroundBrush => _textForegroundBrush ??= GetDefaultTextBrush();
+
+	internal static SolidColorBrush SelectionHighlightColor { get; } = new SolidColorBrush(Color.FromArgb(255, 0, 120, 212));
+
+	internal static void ResetDefaultThemeBrushes()
+	{
+		_textForegroundBrush = null;
+	}
+
+	private static Brush GetDefaultTextBrush()
+	{
+		if (_textForegroundBrush is null)
+		{
+			if (Application.Current.Resources.TryGetValue(DefaultTextForegroundThemeBrushKey, out var defaultBrushObject) &&
+				defaultBrushObject is Brush defaultBrush)
+			{
+				_textForegroundBrush = defaultBrush;
+			}
+			else
+			{
+				// Fallback to black/white
+				_textForegroundBrush = CoreApplication.RequestedTheme == SystemTheme.Dark ?
+					SolidColorBrushHelper.White : SolidColorBrushHelper.Black;
+			}
+		}
+
+		return _textForegroundBrush;
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/DefaultBrushes.cs
+++ b/src/Uno.UI/UI/Xaml/Media/DefaultBrushes.cs
@@ -19,13 +19,16 @@ internal static class DefaultBrushes
 
 	internal static SolidColorBrush SelectionHighlightColor { get; } = new SolidColorBrush(Color.FromArgb(255, 0, 120, 212));
 
-	internal static void ResetDefaultThemeBrushes()
-	{
-		_textForegroundBrush = null;
-	}
+	internal static void ResetDefaultThemeBrushes() => _textForegroundBrush = null;
 
 	private static Brush GetDefaultTextBrush()
 	{
+		if (Application.Current is null)
+		{
+			// Called too early or within unit tests, fallback
+			return SolidColorBrushHelper.Black;
+		}
+
 		if (_textForegroundBrush is null)
 		{
 			if (Application.Current.Resources.TryGetValue(DefaultTextForegroundThemeBrushKey, out var defaultBrushObject) &&

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -452,6 +452,15 @@ namespace Windows.UI.Xaml
 
 		partial void OnVisibilityChangedPartial(Visibility oldValue, Visibility newValue);
 
+		/// <summary>
+		/// Set correct default foreground for the current theme.
+		/// </summary>
+		/// <param name="foregroundProperty">The appropriate property for the calling instance.</param>
+		private protected void SetDefaultForeground(DependencyProperty foregroundProperty)
+		{
+			this.SetValue(foregroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
+		}
+
 		[NotImplemented]
 		protected virtual AutomationPeer OnCreateAutomationPeer() => new AutomationPeer();
 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -47,8 +47,6 @@ namespace Windows.UI.Xaml
 
 		private static readonly Type[] _bringIntoViewRequestedArgs = new[] { typeof(BringIntoViewRequestedEventArgs) };
 
-		private static Brush _defaultTextBrush;
-
 		private readonly SerialDisposable _clipSubscription = new SerialDisposable();
 		private string _uid;
 
@@ -186,31 +184,6 @@ namespace Windows.UI.Xaml
 
 			defaultValue = null;
 			return false;
-		}
-
-		internal static void ResetDefaultThemeBrushes()
-		{
-			_defaultTextBrush = null;
-		}
-
-		internal static Brush GetDefaultTextBrush()
-		{
-			if (_defaultTextBrush is null)
-			{
-				if (Application.Current.Resources.TryGetValue("DefaultTextForegroundThemeBrush", out var defaultBrushObject) &&
-					defaultBrushObject is Brush defaultBrush)
-				{
-					_defaultTextBrush = defaultBrush;
-				}
-				else
-				{
-					// Fallback to black/white
-					_defaultTextBrush = CoreApplication.RequestedTheme == Uno.Helpers.Theming.SystemTheme.Dark ?
-						SolidColorBrushHelper.White : SolidColorBrushHelper.Black;
-				}
-			}
-
-			return _defaultTextBrush;
 		}
 
 		public Vector2 ActualSize => new Vector2((float)GetActualWidth(), (float)GetActualHeight());

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -30,6 +30,9 @@ using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Composition;
 using Windows.Graphics.Display;
 using Uno.UI.Extensions;
+using Windows.UI.Xaml.Documents;
+using Windows.ApplicationModel.Core;
+using Uno.UI.Xaml.Media;
 
 #if __IOS__
 using UIKit;
@@ -43,6 +46,8 @@ namespace Windows.UI.Xaml
 			(UIElement sender, BringIntoViewRequestedEventArgs args) => sender.OnBringIntoViewRequested(args);
 
 		private static readonly Type[] _bringIntoViewRequestedArgs = new[] { typeof(BringIntoViewRequestedEventArgs) };
+
+		private static Brush _defaultTextBrush;
 
 		private readonly SerialDisposable _clipSubscription = new SerialDisposable();
 		private string _uid;
@@ -181,6 +186,31 @@ namespace Windows.UI.Xaml
 
 			defaultValue = null;
 			return false;
+		}
+
+		internal static void ResetDefaultThemeBrushes()
+		{
+			_defaultTextBrush = null;
+		}
+
+		internal static Brush GetDefaultTextBrush()
+		{
+			if (_defaultTextBrush is null)
+			{
+				if (Application.Current.Resources.TryGetValue("DefaultTextForegroundThemeBrush", out var defaultBrushObject) &&
+					defaultBrushObject is Brush defaultBrush)
+				{
+					_defaultTextBrush = defaultBrush;
+				}
+				else
+				{
+					// Fallback to black/white
+					_defaultTextBrush = CoreApplication.RequestedTheme == Uno.Helpers.Theming.SystemTheme.Dark ?
+						SolidColorBrushHelper.White : SolidColorBrushHelper.Black;
+				}
+			}
+
+			return _defaultTextBrush;
 		}
 
 		public Vector2 ActualSize => new Vector2((float)GetActualWidth(), (float)GetActualHeight());


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3482

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

- Missing support for `DefaultTextForegroundThemeBrush`

## What is the new behavior?

- Added support for `DefaultTextForegroundThemeBrush`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.