### PR TITLE
fix(ListView): unnecessary SelectTemplate call on collection reset

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1171,8 +1171,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else if (element is ContentControl contentControl)
 			{
-				contentControl.ClearValue(DataContextProperty);
-
 				if (!isOwnContainer)
 				{
 					static void ClearPropertyWhenNoExpression(ContentControl target, DependencyProperty property)
@@ -1201,6 +1199,10 @@ namespace Windows.UI.Xaml.Controls
 						ClearPropertyWhenNoExpression(contentControl, ContentControl.ContentTemplateSelectorProperty);
 					}
 				}
+
+				// We are clearing the DataContext last. Because if there is a binding set on any of the above properties, Content(Template(Selector)?)?,
+				// clearing the DC can cause the data-bound property to be unnecessarily re-evaluated with an inherited DC from the visual parent.
+				contentControl.ClearValue(DataContextProperty);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12059

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
LV.ItemsSource in certain binding setup can trigger ItemsTemplateSelector.SelectTemplateCore unnecessarily on INotifyCollectionChanged reset events.

## What is the new behavior?
^ doesnt happen anymore.


## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
When we clean up the container, we cleared the DataContext value first, before other properties like Content. And, if Content property is data-bound (without explicit source), the binding will be re-evaluated as its DataContext is changing from a specific item to the now inherited items-source. This often result in SelectTemplateCore being called with the items-source as parameter.