### PR TITLE
fix: Do not throw for already disposed callbacks

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
@@ -1389,7 +1389,7 @@ namespace Uno.UI.Tests.BinderTests
 
 			void OnBrushChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
 			{
-				disposable2 = brush.RegisterDisposablePropertyChangedCallback(OnInnerCallbackBrushChanged);
+				disposable2 = brush.RegisterDisposablePropertyChangedCallback(OnInnerAddCallbackBrushChanged);
 			}
 
 			brush.Color = Colors.Red;
@@ -1398,9 +1398,34 @@ namespace Uno.UI.Tests.BinderTests
 			disposable2?.Dispose();
 		}
 
-		private void OnInnerCallbackBrushChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+		private void OnInnerAddCallbackBrushChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
 		{
 			Assert.Fail();
+		}
+
+		[TestMethod]
+		public void When_RemoveCallback_OnPropertyChanged()
+		{
+			var brush = new SolidColorBrush();
+			IDisposable disposable = null;
+			IDisposable disposable2 = null;
+			disposable = brush.RegisterDisposablePropertyChangedCallback(OnBrushChanged);
+			disposable2 = brush.RegisterDisposablePropertyChangedCallback(OnInnerRemoveCallbackBrushChanged);
+
+			void OnBrushChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+			{
+				disposable2.Dispose();
+			}
+
+			Action act = () => brush.Color = Colors.Red;
+			act.Should().NotThrow();
+
+			disposable?.Dispose();
+			disposable2?.Dispose();
+		}
+
+		private void OnInnerRemoveCallbackBrushChanged(ManagedWeakReference instance, DependencyProperty property, DependencyPropertyChangedEventArgs args)
+		{
 		}
 
 		[TestMethod]
@@ -1410,13 +1435,13 @@ namespace Uno.UI.Tests.BinderTests
 			var secondParent = new Windows.UI.Xaml.Controls.Border();
 			var border = new Windows.UI.Xaml.Controls.Border();
 			firstParent.Child = border;
+
 			IDisposable disposable = null;
 			IDisposable disposable2 = null;
-			border.RegisterParentChangedCallback(1, OnParentChangedCallback);
-
+			disposable = border.RegisterParentChangedCallback(1, OnParentChangedCallback);
 			void OnParentChangedCallback(object instance, object key, DependencyObjectParentChangedEventArgs args)
 			{
-				border.RegisterParentChangedCallback(2, OnInnerParentChangedCallback);
+				disposable2 = border.RegisterParentChangedCallback(2, OnInnerAddParentChangedCallback);
 			}
 
 			firstParent.Child = null;
@@ -1425,9 +1450,36 @@ namespace Uno.UI.Tests.BinderTests
 			disposable2?.Dispose();
 		}
 
-		private void OnInnerParentChangedCallback(object instance, object key, DependencyObjectParentChangedEventArgs args)
+		private void OnInnerAddParentChangedCallback(object instance, object key, DependencyObjectParentChangedEventArgs args)
 		{
 			Assert.Fail();
+		}
+
+		[TestMethod]
+		public void When_RemoveParentChanged_OnParentChanged()
+		{
+			var firstParent = new Windows.UI.Xaml.Controls.Border();
+			var secondParent = new Windows.UI.Xaml.Controls.Border();
+			var border = new Windows.UI.Xaml.Controls.Border();
+			firstParent.Child = border;
+			IDisposable disposable = null;
+			IDisposable disposable2 = null;
+			disposable = border.RegisterParentChangedCallback(1, OnParentChangedCallback);
+			disposable2 = border.RegisterParentChangedCallback(2, OnInnerAddParentChangedCallback);
+			void OnParentChangedCallback(object instance, object key, DependencyObjectParentChangedEventArgs args)
+			{
+				disposable2.Dispose();
+			}
+
+			Action act = () => firstParent.Child = null;
+			act.Should().NotThrow();
+
+			disposable?.Dispose();
+			disposable2?.Dispose();
+		}
+
+		private void OnInnerRemoveParentChangedCallback(object instance, object key, DependencyObjectParentChangedEventArgs args)
+		{
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -993,7 +993,7 @@ namespace Windows.UI.Xaml
 				var weakCallbackRef = WeakReferencePool.RentWeakReference(this, callback);
 
 				ParentChangedCallback weakCallback =
-					(s, _, e) => (weakCallbackRef.Target as ParentChangedCallback)?.Invoke(s, key, e);
+					(s, _, e) => (!weakCallbackRef.IsDisposed ? weakCallbackRef.Target as ParentChangedCallback : null)?.Invoke(s, key, e);
 
 				_parentChangedCallbacks = _parentChangedCallbacks.Add(weakCallback);
 
@@ -1761,7 +1761,7 @@ namespace Windows.UI.Xaml
 			var wr = WeakReferencePool.RentWeakReference(null, callback);
 
 			weakDelegate =
-				(instance, s, e) => (wr.Target as ExplicitPropertyChangedCallback)?.Invoke(instance, s, e);
+				(instance, s, e) => (!wr.IsDisposed ? wr.Target as ExplicitPropertyChangedCallback : null)?.Invoke(instance, s, e);
 
 			weakRelease = new WeakReferenceReturnDisposable(wr);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

If a callback removes another one, which is scheduled to be invoked, `ObjectDisposedException` is thrown.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

Does not happen


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
