### PR TITLE
MediaPlayerElement - Update Documentation

### DIFF
--- a/doc/articles/controls/MediaPlayerElement.md
+++ b/doc/articles/controls/MediaPlayerElement.md
@@ -8,20 +8,20 @@ See [MediaPlayerElement](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xam
 
 ## Media formats
 
-| Supported Formats    									| iOS	| Android	| Remarks							|
-|-------------------------------------------------------|-------|-----------|-----------------------------------|
-| Local/Remote MP3 Support								| X     | X  		|									|
-| Local/Remote MPEG4 Support							| X     | X  		|									|
-| HLSv3	Support											| X     | X  		| 									|
-| HLSv4	Support											| X     | X  		|									|
-| 3GP Support											| X     | X  		| 3GP with AMR Narrow Band (SAMR) audio codec does not work on iOS (See notes) |
-| FLV Support											| -     | X  		|									|
-| MOV Support											| X     | -  		|									|
-| MKV Support											| -     | X  		|									|
-| AVI Support											| -     | X  		| 									|
-| OGG Support											| -     | -  		|									|
-| MPEG-Dash	Support										| -     | -  		| 									|
-| Smooth Streaming Support								| -     | -  		| 									|
+| Supported Formats    									| iOS		| Android	| Wasm		| Skia GTK	| Remarks							|
+|-------------------------------------------------------|-----------|-----------|-----------|-----------|-----------------------------------|
+| Local/Remote MP3 Support								| X  		| X  		| X  		| X  		|									|
+| Local/Remote MPEG4 Support							| X  		| X  		| X  		| X  		|									|
+| HLSv3	Support											| X  		| X  		| X  		| X  		| 									|
+| HLSv4	Support											| X  		| X  		| X  		| X  		|									|
+| 3GP Support											| X  		| X  		| X  		| X  		| 3GP with AMR Narrow Band (SAMR) audio codec does not work on iOS (See notes) |
+| FLV Support											| -  		| X  		| X  		| X  		|									|
+| MOV Support											| X  		| -  		| -  		| -  		|									|
+| MKV Support											| -  		| X  		| X  		| X  		|									|
+| AVI Support											| -  		| X  		| X  		| X  		| 									|
+| OGG Support											| -  		| -  		| X  		| X  		|									|
+| MPEG-Dash	Support										| -  		| -  		| -  		| -  		| 									|
+| Smooth Streaming Support								| -  		| -  		| -  		| -  		| 									|
 
 #### Notes
 
@@ -30,35 +30,35 @@ See [MediaPlayerElement](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xam
 
 ## Features
 
-| Section				| Feature    											| iOS	| Android	| Remarks										|
-|-----------------------|-------------------------------------------------------|-------|-----------|-----------------------------------------------|
-| MediaPlayerElement	| AutoPlay  											| X     | X  		|												|
-|						| Poster image											| X     | X  		| Does not show when playing music				|
-|						| Enable/Disable MediaTransportControls			  		| X     | X  		|												|
-|						| Stretch										  		| X     | X  		| Stretch.None behave like Stretch.Fill on iOS	|
-|						| Pause media when headphones unplugged			  		| X     | X  		| 												|
-| TransportControls		| Transport controls custom style						| X     | X  		|												|
-| 			    		| Play/Pause 											| X     | X  		|												|
-|						| Stop  												| X     | X  		|												|
-| 						| Seek  												| X     | X  		|												|
-|						| Volume change											| X     | X  		|												|
-|						| Mute													| X     | X  		|												|
-|						| Show elapsed time										| X     | X  		|												|
-|						| Show remaining time									| X     | X  		|												|
-|						| Show/Hide MediaTransportControls automatically		| X     | X  		|												|
-|						| MediaTransportControls compact mode					| X     | X  		|												|
-|						| Show/Hide MediaTransportControls commands  			| X     | X  		|												|
-|						| Enable/Disable MediaTransportControls commands  		| X     | X  		|												|
-|						| Skip forward											| X     | X  		|												|
-|						| Skip backward											| X     | X  		|												|
-|						| Show buffering progress						  		| X     | X  		|												|
-|						| Zoom mode												| X     | X  		| 												|
-|						| Full-screen mode								  		| X     | X  		|												|
-|						| Playlists support		  								| X     | X  		|												|
-|						| Change playback rate									| -     | -  		|												|
-|						| Player controls on locked screen support  			| -     | -  		|												|
-|						| Subtitles	support			  							| -     | -  		|												|
-|						| Languages	support			  							| -     | -  		|												|
+| Section				| Feature    											| iOS		| Android	| Wasm		| Skia GTK	| Remarks										|
+|-----------------------|-------------------------------------------------------|-----------|-----------|-----------|-----------|-----------------------------------------------|
+| MediaPlayerElement	| AutoPlay  											| X  		| X  		| X  		| X  		|												|
+|						| Poster image											| X  		| X  		| X  		| X  		| Does not show when playing music				|
+|						| Enable/Disable MediaTransportControls			  		| X  		| X  		| X  		| X  		|												|
+|						| Stretch										  		| X  		| X  		| X  		| X  		| Stretch.None behave like Stretch.Fill on iOS	|
+|						| Pause media when headphones unplugged			  		| X  		| X  		| X  		| X  		| 												|
+| TransportControls		| Transport controls custom style						| X  		| X  		| X  		| X  		|												|
+| 			    		| Play/Pause 											| X  		| X  		| X  		| X  		|												|
+|						| Stop  												| X  		| X  		| X  		| X  		|												|
+| 						| Seek  												| X  		| X  		| X  		| X  		|												|
+|						| Volume change											| X  		| X  		| X  		| X  		|												|
+|						| Mute													| X  		| X  		| X  		| X  		|												|
+|						| Show elapsed time										| X  		| X  		| X  		| X  		|												|
+|						| Show remaining time									| X  		| X  		| X  		| X  		|												|
+|						| Show/Hide MediaTransportControls automatically		| X  		| X  		| X  		| X  		|												|
+|						| MediaTransportControls compact mode					| X  		| X  		| X  		| X  		|												|
+|						| Show/Hide MediaTransportControls commands  			| X  		| X  		| X  		| X  		|												|
+|						| Enable/Disable MediaTransportControls commands  		| X  		| X  		| X  		| X  		|												|
+|						| Skip forward											| X  		| X  		| X  		| X  		|												|
+|						| Skip backward											| X  		| X  		| X  		| X  		|												|
+|						| Show buffering progress						  		| X  		| X  		| X  		| X  		|												|
+|						| Zoom mode												| X  		| X  		| X  		| X  		| 												|
+|						| Full-screen mode								  		| X  		| X  		| X  		| X  		|												|
+|						| Playlists support		  								| X  		| X  		| X  		| X  		|												|
+|						| Change playback rate									| -  		| -  		| X  		| X  		|												|
+|						| Player controls on locked screen support  			| -  		| -  		| -  		| -  		|												|
+|						| Subtitles	support			  							| -  		| -  		| -  		| -  		|												|
+|						| Languages	support			  							| -  		| -  		| -  		| -  		|												|
 
 ## Requirement
 
@@ -91,12 +91,13 @@ Add the following to your AndroidManifest.xml
 
 ## Future improvement
 
-- Playback rate support
 - React to audio focus changes (pause/stop playback or reduce audio volume)
 - Subtitles support
 - Languages support
-- Display poster for audio media
 - Buffering of next playlist element when using MediaPlaybackList
+- Cast to device
+- Playlist for Wasm
+- Download option
 
 ## Known issues
 

--- a/doc/articles/controls/MediaPlayerElement.md
+++ b/doc/articles/controls/MediaPlayerElement.md
@@ -89,6 +89,30 @@ Add the following to your AndroidManifest.xml
 <uses-permission android:name="android.permission.WAKE_LOCK" />
 ```
 
+### WebAssembly
+Using the `MediaPlayerElement` on WebAssembly head requires adding the [`Uno.UI.MediaPlayer.WebAssembly`](https://www.nuget.org/packages/Uno.UI.MediaPlayer.WebAssembly) package to the `MyApp.Wasm` project. 
+
+> [!IMPORTANT]
+> The `Uno.UI.MediaPlayer.WebAssembly` package version must use the same version as the other `Uno.UI.*` or `Uno.WinUI.*` packages in your project.
+
+### Skia.GTK
+Using the `MediaPlayerElement` on the Skia+GTK head requires adding the [`Uno.UI.MediaPlayer.Skia.Gtk`](https://www.nuget.org/packages/Uno.UI.MediaPlayer.Skia.Gtk) package to the `MyApp.Skia.Gtk` project. 
+
+> [!IMPORTANT]
+> The `Uno.UI.MediaPlayer.Skia.Gtk` package version must use the same version as the other `Uno.UI.*` or `Uno.WinUI.*` packages in your project.
+
+#### Skia+GTK on Linux
+The `MediaPlayerElement` support is based on libVLC, and needs the system to provide the appropriate libraries to work properly.
+
+You'll need to install the following packages (Debian based distros):
+
+```
+sudo apt-get install libvlc-dev libx11-dev vlc libgtk2.0-0 libx11dev
+```
+
+#### Skia+GTK on Windows
+Running the `MediaPlayerElement` requires adding the [`VideoLAN.LibVLC.Windows`](https://www.nuget.org/packages/VideoLAN.LibVLC.Windows) package to your application.
+
 ## Future improvement
 
 - React to audio focus changes (pause/stop playback or reduce audio volume)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12437


## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

MediaPlayerElement do not supports Wasm and Skia platforms

## What is the new behavior?

Update the Documentation for MediaPlayerElement that now supports Wasm and Skia platforms

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
