### PR TITLE
fix: NaviViewItem might remain in over state when auto dismiss on click

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/ImageAssert.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/ImageAssert.cs
@@ -32,6 +32,12 @@ namespace Uno.UI.RuntimeTests.Helpers;
 public static partial class ImageAssert
 {
 	#region HasColorAt
+	public static void HasColorAt(RawBitmap screenshot, Windows.Foundation.Point location, string expectedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
+		=> HasColorAtImpl(screenshot, (int)location.X, (int)location.Y, (Color)XamlBindingHelper.ConvertValue(typeof(Color), expectedColorCode), tolerance, line);
+
+	public static void HasColorAt(RawBitmap screenshot, Windows.Foundation.Point location, Color expectedColor, byte tolerance = 0, [CallerLineNumber] int line = 0)
+		=> HasColorAtImpl(screenshot, (int)location.X, (int)location.Y, expectedColor, tolerance, line);
+
 	public static void HasColorAt(RawBitmap screenshot, float x, float y, string expectedColorCode, byte tolerance = 0, [CallerLineNumber] int line = 0)
 		=> HasColorAtImpl(screenshot, (int)x, (int)y, (Color)XamlBindingHelper.ConvertValue(typeof(Color), expectedColorCode), tolerance, line);
 

--- a/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
@@ -7,7 +7,9 @@ using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media.Imaging;
 using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
 
 namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 
@@ -23,6 +25,17 @@ public static class UITestHelper
 		await TestServices.WindowHelper.WaitForIdle();
 
 		return element.GetAbsoluteBounds();
+	}
+
+	public static async Task<RawBitmap> ScreenShot(FrameworkElement element, bool opaque = true)
+	{
+		var renderer = new RenderTargetBitmap();
+		element.UpdateLayout();
+		await TestServices.WindowHelper.WaitForIdle();
+		await renderer.RenderAsync(element);
+		var bitmap = await RawBitmap.From(renderer, element);
+
+		return bitmap;
 	}
 }
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
@@ -86,7 +86,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		[RequiresFullWindow]
 		[Ignore("Failing on CI due to animations")]
-#if __MACOS__
+#if false && __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif
 		public async Task MUX_When_MinimalHierarchicalAndSelectItem_Then_RemoveOverState()
@@ -105,8 +105,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var SUT = new Microsoft.UI.Xaml.Controls.NavigationView
 			{
-				PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal, 
-				IsPaneToggleButtonVisible = true, 
+				PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal,
+				IsPaneToggleButtonVisible = true,
 				IsBackButtonVisible = Microsoft.UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed,
 				IsPaneOpen = false
 			};
@@ -121,7 +121,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var item7 = await Select(0, 7);
 			var item5 = await Select(0, 5);
 
-			
 			// Open the pane and expend the group 0 for screenshot
 			await Expend(0);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
@@ -4,6 +4,9 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Input.Preview.Injection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.ListViewPages;
@@ -34,6 +37,9 @@ using Windows.UI.Xaml.Controls.Primitives;
 
 using static Private.Infrastructure.TestServices;
 using Uno.Extensions;
+using Uno.UI.RuntimeTests.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -74,6 +80,83 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				panel.Children;
 #endif
 			Assert.AreEqual(item2, children.Last());
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[RequiresFullWindow]
+		[Ignore("Failing on CI due to animations")]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task MUX_When_MinimalHierarchicalAndSelectItem_Then_RemoveOverState()
+		{
+			var items = Enumerable
+				.Range(0, 10)
+				.Select(g => new Microsoft.UI.Xaml.Controls.NavigationViewItem
+				{
+					Content = $"Group {g}",
+					MenuItems = Enumerable
+						.Range(0, 30)
+						.Select(i => new Microsoft.UI.Xaml.Controls.NavigationViewItem { Content = $"Group {g} - Item {i}" } as object)
+						.ToList()
+				})
+				.ToList();
+
+			var SUT = new Microsoft.UI.Xaml.Controls.NavigationView
+			{
+				PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal, 
+				IsPaneToggleButtonVisible = true, 
+				IsBackButtonVisible = Microsoft.UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed,
+				IsPaneOpen = false
+			};
+			SUT.MenuItems.AddRange(items);
+
+			await UITestHelper.Load(SUT);
+
+			using var finger = InputInjector.TryCreate()?.GetFinger() ?? throw new InvalidOperationException("Failed to create finger");
+
+			// This might not fail for each item, try to repro on mutliple items
+			var item9 = await Select(0, 9);
+			var item7 = await Select(0, 7);
+			var item5 = await Select(0, 5);
+
+			
+			// Open the pane and expend the group 0 for screenshot
+			await Expend(0);
+
+			var screenShot = await UITestHelper.ScreenShot(SUT);
+
+			ImageAssert.HasColorAt(screenShot, item9.GetLocation().Offset(5), "#E6E6E6");
+			ImageAssert.HasColorAt(screenShot, item7.GetLocation().Offset(5), "#E6E6E6");
+			ImageAssert.HasColorAt(screenShot, item5.GetLocation().Offset(5), "#E6E6E6");
+
+			async Task OpenPane()
+			{
+				SUT.IsPaneOpen = true;
+				await WindowHelper.WaitForIdle();
+			}
+
+			async Task Expend(int group)
+			{
+				await OpenPane();
+
+				items[group].IsExpanded = true;
+				await WindowHelper.WaitForIdle();
+			}
+
+
+			async Task<Rect> Select(int group, int item)
+			{
+				await Expend(group);
+
+				var itemBounds = ((Microsoft.UI.Xaml.Controls.NavigationViewItem)items[group].MenuItems[item]).GetAbsoluteBounds();
+				finger.Press(itemBounds.GetCenter());
+				await WindowHelper.WaitForIdle();
+				await Task.Delay(250 + 100); // Close animation
+
+				return itemBounds;
+			}
 		}
 
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
@@ -40,6 +40,7 @@ using Uno.Extensions;
 using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
+using Uno.UI.Toolkit.Extensions;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -93,13 +94,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		{
 			var items = Enumerable
 				.Range(0, 10)
-				.Select(g => new Microsoft.UI.Xaml.Controls.NavigationViewItem
+				.Select(g =>
 				{
-					Content = $"Group {g}",
-					MenuItems = Enumerable
+					var item = new Microsoft.UI.Xaml.Controls.NavigationViewItem { Content = $"Group {g}" };
+					item.MenuItems.AddRange(Enumerable
 						.Range(0, 30)
-						.Select(i => new Microsoft.UI.Xaml.Controls.NavigationViewItem { Content = $"Group {g} - Item {i}" } as object)
-						.ToList()
+						.Select(i => new Microsoft.UI.Xaml.Controls.NavigationViewItem { Content = $"Group {g} - Item {i}" } as object));
+
+					return item;
 				})
 				.ToList();
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
@@ -1106,11 +1106,17 @@ namespace Microsoft.UI.Xaml.Controls
 			_uno_pointerDeferring?.Stop();
 
 			m_isPressed = false;
+#if false	// UNO specific: This seems to be only for Animated icons (https://github.com/microsoft/microsoft-ui-xaml/commit/c27a05caa0eeebaacdbd2106aebd12a6fc3dd912)
+			// which are not supported yet and causes some trouble with current pointers and lifecycle implementation when used with a minimal NavView
+			// (cf. https://github.com/unoplatform/uno/issues/7327 and https://github.com/unoplatform/uno/issues/11610)
+			// Note: That check has been modified in the WinUI repo to exclude the case where the pointer is touch https://github.com/microsoft/microsoft-ui-xaml/commit/18a981d03ec46763872c9b76bfc2351dc93ab197
+
 			// m_isPointerOver should be true before this event so this doesn't need to be set to true in the else block...
 			// What this flag tracks is complicated because of the NavigationView sub items and the m_capturedPointers that are being tracked..
 			// We do this check because PointerCaptureLost can sometimes take the place of PointerReleased events.
 			// In these cases we need to test if the pointer is over the item to maintain the proper state.
 			if (IsOutOfControlBounds(args.GetCurrentPoint(this).Position))
+#endif
 			{
 				m_isPointerOver = false;
 			}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
@@ -1106,7 +1106,9 @@ namespace Microsoft.UI.Xaml.Controls
 			_uno_pointerDeferring?.Stop();
 
 			m_isPressed = false;
-#if false	// UNO specific: This seems to be only for Animated icons (https://github.com/microsoft/microsoft-ui-xaml/commit/c27a05caa0eeebaacdbd2106aebd12a6fc3dd912)
+#if false
+			// UNO specific: This seems to be only for Animated icons (https://github.com/microsoft/microsoft-ui-xaml/commit/c27a05caa0eeebaacdbd2106aebd12a6fc3dd912)
+
 			// which are not supported yet and causes some trouble with current pointers and lifecycle implementation when used with a minimal NavView
 			// (cf. https://github.com/unoplatform/uno/issues/7327 and https://github.com/unoplatform/uno/issues/11610)
 			// Note: That check has been modified in the WinUI repo to exclude the case where the pointer is touch https://github.com/microsoft/microsoft-ui-xaml/commit/18a981d03ec46763872c9b76bfc2351dc93ab197
@@ -1125,6 +1127,7 @@ namespace Microsoft.UI.Xaml.Controls
 			UpdateVisualState(true);
 		}
 
+#if false // Not used in Uno
 		private bool IsOutOfControlBounds(Point point)
 		{
 			// This is a conservative check. It is okay to say we are
@@ -1138,6 +1141,7 @@ namespace Microsoft.UI.Xaml.Controls
 				point.Y < tolerance ||
 				point.Y > actualHeight - tolerance;
 		}
+#endif
 
 		private void ProcessPointerOver(PointerRoutedEventArgs args)
 		{


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/7327
closes https://github.com/unoplatform/uno/issues/11610

## Bugfix
`NavigationViewItem` might remain in over state when auto dismiss on click

## What is the current behavior?
When an element is clicked and the `NavigationView` self dismiss itself, we receive a `OnPointerCancelled` (as the item is no longer in the visual tree), but it is being ignored as not "in bounds", so we are not clearing the private `isOver` flag.

## What is the new behavior?
We no longer ignore it.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00b0bdf</samp>

Simplify pointer cancellation logic in `NavigationViewItem` to avoid stuck pressed state. This is part of a larger fix for pointer events and visual states in `NavigationView`.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
