### PR TITLE
chore: update toolkit doc commit hash reference

### DIFF
--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -9,7 +9,7 @@ $external_docs = @{
     # use either commit, or branch name to use its latest commit
     "uno.wasm.bootstrap" = "4abadfc93ffeddc82420cc28af04cd7f6b2693ab"
     "uno.themes"         = "3d12f341f3ce9ecd7738e163a3a0904e9b94466f"
-    "uno.toolkit.ui"     = "434712b657f479d1329ff60af3b6f22bb6fdb34c"
+    "uno.toolkit.ui"     = "e358da0eb3e912ed0c8ba01d022ad0fcdb83b0f0"
     "uno.check"          = "5dec33b3cb4c26f578c8d6bd7a84000bf265a14e"
     "uno.xamlmerge.task" = "7e8ffef206e87dfea90c53805c45e93a7d8c0b46"
     "figma-docs"         = "f13d08f2bd7b62fc274b43a4ede4d75909d0f41f"


### PR DESCRIPTION
which contained the fix for the broken doc links

GitHub Issue (If applicable): closes unoplatform/uno.toolkit.ui#456

## PR Type

What kind of change does this PR introduce?
- Documentation content changes

## What is the new behavior?
updated toolkit doc commit hash reference
which contained the fix for the broken doc links

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.