### PR TITLE
fix(itemsRepeater): IR might not re-subscribe to the EVPChanged event on load

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI;
@@ -115,6 +116,55 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 			sut.Children.Count.Should().BeGreaterThan(1);
 		}
 #endif
+
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if !HAS_UNO
+		[Ignore("Custom behavior of uno")]
+#elif __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task When_UnloadAndReload_Then_UnsubscribeAndResubscribeToEffectiveViewportChanged()
+		{
+			var evt = typeof(FrameworkElement).GetField("_effectiveViewportChanged", BindingFlags.Instance | BindingFlags.NonPublic)
+				?? throw new InvalidOperationException("Cannot find the private event backing field.");
+
+			var sut = default(ItemsRepeater);
+			var root = new Border
+			{
+				Child = (sut = new ItemsRepeater
+				{
+					ItemsSource = Enumerable.Range(0, 10).Select(i => $"Item #{i}"),
+					Layout = new StackLayout { Orientation = Orientation.Horizontal },
+					ItemTemplate = new DataTemplate(() => new Border
+					{
+						Width = 100,
+						Height = 100,
+						Background = new SolidColorBrush(Colors.DeepSkyBlue),
+						Margin = new Thickness(10),
+						Child = new TextBlock().Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding()))
+					})
+				})
+			};
+
+			TestServices.WindowHelper.WindowContent = root;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			evt.GetValue(sut).Should().NotBeNull();
+
+			// Unload the IR
+			root.Child = new TextBlock { Text = "IR unloaded" };
+			await TestServices.WindowHelper.WaitForIdle();
+
+			evt.GetValue(sut).Should().BeNull("the ViewportManagerWithPlatformFeatures should have remove handler in the ResetScrollers method");
+
+			// Load again IR
+			root.Child = sut;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			evt.GetValue(sut).Should().NotBeNull("the IR should have invalidate it's measure, causing a layout pass driving to invoke the ViewportManagerWithPlatformFeatures.EnsureScroller which should have re-added handler");
+		}
 
 		private async Task RetryAssert(Action assertion)
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
@@ -608,9 +608,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 		void OnLoaded(object sender, RoutedEventArgs args)
 		{
+#if !HAS_UNO // With uno we always detach from the scroller on unload so we need to force a layouting pass to re-subscribe to scroller and update viewport (in a single pass)
 			// If we skipped an unload event, reset the scrollers now and invalidate measure so that we get a new
 			// layout pass during which we will hookup new scrollers.
 			if (_loadedCounter > _unloadedCounter)
+#endif
 			{
 				InvalidateMeasure();
 				m_viewportManager.ResetScrollers();
@@ -646,8 +648,11 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			_stackLayoutMeasureCounter = 0u;
 			++_unloadedCounter;
+
+#if !HAS_UNO // Avoids leak and useless as we are not validating such count in the loaded
 			// Only reset the scrollers if this unload event is in-sync.
 			if (_unloadedCounter == _loadedCounter)
+#endif
 			{
 				m_viewportManager.ResetScrollers();
 			}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.chefs/issues/443

## Bugfix
`ItemsRepeater` might not re-subscribe to the EVPChanged event on load

## What is the current behavior?
Due to measure caching, the IR might not be re-measured on re-load, but the subscription to the `EffectiveViewportChanged` event is done on first measure.

## What is the new behavior?
Measure is invalidated on load to force the layout engine to measure the IR so will restore its state properly.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
