### PR TITLE
fix: Dancing Skia `ScrollViewers`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -448,7 +448,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var content = new TextBlock()
 			{
 				Text = "Hello",
-				FontSize = 13.621,
+				FontSize = 26.756,
 				UseLayoutRounding = false
 			};
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -435,6 +435,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(320, outerScrollViewer.VerticalOffset);
 		}
 
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_NonRound_Content_Height()
+		{
+			var outerScrollViewer = new ScrollViewer()
+			{
+				Background = new SolidColorBrush(Colors.Yellow)
+			};
+
+			var content = new TextBlock()
+			{
+				Text = "Hello",
+				FontSize = 13.621,
+				UseLayoutRounding = false
+			};
+
+			outerScrollViewer.Content = content;
+
+			WindowHelper.WindowContent = outerScrollViewer;
+			await WindowHelper.WaitForLoaded(outerScrollViewer);
+			Assert.AreEqual(outerScrollViewer.ExtentHeight, outerScrollViewer.ViewportHeight, 0.000001);
+		}
+
 #if __ANDROID__
 		[TestMethod]
 		[RunsOnUIThread]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
@@ -94,8 +94,8 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  bool UseLayoutRounding
 		{
 			get
@@ -554,8 +554,8 @@ namespace Windows.UI.Xaml
 		// Skipping already declared property RightTappedEvent
 		// Skipping already declared property DragEnterEvent
 		// Skipping already declared property TappedEvent
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty UseLayoutRoundingProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			nameof(UseLayoutRounding), typeof(bool), 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -956,7 +956,7 @@ namespace Windows.UI.Xaml
 		internal bool GetUseLayoutRounding()
 		{
 #if __SKIA__
-			return true;
+			return UseLayoutRounding;
 #else
 			return false;
 #endif

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -41,6 +41,19 @@ namespace Windows.UI.Xaml
 			UpdateHitTest();
 		}
 
+		public bool UseLayoutRounding
+		{
+			get => (bool)this.GetValue(UseLayoutRoundingProperty);
+			set => this.SetValue(UseLayoutRoundingProperty, value);
+		}
+
+		public static DependencyProperty UseLayoutRoundingProperty { get; } =
+			DependencyProperty.Register(
+				nameof(UseLayoutRounding),
+				typeof(bool),
+				typeof(UIElement),
+				new FrameworkPropertyMetadata(true));
+
 		internal bool IsChildrenRenderOrderDirty { get; set; } = true;
 
 		partial void InitializeKeyboard();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8932, closes #11066, closes #7514

Related to #7544

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Applies to Material TextBoxes, Flyouts, Popups, other stuff - in general - anything that used ScrollViewer in some specific cases. Layout rounding not supported anywhere except Skia - and there it is supported only very partially - and that is a big problem - for example Grid does tap into this for its layout, but things like Measure and Arrange don't. As a result, what did happen was that ScrollViewer was checking the ScrollContentPresenter's ActualHeight which was layout rounded, because the child Grid underneath made it so, but on the other hand it used ViewportHeight which was not rounded - as a result, it assumed the content is scrollable (because of those few random decimal numbers difference, and it made the ScrollBars to show up. But after they showed up, in the next layout run it found out the bars were not needed after all and hid them and and the cycle repeated. Workaround for now is to make ScrollViewer to apply UseLayoutRounding false on its child Grid for now, but the proper fix will be to implement layout rounding everywhere, which is what I would love to look into next, as it will probably fix a lot of unpredicatable and hard to debug issues.

## What is the new behavior?

- Previous rounding workaround was undone and replaced with a more robust change
- `ScrollViewer` explicitly sets its child `Grid` to not layout round


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.