### PR TITLE
fix(hr): Adjust Page reload for custom frame presenter

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -211,7 +211,11 @@ namespace Uno.UI.RemoteControl.HotReload
 				// In the case of Page, swapping the actual page is not supported, so we
 				// need to swap the content of the page instead. This can happen if the Frame
 				// is using a native presenter which does not use the `Frame.Content` property.
-				oldPage.DataContext = null;
+
+				// Clear any local context, so that the new page can inherit the value coming
+				// from the parent Frame. It may happen if the old page set it explicitly.
+				oldPage.ClearValue(Page.DataContextProperty, DependencyPropertyValuePrecedences.Local);
+
 				oldPage.Content = newPage;
 				newPage.Frame = oldPage.Frame;
 			}

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -206,6 +206,15 @@ namespace Uno.UI.RemoteControl.HotReload
 			{
 				parentAsContentControl.Content = newView;
 			}
+			else if (newView is Page newPage && oldView is Page oldPage)
+			{
+				// In the case of Page, swapping the actual page is not supported, so we
+				// need to swap the content of the page instead. This can happen if the Frame
+				// is using a native presenter which does not use the `Frame.Content` property.
+				oldPage.DataContext = null;
+				oldPage.Content = newPage;
+				newPage.Frame = oldPage.Frame;
+			}
 			else
 			{
 				VisualTreeHelper.SwapViews(oldView, newView);

--- a/src/Uno.UI/UI/Xaml/Application.Components.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Components.cs
@@ -21,6 +21,13 @@ namespace Windows.UI.Xaml
 			{
 				XamlReader.LoadUsingComponent(document, component);
 			}
+			else
+			{
+				if (typeof(VisualTreeHelper).Log().IsEnabled(LogLevel.Debug))
+				{
+					typeof(VisualTreeHelper).Log().LogDebug($"Skipping component load, could not find registration for {resourceLocator}");
+				}
+			}
 		}
 
 		internal static void RegisterComponent(Uri resourceLocator, string xaml)

--- a/src/Uno.UI/UI/Xaml/Application.Components.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Components.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Windows.UI.Xaml.Markup;
+using Uno.Foundation.Logging;
 
 namespace Windows.UI.Xaml
 {
@@ -23,9 +24,9 @@ namespace Windows.UI.Xaml
 			}
 			else
 			{
-				if (typeof(VisualTreeHelper).Log().IsEnabled(LogLevel.Debug))
+				if (typeof(Application).Log().IsEnabled(LogLevel.Debug))
 				{
-					typeof(VisualTreeHelper).Log().LogDebug($"Skipping component load, could not find registration for {resourceLocator}");
+					typeof(Application).Log().LogDebug($"Skipping component load, could not find registration for {resourceLocator}");
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.iOSmacOS.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Uno.Foundation.Logging;
+
 #if __IOS__
 using UIKit;
 using _View = UIKit.UIView;
@@ -30,6 +32,13 @@ namespace Windows.UI.Xaml.Media
 #elif __MACOS__
 				currentSuperview?.AddSubview(newView, NSWindowOrderingMode.Above, currentSuperview.Subviews[Math.Max(0, currentPosition - 1)]);
 #endif
+			}
+			else
+			{
+				if (typeof(VisualTreeHelper).Log().IsEnabled(LogLevel.Debug))
+				{
+					typeof(VisualTreeHelper).Log().LogDebug($"Unable to swap view, could not find old view's position.");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes Page hot reload on targets which are using native `Frame` presenters, which can cause the Frame to become empty.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
