### PR TITLE
chore: Reset dir and trace on error, and open browser when served

### DIFF
--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -19,6 +19,11 @@ function Assert-ExitCodeIsZero()
 {
     if ($LASTEXITCODE -ne 0)
     {
+        popd
+        popd
+
+        Set-PSDebug -Off
+
         throw "Exit code must be zero."
     }
 }

--- a/doc/import_external_docs_test.ps1
+++ b/doc/import_external_docs_test.ps1
@@ -20,6 +20,11 @@ function Assert-ExitCodeIsZero()
 {
     if ($LASTEXITCODE -ne 0)
     {
+        popd
+        popd
+
+        Set-PSDebug -Off
+
         throw "Exit code must be zero."
     }
 }
@@ -59,4 +64,4 @@ docfx
 
 Assert-ExitCodeIsZero
 
-dotnet-serve
+dotnet-serve --open-browser


### PR DESCRIPTION
## PR Type

- Build or CI related changes
- Documentation content changes

## What is the current behavior?

Minor fixes to *import_external_docs.ps1* and *import_external_docs_test.ps1*

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] Contains **NO** breaking changes

## Other information

Related: https://github.com/unoplatform/uno.extensions/pull/1412