### PR TITLE
fix(ItemsControl): desync from modifying ItemsSource of non-INCC/IObservableVector source

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/ViewModelBase.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/ViewModelBase.cs
@@ -10,7 +10,7 @@ namespace Uno.UI.RuntimeTests.Helpers
 	{
 		public event PropertyChangedEventHandler PropertyChanged;
 
-		protected void RaiseAndSetIfChanged<T>(ref T backingField, T value, [CallerMemberName] string propertyName = null)
+		protected void SetAndRaiseIfChanged<T>(ref T backingField, T value, [CallerMemberName] string propertyName = null)
 		{
 			if (!EqualityComparer<T>.Default.Equals(backingField, value))
 			{

--- a/src/Uno.UI.RuntimeTests/Helpers/ViewModelBase.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/ViewModelBase.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+using System.Runtime.CompilerServices;
+
+namespace Uno.UI.RuntimeTests.Helpers
+{
+	public class ViewModelBase : INotifyPropertyChanged
+	{
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected void RaiseAndSetIfChanged<T>(ref T backingField, T value, [CallerMemberName] string propertyName = null)
+		{
+			if (!EqualityComparer<T>.Default.Equals(backingField, value))
+			{
+				backingField = value;
+				RaisePropertyChanged(propertyName);
+			}
+		}
+
+		internal void RaisePropertyChanged(string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.cs
@@ -95,7 +95,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var items = new[] { "item 1", "item 2", "item 3" };
 			foreach (var control in DerivedStyledControlsInstances)
 			{
-				var templateSelector = new KeyedTemplateSelector
+				var templateSelector = new Given_ListViewBase.KeyedTemplateSelector
 				{
 					Templates =
 					{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -1,11 +1,26 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Private.Infrastructure;
+using Uno.Extensions;
+using Uno.UI.RuntimeTests.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.ListViewPages;
+
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -16,32 +31,12 @@ using AppKit;
 #else
 using Uno.UI;
 #endif
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
+
 using static Private.Infrastructure.TestServices;
-using Windows.Foundation;
-using Windows.UI;
-using Windows.UI.Xaml.Media;
-using FluentAssertions;
-using FluentAssertions.Execution;
-using Uno.Extensions;
-using Uno.UI.RuntimeTests.Helpers;
-using System.Runtime.CompilerServices;
-using Windows.UI.Xaml.Data;
-using Uno.UI.RuntimeTests.Extensions;
-using Windows.UI.Xaml.Input;
-using System.Runtime.InteropServices.WindowsRuntime;
-using System.Diagnostics;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
-	[TestClass]
-	[RunsOnUIThread]
-#if __MACOS__
-	[Ignore("Currently fails on macOS, part of #9282! epic")]
-#endif
-	public partial class Given_ListViewBase
+	public partial class Given_ListViewBase // resources
 	{
 		private ResourceDictionary _testsResources;
 
@@ -84,7 +79,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		private DataTemplate BoundHeightItemTemplate => _testsResources["BoundHeightItemTemplate"] as DataTemplate;
 
 		private DataTemplate ReuseCounterItemTemplate => _testsResources["ReuseCounterItemTemplate"] as DataTemplate;
+	}
 
+	[TestClass]
+	[RunsOnUIThread]
+#if __MACOS__
+	[Ignore("Currently fails on macOS, part of #9282! epic")]
+#endif
+	public partial class Given_ListViewBase // test cases
+	{
 		[TestInitialize]
 		public void Init()
 		{
@@ -265,7 +268,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual("item 0", tb?.Text);
 		}
 
-
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_IsItsOwnItemContainer_FromSource()
@@ -365,7 +367,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsInstanceOfType(parent, typeof(ListView));
 		}
 #endif
-
 
 		[TestMethod]
 		[RunsOnUIThread]
@@ -721,46 +722,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 			ListViewItem lvi = null;
 			await WindowHelper.WaitFor(() => (lvi = page.SubjectListView.ContainerFromItem("One") as ListViewItem) != null);
-		}
-
-		private static ContentControl[] GetPanelVisibleChildren(ListViewBase list)
-		{
-#if __ANDROID__ || __IOS__
-			return list
-				.GetItemsPanelChildren()
-				.OfType<ContentControl>()
-				.ToArray();
-#else
-			return list.ItemsPanelRoot
-				.Children
-				.OfType<ContentControl>()
-				.Where(c => c.Visibility == Visibility.Visible) // Managed ItemsStackPanel currently uses the dirty trick of leaving reyclable items attached to panel and collapsed
-				.ToArray();
-#endif
-		}
-
-		private static ContentControl[] GetAllPanelChildren(ListViewBase list)
-		{
-#if __ANDROID__
-			return list
-				.GetItemsPanelChildren()
-				.OfType<ContentControl>()
-				.ToArray();
-#elif __IOS__
-			return list
-				.GetItemsPanelChildren()
-				.OfType<ContentControl>()
-				// iOS does not seem to provide to exclude the recycled items, so we mark
-				// then using IsDisplayed.
-				.Where(c => c.Superview?.Superview is ListViewBaseInternalContainer container && container.IsDisplayed)
-				.ToArray();
-#else
-			return list.ItemsPanelRoot
-				.Children
-				.OfType<ContentControl>()
-				.Where(c => c.Visibility == Visibility.Visible) // Managed ItemsStackPanel currently uses the dirty trick of leaving reyclable items attached to panel and collapsed
-				.ToArray();
-#endif
 		}
 
 		[TestMethod]
@@ -1209,16 +1170,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			dataContextChanged.Should().BeLessThan(35, $"dataContextChanged {dataContextChanged}");
 		}
 #endif
-
-		private static double GetTop(FrameworkElement element, FrameworkElement container)
-		{
-			if (element == null)
-			{
-				return double.NaN;
-			}
-			var transform = element.TransformToVisual(container);
-			return transform.TransformPoint(new Point()).Y;
-		}
 
 		[TestMethod]
 		[RunsOnUIThread]
@@ -2471,11 +2422,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
-		private record TestReleaseObject()
-		{
-			public byte[] test { get; set; } = new byte[1024 * 1024 * 2];
-		}
-
 		[TestMethod]
 		public async Task When_Item_Removed_Then_DataContext_Released()
 		{
@@ -2800,55 +2746,202 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.IsNotNull(vsg, "VisualStateGroup[Name=MultiSelectStates] was not found.");
 			Assert.AreEqual(vsg.CurrentState?.Name, "MultiSelectEnabled");
 		}
+	}
 
-		private bool ApproxEquals(double value1, double value2) => Math.Abs(value1 - value2) <= 2;
-
-		private async Task AssertCollectedReference(WeakReference reference)
+	public partial class Given_ListViewBase // data class, data-context, view-model, template-selector
+	{
+		public class KeyedTemplateSelector : DataTemplateSelector
 		{
-			var sw = Stopwatch.StartNew();
-			while (sw.Elapsed < TimeSpan.FromSeconds(3))
-			{
-				GC.Collect(2);
-				GC.WaitForPendingFinalizers();
+			public IDictionary<object, DataTemplate> Templates { get; } = new Dictionary<object, DataTemplate>();
 
-				if (!reference.IsAlive)
+			protected override DataTemplate SelectTemplateCore(object item, DependencyObject container) => SelectTemplateCore(item); // On UWP only this overload is called when eg Button.ContentTemplateSelector is set
+
+			protected override DataTemplate SelectTemplateCore(object item)
+			{
+				if (item == null)
 				{
-					return;
+					return null;
 				}
 
-				await Task.Delay(100);
+				var template = Templates.UnoGetValueOrDefault(item);
+				return template;
 			}
-
-			Assert.IsFalse(reference.IsAlive);
 		}
 
-		#region Helper classes
-		private class When_Removed_From_Tree_And_Selection_TwoWay_Bound_DataContext : System.ComponentModel.INotifyPropertyChanged
+		public class KeyedTemplateSelector<T> : DataTemplateSelector
 		{
-			public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+			private readonly Func<object, T> _keySelector;
 
+			public KeyedTemplateSelector(Func<object, T> keySelector = null)
+			{
+				this._keySelector = keySelector;
+			}
+
+			public IDictionary<T, DataTemplate> Templates { get; } = new Dictionary<T, DataTemplate>();
+
+			protected override DataTemplate SelectTemplateCore(object item, DependencyObject container) => SelectTemplateCore(item); // On UWP only this overload is called when eg Button.ContentTemplateSelector is set
+
+			protected override DataTemplate SelectTemplateCore(object item)
+			{
+				if (item == null)
+				{
+					return null;
+				}
+
+				T itemT;
+				if (_keySelector != null)
+				{
+					itemT = _keySelector(item);
+				}
+				else if (item is T)
+				{
+					itemT = (T)item;
+				}
+				else
+				{
+					return null;
+				}
+
+				var template = Templates.UnoGetValueOrDefault(itemT);
+				return template;
+			}
+		}
+
+		public enum ItemColor
+		{
+			None,
+			Red,
+			Green,
+			Beige
+		}
+
+		public class ItemColorViewModel
+		{
+			public ItemColor ItemType { get; set; }
+			public int ItemIndex { get; set; }
+			public string DisplayString => $"Item {ItemIndex}";
+		}
+
+		public class ItemHeightViewModel : ViewModelBase
+		{
+			private string _displayString;
+			private double _itemHeight;
+
+			public string DisplayString
+			{
+				get => _displayString;
+				set => RaiseAndSetIfChanged(ref _displayString, value);
+			}
+
+			public double ItemHeight
+			{
+				get => _itemHeight;
+				set => RaiseAndSetIfChanged(ref _itemHeight, value);
+			}
+		}
+
+		public class SourceAwareItem
+		{
+			public int No { get; set; }
+
+			public override string ToString() => $"Item {No}";
+		}
+
+		public class SourceAwareSelector : DataTemplateSelector
+		{
+			private readonly IList<SourceAwareItem> _itemsSource;
+			public DataTemplate _dataTemplateA;
+			private readonly DataTemplate _dataTemplateB;
+
+			public Exception Exception { get; private set; }
+
+			public SourceAwareSelector(IList<SourceAwareItem> itemsSource, DataTemplate dataTemplateA, DataTemplate dataTemplateB)
+			{
+				_itemsSource = itemsSource;
+				_dataTemplateA = dataTemplateA;
+				_dataTemplateB = dataTemplateB;
+			}
+
+			protected override DataTemplate SelectTemplateCore(object item)
+			{
+				if (
+#if __IOS__
+				// On iOS, the template selector may be invoked with a null item. This is arguably also a bug, but not presently under test here.
+				item != null &&
+#endif
+						!_itemsSource.Contains(item)
+				)
+				{
+					var ex = new InvalidOperationException($"Selector called for item not in source ({item})");
+					Exception = Exception ?? ex;
+					throw ex;
+				}
+
+				if (item is SourceAwareItem dataItem && dataItem.No > 2)
+				{
+					return _dataTemplateB;
+				}
+
+				else
+				{
+					return _dataTemplateA;
+				}
+			}
+		}
+
+		public class InfiniteSource<T> : ObservableCollection<T>, ISupportIncrementalLoading
+		{
+			public delegate Task<T[]> AsyncFetch(int start);
+			public delegate T[] Fetch(int start);
+
+			private readonly AsyncFetch _fetchAsync;
+			private int _start;
+
+			public InfiniteSource(AsyncFetch fetch)
+			{
+				_fetchAsync = fetch;
+				_start = 0;
+			}
+
+			public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
+			{
+				return AsyncInfo.Run(async ct =>
+				{
+					var items = await _fetchAsync(_start);
+					foreach (var item in items)
+					{
+						Add(item);
+					}
+					_start += items.Length;
+
+					return new LoadMoreItemsResult { Count = count };
+				});
+			}
+
+			public bool HasMoreItems { get; set; } = true;
+
+			public int LastIndex => _start;
+		}
+
+		private record TestReleaseObject()
+		{
+			public byte[] test { get; set; } = new byte[1024 * 1024 * 2];
+		}
+
+		private class When_Removed_From_Tree_And_Selection_TwoWay_Bound_DataContext : ViewModelBase
+		{
 			public string[] MyItems { get; } = new[] { "Red beans", "Rice" };
 
 			private string _mySelection;
 			public string MySelection
 			{
 				get => _mySelection;
-				set
-				{
-					var changing = _mySelection != value;
-					_mySelection = value;
-					if (changing)
-					{
-						PropertyChanged?.Invoke(this, new global::System.ComponentModel.PropertyChangedEventArgs(nameof(MySelection)));
-					}
-				}
+				set => RaiseAndSetIfChanged(ref _mySelection, value);
 			}
 		}
 
-		private class When_Selection_Events_DataContext : global::System.ComponentModel.INotifyPropertyChanged
+		private class When_Selection_Events_DataContext : ViewModelBase
 		{
-			public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
 			#region SelectedItem
 			private object _selectedItem;
 			public object SelectedItem
@@ -2874,234 +2967,101 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				set => RaiseAndSetIfChanged(ref _selectedIndex, value);
 			}
 			#endregion
-
-			protected void RaiseAndSetIfChanged<T>(ref T backingField, T value, [CallerMemberName] string propertyName = null)
-			{
-				if (!EqualityComparer<T>.Default.Equals(backingField, value))
-				{
-					backingField = value;
-					PropertyChanged?.Invoke(this, new global::System.ComponentModel.PropertyChangedEventArgs(propertyName));
-				}
-			}
 		}
 
-		private class When_DisplayMemberPath_Property_Changed_DataContext : System.ComponentModel.INotifyPropertyChanged
+		private class When_DisplayMemberPath_Property_Changed_DataContext : ViewModelBase
 		{
 			private string _display;
-
-			public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
 			public string Display
 			{
 				get => _display;
-				set
-				{
-					if (value != _display)
-					{
-						_display = value;
-						PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(Display)));
-					}
-				}
+				set => RaiseAndSetIfChanged(ref _display, value);
 			}
-		}
-		#endregion
-	}
-
-	#region Helper classes
-	public partial class OnItemsChangedListView : ListView
-	{
-		public Action ItemsChangedAction;
-
-		protected override void OnItemsChanged(object e)
-		{
-			base.OnItemsChanged(e);
-			ItemsChangedAction?.Invoke();
 		}
 	}
 
-	public class KeyedTemplateSelector : DataTemplateSelector
+	public partial class Given_ListViewBase // helpers
 	{
-		public IDictionary<object, DataTemplate> Templates { get; } = new Dictionary<object, DataTemplate>();
-
-		protected override DataTemplate SelectTemplateCore(object item, DependencyObject container) => SelectTemplateCore(item); // On UWP only this overload is called when eg Button.ContentTemplateSelector is set
-
-		protected override DataTemplate SelectTemplateCore(object item)
+		private static ContentControl[] GetPanelVisibleChildren(ListViewBase list)
 		{
-			if (item == null)
-			{
-				return null;
-			}
-
-			var template = Templates.UnoGetValueOrDefault(item);
-			return template;
-		}
-	}
-
-	public class KeyedTemplateSelector<T> : DataTemplateSelector
-	{
-		private readonly Func<object, T> _keySelector;
-
-		public KeyedTemplateSelector(Func<object, T> keySelector = null)
-		{
-			this._keySelector = keySelector;
-		}
-
-		public IDictionary<T, DataTemplate> Templates { get; } = new Dictionary<T, DataTemplate>();
-
-		protected override DataTemplate SelectTemplateCore(object item, DependencyObject container) => SelectTemplateCore(item); // On UWP only this overload is called when eg Button.ContentTemplateSelector is set
-
-		protected override DataTemplate SelectTemplateCore(object item)
-		{
-			if (item == null)
-			{
-				return null;
-			}
-
-			T itemT;
-			if (_keySelector != null)
-			{
-				itemT = _keySelector(item);
-			}
-			else if (item is T)
-			{
-				itemT = (T)item;
-			}
-			else
-			{
-				return null;
-			}
-
-			var template = Templates.UnoGetValueOrDefault(itemT);
-			return template;
-		}
-	}
-
-	public enum ItemColor
-	{
-		None,
-		Red,
-		Green,
-		Beige
-	}
-
-	public class ItemColorViewModel
-	{
-		public ItemColor ItemType { get; set; }
-		public int ItemIndex { get; set; }
-		public string DisplayString => $"Item {ItemIndex}";
-	}
-
-	public class ItemHeightViewModel : global::System.ComponentModel.INotifyPropertyChanged
-	{
-		private string _displayString;
-		private double _itemHeight;
-
-		public string DisplayString
-		{
-			get => _displayString;
-			set
-			{
-				if (_displayString != value)
-				{
-					_displayString = value;
-					PropertyChanged?.Invoke(this, new global::System.ComponentModel.PropertyChangedEventArgs(nameof(DisplayString)));
-				}
-			}
-		}
-
-		public double ItemHeight
-		{
-			get => _itemHeight; set
-			{
-				_itemHeight = value;
-				PropertyChanged?.Invoke(this, new global::System.ComponentModel.PropertyChangedEventArgs(nameof(ItemHeight)));
-			}
-		}
-
-		public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-	}
-
-	public class SourceAwareItem
-	{
-		public int No { get; set; }
-
-		public override string ToString() => $"Item {No}";
-	}
-
-	public class SourceAwareSelector : DataTemplateSelector
-	{
-		private readonly IList<SourceAwareItem> _itemsSource;
-		public DataTemplate _dataTemplateA;
-		private readonly DataTemplate _dataTemplateB;
-
-		public Exception Exception { get; private set; }
-
-		public SourceAwareSelector(IList<SourceAwareItem> itemsSource, DataTemplate dataTemplateA, DataTemplate dataTemplateB)
-		{
-			_itemsSource = itemsSource;
-			_dataTemplateA = dataTemplateA;
-			_dataTemplateB = dataTemplateB;
-		}
-
-		protected override DataTemplate SelectTemplateCore(object item)
-		{
-			if (
-#if __IOS__
-				// On iOS, the template selector may be invoked with a null item. This is arguably also a bug, but not presently under test here.
-				item != null &&
+#if __ANDROID__ || __IOS__
+			return list
+				.GetItemsPanelChildren()
+				.OfType<ContentControl>()
+				.ToArray();
+#else
+			return list.ItemsPanelRoot
+				.Children
+				.OfType<ContentControl>()
+				.Where(c => c.Visibility == Visibility.Visible) // Managed ItemsStackPanel currently uses the dirty trick of leaving reyclable items attached to panel and collapsed
+				.ToArray();
 #endif
-					!_itemsSource.Contains(item)
-			)
-			{
-				var ex = new InvalidOperationException($"Selector called for item not in source ({item})");
-				Exception = Exception ?? ex;
-				throw ex;
-			}
-
-			if (item is SourceAwareItem dataItem && dataItem.No > 2)
-			{
-				return _dataTemplateB;
-			}
-
-			else
-			{
-				return _dataTemplateA;
-			}
-		}
-	}
-
-	public class InfiniteSource<T> : ObservableCollection<T>, ISupportIncrementalLoading
-	{
-		public delegate Task<T[]> AsyncFetch(int start);
-		public delegate T[] Fetch(int start);
-
-		private readonly AsyncFetch _fetchAsync;
-		private int _start;
-
-		public InfiniteSource(AsyncFetch fetch)
-		{
-			_fetchAsync = fetch;
-			_start = 0;
 		}
 
-		public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
+		private static ContentControl[] GetAllPanelChildren(ListViewBase list)
 		{
-			return AsyncInfo.Run(async ct =>
+#if __ANDROID__
+			return list
+				.GetItemsPanelChildren()
+				.OfType<ContentControl>()
+				.ToArray();
+#elif __IOS__
+			return list
+				.GetItemsPanelChildren()
+				.OfType<ContentControl>()
+				// iOS does not seem to provide to exclude the recycled items, so we mark
+				// then using IsDisplayed.
+				.Where(c => c.Superview?.Superview is ListViewBaseInternalContainer container && container.IsDisplayed)
+				.ToArray();
+#else
+			return list.ItemsPanelRoot
+				.Children
+				.OfType<ContentControl>()
+				.Where(c => c.Visibility == Visibility.Visible) // Managed ItemsStackPanel currently uses the dirty trick of leaving reyclable items attached to panel and collapsed
+				.ToArray();
+#endif
+		}
+
+		private static double GetTop(FrameworkElement element, FrameworkElement container)
+		{
+			if (element == null)
 			{
-				var items = await _fetchAsync(_start);
-				foreach (var item in items)
+				return double.NaN;
+			}
+			var transform = element.TransformToVisual(container);
+			return transform.TransformPoint(new Point()).Y;
+		}
+
+		private bool ApproxEquals(double value1, double value2) => Math.Abs(value1 - value2) <= 2;
+
+		private async Task AssertCollectedReference(WeakReference reference)
+		{
+			var sw = Stopwatch.StartNew();
+			while (sw.Elapsed < TimeSpan.FromSeconds(3))
+			{
+				GC.Collect(2);
+				GC.WaitForPendingFinalizers();
+
+				if (!reference.IsAlive)
 				{
-					Add(item);
+					return;
 				}
-				_start += items.Length;
 
-				return new LoadMoreItemsResult { Count = count };
-			});
+				await Task.Delay(100);
+			}
+
+			Assert.IsFalse(reference.IsAlive);
 		}
 
-		public bool HasMoreItems { get; set; } = true;
+		public partial class OnItemsChangedListView : ListView
+		{
+			public Action ItemsChangedAction;
 
-		public int LastIndex => _start;
+			protected override void OnItemsChanged(object e)
+			{
+				base.OnItemsChanged(e);
+				ItemsChangedAction?.Invoke();
+			}
+		}
 	}
-	#endregion
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase_Items.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase_Items.cs
@@ -119,11 +119,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+#if !NETFX_CORE
+		[Ignore("#12183: ItemsControl.Items no longer map to ItemsSource for simple collection.")]
+#endif
 		public void When_ItemsSource_List_Modified_Change_Is_Reflected()
 		{
-			var listView = new ListView();
 			var items = new List<int>() { 1 };
-			listView.ItemsSource = items;
+			var listView = new ListView { ItemsSource = items };
+
 			Assert.AreEqual(1, listView.Items.Count);
 			items.Add(2);
 			Assert.AreEqual(2, listView.Items.Count);
@@ -142,7 +145,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				notified = true;
 			};
 			items.Add(2);
+#if NETFX_CORE // #12183: ItemsControl.Items no longer map to ItemsSource for simple collection.
 			Assert.AreEqual(2, listView.Items.Count);
+#endif
 			Assert.IsFalse(notified);
 		}
 
@@ -191,6 +196,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+#if !NETFX_CORE
+		[Ignore("#12183: ItemsControl.Items no longer map to ItemsSource for simple collection.")]
+#endif
 		public void When_ItemsSource_Updated_Items_Sync()
 		{
 			var listView = new ListView();


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/nventive-private#457, closes unoplatform/nventive-private#472

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When ListView.ItemsSource is assigned/bound to a non-observable/notifying collection, like List<T>,
adding/removing item to the collection will cause the LV to update and the items' data-context to desync.

## What is the new behavior?
Like on UWP, adding/removing item to the non-observable/notifying collection will NOT update the LV.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->