### PR TITLE
fix(animation): anomalies when quickly transitioning between multiple VisualStates of same VSGroup

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_DoubleAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_DoubleAnimationUsingKeyFrames.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_DoubleAnimationUsingKeyFrames
+{
+	[TestMethod]
+	public async Task When_Quickly_Transitions()
+	{
+		// We are mimicking Fluent-style ToggleSwitch's ToggleStates here.
+		var sut = new TestPages.QuickMultiTransitionsPage();
+		WindowHelper.WindowContent = sut;
+		await WindowHelper.WaitForLoaded(sut);
+		await Task.Delay(1000);
+
+		// Quickly play through multiple visual-states to simulate what happens when tapping(*1) on a ToggleSwitch.
+		/* *1: The full tapping experience is: [InitialState: Off]->Dragging->Off->On or [InitialState: A]->B->A->C
+		 *		where A=Off, B=Dragging, C=Off
+		 * SwitchKnobOn.Opacity	ToggleStates\AOff->COn			1 @[ControlFasterAnimationDuration] f=Linear
+		 * SwitchKnobOn.Opacity	ToggleStates\BDragging->AOff	0 @[ControlFasterAnimationDuration] f=Linear
+		 * SwitchKnobOn.Opacity	ToggleStates\BDragging->COn		1 @[ControlFasterAnimationDuration] f=Linear
+		 * SwitchKnobOn.Opacity	ToggleStates\COn->AOff			0 @[ControlFasterAnimationDuration] f=Linear
+		 * SwitchKnobOn.Opacity	ToggleStates\COn->BDragging		1 @0 f=Linear
+		 * SwitchKnobOn.Opacity	ToggleStates\COn				1 @[ControlFasterAnimationDuration] f=Linear
+		 */
+		VisualStateManager.GoToState(sut, TestPages.QuickMultiTransitionsPage.TestStateNames.PhaseB, useTransitions: true);
+		VisualStateManager.GoToState(sut, TestPages.QuickMultiTransitionsPage.TestStateNames.PhaseA, useTransitions: true);
+		VisualStateManager.GoToState(sut, TestPages.QuickMultiTransitionsPage.TestStateNames.PhaseC, useTransitions: true);
+		await WindowHelper.WaitForIdle();
+		await Task.Delay(1000);
+
+		// Given that it involves a race condition, we use a matrix of 4x4 to boost the failure rate.
+		// If everything went smoothly, the end result should be an opacity of 1 for all the borders.
+		var total = sut.RootGrid.Children.OfType<Border>().Count();
+		var passed = sut.RootGrid.Children.OfType<Border>()
+			.Count(x => x.Opacity == 1.0);
+		Assert.AreEqual(total, passed, $"Only {passed} of {total} Border.Opacity is at expected value of 1.0");
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/TestPages/QuickMultiTransitionsPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/TestPages/QuickMultiTransitionsPage.xaml
@@ -1,0 +1,502 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation.TestPages.QuickMultiTransitionsPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  x:Name="T"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<x:String x:Key="ControlFasterAnimationDuration">00:00:00.083</x:String>
+	</Page.Resources>
+
+	<Grid x:Name="RootGrid"
+		  x:FieldModifier="Public"
+		  Background="Red"
+		  MinWidth="200"
+		  MinHeight="200">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<!--
+			note: We are using a random Grid+RepositionThemeAnimation to block off the final VisualState\Storyboard from running, and
+			relying solely on VSGroup.Transition to "HoldEnd" the values.
+			The RepositionThemeAnimation is necessary here, because it is not implemented as time of this writing, so it will never complete.
+			And, VisualState::Storyboard only start when all timelines of Transition has completed.
+		-->
+		<Grid x:Name="RandomGrid" Opacity="0" />
+
+		<!-- generator:
+			from x in Enumerable.Range(0, 4)
+			from y in Enumerable.Range(0, 4)
+			select $"""<Border x:Name="B{x}{y}" Grid.Column="{x}" Grid.Row="{y}" Background="Green" Opacity="0" />"""
+		-->
+		<Border x:Name="B00"
+				Grid.Column="0"
+				Grid.Row="0"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B01"
+				Grid.Column="0"
+				Grid.Row="1"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B02"
+				Grid.Column="0"
+				Grid.Row="2"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B03"
+				Grid.Column="0"
+				Grid.Row="3"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B10"
+				Grid.Column="1"
+				Grid.Row="0"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B11"
+				Grid.Column="1"
+				Grid.Row="1"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B12"
+				Grid.Column="1"
+				Grid.Row="2"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B13"
+				Grid.Column="1"
+				Grid.Row="3"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B20"
+				Grid.Column="2"
+				Grid.Row="0"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B21"
+				Grid.Column="2"
+				Grid.Row="1"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B22"
+				Grid.Column="2"
+				Grid.Row="2"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B23"
+				Grid.Column="2"
+				Grid.Row="3"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B30"
+				Grid.Column="3"
+				Grid.Row="0"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B31"
+				Grid.Column="3"
+				Grid.Row="1"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B32"
+				Grid.Column="3"
+				Grid.Row="2"
+				Background="Green"
+				Opacity="0" />
+		<Border x:Name="B33"
+				Grid.Column="3"
+				Grid.Row="3"
+				Background="Green"
+				Opacity="0" />
+
+		<!--
+			This is built to mimic ToggleSwitch Fluent-style. For reference: // '->' indicates transition
+			SwitchKnobOn.Opacity	ToggleStates\AOff->COn			1 @[ControlFasterAnimationDuration] f=Linear
+			SwitchKnobOn.Opacity	ToggleStates\BDragging->AOff	0 @[ControlFasterAnimationDuration] f=Linear
+			SwitchKnobOn.Opacity	ToggleStates\BDragging->COn		1 @[ControlFasterAnimationDuration] f=Linear
+			SwitchKnobOn.Opacity	ToggleStates\COn->AOff			0 @[ControlFasterAnimationDuration] f=Linear
+			SwitchKnobOn.Opacity	ToggleStates\COn->BDragging		1 @0 f=Linear
+			SwitchKnobOn.Opacity	ToggleStates\COn				1 @[ControlFasterAnimationDuration] f=Linear
+		-->
+
+		<VisualStateManager.VisualStateGroups>
+			<VisualStateGroup x:Name="TestStates">
+				<!--  scenario: [InitialState: A]->B->A->C  -->
+				<!--  target value: A=0(default), B=("no change") C=1  -->
+
+				<!-- generator:
+					from source in "BAC\0"
+					from target in "BAC"
+					where source != target
+					where !(source == 'A' && target == 'B') // default reset
+					where !(source == '\0' && target != 'C')
+					select $"""
+					{(source != '\0'
+						? $"""<VisualTransition x:Name="Phase{source}Phase{target}Transition" From="Phase{source}" To="Phase{target}">"""
+						: $"""<VisualState x:Name="Phase{target}">""")}
+						<Storyboard>
+							{(source != '\0' && target != 'B' ? $"""<RepositionThemeAnimation TargetName="RandomGrid" FromHorizontalOffset="0"/>""" : "")}
+							{string.Join("\n\t\t",
+								from x in Enumerable.Range(0,4)
+								from y in Enumerable.Range(0, 4)
+								select $$"""
+								<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B{{x}}{{y}}" Storyboard.TargetProperty="Opacity">
+									<LinearDoubleKeyFrame KeyTime="{{(target == 'B' ? "0" : "{StaticResource ControlFasterAnimationDuration}")}}" Value="{{(target == 'A' ? 0 : 1)}}" />
+								</DoubleAnimationUsingKeyFrames>
+								"""
+							)}
+						</Storyboard>
+					</{(source != '\0' ? "VisualTransition" : "VisualState")}>
+					"""
+				-->
+
+				<VisualStateGroup.Transitions>
+					<VisualTransition x:Name="PhaseBPhaseATransition"
+									  From="PhaseB"
+									  To="PhaseA">
+						<Storyboard>
+							<RepositionThemeAnimation TargetName="RandomGrid" FromHorizontalOffset="0" />
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B00" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B01" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B02" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B03" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B10" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B11" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B12" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B13" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B20" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B21" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B22" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B23" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B30" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B31" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B32" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B33" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+						</Storyboard>
+					</VisualTransition>
+					<VisualTransition x:Name="PhaseBPhaseCTransition"
+									  From="PhaseB"
+									  To="PhaseC">
+						<Storyboard>
+							<RepositionThemeAnimation TargetName="RandomGrid" FromHorizontalOffset="0" />
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B00" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B01" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B02" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B03" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B10" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B11" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B12" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B13" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B20" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B21" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B22" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B23" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B30" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B31" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B32" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B33" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+						</Storyboard>
+					</VisualTransition>
+					<VisualTransition x:Name="PhaseAPhaseCTransition"
+									  From="PhaseA"
+									  To="PhaseC">
+						<Storyboard>
+							<RepositionThemeAnimation TargetName="RandomGrid" FromHorizontalOffset="0" />
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B00" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B01" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B02" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B03" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B10" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B11" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B12" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B13" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B20" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B21" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B22" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B23" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B30" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B31" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B32" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B33" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+						</Storyboard>
+					</VisualTransition>
+					<VisualTransition x:Name="PhaseCPhaseBTransition"
+									  From="PhaseC"
+									  To="PhaseB">
+						<Storyboard>
+
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B00" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B01" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B02" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B03" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B10" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B11" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B12" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B13" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B20" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B21" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B22" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B23" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B30" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B31" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B32" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B33" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="0" Value="1" />
+							</DoubleAnimationUsingKeyFrames>
+						</Storyboard>
+					</VisualTransition>
+					<VisualTransition x:Name="PhaseCPhaseATransition"
+									  From="PhaseC"
+									  To="PhaseA">
+						<Storyboard>
+							<RepositionThemeAnimation TargetName="RandomGrid" FromHorizontalOffset="0" />
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B00" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B01" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B02" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B03" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B10" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B11" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B12" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B13" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B20" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B21" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B22" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B23" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B30" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B31" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B32" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+							<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B33" Storyboard.TargetProperty="Opacity">
+								<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="0" />
+							</DoubleAnimationUsingKeyFrames>
+						</Storyboard>
+					</VisualTransition>
+				</VisualStateGroup.Transitions>
+
+				<VisualState x:Name="PhaseA" />
+				<VisualState x:Name="PhaseB" />
+				<VisualState x:Name="PhaseC">
+					<Storyboard>
+
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B00" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B01" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B02" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B03" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B10" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B11" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B12" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B13" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B20" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B21" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B22" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B23" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B30" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B31" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B32" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+						<DoubleAnimationUsingKeyFrames Storyboard.TargetName="B33" Storyboard.TargetProperty="Opacity">
+							<LinearDoubleKeyFrame KeyTime="{StaticResource ControlFasterAnimationDuration}" Value="1" />
+						</DoubleAnimationUsingKeyFrames>
+					</Storyboard>
+				</VisualState>
+			</VisualStateGroup>
+		</VisualStateManager.VisualStateGroups>
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/TestPages/QuickMultiTransitionsPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/TestPages/QuickMultiTransitionsPage.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation.TestPages;
+
+public sealed partial class QuickMultiTransitionsPage : Page
+{
+	public static class TestStateNames
+	{
+		public const string PhaseA = nameof(PhaseA);
+		public const string PhaseB = nameof(PhaseB);
+		public const string PhaseC = nameof(PhaseC);
+	}
+
+	public QuickMultiTransitionsPage()
+	{
+		this.InitializeComponent();
+		this.Loaded += (s, e) => VisualStateManager.GoToState(this, TestStateNames.PhaseA, useTransitions: true);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimationUsingKeyFrames.cs
@@ -15,6 +15,8 @@ namespace Windows.UI.Xaml.Media.Animation
 	partial class ColorAnimationUsingKeyFrames : Timeline, ITimeline
 	{
 		private readonly Stopwatch _activeDuration = new Stopwatch();
+		private bool _wasBeginScheduled;
+		private bool _wasRequestedToStop;
 		private int _replayCount = 1;
 		private ColorOffset? _startingValue;
 		private ColorOffset _finalValue;
@@ -79,7 +81,6 @@ namespace Windows.UI.Xaml.Media.Animation
 			return base.GetCalculatedDuration();
 		}
 
-		bool _wasBeginScheduled;
 		void ITimeline.Begin()
 		{
 			if (!_wasBeginScheduled)
@@ -87,7 +88,9 @@ namespace Windows.UI.Xaml.Media.Animation
 				// We dispatch the begin so that we can use bindings on ColorKeyFrame.Value from RelativeParent.
 				// This works because the template bindings are executed just after the constructor.
 				// WARNING: This does not allow us to bind ColorKeyFrame.Value with ViewModel properties.
+
 				_wasBeginScheduled = true;
+				_wasRequestedToStop = false;
 
 #if !NET461
 #if __ANDROID__
@@ -97,14 +100,17 @@ namespace Windows.UI.Xaml.Media.Animation
 #endif
 #endif
 				{
-					if (KeyFrames.Count < 1)
+					_wasBeginScheduled = false;
+
+					if (KeyFrames.Count < 1 || // nothing to do
+						_wasRequestedToStop // was requested to stop, between Begin() and dispatched here
+					)
 					{
-						return; // nothing to do
+						return;
 					}
 
 					PropertyInfo?.CloneShareableObjectsInPath();
 
-					_wasBeginScheduled = false;
 					_activeDuration.Restart();
 					_replayCount = 1;
 
@@ -207,7 +213,9 @@ namespace Windows.UI.Xaml.Media.Animation
 				_currentAnimator.Cancel();//Stop the animator if it is running
 				_startingValue = null;
 			}
+
 			State = TimelineState.Stopped;
+			_wasRequestedToStop = true;
 		}
 
 		void ITimeline.Stop()
@@ -215,7 +223,9 @@ namespace Windows.UI.Xaml.Media.Animation
 			_currentAnimator?.Cancel(); // stop could be called before the initialization
 			_startingValue = null;
 			ClearValue();
+
 			State = TimelineState.Stopped;
+			_wasRequestedToStop = true;
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
@@ -114,8 +114,8 @@ namespace Windows.UI.Xaml.Media.Animation
 				);
 			}
 
-			// We explicitly call the Stop of the _frameScheduler befire teh Reste dispose it,
-			// so the EndReason will stopped instead of Aborted
+			// We explicitly call the Stop of the _frameScheduler before the Reset dispose it,
+			// so the EndReason will be Stopped instead of Aborted.
 			_frameScheduler?.Stop();
 
 			Reset();

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
@@ -114,6 +114,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		private void Play()
 		{
+			_runningChildren = 0;
 			if (Children != null && Children.Count > 0)
 			{
 				for (int i = 0; i < Children.Count; i++)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8636, shadowing #12050, closes #11979

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Animation cannot be stopped/deactivated while it being scheduled for start.

## What is the new behavior?
Animation stopped/deactivated while it is scheduled for start, will be properly prevented from running.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Various `Timeline` implementations/derived `Begin`s on the dispatcher, and when asked to `Deactivate`/`Stop`, we rely on the associated animator to do so. So when you attempt to cancel an animation right after having started it, the canceling won't go through as the animator is still unassigned.
And, we ended up with situation like in ToggleSwitch where both DraggingToOffTransition+OffToOnTransition are both running, instead of having the former being canceled, and their children timelines each competing for their respective properties. Which ones completing the last become the *sticky* values, and since they are dispatched there is no guarantee on which will. This can be observed when you keep spawning a new ToggleSwitch and tap it once, the resulting visual is pure random.