### PR TITLE
fix: Properly display PosterSource for MediaPlayerElement

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GTKMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GTKMediaPlayer.cs
@@ -33,6 +33,7 @@ public partial class GtkMediaPlayer : FrameworkElement
 	private double _playbackRate;
 	private Rect _transportControlsBounds;
 	private Windows.UI.Xaml.Media.Stretch _stretch = Windows.UI.Xaml.Media.Stretch.Uniform;
+	private double _videoRatio;
 	private readonly MediaPlayerPresenter _owner;
 
 	public GtkMediaPlayer(MediaPlayerPresenter owner)
@@ -72,7 +73,19 @@ public partial class GtkMediaPlayer : FrameworkElement
 
 	public double Duration { get; set; }
 
-	public double VideoRatio { get; set; }
+	public double VideoRatio
+	{
+		get => _videoRatio;
+		set
+		{
+			if (_videoRatio != value)
+			{
+				_videoRatio = value;
+
+				OnVideoRatioChanged?.Invoke(this, EventArgs.Empty);
+			}
+		}
+	}
 
 	public bool IsVideo
 		=> _mediaPlayer?.Media?.Tracks?.Any(x => x.TrackType == TrackType.Video) == true;
@@ -322,20 +335,6 @@ public partial class GtkMediaPlayer : FrameworkElement
 				&& _mediaPlayer?.Media?.Mrl is not null
 				&& _videoContainer is not null)
 			{
-				var currentSize = new Size(ActualWidth, ActualHeight);
-
-				if (currentSize.Height <= 0 || currentSize.Width <= 0)
-				{
-					if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
-					{
-						this.Log().Debug($"Skipping layout update for empty layout slot");
-					}
-
-					return;
-				}
-
-				var playerHeight = (double)currentSize.Height - _transportControlsBounds.Height;
-				var playerWidth = (double)currentSize.Width;
 
 				await _mediaPlayer.Media.Parse(MediaParseOptions.ParseNetwork);
 
@@ -343,6 +342,39 @@ public partial class GtkMediaPlayer : FrameworkElement
 				{
 					// From: https://github.com/videolan/libvlcsharp/blob/bca0a53fe921e6f1f745e4e3ac83a7bd3b2e4a9d/src/LibVLCSharp/Shared/MediaPlayerElement/AspectRatioManager.cs#L188
 					videoWidth = videoWidth * videoSettings.Value.SarNum / videoSettings.Value.SarDen;
+
+					// Update video ratio first, so that the cover can be
+					// removed properly without the mediaplayerpresenter to be
+					// visible.
+					if (videoWidth == 0 || videoHeight == 0)
+					{
+						if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+						{
+							this.Log().Debug($"Source video size is not valid ({videoWidth}x{videoHeight})");
+						}
+
+						return;
+					}
+
+					VideoRatio = (double)videoHeight / (double)videoWidth;
+
+					var currentSize = new Size(ActualWidth, ActualHeight);
+
+					// If the control is not visible, or not sized properly
+					// we cannot display the video window.
+					if (currentSize.Height <= 0 || currentSize.Width <= 0)
+					{
+						if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+						{
+							this.Log().Debug($"Skipping layout update for empty layout slot");
+						}
+
+						return;
+					}
+
+					var playerHeight = (double)currentSize.Height - _transportControlsBounds.Height;
+					var playerWidth = (double)currentSize.Width;
+
 					UpdateVideoSizeAllocate(playerHeight, playerWidth, videoHeight.Value, videoWidth.Value);
 
 					if (forceVideoViewVisibility)

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GTKMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GTKMediaPlayer.cs
@@ -33,8 +33,6 @@ public partial class GtkMediaPlayer : FrameworkElement
 	private double _playbackRate;
 	private Rect _transportControlsBounds;
 	private Windows.UI.Xaml.Media.Stretch _stretch = Windows.UI.Xaml.Media.Stretch.Uniform;
-	private readonly ImmutableArray<string> audioTagAllowedFormats = ImmutableArray.Create(".MP3", ".WAV");
-	private readonly ImmutableArray<string> videoTagAllowedFormats = ImmutableArray.Create(".MP4", ".WEBM", ".OGG");
 	private readonly MediaPlayerPresenter _owner;
 
 	public GtkMediaPlayer(MediaPlayerPresenter owner)
@@ -77,10 +75,10 @@ public partial class GtkMediaPlayer : FrameworkElement
 	public double VideoRatio { get; set; }
 
 	public bool IsVideo
-		=> videoTagAllowedFormats.Contains(Path.GetExtension(Source), StringComparer.OrdinalIgnoreCase);
+		=> _mediaPlayer?.Media?.Tracks?.Any(x => x.TrackType == TrackType.Video) == true;
 
 	public bool IsAudio
-		=> audioTagAllowedFormats.Contains(Path.GetExtension(Source), StringComparer.OrdinalIgnoreCase);
+		=> _mediaPlayer?.Media?.Tracks?.Any(x => x.TrackType == TrackType.Video) == true;
 
 	public void Play()
 	{

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GTKMediaPlayer.events.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GTKMediaPlayer.events.cs
@@ -327,6 +327,7 @@ public partial class GtkMediaPlayer
 			media.Parse(MediaParseOptions.ParseNetwork);
 			_mediaPlayer.Media = media;
 			AddMediaEvents();
+			Duration = (double)(_videoView?.MediaPlayer?.Media?.Duration / 1000 ?? 0);
 			OnSourceLoaded?.Invoke(this, EventArgs.Empty);
 
 			UpdateVideoStretch();
@@ -431,11 +432,6 @@ public partial class GtkMediaPlayer
 			media.MetaChanged += OnStaticMetaChanged;
 			media.StateChanged += OnStaticStateChanged;
 			media.ParsedChanged += OnStaticParsedChanged;
-
-			Duration = (double)(_videoView?.MediaPlayer?.Media?.Duration / 1000 ?? 0);
-			OnSourceLoaded?.Invoke(this, EventArgs.Empty);
-
-			UpdateVideoStretch();
 		}
 		else
 		{
@@ -585,11 +581,6 @@ public partial class GtkMediaPlayer
 
 			UpdateVideoStretch(forceVideoViewVisibility: true);
 		}
-	}
-
-	private void OnMediaPlayerTimeChangeIsMediaParse(object? sender, MediaPlayerTimeChangedEventArgs el)
-	{
-		AddMediaEvents();
 	}
 
 	private void OnEndReached()

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GTKMediaPlayer.events.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GTKMediaPlayer.events.cs
@@ -27,6 +27,7 @@ public partial class GtkMediaPlayer
 	public event EventHandler<object>? OnMetadataLoaded;
 	public event EventHandler<object>? OnTimeUpdate;
 	public event EventHandler<object>? OnSourceLoaded;
+	public event EventHandler<object?>? OnVideoRatioChanged;
 
 	private bool _updateVideoSizeOnFirstTimeStamp = true;
 

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.cs
@@ -193,7 +193,6 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 				throw new InvalidOperationException("Unsupported media source type");
 		}
 		ApplyVideoSource();
-		Events?.RaiseMediaOpened();
 		Events?.RaiseSourceChanged();
 
 		// Set the player back to the paused state, so that the
@@ -336,6 +335,8 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 	public bool RealTimePlayback { get; set; }
 
 	public double AudioBalance { get; set; }
+
+	public bool? IsVideo { get; set; }
 
 	public void SetTransportControlsBounds(Rect bounds)
 	{

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.cs
@@ -101,6 +101,7 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 		_player.OnSourceLoaded += OnPrepared;
 		_player.OnSourceEnded += OnCompletion;
 		_player.OnTimeUpdate += OnTimeUpdate;
+		_player.OnVideoRatioChanged += OnVideoRatioChanged;
 
 		_owner.PlaybackSession.PlaybackStateChanged -= OnStatusChanged;
 		_owner.PlaybackSession.PlaybackStateChanged += OnStatusChanged;

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
@@ -37,6 +37,8 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 		{
 			if (_player is not null)
 			{
+				IsVideo = _player.IsVideo;
+
 				if (mp.IsVideo && Events is not null)
 				{
 					Events?.RaiseVideoRatioChanged(global::System.Math.Max(1, (double)mp.VideoRatio));
@@ -65,6 +67,11 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 					this.Log().Error($"The media player is not available yet");
 				}
 			}
+		}
+
+		if (Events is not null)
+		{
+			Events?.RaiseMediaOpened();
 		}
 	}
 

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
@@ -120,6 +120,7 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			&& _player.IsVideo
 			&& Events is not null)
 		{
+			IsVideo = _player.IsVideo;
 			Events?.RaiseVideoRatioChanged(Math.Max(1, (double)_player.VideoRatio));
 		}
 	}

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
@@ -39,11 +39,6 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			{
 				IsVideo = _player.IsVideo;
 
-				if (mp.IsVideo && Events is not null)
-				{
-					Events?.RaiseVideoRatioChanged(global::System.Math.Max(1, (double)mp.VideoRatio));
-				}
-
 				if (_owner.PlaybackSession.PlaybackState == MediaPlaybackState.Opening)
 				{
 					if (_isPlayRequested)
@@ -71,6 +66,11 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 
 		if (Events is not null)
 		{
+			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			{
+				this.Log().Debug($"Raising MediaOpened");
+			}
+
 			Events?.RaiseMediaOpened();
 		}
 	}
@@ -112,6 +112,16 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 	{
 		var volume = (int)_owner.Volume;
 		_player?.SetVolume(volume);
+	}
+
+	private void OnVideoRatioChanged(object? sender, object? e)
+	{
+		if (_player is not null
+			&& _player.IsVideo
+			&& Events is not null)
+		{
+			Events?.RaiseVideoRatioChanged(Math.Max(1, (double)_player.VideoRatio));
+		}
 	}
 
 	private void OnTimeUpdate(object? sender, object o)

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -147,6 +147,8 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 	public bool CanSeek
 		=> true;
 
+	public bool? IsVideo { get; set; }
+
 	public MediaPlayerAudioDeviceType AudioDeviceType { get; set; }
 
 	public MediaPlayerAudioCategory AudioCategory { get; set; }
@@ -301,7 +303,6 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			}
 
 			ApplyVideoSource();
-			Events?.RaiseMediaOpened();
 			Events?.RaiseSourceChanged();
 		}
 		catch (global::System.Exception ex)
@@ -480,6 +481,8 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 
 			NaturalDuration = TimeSpan.FromSeconds(_player.Duration);
 
+			IsVideo = _player.IsVideo;
+
 			if (mp.IsVideo && Events is not null)
 			{
 				try
@@ -508,6 +511,11 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			}
 
 			_isPlayerPrepared = true;
+		}
+
+		if (Events is not null)
+		{
+			Events?.RaiseMediaOpened();
 		}
 	}
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3294,6 +3294,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Mp3_Extension.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Mov_Extension.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7149,6 +7153,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\ChatBoxViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Mkv_Extension.xaml.cs">
       <DependentUpon>MediaPlayerElement_Mkv_Extension.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Mp3_Extension.xaml.cs">
+      <DependentUpon>MediaPlayerElement_Mp3_Extension.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Mov_Extension.xaml.cs">
       <DependentUpon>MediaPlayerElement_Mov_Extension.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Mp3_Extension.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Mp3_Extension.xaml
@@ -1,0 +1,10 @@
+﻿<Page x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Mp3_Extension"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<MediaPlayerElement Source="https://uno-assets.platform.uno/tests/audio/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp3"
+						PosterSource="https://uno-assets.platform.uno/tests/thumbnails/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.png"
+						AreTransportControlsEnabled="True"
+						AutoPlay="True" />
+
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Mp3_Extension.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Mp3_Extension.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement
+{
+	[SampleControlInfo("MediaPlayerElement", "Using .mp3 (Audio only)", description: "MediaPlayerElement test using .mp3 (Audio only) with PosterSource")]
+	public sealed partial class MediaPlayerElement_Mp3_Extension : Page
+	{
+		public MediaPlayerElement_Mp3_Extension()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -249,7 +249,11 @@ namespace Windows.UI.Xaml.Controls
 		{
 			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{
-				TogglePosterImage(false);
+				// Always show the poster source for audio content.
+				if (session.IsVideo)
+				{
+					TogglePosterImage(false);
+				}
 			});
 		}
 
@@ -326,11 +330,15 @@ namespace Windows.UI.Xaml.Controls
 					&& AutoPlay)
 				{
 					MediaPlayer.Play();
-					TogglePosterImage(false);
 				}
 			}
 		}
 
+		// The PosterSource is displayed in the following situations:
+		//  - When a valid source is not set.For example, Source is not set, Source was set to Null, or the source is invalid (as is the case when a MediaFailed event fires).
+		//  - While media is loading. For example, a valid source is set, but the MediaOpened event has not fired yet.
+		//  - When media is streaming to another device.
+		//  - When the media is audio only.
 		private void TogglePosterImage(bool showPoster)
 		{
 			if (PosterSource != null)
@@ -365,10 +373,8 @@ namespace Windows.UI.Xaml.Controls
 				_mediaPlayerPresenter?.ApplyStretch();
 			}
 
-			if (!IsLoaded && MediaPlayer.PlaybackSession.PlaybackState == MediaPlaybackState.None)
-			{
-				TogglePosterImage(true);
-			}
+			// For video content, show the poster source until it is ready to be displayed.
+			TogglePosterImage(true);
 
 			if (!_isTransportControlsBound)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -239,7 +239,7 @@ namespace Windows.UI.Xaml.Controls
 			};
 		}
 
-		private void OnVideoRatioChanged(MediaPlayer sender, double args)
+		private void OnVideoRatioChanged(Windows.Media.Playback.MediaPlayer sender, double args)
 		{
 			_ = Dispatcher.RunAsync(
 				CoreDispatcherPriority.Normal,

--- a/src/Uno.UWP/Media/Playback/IMediaPlayerExtension.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlayerExtension.cs
@@ -90,6 +90,11 @@ namespace Uno.Media.Playback
 		TimeSpan Position { get; set; }
 
 		/// <summary>
+		/// Determines if the current media content is video
+		/// </summary>
+		bool? IsVideo { get; }
+
+		/// <summary>
 		/// Sets the transport controls bounds so that video can be displayed around controls
 		/// </summary>
 		void SetTransportControlsBounds(Rect bounds);

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -155,8 +155,6 @@ namespace Windows.Media.Playback
 				SetVideoSource(uri);
 
 				_player.PrepareAsync();
-
-				MediaOpened?.Invoke(this, null);
 			}
 			catch (global::System.Exception ex)
 			{
@@ -270,13 +268,17 @@ namespace Windows.Media.Playback
 
 		public void OnPrepared(AndroidMediaPlayer mp)
 		{
-			PlaybackSession.NaturalDuration = TimeSpan.FromMilliseconds(_player.Duration);
-
-			VideoRatioChanged?.Invoke(this, (double)mp.VideoWidth / global::System.Math.Max(mp.VideoHeight, 1));
-
-			if (PlaybackSession.PlaybackState == MediaPlaybackState.Opening)
+			if (mp is not null)
 			{
-				UpdateVideoStretch(_currentStretch);
+				PlaybackSession.NaturalDuration = TimeSpan.FromMilliseconds(_player.Duration);
+
+				VideoRatioChanged?.Invoke(this, (double)mp.VideoWidth / global::System.Math.Max(mp.VideoHeight, 1));
+
+				IsVideo = mp.GetTrackInfo()?.Any(x => x.TrackType == MediaTrackType.Video) == true;
+
+				if (PlaybackSession.PlaybackState == MediaPlaybackState.Opening)
+				{
+					UpdateVideoStretch(_currentStretch);
 
 				if (_isPlayRequested)
 				{
@@ -293,7 +295,10 @@ namespace Windows.Media.Playback
 				}
 			}
 
-			_isPlayerPrepared = true;
+				_isPlayerPrepared = true;
+
+				MediaOpened?.Invoke(this, null);
+			}
 		}
 
 		public bool OnError(AndroidMediaPlayer mp, MediaError what, int extra)
@@ -382,6 +387,8 @@ namespace Windows.Media.Playback
 				}
 			}
 		}
+
+		public bool IsVideo { get; set; }
 
 		internal void UpdateVideoStretch(VideoStretch stretch)
 		{

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -280,20 +280,20 @@ namespace Windows.Media.Playback
 				{
 					UpdateVideoStretch(_currentStretch);
 
-				if (_isPlayRequested)
-				{
-					_player.Start();
-					PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
+					if (_isPlayRequested)
+					{
+						_player.Start();
+						PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
+					}
+					else
+					{
+						// To display first image of media when setting a new source. Otherwise, last image of previous source remains visible
+						_player.Start();
+						_player.Pause();
+						_player.SeekTo(0);
+						PlaybackSession.PlaybackState = MediaPlaybackState.Paused;
+					}
 				}
-				else
-				{
-					// To display first image of media when setting a new source. Otherwise, last image of previous source remains visible
-					_player.Start();
-					_player.Pause();
-					_player.SeekTo(0);
-					PlaybackSession.PlaybackState = MediaPlaybackState.Paused;
-				}
-			}
 
 				_isPlayerPrepared = true;
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOSmacOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOSmacOS.cs
@@ -246,9 +246,6 @@ namespace Windows.Media.Playback
 
 				// Adapt pitch to prevent "metallic echo" when changing playback rate
 				_player.CurrentItem.AudioTimePitchAlgorithm = AVAudioTimePitchAlgorithm.TimeDomain;
-
-				MediaOpened?.Invoke(this, null);
-
 			}
 			catch (Exception ex)
 			{
@@ -358,6 +355,8 @@ namespace Windows.Media.Playback
 		{
 			if (_player?.CurrentItem != null)
 			{
+				IsVideo = _player.CurrentItem.Tracks?.Any(x => x.AssetTrack.FormatDescriptions.Any(x => x.MediaType == CMMediaType.Video)) == true;
+
 				if (_player.CurrentItem.Status == AVPlayerItemStatus.Failed || _player.Status == AVPlayerStatus.Failed)
 				{
 					OnMediaFailed();
@@ -376,6 +375,11 @@ namespace Windows.Media.Playback
 						PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
 						_player.Play();
 					}
+				}
+
+				if (_player.Status == AVPlayerStatus.ReadyToPlay)
+				{
+					MediaOpened?.Invoke(this, null);
 				}
 			}
 		}
@@ -472,6 +476,8 @@ namespace Windows.Media.Playback
 				}
 			}
 		}
+
+		public bool IsVideo { get; set; }
 
 		private void OnSeekCompleted(bool finished)
 		{

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.others.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.others.cs
@@ -160,6 +160,8 @@ namespace Windows.Media.Playback
 			}
 		}
 
+		public bool IsVideo => _extension?.IsVideo ?? false;
+
 		public void SetUriSource(global::System.Uri value)
 			=> _extension?.SetUriSource(value);
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12332 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

MediaPlayerElement does not display PosterSource


## What is the new behavior?

MediaPlayerElement properly displays PosterSource:
- When a valid source is not set.
- While media is loading.
- When the media is audio only.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
