### PR TITLE
fix: Adjust reading package to return null if Logo not specified

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Package.cs
+++ b/src/Uno.UWP/ApplicationModel/Package.cs
@@ -56,7 +56,7 @@ namespace Windows.ApplicationModel
 
 #if (__IOS__ || __ANDROID__ || __MACOS__)
 		[global::Uno.NotImplemented]
-		public global::System.Uri Logo => new Uri("http://example.com");
+		public global::System.Uri? Logo => default;
 #endif
 
 		[Uno.NotImplemented]

--- a/src/Uno.UWP/ApplicationModel/Package.cs
+++ b/src/Uno.UWP/ApplicationModel/Package.cs
@@ -56,7 +56,7 @@ namespace Windows.ApplicationModel
 
 #if (__IOS__ || __ANDROID__ || __MACOS__)
 		[global::Uno.NotImplemented]
-		public global::System.Uri? Logo => default;
+		public global::System.Uri Logo => default;
 #endif
 
 		[Uno.NotImplemented]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12752 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

If manifest file is missing, or logo isn't specified in manifest, the Package.Current.Logo property will return an invalid Uri
Also, because manifest wasn't read, each access for Logo and DisplayName will cause another attempt to read manifest file

## What is the new behavior?

TryParsePackageManifest returns value indicating whether manifest was successfully read
TryParsePackageManifest will only execute the reading of manifest once
Package.Current.Logo is nullable Uri and will only return Uri if a logo path was provided


## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 751c0c8</samp>

Refactored the `Package` class to improve manifest parsing and made the `Logo` property nullable for unsupported platforms.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
