### PR TITLE
feat: Delaying paint until Activation

### DIFF
--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -66,8 +66,7 @@ namespace Windows.UI.Xaml
 
 			if (!_preDrawListener.IsActivated)
 			{
-				var activity = Uno.UI.ContextHelper.Current as Android.App.Activity;
-				if (activity is not null)
+				if (Uno.UI.ContextHelper.Current is Android.App.Activity activity)
 				{
 					_decor = activity.Window.DecorView;
 					if (_decor is not null)

--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -355,7 +355,7 @@ namespace Windows.UI.Xaml
 		#endregion
 
 
-		private class ActivationPreDrawListener : Java.Lang.Object, ViewTreeObserver.IOnPreDrawListener
+		private sealed class ActivationPreDrawListener : Java.Lang.Object, ViewTreeObserver.IOnPreDrawListener
 		{
 			public ActivationPreDrawListener()
 			{

--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -69,10 +69,7 @@ namespace Windows.UI.Xaml
 				if (Uno.UI.ContextHelper.Current is Android.App.Activity activity)
 				{
 					_decor = activity.Window.DecorView;
-					if (_decor is not null)
-					{
-						_decor.ViewTreeObserver.AddOnPreDrawListener(_preDrawListener);
-					}
+					_decor?.ViewTreeObserver.AddOnPreDrawListener(_preDrawListener);
 				}
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11974 

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

Android application ui displays prior to Window.Activate being called

## What is the new behavior?

Splashscreen stays visible until Window.Activate is called at which point the application ui is shown.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
