### PR TITLE
fix: AppBarButton icon color for native renderers

### DIFF
--- a/src/Uno.UI/Controls/CommandBar/AppBarButtonExtensions.cs
+++ b/src/Uno.UI/Controls/CommandBar/AppBarButtonExtensions.cs
@@ -1,0 +1,36 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace Uno.UI
+{
+	internal static class AppBarButtonExtensions
+	{
+		public static bool TryGetIconColor(this AppBarButton appBarButton, out Color iconColor)
+		{
+			iconColor = default;
+
+			if (appBarButton.Icon?.ReadLocalValue(IconElement.ForegroundProperty) != DependencyProperty.UnsetValue &&
+				Brush.TryGetColorWithOpacity(appBarButton.Icon?.Foreground, out var iconForeground))
+			{
+				iconColor = iconForeground;
+				return true;
+			}
+
+			if (Brush.TryGetColorWithOpacity(appBarButton.Foreground, out var buttonForeground))
+			{
+				iconColor = buttonForeground;
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/src/Uno.UI/Controls/CommandBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.UI/Controls/CommandBar/AppBarButtonRenderer.Android.cs
@@ -85,11 +85,9 @@ namespace Uno.UI.Controls
 				native.SetIcon(null);
 				native.SetTitle(element.Label);
 			}
-			else
+			else if (element.Icon is { } icon)
 			{
-				var iconOrContent = element.Icon ?? element.Content;
-
-				switch (iconOrContent)
+				switch (icon)
 				{
 					case BitmapIcon bitmap:
 						var drawable = DrawableHelper.FromUri(bitmap.UriSource);
@@ -98,6 +96,21 @@ namespace Uno.UI.Controls
 						native.SetTitle(null);
 						break;
 
+					case FontIcon: // not supported
+					case PathIcon: // not supported
+					case SymbolIcon: // not supported
+					default:
+						this.Log().Warn($"{icon.GetType().Name ?? "FontIcon, PathIcon, and SymbolIcon"} are not supported. Use BitmapIcon instead with UriSource.");
+						native.SetIcon(null);
+						break;
+				}
+				native.SetActionView(null);
+				native.SetTitle(null);
+			}
+			else
+			{
+				switch (element.Content)
+				{
 					case string text:
 						native.SetIcon(null);
 						native.SetActionView(null);
@@ -140,14 +153,13 @@ namespace Uno.UI.Controls
 			native.SetVisible(element.Visibility == Visibility.Visible);
 
 			// Foreground
-			var foreground = (element.Icon?.Foreground) as SolidColorBrush;
-
-			var foregroundOpacity = foreground?.Opacity ?? 0;
+			var foregroundOpacity = 0d;
 			if (native.Icon != null)
 			{
-				if (foreground != null)
+				if (element.TryGetIconColor(out var iconColor))
 				{
-					DrawableCompat.SetTint(native.Icon, (Android.Graphics.Color)foreground.Color);
+					foregroundOpacity = iconColor.A / 255d;
+					DrawableCompat.SetTint(native.Icon, (Android.Graphics.Color)iconColor);
 				}
 				else
 				{

--- a/src/Uno.UI/Controls/CommandBar/NavigationAppBarButtonRenderer.Android.cs
+++ b/src/Uno.UI/Controls/CommandBar/NavigationAppBarButtonRenderer.Android.cs
@@ -50,16 +50,16 @@ namespace Uno.UI.Controls
 
 				// Foreground
 				var foreground = (element.Foreground as SolidColorBrush);
-				var foregroundOpacity = foreground?.Opacity ?? 0;
+				var foregroundOpacity = foreground?.Opacity ?? 0d;
 
 				if (FeatureConfiguration.AppBarButton.EnableBitmapIconTint)
 				{
-					var foregroundColor = foreground?.Color;
 					if (native.NavigationIcon != null)
 					{
-						if (foreground != null)
+						if (element.TryGetIconColor(out var iconColor))
 						{
-							DrawableCompat.SetTint(native.NavigationIcon, (Android.Graphics.Color)foregroundColor);
+							foregroundOpacity = iconColor.A / 255d;
+							DrawableCompat.SetTint(native.NavigationIcon, (Android.Graphics.Color)iconColor);
 						}
 						else
 						{


### PR DESCRIPTION
related https://github.com/unoplatform/nventive-private/issues/487
related https://github.com/unoplatform/uno/issues/8996

## PR Type

What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?

Setting the Foreground property of a BitmapIcon has no effect when being used within the native renderers for CommandBar on iOS/Android

## What is the new behavior?

Foreground on BitmapIcon is respected and takes precedence over the Foreground of the AppBarButton

