### PR TITLE
chore: Updates to docs toc test automation - ensure latest tools and auto open browser to correct address

### DIFF
--- a/doc/import_external_docs_test.ps1
+++ b/doc/import_external_docs_test.ps1
@@ -1,3 +1,9 @@
+echo 'Updating docfx tool...'
+dotnet tool update --global docfx
+
+echo 'Updating dotnet-serve tool...'
+dotnet tool update --global dotnet-serve
+
 $external_docs = @{
     # use either commit, or branch name to use its latest commit
     "uno.wasm.bootstrap" = "main"
@@ -15,4 +21,4 @@ $external_docs = @{
 
 docfx
 
-dotnet-serve --open-browser
+dotnet-serve --open-browser:_site/articles/intro.html


### PR DESCRIPTION
[Updates to docs toc test automation - auto open browser to correct address](chore: Updates to docs toc test automation - ensure latest tools and auto open browser to correct address)

## PR Type
- Project automation

## What is the current behavior?
When test is done the website open, but need to navigate and manually rename the `_site` route to reach the docs website.

## What is the new behavior?

1. Ensures the latest docfx and dotnet-serve are installed
2. Utilizes the [new feature](https://github.com/natemcmaster/dotnet-serve/issues/141) of specifying a path to open from dotnet-serve and opens the generated docs site

- [x] Contains **NO** breaking changes