### PR TITLE
fix(AutoSuggestBox): fix the AutoSuggestBox not working when using custom ItemContainerStyle

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -230,6 +230,46 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.Focus(FocusState.Programmatic);
 			await WindowHelper.WaitForIdle();
 		}
+
+		[TestMethod]
+		public async Task When_Using_Custom_ItemContainerStyle()
+		{
+			AutoSuggestBox SUT = new AutoSuggestBox
+			{
+				ItemContainerStyle = new Style(typeof(ListViewItem))
+				{
+					Setters =
+								{
+									new Setter(Control.HorizontalAlignmentProperty, HorizontalAlignment.Stretch),
+								},
+				}
+			};
+			string[] suggestions = { "a1", "a2", "b1", "b2" };
+			SUT.TextChanged += (s, e) =>
+			{
+				if (e.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+				{
+					s.ItemsSource = suggestions.Where(i => i.StartsWith(s.Text));
+				}
+			};
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForIdle();
+			var textBox = (TextBox)SUT.GetTemplateChild("TextBox");
+			var listView = (ListView)SUT.GetTemplateChild("SuggestionsList");
+			SUT.Focus(FocusState.Programmatic);
+			textBox.ProcessTextInput("a");
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(() => SUT.IsSuggestionListOpen);
+			Assert.AreEqual(2, listView.Items.Count);
+			Assert.AreEqual("a1", listView.Items[0].ToString());
+			Assert.AreEqual("a2", listView.Items[1].ToString());
+#if __WASM__
+			//ItemsPanelRoot.Children works only on wasm
+			Assert.AreEqual(2, listView.ItemsPanelRoot.Children.Count);
+			Assert.AreEqual("a1", (listView.ItemsPanelRoot.Children[0] as ContentControl).Content.ToString());
+			Assert.AreEqual("a2", (listView.ItemsPanelRoot.Children[1] as ContentControl).Content.ToString());
+#endif
+		}
 #endif
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -106,6 +106,11 @@ namespace Windows.UI.Xaml.Controls
 			UpdateSuggestionList();
 		}
 
+		protected override DependencyObject GetContainerForItemOverride()
+		{
+			return new ListViewItem() { IsGeneratedContainer = true };
+		}
+
 		internal override void OnItemsSourceGroupsChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
 			base.OnItemsSourceGroupsChanged(sender, args);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12583 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f81f078</samp>

This pull request adds support for custom `ItemContainerStyle` in the `AutoSuggestBox` control, and adds a unit test to verify its behavior. It overrides the `GetContainerForItemOverride` method in `AutoSuggestBox.cs` and updates the test class `Given_AutoSuggestBox.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
