### PR TITLE
Restore When_xLoad_StaticResource test

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -6378,7 +6378,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 										{
 											if (_isHotReloadEnabled)
 											{
-												writer.AppendLineIndented($"var owner = global::Uno.UI.Helpers.MarkupHelper.GetElementProperty<{CurrentScope.ClassName}>(sender, \"{{componentName}}_owner\");");
+												writer.AppendLineIndented($"var owner = global::Uno.UI.Helpers.MarkupHelper.GetElementProperty<{CurrentScope.ClassName}>(sender, \"{componentName}_owner\");");
 											}
 
 											// Refresh the bindings when the ElementStub is unloaded. This assumes that

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_xBind_Binding.cs
@@ -17,6 +17,23 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 	public class Given_xBind_Binding
 	{
 		private const int V = 42;
+		private bool _previousPoolingEnabled;
+
+		[TestInitialize]
+		public void Init()
+		{
+			UnitTestsApp.App.EnsureApplication();
+
+			_previousPoolingEnabled = FrameworkTemplatePool.IsPoolingEnabled;
+			FrameworkTemplatePool.IsPoolingEnabled = false;
+		}
+
+		[TestCleanup]
+		public void Cleanup()
+		{
+			FrameworkTemplatePool.IsPoolingEnabled = _previousPoolingEnabled;
+			FrameworkTemplatePool.Scavenge();
+		}
 
 		[TestMethod]
 		public void When_Initial_Value()
@@ -1073,7 +1090,6 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 		}
 
 		[TestMethod]
-		[Ignore("https://github.com/unoplatform/uno/issues/10164")]
 		public async Task When_xLoad_StaticResource()
 		{
 			var SUT = new Binding_xLoad_StaticResources();
@@ -1365,6 +1381,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 
 			while (sw.Elapsed < timeout)
 			{
+				void validate()
 				{
 					var value = getter();
 
@@ -1376,12 +1393,14 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
 					value = null;
 				}
 
+				validate();
+
 				await Task.Yield();
 
 				// Wait for the ElementNameSubject and ComponentHolder
 				// instances to release their references.
 				GC.Collect(2);
-				//GC.WaitForPendingFinalizers();
+				GC.WaitForPendingFinalizers();
 			}
 
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/10164

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restore proper testing of When_xLoad_StaticResource, adjusting for pooling sensitivity and incorrect materialized component lookup.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
