### PR TITLE
fix(skia): Fix element not clipped when render transformed

### DIFF
--- a/src/Uno.UI.Composition/Composition/CompositionShape.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionShape.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Numerics;
+using Uno.Extensions;
 
 namespace Windows.UI.Composition
 {
@@ -9,7 +10,6 @@ namespace Windows.UI.Composition
 	{
 		private Matrix3x2 _transformMatrix = Matrix3x2.Identity;
 		private Vector2 _scale = new Vector2(1, 1);
-		private float _rotationAngleInDegrees;
 		private float _rotationAngle;
 		private Vector2 _offset;
 		private Vector2 _centerPoint;
@@ -34,8 +34,8 @@ namespace Windows.UI.Composition
 
 		public float RotationAngleInDegrees
 		{
-			get => _rotationAngleInDegrees;
-			set => SetProperty(ref _rotationAngleInDegrees, value);
+			get => (float)MathEx.ToDegree(_rotationAngle);
+			set => RotationAngle = (float)MathEx.ToRadians(value);
 		}
 
 		public float RotationAngle

--- a/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSpriteShape.skia.cs
@@ -11,37 +11,31 @@ namespace Windows.UI.Composition
 
 		internal override void Render(SKSurface surface)
 		{
-			SkiaGeometrySource2D? geometrySource = Geometry?.BuildGeometry() as SkiaGeometrySource2D;
-
-			SKPath? geometry = geometrySource?.Geometry;
-			if (geometry == null)
+			if (Geometry?.BuildGeometry() is SkiaGeometrySource2D { Geometry: { } geometry })
 			{
-				return;
-			}
-
-			if (FillBrush != null)
-			{
-				var fillPaint = TryCreateAndClearFillPaint();
-
-				FillBrush.UpdatePaint(fillPaint, geometry.Bounds);
-
-				surface.Canvas.DrawPath(geometry, fillPaint);
-			}
-
-			if (StrokeBrush != null && StrokeThickness > 0)
-			{
-				var fillPaint = TryCreateAndClearFillPaint();
-				var strokePaint = TryCreateAndClearStrokePaint();
-
-				// Set stroke thickness
-				strokePaint.StrokeWidth = StrokeThickness;
-				// TODO: Add support for dashes here
-				// strokePaint.PathEffect = SKPathEffect.CreateDash();
-
-				// Generate stroke geometry for bounds that will be passed to a brush.
-				// - [Future]: This generated geometry should also be used for hit testing.
-				using (var strokeGeometry = strokePaint.GetFillPath(geometry))
+				if (FillBrush != null)
 				{
+					var fillPaint = TryCreateAndClearFillPaint();
+
+					FillBrush.UpdatePaint(fillPaint, geometry.Bounds);
+
+					surface.Canvas.DrawPath(geometry, fillPaint);
+				}
+
+				if (StrokeBrush != null && StrokeThickness > 0)
+				{
+					var fillPaint = TryCreateAndClearFillPaint();
+					var strokePaint = TryCreateAndClearStrokePaint();
+
+					// Set stroke thickness
+					strokePaint.StrokeWidth = StrokeThickness;
+					// TODO: Add support for dashes here
+					// strokePaint.PathEffect = SKPathEffect.CreateDash();
+
+					// Generate stroke geometry for bounds that will be passed to a brush.
+					// - [Future]: This generated geometry should also be used for hit testing.
+					using var strokeGeometry = strokePaint.GetFillPath(geometry);
+
 					StrokeBrush.UpdatePaint(fillPaint, strokeGeometry.Bounds);
 
 					surface.Canvas.DrawPath(strokeGeometry, fillPaint);

--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -81,56 +81,46 @@ namespace Windows.UI.Composition
 
 		internal void RenderVisual(SKSurface surface, Visual visual)
 		{
-			if (visual.Opacity != 0 && visual.IsVisible)
+			if (visual is { Opacity: 0 } or { IsVisible: false })
 			{
-				if (visual.ShadowState is { } shadow)
-				{
-					surface.Canvas.SaveLayer(shadow.Paint);
-				}
-				else
-				{
-					surface.Canvas.Save();
-				}
-
-				var visualMatrix = surface.Canvas.TotalMatrix;
-
-				visualMatrix = visualMatrix.PreConcat(SKMatrix.CreateTranslation(visual.Offset.X, visual.Offset.Y));
-				visualMatrix = visualMatrix.PreConcat(SKMatrix.CreateTranslation(visual.AnchorPoint.X, visual.AnchorPoint.Y));
-
-				if (visual.RotationAngleInDegrees != 0)
-				{
-					visualMatrix = visualMatrix.PreConcat(SKMatrix.CreateRotationDegrees(visual.RotationAngleInDegrees, visual.CenterPoint.X, visual.CenterPoint.Y));
-				}
-
-				if (visual.TransformMatrix != Matrix4x4.Identity)
-				{
-					visualMatrix = visualMatrix.PreConcat(visual.TransformMatrix.ToSKMatrix44().Matrix);
-				}
-
-				surface.Canvas.SetMatrix(visualMatrix);
-
-				ApplyClip(surface, visual);
-
-				using var opacityDisposable = PushOpacity(visual.Opacity);
-
-				visual.Render(surface);
-
-
-				surface.Canvas.Restore();
+				return;
 			}
+
+			if (visual.ShadowState is { } shadow)
+			{
+				surface.Canvas.SaveLayer(shadow.Paint);
+			}
+			else
+			{
+				surface.Canvas.Save();
+			}
+
+			// Set the position of the visual on the canvas (i.e. change coordinates system to the "XAML element" one)
+			surface.Canvas.Translate(visual.Offset.X + visual.AnchorPoint.X, visual.Offset.Y + visual.AnchorPoint.Y);
+
+			// Apply the clipping. This is relative to the visual's coordinate system, before any rendering transformation is applied.
+			ApplyClip(surface, visual);
+
+			// Applied rending transformation matrix (i.e. change coordinates system to the "rendering" one)
+			var transform = GetTransform(visual); 
+			if (!transform.IsIdentity)
+			{
+				var skTransform = transform.ToSKMatrix();
+				surface.Canvas.Concat(ref skTransform);
+			}
+
+			using var opacityDisposable = PushOpacity(visual.Opacity);
+
+			visual.Render(surface);
+
+			surface.Canvas.Restore();
 		}
 
 		private static void ApplyClip(SKSurface surface, Visual visual)
 		{
 			if (visual.Clip is InsetClip insetClip)
 			{
-				var clipRect = new SKRect
-				{
-					Top = insetClip.TopInset - 1,
-					Bottom = insetClip.BottomInset + 1,
-					Left = insetClip.LeftInset - 1,
-					Right = insetClip.RightInset + 1
-				};
+				var clipRect = insetClip.SKRect;
 
 				surface.Canvas.ClipRect(clipRect, SKClipOperation.Intersect, true);
 			}
@@ -140,26 +130,45 @@ namespace Windows.UI.Composition
 			}
 			else if (visual.Clip is CompositionGeometricClip geometricClip)
 			{
-				if (geometricClip.Geometry is CompositionPathGeometry cpg)
+				switch (geometricClip.Geometry)
 				{
-					if (cpg.Path?.GeometrySource is SkiaGeometrySource2D geometrySource)
-					{
+					case CompositionPathGeometry { Path.GeometrySource: SkiaGeometrySource2D geometrySource }:
 						surface.Canvas.ClipPath(geometrySource.Geometry, antialias: true);
-					}
-					else
-					{
+						break;
+					case CompositionPathGeometry cpg:
 						throw new InvalidOperationException($"Clipping with source {cpg.Path?.GeometrySource} is not supported");
-					}
-				}
-				else if (geometricClip.Geometry is null)
-				{
-					// null is nop
-				}
-				else
-				{
-					throw new InvalidOperationException($"Clipping with {geometricClip.Geometry} is not supported");
+					case null:
+						// null is nop
+						break;
+					default:
+						throw new InvalidOperationException($"Clipping with {geometricClip.Geometry} is not supported");
 				}
 			}
+		}
+
+		private static Matrix4x4 GetTransform(Visual visual)
+		{
+			var transform = visual.TransformMatrix;
+
+			var scale = visual.Scale;
+			if (scale != Vector3.One)
+			{
+				transform *= Matrix4x4.CreateScale(scale, visual.CenterPoint);
+			}
+
+			var orientation = visual.Orientation;
+			if (orientation != Quaternion.Identity)
+			{
+				transform *= Matrix4x4.CreateFromQuaternion(orientation);
+			}
+
+			var rotation = visual.RotationAngle;
+			if (rotation is not 0)
+			{
+				transform *= Matrix4x4.CreateFromAxisAngle(visual.RotationAxis, rotation);
+			}
+
+			return transform;
 		}
 
 		partial void InvalidateRenderPartial()

--- a/src/Uno.UI.Composition/Composition/InsetClip.skia.cs
+++ b/src/Uno.UI.Composition/Composition/InsetClip.skia.cs
@@ -1,0 +1,17 @@
+#nullable enable
+using System;
+using System.Linq;
+using SkiaSharp;
+
+namespace Windows.UI.Composition;
+
+partial class InsetClip
+{
+	internal SKRect SKRect => new()
+	{
+		Top = TopInset - 1,
+		Bottom = BottomInset + 1,
+		Left = LeftInset - 1,
+		Right = RightInset + 1
+	};
+}

--- a/src/Uno.UI.Composition/Composition/SkiaExtensions.skia.cs
+++ b/src/Uno.UI.Composition/Composition/SkiaExtensions.skia.cs
@@ -97,5 +97,11 @@ namespace Windows.UI.Composition
 
 			return ret;
 		}
+
+		public static SKMatrix ToSKMatrix(this Matrix4x4 m)
+			=> new(
+				m.M11, m.M21, m.M41,
+				m.M12, m.M22, m.M42,
+				m.M14, m.M24, m.M44);
 	}
 }

--- a/src/Uno.UI.Composition/Composition/Visual.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Numerics;
+using Uno.Extensions;
 
 namespace Windows.UI.Composition
 {
@@ -10,7 +11,8 @@ namespace Windows.UI.Composition
 		private Vector3 _offset;
 		private Vector3 _scale = new Vector3(1, 1, 1);
 		private Vector3 _centerPoint;
-		private float _rotationAngleInDegrees;
+		private Quaternion _orientation = Quaternion.Identity;
+		private float _rotationAngle;
 		private Vector3 _rotationAxis = new Vector3(0, 0, 1);
 		private Matrix4x4 _transformMatrix = Matrix4x4.Identity;
 		private bool _isVisible = true;
@@ -66,13 +68,27 @@ namespace Windows.UI.Composition
 
 		partial void OnScaleChanged(Vector3 value);
 
-		public float RotationAngleInDegrees
+		public Quaternion Orientation
 		{
-			get => _rotationAngleInDegrees;
-			set { SetProperty(ref _rotationAngleInDegrees, value); OnRotationAngleInDegreesChanged(value); }
+			get => _orientation;
+			set { SetProperty(ref _orientation, value); OnOrientationChanged(value); }
 		}
 
-		partial void OnRotationAngleInDegreesChanged(float value);
+		partial void OnOrientationChanged(Quaternion value);
+
+		public float RotationAngleInDegrees
+		{
+			get => (float)MathEx.ToDegree(_rotationAngle);
+			set => RotationAngle = (float)MathEx.ToRadians(value);
+		}
+
+		public float RotationAngle
+		{
+			get => _rotationAngle;
+			set { SetProperty(ref _rotationAngle, value); OnRotationAngleChanged(value); }
+		}
+
+		partial void OnRotationAngleChanged(float value);
 
 		public Vector2 Size
 		{

--- a/src/Uno.UI.Composition/Composition/Visual.iOS.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.iOS.cs
@@ -74,7 +74,7 @@ namespace Windows.UI.Composition
 			Update();
 		}
 
-		partial void OnRotationAngleInDegreesChanged(float value)
+		partial void OnRotationAngleChanged(float value)
 		{
 			UpdateTransform();
 		}

--- a/src/Uno.UI.Composition/Generated/3.0.0.0/Windows.UI.Composition/Visual.cs
+++ b/src/Uno.UI.Composition/Generated/3.0.0.0/Windows.UI.Composition/Visual.cs
@@ -12,34 +12,8 @@ namespace Windows.UI.Composition
 		// Skipping already declared property Scale
 		// Skipping already declared property RotationAxis
 		// Skipping already declared property RotationAngleInDegrees
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  float RotationAngle
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member float Visual.RotationAngle is not implemented. For more information, visit https://aka.platform.uno/notimplemented?m=float%20Visual.RotationAngle");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Composition.Visual", "float Visual.RotationAngle");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "NET461", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public  global::System.Numerics.Quaternion Orientation
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member Quaternion Visual.Orientation is not implemented. For more information, visit https://aka.platform.uno/notimplemented?m=Quaternion%20Visual.Orientation");
-			}
-			set
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Composition.Visual", "Quaternion Visual.Orientation");
-			}
-		}
-		#endif
+		// Skipping already declared property RotationAngle
+		// Skipping already declared property Orientation
 		// Skipping already declared property Opacity
 		// Skipping already declared property Offset
 		// Skipping already declared property IsVisible

--- a/src/Uno.UI.Runtime.Skia.Gtk/GLValidationSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GLValidationSurface.cs
@@ -15,7 +15,7 @@ namespace Uno.UI.Runtime.Skia
 	/// </summary>
 	internal class GLValidationSurface : GLArea
 	{
-		private TaskCompletionSource<RenderSurfaceType> _result = new();
+		private readonly TaskCompletionSource<RenderSurfaceType> _result = new();
 
 		public GLValidationSurface()
 		{

--- a/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
@@ -8,6 +8,8 @@ using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 using Windows.UI.Xaml;
 using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI.Xaml.Media.Imaging;
 
 namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 
@@ -23,6 +25,15 @@ public static class UITestHelper
 		await TestServices.WindowHelper.WaitForIdle();
 
 		return element.GetAbsoluteBounds();
+	}
+
+	public static async Task<RawBitmap> ScreenShot(FrameworkElement element)
+	{
+		var renderer = new RenderTargetBitmap();
+		element.UpdateLayout();
+		await TestServices.WindowHelper.WaitForIdle();
+		await renderer.RenderAsync(element);
+		return await RawBitmap.From(renderer, element);
 	}
 }
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_CompositionClip.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_CompositionClip.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
+
+[TestClass]
+internal class Given_CompositionClip
+{
+#if __SKIA__
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_TransformClippedElement_Then_ClippingAppliedPostRendering()
+	{
+		var sut = new Grid
+		{
+			Width = 300,
+			Height = 300,
+			Background = new SolidColorBrush(Colors.Chartreuse),
+			Children =
+			{
+				new Grid
+				{
+					Width = 200,
+					Height = 200,
+					Background = new SolidColorBrush(Colors.DeepPink),
+					Children =
+					{
+						new Grid
+						{
+							Width = 300,
+							Height = 300,
+							HorizontalAlignment = HorizontalAlignment.Center,
+							VerticalAlignment = VerticalAlignment.Center,
+							Background = new SolidColorBrush(Colors.DeepSkyBlue),
+							RenderTransform = new TranslateTransform { Y = 100 },
+						}
+					}
+				}
+			}
+		};
+
+		await UITestHelper.Load(sut);
+
+		var result = await UITestHelper.ScreenShot(sut);
+
+		ImageAssert.HasColorAt(result, 150, 1, Colors.Chartreuse);
+		ImageAssert.HasColorAt(result, 150, 49, Colors.Chartreuse);
+		ImageAssert.HasColorAt(result, 150, 51, Colors.DeepPink);
+		ImageAssert.HasColorAt(result, 150, 99, Colors.DeepPink);
+		ImageAssert.HasColorAt(result, 150, 101, Colors.DeepSkyBlue);
+		ImageAssert.HasColorAt(result, 150, 249, Colors.DeepSkyBlue);
+		ImageAssert.HasColorAt(result, 150, 299, Colors.Chartreuse);
+	}
+#endif
+}

--- a/src/Uno.UI/Extensions/UIElementExtensions.cs
+++ b/src/Uno.UI/Extensions/UIElementExtensions.cs
@@ -95,13 +95,13 @@ namespace Uno.UI.Extensions
 		private static readonly IndentationFormat _defaultIndentationFormat = IndentationFormat.NumberedSpaces;
 
 		/// <summary>
-		/// The name (<see cref="GetDebugName"/>) indented (<see cref="GetDebugIndent(object?)"/>) for log usage.
+		/// The name (<see cref="GetDebugName"/>) indented (<see cref="GetDebugIndent(object?, IndentationFormat, bool)"/>) for log usage.
 		/// </summary>
 		internal static string GetDebugIdentifier(this object? elt)
 			=> GetDebugIdentifier(elt, _defaultIndentationFormat);
 
 		/// <summary>
-		/// The name (<see cref="GetDebugName"/>) indented (<see cref="GetDebugIndent(object?)"/>) for log usage.
+		/// The name (<see cref="GetDebugName"/>) indented (<see cref="GetDebugIndent(object?, IndentationFormat, bool)"/>) for log usage.
 		/// </summary>
 		internal static string GetDebugIdentifier(this object? elt, IndentationFormat format)
 			=> $"{elt.GetDebugIndent(format)} [{elt.GetDebugName()}]";

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.skia.cs
@@ -201,24 +201,24 @@ namespace Windows.UI.Xaml.Shapes
 				// Border shape (if any)
 				if (borderThickness != Thickness.Empty)
 				{
-					Action<Action<CompositionSpriteShape, SKPath>> createLayer = builder =>
+					void CreateLayer(Action<CompositionSpriteShape, SKPath> builder)
 					{
 						var spriteShape = compositor.CreateSpriteShape();
 						var geometry = new SkiaGeometrySource2D();
 
 						// Border brush
 						Brush.AssignAndObserveBrush(borderBrush, compositor, brush => spriteShape.StrokeBrush = brush)
-								.DisposeWith(disposables);
+							.DisposeWith(disposables);
 
 						builder(spriteShape, geometry.Geometry);
 						spriteShape.Geometry = compositor.CreatePathGeometry(new CompositionPath(geometry));
 
 						shapeVisual.Shapes.Add(spriteShape);
-					};
+					}
 
 					if (borderThickness.Top != 0)
 					{
-						createLayer((l, path) =>
+						CreateLayer((l, path) =>
 						{
 							l.StrokeThickness = (float)borderThickness.Top;
 							var StrokeThicknessAdjust = (float)(borderThickness.Top / 2);
@@ -230,7 +230,7 @@ namespace Windows.UI.Xaml.Shapes
 
 					if (borderThickness.Bottom != 0)
 					{
-						createLayer((l, path) =>
+						CreateLayer((l, path) =>
 						{
 							l.StrokeThickness = (float)borderThickness.Bottom;
 							var StrokeThicknessAdjust = borderThickness.Bottom / 2;
@@ -242,7 +242,7 @@ namespace Windows.UI.Xaml.Shapes
 
 					if (borderThickness.Left != 0)
 					{
-						createLayer((l, path) =>
+						CreateLayer((l, path) =>
 						{
 							l.StrokeThickness = (float)borderThickness.Left;
 							var StrokeThicknessAdjust = borderThickness.Left / 2;
@@ -254,7 +254,7 @@ namespace Windows.UI.Xaml.Shapes
 
 					if (borderThickness.Right != 0)
 					{
-						createLayer((l, path) =>
+						CreateLayer((l, path) =>
 						{
 							l.StrokeThickness = (float)borderThickness.Right;
 							var StrokeThicknessAdjust = borderThickness.Right / 2;

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -93,7 +93,9 @@ namespace Windows.UI.Xaml
 				if (_visual == null)
 				{
 					_visual = Window.Current.Compositor.CreateContainerVisual();
-					_visual.Comment = $"Owner:{GetType()}/{Name}";
+#if DEBUG
+					_visual.Comment = $"Owner: {this.GetDebugDepth():D2}-{this.GetDebugName()}";
+#endif
 				}
 
 				return _visual;


### PR DESCRIPTION
## Bugfix
Element not clipped when render transformed

## What is the current behavior?
When you apply a `RenderTransform` on an element, the clipping is applied in transformed coordinate space (a.k.a. "element's rendering coordinate space") resulting in an invalidate rendering.


## What is the new behavior?
The clipping is now applied in the "element's XAML coordinate space".

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
