### PR TITLE
feat: Remove the Edge Visual Search from WASM

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Image/HtmlImage.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/HtmlImage.wasm.cs
@@ -8,5 +8,7 @@ public class HtmlImage : UIElement
 	{
 		// Avoid the "drag effect" which is set by default in browsers
 		SetAttribute("draggable", "false");
+		HitTestVisibility = HitTestability.Invisible;
+		IsHitTestVisible = false;
 	}
 }

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -174,6 +174,7 @@ embed.uno-frameworkelement.uno-unarranged {
   user-select: none;
   -webkit-user-drag: none;
   user-drag: none;
+  pointer-events: none;
 }
 
 .uno-scrollcontentpresenter {

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -174,7 +174,6 @@ embed.uno-frameworkelement.uno-unarranged {
   user-select: none;
   -webkit-user-drag: none;
   user-drag: none;
-  pointer-events: none;
 }
 
 .uno-scrollcontentpresenter {


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11783

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

 Code style update (formatting)



## What is the current behavior?

It is showing us a Visual Search in the edge.


## What is the new behavior?

Now there will be no more visual search on the wasm


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
