### PR TITLE
fix: Adjust runtime replace to avoid self-reference

### DIFF
--- a/build/uno.winui.runtime-replace.targets
+++ b/build/uno.winui.runtime-replace.targets
@@ -33,10 +33,10 @@
 			<!-- Add the files for the current selected runtime identifier -->
 			<RuntimeCopyLocalItemsMerged
 				Include="%(UnoRuntimeEnabledPackage.PackageBasePath)/uno-runtime/$(UnoRuntimeIdentifier.ToLowerInvariant())/*.dll"
-				NuGetPackageId="%(Identity)" />
+				NuGetPackageId="%(UnoRuntimeEnabledPackage.Identity)" />
 			<RuntimeCopyLocalItemsMerged
 				Include="%(UnoRuntimeEnabledPackage.PackageBasePath)/../uno-runtime/$(UnoRuntimeIdentifier.ToLowerInvariant())/*.dll"
-				NuGetPackageId="%(Identity)" />
+				NuGetPackageId="%(UnoRuntimeEnabledPackage.Identity)" />
 
 			<!-- Add metadata so the .deps.json file is generated properly (.NET 5+) -->
 			<RuntimeCopyLocalItemsToUpdate
@@ -57,10 +57,10 @@
 			<!-- Add the files for the current selected runtime identifier -->
 			<RuntimeCopyLocalItemsMerged
 				Include="%(UnoRuntimeEnabledPackage.PackageBasePath)/uno-runtime/$(_UnoRuntimeTargetFramework)/$(UnoRuntimeIdentifier.ToLowerInvariant())/*.dll"
-				NuGetPackageId="%(Identity)" />
+				NuGetPackageId="%(UnoRuntimeEnabledPackage.Identity)" />
 			<RuntimeCopyLocalItemsMerged
 				Include="%(UnoRuntimeEnabledPackage.PackageBasePath)/../uno-runtime/$(_UnoRuntimeTargetFramework)/$(UnoRuntimeIdentifier.ToLowerInvariant())/*.dll"
-				NuGetPackageId="%(Identity)" />
+				NuGetPackageId="%(UnoRuntimeEnabledPackage.Identity)" />
 
 			<!-- Add metadata so the .deps.json file is generated properly (.NET 5+) -->
 			<RuntimeCopyLocalItemsToUpdate


### PR DESCRIPTION
Fixes the following message:

```
MSB4120: Item 'RuntimeCopyLocalItemsMerged' definition within target references itself via
(qualified or unqualified) metadatum 'Identity'. This can lead to unintended expansion and
cross-applying of pre-existing items. More info: https://aka.ms/msbuild/metadata-self-ref
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b709f73</samp>

Fix runtime assembly package IDs in .deps.json for WinUI projects. Use `UnoRuntimeEnabledPackage` metadata in `uno.winui.runtime-replace.targets`.