### PR TITLE
Add autoplay tag on Wasm video

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 using Windows.UI.Xaml.Controls.Maps;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Notifications;
+using System.Numerics;
 
 namespace Uno.UI.Media;
 
@@ -28,6 +29,7 @@ internal partial class HtmlMediaPlayer : Border
 	private UIElement _activeElement;
 	private string _activeElementName;
 	public bool IsPause;
+	public bool IsAutoPlayRequested;
 
 	public event EventHandler<object> OnSourceLoaded;
 	public event EventHandler<object> OnStatusChanged;
@@ -314,10 +316,10 @@ internal partial class HtmlMediaPlayer : Border
 
 	private void OnHtmlMetadataLoaded(object sender, EventArgs e)
 	{
-		if (_activeElement != null)
-		{
-			Duration = NativeMethods.GetDuration(_activeElement.HtmlId);
-		}
+		//if (_activeElement != null)
+		//{
+		//	Duration = NativeMethods.GetDuration(_activeElement.HtmlId);
+		//}
 		OnMetadataLoaded?.Invoke(this, Duration);
 	}
 
@@ -339,12 +341,14 @@ internal partial class HtmlMediaPlayer : Border
 			this.Log().Debug($"{_activeElementName} source loaded: [{Source}]");
 		}
 
+		TimeUpdated -= OnHtmlTimeUpdated;
 		TimeUpdated += OnHtmlTimeUpdated;
 		if (_activeElement != null)
 		{
-			Duration = NativeMethods.GetDuration(_activeElement.HtmlId);
+			Duration = NativeMethods.GetDuration(_htmlVideo.HtmlId);
 		}
 		OnSourceLoaded?.Invoke(this, EventArgs.Empty);
+		IsAutoPlayRequested = false;
 	}
 
 	private void OnHtmlStatusPlayChanged(object sender, EventArgs e)
@@ -370,7 +374,7 @@ internal partial class HtmlMediaPlayer : Border
 
 	private void OnHtmlSourceFailed(object sender, HtmlCustomEventArgs e)
 	{
-		TimeUpdated += OnHtmlTimeUpdated;
+		TimeUpdated -= OnHtmlTimeUpdated;
 		if (_activeElement != null)
 		{
 			_activeElement.SetCssStyle("visibility", "hidden");
@@ -406,10 +410,12 @@ internal partial class HtmlMediaPlayer : Border
 									? player._htmlAudio
 									: default);
 			player._activeElementName = player.IsVideo ? "Video" : player.IsAudio ? "Audio" : "";
-
 			if (player._activeElement != null)
 			{
-
+				if (player.AutoPlay)
+				{
+					player._activeElement.SetHtmlAttribute("autoplay", "autoplay");
+				}
 				player._activeElement.SetHtmlAttribute("src", encodedSource);
 				player._activeElement.SetCssStyle("visibility", "visible");
 
@@ -438,12 +444,106 @@ internal partial class HtmlMediaPlayer : Border
 	{
 		if (dependencyobject is HtmlMediaPlayer player)
 		{
-			if (player._activeElement != null)
-			{
-				NativeMethods.SetAutoPlay(player._activeElement.HtmlId, (bool)args.NewValue);
-			}
+			player.IsAutoPlayRequested = (bool)args.NewValue;
+			//if (player._activeElement != null)
+			//{
+
+			//	if (player._htmlVideo != null && player.IsAutoPlayRequested)
+			//	{
+			//		if (!string.IsNullOrEmpty(player._htmlVideo.GetHtmlAttribute("autoplay")))
+			//		{
+			//			player._htmlVideo.RemoveAttribute("autoplay");
+			//		}
+			//		player._htmlVideo.SetHtmlAttribute("autoplay", "autoplay");
+			//		player._htmlVideo.SetCssStyle("visibility", "visible");
+			//	}
+			//	else
+			//	{
+			//		if (!string.IsNullOrEmpty(player._htmlVideo.GetHtmlAttribute("autoplay")))
+			//		{
+			//			player._htmlVideo.RemoveAttribute("autoplay");
+			//			player._htmlVideo.SetCssStyle("visibility", "hidden");
+			//		}
+			//	}
+
+			//	if (player._htmlAudio != null && player.IsAutoPlayRequested)
+			//	{
+			//		if (!string.IsNullOrEmpty(player._htmlAudio.GetHtmlAttribute("autoplay")))
+			//		{
+			//			player._htmlAudio.RemoveAttribute("autoplay");
+			//		}
+			//		player._htmlAudio.SetHtmlAttribute("autoplay", "autoplay");
+			//		player._htmlAudio.SetCssStyle("visibility", "visible");
+			//	}
+			//	else
+			//	{
+			//		if (!string.IsNullOrEmpty(player._htmlAudio.GetHtmlAttribute("autoplay")))
+			//		{
+			//			player._htmlAudio.RemoveAttribute("autoplay");
+			//			player._htmlAudio.SetCssStyle("visibility", "hidden");
+			//		}
+			//	}
+			//}
 		}
 	}
+	//private static void OnAutoPlayChanged(DependencyObject dependencyobject, DependencyPropertyChangedEventArgs args)
+	//{
+	//	if (dependencyobject is HtmlMediaPlayer player)
+	//	{
+	//		player.IsAutoPlayRequested = (bool)args.NewValue;
+
+	//		if (player._htmlVideo != null && player.IsAutoPlayRequested)
+	//		{
+	//			if (!string.IsNullOrEmpty(player._htmlVideo.GetHtmlAttribute("autoplay")))
+	//			{
+	//				player._htmlVideo.RemoveAttribute("autoplay");
+	//			}
+	//			player._htmlVideo.SetHtmlAttribute("autoplay", "autoplay");
+	//			player._htmlVideo.SetCssStyle("visibility", "visible");
+	//		}
+	//		else
+	//		{
+	//			if (!string.IsNullOrEmpty(player._htmlVideo.GetHtmlAttribute("autoplay")))
+	//			{
+	//				player._htmlVideo.RemoveAttribute("autoplay");
+	//				player._htmlVideo.SetCssStyle("visibility", "hidden");
+	//			}
+	//		}
+	//		if (player._htmlAudio != null && player.IsAutoPlayRequested)
+	//		{
+	//			if (!string.IsNullOrEmpty(player._htmlAudio.GetHtmlAttribute("autoplay")))
+	//			{
+	//				player._htmlAudio.RemoveAttribute("autoplay");
+	//			}
+	//			player._htmlAudio.SetHtmlAttribute("autoplay", "autoplay");
+	//			player._htmlAudio.SetCssStyle("visibility", "visible");
+	//		}
+	//		else
+	//		{
+	//			if (!string.IsNullOrEmpty(player._htmlAudio.GetHtmlAttribute("autoplay")))
+	//			{
+	//				player._htmlAudio.RemoveAttribute("autoplay");
+	//				player._htmlAudio.SetCssStyle("visibility", "hidden");
+	//			}
+	//		}
+	//		//NativeMethods.SetAutoPlay(player._activeElement.HtmlId, (bool)args.NewValue);
+	//		//if (player.AutoPlay)
+	//		//{
+	//		//	player._htmlVideo.SetHtmlAttribute("autoplay", "autoplay");
+	//		//}
+
+	//		//if (player._activeElement != null/* && !player.IsAutoPlay*/)
+	//		//{
+
+	//		//	if (player._isPlaying && !(bool)args.NewValue)
+	//		//	{
+	//		//		player._isPlaying = false;
+	//		//		player.IsPause = true;
+	//		//		NativeMethods.Pause(player._activeElement.HtmlId);
+	//		//	}
+	//		//}
+	//	}
+	//}
 
 	public static DependencyProperty AreTransportControlsEnabledProperty { get; } = DependencyProperty.Register(
 		"AreTransportControlsEnabled", typeof(bool), typeof(HtmlMediaPlayer), new PropertyMetadata(true,
@@ -566,14 +666,14 @@ internal partial class HtmlMediaPlayer : Border
 
 	public void Play()
 	{
-		TimeUpdated -= OnHtmlTimeUpdated;
-		TimeUpdated += OnHtmlTimeUpdated;
 		if (this.Log().IsEnabled(LogLevel.Debug))
 		{
 			this.Log().Debug($"Play()");
 		}
-		if (_activeElement != null && !_isPlaying)
+		if (_activeElement != null && !_isPlaying && !IsAutoPlayRequested)
 		{
+			TimeUpdated -= OnHtmlTimeUpdated;
+			TimeUpdated += OnHtmlTimeUpdated;
 			IsPause = false;
 			_isPlaying = true;
 			NativeMethods.Play(_activeElement.HtmlId);

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -11,6 +11,7 @@ using Windows.Media.Core;
 using Windows.Media.Playback;
 using Windows.Storage;
 using Windows.Storage.Streams;
+using Windows.UI.Xaml.Controls.Maps;
 
 [assembly: ApiExtension(typeof(IMediaPlayerExtension), typeof(Uno.UI.Media.MediaPlayerExtension))]
 
@@ -321,6 +322,7 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 
 		if (_player is not null && _uri is not null)
 		{
+			_player.AutoPlay = _owner.AutoPlay;
 			_player.Source = _uri.OriginalString;
 		}
 		else
@@ -463,7 +465,7 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			this.Log().Debug($"OnStatusChanged: {args}");
 		}
 
-		if ((MediaPlaybackState)args == MediaPlaybackState.Playing)
+		if ((MediaPlaybackState)args == MediaPlaybackState.Playing && _isPlayerPrepared)
 		{
 			_player?.Play();
 		}
@@ -498,9 +500,12 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			{
 				if (_isPlayRequested)
 				{
-					_player.Play();
-					_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
+					if (!_player.IsAutoPlayRequested)
+					{
+						_player.Play();
+					}
 				}
+				_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
 			}
 
 			_isPlayerPrepared = true;

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -351,19 +351,20 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnApplyTemplate();
 
+			if (MediaPlayer == null)
+			{
+				MediaPlayer = new Windows.Media.Playback.MediaPlayer(AutoPlay);
+			}
+
 			_layoutRoot = this.GetTemplateChild(LayoutRootName) as Grid;
 			_posterImage = this.GetTemplateChild(PosterImageName) as Image;
 			_mediaPlayerPresenter = this.GetTemplateChild(MediaPlayerPresenterName) as MediaPlayerPresenter;
+			_mediaPlayerPresenter?.ApplyStretch();
 
 			_transportControlsPresenter = this.GetTemplateChild(TransportControlsPresenterName) as ContentPresenter;
 			_transportControlsPresenter.Content = TransportControls;
 			TransportControls.ApplyTemplate();
 
-			if (MediaPlayer == null)
-			{
-				MediaPlayer = new Windows.Media.Playback.MediaPlayer();
-				_mediaPlayerPresenter?.ApplyStretch();
-			}
 
 			if (!IsLoaded && MediaPlayer.PlaybackSession.PlaybackState == MediaPlaybackState.None)
 			{

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.cs
@@ -82,12 +82,12 @@ namespace Windows.Media.Playback
 
 		#endregion
 
-		public MediaPlayer()
+		public MediaPlayer(bool autoPlay = false)
 		{
+			AutoPlay = autoPlay;
 			PlaybackSession = new MediaPlaybackSession(this);
 			Initialize();
 		}
-
 		internal void SetOption(string name, object value)
 		{
 			OnOptionChanged(name, value);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12533 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Given this link: https://playgroundcanary.z19.web.core.windows.net/#7486d066, the video may not play immediately with the following error:

play() failed because the user didn't interact with the document first.
We may not be able to fix this issue, as it's a browser security behavior, but need to reset the playback mode to paused.

## What is the new behavior?

When the video is set to auto play, we use the autoplay tag on html video/audio.


## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f524d9</samp>

This pull request enhances the media playback functionality in WebAssembly by improving the `HtmlMediaPlayer` and `MediaPlayerExtension` classes, and by adding an `AutoPlay` property to the `MediaPlayer` class. It also simplifies the `MediaPlayerElement` template initialization and fixes some issues with the media duration and position.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information


Internal Issue (If applicable):