### PR TITLE
perf: Reduce array allocations when setting a single property on Wasm

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -281,7 +281,7 @@ namespace Windows.UI.Xaml
 		}
 
 		protected internal void SetProperty(string name, string value)
-			=> SetProperty((name, value));
+			=> Uno.UI.Xaml.WindowManagerInterop.SetProperty(HtmlId, name, value);
 
 		protected internal void SetProperty(params (string name, string value)[] properties)
 		{

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -716,11 +716,11 @@ namespace Uno.UI.Xaml
 #if NET7_0_OR_GREATER
 			NativeMethods.SetProperty(htmlId, name, value);
 #else
-			var parms = new WindowManagerSetPropertyParams()
+			var parms = new WindowManagerSetSinglePropertyParams()
 			{
 				HtmlId = htmlId,
-				Pairs_Length = pairs.Length,
-				Pairs = pairs,
+				Name = name,
+				Value = value,
 			};
 
 			TSInteropMarshaller.InvokeJS("Uno:setSinglePropertyNative", parms);

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -711,6 +711,33 @@ namespace Uno.UI.Xaml
 #endif
 		}
 
+		internal static void SetProperty(IntPtr htmlId, string name, string value)
+		{
+#if NET7_0_OR_GREATER
+			NativeMethods.SetProperty(htmlId, name, value);
+#else
+			var parms = new WindowManagerSetPropertyParams()
+			{
+				HtmlId = htmlId,
+				Pairs_Length = pairs.Length,
+				Pairs = pairs,
+			};
+
+			TSInteropMarshaller.InvokeJS("Uno:setSinglePropertyNative", parms);
+#endif
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct WindowManagerSetSinglePropertyParams
+		{
+			public IntPtr HtmlId;
+
+			public string Name;
+
+			public string Value;
+		}
+
 		[TSInteropMessage]
 		[StructLayout(LayoutKind.Sequential, Pack = 4)]
 		private struct WindowManagerSetPropertyParams
@@ -1346,6 +1373,9 @@ namespace Uno.UI.Xaml
 
 			[JSImport("globalThis.Uno.UI.WindowManager.current.setPropertyNativeFast")]
 			internal static partial void SetProperties(IntPtr htmlId, string[] pairs);
+
+			[JSImport("globalThis.Uno.UI.WindowManager.current.setSinglePropertyNativeFast")]
+			internal static partial void SetProperty(IntPtr htmlId, string name, string value);
 
 			[JSImport("globalThis.Uno.UI.WindowManager.current.setRootElement")]
 			internal static partial void SetRootElement(IntPtr htmlId);

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -473,6 +473,29 @@ namespace Uno.UI {
 			}
 		}
 
+		public setSinglePropertyNative(pParams: number): boolean {
+
+			const params = WindowManagerSetSinglePropertyParams.unmarshal(pParams);
+
+			this.setSinglePropertyNativeFast(params.HtmlId, params.Name, params.Value);
+
+			return true;
+		}
+
+		public setSinglePropertyNativeFast(htmlId: number, name: string, value: string) {
+
+			const element = this.getView(htmlId);
+			if (value === "true") {
+				(element as any)[name] = true;
+			}
+			else if (value === "false") {
+				(element as any)[name] = false;
+			}
+			else {
+				(element as any)[name] = value;
+			}
+		}
+
 		/**
 			* Get a property for an element.
 			*/


### PR DESCRIPTION
GitHub Issue (If applicable): Part of #8597

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9634171</samp>

This pull request refactors the interop code for setting a single property on a UI element from C# to TypeScript on WebAssembly. It introduces new methods and structs in `WindowManagerInterop.wasm.cs`, `NativeMethods.wasm.cs`, and `WindowManager.ts` to optimize the performance and reduce the memory allocation of the interop calls. It also updates the `SetProperty` method in `UIElement.wasm.cs` to use the new interop methods.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
