### PR TITLE
fix(mediaPlayer): Fix clipping of transport control

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
@@ -53,6 +53,37 @@ namespace Windows.UI.Xaml.Controls
 			_subscriptions.Disposable = AttachThumbEventHandlers(_progressSlider);
 		}
 
+		private void UnbindMediaPlayer()
+		{
+			try
+			{
+				_subscriptions.Disposable = null;
+
+				if (_mediaPlayer != null)
+				{
+					_mediaPlayer.PlaybackSession.PlaybackStateChanged -= OnPlaybackStateChanged;
+					_mediaPlayer.PlaybackSession.BufferingProgressChanged -= OnBufferingProgressChanged;
+					_mediaPlayer.PlaybackSession.NaturalDurationChanged -= OnNaturalDurationChanged;
+					_mediaPlayer.PlaybackSession.PositionChanged -= OnPositionChanged;
+				}
+
+				_playPauseButton.Maybe(p => p.Tapped -= PlayPause);
+				_playPauseButtonOnLeft.Maybe(p => p.Tapped -= PlayPause);
+				_audioMuteButton.Maybe(p => p.Tapped -= ToggleMute);
+				_volumeSlider.Maybe(p => p.ValueChanged -= OnVolumeChanged);
+				_stopButton.Maybe(p => p.Tapped -= Stop);
+				_skipForwardButton.Maybe(p => p.Tapped -= SkipForward);
+				_skipBackwardButton.Maybe(p => p.Tapped -= SkipBackward);
+				_fastForwardButton.Maybe(p => p.Tapped -= ForwardButton);
+				_rewindButton.Maybe(p => p.Tapped -= RewindButton);
+				_progressSlider.Maybe(p => p.Tapped -= TappedProgressSlider);
+			}
+			catch (Exception ex)
+			{
+				this.Log().Error($"Unable to unbind MediaTransportControls properly: {ex.Message}", ex);
+			}
+		}
+
 		public void TappedProgressSlider(object sender, RoutedEventArgs e)
 		{
 			if (double.IsNaN(_progressSlider.Value))
@@ -78,34 +109,6 @@ namespace Windows.UI.Xaml.Controls
 			if (_mediaPlayer != null)
 			{
 				_subscriptions.Disposable = AttachThumbEventHandlers(_progressSlider);
-			}
-		}
-
-		private void UnbindMediaPlayer()
-		{
-			try
-			{
-				_subscriptions.Disposable = null;
-
-				if (_mediaPlayer != null)
-				{
-					_mediaPlayer.PlaybackSession.PlaybackStateChanged -= OnPlaybackStateChanged;
-					_mediaPlayer.PlaybackSession.BufferingProgressChanged -= OnBufferingProgressChanged;
-					_mediaPlayer.PlaybackSession.NaturalDurationChanged -= OnNaturalDurationChanged;
-					_mediaPlayer.PlaybackSession.PositionChanged -= OnPositionChanged;
-				}
-
-				_playPauseButton.Maybe(p => p.Tapped -= PlayPause);
-				_playPauseButtonOnLeft.Maybe(p => p.Tapped -= PlayPause);
-				_audioMuteButton.Maybe(p => p.Tapped -= ToggleMute);
-				_volumeSlider.Maybe(p => p.ValueChanged -= OnVolumeChanged);
-				_stopButton.Maybe(p => p.Tapped -= Stop);
-				_skipForwardButton.Maybe(p => p.Tapped -= SkipForward);
-				_skipBackwardButton.Maybe(p => p.Tapped -= SkipBackward);
-			}
-			catch (Exception ex)
-			{
-				this.Log().Error($"Unable to unbind MediaTransportControls properly: {ex.Message}", ex);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -57,6 +57,7 @@ namespace Windows.UI.Xaml.Controls
 	[TemplatePart(Name = "BufferingProgressBar", Type = typeof(ProgressBar))]
 	[TemplatePart(Name = "DownloadProgressIndicator", Type = typeof(ProgressBar))]
 	[TemplatePart(Name = "ControlPanelGrid", Type = typeof(Grid))]
+	[TemplatePart(Name = ControlPanelBorderName, Type = typeof(Border))]
 	public partial class MediaTransportControls : Control
 	{
 		private const string RootGridName = "RootGrid";
@@ -88,6 +89,7 @@ namespace Windows.UI.Xaml.Controls
 		private const string DownloadProgressIndicatorName = "DownloadProgressIndicator";
 		private const string CompactOverlayButtonName = "CompactOverlayButton";
 		private const string ControlPanelGridName = "ControlPanelGrid";
+		private const string ControlPanelBorderName = "ControlPanel_ControlPanelVisibilityStates_Border";
 
 		private Grid _rootGrid;
 		private Button _playPauseButton;
@@ -117,6 +119,7 @@ namespace Windows.UI.Xaml.Controls
 		private Border _timelineContainer;
 		private ProgressBar _downloadProgressIndicator;
 		private Grid _controlPanelGrid;
+		private Border _controlPanelBorder;
 
 		private DispatcherTimer _controlsVisibilityTimer;
 		private bool _wasPlaying;
@@ -234,12 +237,8 @@ namespace Windows.UI.Xaml.Controls
 			_castButton = this.GetTemplateChild(CastButtonName) as Button;
 
 			_zoomButton = this.GetTemplateChild(ZoomButtonName) as Button;
-
-			if (_zoomButton != null)
-			{
-				_zoomButton?.SetBinding(Button.VisibilityProperty, new Binding { Path = "IsZoomButtonVisible", Source = this, Mode = BindingMode.OneWay, FallbackValue = Visibility.Collapsed, Converter = trueToVisible });
-				_zoomButton?.SetBinding(Button.IsEnabledProperty, new Binding { Path = "IsZoomEnabled", Source = this, Mode = BindingMode.OneWay, FallbackValue = true });
-			}
+			_zoomButton?.SetBinding(Button.VisibilityProperty, new Binding { Path = "IsZoomButtonVisible", Source = this, Mode = BindingMode.OneWay, FallbackValue = Visibility.Collapsed, Converter = trueToVisible });
+			_zoomButton?.SetBinding(Button.IsEnabledProperty, new Binding { Path = "IsZoomEnabled", Source = this, Mode = BindingMode.OneWay, FallbackValue = true });
 
 			_playbackRateButton = this.GetTemplateChild(PlaybackRateButtonName) as Button;
 			_playbackRateButton?.SetBinding(Button.VisibilityProperty, new Binding { Path = "IsPlaybackRateButtonVisible", Source = this, Mode = BindingMode.OneWay, FallbackValue = Visibility.Collapsed, Converter = trueToVisible });
@@ -250,6 +249,8 @@ namespace Windows.UI.Xaml.Controls
 			_compactOverlayButton?.SetBinding(Button.IsEnabledProperty, new Binding { Path = "IsCompactOverlayEnabled", Source = this, Mode = BindingMode.OneWay, FallbackValue = true });
 
 			_controlPanelGrid = this.GetTemplateChild(ControlPanelGridName) as Grid;
+
+			_controlPanelBorder = this.GetTemplateChild(ControlPanelBorderName) as Border;
 
 			_repeatVideoButton = this.GetTemplateChild(RepeatVideoButtonName) as Button;
 			_repeatVideoButton?.SetBinding(Button.VisibilityProperty, new Binding { Path = "IsRepeatButtonVisible", Source = this, Mode = BindingMode.OneWay, FallbackValue = Visibility.Collapsed, Converter = trueToVisible });
@@ -380,6 +381,13 @@ namespace Windows.UI.Xaml.Controls
 				_loadedSubscriptions.Add(() => _controlPanelGrid.SizeChanged -= ControlPanelGridSizeChanged);
 			}
 
+			if (_controlPanelBorder is not null)
+			{
+				_controlPanelBorder.SizeChanged += ControlPanelBorderSizeChanged;
+
+				_loadedSubscriptions.Add(() => _controlPanelBorder.SizeChanged -= ControlPanelBorderSizeChanged);
+			}
+
 			if (_repeatVideoButton is not null)
 			{
 				_repeatVideoButton.Tapped += IsRepeatEnabledButtonTapped;
@@ -437,6 +445,14 @@ namespace Windows.UI.Xaml.Controls
 		private void ControlPanelGridSizeChanged(object sender, SizeChangedEventArgs args)
 		{
 			OnControlsBoundsChanged();
+		}
+
+		private static void ControlPanelBorderSizeChanged(object sender, SizeChangedEventArgs args)
+		{
+			if (sender is Border border)
+			{
+				border.Clip = new RectangleGeometry { Rect = new Rect(0, 0, args.NewSize.Width, args.NewSize.Height) };
+			}
 		}
 
 		private void FullWindowButtonTapped(object sender, RoutedEventArgs e)


### PR DESCRIPTION
~NOTE: This should be merged only once https://github.com/unoplatform/uno/pull/12198 has been merged !~

## Bugfix
Clipping of transport control of `MediaPlayerElement`

## What is the current behavior?
When fade in/out the `MediaTransportControl`, it appears out of the bounds of the `MediaPlayerElement`

## What is the new behavior?
It's now clipped

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
