### PR TITLE
fix(textbox): Fix TextBox keyboard navigation only working vertically

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2418,6 +2418,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Keyboard_Navigation.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_IsTabStop.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5732,6 +5736,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Snap_Rubberband.xaml.cs">
       <DependentUpon>ListView_Snap_Rubberband.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Keyboard_Navigation.xaml.cs">
+      <DependentUpon>TextBox_Keyboard_Navigation.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PlaceholderForeground.xaml.cs">
       <DependentUpon>TextBox_PlaceholderForeground.xaml</DependentUpon>
     </Compile>
@@ -9020,6 +9027,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)Asset_GetFileFromApplicationUriAsync.xml" />
+    <Content Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Keyboard_Navigation.xaml" />
     <Content Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media_Animation\BeginTime_MultipleAnimations_Expected.gif" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)EmbeddedResources\LockScreen.png" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)EmbeddedResources\Wallpaper.png" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml
@@ -7,21 +7,29 @@
 			 d:DesignHeight="300"
 			 d:DesignWidth="400">
 
-	<Grid XYFocusKeyboardNavigation="Enabled">
+	<Grid XYFocusKeyboardNavigation="Enabled" KeyDown="Grid_KeyDown">
         <Grid.RowDefinitions>
             <RowDefinition Height="50"/>
             <RowDefinition Height="50"/>
             <RowDefinition Height="50"/>
+            <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="350"/>
             <ColumnDefinition Width="350"/>
+            <ColumnDefinition Width="350"/>
         </Grid.ColumnDefinitions>
-        <TextBox Grid.Column="0" Grid.Row="0" Text="Some"/>
-        <TextBox Grid.Column="1" Grid.Row="0" Text="Totally"/>
-        <TextBox Grid.Column="0" Grid.Row="1" Text="Random"/>
-        <TextBox Grid.Column="1" Grid.Row="1" Text="Text"/>
-        <Button Grid.Column="0" Grid.Row="2" Width="80" Height="30" Content="Button1"/>
-        <Button Grid.Column="1" Grid.Row="2"  Width="80" Height="30" Content="Button2"/>
+        <TextBox Grid.Column="0" Grid.Row="0" Text="Lorem"/>
+        <TextBox Grid.Column="1" Grid.Row="0" Text="ipsum"/>
+        <TextBox Grid.Column="2" Grid.Row="0" Text="dolor"/>
+        <TextBox Grid.Column="0" Grid.Row="1" Text="sit"/>
+        <TextBox Grid.Column="1" Grid.Row="1" Text="amet"/>
+        <TextBox Grid.Column="2" Grid.Row="1" Text="consectetur"/>
+        <Button Grid.Column="0" Grid.Row="2" Width="80" Height="30" Content="Clear" Click="Button_OnClick"/>
+        <Button Grid.Column="1" Grid.Row="2"  Width="80" Height="30" Content="Clear" Click="Button_OnClick"/>
+        <Button Grid.Column="2" Grid.Row="2"  Width="80" Height="30" Content="Clear" Click="Button_OnClick"/>
+		<ScrollViewer Grid.Column="0" Grid.Row="3">
+			<TextBlock x:Name="myContent" Text="Event info:&#x0a;" />
+		</ScrollViewer>
     </Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml
@@ -19,11 +19,11 @@
             <ColumnDefinition Width="350"/>
             <ColumnDefinition Width="350"/>
         </Grid.ColumnDefinitions>
-        <TextBox Grid.Column="0" Grid.Row="0" Text="Lorem"/>
+        <PasswordBox Grid.Column="0" Grid.Row="0" Password="Lorem"/>
         <TextBox Grid.Column="1" Grid.Row="0" Text="ipsum"/>
         <TextBox Grid.Column="2" Grid.Row="0" Text="dolor"/>
         <TextBox Grid.Column="0" Grid.Row="1" Text="sit"/>
-        <TextBox Grid.Column="1" Grid.Row="1" Text="amet"/>
+        <PasswordBox Grid.Column="1" Grid.Row="1" Password="amet"/>
         <TextBox Grid.Column="2" Grid.Row="1" Text="consectetur"/>
         <Button Grid.Column="0" Grid.Row="2" Width="80" Height="30" Content="Clear" Click="Button_OnClick"/>
         <Button Grid.Column="1" Grid.Row="2"  Width="80" Height="30" Content="Clear" Click="Button_OnClick"/>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests.TextBox_Keyboard_Navigation"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid XYFocusKeyboardNavigation="Enabled">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="50"/>
+            <RowDefinition Height="50"/>
+            <RowDefinition Height="50"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="350"/>
+            <ColumnDefinition Width="350"/>
+        </Grid.ColumnDefinitions>
+        <TextBox Grid.Column="0" Grid.Row="0" Text="Some"/>
+        <TextBox Grid.Column="1" Grid.Row="0" Text="Totally"/>
+        <TextBox Grid.Column="0" Grid.Row="1" Text="Random"/>
+        <TextBox Grid.Column="1" Grid.Row="1" Text="Text"/>
+        <Button Grid.Column="0" Grid.Row="2" Width="80" Height="30" Content="Button1"/>
+        <Button Grid.Column="1" Grid.Row="2"  Width="80" Height="30" Content="Button2"/>
+    </Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml.cs
@@ -19,9 +19,9 @@ public sealed partial class TextBox_Keyboard_Navigation : UserControl
 	public void Grid_KeyDown(object sender, KeyRoutedEventArgs keyRoutedEventArgs)
 	{
 		if (keyRoutedEventArgs.Key == VirtualKey.Left ||
-		    keyRoutedEventArgs.Key == VirtualKey.Up ||
-		    keyRoutedEventArgs.Key == VirtualKey.Right ||
-		    keyRoutedEventArgs.Key == VirtualKey.Down)
+			keyRoutedEventArgs.Key == VirtualKey.Up ||
+			keyRoutedEventArgs.Key == VirtualKey.Right ||
+			keyRoutedEventArgs.Key == VirtualKey.Down)
 		{
 			myContent.Text += $"{keyRoutedEventArgs.Key} bubbled up to outer grid\n";
 		}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml.cs
@@ -1,15 +1,31 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using Windows.System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 using Uno.UI.Samples.Controls;
 
-namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests;
+
+[Sample("TextBox", Name = "TextBox_Keyboard_Navigation",
+	Description =
+		"When XYFocusKeyboardNavigation is enabled for the surrounding grid and arrow keys are pressed, a TextBox should move to neighbouring TextBoxes as expected i.e. a left arrow input when the caret is at the beginning should navigate to the TextBox of the current TextBox\'s left, and similarly for a right arrow input when the caret is at the end of the TextBox.")]
+public sealed partial class TextBox_Keyboard_Navigation : UserControl
 {
-	[Sample("TextBox", Name = "TextBox_Keyboard_Navigation",
-		Description = "When XYFocusKeyboardNavigation is enabled for the surrounding grid and arrow keys are pressed, a TextBox should move to neighbouring TextBoxes as expected i.e. a left arrow input when the caret is at the beginning should navigate to the TextBox of the current TextBox\'s left, and similarly for a right arrow input when the caret is at the end of the TextBox.")]
-	public sealed partial class TextBox_Keyboard_Navigation : UserControl
+	public TextBox_Keyboard_Navigation()
 	{
-		public TextBox_Keyboard_Navigation()
+		InitializeComponent();
+	}
+
+	public void Grid_KeyDown(object sender, KeyRoutedEventArgs keyRoutedEventArgs)
+	{
+		if (keyRoutedEventArgs.Key == VirtualKey.Left ||
+		    keyRoutedEventArgs.Key == VirtualKey.Up ||
+		    keyRoutedEventArgs.Key == VirtualKey.Right ||
+		    keyRoutedEventArgs.Key == VirtualKey.Down)
 		{
-			this.InitializeComponent();
+			myContent.Text += $"{keyRoutedEventArgs.Key} bubbled up to outer grid\n";
 		}
 	}
+
+	public void Button_OnClick(object sender, RoutedEventArgs e) => myContent.Text = "Event info:\n";
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml.cs
@@ -6,7 +6,7 @@ using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests;
 
-[Sample("TextBox", Name = "TextBox_Keyboard_Navigation",
+[Sample("TextBox", Name = "TextBox_Keyboard_Navigation", IsManualTest = true, IgnoreInSnapshotTests = true,
 	Description =
 		"When XYFocusKeyboardNavigation is enabled for the surrounding grid and arrow keys are pressed, a TextBox should move to neighbouring TextBoxes as expected i.e. a left arrow input when the caret is at the beginning should navigate to the TextBox of the current TextBox\'s left, and similarly for a right arrow input when the caret is at the end of the TextBox.")]
 public sealed partial class TextBox_Keyboard_Navigation : UserControl

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_Keyboard_Navigation.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBoxTests
+{
+	[Sample("TextBox", Name = "TextBox_Keyboard_Navigation",
+		Description = "When XYFocusKeyboardNavigation is enabled for the surrounding grid and arrow keys are pressed, a TextBox should move to neighbouring TextBoxes as expected i.e. a left arrow input when the caret is at the beginning should navigate to the TextBox of the current TextBox\'s left, and similarly for a right arrow input when the caret is at the end of the TextBox.")]
+	public sealed partial class TextBox_Keyboard_Navigation : UserControl
+	{
+		public TextBox_Keyboard_Navigation()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkTextBoxView.cs
@@ -73,6 +73,9 @@ internal abstract class GtkTextBoxView : IOverlayTextBoxView
 
 	public abstract (int start, int length) Selection { get; set; }
 
+	// On Gtk, KeyDown is fired before Selection is updated, so nothing special needs to be done.
+	public (int start, int length) SelectionBeforeKeyDown => Selection;
+
 	public abstract bool IsCompatible(TextBox textBox);
 
 	public abstract IDisposable ObserveTextChanges(EventHandler onChanged);

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/PasswordTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/PasswordTextBoxView.cs
@@ -31,7 +31,6 @@ internal class PasswordTextBoxView : WpfTextBoxView
 		_grid.Children.Add(_passwordBox);
 		_grid.Children.Add(_textBox);
 
-		_textBox.PreviewKeyDown += OnPreviewKeyDown;
 		_passwordBox.PreviewKeyDown += OnPreviewKeyDown;
 	}
 
@@ -132,7 +131,17 @@ internal class PasswordTextBoxView : WpfTextBoxView
 	
 	private void OnPreviewKeyDown(object sender, KeyEventArgs e)
 	{
-		// On WPF, KeyDown is fired AFTER Selection is already changed to the new value
-		SelectionBeforeKeyDown = Selection;
+		// WpfTextBox's cursor/selection position isn't accessible even with reflection
+		// for security reasons. This prevents TextBox keyboard navigation from working
+		// correctly. So at least we just set SelectionBeforeKeyDown to any fake value
+		// that prevents keyboard navigation from triggering all together.
+		if (e.Key == Key.Left || e.Key == Key.LeftShift || e.Key == Key.LeftCtrl || e.Key == Key.LeftAlt)
+		{
+			SelectionBeforeKeyDown = (_passwordBox.Password.Length, 0);
+		}
+		else
+		{
+			SelectionBeforeKeyDown = (0, 0);
+		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/PasswordTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/PasswordTextBoxView.cs
@@ -51,7 +51,7 @@ internal class PasswordTextBoxView : WpfTextBoxView
 		get => (_textBox.SelectionStart, _textBox.SelectionLength);
 		set => (_textBox.SelectionStart, _textBox.SelectionLength) = value;
 	}
-	
+
 	public override (int start, int length) SelectionBeforeKeyDown
 	{
 		get => (_selectionBeforeKeyDown.start, _selectionBeforeKeyDown.length);
@@ -128,7 +128,7 @@ internal class PasswordTextBoxView : WpfTextBoxView
 	private void OnCommonTextChanged() => _textChangedWatcher?.Invoke(this, EventArgs.Empty);
 
 	private WpfElement GetDisplayedElement() => _textBox.Visibility == Visibility.Visible ? _textBox : _passwordBox;
-	
+
 	private void OnPreviewKeyDown(object sender, KeyEventArgs e)
 	{
 		// WpfTextBox's cursor/selection position isn't accessible even with reflection

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextTextBoxView.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Uno.Disposables;
 using Uno.UI.Runtime.Skia.Wpf.UI.Controls;
 using Windows.UI.Xaml.Controls;
@@ -14,9 +15,11 @@ namespace Uno.UI.Runtime.Skia.Wpf.Extensions.UI.Xaml.Controls;
 internal class TextTextBoxView : WpfTextBoxView
 {
 	private readonly WpfTextViewTextBox _textBox = new();
+	private (int start, int length) _selectionBeforeKeyDown;
 
 	public TextTextBoxView()
 	{
+		_textBox.PreviewKeyDown += OnPreviewKeyDown;
 	}
 
 	public override string Text
@@ -31,6 +34,12 @@ internal class TextTextBoxView : WpfTextBoxView
 	{
 		get => (_textBox.SelectionStart, _textBox.SelectionLength);
 		set => (_textBox.SelectionStart, _textBox.SelectionLength) = value;
+	}
+
+	public override (int start, int length) SelectionBeforeKeyDown
+	{
+		get => (_selectionBeforeKeyDown.start, _selectionBeforeKeyDown.length);
+		protected set => (_selectionBeforeKeyDown.start, _selectionBeforeKeyDown.length) = value;
 	}
 
 	public override void SetFocus() => _textBox.Focus();
@@ -48,5 +57,11 @@ internal class TextTextBoxView : WpfTextBoxView
 	{
 		SetControlProperties(_textBox, winUITextBox);
 		SetTextBoxProperties(_textBox, winUITextBox);
+	}
+
+	private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+	{
+		// On WPF, KeyDown is fired AFTER Selection is already changed to the new value
+		SelectionBeforeKeyDown = Selection;
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/WpfTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/WpfTextBoxView.cs
@@ -25,6 +25,8 @@ internal abstract class WpfTextBoxView : IOverlayTextBoxView
 	public bool IsDisplayed => RootElement.Parent is not null;
 
 	public abstract (int start, int length) Selection { get; set; }
+	
+	public abstract (int start, int length) SelectionBeforeKeyDown { get; protected set; }
 
 	/// <summary>
 	/// Represents the root element of the input layout.

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/WpfTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/WpfTextBoxView.cs
@@ -25,7 +25,7 @@ internal abstract class WpfTextBoxView : IOverlayTextBoxView
 	public bool IsDisplayed => RootElement.Parent is not null;
 
 	public abstract (int start, int length) Selection { get; set; }
-	
+
 	public abstract (int start, int length) SelectionBeforeKeyDown { get; protected set; }
 
 	/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxView.skia.cs
@@ -15,6 +15,12 @@ internal interface IOverlayTextBoxView
 	(int start, int length) Selection { get; set; }
 
 	/// <summary>
+	/// On some platforms (namely Skia.WPF) KeyDown is fired after Selection is already set to the new value.
+	/// This property is provided to allow access to the selection value right before KeyDown.
+	/// </summary>
+	(int start, int length) SelectionBeforeKeyDown { get; }
+
+	/// <summary>
 	/// Returns a value indicating whether this TextBoxView is compatible with the given TextBox state.
 	/// </summary>
 	/// <param name="textBox">TextBox.</param>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxViewExtension.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxViewExtension.skia.cs
@@ -28,7 +28,7 @@ internal interface IOverlayTextBoxViewExtension
 	int GetSelectionStart();
 
 	int GetSelectionLength();
-	
+
 	int GetSelectionStartBeforeKeyDown();
 
 	int GetSelectionLengthBeforeKeyDown();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxViewExtension.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxViewExtension.skia.cs
@@ -28,6 +28,10 @@ internal interface IOverlayTextBoxViewExtension
 	int GetSelectionStart();
 
 	int GetSelectionLength();
+	
+	int GetSelectionStartBeforeKeyDown();
+
+	int GetSelectionLengthBeforeKeyDown();
 
 	void UpdateProperties();
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/OverlayTextBoxViewExtension.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/OverlayTextBoxViewExtension.skia.cs
@@ -216,6 +216,11 @@ internal abstract class OverlayTextBoxViewExtension : IOverlayTextBoxViewExtensi
 			_selectionLengthCache ?? 0 :
 			_textBoxView?.Selection.length ?? 0;
 	}
+
+	public int GetSelectionStartBeforeKeyDown() => _textBoxView!.SelectionBeforeKeyDown.start;
+
+	public int GetSelectionLengthBeforeKeyDown() => _textBoxView!.SelectionBeforeKeyDown.length;
+
 	private void EnsureTextBoxView(TextBox textBox)
 	{
 		if (_textBoxView is null ||

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -971,7 +971,7 @@ namespace Windows.UI.Xaml.Controls
 					}
 					break;
 				case VirtualKey.Down:
-					if (SelectionStart != Text.Length)
+					if (TextBoxView.SelectionBeforeKeyDown.start != Text.Length)
 					{
 						SelectionStart = Text.Length;
 						args.Handled = true;
@@ -982,13 +982,13 @@ namespace Windows.UI.Xaml.Controls
 					}
 					break;
 				case VirtualKey.Left:
-					if (SelectionStart != 0)
+					if (TextBoxView.SelectionBeforeKeyDown.start != 0)
 					{
 						args.Handled = true;
 					}
 					break;
 				case VirtualKey.Right:
-					if (SelectionStart != Text.Length)
+					if (TextBoxView.SelectionBeforeKeyDown.start != Text.Length)
 					{
 						args.Handled = true;
 					}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -965,20 +965,30 @@ namespace Windows.UI.Xaml.Controls
 			switch (args.Key)
 			{
 				case VirtualKey.Up:
+					if (AcceptsReturn)
+					{
+						args.Handled = true;
+					}
+					break;
 				case VirtualKey.Down:
+					if (SelectionStart != Text.Length)
+					{
+						SelectionStart = Text.Length;
+						args.Handled = true;
+					}
 					if (AcceptsReturn)
 					{
 						args.Handled = true;
 					}
 					break;
 				case VirtualKey.Left:
-					if (SelectionLength != 0 || SelectionStart != 0)
+					if (SelectionStart != 0)
 					{
 						args.Handled = true;
 					}
 					break;
 				case VirtualKey.Right:
-					if (SelectionLength != 0 || (SelectionStart != Text.Length))
+					if (SelectionStart != Text.Length)
 					{
 						args.Handled = true;
 					}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -959,10 +959,10 @@ namespace Windows.UI.Xaml.Controls
 		protected override void OnKeyDown(KeyRoutedEventArgs args)
 		{
 			base.OnKeyDown(args);
-			
-			
+
+
 			// On skia, sometimes SelectionStart is updated to a new value before KeyDown is fired, so
-			// we need to get selectionStart from another source on Skia. 
+			// we need to get selectionStart from another source on Skia.
 #if __SKIA__
 			var selectionStart = TextBoxView.SelectionBeforeKeyDown.start;
 #else

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -972,7 +972,17 @@ namespace Windows.UI.Xaml.Controls
 					}
 					break;
 				case VirtualKey.Left:
+					if (SelectionLength != 0 || SelectionStart != 0)
+					{
+						args.Handled = true;
+					}
+					break;
 				case VirtualKey.Right:
+					if (SelectionLength != 0 || (SelectionStart != Text.Length))
+					{
+						args.Handled = true;
+					}
+					break;
 				case VirtualKey.Home:
 				case VirtualKey.End:
 					args.Handled = true;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -959,6 +959,15 @@ namespace Windows.UI.Xaml.Controls
 		protected override void OnKeyDown(KeyRoutedEventArgs args)
 		{
 			base.OnKeyDown(args);
+			
+			
+			// On skia, sometimes SelectionStart is updated to a new value before KeyDown is fired, so
+			// we need to get selectionStart from another source on Skia. 
+#if __SKIA__
+			var selectionStart = TextBoxView.SelectionBeforeKeyDown.start;
+#else
+			var selectionStart = SelectionStart;
+#endif
 
 			// Note: On windows only keys that are "moving the cursor" are handled
 			//		 AND ** only KeyDown ** is handled (not KeyUp)
@@ -971,7 +980,7 @@ namespace Windows.UI.Xaml.Controls
 					}
 					break;
 				case VirtualKey.Down:
-					if (TextBoxView.SelectionBeforeKeyDown.start != Text.Length)
+					if (selectionStart != Text.Length)
 					{
 						SelectionStart = Text.Length;
 						args.Handled = true;
@@ -982,13 +991,13 @@ namespace Windows.UI.Xaml.Controls
 					}
 					break;
 				case VirtualKey.Left:
-					if (TextBoxView.SelectionBeforeKeyDown.start != 0)
+					if (selectionStart != 0)
 					{
 						args.Handled = true;
 					}
 					break;
 				case VirtualKey.Right:
-					if (TextBoxView.SelectionBeforeKeyDown.start != Text.Length)
+					if (selectionStart != Text.Length)
 					{
 						args.Handled = true;
 					}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -33,6 +33,9 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		public (int start, int length) SelectionBeforeKeyDown =>
+			(_textBoxExtension!.GetSelectionStartBeforeKeyDown(), _textBoxExtension.GetSelectionLengthBeforeKeyDown());
+
 		internal IOverlayTextBoxViewExtension? Extension => _textBoxExtension;
 
 		public TextBox? TextBox


### PR DESCRIPTION
Now works in both directions (with quirks). Also added a new sample to showcase this.

GitHub Issue (If applicable): closes #11730

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
Details are in the related issue.

## What is the new behavior?
Keyboard navigation should work horizontally as well. Currently, it isn't fully working. The navigation works, but it triggers 1 character early. Specifically, if the cursor is currently on the character before last in a textbox and the right arrow is pressed, the focus is moved to the neighbouring textbox (instead of the last character in the original textbox). A similar situation happens when going left as well. 

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2645857</samp>

This pull request adds a new UI test for text box keyboard navigation using `XYFocusKeyboardNavigation`, a property that enables the arrow keys to move the focus between elements in a grid. It also modifies the `TextBox` class to support this behavior by letting the grid handle the left and right arrow keys when the text box has a selection or a caret position at the edge. The changes affect the files `TextBox_Keyboard_Navigation.xaml`, `TextBox_Keyboard_Navigation.xaml.cs`, `TextBox.cs`, and `UITests.Shared.projitems`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->