### PR TITLE
fix: avoid calls to CGColorCreateSRGB before iOS13

### DIFF
--- a/src/Uno.UWP/UI/Color.iOS.cs
+++ b/src/Uno.UWP/UI/Color.iOS.cs
@@ -10,14 +10,14 @@ namespace Windows.UI
 {
 	public partial struct Color : IFormattable
 	{
-		private static bool legacy = !UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
+		private static bool legacy = !UIKit.UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
 
 		public static implicit operator UIKit.UIColor(Color color) => UIKit.UIColor.FromRGBA(color.R, color.G, color.B, color.A);
 		public static implicit operator CGColor(Color color)
 		{
 			if (legacy)
 			{
-				return UIKit.UIColor.FromRgba(color.R, color.G, color.B, color.A).CGColor;
+				return UIKit.UIColor.FromRGBA(color.R, color.G, color.B, color.A).CGColor;
 			}
 			else
 			{

--- a/src/Uno.UWP/UI/Color.iOS.cs
+++ b/src/Uno.UWP/UI/Color.iOS.cs
@@ -10,8 +10,17 @@ namespace Windows.UI
 {
 	public partial struct Color : IFormattable
 	{
+		private static bool legacy = !UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
+
 		public static implicit operator UIKit.UIColor(Color color) => UIKit.UIColor.FromRGBA(color.R, color.G, color.B, color.A);
-		public static implicit operator CGColor(Color color) => CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
+		public static implicit operator CGColor(Color color)
+		{
+			if (legacy) {
+				return AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A).CGColor;
+			} else {
+				return CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
+			}
+		}
 
 		public static implicit operator Color(UIKit.UIColor color) => color.CGColor;
 

--- a/src/Uno.UWP/UI/Color.iOS.cs
+++ b/src/Uno.UWP/UI/Color.iOS.cs
@@ -15,9 +15,12 @@ namespace Windows.UI
 		public static implicit operator UIKit.UIColor(Color color) => UIKit.UIColor.FromRGBA(color.R, color.G, color.B, color.A);
 		public static implicit operator CGColor(Color color)
 		{
-			if (legacy) {
+			if (legacy)
+			{
 				return UIKit.UIColor.FromRgba(color.R, color.G, color.B, color.A).CGColor;
-			} else {
+			}
+			else
+			{
 				return CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
 			}
 		}

--- a/src/Uno.UWP/UI/Color.iOS.cs
+++ b/src/Uno.UWP/UI/Color.iOS.cs
@@ -16,7 +16,7 @@ namespace Windows.UI
 		public static implicit operator CGColor(Color color)
 		{
 			if (legacy) {
-				return AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A).CGColor;
+				return UIKit.UIColor.FromRgba(color.R, color.G, color.B, color.A).CGColor;
 			} else {
 				return CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
 			}

--- a/src/Uno.UWP/UI/Color.macOS.cs
+++ b/src/Uno.UWP/UI/Color.macOS.cs
@@ -10,13 +10,15 @@ namespace Windows.UI
 {
 	public partial struct Color : IFormattable
 	{
+#pragma warning disable CS0618 // Type or member is obsolete
 		private static bool legacy = !ObjCRuntime.PlatformHelper.CheckSystemVersion(10, 15);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		public static implicit operator AppKit.NSColor(Color color) => AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A);
 		public static implicit operator CGColor(Color color)
 		{
 			if (legacy) {
-				return UIKit.UIColor.FromRGBA(color.R, color.G, color.B, color.A).CGColor;
+				return AppKit.NSColor.FromRGBA(color.R, color.G, color.B, color.A).CGColor;
 			} else {
 				return CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
 			}

--- a/src/Uno.UWP/UI/Color.macOS.cs
+++ b/src/Uno.UWP/UI/Color.macOS.cs
@@ -10,8 +10,17 @@ namespace Windows.UI
 {
 	public partial struct Color : IFormattable
 	{
+		private static bool legacy = !ObjCRuntime.PlatformHelper.CheckSystemVersion(10, 15);
+
 		public static implicit operator AppKit.NSColor(Color color) => AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A);
-		public static implicit operator CGColor(Color color) => CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
+		public static implicit operator CGColor(Color color)
+		{
+			if (legacy) {
+				return UIKit.UIColor.FromRGBA(color.R, color.G, color.B, color.A).CGColor;
+			} else {
+				return CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
+			}
+		}
 
 		public static implicit operator Color(AppKit.NSColor color) => color.CGColor;
 

--- a/src/Uno.UWP/UI/Color.macOS.cs
+++ b/src/Uno.UWP/UI/Color.macOS.cs
@@ -17,9 +17,12 @@ namespace Windows.UI
 		public static implicit operator AppKit.NSColor(Color color) => AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A);
 		public static implicit operator CGColor(Color color)
 		{
-			if (legacy) {
-				return AppKit.NSColor.FromRGBA(color.R, color.G, color.B, color.A).CGColor;
-			} else {
+			if (legacy)
+			{
+				return AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A).CGColor;
+			}
+			else
+			{
 				return CGColor.CreateSrgb(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
 			}
 		}

--- a/src/Uno.UWP/UI/Color.macOS.cs
+++ b/src/Uno.UWP/UI/Color.macOS.cs
@@ -10,9 +10,13 @@ namespace Windows.UI
 {
 	public partial struct Color : IFormattable
 	{
+#if NET6_0_OR_GREATER
+		private static bool legacy = OperatingSystem.IsMacOSVersionAtLeast(10, 15);
+#else
 #pragma warning disable CS0618 // Type or member is obsolete
 		private static bool legacy = !ObjCRuntime.PlatformHelper.CheckSystemVersion(10, 15);
 #pragma warning restore CS0618 // Type or member is obsolete
+#endif
 
 		public static implicit operator AppKit.NSColor(Color color) => AppKit.NSColor.FromRgba(color.R, color.G, color.B, color.A);
 		public static implicit operator CGColor(Color color)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #https://github.com/unoplatform/uno/issues/12339

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`System.EntryPointNotFoundException` when trying to convert colors (on iOS or macOS) when running iOS 12.x or earlier (or before macOS 10.15).

## What is the new behavior?

No exception.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

https://developer.apple.com/documentation/coregraphics/3042355-cgcolorcreatesrgb

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
