### PR TITLE
[WIP] perf: `Brush` change subscription

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -7,12 +7,10 @@ using System;
 using Uno.Extensions;
 using Uno.UI.Common;
 using Uno.UI.DataBinding;
-using Uno.UI.Xaml.Input;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Text;
-using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
@@ -421,11 +419,12 @@ namespace Windows.UI.Xaml.Controls
 			_foregroundBrushSubscription.Disposable = null;
 			if (newValue is SolidColorBrush brush)
 			{
-				OnForegroundColorChangedPartial(brush);
-				_foregroundBrushSubscription.Disposable =
-					Brush.AssignAndObserveBrush(brush, c => OnForegroundColorChangedPartial(brush));
+				OnForegroundBrushChanged();
+				_foregroundBrushSubscription.Disposable = brush.SubscribeToChanges(OnForegroundBrushChanged);
 			}
 		}
+
+		private void OnForegroundBrushChanged() => OnForegroundColorChangedPartial(Foreground);
 
 		partial void OnForegroundColorChangedPartial(Brush newValue);
 
@@ -475,14 +474,16 @@ namespace Windows.UI.Xaml.Controls
 			_selectionHighlightColorSubscription.Disposable = null;
 			if (brush is not null)
 			{
-				OnSelectionHighlightColorChangedPartial(brush);
-				_selectionHighlightColorSubscription.Disposable = Brush.AssignAndObserveBrush(brush, c => OnSelectionHighlightColorChangedPartial(brush));
+				OnSelectionHighlightColorBrushChanged();
+				_selectionHighlightColorSubscription.Disposable = brush.SubscribeToChanges(OnSelectionHighlightColorBrushChanged);
 			}
 			else
 			{
 				OnSelectionHighlightColorChangedPartial(DefaultBrushes.SelectionHighlightColor);
 			}
 		}
+
+		private void OnSelectionHighlightColorBrushChanged() => OnSelectionHighlightColorChangedPartial(SelectionHighlightColor);
 
 		partial void OnSelectionHighlightColorChangedPartial(SolidColorBrush brush);
 

--- a/src/Uno.UI/UI/Xaml/Media/Brush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.cs
@@ -35,6 +35,7 @@ namespace Windows.UI.Xaml.Media
 
 		protected virtual void OnOpacityChanged(double oldValue, double newValue)
 		{
+			RaiseBrushChanged();
 		}
 
 		#endregion
@@ -61,6 +62,7 @@ namespace Windows.UI.Xaml.Media
 
 		protected virtual void OnRelativeTransformChanged(Transform oldValue, Transform newValue)
 		{
+			RaiseBrushChanged();
 		}
 
 		private protected Color GetColorWithOpacity(Color referenceColor)
@@ -99,7 +101,15 @@ namespace Windows.UI.Xaml.Media
 		internal bool SupportsAssignAndObserveBrush => true;
 #endif
 
-
+		private protected void RaiseBrushChanged()
+		{
+			var currentCallbacks = _brushChangedCallbacks.Data;
+			for (var callbackIndex = 0; callbackIndex < currentCallbacks.Length; callbackIndex++)
+			{
+				var callback = currentCallbacks[callbackIndex];
+				callback.Invoke();
+			}
+		}
 
 		internal IDisposable SubscribeToChanges(BrushChangedCallback onChanged)
 		{

--- a/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.skia.cs
@@ -40,11 +40,7 @@ namespace Windows.UI.Xaml.Media
 
 			if (brush is SolidColorBrush colorBrush)
 			{
-				UpdateColorWhenAnyChanged(colorBrush, new[]
-				{
-					SolidColorBrush.ColorProperty,
-					SolidColorBrush.OpacityProperty
-				});
+
 			}
 			else if (brush is GradientBrush gradientBrush)
 			{

--- a/src/Uno.UI/UI/Xaml/Media/BrushChangedCallback.cs
+++ b/src/Uno.UI/UI/Xaml/Media/BrushChangedCallback.cs
@@ -1,0 +1,3 @@
+﻿namespace Uno.UI.Xaml.Media;
+
+internal delegate void BrushChangedCallback();

--- a/src/Uno.UI/UI/Xaml/Media/BrushChangedDisposable.cs
+++ b/src/Uno.UI/UI/Xaml/Media/BrushChangedDisposable.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Uno.UI.DataBinding;
+
+namespace Windows.UI.Xaml.Media;
+
+/// <summary>
+/// Disposable that returns a <see cref="ManagedWeakReference"/> to the pool.
+/// </summary>
+internal struct BrushChangedDisposable : IDisposable
+{
+	private readonly Brush _brush;
+	private readonly WeakReferenceReturnDisposable _callbackDisposable;
+
+	public BrushChangedDisposable(Brush brush, WeakReferenceReturnDisposable callbackDisposable)
+	{
+		_brush = brush;
+		_callbackDisposable = callbackDisposable;
+	}
+
+	public void Dispose()
+	{
+		_callbackDisposable.Dispose();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/SolidColorBrush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/SolidColorBrush.cs
@@ -71,6 +71,8 @@ namespace Windows.UI.Xaml.Media
 		partial void OnColorChanged(Windows.UI.Color oldValue, Windows.UI.Color newValue)
 		{
 			UpdateColorWithOpacity(newValue);
+
+			RaiseBrushChanged();
 		}
 
 		protected override void OnOpacityChanged(double oldValue, double newValue)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

Replaces #12234

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9032c90</samp>

This pull request improves the performance and memory usage of the brush system by adding a new feature to `Brush.cs` that allows subscribing to brush changes without creating new delegates or closures. It also simplifies and refactors the using directives and the brush change handling in `TextBlock.cs` and `TextBox.cs`. It moves some types to separate files for clarity and consistency. It updates the `Brush.skia.cs` and `SolidColorBrush.cs` files to use the new feature.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
