### PR TITLE
fix: Raise `ImageFailed` on Skia, correctly arrange empty `Image`

### DIFF
--- a/src/SamplesApp/UnoIslands.Skia.WPF/UnoIslands.Skia.Wpf.csproj
+++ b/src/SamplesApp/UnoIslands.Skia.WPF/UnoIslands.Skia.Wpf.csproj
@@ -82,7 +82,8 @@
 	  </Compile>
 	</ItemGroup>
 
-	<Import Project="..\..\build\*.Skia.Wpf.props" />
-	<Import Project="..\..\build\*.Skia.Wpf.targets" />
+	<Import Project="..\..\..\build\*.Skia.Wpf.props" />
+	<Import Project="..\..\..\build\*.Skia.Wpf.targets" />
+	<Import Project="..\..\..\build\uno.winui.runtime-replace.targets" />
 
 </Project>

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia.WPF/UnoIslandsSamplesApp.Skia.Wpf.csproj
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia.WPF/UnoIslandsSamplesApp.Skia.Wpf.csproj
@@ -1,12 +1,16 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 	<PropertyGroup>
-		<TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net6.0-windows</TargetFrameworks>
 
 		<!--
 		Enable implicit dotnet runtime forward rolling, as the specifed target framework
 		project may run with only a later version of the .NET runtime installed.
 		-->
 		<RollForward>Major</RollForward>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(MSBuildRuntimeType)'=='Core' or '$(BuildingInsideVisualStudio)'=='true'">
+		<TargetFrameworks>net7.0-windows</TargetFrameworks>
 	</PropertyGroup>
 
 	<Import Project="../../targetframework-override.props" />
@@ -34,6 +38,7 @@
 		<Reference Include="WindowsBase" />
 		<Reference Include="PresentationCore" />
 		<Reference Include="PresentationFramework" />
+		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -46,7 +51,15 @@
 
 	<ItemGroup>
 		<PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-		<PackageReference Include="SkiaSharp.Views.WPF" Version="2.80.3" />
+		<PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.3" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='net6.0-windows'">
+		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='net7.0-windows'">
+		<PackageReference Include="System.Drawing.Common" Version="7.0.0-rc.1.22426.10" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -93,7 +106,8 @@
 		</None>
 	</ItemGroup>
 
-	<Import Project="..\..\build\*.Skia.Wpf.props" />
-	<Import Project="..\..\build\*.Skia.Wpf.targets" />
-
+	<Import Project="..\..\..\build\*.Skia.Wpf.props" />
+	<Import Project="..\..\..\build\*.Skia.Wpf.targets" />
+	<Import Project="..\..\..\build\uno.winui.runtime-replace.targets" />
+	
 </Project>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -452,9 +452,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_SVGImageSource()
 		{
-#if __SKIA__
-			Assert.Inconclusive(); // SVGImage Load not implemented on Skia
-#endif
 			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
@@ -471,10 +468,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_SVGImageSource_Uri_Is_Null()
 		{
-
-#if __SKIA__
-			Assert.Inconclusive(); // SVGImage Load not implemented on Skia
-#endif
 			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
@@ -490,9 +483,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_SVGImageSource_Uri_Is_Set_Null()
 		{
-#if __SKIA__
-			Assert.Inconclusive(); // SVGImage Load not implemented on Skia
-#endif
 			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -509,7 +509,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			};
 			image.Source = new BitmapImage(new Uri("ms-appx:///image/definitely/does/not/exist.png"));
 
-			Assert.IsTrue(imageFailedRaised);
+			await WindowHelper.WaitFor(() => imageFailedRaised);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -497,6 +497,23 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		public async Task When_ImageFailed()
+		{
+			var image = new Image() { Width = 100, Height = 100 };
+			TestServices.WindowHelper.WindowContent = image;
+			await WindowHelper.WaitForLoaded(image);
+			bool imageFailedRaised = false;
+			image.ImageFailed += (s, e) =>
+			{
+				imageFailedRaised = true;
+			};
+			image.Source = new BitmapImage(new Uri("ms-appx:///image/definitely/does/not/exist.png"));
+
+			Assert.IsTrue(imageFailedRaised);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
@@ -132,7 +132,7 @@ namespace Windows.UI.Xaml.Controls
 
 			_imageFetchDisposable.Disposable = null;
 
-			if (imageSource != null && imageSource.UseTargetSize)
+			if (imageSource is not null && imageSource.UseTargetSize)
 			{
 				// If the ImageSource has the UseTargetSize set, the image
 				// must not be loaded until the first layout has been done.
@@ -146,7 +146,7 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
-			if (imageSource.ResourceFailed)
+			if (imageSource?.ResourceFailed == true)
 			{
 				// Currently resource-based images are evaluated immediately
 				// in the constructor - so we have to raise ImageFailed late.				

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
@@ -146,6 +146,13 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
+			if (imageSource.ResourceFailed)
+			{
+				// Currently resource-based images are evaluated immediately
+				// in the constructor - so we have to raise ImageFailed late.				
+				OnImageFailed(imageSource, new InvalidOperationException("Resource could not be found"));
+			}
+
 			if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 			{
 				this.Log().Debug(this.ToString() + " TryOpenImage - proceeding");

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
@@ -3,11 +3,11 @@ using System.Linq;
 using System.Numerics;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
+using Uno.UI.Xaml.Media;
 using Windows.Foundation;
 using Windows.UI.Composition;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
-using Uno.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -124,24 +124,20 @@ namespace Windows.UI.Xaml.Controls
 
 		private void TryProcessPendingSource()
 		{
-			if (_pendingImageData.HasData)
+			var currentData = _pendingImageData;
+			_pendingImageData = new();
+			if (currentData.HasData)
 			{
-				_currentSurface = _pendingImageData.CompositionSurface;
+				_currentSurface = currentData.CompositionSurface;
 				_surfaceBrush = Visual.Compositor.CreateSurfaceBrush(_currentSurface);
 				_imageSprite.Brush = _surfaceBrush;
-
-				_pendingImageData = new();
-
-				if (_pendingImageData is not { Kind: ImageDataKind.Error })
-				{
-					ImageOpened?.Invoke(this, new RoutedEventArgs(this));
-				}
-				else
-				{
-					ImageFailed?.Invoke(this, new(
-						this,
-						_pendingImageData.Error?.Message ?? "Unknown error"));
-				}
+				ImageOpened?.Invoke(this, new RoutedEventArgs(this));
+			}
+			else if (currentData is { Kind: ImageDataKind.Error })
+			{
+				ImageFailed?.Invoke(this, new(
+					this,
+					currentData.Error?.Message ?? "Unknown error"));
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
@@ -183,7 +183,7 @@ namespace Windows.UI.Xaml.Controls
 			else
 			{
 				_imageSprite.Size = default;
-				return default;
+				return base.ArrangeOverride(finalSize);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
@@ -91,6 +91,8 @@ namespace Windows.UI.Xaml.Media
 				|| ResourceId != null;
 		}
 
+		internal bool ResourceFailed => ResourceString is not null && ResourceId is null;
+
 		internal BitmapDrawable? BitmapDrawable { get; private set; }
 
 		internal int? ResourceId


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12689 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- `ImageFailed` is not raised
- Empty `Image` always arranges as zero size, even if it has explicit size set


## What is the new behavior?

- Fixed!

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 620c190</samp>

This pull request enhances the support and testing of the `Image` control on the Skia platform, by adding SVG support, fixing image loading and event handling bugs, and improving code style.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
