### PR TITLE
ci: Restore 17.6 test runners

### DIFF
--- a/build/ci/.azure-devops-unit-tests.yml
+++ b/build/ci/.azure-devops-unit-tests.yml
@@ -72,18 +72,8 @@ jobs:
 
   - task: VisualStudioTestPlatformInstaller@1
     inputs:
-      # 17.5.0 is forced because 17.6.0 issue with: 
-      # https://github.com/microsoft/vstest/issues/4467
-      # 
-      ##[error]DiscoveryMessage : System.InvalidOperationException: The provided manager was not found in any slot.
-      # at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.ParallelOperationManager`3.ClearCompletedSlot(TManager completedManager)
-      # at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.ParallelOperationManager`3.RunNextWork(TManager completedManager)
-      # at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel.ParallelProxyDiscoveryManager.HandlePartialDiscoveryComplete(IProxyDiscoveryManager proxyDiscoveryManager, Int64 totalTests, IEnumerable`1 lastChunk, Boolean isAborted)
-      # at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.Parallel.ParallelDiscoveryEventsHandler.HandleDiscoveryComplete(DiscoveryCompleteEventArgs discoveryCompleteEventArgs, IEnumerable`1 lastChunk)
-      # at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.ProxyDiscoveryManager.InitializeDiscovery(DiscoveryCriteria discoveryCriteria, ITestDiscoveryEventsHandler2 eventHandler, Boolean skipDefaultAdapters)
-      # at Microsoft.VisualStudio.TestPlatform.CrossPlatEngine.Client.ProxyDiscoveryManager.DiscoverTests(DiscoveryCriteria discoveryCriteria, ITestDiscoveryEventsHandler2 eventHandler)
       versionSelector: specificVersion
-      testPlatformVersion: 17.5.0
+      testPlatformVersion: 17.6.0
 
   - task: VSTest@2
     inputs:

--- a/src/Uno.Analyzers.Tests/Uno.Analyzers.Tests.csproj
+++ b/src/Uno.Analyzers.Tests/Uno.Analyzers.Tests.csproj
@@ -10,6 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+		<PackageReference Include="Microsoft.NET.Test.SDK" Version="17.4.1" />
 		<PackageReference Include="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersionForAnalyzersTests)" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForAnalyzersTests)" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzersTests)" />


### PR DESCRIPTION
Add missing test sdk reference to fix issue related to https://github.com/microsoft/vstest/issues/4467