### PR TITLE
fix: Ensure theme is initialized before UI

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -102,6 +102,11 @@ namespace SamplesApp
 #endif
 			override void OnLaunched(LaunchActivatedEventArgs e)
 		{
+			if (InternalRequestedTheme is null)
+			{
+				throw new AssertFailedException("Requested theme should be initialized before calling OnLaunched");
+			}
+
 #if __IOS__ && !NET6_0_OR_GREATER
 			// requires Xamarin Test Cloud Agent
 			Xamarin.Calabash.Start();

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -102,11 +102,6 @@ namespace SamplesApp
 #endif
 			override void OnLaunched(LaunchActivatedEventArgs e)
 		{
-			if (InternalRequestedTheme is null)
-			{
-				throw new AssertFailedException("Requested theme should be initialized before calling OnLaunched");
-			}
-
 #if __IOS__ && !NET6_0_OR_GREATER
 			// requires Xamarin Test Cloud Agent
 			Xamarin.Calabash.Start();

--- a/src/Uno.UI/UI/Xaml/Application.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Android.cs
@@ -23,6 +23,7 @@ namespace Windows.UI.Xaml
 		{
 			Window.Current.ToString();
 			Current = this;
+			InitializeSystemTheme();
 			PermissionsHelper.Initialize();
 		}
 

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -138,7 +138,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private ApplicationTheme? InternalRequestedTheme
+		internal ApplicationTheme? InternalRequestedTheme
 		{
 			get => _requestedTheme;
 			set

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -127,7 +127,7 @@ namespace Windows.UI.Xaml
 			InternalRequestedTheme = GetSystemTheme();
 		}
 
-		internal ApplicationTheme InternalRequestedTheme
+		private ApplicationTheme InternalRequestedTheme
 		{
 			get => _requestedTheme;
 			set

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -259,6 +259,8 @@ namespace Windows.UI.Xaml
 		internal void InitializationCompleted()
 		{
 			SystemThemeHelper.SystemThemeChanged += OnSystemThemeChanged;
+			EnsureInternalRequestedTheme();
+
 			_initializationComplete = true;
 
 #if !HAS_UNO_WINUI

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -1,19 +1,15 @@
 using System;
-using System.Globalization;
 using Uno;
 using Uno.UI;
 using Uno.Diagnostics.Eventing;
 using Windows.ApplicationModel.Activation;
-using Windows.Foundation;
 using Windows.Foundation.Metadata;
-using Windows.UI.Xaml.Controls.Primitives;
 using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel;
 using Windows.Globalization;
 using Uno.Helpers.Theming;
 using Windows.UI.ViewManagement;
 using Uno.Extensions;
-using System.Collections.Generic;
 using Uno.Foundation.Logging;
 using Windows.UI.Xaml.Data;
 using Uno.Foundation.Extensibility;
@@ -56,7 +52,7 @@ namespace Windows.UI.Xaml
 	{
 		private bool _initializationComplete;
 		private readonly static IEventProvider _trace = Tracing.Get(TraceProvider.Id);
-		private ApplicationTheme? _requestedTheme;
+		private ApplicationTheme _requestedTheme = ApplicationTheme.Dark;
 		private SpecializedResourceDictionary.ResourceKey _requestedThemeForResources;
 		private bool _isInBackground;
 
@@ -114,11 +110,7 @@ namespace Windows.UI.Xaml
 
 		public ApplicationTheme RequestedTheme
 		{
-			get
-			{
-				EnsureInternalRequestedTheme();
-				return InternalRequestedTheme.Value;
-			}
+			get => InternalRequestedTheme;
 			set
 			{
 				if (_initializationComplete)
@@ -129,21 +121,19 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private void EnsureInternalRequestedTheme()
+		private void InitializeSystemTheme()
 		{
-			if (InternalRequestedTheme == null)
-			{
-				// just cache the theme, but do not notify about a change unnecessarily
-				InternalRequestedTheme = GetSystemTheme();
-			}
+			// just cache the theme, but do not notify about a change unnecessarily
+			InternalRequestedTheme = GetSystemTheme();
 		}
 
-		internal ApplicationTheme? InternalRequestedTheme
+		internal ApplicationTheme InternalRequestedTheme
 		{
 			get => _requestedTheme;
 			set
 			{
 				_requestedTheme = value;
+
 				// Sync with core application's theme
 				CoreApplication.RequestedTheme = value == ApplicationTheme.Dark ? SystemTheme.Dark : SystemTheme.Light;
 
@@ -166,12 +156,7 @@ namespace Windows.UI.Xaml
 
 		internal SpecializedResourceDictionary.ResourceKey RequestedThemeForResources
 		{
-			get
-			{
-				EnsureInternalRequestedTheme();
-				return _requestedThemeForResources;
-			}
-
+			get => _requestedThemeForResources;
 			private set
 			{
 				_requestedThemeForResources = value;
@@ -259,7 +244,6 @@ namespace Windows.UI.Xaml
 		internal void InitializationCompleted()
 		{
 			SystemThemeHelper.SystemThemeChanged += OnSystemThemeChanged;
-			EnsureInternalRequestedTheme();
 
 			_initializationComplete = true;
 

--- a/src/Uno.UI/UI/Xaml/Application.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.iOS.cs
@@ -38,6 +38,7 @@ namespace Windows.UI.Xaml
 		{
 			Current = this;
 			SetCurrentLanguage();
+			InitializeSystemTheme();
 			ResourceHelper.ResourcesService = new ResourcesService(new[] { NSBundle.MainBundle });
 
 			SubscribeBackgroundNotifications();

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -40,6 +40,7 @@ namespace Windows.UI.Xaml
 		{
 			Current = this;
 			SetCurrentLanguage();
+			InitializeSystemTheme();
 			ResourceHelper.ResourcesService = new ResourcesService(new[] { NSBundle.MainBundle });
 
 			SubscribeBackgroundNotifications();

--- a/src/Uno.UI/UI/Xaml/Application.net.cs
+++ b/src/Uno.UI/UI/Xaml/Application.net.cs
@@ -9,5 +9,6 @@ public partial class Application
 	public Application()
 	{
 		Current = this;
+		InitializeSystemTheme();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Application.netstdref.cs
+++ b/src/Uno.UI/UI/Xaml/Application.netstdref.cs
@@ -9,5 +9,6 @@ public partial class Application
 	public Application()
 	{
 		Current = this;
+		InitializeSystemTheme();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Application.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Application.skia.cs
@@ -23,6 +23,7 @@ namespace Windows.UI.Xaml
 		{
 			Current = this;
 			SetCurrentLanguage();
+			InitializeSystemTheme();
 
 			Package.SetEntryAssembly(this.GetType().Assembly);
 

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -46,6 +46,7 @@ namespace Windows.UI.Xaml
 			}
 
 			Current = this;
+			InitializeSystemTheme();
 			Package.SetEntryAssembly(this.GetType().Assembly);
 
 			global::Uno.Foundation.Extensibility.ApiExtensibility.Register(

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
@@ -342,6 +342,7 @@ namespace Windows.UI.Xaml.Documents
 		private void SetDefaultForeground(DependencyProperty foregroundProperty)
 		{
 			this.SetValue(foregroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
+			((IDependencyObjectStoreProvider)this).Store.SetLastUsedTheme(Application.Current?.RequestedThemeForResources);
 		}
 #endif
 	}

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -459,6 +459,7 @@ namespace Windows.UI.Xaml
 		private protected void SetDefaultForeground(DependencyProperty foregroundProperty)
 		{
 			this.SetValue(foregroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
+			((IDependencyObjectStoreProvider)this).Store.SetLastUsedTheme(Application.Current?.RequestedThemeForResources);
 		}
 
 		[NotImplemented]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12255

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Previously the active application theme was initialized when first requested, which meant the theme for default foreground could be set to default (light in case of Uno)

## What is the new behavior?

Active theme is set explicitly after app initialization is completed.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.