### PR TITLE
fix(lottie): Improved the loadeability of Lottie library on Wasm

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.d.ts
+++ b/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.d.ts
@@ -1,4 +1,4 @@
-declare const require: any;
+declare const require: unknown | undefined;
 declare const config: any;
 declare namespace Uno.UI {
     import AnimationData = Lottie.AnimationData;

--- a/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.js
+++ b/src/AddIns/Uno.UI.Lottie/WasmScripts/uno-lottie.js
@@ -63,7 +63,7 @@ var Uno;
             static setProgress(elementId, progress) {
                 Lottie.withPlayer(p => {
                     const animation = Lottie._runningAnimations[elementId].animation;
-                    var frame = Lottie._numberOfFrames * progress;
+                    let frame = Lottie._numberOfFrames * progress;
                     if (frame < animation.firstFrame) {
                         frame = frame - animation.firstFrame;
                     }
@@ -194,7 +194,17 @@ var Uno;
                     action(Lottie._player);
                 }
                 else {
-                    require([`${config.uno_app_base}/lottie`], (p) => {
+                    if (typeof require !== "function") {
+                        console.error("RequireJS not present.");
+                        return;
+                    }
+                    const dependencyToLoad = "/lottie";
+                    const lottieDependencyName = config.uno_dependencies.find((d) => d.endsWith(dependencyToLoad));
+                    require([lottieDependencyName], (p) => {
+                        if (!p) {
+                            console.error("Unable to load lottie player.");
+                            return;
+                        }
                         if (!Lottie._player) {
                             Lottie._player = p;
                         }

--- a/src/AddIns/Uno.UI.Lottie/ts/Uno.UI.Lottie.ts
+++ b/src/AddIns/Uno.UI.Lottie/ts/Uno.UI.Lottie.ts
@@ -1,4 +1,4 @@
-﻿declare const require: any;
+﻿declare const require: unknown | undefined;
 declare const config: any;
 
 namespace Uno.UI {
@@ -102,7 +102,7 @@ namespace Uno.UI {
 		public static setProgress(elementId: number, progress: number): string {
 			Lottie.withPlayer(p => {
 				const animation = Lottie._runningAnimations[elementId].animation;
-				var frame = Lottie._numberOfFrames * progress;
+				let frame = Lottie._numberOfFrames * progress;
 				if (frame < (animation as any).firstFrame) {
 					frame = frame - (animation as any).firstFrame
 				} else {
@@ -266,7 +266,18 @@ namespace Uno.UI {
 			if (Lottie._player) {
 				action(Lottie._player);
 			} else {
-				require([`${config.uno_app_base}/lottie`], (p: LottiePlayer) => {
+				if (typeof require !== "function") {
+					console.error("RequireJS not present.");
+					return;
+				}
+
+				const dependencyToLoad = "/lottie";
+				const lottieDependencyName = config.uno_dependencies.find((d: string) => d.endsWith(dependencyToLoad));
+				require([lottieDependencyName], (p: LottiePlayer) => {
+					if(!p) {
+						console.error("Unable to load lottie player.");
+						return;
+					}
 					if (!Lottie._player) {
 						Lottie._player = p;
 					}


### PR DESCRIPTION
# Bugfix

The Lottie library was not loading properly on Wasm when the application was using the _embedded mode_.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~~
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
