### PR TITLE
fix: Ensure Commands are executed when RadioButton is toggled through AutomationPeer

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioButton.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioButton.cs
@@ -385,10 +385,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 	}
 
-#pragma warning disable CS0067
 	public class TestCommand : ICommand
 	{
-		public event EventHandler CanExecuteChanged;
+		public event EventHandler CanExecuteChanged { add { } remove { } }
 		public event EventHandler CommandFired;
 
 		public TestCommand()
@@ -402,5 +401,4 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		public void Execute(object o) => CommandFired.Invoke(this, null);
 	}
-#pragma warning restore CS0067
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioButton.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioButton.cs
@@ -1,7 +1,11 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using FluentAssertions;
+using Microsoft.UI.Xaml.Tests.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using static Private.Infrastructure.TestServices;
 
@@ -341,5 +345,62 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.IsFalse(radioButtonNull2.IsChecked);
 		}
+
+		[TestMethod]
+		public async Task When_AutomationPeer_Toggle()
+		{
+			var radioButton = new RadioButton();
+
+			WindowHelper.WindowContent = radioButton;
+
+			await WindowHelper.WaitForIdle();
+
+			using (var clickEvent = new EventTester<RadioButton, RoutedEventArgs>(radioButton, "Click"))
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(radioButton) as RadioButtonAutomationPeer;
+				peer.Toggle();
+
+				Assert.IsTrue(await clickEvent.WaitAsync(TimeSpan.FromSeconds(3)));
+			}
+		}
+
+		[TestMethod]
+		public async Task When_AutomationPeer_Toggle_With_Command()
+		{
+			var radioButton = new RadioButton();
+			var command = new TestCommand();
+			radioButton.Command = command;
+
+			WindowHelper.WindowContent = radioButton;
+
+			await WindowHelper.WaitForIdle();
+
+			using (var commandFired = new EventTester<TestCommand, EventArgs>(command, "CommandFired"))
+			{
+				var peer = FrameworkElementAutomationPeer.CreatePeerForElement(radioButton) as RadioButtonAutomationPeer;
+				peer.Toggle();
+
+				Assert.IsTrue(await commandFired.WaitAsync(TimeSpan.FromSeconds(3)));
+			}
+		}
 	}
+
+#pragma warning disable CS0067
+	public class TestCommand : ICommand
+	{
+		public event EventHandler CanExecuteChanged;
+		public event EventHandler CommandFired;
+
+		public TestCommand()
+		{
+		}
+
+		public bool CanExecute(object o)
+		{
+			return true;
+		}
+
+		public void Execute(object o) => CommandFired.Invoke(this, null);
+	}
+#pragma warning restore CS0067
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.cs
@@ -101,6 +101,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public void OnTemplateRecycled() => IsChecked = false;
 
-		internal void AutomationPeerToggle() => OnToggle();
+		internal void AutomationPeerToggle() => OnClick();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.mux.cs
@@ -187,7 +187,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		}
 
 		/// <summary>
-		/// Raises the Click routed event.
+		/// Toggles the IsChecked state.
 		/// </summary>
 		private void OnToggleImpl()
 		{


### PR DESCRIPTION
closes #10557 


## PR Type

What kind of change does this PR introduce?
- Bugfix

