### PR TITLE
Multiple MediaPlayerElement controls on the same page

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -45,8 +45,8 @@ internal partial class HtmlMediaPlayer : Border
 		AddChild(_htmlVideo);
 		AddChild(_htmlAudio);
 
-		ActiveElement = IsVideo ? _htmlVideo : IsAudio ? _htmlAudio : default;
-		ActiveElementName = IsVideo ? "Video" : IsAudio ? "Audio" : "";
+		_activeElement = IsVideo ? _htmlVideo : IsAudio ? _htmlAudio : default;
+		_activeElementName = IsVideo ? "Video" : IsAudio ? "Audio" : "";
 
 		Loaded += OnLoaded;
 		Unloaded += OnUnloaded;
@@ -59,8 +59,8 @@ internal partial class HtmlMediaPlayer : Border
 		{
 			this.Log().Debug($"HtmlMediaPlayer Loaded");
 		}
-		ActiveElement = IsVideo ? _htmlVideo : IsAudio ? _htmlAudio : default;
-		ActiveElementName = IsVideo ? "Video" : IsAudio ? "Audio" : "";
+		_activeElement = IsVideo ? _htmlVideo : IsAudio ? _htmlAudio : default;
+		_activeElementName = IsVideo ? "Video" : IsAudio ? "Audio" : "";
 		SourceLoaded += OnHtmlSourceLoaded;
 		SourceFailed += OnHtmlSourceFailed;
 		SourceEnded += OnHtmlSourceEnded;
@@ -109,21 +109,21 @@ internal partial class HtmlMediaPlayer : Border
 	{
 		get
 		{
-			if (ActiveElement == null)
+			if (_activeElement == null)
 			{
 				return 0;
 			}
-			return NativeMethods.GetCurrentPosition(ActiveElement.HtmlId);
+			return NativeMethods.GetCurrentPosition(_activeElement.HtmlId);
 		}
 		set
 		{
-			if (ActiveElement != null)
+			if (_activeElement != null)
 			{
 				if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 				{
-					this.Log().Debug($"{ActiveElementName} on ID {ActiveElement.HtmlId} SetCurrentPosition : [{value}]");
+					this.Log().Debug($"{_activeElementName} on ID {_activeElement.HtmlId} SetCurrentPosition : [{value}]");
 				}
-				NativeMethods.SetCurrentPosition(ActiveElement.HtmlId, value);
+				NativeMethods.SetCurrentPosition(_activeElement.HtmlId, value);
 			}
 		}
 	}
@@ -162,17 +162,17 @@ internal partial class HtmlMediaPlayer : Border
 	{
 		add
 		{
-			if (ActiveElement == null)
+			if (_activeElement == null)
 			{
 				return;
 			}
-			ActiveElement.RegisterHtmlEventHandler("timeupdate", value);
+			_activeElement.RegisterHtmlEventHandler("timeupdate", value);
 		}
 		remove
 		{
-			if (ActiveElement != null)
+			if (_activeElement != null)
 			{
-				ActiveElement.UnregisterHtmlEventHandler("timeupdate", value);
+				_activeElement.UnregisterHtmlEventHandler("timeupdate", value);
 			}
 		}
 	}
@@ -184,17 +184,17 @@ internal partial class HtmlMediaPlayer : Border
 	{
 		add
 		{
-			if (ActiveElement == null)
+			if (_activeElement == null)
 			{
 				return;
 			}
-			ActiveElement.RegisterHtmlEventHandler("loadedmetadata", value);
+			_activeElement.RegisterHtmlEventHandler("loadedmetadata", value);
 		}
 		remove
 		{
-			if (ActiveElement != null)
+			if (_activeElement != null)
 			{
-				ActiveElement.UnregisterHtmlEventHandler("loadedmetadata", value);
+				_activeElement.UnregisterHtmlEventHandler("loadedmetadata", value);
 			}
 		}
 	}
@@ -206,17 +206,17 @@ internal partial class HtmlMediaPlayer : Border
 	{
 		add
 		{
-			if (ActiveElement == null)
+			if (_activeElement == null)
 			{
 				return;
 			}
-			ActiveElement.RegisterHtmlEventHandler("ended", value);
+			_activeElement.RegisterHtmlEventHandler("ended", value);
 		}
 		remove
 		{
-			if (ActiveElement != null)
+			if (_activeElement != null)
 			{
-				ActiveElement.UnregisterHtmlEventHandler("ended", value);
+				_activeElement.UnregisterHtmlEventHandler("ended", value);
 			}
 		}
 	}
@@ -274,9 +274,9 @@ internal partial class HtmlMediaPlayer : Border
 
 	private void OnHtmlMetadataLoaded(object sender, EventArgs e)
 	{
-		if (ActiveElement != null)
+		if (_activeElement != null)
 		{
-			Duration = NativeMethods.GetDuration(ActiveElement.HtmlId);
+			Duration = NativeMethods.GetDuration(_activeElement.HtmlId);
 		}
 		OnMetadataLoaded?.Invoke(this, Duration);
 	}
@@ -288,21 +288,21 @@ internal partial class HtmlMediaPlayer : Border
 			this.Log().Debug($"Media opened [{Source}]");
 		}
 
-		ActiveElement = IsVideo ? _htmlVideo : IsAudio ? _htmlAudio : default;
-		ActiveElementName = IsVideo ? "Video" : IsAudio ? "Audio" : "";
-		if (ActiveElement != null)
+		_activeElement = IsVideo ? _htmlVideo : IsAudio ? _htmlAudio : default;
+		_activeElementName = IsVideo ? "Video" : IsAudio ? "Audio" : "";
+		if (_activeElement != null)
 		{
-			ActiveElement.SetCssStyle("visibility", "visible");
+			_activeElement.SetCssStyle("visibility", "visible");
 		}
 		if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 		{
-			this.Log().Debug($"{ActiveElementName} source loaded: [{Source}]");
+			this.Log().Debug($"{_activeElementName} source loaded: [{Source}]");
 		}
 
 		TimeUpdated += OnHtmlTimeUpdated;
-		if (ActiveElement != null)
+		if (_activeElement != null)
 		{
-			Duration = NativeMethods.GetDuration(ActiveElement.HtmlId);
+			Duration = NativeMethods.GetDuration(_activeElement.HtmlId);
 		}
 		OnSourceLoaded?.Invoke(this, EventArgs.Empty);
 	}
@@ -310,13 +310,13 @@ internal partial class HtmlMediaPlayer : Border
 	private void OnHtmlSourceFailed(object sender, HtmlCustomEventArgs e)
 	{
 		TimeUpdated += OnHtmlTimeUpdated;
-		if (ActiveElement != null)
+		if (_activeElement != null)
 		{
-			ActiveElement.SetCssStyle("visibility", "hidden");
+			_activeElement.SetCssStyle("visibility", "hidden");
 		}
 		if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 		{
-			this.Log().Error($"{ActiveElementName} source failed: [{Source}]");
+			this.Log().Error($"{_activeElementName} source failed: [{Source}]");
 		}
 		OnSourceFailed?.Invoke(this, e.Detail);
 	}
@@ -339,22 +339,22 @@ internal partial class HtmlMediaPlayer : Border
 				player.Log().Debug($"HtmlMediaPlayer.OnSourceChanged: {args.NewValue} isVideo:{player.IsVideo} isAudio:{player.IsAudio}");
 			}
 
-			player.ActiveElement = player.IsVideo 
+			player._activeElement = player.IsVideo 
 						? player._htmlVideo 
 						: (player.IsAudio 
 									? player._htmlAudio 
 									: default);
-			player.ActiveElementName = player.IsVideo ? "Video" : player.IsAudio ? "Audio" : "";
+			player._activeElementName = player.IsVideo ? "Video" : player.IsAudio ? "Audio" : "";
 
-			if (player.ActiveElement != null)
+			if (player._activeElement != null)
 			{
 
-				player.ActiveElement.SetHtmlAttribute("src", encodedSource);
-				player.ActiveElement.SetCssStyle("visibility", "visible");
+				player._activeElement.SetHtmlAttribute("src", encodedSource);
+				player._activeElement.SetCssStyle("visibility", "visible");
 
 				if (player.Log().IsEnabled(LogLevel.Debug))
 				{
-					player.Log().Debug($"{player.ActiveElementName} source changed: [{player.Source}]");
+					player.Log().Debug($"{player._activeElementName} source changed: [{player.Source}]");
 				}
 				player.OnSourceLoaded?.Invoke(player, EventArgs.Empty);
 			}
@@ -377,9 +377,9 @@ internal partial class HtmlMediaPlayer : Border
 	{
 		if (dependencyobject is HtmlMediaPlayer player)
 		{
-			if (player.ActiveElement != null)
+			if (player._activeElement != null)
 			{
-				NativeMethods.SetAutoPlay(player.ActiveElement.HtmlId, (bool)args.NewValue);
+				NativeMethods.SetAutoPlay(player._activeElement.HtmlId, (bool)args.NewValue);
 			}
 		}
 	}
@@ -394,24 +394,24 @@ internal partial class HtmlMediaPlayer : Border
 		if (dependencyobject is HtmlMediaPlayer player)
 		{
 			var enabled = (bool)args.NewValue;
-			if (player.ActiveElement != null)
+			if (player._activeElement != null)
 			{
 				if (enabled)
 				{
-					if (!string.IsNullOrEmpty(player.ActiveElement.GetHtmlAttribute("controls")))
+					if (!string.IsNullOrEmpty(player._activeElement.GetHtmlAttribute("controls")))
 					{
-						player.ActiveElement.SetHtmlAttribute("controls", "");
+						player._activeElement.SetHtmlAttribute("controls", "");
 					}
 					else
 					{
-						player.ActiveElement.SetHtmlAttribute("controls", "controls");
+						player._activeElement.SetHtmlAttribute("controls", "controls");
 					}
 				}
 				else
 				{
-					if (!string.IsNullOrEmpty(player.ActiveElement.GetHtmlAttribute("controls")))
+					if (!string.IsNullOrEmpty(player._activeElement.GetHtmlAttribute("controls")))
 					{
-						player.ActiveElement.SetHtmlAttribute("controls", "");
+						player._activeElement.SetHtmlAttribute("controls", "");
 					}
 				}
 			}
@@ -486,9 +486,9 @@ internal partial class HtmlMediaPlayer : Border
 		{
 			this.Log().Debug($"Play()");
 		}
-		if (ActiveElement != null && !_isPlaying)
+		if (_activeElement != null && !_isPlaying)
 		{
-			NativeMethods.Play(ActiveElement.HtmlId);
+			NativeMethods.Play(_activeElement.HtmlId);
 			_isPlaying = true;
 		}
 	}
@@ -500,9 +500,9 @@ internal partial class HtmlMediaPlayer : Border
 		{
 			this.Log().Debug($"Pause()");
 		}
-		if (ActiveElement != null && _isPlaying)
+		if (_activeElement != null && _isPlaying)
 		{
-			NativeMethods.Pause(ActiveElement.HtmlId);
+			NativeMethods.Pause(_activeElement.HtmlId);
 			_isPlaying = false;
 		}
 	}
@@ -514,9 +514,9 @@ internal partial class HtmlMediaPlayer : Border
 		{
 			this.Log().Debug($"Stop()");
 		}
-		if (ActiveElement != null)
+		if (_activeElement != null)
 		{
-			NativeMethods.Stop(ActiveElement.HtmlId);
+			NativeMethods.Stop(_activeElement.HtmlId);
 			_isPlaying = false;
 		}
 	}
@@ -536,19 +536,19 @@ internal partial class HtmlMediaPlayer : Border
 	public void SetIsLoopingEnabled(bool value)
 	{
 		_isLoopingEnabled = value;
-		if (ActiveElement != null)
+		if (_activeElement != null)
 		{
 			if (_isLoopingEnabled)
 			{
-				ActiveElement.SetHtmlAttribute("loop", "loop");
+				_activeElement.SetHtmlAttribute("loop", "loop");
 			}
 			else
 			{
-				ActiveElement.ClearHtmlAttribute("loop");
+				_activeElement.ClearHtmlAttribute("loop");
 			}
 			if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 			{
-				this.Log().Debug($"{ActiveElementName} loop {_isLoopingEnabled}: [{Source}]");
+				this.Log().Debug($"{_activeElementName} loop {_isLoopingEnabled}: [{Source}]");
 			}
 		}
 	}

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -481,7 +481,6 @@ internal partial class HtmlMediaPlayer : Border
 
 	public void Play()
 	{
-
 		TimeUpdated += OnHtmlTimeUpdated;
 		if (this.Log().IsEnabled(LogLevel.Debug))
 		{

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -339,7 +339,11 @@ internal partial class HtmlMediaPlayer : Border
 				player.Log().Debug($"HtmlMediaPlayer.OnSourceChanged: {args.NewValue} isVideo:{player.IsVideo} isAudio:{player.IsAudio}");
 			}
 
-			player.ActiveElement = player.IsVideo ? player._htmlVideo : player.IsAudio ? player._htmlAudio : default;
+			player.ActiveElement = player.IsVideo 
+						? player._htmlVideo 
+						: (player.IsAudio 
+									? player._htmlAudio 
+									: default);
 			player.ActiveElementName = player.IsVideo ? "Video" : player.IsAudio ? "Audio" : "";
 
 			if (player.ActiveElement != null)

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -24,8 +24,8 @@ internal partial class HtmlMediaPlayer : Border
 		ImmutableArray.Create(new string[] { ".MP3", ".WAV" });
 	private readonly ImmutableArray<string> videoTagAllowedFormats =
 		ImmutableArray.Create(new string[] { ".MP4", ".WEBM", ".OGG" });
-	private UIElement ActiveElement;
-	private string ActiveElementName;
+	private UIElement _activeElement;
+	private string _activeElementName;
 
 	public event EventHandler<object> OnSourceLoaded;
 	public event EventHandler<object> OnSourceFailed;

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -259,11 +259,6 @@ internal partial class HtmlMediaPlayer : Border
 
 	private void OnHtmlTimeUpdated(object sender, EventArgs e)
 	{
-		//if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
-		//{
-		//	this.Log().Debug($"Time updated [{Source}]");
-		//}
-
 		OnTimeUpdate?.Invoke(this, EventArgs.Empty);
 	}
 
@@ -273,7 +268,7 @@ internal partial class HtmlMediaPlayer : Border
 		{
 			this.Log().Debug($"Media ended [{Source}]");
 		}
-
+		_isPlaying = false;
 		OnSourceEnded?.Invoke(this, EventArgs.Empty);
 	}
 

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlVideo.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlVideo.cs
@@ -1,5 +1,4 @@
 ﻿#nullable enable
-
 using Windows.UI.Xaml;
 
 namespace Uno.UI.Media;

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -184,6 +184,10 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 				{
 					if (_owner.PlaybackSession.PlaybackState != MediaPlaybackState.None && _player is not null && _player.Source is not null)
 					{
+						if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+						{
+							this.Log().Debug($"Position {value.TotalSeconds}");
+						}
 						_player.CurrentPosition = (int)value.TotalSeconds;
 						OnSeekComplete();
 					}
@@ -489,9 +493,9 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 				}
 				else
 				{
-					// To display first image of media when setting a new source. Otherwise, last image of previous source remains visible
-					_player.Play();
-					_player.Stop();
+					//// To display first image of media when setting a new source. Otherwise, last image of previous source remains visible
+					//_player.Play();
+					//_player.Stop();	
 				}
 			}
 
@@ -588,5 +592,10 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			_isPlayRequested = false;
 			_isPlayerPrepared = false;
 		}
+	}
+
+	public void SetTransportControlsBounds(Rect bounds)
+	{
+		//_player?.SetTransportControlsBounds(bounds);
 	}
 }

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -491,12 +491,6 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 					_player.Play();
 					_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
 				}
-				else
-				{
-					//// To display first image of media when setting a new source. Otherwise, last image of previous source remains visible
-					//_player.Play();
-					//_player.Stop();	
-				}
 			}
 
 			_isPlayerPrepared = true;
@@ -592,10 +586,5 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			_isPlayRequested = false;
 			_isPlayerPrepared = false;
 		}
-	}
-
-	public void SetTransportControlsBounds(Rect bounds)
-	{
-		//_player?.SetTransportControlsBounds(bounds);
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3242,6 +3242,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Multiple.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Full.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7092,6 +7096,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Flv_Extension.xaml.cs">
       <DependentUpon>MediaPlayerElement_Flv_Extension.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Multiple.xaml.cs">
+      <DependentUpon>MediaPlayerElement_Multiple.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Full.xaml.cs">
       <DependentUpon>MediaPlayerElement_Full.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Multiple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Multiple.xaml
@@ -1,0 +1,89 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Multiple"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Windows_UI_Xaml_Controls.MediaPlayerElement"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<ScrollViewer>
+		<Grid>
+
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="200" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+
+				<RowDefinition Height="200" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+			</Grid.RowDefinitions>
+
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="Auto" />
+			</Grid.ColumnDefinitions>
+			<TextBlock Text="Test Two MediaPlayers on UI."
+					   TextWrapping="Wrap"
+					   Margin="12"
+					   Grid.Row="0"
+					   Grid.ColumnSpan="2" />
+
+
+			<MediaPlayerElement x:Name="Mpe"
+								AreTransportControlsEnabled="True"
+								AutoPlay="True"
+								Grid.ColumnSpan="2"
+								Grid.Row="1" />
+
+			<TextBlock Text="Change the source of the video player dynamically by entering a different url. An empty url should clear the video."
+					   TextWrapping="Wrap"
+					   Margin="12"
+					   Grid.Row="2"
+					   Grid.ColumnSpan="2" />
+
+			<TextBox x:Name="SourceTextBox"
+					 Text="https://ia800201.us.archive.org/12/items/BigBuckBunny_328/BigBuckBunny_512kb.mp4"
+					 HorizontalAlignment="Stretch"
+					 Margin="12"
+					 Grid.Row="3" />
+
+			<Button x:Name="UpdateButton"
+					Content="Update source"
+					Width="125"
+					Margin="12"
+					Click="UpdateButton_Click"
+					Grid.Row="3"
+					Grid.Column="1" />
+
+			<MediaPlayerElement x:Name="MpeTwo"
+								AreTransportControlsEnabled="True"
+								AutoPlay="True"
+								Grid.Row="4"
+								Grid.ColumnSpan="2" />
+
+			<TextBlock Text="Change the source of the video player dynamically by entering a different url. An empty url should clear the video."
+					   TextWrapping="Wrap"
+					   Margin="12"
+					   Grid.Row="5"
+					   Grid.ColumnSpan="2" />
+
+			<TextBox x:Name="SourceTwoTextBox"
+					 Text="https://uno-assets.platform.uno/tests/videos/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp4"
+					 HorizontalAlignment="Stretch"
+					 Margin="12"
+					 Grid.Row="6" />
+
+			<Button x:Name="UpdateButtonTwo"
+					Content="Update source"
+					Width="125"
+					Margin="12"
+					Click="UpdateButtonTwo_Click"
+					Grid.Row="6"
+					Grid.Column="1" />
+		</Grid>
+	</ScrollViewer>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Multiple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Multiple.xaml.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Media.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement
+{
+	[SampleControlInfo("MediaPlayerElement", "Multiple", description: "Test for dynamic Multiple sources")]
+	public sealed partial class MediaPlayerElement_Multiple : UserControl
+	{
+		public MediaPlayerElement_Multiple()
+		{
+			this.InitializeComponent();
+		}
+
+		private void UpdateButton_Click(object sender, RoutedEventArgs e)
+		{
+#if !HAS_UNO_WINUI
+			var uri = SourceTextBox.Text;
+
+			if (!string.IsNullOrEmpty(uri))
+			{
+				Mpe.Source = MediaSource.CreateFromUri(new Uri(uri));
+			}
+			else
+			{
+				Mpe.Source = null;
+			}
+#endif
+		}
+		private void UpdateButtonTwo_Click(object sender, RoutedEventArgs e)
+		{
+#if !HAS_UNO_WINUI
+			var uri = SourceTwoTextBox.Text;
+
+			if (!string.IsNullOrEmpty(uri))
+			{
+				MpeTwo.Source = MediaSource.CreateFromUri(new Uri(uri));
+			}
+			else
+			{
+				MpeTwo.Source = null;
+			}
+#endif
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -270,6 +270,11 @@ namespace Windows.UI.Xaml.Controls
 				_rootGrid.Tapped -= OnRootGridTapped;
 				_rootGrid.Tapped += OnRootGridTapped;
 			}
+			if (_controlPanelGrid != null)
+			{
+				_controlPanelGrid.Tapped -= OnPaneGridTapped;
+				_controlPanelGrid.Tapped += OnPaneGridTapped;
+			}
 
 			if (_mediaPlayer != null)
 			{
@@ -348,6 +353,14 @@ namespace Windows.UI.Xaml.Controls
 			});
 		}
 
+		private void OnPaneGridTapped(object sender, TappedRoutedEventArgs e)
+		{
+			if (ShowAndHideAutomatically)
+			{
+				ResetControlsVisibilityTimer();
+			}
+			e.Handled = true;
+		}
 		private void OnRootGridTapped(object sender, TappedRoutedEventArgs e)
 		{
 			if (_isInteractive)

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -119,6 +119,38 @@ namespace Windows.UI.Xaml.Controls
 			};
 			_controlsVisibilityTimer.Elapsed += ControlsVisibilityTimerElapsed;
 			DefaultStyleKey = typeof(MediaTransportControls);
+			Loaded += MediaTransportControls_Loaded;
+			Unloaded += MediaTransportControls_Unloaded;
+		}
+
+		private void MediaTransportControls_Unloaded(object sender, RoutedEventArgs e)
+		{
+			_rootGrid = this.GetTemplateChild(RootGridName) as Grid;
+			if (_rootGrid != null)
+			{
+				_rootGrid.Tapped -= OnRootGridTapped;
+			}
+
+			_controlPanelGrid = this.GetTemplateChild(ControlPanelGridName) as Grid;
+			if (_controlPanelGrid != null)
+			{
+				_controlPanelGrid.Tapped -= OnPaneGridTapped;
+			}
+		}
+
+		private void MediaTransportControls_Loaded(object sender, RoutedEventArgs e)
+		{
+			_rootGrid = this.GetTemplateChild(RootGridName) as Grid;
+			if (_rootGrid != null)
+			{
+				_rootGrid.Tapped += OnRootGridTapped;
+			}
+
+			_controlPanelGrid = this.GetTemplateChild(ControlPanelGridName) as Grid;
+			if (_controlPanelGrid != null)
+			{
+				_controlPanelGrid.Tapped += OnPaneGridTapped;
+			}
 		}
 
 		internal void SetMediaPlayerElement(MediaPlayerElement mediaPlayerElement)
@@ -267,19 +299,6 @@ namespace Windows.UI.Xaml.Controls
 
 			UpdateMediaTransportControlMode();
 
-			_rootGrid = this.GetTemplateChild(RootGridName) as Grid;
-			if (_rootGrid != null)
-			{
-				_rootGrid.Tapped -= OnRootGridTapped;
-				_rootGrid.Tapped += OnRootGridTapped;
-			}
-
-			_controlPanelGrid = this.GetTemplateChild(ControlPanelGridName) as Grid;
-			if (_controlPanelGrid != null)
-			{
-				_controlPanelGrid.Tapped -= OnPaneGridTapped;
-				_controlPanelGrid.Tapped += OnPaneGridTapped;
-			}
 			if (_mediaPlayer != null)
 			{
 				BindMediaPlayer();

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -43,6 +43,7 @@ namespace Windows.UI.Xaml.Controls
 	[TemplatePart(Name = "ProgressSlider", Type = typeof(Slider))]
 	[TemplatePart(Name = "BufferingProgressBar", Type = typeof(ProgressBar))]
 	[TemplatePart(Name = "DownloadProgressIndicator", Type = typeof(ProgressBar))]
+	[TemplatePart(Name = "ControlPanelGrid", Type = typeof(Grid))]
 	public partial class MediaTransportControls : Control
 	{
 		private const string RootGridName = "RootGrid";
@@ -73,6 +74,7 @@ namespace Windows.UI.Xaml.Controls
 		private const string HorizontalThumbName = "HorizontalThumb";
 		private const string DownloadProgressIndicatorName = "DownloadProgressIndicator";
 		private const string CompactOverlayButtonName = "CompactOverlayButton";
+		private const string ControlPanelGridName = "ControlPanelGrid";
 
 		private Grid _rootGrid;
 		private Button _playPauseButton;
@@ -101,6 +103,7 @@ namespace Windows.UI.Xaml.Controls
 		private ProgressBar _bufferingProgressBar;
 		private Border _timelineContainer;
 		private ProgressBar _downloadProgressIndicator;
+		private Grid _controlPanelGrid;
 
 		private Timer _controlsVisibilityTimer;
 		private bool _wasPlaying;
@@ -270,12 +273,13 @@ namespace Windows.UI.Xaml.Controls
 				_rootGrid.Tapped -= OnRootGridTapped;
 				_rootGrid.Tapped += OnRootGridTapped;
 			}
+
+			_controlPanelGrid = this.GetTemplateChild(ControlPanelGridName) as Grid;
 			if (_controlPanelGrid != null)
 			{
 				_controlPanelGrid.Tapped -= OnPaneGridTapped;
 				_controlPanelGrid.Tapped += OnPaneGridTapped;
 			}
-
 			if (_mediaPlayer != null)
 			{
 				BindMediaPlayer();


### PR DESCRIPTION
GitHub Issue (If applicable): closes: #12350 

Reference: https://github.com/unoplatform/uno/issues/11967

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Today when we have two media player on the UI just the last one works.

## What is the new behavior?

Now we can get as many MediaPlayer as we want

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
