### PR TITLE
chore: Add --force option and reset

### DIFF
--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -77,14 +77,15 @@ foreach ($repoPath in $external_docs.keys)
     pushd $repoPath
 
     echo "Checking out $repoUrl@$repoBranch..."
-    git checkout $repoBranch
+    git fetch
+    git checkout --force $repoBranch
     Assert-ExitCodeIsZero
 
     # if not detached
     if ((git symbolic-ref -q HEAD) -ne $null)
     {
         echo "Pulling $repoUrl@$repoBranch..."
-        git pull
+        git reset --hard
         Assert-ExitCodeIsZero
     }
 


### PR DESCRIPTION
## PR Type

- Build or CI related changes
- Project automation

This PR replaces pull with reset --hard and adds --force to checkout to avoid errors if branch was force pushed or if a different brach was previously checked out when generating docs and brach/commit was changed.