### PR TITLE
test: `Popup` closes on visual tree removal

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -108,7 +108,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 
 			Assert.AreEqual(1, VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot).Count);
 
-			VisualTreeHelper.CloseAllPopups(WindowHelper.XamlRoot);
+			popup.IsOpen = false;
 		}
 
 		private static bool CanReach(DependencyObject startingElement, DependencyObject targetElement)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives.PopupPages;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media;
 using static Private.Infrastructure.TestServices;
@@ -75,6 +72,36 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 			popup.IsOpen = true;
 			// Should not throw
 			popup.IsOpen = false;
+		}
+
+		[TestMethod]
+		public async Task When_Removed_From_Visualree_Immediately()
+		{
+			var stackPanel = new StackPanel();
+			var popup = new Popup()
+			{
+				Child = new Button() { Content = "Test" }
+			};
+			stackPanel.Children.Add(popup);
+			WindowHelper.WindowContent = stackPanel;
+			await WindowHelper.WaitForLoaded(stackPanel);
+
+			Assert.IsFalse(popup.IsOpen);
+
+			popup.IsOpen = true;
+
+			Assert.AreEqual(1, VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot).Count);
+
+			stackPanel.Children.Remove(popup);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(popup.IsOpen);
+			Assert.AreEqual(0, VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot).Count);
+
+			popup.IsOpen = true;
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot).Count);
 		}
 
 		private static bool CanReach(DependencyObject startingElement, DependencyObject targetElement)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -75,13 +75,18 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 		}
 
 		[TestMethod]
-		public async Task When_Removed_From_Visualree_Immediately()
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task When_Removed_From_VisualTree()
 		{
 			var stackPanel = new StackPanel();
+			var button = new Button() { Content = "Test" };
 			var popup = new Popup()
 			{
 				Child = new Button() { Content = "Test" }
 			};
+			stackPanel.Children.Add(button);
 			stackPanel.Children.Add(popup);
 			WindowHelper.WindowContent = stackPanel;
 			await WindowHelper.WaitForLoaded(stackPanel);
@@ -102,6 +107,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(1, VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot).Count);
+
+			VisualTreeHelper.CloseAllPopups(WindowHelper.XamlRoot);
 		}
 
 		private static bool CanReach(DependencyObject startingElement, DependencyObject targetElement)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1809

## PR Type

What kind of change does this PR introduce?

Test

## What is the current behavior?

No test


## What is the new behavior?

Test added


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
