### PR TITLE
fix(media): Only show transport controls on mouse move

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -737,6 +737,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 			e.Handled = true;
 		}
+
 		private void OnRootGridTapped(object sender, TappedRoutedEventArgs e)
 		{
 			if (e.PointerDeviceType == PointerDeviceType.Touch)
@@ -752,14 +753,20 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 		}
+
 		private void OnRootGridPointerMoved(object sender, PointerRoutedEventArgs e)
 		{
-			Show();
+			if (e.Pointer.PointerDeviceType != PointerDeviceType.Touch)
+			{
+				Show();
+			}
 		}
+
 		private void ControlPanelGridSizeChanged(object sender, SizeChangedEventArgs args)
 		{
 			OnControlsBoundsChanged();
 		}
+
 		private static void ControlPanelBorderSizeChanged(object sender, SizeChangedEventArgs args)
 		{
 			if (sender is Border border)


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/11967

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Don't show the transport controls on touch move, only for other pointer types.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
