### PR TITLE
fix: android resource encoding blank filenames

### DIFF
--- a/src/Uno.UI.Tests/Resources/Given_AndroidResourceConverter.cs
+++ b/src/Uno.UI.Tests/Resources/Given_AndroidResourceConverter.cs
@@ -54,6 +54,10 @@ namespace Uno.UI.Tests.Resources
 	{
 		[TestMethod]
 		[DataRow(@"logo", @"logo")]
+		[DataRow(@"", @"")]
+		[DataRow(null, @"")]
+		[DataRow(" ", @"_")]
+		[DataRow("  ", @"__")]
 		public void When_Encode(string input, string expected)
 		{
 			Assert.AreEqual(expected, AndroidResourceNameEncoder.Encode(input));
@@ -68,6 +72,9 @@ namespace Uno.UI.Tests.Resources
 		[DataRow(@"test/test2/logo-1.png", @"test/test2/logo_1.png")]
 		[DataRow(@"test/test2/test-3/logo-1.png", @"test/test2/test_3/logo_1.png")]
 		[DataRow(@"1test/logo-1.png", @"__1test/logo_1.png")]
+		[DataRow(@".png", @".png")]
+		[DataRow(@"test space/logo.png", @"test_space/logo.png")]
+		[DataRow(@"test space/.png", @"test_space/.png")]
 		public void When_EncodeResourcePath(string input, string expected)
 		{
 			Assert.AreEqual(expected, AndroidResourceNameEncoder.EncodeResourcePath(input));
@@ -82,6 +89,9 @@ namespace Uno.UI.Tests.Resources
 		[DataRow(@"test\test2\logo-1.png", @"Assets\test\test2\logo_1.png")]
 		[DataRow(@"test\test2\test-3\logo-1.png", @"Assets\test\test2\test_3\logo_1.png")]
 		[DataRow(@"1test\logo-1.png", @"Assets\__1test\logo_1.png")]
+		[DataRow(@".png", @"Assets\.png")]
+		[DataRow(@"test\.png", @"Assets\test\.png")]
+		[DataRow(@"test with spaces\.png", @"Assets\test_with_spaces\.png")]
 		public void When_EncodeFileSystemPath(string input, string expected)
 		{
 			Assert.AreEqual(expected, AndroidResourceNameEncoder.EncodeFileSystemPath(input));
@@ -95,7 +105,9 @@ namespace Uno.UI.Tests.Resources
 		[DataRow(@"test/logo-1.png", @"test_logo_1.png")]
 		[DataRow(@"test/test2/logo-1.png", @"test_test2_logo_1.png")]
 		[DataRow(@"test/test2/test-3/logo-1.png", @"test_test2_test_3_logo_1.png")]
-		[DataRow(@"1test/logo-1.png", @"__1test_logo_1.png")]
+		[DataRow(@".png", @".png")]
+		[DataRow(@"test/.png", @"test_.png")]
+		[DataRow(@"test with spaces/.png", @"test_with_spaces_.png")]
 		public void When_EncodeDrawablePath(string input, string expected)
 		{
 			Assert.AreEqual(expected, AndroidResourceNameEncoder.EncodeDrawablePath(input));

--- a/src/Uno.UWP/Helpers/AndroidResourceNameEncoder.cs
+++ b/src/Uno.UWP/Helpers/AndroidResourceNameEncoder.cs
@@ -16,6 +16,8 @@ namespace Uno
 		/// <returns>The encoded resource name for the Android Strings.xml file.</returns>
 		public static string Encode(string key)
 		{
+			key ??= string.Empty;
+
 			var charArray = key.ToCharArray();
 			for (int i = 0; i < charArray.Length; i++)
 			{
@@ -31,7 +33,7 @@ namespace Uno
 			key = new string(charArray);
 
 			//Checks if the keys are starting by a number because they are invalid in C#
-			if (int.TryParse(key.Substring(0, 1), out _))
+			if (!string.IsNullOrEmpty(key) && int.TryParse(key.Substring(0, 1), out _))
 			{
 				key = $"{NumberPrefix}{key}";
 			}


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/12728

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Attempting to retarget assets with no filename (`.png`) will cause an exception during the RetargetAsserts tasks

## What is the new behavior?

Handle cases with a blank or null filename gracefully

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
copilot:summary

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
