### PR TITLE
[MPE][Skia] The fluent style for transport controls is clipping at the top

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -768,11 +768,12 @@ namespace Windows.UI.Xaml.Controls
 				_mediaPlayer is { } &&
 				XamlRoot?.Content is UIElement root)
 			{
+				var marginBottom = XamlRoot.Size.Height - m_tpControlPanelGrid.LayoutSlot.Height - m_tpControlPanelGrid.RelativePosition.Y;
 				var bounds = new Rect(
 					0,
 					0,
 					m_tpControlPanelGrid.ActualWidth,
-					_isShowingControls ? m_tpControlPanelGrid.ActualHeight : 0
+					_isShowingControls ? m_tpControlPanelGrid.ActualHeight + (marginBottom > 0 ? marginBottom : 0) : 0
 				);
 				var transportBounds = TransformToVisual(root).TransformBounds(bounds);
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -768,18 +768,21 @@ namespace Windows.UI.Xaml.Controls
 				_mediaPlayer is { } &&
 				XamlRoot?.Content is UIElement root)
 			{
-				var marginBottom = XamlRoot.Size.Height - m_tpControlPanelGrid.LayoutSlot.Height - m_tpControlPanelGrid.RelativePosition.Y;
-				var bounds = new Rect(
-					0,
-					0,
-					m_tpControlPanelGrid.ActualWidth,
-					_isShowingControls ? m_tpControlPanelGrid.ActualHeight + (marginBottom > 0 ? marginBottom : 0) : 0
-				);
-				var transportBounds = TransformToVisual(root).TransformBounds(bounds);
-
-				_mediaPlayer.SetTransportControlBounds(transportBounds);
+				var slot = m_tpControlPanelGrid
+					.TransformToVisual(m_tpControlPanelGrid.Parent as UIElement)
+					.TransformBounds(m_tpControlPanelGrid.LayoutSlotWithMarginsAndAlignments);
+				slot.Height += m_tpControlPanelGrid.Padding.Top
+								+ m_tpControlPanelGrid.Padding.Bottom
+								+ Margin.Top
+								+ Margin.Bottom;
+				if (!_isShowingControls)
+				{
+					slot.Height = 0;
+				}
+				_mediaPlayer.SetTransportControlBounds(slot);
 			}
 		}
+
 		private void OnPaneGridTapped(object sender, TappedRoutedEventArgs e)
 		{
 			if (ShowAndHideAutomatically)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12509

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
