### PR TITLE
[MPE][Wasm] Early media error causes autoplay to fail - Event State Version

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.NativeMethods.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.NativeMethods.cs
@@ -47,6 +47,17 @@ partial class HtmlMediaPlayer
 			=> throw new NotSupportedException();
 #endif
 
+
+#if USE_JSIMPORT
+		[JSImport("globalThis.Uno.UI.Media.HtmlMediaPlayer.getPaused")]
+#endif
+		internal static partial bool GetPaused(nint htmlId);
+
+#if !USE_JSIMPORT
+		internal static partial bool GetPaused(nint htmlId)
+			=> throw new NotSupportedException();
+#endif
+
 #if USE_JSIMPORT
 		[JSImport("globalThis.Uno.UI.Media.HtmlMediaPlayer.setCurrentPosition")]
 #endif

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -347,7 +347,10 @@ internal partial class HtmlMediaPlayer : Border
 		}
 		OnSourceLoaded?.Invoke(this, EventArgs.Empty);
 
-		IsPause = NativeMethods.GetPaused(_activeElement.HtmlId);
+		if (_activeElement != null)
+		{
+			IsPause = NativeMethods.GetPaused(_activeElement.HtmlId);
+		}
 		_isPlaying = !IsPause;
 		OnStatusChanged?.Invoke(this, EventArgs.Empty);
 	}

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -69,7 +69,6 @@ internal partial class HtmlMediaPlayer : Border
 		StatusPlayChanged += OnHtmlStatusPlayChanged;
 		StatusPauseChanged += OnHtmlStatusPauseChanged;
 		SourceFailed += OnHtmlSourceFailed;
-		SourceSuspend += OnHtmlSourceSuspend;
 		SourceEnded += OnHtmlSourceEnded;
 		MetadataLoaded += OnHtmlMetadataLoaded;
 
@@ -86,7 +85,6 @@ internal partial class HtmlMediaPlayer : Border
 		StatusPlayChanged -= OnHtmlStatusPlayChanged;
 		StatusPauseChanged -= OnHtmlStatusPauseChanged;
 		SourceFailed -= OnHtmlSourceFailed;
-		SourceSuspend -= OnHtmlSourceSuspend;
 		SourceEnded -= OnHtmlSourceEnded;
 		MetadataLoaded -= OnHtmlMetadataLoaded;
 		TimeUpdated -= OnHtmlTimeUpdated;
@@ -300,23 +298,6 @@ internal partial class HtmlMediaPlayer : Border
 		}
 	}
 
-	/// <summary>
-	/// Occurs when there is an Suspend associated with video. To fix the autoplay validation
-	/// </summary>		
-	event EventHandler<HtmlCustomEventArgs> SourceSuspend
-	{
-		add
-		{
-			_htmlVideo.RegisterHtmlCustomEventHandler("suspend", value, isDetailJson: false);
-			_htmlAudio.RegisterHtmlCustomEventHandler("suspend", value, isDetailJson: false);
-		}
-		remove
-		{
-			_htmlVideo.UnregisterHtmlCustomEventHandler("suspend", value);
-			_htmlAudio.UnregisterHtmlCustomEventHandler("suspend", value);
-		}
-	}
-
 	private void OnHtmlTimeUpdated(object sender, EventArgs e)
 	{
 		OnTimeUpdate?.Invoke(this, EventArgs.Empty);
@@ -365,6 +346,9 @@ internal partial class HtmlMediaPlayer : Border
 			Duration = NativeMethods.GetDuration(_activeElement.HtmlId);
 		}
 		OnSourceLoaded?.Invoke(this, EventArgs.Empty);
+
+		IsPause = NativeMethods.GetPaused(_activeElement.HtmlId);
+		_isPlaying = !IsPause;
 		OnStatusChanged?.Invoke(this, EventArgs.Empty);
 	}
 
@@ -387,24 +371,6 @@ internal partial class HtmlMediaPlayer : Border
 
 		IsPause = true;
 		OnStatusChanged?.Invoke(this, EventArgs.Empty);
-	}
-
-	private void OnHtmlSourceSuspend(object sender, HtmlCustomEventArgs e)
-	{
-		if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
-		{
-			this.Log().Error($"{_activeElementName} source Suspend: [{Source}]");
-		}
-		if (_activeElement != null)
-		{
-			IsPause = NativeMethods.GetPaused(_activeElement.HtmlId);
-		}
-		if (IsPause)
-		{
-			IsPause = true;
-			_isPlaying = false;
-			OnStatusChanged?.Invoke(this, EventArgs.Empty);
-		}
 	}
 
 	private void OnHtmlSourceFailed(object sender, HtmlCustomEventArgs e)

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/WasmScripts/uno.ui.media.d.ts
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/WasmScripts/uno.ui.media.d.ts
@@ -3,6 +3,7 @@ declare namespace Uno.UI.Media {
         static videoWidth(htmlId: number): number;
         static videoHeight(htmlId: number): number;
         static getCurrentPosition(htmlId: number): number;
+        static getPaused(htmlId: number): number;
         static setCurrentPosition(htmlId: number, currentTime: number): void;
         static setAttribute(htmlId: number, name: string, value: string): void;
         static removeAttribute(htmlId: number, name: string): void;

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/WasmScripts/uno.ui.media.js
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/WasmScripts/uno.ui.media.js
@@ -15,6 +15,9 @@ var Uno;
                 static getCurrentPosition(htmlId) {
                     return document.getElementById(htmlId.toString()).currentTime;
                 }
+                static getPaused(htmlId) {
+                    return document.getElementById(htmlId.toString()).paused;
+                }
                 static setCurrentPosition(htmlId, currentTime) {
                     document.getElementById(htmlId.toString()).currentTime = currentTime;
                 }

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/ts/MediaElement.ts
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/ts/MediaElement.ts
@@ -13,6 +13,10 @@ namespace Uno.UI.Media {
 			return document.getElementById(htmlId.toString()).currentTime;
 		}
 
+		public static getPaused(htmlId: number): number {
+			return document.getElementById(htmlId.toString()).paused;
+		}
+
 		public static setCurrentPosition(htmlId: number, currentTime: number) {
 			document.getElementById(htmlId.toString()).currentTime = currentTime;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
@@ -320,7 +320,7 @@ namespace Windows.UI.Xaml.Controls
 		private void OnPointerExited(object sender, PointerRoutedEventArgs e)
 		{
 			_isScrubbing = false;
-			if (_wasPlaying)
+			if (_wasPlaying && _mediaPlayer != null && !_mediaPlayer.PlaybackSession.IsPlaying)
 			{
 				_mediaPlayer?.Play();
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
@@ -320,7 +320,7 @@ namespace Windows.UI.Xaml.Controls
 		private void OnPointerExited(object sender, PointerRoutedEventArgs e)
 		{
 			_isScrubbing = false;
-			if (_wasPlaying && _mediaPlayer != null && !_mediaPlayer.PlaybackSession.IsPlaying)
+			if (_wasPlaying)
 			{
 				_mediaPlayer?.Play();
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12533 

## PR Type

What kind of change does this PR introduce?

- Bugfix
- 
## What is the current behavior?

Given this link: https://playgroundcanary.z19.web.core.windows.net/#7486d066, the video may not play immediately with the following error:

play() failed because the user didn't interact with the document first.
We may not be able to fix this issue, as it's a browser security behavior, but need to reset the playback mode to paused.

## What is the new behavior?

When the broser validate that the user do not interact with the document, the Playback is set to paused.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efe20c3</samp>

This pull request adds support for handling the `SourceSuspend` event in the `HtmlMediaPlayer` class and its related files. This event occurs when the HTML media element is suspended due to autoplay validation. The changes also fix a bug that caused the media to resume playback when the user stopped scrubbing the progress bar if the media was already paused or suspended.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information


Internal Issue (If applicable):
