### PR TITLE
Update docs playlist

### DIFF
--- a/doc/articles/controls/MediaPlayerElement.md
+++ b/doc/articles/controls/MediaPlayerElement.md
@@ -36,7 +36,7 @@ See [MediaPlayerElement](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xam
 |						| Poster image											| X  		| X  		| X  		| X  		| Does not show when playing music				|
 |						| Enable/Disable MediaTransportControls			  		| X  		| X  		| X  		| X  		|												|
 |						| Stretch										  		| X  		| X  		| X  		| X  		| Stretch.None behave like Stretch.Fill on iOS	|
-|						| Pause media when headphones unplugged			  		| X  		| X  		| X  		| X  		| 												|
+|						| Pause media when headphones unplugged			  		| X  		| X  		| -  		| -  		| 												|
 | TransportControls		| Transport controls custom style						| X  		| X  		| X  		| X  		|												|
 | 			    		| Play/Pause 											| X  		| X  		| X  		| X  		|												|
 |						| Stop  												| X  		| X  		| X  		| X  		|												|
@@ -54,7 +54,7 @@ See [MediaPlayerElement](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xam
 |						| Show buffering progress						  		| X  		| X  		| X  		| X  		|												|
 |						| Zoom mode												| X  		| X  		| X  		| X  		| 												|
 |						| Full-screen mode								  		| X  		| X  		| X  		| X  		|												|
-|						| Playlists support		  								| X  		| X  		| X  		| X  		|												|
+|						| Playlists support		  								| X  		| X  		| -  		| -  		|												|
 |						| Change playback rate									| -  		| -  		| X  		| X  		|												|
 |						| Player controls on locked screen support  			| -  		| -  		| -  		| -  		|												|
 |						| Subtitles	support			  							| -  		| -  		| -  		| -  		|												|


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

- Documentation content changes

## What is the current behavior?

The 
Playlists support and 
Pause media when headphones unplugged
is mark on wasm and skia

## What is the new behavior?

The 
Playlists support and 
Pause media when headphones unplugged
is not mark on wasm and skia


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
