### PR TITLE
fix(Wasm): error CS0759: No defining declaration found for implementing declaration of partial method 'HtmlMediaPlayer.NativeMethods.setAttribute(nint, string, string)'

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.NativeMethods.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.NativeMethods.cs
@@ -73,7 +73,7 @@ partial class HtmlMediaPlayer
 		internal static partial void SetAttribute(nint htmlId, string name, string value);
 
 #if !USE_JSIMPORT
-		internal static partial void setAttribute(nint htmlId, string name, string value)
+		internal static partial void SetAttribute(nint htmlId, string name, string value)
 			=> throw new NotSupportedException();
 #endif
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Try to launch the Uno Sample App on Wasm (**while overriding with netstandard2.0**)
`error CS0759: No defining declaration found for implementing declaration of partial method 'HtmlMediaPlayer.NativeMethods.setAttribute(nint, string, string)'`

## What is the new behavior?

Error CS0759 fixed


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

