### PR TITLE
fix(skia): UIElement.KeyDown firing twice per input

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkCoreWindowExtension.Keyboard.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkCoreWindowExtension.Keyboard.cs
@@ -82,7 +82,7 @@ namespace Uno.UI.Runtime.Skia
 					this.Log().Trace($"OnKeyReleaseEvent: {evt.Key} -> {virtualKey}");
 				}
 
-				_ownerEvents.RaiseNativeKeyDownReceived(
+				_ownerEvents.RaiseNativeKeyUpReceived(
 					new KeyEventArgs(
 						"keyboard",
 						virtualKey,


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12302

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
UIElement.KeyDown firing twice per input.

## What is the new behavior?
^ no more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
regression from: https://github.com/unoplatform/uno/pull/12105
both OnKeyPressEvent & OnKeyReleaseEvent are calling RaiseNativeKeyDownReceived
likely we should be calling RaiseNativeKeyUpReceived for release, and looking at other platforms' impl confirms that