### PR TITLE
[MPE][Wasm] Early media error causes autoplay to fail - playground issue

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -352,7 +352,6 @@ internal partial class HtmlMediaPlayer : Border
 		if (_activeElement != null)
 		{
 			PlayerState = NativeMethods.GetPaused(_activeElement.HtmlId) ? HtmlMediaPlayerState.Paused : HtmlMediaPlayerState.Playing;
-			_activeElement.SetCssStyle("visibility", "visible");
 		}
 
 		OnStatusChanged?.Invoke(this, EventArgs.Empty);

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayerState.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayerState.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Uno.UI.Media;
+
+public enum HtmlMediaPlayerState
+{
+	None = 0,
+	Opening = 1,
+	Playing = 3,
+	Paused = 4,
+}

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayerState.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayerState.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Uno.UI.Media;
 
-public enum HtmlMediaPlayerState
+internal enum HtmlMediaPlayerState
 {
 	None = 0,
 	Opening = 1,

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -235,14 +235,14 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 	{
 		if (this.Log().IsEnabled(LogLevel.Debug))
 		{
-			this.Log().Debug($"MediaPlayerExtension.OnStatusMediaChanged Paused ({_player?.IsPause.ToString()})");
+			this.Log().Debug($"MediaPlayerExtension.OnStatusMediaChanged to state {_player?.PlayerState.ToString()}");
 		}
 
-		if (_player?.IsPause == true && _owner.PlaybackSession.PlaybackState == MediaPlaybackState.Playing)
+		if (_player?.PlayerState == HtmlMediaPlayerState.Paused && _owner.PlaybackSession.PlaybackState == MediaPlaybackState.Playing)
 		{
 			_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Paused;
 		}
-		else if (_player?.IsPause == false && _owner.PlaybackSession.PlaybackState == MediaPlaybackState.Paused)
+		else if (_player?.PlayerState == HtmlMediaPlayerState.Playing && _owner.PlaybackSession.PlaybackState == MediaPlaybackState.Paused)
 		{
 			_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): 
https://github.com/unoplatform/uno/issues/12533

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The publish url on playground show the incorrect icon for play or pause.
See the link https://playgroundcanary.z19.web.core.windows.net/#bcb300bd
![image](https://github.com/unoplatform/uno/assets/116665025/e198787a-fd13-4830-8e98-567752e19178)


## What is the new behavior?

Now the icon shows the Play when the video is blocked by the browser on the autoplay.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 801f41c</samp>

This pull request improves the media playback state management of the `HtmlMediaPlayer` class for WebAssembly by introducing a new `HtmlMediaPlayerState` enum and using it instead of the `IsPause` field. It also updates the `MediaPlayerExtension` class and removes some unused or redundant code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
