### PR TITLE
[Gallery][Wasm/Skia] MediaPlayerElement sample using a playlist not working

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.cs
@@ -29,7 +29,6 @@ public partial class GtkMediaPlayer : FrameworkElement
 	private VideoView? _videoView;
 	private Uri? _mediaPath;
 	private bool _isEnding;
-	private bool _isLoopingEnabled;
 	private double _playbackRate;
 	private Rect _transportControlsBounds;
 	private Windows.UI.Xaml.Media.Stretch _stretch = Windows.UI.Xaml.Media.Stretch.Uniform;
@@ -517,11 +516,6 @@ public partial class GtkMediaPlayer : FrameworkElement
 				_mediaPlayer.Time = (long)value;
 			}
 		}
-	}
-
-	public void SetIsLoopingEnabled(bool value)
-	{
-		_isLoopingEnabled = value;
 	}
 
 	internal void UpdateVideoStretch(Windows.UI.Xaml.Media.Stretch stretch)

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.events.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.events.cs
@@ -651,10 +651,6 @@ public partial class GtkMediaPlayer
 				UpdateMedia();
 
 				OnSourceEnded?.Invoke(this, EventArgs.Empty);
-				if (_isLoopingEnabled)
-				{
-					_mediaPlayer.Play();
-				}
 				_videoView.Visible = true;
 				_isEnding = false;
 			});

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.cs
@@ -177,9 +177,16 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 
 		switch (_owner.Source)
 		{
-			case MediaPlaybackList playlist when playlist.Items.Count > 0 && _playlistItems is not null:
+			case MediaPlaybackList playlist when playlist.Items.Count > 0:
 				SetPlaylistItems(playlist);
-				_uri = _playlistItems[0];
+				if (_playlistItems is not null)
+				{
+					_uri = _playlistItems[0];
+				}
+				else
+				{
+					throw new InvalidOperationException("Playlist Items could not be set");
+				}
 				break;
 
 			case MediaPlaybackItem item:
@@ -189,6 +196,7 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			case MediaSource source:
 				_uri = source.Uri;
 				break;
+
 
 			default:
 				throw new InvalidOperationException("Unsupported media source type");

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
@@ -89,12 +89,31 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 	{
 		Events?.RaiseMediaEnded();
 		_owner.PlaybackSession.PlaybackState = MediaPlaybackState.None;
-
-		// Play next item in playlist, if any
-		if (_playlistItems != null && _playlistIndex < _playlistItems.Count - 1)
+		if (IsLoopingEnabled && !IsLoopingAllEnabled)
 		{
-			_uri = _playlistItems[++_playlistIndex];
-			ApplyVideoSource();
+			ReInitializeSource();
+			Play();
+		}
+		else
+		{
+			// Play first item in playlist, if any and repeat all
+			if (_playlistItems != null && _playlistIndex >= _playlistItems.Count - 1 && IsLoopingAllEnabled)
+			{
+				_playlistIndex = 0;
+				_uri = _playlistItems[_playlistIndex];
+				ReInitializeSource();
+				Play();
+			}
+			else
+			{
+				// Play next item in playlist, if any
+				if (_playlistItems != null && _playlistIndex < _playlistItems.Count - 1)
+				{
+					_uri = _playlistItems[++_playlistIndex];
+					ReInitializeSource();
+					Play();
+				}
+			}
 		}
 	}
 

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -165,18 +165,13 @@ internal partial class HtmlMediaPlayer : Border
 	{
 		add
 		{
-			if (_activeElement == null)
-			{
-				return;
-			}
-			_activeElement.RegisterHtmlEventHandler("timeupdate", value);
+			_htmlVideo.RegisterHtmlEventHandler("timeupdate", value);
+			_htmlAudio.RegisterHtmlEventHandler("timeupdate", value);
 		}
 		remove
 		{
-			if (_activeElement != null)
-			{
-				_activeElement.UnregisterHtmlEventHandler("timeupdate", value);
-			}
+			_htmlVideo.UnregisterHtmlEventHandler("timeupdate", value);
+			_htmlAudio.UnregisterHtmlEventHandler("timeupdate", value);
 		}
 	}
 
@@ -187,18 +182,13 @@ internal partial class HtmlMediaPlayer : Border
 	{
 		add
 		{
-			if (_activeElement == null)
-			{
-				return;
-			}
-			_activeElement.RegisterHtmlEventHandler("loadedmetadata", value);
+			_htmlVideo.RegisterHtmlEventHandler("loadedmetadata", value);
+			_htmlAudio.RegisterHtmlEventHandler("loadedmetadata", value);
 		}
 		remove
 		{
-			if (_activeElement != null)
-			{
-				_activeElement.UnregisterHtmlEventHandler("loadedmetadata", value);
-			}
+			_htmlVideo.UnregisterHtmlEventHandler("loadedmetadata", value);
+			_htmlAudio.UnregisterHtmlEventHandler("loadedmetadata", value);
 		}
 	}
 
@@ -455,7 +445,7 @@ internal partial class HtmlMediaPlayer : Border
 				}
 			}
 
-			player.TimeUpdated += player.OnHtmlTimeUpdated;
+			//player.TimeUpdated += player.OnHtmlTimeUpdated;
 		}
 	}
 

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/HtmlMediaPlayer.cs
@@ -209,18 +209,13 @@ internal partial class HtmlMediaPlayer : Border
 	{
 		add
 		{
-			if (_activeElement == null)
-			{
-				return;
-			}
-			_activeElement.RegisterHtmlEventHandler("ended", value);
+			_htmlVideo.RegisterHtmlEventHandler("ended", value);
+			_htmlAudio.RegisterHtmlEventHandler("ended", value);
 		}
 		remove
 		{
-			if (_activeElement != null)
-			{
-				_activeElement.UnregisterHtmlEventHandler("ended", value);
-			}
+			_htmlVideo.UnregisterHtmlEventHandler("ended", value);
+			_htmlAudio.UnregisterHtmlEventHandler("ended", value);
 		}
 	}
 
@@ -460,6 +455,7 @@ internal partial class HtmlMediaPlayer : Border
 				}
 			}
 
+			player.TimeUpdated += player.OnHtmlTimeUpdated;
 		}
 	}
 
@@ -648,27 +644,6 @@ internal partial class HtmlMediaPlayer : Border
 		{
 			_playbackRate = value;
 			NativeMethods.SetPlaybackRate(IsAudio ? _htmlAudio.HtmlId : _htmlVideo.HtmlId, value);
-		}
-	}
-
-	private bool _isLoopingEnabled;
-	public void SetIsLoopingEnabled(bool value)
-	{
-		_isLoopingEnabled = value;
-		if (_activeElement != null)
-		{
-			if (_isLoopingEnabled)
-			{
-				_activeElement.SetHtmlAttribute("loop", "loop");
-			}
-			else
-			{
-				_activeElement.ClearHtmlAttribute("loop");
-			}
-			if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
-			{
-				this.Log().Debug($"{_activeElementName} loop {_isLoopingEnabled}: [{Source}]");
-			}
 		}
 	}
 }

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -292,9 +292,16 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 
 			switch (_owner.Source)
 			{
-				case MediaPlaybackList playlist when playlist.Items.Count > 0 && _playlistItems is not null:
+				case MediaPlaybackList playlist when playlist.Items.Count > 0:
 					SetPlaylistItems(playlist);
-					_uri = _playlistItems[0];
+					if (_playlistItems is not null)
+					{
+						_uri = _playlistItems[0];
+					}
+					else
+					{
+						throw new InvalidOperationException("Playlist Items could not be set");
+					}
 					break;
 
 				case MediaPlaybackItem item:

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -294,7 +294,7 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 			{
 				case MediaPlaybackList playlist when playlist.Items.Count > 0:
 					SetPlaylistItems(playlist);
-					if (_playlistItems is not null)
+					if (_playlistItems is not null && _playlistItems.Any())
 					{
 						_uri = _playlistItems[0];
 					}

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -251,13 +251,14 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 		if (this.Log().IsEnabled(LogLevel.Debug))
 		{
 			this.Log().Debug($"MediaPlayerExtension.OnStatusMediaChanged to state {_player?.PlayerState.ToString()}");
+			this.Log().Debug($"MediaPlayerExtension owner PlaybackSession PlaybackState {_owner?.PlaybackSession?.PlaybackState.ToString()}");
 		}
 
-		if (_player?.PlayerState == HtmlMediaPlayerState.Paused && _owner.PlaybackSession.PlaybackState == MediaPlaybackState.Playing)
+		if (_player?.PlayerState == HtmlMediaPlayerState.Paused && _owner?.PlaybackSession.PlaybackState == MediaPlaybackState.Playing)
 		{
 			_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Paused;
 		}
-		else if (_player?.PlayerState == HtmlMediaPlayerState.Playing && _owner.PlaybackSession.PlaybackState == MediaPlaybackState.Paused)
+		else if (_player?.PlayerState == HtmlMediaPlayerState.Playing && _owner?.PlaybackSession.PlaybackState == MediaPlaybackState.Paused)
 		{
 			_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
 		}
@@ -609,7 +610,6 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 		_owner.PlaybackSession.PlaybackState = MediaPlaybackState.None;
 		if (IsLoopingEnabled && !IsLoopingAllEnabled)
 		{
-			//ReInitializeSource();
 			Play();
 		}
 		else

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -533,6 +533,23 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 		}
 	}
 
+	private void SetPrepared(HtmlMediaPlayer _player)
+	{
+		if (_owner.PlaybackSession.PlaybackState == MediaPlaybackState.Opening)
+		{
+			if (_isPlayRequested)
+			{
+				_player.Play();
+				_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
+			}
+			else
+			{
+				_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Paused;
+			}
+		}
+		_isPlayerPrepared = true;
+	}
+
 	public void OnPrepared(object? sender, object what)
 	{
 		if (sender is HtmlMediaPlayer mp && _player is not null)
@@ -559,21 +576,10 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 				}
 				catch { }
 			}
-
-			if (_owner.PlaybackSession.PlaybackState == MediaPlaybackState.Opening)
+			if (NaturalDuration > TimeSpan.Zero)
 			{
-				if (_isPlayRequested)
-				{
-					_player.Play();
-					_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Playing;
-				}
-				else
-				{
-					_owner.PlaybackSession.PlaybackState = MediaPlaybackState.Paused;
-				}
+				SetPrepared(_player);
 			}
-
-			_isPlayerPrepared = true;
 		}
 
 		if (Events is not null)

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/WasmScripts/uno.ui.media.js
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/WasmScripts/uno.ui.media.js
@@ -13,13 +13,24 @@ var Uno;
                     return document.getElementById(htmlId.toString()).videoHeight;
                 }
                 static getCurrentPosition(htmlId) {
-                    return document.getElementById(htmlId.toString()).currentTime;
+                    const element = document.getElementById(htmlId);
+                    if (element !== null && element !== undefined) {
+                        return element.currentTime;
+                    }
+                    else {
+                        return 0;
+                    }
+                    //return document.getElementById(htmlId.toString()).currentTime;
                 }
                 static getPaused(htmlId) {
                     return document.getElementById(htmlId.toString()).paused;
                 }
                 static setCurrentPosition(htmlId, currentTime) {
-                    document.getElementById(htmlId.toString()).currentTime = currentTime;
+                    const element = document.getElementById(htmlId);
+                    if (element !== null && element !== undefined) {
+                        element.currentTime = currentTime;
+                    }
+                    //document.getElementById(htmlId.toString()).currentTime = currentTime;
                 }
                 static setAttribute(htmlId, name, value) {
                     document.getElementById(htmlId.toString()).setAttribute(name, value);

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/WasmScripts/uno.ui.media.js
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/WasmScripts/uno.ui.media.js
@@ -20,17 +20,18 @@ var Uno;
                     else {
                         return 0;
                     }
-                    //return document.getElementById(htmlId.toString()).currentTime;
                 }
                 static getPaused(htmlId) {
-                    return document.getElementById(htmlId.toString()).paused;
+                    const element = document.getElementById(htmlId);
+                    if (element !== null && element !== undefined) {
+                        return element.paused;
+                    }
                 }
                 static setCurrentPosition(htmlId, currentTime) {
                     const element = document.getElementById(htmlId);
                     if (element !== null && element !== undefined) {
                         element.currentTime = currentTime;
                     }
-                    //document.getElementById(htmlId.toString()).currentTime = currentTime;
                 }
                 static setAttribute(htmlId, name, value) {
                     document.getElementById(htmlId.toString()).setAttribute(name, value);

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/ts/MediaElement.ts
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/ts/MediaElement.ts
@@ -16,11 +16,13 @@ namespace Uno.UI.Media {
 			} else {
 				return 0;
 			}
-			//return document.getElementById(htmlId.toString()).currentTime;
 		}
 
 		public static getPaused(htmlId: number): number {
-			return document.getElementById(htmlId.toString()).paused;
+			const element = document.getElementById(htmlId);
+			if (element !== null && element !== undefined) {
+				return element.paused;
+			}
 		}
 
 		public static setCurrentPosition(htmlId: number, currentTime: number) {
@@ -28,7 +30,6 @@ namespace Uno.UI.Media {
 			if (element !== null && element !== undefined) {
 				element.currentTime = currentTime;
 			}
-			//document.getElementById(htmlId.toString()).currentTime = currentTime;
 		}
 
 		public static setAttribute(htmlId: number, name: string, value: string) {

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/ts/MediaElement.ts
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/ts/MediaElement.ts
@@ -10,7 +10,13 @@ namespace Uno.UI.Media {
 		}
 
 		public static getCurrentPosition(htmlId: number): number {
-			return document.getElementById(htmlId.toString()).currentTime;
+			const element = document.getElementById(htmlId);
+			if (element !== null && element !== undefined) {
+				return element.currentTime;
+			} else {
+				return 0;
+			}
+			//return document.getElementById(htmlId.toString()).currentTime;
 		}
 
 		public static getPaused(htmlId: number): number {
@@ -18,7 +24,11 @@ namespace Uno.UI.Media {
 		}
 
 		public static setCurrentPosition(htmlId: number, currentTime: number) {
-			document.getElementById(htmlId.toString()).currentTime = currentTime;
+			const element = document.getElementById(htmlId);
+			if (element !== null && element !== undefined) {
+				element.currentTime = currentTime;
+			}
+			//document.getElementById(htmlId.toString()).currentTime = currentTime;
 		}
 
 		public static setAttribute(htmlId: number, name: string, value: string) {

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3306,6 +3306,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Playlist.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>	
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Minimal.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7212,6 +7216,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Full.xaml.cs">
       <DependentUpon>MediaPlayerElement_Full.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Playlist.xaml.cs">
+      <DependentUpon>MediaPlayerElement_Playlist.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Minimal.xaml.cs">
       <DependentUpon>MediaPlayerElement_Minimal.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Playlist.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Playlist.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Playlist"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="">
+
+	<MediaPlayerElement x:Name="mpe"
+						AreTransportControlsEnabled="True"
+						AutoPlay="True">
+		<MediaPlayerElement.TransportControls>
+			<MediaTransportControls IsRepeatButtonVisible="True"
+									IsRepeatEnabled="True" />
+		</MediaPlayerElement.TransportControls>
+	</MediaPlayerElement>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Playlist.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Playlist.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.Media.Core;
+using Windows.Media.Playback;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement
+{
+	[SampleControlInfo("MediaPlayerElement", "Playlist", ignoreInSnapshotTests: true, description: "Test the playlist and the Repeat")]
+	public sealed partial class MediaPlayerElement_Playlist : UserControl
+	{
+		public MediaPlayerElement_Playlist()
+		{
+			this.InitializeComponent();
+			InitializePlaybackList();
+		}
+
+		private void InitializePlaybackList()
+		{
+			var mediaPlaybackList = new MediaPlaybackList();
+			mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Mobile_Development_in_VS_Code_with_Uno_Platform_orDotNetMAUI.mp4"))));
+			mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/audio/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp3"))));
+			mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp4"))));
+			if (mpe.MediaPlayer == null)
+			{
+				mpe.MediaPlayer = new MediaPlayer();
+			}
+			mpe.MediaPlayer.Source = mediaPlaybackList;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Playlist.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Playlist.xaml.cs
@@ -37,7 +37,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement
 			mediaPlaybackList.Items.Add(new MediaPlaybackItem(MediaSource.CreateFromUri(new Uri("https://uno-assets.platform.uno/tests/videos/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp4"))));
 			if (mpe.MediaPlayer == null)
 			{
-				mpe.MediaPlayer = new MediaPlayer();
+				mpe.SetMediaPlayer(new Windows.Media.Playback.MediaPlayer());
 			}
 			mpe.MediaPlayer.Source = mediaPlaybackList;
 		}

--- a/src/Uno.UI-Skia-only.slnf
+++ b/src/Uno.UI-Skia-only.slnf
@@ -9,7 +9,6 @@
       "SamplesApp\\Benchmarks.Shared\\SamplesApp.Benchmarks.shproj",
       "SamplesApp\\SamplesApp.Shared\\SamplesApp.Shared.shproj",
       "SamplesApp\\SamplesApp.Skia.Gtk\\SamplesApp.Skia.Gtk.csproj",
-	  "SamplesApp\\SamplesApp.Skia.Tizen\\SamplesApp.Skia.Tizen.csproj",
       "SamplesApp\\SamplesApp.Skia.Linux.FrameBuffer\\SamplesApp.Skia.Linux.FrameBuffer.csproj",
       "SamplesApp\\SamplesApp.Skia.Wpf\\SamplesApp.Skia.Wpf.csproj",
       "SamplesApp\\SamplesApp.Skia\\SamplesApp.Skia.csproj",

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -777,24 +777,49 @@ namespace Windows.UI.Xaml.Controls
 			{
 				return;
 			}
-
-			_mpe.MediaPlayer.IsLoopingEnabled = !_mpe.MediaPlayer.IsLoopingEnabled;
+			if (_mpe.MediaPlayer.IsLoopingEnabled
+				&& !_mpe.MediaPlayer.IsLoopingAllEnabled
+				&& _mpe.MediaPlayer.Source is MediaPlaybackList)
+			{
+				_mpe.MediaPlayer.IsLoopingAllEnabled = true;
+			}
+			else
+			{
+				_mpe.MediaPlayer.IsLoopingEnabled = !_mpe.MediaPlayer.IsLoopingEnabled;
+				_mpe.MediaPlayer.IsLoopingAllEnabled = false;
+			}
 			UpdateRepeatStates();
 		}
 		private void PreviousTrackButtonTapped(object sender, RoutedEventArgs e)
 		{
-			if (_mediaPlayer is not null)
+			if (_mpe is not null
+				&& _mpe.MediaPlayer.Source is MediaPlaybackList)
 			{
-				_mediaPlayer.PlaybackSession.Position = TimeSpan.Zero;
-				_mediaPlayer.PlaybackSession.Position = TimeSpan.Zero;
+				_mpe?.MediaPlayer?.PreviousTrack();
+			}
+			else
+			{
+				if (_mediaPlayer is not null)
+				{
+					_mediaPlayer.PlaybackSession.Position = TimeSpan.Zero;
+					_mediaPlayer.PlaybackSession.Position = TimeSpan.Zero;
+				}
 			}
 		}
 		private void NextTrackButtonTapped(object sender, RoutedEventArgs e)
 		{
-			if (_mediaPlayer is not null)
+			if (_mpe is not null
+				&& _mpe.MediaPlayer.Source is MediaPlaybackList)
 			{
-				_mediaPlayer.PlaybackSession.Position = _mediaPlayer.PlaybackSession.NaturalDuration;
-				_mediaPlayer.PlaybackSession.Position = _mediaPlayer.PlaybackSession.NaturalDuration;
+				_mpe?.MediaPlayer?.NextTrack();
+			}
+			else
+			{
+				if (_mediaPlayer is not null)
+				{
+					_mediaPlayer.PlaybackSession.Position = _mediaPlayer.PlaybackSession.NaturalDuration;
+					_mediaPlayer.PlaybackSession.Position = _mediaPlayer.PlaybackSession.NaturalDuration;
+				}
 			}
 		}
 		private void ZoomButtonTapped(object sender, RoutedEventArgs e)
@@ -1155,14 +1180,18 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
-			var state = _mpe.MediaPlayer.IsLoopingEnabled
+			var state = _mpe.MediaPlayer.IsLoopingAllEnabled
 				? VisualState.RepeatStates.RepeatAllState
-				: VisualState.RepeatStates.RepeatNoneState;
+				: _mpe.MediaPlayer.IsLoopingEnabled
+					? VisualState.RepeatStates.RepeatOneState
+					: VisualState.RepeatStates.RepeatNoneState;
 			VisualStateManager.GoToState(this, state, useTransitions);
 
-			var uiaKey = _mpe.MediaPlayer.IsLoopingEnabled
+			var uiaKey = _mpe.MediaPlayer.IsLoopingAllEnabled
 				? UIAKeys.UIA_MEDIA_REPEAT_ALL
-				: UIAKeys.UIA_MEDIA_REPEAT_NONE;
+				: _mpe.MediaPlayer.IsLoopingEnabled
+					? UIAKeys.UIA_MEDIA_REPEAT_ONE
+					: UIAKeys.UIA_MEDIA_REPEAT_NONE;
 			SetAutomationNameAndTooltip(m_tpRepeatButton, uiaKey);
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -777,6 +777,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				return;
 			}
+#if !(__ANDROID__ || __IOS__ || __MACOS__)
 			if (_mpe.MediaPlayer.IsLoopingEnabled
 				&& !_mpe.MediaPlayer.IsLoopingAllEnabled
 				&& _mpe.MediaPlayer.Source is MediaPlaybackList)
@@ -788,10 +789,15 @@ namespace Windows.UI.Xaml.Controls
 				_mpe.MediaPlayer.IsLoopingEnabled = !_mpe.MediaPlayer.IsLoopingEnabled;
 				_mpe.MediaPlayer.IsLoopingAllEnabled = false;
 			}
+#else
+			_mpe.MediaPlayer.IsLoopingEnabled = !_mpe.MediaPlayer.IsLoopingEnabled;
+#endif
 			UpdateRepeatStates();
 		}
 		private void PreviousTrackButtonTapped(object sender, RoutedEventArgs e)
 		{
+#if !(__ANDROID__ || __IOS__ || __MACOS__)
+
 			if (_mpe is not null
 				&& _mpe.MediaPlayer.Source is MediaPlaybackList)
 			{
@@ -805,9 +811,17 @@ namespace Windows.UI.Xaml.Controls
 					_mediaPlayer.PlaybackSession.Position = TimeSpan.Zero;
 				}
 			}
+#else
+			if (_mediaPlayer is not null)
+			{
+				_mediaPlayer.PlaybackSession.Position = TimeSpan.Zero;
+				_mediaPlayer.PlaybackSession.Position = TimeSpan.Zero;
+			}
+#endif
 		}
 		private void NextTrackButtonTapped(object sender, RoutedEventArgs e)
 		{
+#if !(__ANDROID__ || __IOS__ || __MACOS__)
 			if (_mpe is not null
 				&& _mpe.MediaPlayer.Source is MediaPlaybackList)
 			{
@@ -821,6 +835,13 @@ namespace Windows.UI.Xaml.Controls
 					_mediaPlayer.PlaybackSession.Position = _mediaPlayer.PlaybackSession.NaturalDuration;
 				}
 			}
+#else
+			if (_mediaPlayer is not null)
+			{
+				_mediaPlayer.PlaybackSession.Position = _mediaPlayer.PlaybackSession.NaturalDuration;
+				_mediaPlayer.PlaybackSession.Position = _mediaPlayer.PlaybackSession.NaturalDuration;
+			}
+#endif
 		}
 		private void ZoomButtonTapped(object sender, RoutedEventArgs e)
 		{
@@ -1179,7 +1200,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				return;
 			}
-
+#if !(__ANDROID__ || __IOS__ || __MACOS__)
 			var state = _mpe.MediaPlayer.IsLoopingAllEnabled
 				? VisualState.RepeatStates.RepeatAllState
 				: _mpe.MediaPlayer.IsLoopingEnabled
@@ -1193,6 +1214,17 @@ namespace Windows.UI.Xaml.Controls
 					? UIAKeys.UIA_MEDIA_REPEAT_ONE
 					: UIAKeys.UIA_MEDIA_REPEAT_NONE;
 			SetAutomationNameAndTooltip(m_tpRepeatButton, uiaKey);
+#else
+			var state = _mpe.MediaPlayer.IsLoopingEnabled
+					? VisualState.RepeatStates.RepeatAllState
+					: VisualState.RepeatStates.RepeatNoneState;
+			VisualStateManager.GoToState(this, state, useTransitions);
+
+			var uiaKey = _mpe.MediaPlayer.IsLoopingEnabled
+					? UIAKeys.UIA_MEDIA_REPEAT_ALL
+					: UIAKeys.UIA_MEDIA_REPEAT_NONE;
+			SetAutomationNameAndTooltip(m_tpRepeatButton, uiaKey);
+#endif
 		}
 	}
 

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
@@ -17,10 +17,10 @@ namespace Windows.Media.Playback
 				throw new global::System.NotImplementedException("The member MediaPlaybackAudioTrackList MediaPlaybackItem.AudioTracks is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=MediaPlaybackAudioTrackList%20MediaPlaybackItem.AudioTracks");
 			}
 		}
-#endif
-#if false || false || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Windows.Media.Core.MediaSource Source
+		#endif
+		#if false || false || IS_UNIT_TESTS || false || false || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("IS_UNIT_TESTS", "__NETSTD_REFERENCE__")]
+		public  global::Windows.Media.Core.MediaSource Source
 		{
 			get
 			{
@@ -146,7 +146,7 @@ namespace Windows.Media.Playback
 		}
 #endif
 		// Forced skipping of method Windows.Media.Playback.MediaPlaybackItem.MediaPlaybackItem(Windows.Media.Core.MediaSource, System.TimeSpan, System.TimeSpan)
-#if false || false || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
+#if false || false || IS_UNIT_TESTS || false || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public MediaPlaybackItem(global::Windows.Media.Core.MediaSource source) 
 		{
@@ -169,9 +169,9 @@ namespace Windows.Media.Playback
 		// Forced skipping of method Windows.Media.Playback.MediaPlaybackItem.DurationLimit.get
 		// Forced skipping of method Windows.Media.Playback.MediaPlaybackItem.CanSkip.get
 		// Forced skipping of method Windows.Media.Playback.MediaPlaybackItem.CanSkip.set
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public global::Windows.Media.Playback.MediaItemDisplayProperties GetDisplayProperties()
+#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || false || false || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Media.Playback.MediaItemDisplayProperties GetDisplayProperties()
 		{
 			throw new global::System.NotImplementedException("The member MediaItemDisplayProperties MediaPlaybackItem.GetDisplayProperties() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=MediaItemDisplayProperties%20MediaPlaybackItem.GetDisplayProperties%28%29");
 		}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
@@ -169,8 +169,8 @@ namespace Windows.Media.Playback
 		// Forced skipping of method Windows.Media.Playback.MediaPlaybackItem.DurationLimit.get
 		// Forced skipping of method Windows.Media.Playback.MediaPlaybackItem.CanSkip.get
 		// Forced skipping of method Windows.Media.Playback.MediaPlaybackItem.CanSkip.set
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || false || false || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__NETSTD_REFERENCE__", "__MACOS__")]
+#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.Media.Playback.MediaItemDisplayProperties GetDisplayProperties()
 		{
 			throw new global::System.NotImplementedException("The member MediaItemDisplayProperties MediaPlaybackItem.GetDisplayProperties() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=MediaItemDisplayProperties%20MediaPlaybackItem.GetDisplayProperties%28%29");

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackList.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackList.cs
@@ -55,10 +55,10 @@ namespace Windows.Media.Playback
 				throw new global::System.NotImplementedException("The member uint MediaPlaybackList.CurrentItemIndex is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=uint%20MediaPlaybackList.CurrentItemIndex");
 			}
 		}
-#endif
-#if false || false || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || false
-		[global::Uno.NotImplemented("IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public global::Windows.Foundation.Collections.IObservableVector<global::Windows.Media.Playback.MediaPlaybackItem> Items
+		#endif
+		#if false || false || IS_UNIT_TESTS || false || false || __NETSTD_REFERENCE__ || false
+		[global::Uno.NotImplemented("IS_UNIT_TESTS", "__WASM__", "__NETSTD_REFERENCE__")]
+		public  global::Windows.Foundation.Collections.IObservableVector<global::Windows.Media.Playback.MediaPlaybackItem> Items
 		{
 			get
 			{

--- a/src/Uno.UWP/Media/Playback/IMediaPlaybackList.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlaybackList.cs
@@ -1,4 +1,4 @@
-#if __IOS__ || __ANDROID__ || __MACOS__
+#if __IOS__ || __ANDROID__ || __MACOS__ || __SKIA__ || __WASM__
 
 namespace Windows.Media.Playback
 {

--- a/src/Uno.UWP/Media/Playback/IMediaPlayerExtension.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlayerExtension.cs
@@ -30,6 +30,11 @@ namespace Uno.Media.Playback
 		bool IsLoopingEnabled { get; set; }
 
 		/// <summary>
+		/// Gets or sets the looping all mode
+		/// </summary>
+		bool IsLoopingAllEnabled { get; set; }
+
+		/// <summary>
 		/// Gets the current player state
 		/// </summary>
 		MediaPlayerState CurrentState { get; }
@@ -173,5 +178,15 @@ namespace Uno.Media.Playback
 		/// Notifies the extension that an option has changed
 		/// </summary>
 		void OnOptionChanged(string name, object value);
+
+		/// <summary>
+		/// Previous Track on a Playlist
+		/// </summary>
+		void PreviousTrack();
+
+		/// <summary>
+		/// Next Track on a Playlist
+		/// </summary>
+		void NextTrack();
 	}
 }

--- a/src/Uno.UWP/Media/Playback/MediaPlaybackItem.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlaybackItem.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__ || __IOS__ || __MACOS__
+﻿#if __ANDROID__ || __IOS__ || __MACOS__ || __SKIA__ || __WASM__
 using Windows.Media.Core;
 
 namespace Windows.Media.Playback

--- a/src/Uno.UWP/Media/Playback/MediaPlaybackList.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlaybackList.cs
@@ -1,5 +1,6 @@
-#if __ANDROID__ || __IOS__ || __MACOS__
+#if __ANDROID__ || __IOS__ || __MACOS__ || __SKIA__ || __WASM__
 using Windows.Foundation.Collections;
+using Windows.Media.Playback;
 
 namespace Windows.Media.Playback
 {

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.others.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.others.cs
@@ -70,6 +70,17 @@ namespace Windows.Media.Playback
 			}
 		}
 
+		public bool IsLoopingAllEnabled
+		{
+			get => _extension?.IsLoopingAllEnabled ?? false;
+			set
+			{
+				if (_extension is not null)
+				{
+					_extension.IsLoopingAllEnabled = value;
+				}
+			}
+		}
 		public MediaPlayerState CurrentState
 			=> _extension?.CurrentState ?? MediaPlayerState.Closed;
 
@@ -200,6 +211,11 @@ namespace Windows.Media.Playback
 
 		public void OnVolumeChanged()
 			=> _extension?.OnVolumeChanged();
+
+		public void PreviousTrack()
+			=> _extension?.PreviousTrack();
+		public void NextTrack()
+			=> _extension?.NextTrack();
 
 		public event TypedEventHandler<MediaPlayer, object> BufferingEnded;
 		public event TypedEventHandler<MediaPlayer, object> BufferingStarted;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12394 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The MediaPlayerElement sample using a playlist is not working on Wasm and Skia

## What is the new behavior?

The MediaPlayerElement sample using a playlist should work on Wasm and Skia like the other platforms

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb371e8</samp>

This pull request adds support for the `MediaPlaybackList` feature to the Skia and WebAssembly platforms, and adds a new sample to the SamplesApp project that demonstrates how to use the `MediaPlayerElement` with a playlist and a repeat button. It also improves the error handling and code quality of the media player extensions for Skia.Gtk and WebAssembly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
