### PR TITLE
perf: Avoid native call to get parent while bubbling events

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -719,11 +719,13 @@ namespace Windows.UI.Xaml
 				args.CanBubbleNatively = false;
 			}
 
-#if __IOS__ || __ANDROID__
-			var parent = this.FindFirstParent<UIElement>();
-#else
 			var parent = this.GetParent() as UIElement;
+#if __IOS__ || __ANDROID__
+			// This is for safety (legacy support) and should be removed.
+			// A common issue is the managed parent being cleared before unload event raised.
+			parent ??= this.FindFirstParent<UIElement>();
 #endif
+
 			// [11] A parent is defined?
 			if (parent == null)
 			{


### PR DESCRIPTION
## Performance
Avoid native call to get parent while bubbling events

## What is the current behavior?
When bubbling routed events, on iOS and Android, we are getting the parent using native API

## What is the new behavior?
Use the managed clone

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
