### PR TITLE
fix(media): more button not hidden

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -520,7 +520,7 @@ namespace Windows.UI.Xaml.Controls
 
 			BindTapped(_rootGrid, OnRootGridTapped);
 			Bind(_rootGrid, x => x.PointerMoved += OnRootGridPointerMoved, x => x.PointerMoved -= OnRootGridPointerMoved);
-			BindLoaded(m_tpCommandBar, OnCommandBarLoaded);
+			BindLoaded(m_tpCommandBar, OnCommandBarLoaded, invokeHandlerIfAlreadyLoaded: true);
 			BindSizeChanged(m_tpControlPanelGrid, ControlPanelGridSizeChanged);
 			BindTapped(m_tpControlPanelGrid, OnPaneGridTapped);
 			BindSizeChanged(_controlPanelBorder, ControlPanelBorderSizeChanged);
@@ -579,12 +579,19 @@ namespace Windows.UI.Xaml.Controls
 					disposables.Add(() => target.Tapped -= handler);
 				}
 			}
-			void BindLoaded(FrameworkElement? target, RoutedEventHandler handler)
+			void BindLoaded(FrameworkElement? target, RoutedEventHandler handler, bool invokeHandlerIfAlreadyLoaded = false)
 			{
 				if (target is { })
 				{
+					// register before invoking so that fire-once handler can self-unsubscribed
+
 					target.Loaded += handler;
 					disposables.Add(() => target.Loaded -= handler);
+
+					if (invokeHandlerIfAlreadyLoaded && target.IsLoaded)
+					{
+						handler.Invoke(target, default);
+					}
 				}
 			}
 			void BindSizeChanged(FrameworkElement? target, SizeChangedEventHandler handler)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12335

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
`...` more button is not hidden when it is supposed to.

## What is the new behavior?
^ no more

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
regression from #12440
In that pr, the event subscription has been delay after the MTC is loaded. In doing so, the Loaded event of course won't trigger anymore due to how late it was subscribed.