### PR TITLE
fix(ScrollView): Android FastScrolling wrong Offsets

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -462,6 +462,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		[RunsOnUIThread]
 		[RequiresFullWindow]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282! epic")]
+#endif
 		public async Task When_ChangeView_Offset()
 		{
 			const double offset = 100;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -461,6 +461,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[RequiresFullWindow]
 		public async Task When_ChangeView_Offset()
 		{
 			const double offset = 100;
@@ -494,16 +495,26 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			scroll.Content = stackPanel;
 
-			WindowHelper.WindowContent = scroll;
+			try
+			{
 
-			await WindowHelper.WaitForLoaded(scroll);
+				var container = new Border() { Child = scroll };
 
-			_ = scroll.ChangeView(null, offset, null, true);
+				WindowHelper.WindowContent = container;
 
-			await WindowHelper.WaitFor(() => scrollChanged);
+				await WindowHelper.WaitForLoaded(scroll);
 
-			var loc = target.TransformToVisual(scroll).TransformPoint(new Point(0, 0));
-			Assert.AreEqual(offset, loc.Y);
+				_ = scroll.ChangeView(null, offset, null, true);
+
+				await WindowHelper.WaitFor(() => scrollChanged);
+
+				var loc = target.TransformToVisual(scroll).TransformPoint(new Point(0, 0));
+				Assert.AreEqual(offset, loc.Y);
+			}
+			finally
+			{
+				WindowHelper.WindowContent = null;
+			}
 		}
 
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -459,6 +459,54 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(outerScrollViewer.ExtentHeight, outerScrollViewer.ViewportHeight, 0.000001);
 		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_ChangeView_Offset()
+		{
+			const double offset = 100;
+
+			var scroll = new ScrollViewer()
+			{
+				Background = new SolidColorBrush(Colors.Yellow)
+			};
+
+			var stackPanel = new StackPanel()
+			{
+				Orientation = Orientation.Vertical,
+				Height = 5000,
+			};
+
+			stackPanel.Children.Add(new Border() { Height = 200 });
+
+			var target = new Border()
+			{
+				Background = new SolidColorBrush(Colors.Lime),
+				Height = 50,
+			};
+
+			stackPanel.Children.Add(target);
+
+			var scrollChanged = false;
+			scroll.ViewChanged += (s, e) =>
+			{
+				scrollChanged = true;
+			};
+
+			scroll.Content = stackPanel;
+
+			WindowHelper.WindowContent = scroll;
+
+			await WindowHelper.WaitForLoaded(scroll);
+
+			_ = scroll.ChangeView(null, offset, null, true);
+
+			await WindowHelper.WaitFor(() => scrollChanged);
+
+			var loc = target.TransformToVisual(scroll).TransformPoint(new Point(0, 0));
+			Assert.AreEqual(offset, loc.Y);
+		}
+
+
 #if __ANDROID__
 		[TestMethod]
 		[RunsOnUIThread]

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Native.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Native.cs
@@ -115,9 +115,10 @@ namespace Windows.UI.Xaml.Controls
 		#region Native SCP to SCP
 		internal void OnNativeScroll(double horizontalOffset, double verticalOffset, bool isIntermediate)
 		{
+			ScrollOffsets = new Point(horizontalOffset, verticalOffset);
+
 			Scroller?.OnPresenterScrolled(horizontalOffset, verticalOffset, isIntermediate);
 
-			ScrollOffsets = new Point(horizontalOffset, verticalOffset);
 			InvalidateViewport();
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/tradezero-private/issues/4

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Fast scrolling on Android returned the wrong location for a scroll child.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behaviour?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
