### PR TITLE
fix(mpe): AutoPlay=false stuck in Opening state

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -501,6 +501,10 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 					_player.Play();
 					_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
 				}
+				else
+				{
+					_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Paused;
+				}
 			}
 
 			_isPlayerPrepared = true;

--- a/src/Uno.Foundation/Extensibility/ApiExtensibility.cs
+++ b/src/Uno.Foundation/Extensibility/ApiExtensibility.cs
@@ -59,6 +59,16 @@ public static class ApiExtensibility
 	}
 
 	/// <summary>
+	/// Checks if an extension builder for the specified <typeparamref name="T"/> type has been registered.
+	/// </summary>
+	/// <typeparam name="T">A registered type</typeparam>
+	/// <returns>If registered or not.</returns>
+	public static bool IsRegistered<T>()
+	{
+		return _registrations.ContainsKey(typeof(T));
+	}
+
+	/// <summary>
 	/// Creates an instance of an extension of the specified <typeparamref name="T"/> type
 	/// </summary>
 	/// <typeparam name="T">A registered type</typeparam>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
@@ -1,0 +1,48 @@
+using System;
+using Windows.Media.Core;
+using Windows.Media.Playback;
+using Windows.UI.Xaml.Controls;
+using static Private.Infrastructure.TestServices;
+
+#if HAS_UNO
+using Uno.Foundation.Extensibility;
+using Uno.Media.Playback;
+#endif
+
+using _MediaPlayer = Windows.Media.Playback.MediaPlayer; // alias to avoid same name root namespace from ios/macos
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	[TestClass]
+	[RunsOnUIThread]
+	public partial class Given_MediaPlayerElement
+	{
+		private static readonly Uri TestVideoUrl = new Uri("https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/Big_Buck_Bunny_720_10s_5MB.mp4");
+
+		[TestMethod]
+		public async void When_NotAutoPlay_Source()
+		{
+#if HAS_UNO
+			if (_MediaPlayer.ImplementedByExtensions && !ApiExtensibility.IsRegistered<IMediaPlayerExtension>())
+			{
+				Assert.Inconclusive("Platform not supported.");
+			}
+#endif
+
+			var sut = new MediaPlayerElement()
+			{
+				AutoPlay = false,
+				Source = MediaSource.CreateFromUri(TestVideoUrl),
+			};
+			WindowHelper.WindowContent = sut;
+			await WindowHelper.WaitForLoaded(sut);
+
+			// PlaybackState should transition out of Opening state when the video is ready to play.
+			await WindowHelper.WaitFor(
+				condition: () => sut.MediaPlayer?.PlaybackSession?.PlaybackState == Windows.Media.Playback.MediaPlaybackState.Paused,
+				timeoutMS: 5000,
+				message: "Timeout waiting for the media player to enter Paused state."
+			);
+		}
+	}
+}

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -289,6 +289,7 @@ namespace Windows.Media.Playback
 					_player.Start();
 					_player.Pause();
 					_player.SeekTo(0);
+					PlaybackSession.PlaybackState = MediaPlaybackState.Paused;
 				}
 			}
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.cs
@@ -9,6 +9,13 @@ namespace Windows.Media.Playback
 {
 	public partial class MediaPlayer
 	{
+		internal const bool ImplementedByExtensions =
+#if __ANDROID__ || __IOS__ || __MACOS__
+			false;
+#else
+			true;
+#endif
+
 		#region Properties
 
 		private IMediaPlaybackSource _source;

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOSmacOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOSmacOS.cs
@@ -364,7 +364,8 @@ namespace Windows.Media.Playback
 					return;
 				}
 
-				if (_player.Status == AVPlayerStatus.ReadyToPlay && PlaybackSession.PlaybackState == MediaPlaybackState.Buffering)
+				if (_player.Status == AVPlayerStatus.ReadyToPlay &&
+					PlaybackSession.PlaybackState is MediaPlaybackState.Opening or MediaPlaybackState.Buffering)
 				{
 					if (_player.Rate == 0.0)
 					{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12535

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
Setting MPE.AutoPlay=false no longer cause the media player to be stuck in the Opening state for wasm, ios/macos and android.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb750a5</samp>

This pull request fixes the playback state of media player elements that have a source but not autoplay on various platforms. It updates the `MediaPlayerExtension` class and the `MediaPlayer` classes for Android, iOS, and macOS to set the playback state to paused when the media player is prepared or ready to play. It also adds a new test case in `Given_MediaPlayerElement.cs` to verify this behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->