### PR TITLE
docs: Adjust packages for mediaplayer for winui/uwp

### DIFF
--- a/doc/articles/controls/MediaPlayerElement.md
+++ b/doc/articles/controls/MediaPlayerElement.md
@@ -90,16 +90,22 @@ Add the following to your AndroidManifest.xml
 ```
 
 ### WebAssembly
-Using the `MediaPlayerElement` on WebAssembly head requires adding the [`Uno.UI.MediaPlayer.WebAssembly`](https://www.nuget.org/packages/Uno.UI.MediaPlayer.WebAssembly) package to the `MyApp.Wasm` project. 
+Using the `MediaPlayerElement` on WebAssembly head requires adding the [`Uno.WinUI.MediaPlayer.WebAssembly`](https://www.nuget.org/packages/Uno.WinUI.MediaPlayer.WebAssembly) package to the `MyApp.Wasm` project. 
 
 > [!IMPORTANT]
-> The `Uno.UI.MediaPlayer.WebAssembly` package version must use the same version as the other `Uno.UI.*` or `Uno.WinUI.*` packages in your project.
+> The `Uno.WinUI.MediaPlayer.WebAssembly` package version must use the same version as the other `Uno.WinUI.*` packages in your project.
+
+> [!NOTE]
+> When using UWP APIs and the `Uno.UI.*` packages, you'll need to install the [`Uno.UI.MediaPlayer.WebAssembly`](https://www.nuget.org/packages/Uno.UI.MediaPlayer.WebAssembly) package instead.
 
 ### Skia.GTK
-Using the `MediaPlayerElement` on the Skia+GTK head requires adding the [`Uno.UI.MediaPlayer.Skia.Gtk`](https://www.nuget.org/packages/Uno.UI.MediaPlayer.Skia.Gtk) package to the `MyApp.Skia.Gtk` project. 
+Using the `MediaPlayerElement` on the Skia+GTK head requires adding the [`Uno.WinUI.MediaPlayer.Skia.Gtk`](https://www.nuget.org/packages/Uno.WinUI.MediaPlayer.Skia.Gtk) package to the `MyApp.Skia.Gtk` project. 
 
 > [!IMPORTANT]
-> The `Uno.UI.MediaPlayer.Skia.Gtk` package version must use the same version as the other `Uno.UI.*` or `Uno.WinUI.*` packages in your project.
+> The `Uno.WinUI.MediaPlayer.Skia.Gtk` package version must use the same version as the other `Uno.WinUI.*` packages in your project.
+
+> [!NOTE]
+> When using UWP APIs and the `Uno.UI.*` packages, you'll need to install the [`Uno.UI.MediaPlayer.Skia.Gtk`](https://www.nuget.org/packages/Uno.UI.MediaPlayer.Skia.Gtk) package instead.
 
 #### Skia+GTK on Linux
 The `MediaPlayerElement` support is based on libVLC, and needs the system to provide the appropriate libraries to work properly.


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8ffff58</samp>

### Summary
📝🎥🚚

<!--
1.  📝 - This emoji represents documentation changes, as the change updates the documentation to reflect the new package names and adds a note for users.
2.  🎥 - This emoji represents media-related changes, as the change affects the `MediaPlayerElement` support, which is used for playing video and audio content.
3.  🚚 - This emoji represents moving or renaming changes, as the change renames the packages from `Uno.UI.*` to `Uno.WinUI.*` and moves them to a different namespace.
-->
Update `MediaPlayerElement` documentation for WebAssembly and Skia+GTK to use `Uno.WinUI.*` packages. Add note for UWP and `Uno.UI.*` users.

> _`Uno.WinUI` now_
> _Media player docs updated_
> _Still support `Uno.UI` - kireji_

### Walkthrough
* Update the documentation for `MediaPlayerElement` support on WebAssembly and Skia+GTK heads ([link](https://github.com/unoplatform/uno/pull/12567/files?diff=unified&w=0#diff-0b932d4dcfaac3a1bff0cfd46a927ec6ffbf745de54ad90210a39d0e4cd1e226L93-R109))

