### PR TITLE
Update when back from fullscreen for wasm

### DIFF
--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/MediaTransportControls_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/MediaTransportControls_themeresources.xaml
@@ -262,7 +262,9 @@
                                                         <Thumb x:Name="HorizontalThumb" Style="{StaticResource SliderThumbStyle}" Height="24" Width="24" Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" FocusVisualMargin="-14,-6,-14,-6" AutomationProperties.AccessibilityView="Raw">
                                                             <ToolTipService.ToolTip>
                                                                 <ToolTip x:Name="ThumbnailTooltip">
-                                                                    <ContentPresenter Content="{Binding}" />
+                                                                    <!-- UNO TODO Binding ContentPresenter.Content is flagged as an error by Uno because it can have unpredictable results -->
+                                                                    <!--<ContentPresenter Content="{Binding}" />-->
+                                                                    <ContentControl Content="{Binding}" />
                                                                 </ToolTip>
                                                             </ToolTipService.ToolTip>
                                                             <Thumb.DataContext>
@@ -676,11 +678,12 @@
                             <!-- Closed Captioning  visibility states -->
                             <!-- Focus states -->
                             <VisualStateGroup x:Name="FocusStates">
-                                <VisualState x:Name="Focused">
+                                 <VisualState x:Name="Focused">
                                     <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetName="FocusVisualWhite" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
-                                        <DoubleAnimation Storyboard.TargetName="FocusVisualBlack" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
-                                    </Storyboard>
+										<!--UNO TODO: There's no element called 'FocusVisualWhite', which presumably fails silently on Windows, but causes a compile-time error on Uno-->
+                                        <!-- <DoubleAnimation Storyboard.TargetName="FocusVisualWhite" Storyboard.TargetProperty="Opacity" To="1" Duration="0" /> -->
+                                        <!-- <DoubleAnimation Storyboard.TargetName="FocusVisualBlack" Storyboard.TargetProperty="Opacity" To="1" Duration="0" /> -->
+									</Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Unfocused" />
                                 <VisualState x:Name="PointerFocused" />

--- a/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
+++ b/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
@@ -1107,22 +1107,8 @@
       <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBackgroundThemeBrush" Color="#FF5F37BE" />
       <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBorderThemeBrush" Color="#FF5F37BE" />
       <Thickness x:Key="MediaTransportControlsTitleSafeBounds">48,0,48,27</Thickness>
-      <StaticResource x:Key="MediaTransportControlsPanelBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
+      <StaticResource x:Key="MediaTransportControlsPanelBackground" ResourceKey="SystemControlPageBackgroundAltMediumBrush" />
       <StaticResource x:Key="MediaTransportControlsFlyoutBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
-      <StaticResource x:Key="MediaTransportControlsThumbBorderBackground" ResourceKey="ControlStrongFillColorDefaultBrush" />
-      <StaticResource x:Key="MediaTransportControlsFillTimeElapsedText" ResourceKey="TextFillColorSecondaryBrush" />
-      <StaticResource x:Key="MediaTransportControlsFillMediaText" ResourceKey="TextFillColorPrimaryBrush" />
-      <StaticResource x:Key="MediaTransportControlsBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
-      <Thickness x:Key="MediaTransportControlsMargin">12</Thickness>
-      <Thickness x:Key="MediaTransportControlsProgressSliderMargin">7,2,7,1</Thickness>
-      <Thickness x:Key="MediaTransportControlsProgressSliderCompactMargin">12,-1,8,1</Thickness>
-      <x:Double x:Key="MediaTransportControlsBorderThickness">1</x:Double>
-      <x:Double x:Key="MediaTransportControlsAppBarButtonHeight">40</x:Double>
-      <x:Double x:Key="MediaTransportControlsAppBarButtonWidth">40</x:Double>
-      <x:Double x:Key="MediaTransportControlsSliderHeight">32</x:Double>
-      <x:Double x:Key="MediaTransportControlsSliderWidth">190</x:Double>
-      <x:Double x:Key="MediaTransportControlsMinWidth">296</x:Double>
-      <x:Double x:Key="MediaTransportControlsMaxWidth">720</x:Double>
       <StaticResource x:Key="MenuBarBackground" ResourceKey="SubtleFillColorTransparentBrush" />
       <StaticResource x:Key="MenuBarItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
       <StaticResource x:Key="MenuBarItemBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
@@ -2853,22 +2839,8 @@
       <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBackgroundThemeBrush" Color="#FF5F37BE" />
       <SolidColorBrush x:Key="ListViewItemSelectedPointerOverBorderThemeBrush" Color="#FF5F37BE" />
       <Thickness x:Key="MediaTransportControlsTitleSafeBounds">48,0,48,27</Thickness>
-      <StaticResource x:Key="MediaTransportControlsPanelBackground" ResourceKey="AcrylicInAppFillColorDefaultBrush" />
+      <StaticResource x:Key="MediaTransportControlsPanelBackground" ResourceKey="SystemControlPageBackgroundAltMediumBrush" />
       <StaticResource x:Key="MediaTransportControlsFlyoutBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
-      <StaticResource x:Key="MediaTransportControlsThumbBorderBackground" ResourceKey="ControlStrongFillColorDefaultBrush" />
-      <StaticResource x:Key="MediaTransportControlsFillTimeElapsedText" ResourceKey="TextFillColorSecondaryBrush" />
-      <StaticResource x:Key="MediaTransportControlsFillMediaText" ResourceKey="TextFillColorPrimaryBrush" />
-      <StaticResource x:Key="MediaTransportControlsBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
-      <Thickness x:Key="MediaTransportControlsMargin">12</Thickness>
-      <Thickness x:Key="MediaTransportControlsProgressSliderMargin">7,2,7,1</Thickness>
-      <Thickness x:Key="MediaTransportControlsProgressSliderCompactMargin">12,-1,8,1</Thickness>
-      <x:Double x:Key="MediaTransportControlsBorderThickness">1</x:Double>
-      <x:Double x:Key="MediaTransportControlsAppBarButtonHeight">40</x:Double>
-      <x:Double x:Key="MediaTransportControlsAppBarButtonWidth">40</x:Double>
-      <x:Double x:Key="MediaTransportControlsSliderHeight">32</x:Double>
-      <x:Double x:Key="MediaTransportControlsSliderWidth">190</x:Double>
-      <x:Double x:Key="MediaTransportControlsMinWidth">296</x:Double>
-      <x:Double x:Key="MediaTransportControlsMaxWidth">720</x:Double>
       <StaticResource x:Key="MenuBarBackground" ResourceKey="SubtleFillColorTransparentBrush" />
       <StaticResource x:Key="MenuBarItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
       <StaticResource x:Key="MenuBarItemBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
@@ -4586,20 +4558,6 @@
       <Thickness x:Key="MediaTransportControlsTitleSafeBounds">48,0,48,27</Thickness>
       <StaticResource x:Key="MediaTransportControlsPanelBackground" ResourceKey="SystemControlPageBackgroundAltMediumBrush" />
       <StaticResource x:Key="MediaTransportControlsFlyoutBackground" ResourceKey="SystemControlPageBackgroundAltMediumBrush" />
-      <StaticResource x:Key="MediaTransportControlsThumbBorderBackground" ResourceKey="SystemControlBackgroundBaseMediumBrush" />
-      <StaticResource x:Key="MediaTransportControlsFillTimeElapsedText" ResourceKey="SystemControlPageTextBaseMediumBrush" />
-      <StaticResource x:Key="MediaTransportControlsFillMediaText" ResourceKey="SystemControlForegroundBaseHighBrush" />
-      <StaticResource x:Key="MediaTransportControlsBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
-      <Thickness x:Key="MediaTransportControlsMargin">12</Thickness>
-      <Thickness x:Key="MediaTransportControlsProgressSliderMargin">7,2,7,1</Thickness>
-      <Thickness x:Key="MediaTransportControlsProgressSliderCompactMargin">12,-1,8,1</Thickness>
-      <x:Double x:Key="MediaTransportControlsBorderThickness">1</x:Double>
-      <x:Double x:Key="MediaTransportControlsAppBarButtonHeight">40</x:Double>
-      <x:Double x:Key="MediaTransportControlsAppBarButtonWidth">40</x:Double>
-      <x:Double x:Key="MediaTransportControlsSliderHeight">32</x:Double>
-      <x:Double x:Key="MediaTransportControlsSliderWidth">190</x:Double>
-      <x:Double x:Key="MediaTransportControlsMinWidth">296</x:Double>
-      <x:Double x:Key="MediaTransportControlsMaxWidth">720</x:Double>
       <StaticResource x:Key="MenuBarBackground" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="MenuBarItemBackground" ResourceKey="SystemControlTransparentBrush" />
       <StaticResource x:Key="MenuBarItemBackgroundPointerOver" ResourceKey="SystemControlBackgroundListLowBrush" />
@@ -17203,51 +17161,493 @@
     <Setter Property="IsTabStop" Value="False" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="FlowDirection" Value="LeftToRight" />
-    <Setter Property="Margin" Value="{ThemeResource MediaTransportControlsMargin}" />
-    <Setter Property="MaxWidth" Value="{ThemeResource MediaTransportControlsMaxWidth}" />
-    <Setter Property="MinWidth" Value="{ThemeResource MediaTransportControlsMinWidth}" />
     <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
     <Setter Property="IsTextScaleFactorEnabled" Value="False" />
-    <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="MediaTransportControls">
           <Grid x:Name="RootGrid" Background="Transparent">
             <Grid.Resources>
-              <!-- New AppBar button style 40x40 pixels in size -->
-              <Style x:Key="AppBarButtonStyle" TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}">
-                <Setter Property="Height" Value="{ThemeResource MediaTransportControlsAppBarButtonHeight}" />
-                <Setter Property="Width" Value="{ThemeResource MediaTransportControlsAppBarButtonWidth}" />
+              <!-- New AppBar button style 48x48 pixels in size -->
+              <Style x:Key="AppBarButtonStyle" TargetType="AppBarButton" BasedOn="{StaticResource AppBarButtonRevealStyle}">
+                <Setter Property="Width" Value="{ThemeResource MTCMediaButtonWidth}" />
+                <Setter Property="Height" Value="{ThemeResource MTCMediaButtonHeight}" />
                 <Setter Property="AllowFocusOnInteraction" Value="True" />
               </Style>
-              <!-- New AppBarToggle button style 40x40 pixels in size -->
-              <Style x:Key="AppBarToggleButtonStyle" TargetType="AppBarToggleButton" BasedOn="{StaticResource DefaultAppBarToggleButtonStyle}">
-                <Setter Property="Height" Value="{ThemeResource MediaTransportControlsAppBarButtonHeight}" />
-                <Setter Property="Width" Value="{ThemeResource MediaTransportControlsAppBarButtonWidth}" />
+              <!-- New AppBarToggle button style 48x48 pixels in size -->
+              <Style x:Key="AppBarToggleButtonStyle" TargetType="AppBarToggleButton" BasedOn="{StaticResource AppBarToggleButtonRevealStyle}">
+                <Setter Property="Width" Value="{ThemeResource MTCMediaButtonWidth}" />
+                <Setter Property="Height" Value="{ThemeResource MTCMediaButtonHeight}" />
                 <Setter Property="AllowFocusOnInteraction" Value="True" />
               </Style>
               <!-- New CommandBar Style -->
-              <Style x:Key="CommandBarStyle" TargetType="CommandBar" BasedOn="{StaticResource DefaultCommandBarStyle}">
+              <Style x:Key="CommandBarStyle" TargetType="CommandBar">
+                <Setter Property="Height" Value="{ThemeResource MTCMediaButtonHeight}" />
                 <Setter Property="Background" Value="Transparent" />
-                <Setter Property="DefaultLabelPosition" Value="Collapsed" />
               </Style>
               <!-- Style for Error Message text -->
               <Style x:Key="MediaTextBlockStyle" TargetType="TextBlock">
                 <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="Foreground" Value="{ThemeResource MediaTransportControlsFillMediaText}" />
+                <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
                 <Setter Property="FontSize" Value="{ThemeResource MTCMediaFontSize}" />
                 <Setter Property="FontFamily" Value="{ThemeResource MTCMediaFontFamily}" />
                 <Setter Property="Style" Value="{ThemeResource CaptionTextBlockStyle }" />
                 <Setter Property="IsTextScaleFactorEnabled" Value="False" />
               </Style>
+              <!-- Style for Position slider used in Media Transport Controls -->
+              <Style x:Key="MediaSliderStyle" TargetType="Slider">
+                <Setter Property="Background" Value="{ThemeResource SliderTrackFill}" />
+                <Setter Property="BorderThickness" Value="{ThemeResource SliderBorderThemeThickness}" />
+                <Setter Property="Foreground" Value="{ThemeResource SliderTrackValueFill}" />
+                <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+                <Setter Property="ManipulationMode" Value="None" />
+                <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                <Setter Property="FocusVisualMargin" Value="-7,0,-7,0" />
+                <Setter Property="IsFocusEngagementEnabled" Value="True" />
+                <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="Slider">
+                      <Grid Margin="{TemplateBinding Padding}">
+                        <Grid.Resources>
+                          <Style TargetType="Thumb" x:Key="SliderThumbStyle">
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Setter Property="Background" Value="{ThemeResource SliderThumbBackground}" />
+                            <Setter Property="Foreground" Value="{ThemeResource SystemControlBackgroundChromeMediumBrush}" />
+                            <Setter Property="Template">
+                              <Setter.Value>
+                                <ControlTemplate TargetType="Thumb">
+                                  <Ellipse x:Name="ellipse" Stroke="{TemplateBinding Background}" StrokeThickness="2" Fill="{TemplateBinding Foreground}" />
+                                </ControlTemplate>
+                              </Setter.Value>
+                            </Setter>
+                          </Style>
+                          <Style TargetType="ProgressBar" x:Key="MediaSliderProgressBarStyle">
+                            <Setter Property="Height" Value="{ThemeResource SliderTrackThemeHeight}" />
+                            <Setter Property="Minimum" Value="0" />
+                            <Setter Property="Maximum" Value="100" />
+                            <Setter Property="Foreground" Value="{ThemeResource SystemControlHighlightChromeAltLowBrush}" />
+                            <Setter Property="Background" Value="Transparent" />
+                            <Setter Property="BorderBrush" Value="Transparent" />
+                            <Setter Property="BorderThickness" Value="1" />
+                          </Style>
+                        </Grid.Resources>
+                        <Grid.RowDefinitions>
+                          <RowDefinition Height="Auto" />
+                          <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <VisualStateManager.VisualStateGroups>
+                          <VisualStateGroup x:Name="CommonStates">
+                            <VisualState x:Name="Normal" />
+                            <VisualState x:Name="Pressed">
+                              <Storyboard>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackFillPressed}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalTrackRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackFillPressed}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="Background">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderThumbBackgroundPressed}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="Background">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderThumbBackgroundPressed}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SliderContainer" Storyboard.TargetProperty="Background">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderContainerBackgroundPressed}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalDecreaseRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackValueFillPressed}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalDecreaseRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackValueFillPressed}" />
+                                </ObjectAnimationUsingKeyFrames>
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="Disabled">
+                              <Storyboard>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter" Storyboard.TargetProperty="Foreground">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderHeaderForegroundDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalDecreaseRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackValueFillDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackFillDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalDecreaseRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackValueFillDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalTrackRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackFillDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="Background">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderThumbBackgroundDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="Background">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderThumbBackgroundDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TopTickBar" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTickBarFillDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BottomTickBar" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTickBarFillDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LeftTickBar" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTickBarFillDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RightTickBar" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTickBarFillDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SliderContainer" Storyboard.TargetProperty="Background">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderContainerBackgroundDisabled}" />
+                                </ObjectAnimationUsingKeyFrames>
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="PointerOver">
+                              <Storyboard>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalTrackRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackFillPointerOver}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalTrackRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackFillPointerOver}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="Background">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderThumbBackgroundPointerOver}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="Background">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderThumbBackgroundPointerOver}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SliderContainer" Storyboard.TargetProperty="Background">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderContainerBackgroundPointerOver}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalDecreaseRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackValueFillPointerOver}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalDecreaseRect" Storyboard.TargetProperty="Fill">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SliderTrackValueFillPointerOver}" />
+                                </ObjectAnimationUsingKeyFrames>
+                              </Storyboard>
+                            </VisualState>
+                          </VisualStateGroup>
+                          <VisualStateGroup x:Name="FocusEngagementStates">
+                            <VisualState x:Name="FocusDisengaged" />
+                            <VisualState x:Name="FocusEngagedHorizontal">
+                              <Storyboard>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SliderContainer" Storyboard.TargetProperty="(Control.IsTemplateFocusTarget)">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="False" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HorizontalThumb" Storyboard.TargetProperty="(Control.IsTemplateFocusTarget)">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="True" />
+                                </ObjectAnimationUsingKeyFrames>
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="FocusEngagedVertical">
+                              <Storyboard>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SliderContainer" Storyboard.TargetProperty="(Control.IsTemplateFocusTarget)">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="False" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="VerticalThumb" Storyboard.TargetProperty="(Control.IsTemplateFocusTarget)">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="True" />
+                                </ObjectAnimationUsingKeyFrames>
+                              </Storyboard>
+                            </VisualState>
+                          </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <ContentPresenter x:Name="HeaderContentPresenter" x:DeferLoadStrategy="Lazy" Visibility="Collapsed" Foreground="{ThemeResource SliderHeaderForeground}" Margin="{ThemeResource SliderHeaderThemeMargin}" Content="{TemplateBinding Header}" ContentTemplate="{TemplateBinding HeaderTemplate}" FontWeight="{ThemeResource SliderHeaderThemeFontWeight}" TextWrapping="Wrap" />
+                        <Grid x:Name="SliderContainer" Background="{ThemeResource SliderContainerBackground}" Grid.Row="1" Control.IsTemplateFocusTarget="True">
+                          <Grid x:Name="HorizontalTemplate" MinHeight="44">
+                            <Grid.ColumnDefinitions>
+                              <ColumnDefinition Width="Auto" />
+                              <ColumnDefinition Width="Auto" />
+                              <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                              <RowDefinition Height="18" />
+                              <RowDefinition Height="Auto" />
+                              <RowDefinition Height="18" />
+                            </Grid.RowDefinitions>
+                            <Rectangle x:Name="HorizontalTrackRect" Fill="{TemplateBinding Background}" Height="{ThemeResource SliderTrackThemeHeight}" Grid.Row="1" Grid.ColumnSpan="3" contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}" contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}" contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
+                            <ProgressBar x:Name="DownloadProgressIndicator" Style="{StaticResource MediaSliderProgressBarStyle}" Grid.Row="1" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+                            <Rectangle x:Name="HorizontalDecreaseRect" Fill="{TemplateBinding Foreground}" Grid.Row="1" contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}" contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}" contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
+                            <TickBar x:Name="TopTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderTickBarFill}" Height="{ThemeResource SliderOutsideTickBarThemeHeight}" VerticalAlignment="Bottom" Margin="0,0,0,4" Grid.ColumnSpan="3" />
+                            <TickBar x:Name="HorizontalInlineTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderInlineTickBarFill}" Height="{ThemeResource SliderTrackThemeHeight}" Grid.Row="1" Grid.ColumnSpan="3" />
+                            <TickBar x:Name="BottomTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderTickBarFill}" Height="{ThemeResource SliderOutsideTickBarThemeHeight}" VerticalAlignment="Top" Margin="0,4,0,0" Grid.Row="2" Grid.ColumnSpan="3" />
+                            <Thumb x:Name="HorizontalThumb" Style="{StaticResource SliderThumbStyle}" Height="24" Width="24" Grid.Row="0" Grid.RowSpan="3" Grid.Column="1" FocusVisualMargin="-14,-6,-14,-6" AutomationProperties.AccessibilityView="Raw">
+                              <ToolTipService.ToolTip>
+                                <ToolTip x:Name="ThumbnailTooltip">
+                                  <!-- UNO TODO Binding ContentPresenter.Content is flagged as an error by Uno because it can have unpredictable results -->
+                                  <!--<ContentPresenter Content="{Binding}" />-->
+                                  <ContentControl Content="{Binding}" />
+                                </ToolTip>
+                              </ToolTipService.ToolTip>
+                              <Thumb.DataContext>
+                                <Grid Height="112" Width="192">
+                                  <Image x:Name="ThumbnailImage" />
+                                  <Border Background="{ThemeResource SystemControlBackgroundBaseMediumBrush}" VerticalAlignment="Bottom" HorizontalAlignment="Left">
+                                    <TextBlock x:Name="TimeElapsedPreview" Margin="6,1,6,3" Style="{StaticResource BodyTextBlockStyle}" IsTextScaleFactorEnabled="False" Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}" />
+                                  </Border>
+                                </Grid>
+                              </Thumb.DataContext>
+                            </Thumb>
+                          </Grid>
+                          <Grid x:Name="VerticalTemplate" MinWidth="44" Visibility="Collapsed">
+                            <Grid.RowDefinitions>
+                              <RowDefinition Height="*" />
+                              <RowDefinition Height="Auto" />
+                              <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                              <ColumnDefinition Width="18" />
+                              <ColumnDefinition Width="Auto" />
+                              <ColumnDefinition Width="18" />
+                            </Grid.ColumnDefinitions>
+                            <Rectangle x:Name="VerticalTrackRect" Fill="{TemplateBinding Background}" Width="{ThemeResource SliderTrackThemeHeight}" Grid.Column="1" Grid.RowSpan="3" contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}" contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}" contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
+                            <Rectangle x:Name="VerticalDecreaseRect" Fill="{TemplateBinding Foreground}" Grid.Column="1" Grid.Row="2" contract7Present:RadiusX="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}" contract7Present:RadiusY="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" contract7NotPresent:RadiusX="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource TopLeftCornerRadiusDoubleValueConverter}}" contract7NotPresent:RadiusY="{Binding Source={ThemeResource ControlCornerRadius}, Converter={StaticResource BottomRightCornerRadiusDoubleValueConverter}}" />
+                            <TickBar x:Name="LeftTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderTickBarFill}" Width="{ThemeResource SliderOutsideTickBarThemeHeight}" HorizontalAlignment="Right" Margin="0,0,4,0" Grid.RowSpan="3" />
+                            <TickBar x:Name="VerticalInlineTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderInlineTickBarFill}" Width="{ThemeResource SliderTrackThemeHeight}" Grid.Column="1" Grid.RowSpan="3" />
+                            <TickBar x:Name="RightTickBar" Visibility="Collapsed" Fill="{ThemeResource SliderTickBarFill}" Width="{ThemeResource SliderOutsideTickBarThemeHeight}" HorizontalAlignment="Left" Margin="4,0,0,0" Grid.Column="2" Grid.RowSpan="3" />
+                            <Thumb x:Name="VerticalThumb" Style="{StaticResource SliderThumbStyle}" DataContext="{TemplateBinding Value}" Width="24" Height="8" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3" FocusVisualMargin="-6,-14,-6,-14" AutomationProperties.AccessibilityView="Raw" />
+                          </Grid>
+                        </Grid>
+                      </Grid>
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
               <!-- Style for Volume Flyout used in Media Transport Controls -->
-              <Style x:Key="FlyoutStyle" TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenterStyle}">
+              <Style x:Key="FlyoutStyle" TargetType="FlyoutPresenter">
                 <Setter Property="Background" Value="{ThemeResource MediaTransportControlsFlyoutBackground}" />
                 <Setter Property="Padding" Value="0" />
                 <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
               </Style>
-              <Style x:Key="MediaSliderStyle" TargetType="Slider" BasedOn="{StaticResource DefaultSliderStyle}" />
-              <Style x:Key="MediaControlAppBarButtonStyle" TargetType="AppBarButton" BasedOn="{StaticResource DefaultAppBarButtonStyle}" />
+              <Style x:Key="MediaControlAppBarButtonStyle" TargetType="AppBarButton">
+                <Setter Property="Background" Value="{ThemeResource AppBarButtonRevealBackground}" />
+                <Setter Property="Foreground" Value="{ThemeResource AppBarButtonForeground}" />
+                <Setter Property="BorderBrush" Value="{ThemeResource AppBarButtonRevealBorderBrush}" />
+                <Setter Property="BorderThickness" Value="{ThemeResource AppBarButtonRevealBorderThemeThickness}" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
+                <Setter Property="VerticalAlignment" Value="Top" />
+                <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                <Setter Property="FontWeight" Value="Normal" />
+                <Setter Property="Width" Value="{ThemeResource MTCMediaButtonWidth}" />
+                <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                <Setter Property="AllowFocusOnInteraction" Value="False" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="AppBarButton">
+                      <Grid x:Name="Root" MinWidth="{TemplateBinding MinWidth}" MaxWidth="{TemplateBinding MaxWidth}" Background="{TemplateBinding Background}" contract7Present:CornerRadius="{TemplateBinding CornerRadius}" Margin="1,0">
+                        <VisualStateManager.VisualStateGroups>
+                          <VisualStateGroup x:Name="ApplicationViewStates">
+                            <VisualState x:Name="FullSize" />
+                            <VisualState x:Name="Compact">
+                              <Storyboard>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TextLabel" Storyboard.TargetProperty="Visibility">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentViewbox" Storyboard.TargetProperty="Margin">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AppBarButtonContentViewboxCompactMargin}" />
+                                </ObjectAnimationUsingKeyFrames>
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="LabelOnRight">
+                              <Storyboard>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentViewbox" Storyboard.TargetProperty="Margin">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AppBarButtonContentViewboxMargin}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="MinHeight">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AppBarThemeCompactHeight}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TextLabel" Storyboard.TargetProperty="(Grid.Row)">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="0" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TextLabel" Storyboard.TargetProperty="(Grid.Column)">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="1" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TextLabel" Storyboard.TargetProperty="TextAlignment">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="Left" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TextLabel" Storyboard.TargetProperty="Margin">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AppBarButtonTextLabelOnRightMargin}" />
+                                </ObjectAnimationUsingKeyFrames>
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="LabelCollapsed">
+                              <Storyboard>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentRoot" Storyboard.TargetProperty="MinHeight">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AppBarThemeCompactHeight}" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TextLabel" Storyboard.TargetProperty="Visibility">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed" />
+                                </ObjectAnimationUsingKeyFrames>
+                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentViewbox" Storyboard.TargetProperty="Margin">
+                                  <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AppBarButtonContentViewboxCompactMargin}" />
+                                </ObjectAnimationUsingKeyFrames>
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="Overflow">
+                              <VisualState.Setters>
+                                <Setter Target="ContentRoot.MinHeight" Value="0" />
+                                <Setter Target="ContentViewbox.Visibility" Value="Collapsed" />
+                                <Setter Target="TextLabel.Visibility" Value="Collapsed" />
+                                <Setter Target="OverflowTextLabel.Visibility" Value="Visible" />
+                              </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="OverflowWithToggleButtons">
+                              <VisualState.Setters>
+                                <Setter Target="ContentRoot.MinHeight" Value="0" />
+                                <Setter Target="ContentViewbox.Visibility" Value="Collapsed" />
+                                <Setter Target="TextLabel.Visibility" Value="Collapsed" />
+                                <Setter Target="OverflowTextLabel.Visibility" Value="Visible" />
+                                <Setter Target="OverflowTextLabel.Margin" Value="38,0,12,0" />
+                              </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="OverflowWithMenuIcons">
+                              <VisualState.Setters>
+                                <Setter Target="ContentRoot.MinHeight" Value="0" />
+                                <Setter Target="ContentViewbox.HorizontalAlignment" Value="Left" />
+                                <Setter Target="ContentViewbox.VerticalAlignment" Value="Center" />
+                                <Setter Target="ContentViewbox.Width" Value="16" />
+                                <Setter Target="ContentViewbox.Height" Value="16" />
+                                <Setter Target="ContentViewbox.Margin" Value="12,0,12,0" />
+                                <Setter Target="TextLabel.Visibility" Value="Collapsed" />
+                                <Setter Target="OverflowTextLabel.Visibility" Value="Visible" />
+                                <Setter Target="OverflowTextLabel.Margin" Value="38,0,12,0" />
+                              </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="OverflowWithToggleButtonsAndMenuIcons">
+                              <VisualState.Setters>
+                                <Setter Target="ContentRoot.MinHeight" Value="0" />
+                                <Setter Target="ContentViewbox.HorizontalAlignment" Value="Left" />
+                                <Setter Target="ContentViewbox.VerticalAlignment" Value="Center" />
+                                <Setter Target="ContentViewbox.Width" Value="16" />
+                                <Setter Target="ContentViewbox.Height" Value="16" />
+                                <Setter Target="ContentViewbox.Margin" Value="38,0,12,0" />
+                                <Setter Target="TextLabel.Visibility" Value="Collapsed" />
+                                <Setter Target="OverflowTextLabel.Visibility" Value="Visible" />
+                                <Setter Target="OverflowTextLabel.Margin" Value="76,0,12,0" />
+                              </VisualState.Setters>
+                            </VisualState>
+                          </VisualStateGroup>
+                          <VisualStateGroup x:Name="CommonStates">
+                            <VisualState x:Name="Normal">
+                              <Storyboard>
+                                <PointerUpThemeAnimation Storyboard.TargetName="OverflowTextLabel" />
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="PointerOver">
+                              <VisualState.Setters>
+                                <Setter Target="Root.(media:RevealBrush.State)" Value="PointerOver" />
+                                <Setter Target="Root.Background" Value="{ThemeResource AppBarButtonRevealBackgroundPointerOver}" />
+                                <Setter Target="Border.BorderBrush" Value="{ThemeResource AppBarButtonRevealBorderBrushPointerOver}" />
+                                <Setter Target="Content.Foreground" Value="{ThemeResource AppBarButtonForegroundPointerOver}" />
+                                <Setter Target="TextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundPointerOver}" />
+                                <Setter Target="OverflowTextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundPointerOver}" />
+                              </VisualState.Setters>
+                              <Storyboard>
+                                <PointerUpThemeAnimation Storyboard.TargetName="OverflowTextLabel" />
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="Pressed">
+                              <VisualState.Setters>
+                                <Setter Target="Root.(media:RevealBrush.State)" Value="Pressed" />
+                                <Setter Target="Root.Background" Value="{ThemeResource AppBarButtonRevealBackgroundPressed}" />
+                                <Setter Target="Border.BorderBrush" Value="{ThemeResource AppBarButtonRevealBorderBrushPressed}" />
+                                <Setter Target="Content.Foreground" Value="{ThemeResource AppBarButtonForegroundPressed}" />
+                                <Setter Target="TextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundPressed}" />
+                                <Setter Target="OverflowTextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundPressed}" />
+                              </VisualState.Setters>
+                              <Storyboard>
+                                <PointerDownThemeAnimation Storyboard.TargetName="OverflowTextLabel" />
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="Disabled">
+                              <VisualState.Setters>
+                                <Setter Target="Root.Background" Value="{ThemeResource AppBarButtonRevealBackgroundDisabled}" />
+                                <Setter Target="Border.BorderBrush" Value="{ThemeResource AppBarButtonRevealBorderBrushDisabled}" />
+                                <Setter Target="Content.Foreground" Value="{ThemeResource AppBarButtonForegroundDisabled}" />
+                                <Setter Target="TextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundDisabled}" />
+                                <Setter Target="OverflowTextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundDisabled}" />
+                                <Setter Target="KeyboardAcceleratorTextLabel.Foreground" Value="{ThemeResource AppBarButtonKeyboardAcceleratorTextForegroundDisabled}" />
+                              </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="OverflowNormal">
+                              <Storyboard>
+                                <PointerUpThemeAnimation Storyboard.TargetName="ContentRoot" />
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="OverflowPointerOver">
+                              <VisualState.Setters>
+                                <Setter Target="Root.Background" Value="{ThemeResource AppBarButtonRevealBackgroundPointerOver}" />
+                                <Setter Target="Border.BorderBrush" Value="{ThemeResource AppBarButtonRevealBorderBrushPointerOver}" />
+                                <Setter Target="Content.Foreground" Value="{ThemeResource AppBarButtonForegroundPointerOver}" />
+                                <Setter Target="TextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundPointerOver}" />
+                                <Setter Target="OverflowTextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundPointerOver}" />
+                                <Setter Target="KeyboardAcceleratorTextLabel.Foreground" Value="{ThemeResource AppBarButtonKeyboardAcceleratorTextForegroundPointerOver}" />
+                              </VisualState.Setters>
+                              <Storyboard>
+                                <PointerUpThemeAnimation Storyboard.TargetName="ContentRoot" />
+                              </Storyboard>
+                            </VisualState>
+                            <VisualState x:Name="OverflowPressed">
+                              <VisualState.Setters>
+                                <Setter Target="Root.Background" Value="{ThemeResource AppBarButtonRevealBackgroundPressed}" />
+                                <Setter Target="Border.BorderBrush" Value="{ThemeResource AppBarButtonRevealBorderBrushPressed}" />
+                                <Setter Target="Content.Foreground" Value="{ThemeResource AppBarButtonForegroundPressed}" />
+                                <Setter Target="TextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundPressed}" />
+                                <Setter Target="OverflowTextLabel.Foreground" Value="{ThemeResource AppBarButtonForegroundPressed}" />
+                                <Setter Target="KeyboardAcceleratorTextLabel.Foreground" Value="{ThemeResource AppBarButtonKeyboardAcceleratorTextForegroundPressed}" />
+                              </VisualState.Setters>
+                              <Storyboard>
+                                <PointerDownThemeAnimation Storyboard.TargetName="ContentRoot" />
+                              </Storyboard>
+                            </VisualState>
+                          </VisualStateGroup>
+                          <VisualStateGroup x:Name="InputModeStates">
+                            <VisualState x:Name="InputModeDefault" />
+                            <VisualState x:Name="TouchInputMode">
+                              <VisualState.Setters>
+                                <Setter Target="OverflowTextLabel.Padding" Value="{ThemeResource AppBarButtonOverflowTextTouchMargin}" />
+                              </VisualState.Setters>
+                            </VisualState>
+                            <VisualState x:Name="GameControllerInputMode">
+                              <VisualState.Setters>
+                                <Setter Target="OverflowTextLabel.Padding" Value="{ThemeResource AppBarButtonOverflowTextTouchMargin}" />
+                              </VisualState.Setters>
+                            </VisualState>
+                          </VisualStateGroup>
+                          <VisualStateGroup x:Name="KeyboardAcceleratorTextVisibility">
+                            <VisualState x:Name="KeyboardAcceleratorTextCollapsed" />
+                            <VisualState x:Name="KeyboardAcceleratorTextVisible">
+                              <VisualState.Setters>
+                                <Setter Target="KeyboardAcceleratorTextLabel.Visibility" Value="Visible" />
+                              </VisualState.Setters>
+                            </VisualState>
+                          </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid x:Name="ContentRoot" Margin="-1,0">
+                          <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                          </Grid.ColumnDefinitions>
+                          <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                          </Grid.RowDefinitions>
+                          <Viewbox x:Name="ContentViewbox" Height="{ThemeResource AppBarButtonContentHeight}" Margin="12" HorizontalAlignment="Stretch" AutomationProperties.AccessibilityView="Raw">
+                            <ContentPresenter x:Name="Content" Content="{TemplateBinding Icon}" Foreground="{TemplateBinding Foreground}" />
+                          </Viewbox>
+                          <TextBlock x:Name="TextLabel" Grid.Row="1" Text="{TemplateBinding Label}" Foreground="{TemplateBinding Foreground}" FontSize="12" FontFamily="{TemplateBinding FontFamily}" TextAlignment="Center" TextWrapping="Wrap" Margin="{ThemeResource AppBarButtonTextLabelMargin}" AutomationProperties.AccessibilityView="Raw" Visibility="Collapsed" />
+                          <TextBlock x:Name="OverflowTextLabel" Text="{TemplateBinding Label}" Foreground="{TemplateBinding Foreground}" FontSize="15" FontFamily="{TemplateBinding FontFamily}" TextAlignment="Left" TextTrimming="Clip" TextWrapping="NoWrap" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="12,0,12,0" Padding="{ThemeResource AppBarButtonOverflowTextLabelPadding}" Visibility="Collapsed" AutomationProperties.AccessibilityView="Raw" />
+                          <TextBlock x:Name="KeyboardAcceleratorTextLabel" Grid.Column="1" Style="{ThemeResource CaptionTextBlockStyle}" Text="{TemplateBinding KeyboardAcceleratorTextOverride}" MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.KeyboardAcceleratorTextMinWidth}" Margin="24,0,12,0" Foreground="{ThemeResource AppBarButtonKeyboardAcceleratorTextForeground}" HorizontalAlignment="Right" VerticalAlignment="Center" contract5Present:HorizontalTextAlignment="Right" Visibility="Collapsed" AutomationProperties.AccessibilityView="Raw" />
+                          <Border x:Name="Border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" contract7Present:CornerRadius="{TemplateBinding CornerRadius}" Grid.RowSpan="2" Grid.ColumnSpan="2" Margin="1,0" />
+                        </Grid>
+                      </Grid>
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
             </Grid.Resources>
             <VisualStateManager.VisualStateGroups>
               <!-- ControlPanel Visibility states -->
@@ -17326,8 +17726,9 @@
               <VisualStateGroup x:Name="FocusStates">
                 <VisualState x:Name="Focused">
                   <Storyboard>
-                    <win:DoubleAnimation Storyboard.TargetName="FocusVisualWhite" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
-                    <win:DoubleAnimation Storyboard.TargetName="FocusVisualBlack" Storyboard.TargetProperty="Opacity" To="1" Duration="0" />
+                    <!--UNO TODO: There's no element called 'FocusVisualWhite', which presumably fails silently on Windows, but causes a compile-time error on Uno-->
+                    <!-- <DoubleAnimation Storyboard.TargetName="FocusVisualWhite" Storyboard.TargetProperty="Opacity" To="1" Duration="0" /> -->
+                    <!-- <DoubleAnimation Storyboard.TargetName="FocusVisualBlack" Storyboard.TargetProperty="Opacity" To="1" Duration="0" /> -->
                   </Storyboard>
                 </VisualState>
                 <VisualState x:Name="Unfocused" />
@@ -17342,11 +17743,8 @@
                     <Setter Target="TimeTextGrid.Visibility" Value="Collapsed" />
                     <Setter Target="MediaTransportControls_Command_Border.(Grid.Column)" Value="2" />
                     <Setter Target="MediaTransportControls_Command_Border.(Grid.Row)" Value="1" />
-                    <Setter Target="ControlPanelGrid.Height" Value="48" />
                     <Setter Target="MediaControlsCommandBar.Margin" Value="0" />
                     <Setter Target="PlayPauseButton.Visibility" Value="Collapsed" />
-                    <Setter Target="ProgressSlider.Margin" Value="{ThemeResource MediaTransportControlsProgressSliderCompactMargin}" />
-                    <Setter Target="ControlPanelGrid.Padding" Value="3" />
                   </VisualState.Setters>
                 </VisualState>
               </VisualStateGroup>
@@ -17355,13 +17753,8 @@
                 <VisualState x:Name="PlayState" />
                 <VisualState x:Name="PauseState">
                   <VisualState.Setters>
-                    <!--
-                                        <Setter Target="PlayPauseSymbolLeft.Glyph" Value="&#xF8AE;" />
-                                        <Setter Target="PlayPauseSymbol.Glyph" Value="&#xF8AE;" />
-                                        UNO TODO: Missing glyph
-                                        -->
-                    <Setter Target="PlayPauseSymbolLeft.Glyph" Value="&#xF8AE;" />
-                    <Setter Target="PlayPauseSymbol.Glyph" Value="&#xF8AE;" />
+                    <Setter Target="PlayPauseSymbolLeft.Symbol" Value="Pause" />
+                    <Setter Target="PlayPauseSymbol.Symbol" Value="Pause" />
                   </VisualState.Setters>
                 </VisualState>
               </VisualStateGroup>
@@ -17401,7 +17794,7 @@
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
             <Border x:Name="ControlPanel_ControlPanelVisibilityStates_Border">
-              <Grid x:Name="ControlPanelGrid" Background="{ThemeResource MediaTransportControlsPanelBackground}" VerticalAlignment="Bottom" RenderTransformOrigin="0.5,0.5" BorderBrush="{ThemeResource MediaTransportControlsBorderBrush}" BorderThickness="{ThemeResource MediaTransportControlsBorderThickness}" contract7Present:CornerRadius="{TemplateBinding CornerRadius}" contract7NotPresent:CornerRadius="{ThemeResource OverlayCornerRadius}">
+              <Grid x:Name="ControlPanelGrid" Background="{ThemeResource MediaTransportControlsPanelBackground}" VerticalAlignment="Bottom" RenderTransformOrigin="0.5,0.5">
                 <Grid.RenderTransform>
                   <TranslateTransform x:Name="TranslateVertical" />
                 </Grid.RenderTransform>
@@ -17416,7 +17809,7 @@
                   <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <Border x:Name="ErrorBorder" Width="320" Height="96" Grid.ColumnSpan="3" HorizontalAlignment="Center" Background="{ThemeResource MediaTransportControlsPanelBackground}" Visibility="Collapsed">
-                  <TextBlock x:Name="ErrorTextBlock" Style="{StaticResource CaptionTextBlockStyle}" TextWrapping="WrapWholeWords" Margin="12" />
+                  <TextBlock x:Name="ErrorTextBlock" Style="{StaticResource MediaTextBlockStyle}" TextWrapping="WrapWholeWords" Margin="12" />
                 </Border>
                 <Border x:Name="MediaTransportControls_Timeline_Border" Grid.Column="1" Grid.Row="1">
                   <Grid x:Name="MediaTransportControls_Timeline_Grid">
@@ -17427,49 +17820,35 @@
                       <RowDefinition />
                       <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <Slider x:Name="ProgressSlider" Margin="7,2,7,1" MinWidth="80" Height="{ThemeResource MediaTransportControlsSliderHeight}" VerticalAlignment="Center" IsThumbToolTipEnabled="False" />
+                    <Slider x:Name="ProgressSlider" Style="{StaticResource MediaSliderStyle}" Margin="12,0" MinWidth="80" Height="33" VerticalAlignment="Center" IsThumbToolTipEnabled="False" />
                     <ProgressBar x:Name="BufferingProgressBar" Height="4" IsIndeterminate="True" IsHitTestVisible="False" VerticalAlignment="Top" Margin="0,2,0,0" Visibility="Collapsed" />
-                    <Grid x:Name="TimeTextGrid" Margin="7,0,7,2" Grid.Row="1" Height="16">
-                      <TextBlock x:Name="TimeElapsedElement" Style="{StaticResource CaptionTextBlockStyle}" Margin="0" Text="00:00" HorizontalAlignment="Left" VerticalAlignment="Bottom" />
-                      <TextBlock x:Name="TimeRemainingElement" Style="{StaticResource CaptionTextBlockStyle}" Text="00:00" HorizontalAlignment="Right" VerticalAlignment="Bottom" />
+                    <Grid x:Name="TimeTextGrid" Margin="12,0" Grid.Row="1" Height="15">
+                      <TextBlock x:Name="TimeElapsedElement" Style="{StaticResource MediaTextBlockStyle}" Margin="0" Text="00:00" HorizontalAlignment="Left" VerticalAlignment="Bottom" />
+                      <TextBlock x:Name="TimeRemainingElement" Style="{StaticResource MediaTextBlockStyle}" Text="00:00" HorizontalAlignment="Right" VerticalAlignment="Bottom" />
                     </Grid>
                   </Grid>
                 </Border>
                 <Border x:Name="LeftSidePlayBorder" Grid.Column="0" Grid.Row="1" Visibility="Collapsed">
                   <AppBarButton x:Name="PlayPauseButtonOnLeft" Margin="0" VerticalAlignment="Center" Style="{StaticResource AppBarButtonStyle}">
-                    <AppBarButton.Resources>
-                      <Thickness x:Key="AppBarButtonInnerBorderMargin">5</Thickness>
-                      <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,12</Thickness>
-                    </AppBarButton.Resources>
                     <AppBarButton.Icon>
-                      <FontIcon x:Name="PlayPauseSymbolLeft" Glyph="&#xF5B0;" />
+                      <SymbolIcon x:Name="PlayPauseSymbolLeft" Symbol="Play" />
                     </AppBarButton.Icon>
                   </AppBarButton>
                 </Border>
                 <Border x:Name="MediaTransportControls_Command_Border" Grid.Column="1" Grid.Row="2">
-                  <CommandBar x:Name="MediaControlsCommandBar" Margin="0,3" Style="{StaticResource CommandBarStyle}" IsDynamicOverflowEnabled="False">
-                    <CommandBar.Resources>
-                      <Thickness x:Key="AppBarButtonInnerBorderMargin">5</Thickness>
-                      <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,12</Thickness>
-                      <x:Double x:Key="AppBarThemeCompactHeight">40</x:Double>
-                      <x:Double x:Key="AppBarMoreButtonColumnMinWidth">0</x:Double>
-                    </CommandBar.Resources>
+                  <CommandBar x:Name="MediaControlsCommandBar" Margin="0,0" Style="{StaticResource CommandBarStyle}" IsDynamicOverflowEnabled="False">
                     <CommandBar.PrimaryCommands>
                       <AppBarButton x:Name="VolumeMuteButton" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="19">
                         <AppBarButton.Flyout>
                           <Flyout x:Name="VolumeFlyout" FlyoutPresenterStyle="{StaticResource FlyoutStyle}" contract8Present:ShouldConstrainToRootBounds="False">
-                            <StackPanel Orientation="Horizontal" Padding="3,11">
-                              <AppBarButton x:Name="AudioMuteButton" Style="{StaticResource AppBarButtonStyle}" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                <AppBarButton.Resources>
-                                  <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,12</Thickness>
-                                  <Thickness x:Key="AppBarButtonInnerBorderMargin">5</Thickness>
-                                </AppBarButton.Resources>
+                            <StackPanel Orientation="Horizontal">
+                              <AppBarButton x:Name="AudioMuteButton" Style="{StaticResource MediaControlAppBarButtonStyle}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="12">
                                 <AppBarButton.Icon>
                                   <SymbolIcon x:Name="AudioMuteSymbol" Symbol="Volume" />
                                 </AppBarButton.Icon>
                               </AppBarButton>
-                              <Slider x:Name="VolumeSlider" Value="50" IsThumbToolTipEnabled="False" Height="{ThemeResource MediaTransportControlsSliderHeight}" Width="{ThemeResource MediaTransportControlsSliderWidth}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="12,0,8,0" />
-                              <TextBlock x:Name="VolumeValue" Style="{StaticResource MediaTextBlockStyle}" Text="{Binding ElementName=VolumeSlider,Path=Value}" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Right" Width="24" Margin="8,0,16,0" />
+                              <Slider x:Name="VolumeSlider" Value="50" IsThumbToolTipEnabled="False" Width="{ThemeResource MTCHorizontalVolumeSliderWidth}" VerticalAlignment="Center" HorizontalAlignment="Center" Margin="0" />
+                              <TextBlock x:Name="VolumeValue" Style="{StaticResource MediaTextBlockStyle}" Text="{Binding ElementName=VolumeSlider,Path=Value}" HorizontalAlignment="Center" VerticalAlignment="Center" Width="24" Margin="12" />
                             </StackPanel>
                           </Flyout>
                         </AppBarButton.Flyout>
@@ -17494,39 +17873,26 @@
                           <FontIcon Glyph="&#xED3C;" />
                         </AppBarButton.Icon>
                       </AppBarButton>
-                      <AppBarButton x:Name="PreviousTrackButton" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="3" Visibility="Collapsed">
-                        <AppBarButton.Icon>
-                          <FontIcon Glyph="&#xF8AC;" />
-                        </AppBarButton.Icon>
-                      </AppBarButton>
+                      <AppBarButton x:Name="PreviousTrackButton" Icon="Previous" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="3" Visibility="Collapsed" />
                       <AppBarButton x:Name="RewindButton" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="1" Visibility="Collapsed">
                         <AppBarButton.Icon>
-                          <FontIcon Glyph="&#xE627;" />
+                          <FontIcon Glyph="&#xEB9E;" />
                         </AppBarButton.Icon>
                       </AppBarButton>
                       <AppBarButton x:Name="PlayPauseButton" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="23">
                         <AppBarButton.Icon>
-                          <FontIcon x:Name="PlayPauseSymbol" Glyph="&#xF5B0;" />
+                          <SymbolIcon x:Name="PlayPauseSymbol" Symbol="Play" />
                         </AppBarButton.Icon>
                       </AppBarButton>
                       <AppBarButton x:Name="FastForwardButton" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="1" Visibility="Collapsed">
                         <AppBarButton.Icon>
-                          <FontIcon Glyph="&#xE628;" />
+                          <FontIcon Glyph="&#xEB9D;" />
                         </AppBarButton.Icon>
                       </AppBarButton>
-                      <AppBarButton x:Name="NextTrackButton" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="3" Visibility="Collapsed">
-                        <AppBarButton.Icon>
-                          <FontIcon Glyph="&#xF8AD;" />
-                        </AppBarButton.Icon>
-                      </AppBarButton>
+                      <AppBarButton x:Name="NextTrackButton" Icon="Next" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="3" Visibility="Collapsed" />
                       <AppBarButton x:Name="SkipForwardButton" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="5" Visibility="Collapsed">
                         <AppBarButton.Icon>
                           <FontIcon Glyph="&#xED3D;" />
-                        </AppBarButton.Icon>
-                      </AppBarButton>
-                      <AppBarButton x:Name="RepeatVideoButton" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="10" Visibility="Collapsed">
-                        <AppBarButton.Icon>
-                          <FontIcon Glyph="&#xE8EE;" />
                         </AppBarButton.Icon>
                       </AppBarButton>
                       <AppBarButton x:Name="PlaybackRateButton" Style="{StaticResource AppBarButtonStyle}" MediaTransportControlsHelper.DropoutOrder="10" Visibility="Collapsed">

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -184,7 +184,7 @@ namespace Windows.UI.Xaml.Controls
 					this.Add(_layoutRoot);
 #elif __MACOS__
 					this.AddSubview(_layoutRoot);
-#elif __SKIA__
+#elif __SKIA__ || __WASM__
 					this.AddChild(_layoutRoot);
 					_mediaPlayerPresenter?.ExitFullScreen();
 #else


### PR DESCRIPTION
GitHub Issue (If applicable): closes #


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In wasm the full screen does not come back.

## What is the new behavior?

In wasm the fullscreen does come back.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
