### PR TITLE
docs: update Linux/Rider templates package name

### DIFF
--- a/doc/articles/get-started-dotnet-new.md
+++ b/doc/articles/get-started-dotnet-new.md
@@ -130,6 +130,6 @@ For additional information about UI Tests creation, visit the [Uno.UITest](https
 
 Using a command line or terminal, run the following command:
 
-`dotnet new -u Uno.ProjectTemplates.Dotnet`
+`dotnet new -u Uno.Templates`
 
 [!include[getting-help](getting-help.md)]

--- a/doc/articles/get-started-rider.md
+++ b/doc/articles/get-started-rider.md
@@ -53,7 +53,7 @@ At this time, there isn't a template for the Rider IDE like there is for Visual 
 
 Installs Uno template:  
 ```bash
-dotnet new -i Uno.ProjectTemplates.Dotnet
+dotnet new -i Uno.Templates
 ```
 Creates a new project:  
 ```bash

--- a/doc/articles/get-started-with-linux.md
+++ b/doc/articles/get-started-with-linux.md
@@ -27,7 +27,7 @@ Using VS 2019 16.6 or later:
     - If you still want to use WSL 2 anyways, you can try [following those steps](https://skeptric.com/wsl2-xserver).
 - Install the [`dotnet new` templates](get-started-dotnet-new.md):
     ```
-    dotnet new -i Uno.ProjectTemplates.Dotnet
+    dotnet new -i Uno.Templates
     ```
 - Then create a new project using:
     ```
@@ -77,7 +77,7 @@ Now let's run the application:
     ```
 - Install the `dotnet new` templates:
     ```bash
-    dotnet new -i Uno.ProjectTemplates.Dotnet
+    dotnet new -i Uno.Templates
     ```
 
 You may also need to [install the Microsoft fonts](https://wiki.archlinux.org/title/Microsoft_fonts) manually.
@@ -89,7 +89,7 @@ You may also need to [install the Microsoft fonts](https://wiki.archlinux.org/ti
 
 - Install the `dotnet new` templates:
     ```bash
-    dotnet new -i Uno.ProjectTemplates.Dotnet
+    dotnet new -i Uno.Templates
     ```
 - Then create a new project using:
     ```bash

--- a/doc/articles/guides/azure-static-webapps.md
+++ b/doc/articles/guides/azure-static-webapps.md
@@ -15,7 +15,7 @@ Here is how to publish an app from GitHub, using Uno Platform:
 -	In a new repository, create a Uno Platform app using the following command:
     ```
     cd <repository-name>
-    dotnet new -i Uno.ProjectTemplates.Dotnet
+    dotnet new -i Uno.Templates
     dotnet new unoapp -o MyApp
     ```
 -	If the <TargetFramework> value in the `MyApp.Wasm.csproj` is not `net5.0`, [follow the upgrading steps provided here](https://github.com/unoplatform/uno/blob/master/doc/articles/migrating-from-previous-releases.md#migrating-webassembly-projects-to-net-5).

--- a/doc/articles/guides/silverlight-migration/01-create-uno-solution.md
+++ b/doc/articles/guides/silverlight-migration/01-create-uno-solution.md
@@ -17,7 +17,7 @@ You can use the dotnet cli templates to create an Uno solution with just the pro
 1. To install the Uno dotnet cli templates, enter the following command:
 
     ```powershell
-    dotnet new -i Uno.ProjectTemplates.Dotnet
+    dotnet new -i Uno.Templates
     ```
 
 1. To create the Uno solution with just UWP and WASM heads, enter the following command:


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## Details

The "getting started" instructions for both Linux and Rider currently point to the deprecated Uno.ProjectTemplates.Dotnet [0] package. The instructions should be updated to use Uno.Templates [1].

[0] https://www.nuget.org/packages/Uno.ProjectTemplates.Dotnet/
[1] https://www.nuget.org/packages/uno.templates/