### PR TITLE
feat: Support icon elements for NativeCommandBarPresenter

### DIFF
--- a/src/Uno.UI/Controls/CommandBar/AppBarButtonRenderer.Android.cs
+++ b/src/Uno.UI/Controls/CommandBar/AppBarButtonRenderer.Android.cs
@@ -85,30 +85,19 @@ namespace Uno.UI.Controls
 				native.SetIcon(null);
 				native.SetTitle(element.Label);
 			}
-			else if (element.Icon != null)
+			else
 			{
-				switch (element.Icon)
+				var iconOrContent = element.Icon ?? element.Content;
+
+				switch (iconOrContent)
 				{
 					case BitmapIcon bitmap:
 						var drawable = DrawableHelper.FromUri(bitmap.UriSource);
 						native.SetIcon(drawable);
+						native.SetActionView(null);
+						native.SetTitle(null);
 						break;
 
-					case FontIcon font: // not supported
-					case PathIcon path: // not supported
-					case SymbolIcon symbol: // not supported
-					default:
-						this.Log().Warn($"{GetType().Name ?? "FontIcon, PathIcon and SymbolIcon"} are not supported. Use BitmapIcon instead with UriSource.");
-						native.SetIcon(null);
-						break;
-				}
-				native.SetActionView(null);
-				native.SetTitle(null);
-			}
-			else
-			{
-				switch (element.Content)
-				{
 					case string text:
 						native.SetIcon(null);
 						native.SetActionView(null);

--- a/src/Uno.UI/Controls/CommandBar/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBar/AppBarButtonRenderer.iOS.cs
@@ -86,63 +86,44 @@ namespace Uno.UI.Controls
 			var native = Native;
 			var element = Element;
 
-			if (element.Icon != null)
+			var iconOrContent = element.Icon ?? element.Content;
+			switch (element.Icon)
 			{
-				switch (element.Icon)
-				{
-					case BitmapIcon bitmap:
-						native.Image = UIImageHelper.FromUri(bitmap.UriSource);
-						native.ClearCustomView();
-						native.Title = null;
-						break;
+				case BitmapIcon bitmap:
+					native.Image = UIImageHelper.FromUri(bitmap.UriSource);
+					native.ClearCustomView();
+					native.Title = null;
+					break;
 
-					case FontIcon font: // not supported
-					case PathIcon path: // not supported
-					case SymbolIcon symbol: // not supported
-					default:
-						this.Log().Warn($"{GetType().Name ?? "FontIcon, PathIcon and SymbolIcon"} are not supported. Use BitmapIcon instead with UriSource.");
-						native.Image = null;
-						native.ClearCustomView();
-						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set. 
-						// We default to an empty string to ensure it is added.
-						native.Title = string.Empty;
-						break;
-				}
-			}
-			else
-			{
-				switch (element.Content)
-				{
-					case string text:
-						native.Image = null;
-						native.ClearCustomView();
-						native.Title = text;
-						break;
+				case string text:
+					native.Image = null;
+					native.ClearCustomView();
+					native.Title = text;
+					break;
 
-					case FrameworkElement fe:
-						var currentParent = element.GetParent();
-						_appBarButtonWrapper.Child = element;
+				case FrameworkElement fe:
+					var currentParent = element.GetParent();
+					_appBarButtonWrapper.Child = element;
 
-						//Restore the original parent if any, as we
-						// want the DataContext to flow properly from the
-						// CommandBar.
-						element.SetParent(currentParent);
+					//Restore the original parent if any, as we
+					// want the DataContext to flow properly from the
+					// CommandBar.
+					element.SetParent(currentParent);
 
-						native.Image = null;
-						native.CustomView = fe.Visibility == Visibility.Visible ? _appBarButtonWrapper : null;
-						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
-						// We default to an empty string to ensure it is added, in order to support late-bound Content.
-						native.Title = string.Empty;
-						break;
+					native.Image = null;
+					native.CustomView = fe.Visibility == Visibility.Visible ? _appBarButtonWrapper : null;
+					// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
+					// We default to an empty string to ensure it is added, in order to support late-bound Content.
+					native.Title = string.Empty;
+					break;
 
-					default:
-						native.Image = null;
-						native.ClearCustomView();
-						// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set. 
-						// We default to an empty string to ensure it is added.
-						native.Title = string.Empty;
-						break;
-				}
+				default:
+					native.Image = null;
+					native.ClearCustomView();
+					// iOS doesn't add the UIBarButtonItem to the native logical tree unless it has an Image or Title set.
+					// We default to an empty string to ensure it is added.
+					native.Title = string.Empty;
+					break;
 			}
 
 			// Label

--- a/src/Uno.UI/Controls/CommandBar/AppBarButtonRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBar/AppBarButtonRenderer.iOS.cs
@@ -87,7 +87,7 @@ namespace Uno.UI.Controls
 			var element = Element;
 
 			var iconOrContent = element.Icon ?? element.Content;
-			switch (element.Icon)
+			switch (iconOrContent)
 			{
 				case BitmapIcon bitmap:
 					native.Image = UIImageHelper.FromUri(bitmap.UriSource);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12688

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8a7984</samp>

This pull request refactors the `AppBarButtonRenderer` on Android and iOS to simplify the logic for setting the native icon or content. The goal is to fix a bug related to the `AppBarButton` icon not showing in some cases.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
