### PR TITLE
Update docs for Media Player Element Seeking not not working properly on Wasm

### DIFF
--- a/doc/articles/controls/MediaPlayerElement.md
+++ b/doc/articles/controls/MediaPlayerElement.md
@@ -40,7 +40,7 @@ See [MediaPlayerElement](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xam
 | TransportControls		| Transport controls custom style						| X  		| X  		| X  		| X  		|												|
 | 			    		| Play/Pause 											| X  		| X  		| X  		| X  		|												|
 |						| Stop  												| X  		| X  		| X  		| X  		|												|
-| 						| Seek  												| X  		| X  		| X  		| X  		|												|
+| 						| Seek  												| X  		| X  		| X  		| X  		| Wasm not working properly						|
 |						| Volume change											| X  		| X  		| X  		| X  		|												|
 |						| Mute													| X  		| X  		| X  		| X  		|												|
 |						| Show elapsed time										| X  		| X  		| X  		| X  		|												|


### PR DESCRIPTION
GitHub Issue (If applicable): closes #


## PR Type

- Documentation content changes

## What is the current behavior?

on Wasm do not exists Remarks

## What is the new behavior?

Now there is a Remarks about Seeking

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
