### PR TITLE
fix: Fix setting source on WriteableBitmap for Android and Skia

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -243,7 +243,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 
 			await renderer.RenderAsync(parent);
 			var snapshot = await RawBitmap.From(renderer, rect);
+
+#if !__IOS__ && !__MACOS__ // https://github.com/unoplatform/uno/issues/12705
 			ImageAssert.HasColorAt(snapshot, 1, 1, Color.FromArgb(0xFF, 0xFA, 0xB8, 0x63), tolerance: 5);
+#endif
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -207,6 +207,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 
 			Assert.AreEqual(147, writeableBitmap.PixelWidth);
 			Assert.AreEqual(147, writeableBitmap.PixelHeight);
+
+			var parent = new Border()
+			{
+				Width = 147,
+				Height = 147,
+			};
+
+			var rect = new Rectangle
+			{
+				Width = 147,
+				Height = 147,
+			};
+
+			parent.Child = rect;
+
+			WindowHelper.WindowContent = parent;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(rect);
+
+			rect.Fill = new ImageBrush
+			{
+				ImageSource = writeableBitmap
+			};
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -231,6 +231,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			{
 				ImageSource = writeableBitmap
 			};
+
+			await WindowHelper.WaitForIdle();
+
+			var renderer = new RenderTargetBitmap();
+
+			await renderer.RenderAsync(parent);
+			var snapshot = await RawBitmap.From(renderer, rect);
+			ImageAssert.HasColorAt(snapshot, 1, 1, Color.FromArgb(0xFF, 0xFA, 0xB8, 0x63), tolerance: 5);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -198,6 +198,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 #endif
 		public async Task When_WriteableBitmap_SetSource_Should_Update_PixelWidth_And_PixelHeight()
 		{
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+
 			var writeableBitmap = new WriteableBitmap(1, 1);
 			var file = await StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/ingredient3.png"));
 			using (var stream = await file.OpenReadAsync())

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapSource.cs
@@ -101,7 +101,6 @@ namespace Windows.UI.Xaml.Media.Imaging
 		}
 
 		partial void UpdatePixelWidthAndHeightPartial(Stream stream);
-
 		private protected virtual void OnSetSource() { }
 
 		private

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.Android.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Diagnostics;
 using System.IO;
-using Windows.Foundation;
-using Windows.Storage.Streams;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Android.Graphics;
-using Android.Graphics.Drawables;
+using Java.Nio;
+using Uno.Extensions;
 using Uno.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Media.Imaging
@@ -32,6 +34,24 @@ namespace Windows.UI.Xaml.Media.Imaging
 
 			image = ImageData.FromBitmap(Bitmap.CreateBitmap(drawableBuffer, PixelWidth, PixelHeight, Bitmap.Config.Argb8888));
 			return image.HasData;
+		}
+
+		private void DecodeStreamIntoBuffer()
+		{
+			if (Stream.CanSeek)
+			{
+				Stream.Position = 0;
+			}
+
+			var image = BitmapFactory.DecodeStream(Stream);
+
+			var pixels = new int[PixelWidth * PixelHeight];
+			image.GetPixels(pixels, 0, PixelWidth, 0, 0, PixelWidth, PixelHeight);
+
+			var pixelsBytes = MemoryMarshal.Cast<int, byte>(pixels.AsSpan());
+
+			pixelsBytes.CopyTo(_buffer.Span);
+			Debug.Assert(_buffer.Span.Length == PixelWidth * PixelHeight * 4);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.cs
@@ -1,6 +1,5 @@
 using System;
-using System.IO;
-using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
 using Windows.Storage.Streams;
 using UwpBuffer = Windows.Storage.Streams.Buffer;
 
@@ -38,14 +37,16 @@ namespace Windows.UI.Xaml.Media.Imaging
 			Invalidated?.Invoke(this, EventArgs.Empty);
 		}
 
-		private protected override void OnSetSource()
+		private protected
+#if __SKIA__
+			unsafe
+#endif
+			override void OnSetSource()
 		{
 			UpdateBuffer();
-#if __NETSTD__
-			_stream.AsStream().CopyTo(_buffer.AsStream());
-#else
-			Stream.CopyTo(_buffer.AsStream());
-			Stream.Position = 0;
+
+#if __ANDROID__ || __SKIA__ // TODO: Other platforms.
+			DecodeStreamIntoBuffer();
 #endif
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.skia.cs
@@ -26,9 +26,10 @@ namespace Windows.UI.Xaml.Media.Imaging
 		{
 			using var img = SKImage.FromEncodedData(_stream.AsStream());
 			var info = img.Info;
+
 			fixed (byte* data = &MemoryMarshal.GetReference(_buffer.Span))
 			{
-				img.ReadPixels(info, (nint)data, PixelWidth * 4);
+				img.ReadPixels(info.WithColorType(SKColorType.Bgra8888), (nint)data, PixelWidth * 4);
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/WriteableBitmap.skia.cs
@@ -1,11 +1,9 @@
-using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using Windows.Foundation;
-using Windows.Storage.Streams;
-using Uno.Foundation;
+using System.Threading.Tasks;
 using Windows.UI.Composition;
 using Uno.UI.Xaml.Media;
+using SkiaSharp;
 
 namespace Windows.UI.Xaml.Media.Imaging
 {
@@ -22,6 +20,16 @@ namespace Windows.UI.Xaml.Media.Imaging
 			image = ImageData.FromCompositionSurface(_surface);
 
 			return true;
+		}
+
+		private unsafe void DecodeStreamIntoBuffer()
+		{
+			using var img = SKImage.FromEncodedData(_stream.AsStream());
+			var info = img.Info;
+			fixed (byte* data = &MemoryMarshal.GetReference(_buffer.Span))
+			{
+				img.ReadPixels(info, (nint)data, PixelWidth * 4);
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): Android and Skia part of https://github.com/unoplatform/uno/issues/12705

Work is still needed for other platforms.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5500d6c</samp>

This pull request adds support for creating `WriteableBitmap` objects from image streams on Android and Skia platforms. It also adds a unit test to verify the functionality and makes some minor formatting changes to the `WriteableBitmap` and `BitmapSource` classes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
