### PR TITLE
[MPE][Wasm] Seeking bar can seek only once

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -566,6 +566,8 @@ internal partial class HtmlMediaPlayer : Border
 
 	public void Play()
 	{
+		IsPause = false;
+		TimeUpdated -= OnHtmlTimeUpdated;
 		TimeUpdated += OnHtmlTimeUpdated;
 		if (this.Log().IsEnabled(LogLevel.Debug))
 		{
@@ -573,9 +575,11 @@ internal partial class HtmlMediaPlayer : Border
 		}
 		if (_activeElement != null && !_isPlaying)
 		{
-			NativeMethods.Play(_activeElement.HtmlId);
+			IsPause = false;
 			_isPlaying = true;
+			NativeMethods.Play(_activeElement.HtmlId);
 		}
+		_isPlaying = true;
 	}
 
 	public void Pause()
@@ -587,8 +591,9 @@ internal partial class HtmlMediaPlayer : Border
 		}
 		if (_activeElement != null && _isPlaying)
 		{
-			NativeMethods.Pause(_activeElement.HtmlId);
 			_isPlaying = false;
+			IsPause = true;
+			NativeMethods.Pause(_activeElement.HtmlId);
 		}
 	}
 
@@ -603,6 +608,7 @@ internal partial class HtmlMediaPlayer : Border
 		{
 			NativeMethods.Stop(_activeElement.HtmlId);
 			_isPlaying = false;
+			IsPause = true;
 		}
 	}
 

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -566,7 +566,6 @@ internal partial class HtmlMediaPlayer : Border
 
 	public void Play()
 	{
-		IsPause = false;
 		TimeUpdated -= OnHtmlTimeUpdated;
 		TimeUpdated += OnHtmlTimeUpdated;
 		if (this.Log().IsEnabled(LogLevel.Debug))
@@ -579,7 +578,6 @@ internal partial class HtmlMediaPlayer : Border
 			_isPlaying = true;
 			NativeMethods.Play(_activeElement.HtmlId);
 		}
-		_isPlaying = true;
 	}
 
 	public void Pause()

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -221,6 +221,7 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 		_player.OnSourceEnded += OnCompletion;
 		_player.OnTimeUpdate += OnTimeUpdate;
 
+		_player.OnStatusChanged -= OnStatusMediaChanged;
 		_player.OnStatusChanged += OnStatusMediaChanged;
 
 		_owner.PlaybackSession.PlaybackStateChanged -= OnStatusChanged;
@@ -237,26 +238,13 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			this.Log().Debug($"MediaPlayerExtension.OnStatusMediaChanged Paused ({_player?.IsPause.ToString()})");
 		}
 
-		switch (_owner.PlaybackSession.PlaybackState)
+		if (_player?.IsPause == true && _owner.PlaybackSession.PlaybackState == MediaPlaybackState.Playing)
 		{
-			case MediaPlaybackState.None:
-				break;
-			case MediaPlaybackState.Opening:
-				break;
-			case MediaPlaybackState.Buffering:
-				break;
-			case MediaPlaybackState.Playing:
-				if (_player?.IsPause == true)
-				{
-					_owner.PlaybackSession.MediaPlayer.Pause();
-				}
-				break;
-			case MediaPlaybackState.Paused:
-				if (_player?.IsPause == false)
-				{
-					_owner.PlaybackSession.MediaPlayer.Play();
-				}
-				break;
+			_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Paused;
+		}
+		else if (_player?.IsPause == false && _owner.PlaybackSession.PlaybackState == MediaPlaybackState.Paused)
+		{
+			_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
@@ -69,6 +69,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public void TappedProgressSlider(object sender, RoutedEventArgs e)
 		{
+			_isScrubbing = true;
 			if (m_tpMediaPositionSlider is null || double.IsNaN(m_tpMediaPositionSlider.Value))
 			{
 				return;
@@ -84,9 +85,10 @@ namespace Windows.UI.Xaml.Controls
 				{
 					_mediaPlayer.Play();
 				}
-
 				_skipPlayPauseStateUpdate = false;
+
 			}
+			_isScrubbing = false;
 		}
 
 		private void OnPlaybackStateChanged(MediaPlaybackSession sender, object args)
@@ -156,6 +158,13 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnPositionChanged(MediaPlaybackSession sender, object args)
 		{
+			if (_isScrubbing)
+			{
+				if (_mediaPlayer != null && _isScrubbing)
+				{
+					_mediaPlayer.Pause();
+				}
+			}
 			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{
 				var elapsed = args as TimeSpan? ?? TimeSpan.Zero;
@@ -321,8 +330,12 @@ namespace Windows.UI.Xaml.Controls
 
 			if (_mediaPlayer != null)
 			{
-				_mediaPlayer.PlaybackSession.Position = TimeSpan.FromSeconds(m_tpMediaPositionSlider.Value);
+				_wasPlaying = _mediaPlayer.PlaybackSession.IsPlaying;
+				_skipPlayPauseStateUpdate = true;
+				_isScrubbing = true;
 
+				_mediaPlayer.Pause();
+				_mediaPlayer.PlaybackSession.Position = TimeSpan.FromSeconds(m_tpMediaPositionSlider.Value);
 				if (_wasPlaying)
 				{
 					_mediaPlayer.Play();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12531 


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

There is a loop in the seeking

## What is the new behavior?

Now there is no loop on the MediaPlayer

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
