### PR TITLE
chore: fix CA1815 violations in Uno.UWP/Uno.Skia

### DIFF
--- a/src/Uno.UWP/UI/Core/CorePhysicalKeyStatus.cs
+++ b/src/Uno.UWP/UI/Core/CorePhysicalKeyStatus.cs
@@ -20,8 +20,16 @@ namespace Windows.UI.Core
 
 		public override bool Equals(object? obj) => obj is CorePhysicalKeyStatus other && Equals(other);
 
-		public override int GetHashCode() => HashCode.Combine(RepeatCount, ScanCode, IsExtendedKey, IsMenuKeyDown,
-			WasKeyDown, IsKeyReleased);
+		public override int GetHashCode() =>
+			new
+			{
+				RepeatCount,
+				ScanCode,
+				IsExtendedKey,
+				IsMenuKeyDown,
+				WasKeyDown,
+				IsKeyReleased
+			}.GetHashCode();
 
 		public static bool operator ==(CorePhysicalKeyStatus left, CorePhysicalKeyStatus right) => left.Equals(right);
 

--- a/src/Uno.UWP/UI/Core/CorePhysicalKeyStatus.cs
+++ b/src/Uno.UWP/UI/Core/CorePhysicalKeyStatus.cs
@@ -20,16 +20,17 @@ namespace Windows.UI.Core
 
 		public override bool Equals(object? obj) => obj is CorePhysicalKeyStatus other && Equals(other);
 
-		public override int GetHashCode() =>
-			new
-			{
-				RepeatCount,
-				ScanCode,
-				IsExtendedKey,
-				IsMenuKeyDown,
-				WasKeyDown,
-				IsKeyReleased
-			}.GetHashCode();
+		public override int GetHashCode()
+		{
+			var hashCode = -1614557298;
+			hashCode = hashCode * -1521134295 + RepeatCount.GetHashCode();
+			hashCode = hashCode * -1521134295 + ScanCode.GetHashCode();
+			hashCode = hashCode * -1521134295 + IsExtendedKey.GetHashCode();
+			hashCode = hashCode * -1521134295 + IsMenuKeyDown.GetHashCode();
+			hashCode = hashCode * -1521134295 + WasKeyDown.GetHashCode();
+			hashCode = hashCode * -1521134295 + IsKeyReleased.GetHashCode();
+			return hashCode;
+		}
 
 		public static bool operator ==(CorePhysicalKeyStatus left, CorePhysicalKeyStatus right) => left.Equals(right);
 

--- a/src/Uno.UWP/UI/Core/CorePhysicalKeyStatus.cs
+++ b/src/Uno.UWP/UI/Core/CorePhysicalKeyStatus.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System;
+
 namespace Windows.UI.Core
 {
 	public partial struct CorePhysicalKeyStatus
@@ -10,5 +12,19 @@ namespace Windows.UI.Core
 		public bool IsMenuKeyDown;
 		public bool WasKeyDown;
 		public bool IsKeyReleased;
+
+		public bool Equals(CorePhysicalKeyStatus other) =>
+			RepeatCount == other.RepeatCount && ScanCode == other.ScanCode &&
+			IsExtendedKey == other.IsExtendedKey && IsMenuKeyDown == other.IsMenuKeyDown &&
+			WasKeyDown == other.WasKeyDown && IsKeyReleased == other.IsKeyReleased;
+
+		public override bool Equals(object? obj) => obj is CorePhysicalKeyStatus other && Equals(other);
+
+		public override int GetHashCode() => HashCode.Combine(RepeatCount, ScanCode, IsExtendedKey, IsMenuKeyDown,
+			WasKeyDown, IsKeyReleased);
+
+		public static bool operator ==(CorePhysicalKeyStatus left, CorePhysicalKeyStatus right) => left.Equals(right);
+
+		public static bool operator !=(CorePhysicalKeyStatus left, CorePhysicalKeyStatus right) => !(left == right);
 	}
 }

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPoint.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPoint.cs
@@ -14,7 +14,13 @@ public partial struct InjectedInputPoint
 
 	public override bool Equals(object? obj) => obj is InjectedInputPoint other && Equals(other);
 
-	public override int GetHashCode() => new { PositionX, PositionY }.GetHashCode();
+	public override int GetHashCode()
+	{
+		var hashCode = -700598033;
+		hashCode = hashCode * -1521134295 + PositionX.GetHashCode();
+		hashCode = hashCode * -1521134295 + PositionY.GetHashCode();
+		return hashCode;
+	}
 
 	public static bool operator ==(InjectedInputPoint left, InjectedInputPoint right) => left.Equals(right);
 

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPoint.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPoint.cs
@@ -14,7 +14,7 @@ public partial struct InjectedInputPoint
 
 	public override bool Equals(object? obj) => obj is InjectedInputPoint other && Equals(other);
 
-	public override int GetHashCode() => HashCode.Combine(PositionX, PositionY);
+	public override int GetHashCode() => new { PositionX, PositionY }.GetHashCode();
 
 	public static bool operator ==(InjectedInputPoint left, InjectedInputPoint right) => left.Equals(right);
 

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPoint.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPoint.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System;
+
 namespace Windows.UI.Input.Preview.Injection;
 
 public partial struct InjectedInputPoint
@@ -7,4 +9,14 @@ public partial struct InjectedInputPoint
 	public int PositionX;
 
 	public int PositionY;
+
+	public bool Equals(InjectedInputPoint other) => PositionX == other.PositionX && PositionY == other.PositionY;
+
+	public override bool Equals(object? obj) => obj is InjectedInputPoint other && Equals(other);
+
+	public override int GetHashCode() => HashCode.Combine(PositionX, PositionY);
+
+	public static bool operator ==(InjectedInputPoint left, InjectedInputPoint right) => left.Equals(right);
+
+	public static bool operator !=(InjectedInputPoint left, InjectedInputPoint right) => !(left == right);
 }

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPointerInfo.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPointerInfo.cs
@@ -99,8 +99,14 @@ public partial struct InjectedInputPointerInfo
 
 	public override bool Equals(object? obj) => obj is InjectedInputPointerInfo other && Equals(other);
 
-	public override int GetHashCode() => HashCode.Combine(PointerId, (int)PointerOptions, PixelLocation,
-		TimeOffsetInMilliseconds, PerformanceCount);
+	public override int GetHashCode() => new
+	{
+		PointerId,
+		PointerOptions,
+		PixelLocation,
+		TimeOffsetInMilliseconds,
+		PerformanceCount
+	}.GetHashCode();
 
 	public static bool operator ==(InjectedInputPointerInfo left, InjectedInputPointerInfo right) => left.Equals(right);
 

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPointerInfo.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPointerInfo.cs
@@ -99,14 +99,16 @@ public partial struct InjectedInputPointerInfo
 
 	public override bool Equals(object? obj) => obj is InjectedInputPointerInfo other && Equals(other);
 
-	public override int GetHashCode() => new
+	public override int GetHashCode()
 	{
-		PointerId,
-		PointerOptions,
-		PixelLocation,
-		TimeOffsetInMilliseconds,
-		PerformanceCount
-	}.GetHashCode();
+		var hashCode = -2014432303;
+		hashCode = hashCode * -1521134295 + PointerId.GetHashCode();
+		hashCode = hashCode * -1521134295 + PointerOptions.GetHashCode();
+		hashCode = hashCode * -1521134295 + PixelLocation.GetHashCode();
+		hashCode = hashCode * -1521134295 + TimeOffsetInMilliseconds.GetHashCode();
+		hashCode = hashCode * -1521134295 + PerformanceCount.GetHashCode();
+		return hashCode;
+	}
 
 	public static bool operator ==(InjectedInputPointerInfo left, InjectedInputPointerInfo right) => left.Equals(right);
 

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPointerInfo.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPointerInfo.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.System;
@@ -32,7 +33,7 @@ public partial struct InjectedInputPointerInfo
 		// IsMiddleButtonPressed = // Mouse only
 		// IsRightButtonPressed = // stateful, cf. below,
 		// IsHorizontalMouseWheel = // Mouse only
-		// IsXButton1Pressed = 
+		// IsXButton1Pressed =
 		// IsXButton2Pressed =
 		// IsBarrelButtonPressed = // Pen only
 		// IsEraser = // Pen only
@@ -56,6 +57,7 @@ public partial struct InjectedInputPointerInfo
 				update |= PointerUpdateKind.LeftButtonReleased;
 			}
 		}
+
 		if (PointerOptions.HasFlag(InjectedInputPointerOptions.SecondButton))
 		{
 			if (PointerOptions.HasFlag(InjectedInputPointerOptions.PointerDown))
@@ -89,4 +91,18 @@ public partial struct InjectedInputPointerInfo
 
 		return point;
 	}
+
+	public bool Equals(InjectedInputPointerInfo other) =>
+		PointerId == other.PointerId && PointerOptions.Equals(other.PointerOptions) &&
+		PixelLocation.Equals(other.PixelLocation) &&
+		TimeOffsetInMilliseconds == other.TimeOffsetInMilliseconds && PerformanceCount == other.PerformanceCount;
+
+	public override bool Equals(object? obj) => obj is InjectedInputPointerInfo other && Equals(other);
+
+	public override int GetHashCode() => HashCode.Combine(PointerId, (int)PointerOptions, PixelLocation,
+		TimeOffsetInMilliseconds, PerformanceCount);
+
+	public static bool operator ==(InjectedInputPointerInfo left, InjectedInputPointerInfo right) => left.Equals(right);
+
+	public static bool operator !=(InjectedInputPointerInfo left, InjectedInputPointerInfo right) => !(left == right);
 }

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputRectangle.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputRectangle.cs
@@ -19,7 +19,15 @@ public partial struct InjectedInputRectangle
 
 	public override bool Equals(object? obj) => obj is InjectedInputRectangle other && Equals(other);
 
-	public override int GetHashCode() => new { Left, Top, Bottom, Right }.GetHashCode();
+	public override int GetHashCode()
+	{
+		var hashCode = -1083629557;
+		hashCode = hashCode * -1521134295 + Left.GetHashCode();
+		hashCode = hashCode * -1521134295 + Top.GetHashCode();
+		hashCode = hashCode * -1521134295 + Bottom.GetHashCode();
+		hashCode = hashCode * -1521134295 + Right.GetHashCode();
+		return hashCode;
+	}
 
 	public static bool operator ==(InjectedInputRectangle left, InjectedInputRectangle right) => left.Equals(right);
 

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputRectangle.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputRectangle.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System;
+
 namespace Windows.UI.Input.Preview.Injection;
 
 public partial struct InjectedInputRectangle
@@ -11,4 +13,15 @@ public partial struct InjectedInputRectangle
 	public int Bottom;
 
 	public int Right;
+
+	public bool Equals(InjectedInputRectangle other) =>
+		Left == other.Left && Top == other.Top && Bottom == other.Bottom && Right == other.Right;
+
+	public override bool Equals(object? obj) => obj is InjectedInputRectangle other && Equals(other);
+
+	public override int GetHashCode() => HashCode.Combine(Left, Top, Bottom, Right);
+
+	public static bool operator ==(InjectedInputRectangle left, InjectedInputRectangle right) => left.Equals(right);
+
+	public static bool operator !=(InjectedInputRectangle left, InjectedInputRectangle right) => !(left == right);
 }

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputRectangle.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputRectangle.cs
@@ -19,7 +19,7 @@ public partial struct InjectedInputRectangle
 
 	public override bool Equals(object? obj) => obj is InjectedInputRectangle other && Equals(other);
 
-	public override int GetHashCode() => HashCode.Combine(Left, Top, Bottom, Right);
+	public override int GetHashCode() => new { Left, Top, Bottom, Right }.GetHashCode();
 
 	public static bool operator ==(InjectedInputRectangle left, InjectedInputRectangle right) => left.Equals(right);
 


### PR DESCRIPTION
Updated some structs to follow CA1815 [0].

[0] https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1815