### PR TITLE
MediaPlayerElement fullscreen working properly

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerPresenterExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerPresenterExtension.cs
@@ -30,7 +30,6 @@ public class MediaPlayerPresenterExtension : IMediaPlayerPresenterExtension
 		_owner.Child = _htmlPlayer = new HtmlMediaPlayer();
 	}
 
-	public void ExitFullScreen() => throw new NotImplementedException();
 
 	public void MediaPlayerChanged()
 	{
@@ -51,8 +50,15 @@ public class MediaPlayerPresenterExtension : IMediaPlayerPresenterExtension
 			}
 		}
 	}
+	public void ExitFullScreen()
+	{
+		_htmlPlayer.ExitFullScreen();
+	}
 
-	public void RequestFullScreen() => throw new NotImplementedException();
+	public void RequestFullScreen()
+	{
+		_htmlPlayer.RequestFullScreen();
+	}
 	public void StretchChanged()
 	{
 		if (_owner is not null)

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -184,6 +184,9 @@ namespace Windows.UI.Xaml.Controls
 					this.Add(_layoutRoot);
 #elif __MACOS__
 					this.AddSubview(_layoutRoot);
+#elif __WASM__
+					this.AddChild(_layoutRoot);
+					_mediaPlayerPresenter?.ExitFullScreen();
 #else
 					_mediaPlayerPresenter?.ExitFullScreen();
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12330 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

MediaPlayerElement full screen not working properly on Wasm

## What is the new behavior?

MediaPlayerElement full screen working properly on Wasm



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
