### PR TITLE
fix: Raise OnWindowCreated after Application.Current is set

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -297,6 +297,16 @@ namespace SamplesApp
 			}
 		}
 
+#if !HAS_UNO_WINUI
+		protected override void OnWindowCreated(global::Windows.UI.Xaml.WindowCreatedEventArgs args)
+		{
+			if (Current is null)
+			{
+				throw new InvalidOperationException("The Window should be created later in the application lifecycle.");
+			}
+		}
+#endif
+
 		private void InitializeFrame(string arguments = null)
 		{
 			Frame rootFrame = Windows.UI.Xaml.Window.Current.Content as Frame;

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -259,6 +259,11 @@ namespace Windows.UI.Xaml
 		{
 			SystemThemeHelper.SystemThemeChanged += OnSystemThemeChanged;
 			_initializationComplete = true;
+
+#if !HAS_UNO_WINUI
+			// Delayed raise of OnWindowCreated.
+			Window.Current.RaiseCreated();
+#endif
 		}
 
 		internal void RaiseRecoverableUnhandledException(Exception e) => UnhandledException?.Invoke(this, new UnhandledExceptionEventArgs(e, false));

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -262,7 +262,7 @@ namespace Windows.UI.Xaml
 
 #if !HAS_UNO_WINUI
 			// Delayed raise of OnWindowCreated.
-			Window.Current.RaiseCreated();
+			Windows.UI.Xaml.Window.Current.RaiseCreated();
 #endif
 		}
 
@@ -393,7 +393,7 @@ namespace Windows.UI.Xaml
 		{
 		}
 
-		internal void RaiseWindowCreated(Window window)
+		internal void RaiseWindowCreated(Windows.UI.Xaml.Window window)
 		{
 			OnWindowCreated(new WindowCreatedEventArgs(window));
 		}

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -27,6 +27,7 @@ namespace Windows.UI.Xaml
 
 		private UIElement _content;
 		private RootVisual _rootVisual;
+		private bool _windowCreatedRaised;
 
 		private CoreWindowActivationState? _lastActivationState;
 		private Brush _background;
@@ -89,17 +90,8 @@ namespace Windows.UI.Xaml
 		private void InitializeCommon()
 		{
 			InitDragAndDrop();
-			if (Application.Current != null)
-			{
-				Application.Current.RaiseWindowCreated(this);
-			}
-			else
-			{
-				if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Warning))
-				{
-					this.Log().Warn("Unable to raise WindowCreatedEvent, there is no active Application");
-				}
-			}
+
+			RaiseCreated();
 
 			Background = SolidColorBrushHelper.White;
 		}
@@ -245,6 +237,15 @@ namespace Windows.UI.Xaml
 				(h, s, e) =>
 					(h as Windows.UI.Xaml.WindowSizeChangedEventHandler)?.Invoke(s, (WindowSizeChangedEventArgs)e)
 			);
+		}
+
+		internal void RaiseCreated()
+		{
+			if (Application.Current is not null && !_windowCreatedRaised)
+			{
+				_windowCreatedRaised = true;
+				Application.Current.RaiseWindowCreated(this);
+			}
 		}
 
 		internal void OnActivated(CoreWindowActivationState state)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12194

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`OnWindowCreated` is called immediately after a `Window` is created.

## What is the new behavior?

In UWP, `OnWindowCreated` is delayed just before `OnLaunched`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.