### PR TITLE
fix(lottie): Fixed a regression with lottie module loadingon WASM

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/ts/Uno.UI.Lottie.ts
+++ b/src/AddIns/Uno.UI.Lottie/ts/Uno.UI.Lottie.ts
@@ -272,7 +272,7 @@ namespace Uno.UI {
 				}
 
 				const dependencyToLoad = "/lottie";
-				const lottieDependencyName = config.uno_dependencies.find((d: string) => d.endsWith(dependencyToLoad));
+				const lottieDependencyName = config.uno_dependencies.find((d: string) => d.endsWith(dependencyToLoad) || d.endsWith(dependencyToLoad + ".js"));
 				require([lottieDependencyName], (p: LottiePlayer) => {
 					if(!p) {
 						console.error("Unable to load lottie player.");


### PR DESCRIPTION
# Bugfix

When the `<WasmShellWebAppBasePath />` was used in the csproj, the loading was not done properly because the denpendencies where using extensions (`.js`) to load them.

## What is the new behavior?
Now support both with and without the extension.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
