### PR TITLE
feat: Add `Windows.Services.Store.StoreContract` API surface

### DIFF
--- a/src/Uno.Foundation/Metadata/ApiInformation.shared.cs
+++ b/src/Uno.Foundation/Metadata/ApiInformation.shared.cs
@@ -31,6 +31,10 @@ public partial class ApiInformation
 				// See C:\Program Files (x86)\Windows Kits\10\References\[version]\Windows.ApplicationModel.Calls.CallsPhoneContract
 				return majorVersion <= 6; // SDK 10.0.22000.0
 
+			case "Windows.Services.Store.StoreContract":
+				// See C:\Program Files (x86)\Windows Kits\10\References\[version]\Windows.Services.Store.StoreContract
+				return majorVersion <= 4; // SDK 10.0.22000.0
+
 			case "Windows.UI.Xaml.Hosting.HostingContract":
 				// See C:\Program Files (x86)\Windows Kits\10\References\[version]\Windows.UI.Xaml.Hosting.HostingContract
 				return majorVersion <= 5; // SDK 10.0.22000.0			

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Foundation/Metadata/Given_ApiInformation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Foundation/Metadata/Given_ApiInformation.cs
@@ -20,5 +20,18 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Foundation.Metadata
 			var secondIsPresent = ApiInformation.IsPropertyPresent("Windows.UI.Xaml.Application", "Current");
 			Assert.IsTrue(secondIsPresent);
 		}
+
+		[TestMethod]
+		public void When_StoreContract()
+		{
+			var isPresent = ApiInformation.IsApiContractPresent("Windows.Services.Store.StoreContract", 1);
+			Assert.IsTrue(isPresent);
+			isPresent = ApiInformation.IsApiContractPresent("Windows.Services.Store.StoreContract", 2, 3);
+			Assert.IsTrue(isPresent);
+			isPresent = ApiInformation.IsApiContractPresent("Windows.Services.Store.StoreContract", 4);
+			Assert.IsTrue(isPresent);
+			isPresent = ApiInformation.IsApiContractPresent("Windows.Services.Store.StoreContract", 100);
+			Assert.IsFalse(isPresent);
+		}
 	}
 }

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreAcquireLicenseResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreAcquireLicenseResult.cs
@@ -1,0 +1,33 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreAcquireLicenseResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StoreAcquireLicenseResult.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StoreAcquireLicenseResult.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StorePackageLicense StorePackageLicense
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StorePackageLicense StoreAcquireLicenseResult.StorePackageLicense is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StorePackageLicense%20StoreAcquireLicenseResult.StorePackageLicense");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreAcquireLicenseResult.StorePackageLicense.get
+		// Forced skipping of method Windows.Services.Store.StoreAcquireLicenseResult.ExtendedError.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreAppLicense.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreAppLicense.cs
@@ -1,0 +1,121 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreAppLicense 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyDictionary<string, global::Windows.Services.Store.StoreLicense> AddOnLicenses
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyDictionary<string, StoreLicense> StoreAppLicense.AddOnLicenses is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyDictionary%3Cstring%2C%20StoreLicense%3E%20StoreAppLicense.AddOnLicenses");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.DateTimeOffset ExpirationDate
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member DateTimeOffset StoreAppLicense.ExpirationDate is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=DateTimeOffset%20StoreAppLicense.ExpirationDate");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ExtendedJsonData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreAppLicense.ExtendedJsonData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreAppLicense.ExtendedJsonData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsActive
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreAppLicense.IsActive is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreAppLicense.IsActive");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsTrial
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreAppLicense.IsTrial is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreAppLicense.IsTrial");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsTrialOwnedByThisUser
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreAppLicense.IsTrialOwnedByThisUser is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreAppLicense.IsTrialOwnedByThisUser");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string SkuStoreId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreAppLicense.SkuStoreId is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreAppLicense.SkuStoreId");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.TimeSpan TrialTimeRemaining
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member TimeSpan StoreAppLicense.TrialTimeRemaining is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=TimeSpan%20StoreAppLicense.TrialTimeRemaining");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string TrialUniqueId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreAppLicense.TrialUniqueId is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreAppLicense.TrialUniqueId");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsDiscLicense
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreAppLicense.IsDiscLicense is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreAppLicense.IsDiscLicense");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.SkuStoreId.get
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.IsActive.get
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.IsTrial.get
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.ExpirationDate.get
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.ExtendedJsonData.get
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.AddOnLicenses.get
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.TrialTimeRemaining.get
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.IsTrialOwnedByThisUser.get
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.TrialUniqueId.get
+		// Forced skipping of method Windows.Services.Store.StoreAppLicense.IsDiscLicense.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreAvailability.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreAvailability.cs
@@ -1,0 +1,69 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreAvailability 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.DateTimeOffset EndDate
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member DateTimeOffset StoreAvailability.EndDate is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=DateTimeOffset%20StoreAvailability.EndDate");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ExtendedJsonData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreAvailability.ExtendedJsonData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreAvailability.ExtendedJsonData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StorePrice Price
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StorePrice StoreAvailability.Price is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StorePrice%20StoreAvailability.Price");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string StoreId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreAvailability.StoreId is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreAvailability.StoreId");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreAvailability.StoreId.get
+		// Forced skipping of method Windows.Services.Store.StoreAvailability.EndDate.get
+		// Forced skipping of method Windows.Services.Store.StoreAvailability.Price.get
+		// Forced skipping of method Windows.Services.Store.StoreAvailability.ExtendedJsonData.get
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StorePurchaseResult> RequestPurchaseAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StorePurchaseResult> StoreAvailability.RequestPurchaseAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStorePurchaseResult%3E%20StoreAvailability.RequestPurchaseAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StorePurchaseResult> RequestPurchaseAsync( global::Windows.Services.Store.StorePurchaseProperties storePurchaseProperties)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StorePurchaseResult> StoreAvailability.RequestPurchaseAsync(StorePurchaseProperties storePurchaseProperties) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStorePurchaseResult%3E%20StoreAvailability.RequestPurchaseAsync%28StorePurchaseProperties%20storePurchaseProperties%29");
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreCanAcquireLicenseResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreCanAcquireLicenseResult.cs
@@ -1,0 +1,44 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreCanAcquireLicenseResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StoreCanAcquireLicenseResult.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StoreCanAcquireLicenseResult.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string LicensableSku
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreCanAcquireLicenseResult.LicensableSku is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreCanAcquireLicenseResult.LicensableSku");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreCanLicenseStatus Status
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreCanLicenseStatus StoreCanAcquireLicenseResult.Status is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreCanLicenseStatus%20StoreCanAcquireLicenseResult.Status");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreCanAcquireLicenseResult.ExtendedError.get
+		// Forced skipping of method Windows.Services.Store.StoreCanAcquireLicenseResult.LicensableSku.get
+		// Forced skipping of method Windows.Services.Store.StoreCanAcquireLicenseResult.Status.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreCanLicenseStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreCanLicenseStatus.cs
@@ -1,0 +1,25 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StoreCanLicenseStatus 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		NotLicensableToUser = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Licensable = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		LicenseActionNotApplicableToProduct = 2,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		NetworkError = 3,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ServerError = 4,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreCollectionData.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreCollectionData.cs
@@ -1,0 +1,99 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreCollectionData 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.DateTimeOffset AcquiredDate
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member DateTimeOffset StoreCollectionData.AcquiredDate is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=DateTimeOffset%20StoreCollectionData.AcquiredDate");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string CampaignId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreCollectionData.CampaignId is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreCollectionData.CampaignId");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string DeveloperOfferId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreCollectionData.DeveloperOfferId is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreCollectionData.DeveloperOfferId");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.DateTimeOffset EndDate
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member DateTimeOffset StoreCollectionData.EndDate is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=DateTimeOffset%20StoreCollectionData.EndDate");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ExtendedJsonData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreCollectionData.ExtendedJsonData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreCollectionData.ExtendedJsonData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsTrial
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreCollectionData.IsTrial is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreCollectionData.IsTrial");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.DateTimeOffset StartDate
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member DateTimeOffset StoreCollectionData.StartDate is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=DateTimeOffset%20StoreCollectionData.StartDate");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.TimeSpan TrialTimeRemaining
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member TimeSpan StoreCollectionData.TrialTimeRemaining is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=TimeSpan%20StoreCollectionData.TrialTimeRemaining");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreCollectionData.IsTrial.get
+		// Forced skipping of method Windows.Services.Store.StoreCollectionData.CampaignId.get
+		// Forced skipping of method Windows.Services.Store.StoreCollectionData.DeveloperOfferId.get
+		// Forced skipping of method Windows.Services.Store.StoreCollectionData.AcquiredDate.get
+		// Forced skipping of method Windows.Services.Store.StoreCollectionData.StartDate.get
+		// Forced skipping of method Windows.Services.Store.StoreCollectionData.EndDate.get
+		// Forced skipping of method Windows.Services.Store.StoreCollectionData.TrialTimeRemaining.get
+		// Forced skipping of method Windows.Services.Store.StoreCollectionData.ExtendedJsonData.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreConsumableResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreConsumableResult.cs
@@ -1,0 +1,55 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreConsumableResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  uint BalanceRemaining
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member uint StoreConsumableResult.BalanceRemaining is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=uint%20StoreConsumableResult.BalanceRemaining");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StoreConsumableResult.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StoreConsumableResult.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreConsumableStatus Status
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreConsumableStatus StoreConsumableResult.Status is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreConsumableStatus%20StoreConsumableResult.Status");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Guid TrackingId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Guid StoreConsumableResult.TrackingId is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Guid%20StoreConsumableResult.TrackingId");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreConsumableResult.Status.get
+		// Forced skipping of method Windows.Services.Store.StoreConsumableResult.TrackingId.get
+		// Forced skipping of method Windows.Services.Store.StoreConsumableResult.BalanceRemaining.get
+		// Forced skipping of method Windows.Services.Store.StoreConsumableResult.ExtendedError.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreConsumableStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreConsumableStatus.cs
@@ -1,0 +1,22 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StoreConsumableStatus 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Succeeded = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		InsufficentQuantity = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		NetworkError = 2,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ServerError = 3,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreContext.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreContext.cs
@@ -1,0 +1,297 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if false || false || false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreContext 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.System.User User
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member User StoreContext.User is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=User%20StoreContext.User");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool CanSilentlyDownloadStorePackageUpdates
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreContext.CanSilentlyDownloadStorePackageUpdates is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreContext.CanSilentlyDownloadStorePackageUpdates");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreContext.User.get
+		// Forced skipping of method Windows.Services.Store.StoreContext.OfflineLicensesChanged.add
+		// Forced skipping of method Windows.Services.Store.StoreContext.OfflineLicensesChanged.remove
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<string> GetCustomerPurchaseIdAsync( string serviceTicket,  string publisherUserId)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<string> StoreContext.GetCustomerPurchaseIdAsync(string serviceTicket, string publisherUserId) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3Cstring%3E%20StoreContext.GetCustomerPurchaseIdAsync%28string%20serviceTicket%2C%20string%20publisherUserId%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<string> GetCustomerCollectionsIdAsync( string serviceTicket,  string publisherUserId)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<string> StoreContext.GetCustomerCollectionsIdAsync(string serviceTicket, string publisherUserId) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3Cstring%3E%20StoreContext.GetCustomerCollectionsIdAsync%28string%20serviceTicket%2C%20string%20publisherUserId%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreAppLicense> GetAppLicenseAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreAppLicense> StoreContext.GetAppLicenseAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreAppLicense%3E%20StoreContext.GetAppLicenseAsync%28%29");
+		}
+		#endif
+		#if false || false || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreProductResult> GetStoreProductForCurrentAppAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreProductResult> StoreContext.GetStoreProductForCurrentAppAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreProductResult%3E%20StoreContext.GetStoreProductForCurrentAppAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreProductQueryResult> GetStoreProductsAsync( global::System.Collections.Generic.IEnumerable<string> productKinds,  global::System.Collections.Generic.IEnumerable<string> storeIds)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreProductQueryResult> StoreContext.GetStoreProductsAsync(IEnumerable<string> productKinds, IEnumerable<string> storeIds) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreProductQueryResult%3E%20StoreContext.GetStoreProductsAsync%28IEnumerable%3Cstring%3E%20productKinds%2C%20IEnumerable%3Cstring%3E%20storeIds%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreProductQueryResult> GetAssociatedStoreProductsAsync( global::System.Collections.Generic.IEnumerable<string> productKinds)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreProductQueryResult> StoreContext.GetAssociatedStoreProductsAsync(IEnumerable<string> productKinds) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreProductQueryResult%3E%20StoreContext.GetAssociatedStoreProductsAsync%28IEnumerable%3Cstring%3E%20productKinds%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreProductPagedQueryResult> GetAssociatedStoreProductsWithPagingAsync( global::System.Collections.Generic.IEnumerable<string> productKinds,  uint maxItemsToRetrievePerPage)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreProductPagedQueryResult> StoreContext.GetAssociatedStoreProductsWithPagingAsync(IEnumerable<string> productKinds, uint maxItemsToRetrievePerPage) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreProductPagedQueryResult%3E%20StoreContext.GetAssociatedStoreProductsWithPagingAsync%28IEnumerable%3Cstring%3E%20productKinds%2C%20uint%20maxItemsToRetrievePerPage%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreProductQueryResult> GetUserCollectionAsync( global::System.Collections.Generic.IEnumerable<string> productKinds)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreProductQueryResult> StoreContext.GetUserCollectionAsync(IEnumerable<string> productKinds) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreProductQueryResult%3E%20StoreContext.GetUserCollectionAsync%28IEnumerable%3Cstring%3E%20productKinds%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreProductPagedQueryResult> GetUserCollectionWithPagingAsync( global::System.Collections.Generic.IEnumerable<string> productKinds,  uint maxItemsToRetrievePerPage)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreProductPagedQueryResult> StoreContext.GetUserCollectionWithPagingAsync(IEnumerable<string> productKinds, uint maxItemsToRetrievePerPage) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreProductPagedQueryResult%3E%20StoreContext.GetUserCollectionWithPagingAsync%28IEnumerable%3Cstring%3E%20productKinds%2C%20uint%20maxItemsToRetrievePerPage%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreConsumableResult> ReportConsumableFulfillmentAsync( string productStoreId,  uint quantity,  global::System.Guid trackingId)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreConsumableResult> StoreContext.ReportConsumableFulfillmentAsync(string productStoreId, uint quantity, Guid trackingId) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreConsumableResult%3E%20StoreContext.ReportConsumableFulfillmentAsync%28string%20productStoreId%2C%20uint%20quantity%2C%20Guid%20trackingId%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreConsumableResult> GetConsumableBalanceRemainingAsync( string productStoreId)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreConsumableResult> StoreContext.GetConsumableBalanceRemainingAsync(string productStoreId) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreConsumableResult%3E%20StoreContext.GetConsumableBalanceRemainingAsync%28string%20productStoreId%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreAcquireLicenseResult> AcquireStoreLicenseForOptionalPackageAsync( global::Windows.ApplicationModel.Package optionalPackage)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreAcquireLicenseResult> StoreContext.AcquireStoreLicenseForOptionalPackageAsync(Package optionalPackage) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreAcquireLicenseResult%3E%20StoreContext.AcquireStoreLicenseForOptionalPackageAsync%28Package%20optionalPackage%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StorePurchaseResult> RequestPurchaseAsync( string storeId)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StorePurchaseResult> StoreContext.RequestPurchaseAsync(string storeId) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStorePurchaseResult%3E%20StoreContext.RequestPurchaseAsync%28string%20storeId%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StorePurchaseResult> RequestPurchaseAsync( string storeId,  global::Windows.Services.Store.StorePurchaseProperties storePurchaseProperties)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StorePurchaseResult> StoreContext.RequestPurchaseAsync(string storeId, StorePurchaseProperties storePurchaseProperties) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStorePurchaseResult%3E%20StoreContext.RequestPurchaseAsync%28string%20storeId%2C%20StorePurchaseProperties%20storePurchaseProperties%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StorePackageUpdate>> GetAppAndOptionalStorePackageUpdatesAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyList<StorePackageUpdate>> StoreContext.GetAppAndOptionalStorePackageUpdatesAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CIReadOnlyList%3CStorePackageUpdate%3E%3E%20StoreContext.GetAppAndOptionalStorePackageUpdatesAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Services.Store.StorePackageUpdateResult, global::Windows.Services.Store.StorePackageUpdateStatus> RequestDownloadStorePackageUpdatesAsync( global::System.Collections.Generic.IEnumerable<global::Windows.Services.Store.StorePackageUpdate> storePackageUpdates)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<StorePackageUpdateResult, StorePackageUpdateStatus> StoreContext.RequestDownloadStorePackageUpdatesAsync(IEnumerable<StorePackageUpdate> storePackageUpdates) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperationWithProgress%3CStorePackageUpdateResult%2C%20StorePackageUpdateStatus%3E%20StoreContext.RequestDownloadStorePackageUpdatesAsync%28IEnumerable%3CStorePackageUpdate%3E%20storePackageUpdates%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Services.Store.StorePackageUpdateResult, global::Windows.Services.Store.StorePackageUpdateStatus> RequestDownloadAndInstallStorePackageUpdatesAsync( global::System.Collections.Generic.IEnumerable<global::Windows.Services.Store.StorePackageUpdate> storePackageUpdates)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<StorePackageUpdateResult, StorePackageUpdateStatus> StoreContext.RequestDownloadAndInstallStorePackageUpdatesAsync(IEnumerable<StorePackageUpdate> storePackageUpdates) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperationWithProgress%3CStorePackageUpdateResult%2C%20StorePackageUpdateStatus%3E%20StoreContext.RequestDownloadAndInstallStorePackageUpdatesAsync%28IEnumerable%3CStorePackageUpdate%3E%20storePackageUpdates%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Services.Store.StorePackageUpdateResult, global::Windows.Services.Store.StorePackageUpdateStatus> RequestDownloadAndInstallStorePackagesAsync( global::System.Collections.Generic.IEnumerable<string> storeIds)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<StorePackageUpdateResult, StorePackageUpdateStatus> StoreContext.RequestDownloadAndInstallStorePackagesAsync(IEnumerable<string> storeIds) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperationWithProgress%3CStorePackageUpdateResult%2C%20StorePackageUpdateStatus%3E%20StoreContext.RequestDownloadAndInstallStorePackagesAsync%28IEnumerable%3Cstring%3E%20storeIds%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreProductResult> FindStoreProductForPackageAsync( global::System.Collections.Generic.IEnumerable<string> productKinds,  global::Windows.ApplicationModel.Package package)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreProductResult> StoreContext.FindStoreProductForPackageAsync(IEnumerable<string> productKinds, Package package) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreProductResult%3E%20StoreContext.FindStoreProductForPackageAsync%28IEnumerable%3Cstring%3E%20productKinds%2C%20Package%20package%29");
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreContext.CanSilentlyDownloadStorePackageUpdates.get
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Services.Store.StorePackageUpdateResult, global::Windows.Services.Store.StorePackageUpdateStatus> TrySilentDownloadStorePackageUpdatesAsync( global::System.Collections.Generic.IEnumerable<global::Windows.Services.Store.StorePackageUpdate> storePackageUpdates)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<StorePackageUpdateResult, StorePackageUpdateStatus> StoreContext.TrySilentDownloadStorePackageUpdatesAsync(IEnumerable<StorePackageUpdate> storePackageUpdates) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperationWithProgress%3CStorePackageUpdateResult%2C%20StorePackageUpdateStatus%3E%20StoreContext.TrySilentDownloadStorePackageUpdatesAsync%28IEnumerable%3CStorePackageUpdate%3E%20storePackageUpdates%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Services.Store.StorePackageUpdateResult, global::Windows.Services.Store.StorePackageUpdateStatus> TrySilentDownloadAndInstallStorePackageUpdatesAsync( global::System.Collections.Generic.IEnumerable<global::Windows.Services.Store.StorePackageUpdate> storePackageUpdates)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<StorePackageUpdateResult, StorePackageUpdateStatus> StoreContext.TrySilentDownloadAndInstallStorePackageUpdatesAsync(IEnumerable<StorePackageUpdate> storePackageUpdates) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperationWithProgress%3CStorePackageUpdateResult%2C%20StorePackageUpdateStatus%3E%20StoreContext.TrySilentDownloadAndInstallStorePackageUpdatesAsync%28IEnumerable%3CStorePackageUpdate%3E%20storePackageUpdates%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreCanAcquireLicenseResult> CanAcquireStoreLicenseForOptionalPackageAsync( global::Windows.ApplicationModel.Package optionalPackage)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreCanAcquireLicenseResult> StoreContext.CanAcquireStoreLicenseForOptionalPackageAsync(Package optionalPackage) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreCanAcquireLicenseResult%3E%20StoreContext.CanAcquireStoreLicenseForOptionalPackageAsync%28Package%20optionalPackage%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreCanAcquireLicenseResult> CanAcquireStoreLicenseAsync( string productStoreId)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreCanAcquireLicenseResult> StoreContext.CanAcquireStoreLicenseAsync(string productStoreId) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreCanAcquireLicenseResult%3E%20StoreContext.CanAcquireStoreLicenseAsync%28string%20productStoreId%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreProductQueryResult> GetStoreProductsAsync( global::System.Collections.Generic.IEnumerable<string> productKinds,  global::System.Collections.Generic.IEnumerable<string> storeIds,  global::Windows.Services.Store.StoreProductOptions storeProductOptions)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreProductQueryResult> StoreContext.GetStoreProductsAsync(IEnumerable<string> productKinds, IEnumerable<string> storeIds, StoreProductOptions storeProductOptions) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreProductQueryResult%3E%20StoreContext.GetStoreProductsAsync%28IEnumerable%3Cstring%3E%20productKinds%2C%20IEnumerable%3Cstring%3E%20storeIds%2C%20StoreProductOptions%20storeProductOptions%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreQueueItem>> GetAssociatedStoreQueueItemsAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyList<StoreQueueItem>> StoreContext.GetAssociatedStoreQueueItemsAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CIReadOnlyList%3CStoreQueueItem%3E%3E%20StoreContext.GetAssociatedStoreQueueItemsAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreQueueItem>> GetStoreQueueItemsAsync( global::System.Collections.Generic.IEnumerable<string> storeIds)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyList<StoreQueueItem>> StoreContext.GetStoreQueueItemsAsync(IEnumerable<string> storeIds) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CIReadOnlyList%3CStoreQueueItem%3E%3E%20StoreContext.GetStoreQueueItemsAsync%28IEnumerable%3Cstring%3E%20storeIds%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Services.Store.StorePackageUpdateResult, global::Windows.Services.Store.StorePackageUpdateStatus> RequestDownloadAndInstallStorePackagesAsync( global::System.Collections.Generic.IEnumerable<string> storeIds,  global::Windows.Services.Store.StorePackageInstallOptions storePackageInstallOptions)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<StorePackageUpdateResult, StorePackageUpdateStatus> StoreContext.RequestDownloadAndInstallStorePackagesAsync(IEnumerable<string> storeIds, StorePackageInstallOptions storePackageInstallOptions) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperationWithProgress%3CStorePackageUpdateResult%2C%20StorePackageUpdateStatus%3E%20StoreContext.RequestDownloadAndInstallStorePackagesAsync%28IEnumerable%3Cstring%3E%20storeIds%2C%20StorePackageInstallOptions%20storePackageInstallOptions%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperationWithProgress<global::Windows.Services.Store.StorePackageUpdateResult, global::Windows.Services.Store.StorePackageUpdateStatus> DownloadAndInstallStorePackagesAsync( global::System.Collections.Generic.IEnumerable<string> storeIds)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperationWithProgress<StorePackageUpdateResult, StorePackageUpdateStatus> StoreContext.DownloadAndInstallStorePackagesAsync(IEnumerable<string> storeIds) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperationWithProgress%3CStorePackageUpdateResult%2C%20StorePackageUpdateStatus%3E%20StoreContext.DownloadAndInstallStorePackagesAsync%28IEnumerable%3Cstring%3E%20storeIds%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreUninstallStorePackageResult> RequestUninstallStorePackageAsync( global::Windows.ApplicationModel.Package package)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreUninstallStorePackageResult> StoreContext.RequestUninstallStorePackageAsync(Package package) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreUninstallStorePackageResult%3E%20StoreContext.RequestUninstallStorePackageAsync%28Package%20package%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreUninstallStorePackageResult> RequestUninstallStorePackageByStoreIdAsync( string storeId)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreUninstallStorePackageResult> StoreContext.RequestUninstallStorePackageByStoreIdAsync(string storeId) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreUninstallStorePackageResult%3E%20StoreContext.RequestUninstallStorePackageByStoreIdAsync%28string%20storeId%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreUninstallStorePackageResult> UninstallStorePackageAsync( global::Windows.ApplicationModel.Package package)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreUninstallStorePackageResult> StoreContext.UninstallStorePackageAsync(Package package) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreUninstallStorePackageResult%3E%20StoreContext.UninstallStorePackageAsync%28Package%20package%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreUninstallStorePackageResult> UninstallStorePackageByStoreIdAsync( string storeId)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreUninstallStorePackageResult> StoreContext.UninstallStorePackageByStoreIdAsync(string storeId) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreUninstallStorePackageResult%3E%20StoreContext.UninstallStorePackageByStoreIdAsync%28string%20storeId%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreRateAndReviewResult> RequestRateAndReviewAppAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreRateAndReviewResult> StoreContext.RequestRateAndReviewAppAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreRateAndReviewResult%3E%20StoreContext.RequestRateAndReviewAppAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreQueueItem>> SetInstallOrderForAssociatedStoreQueueItemsAsync( global::System.Collections.Generic.IEnumerable<global::Windows.Services.Store.StoreQueueItem> items)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyList<StoreQueueItem>> StoreContext.SetInstallOrderForAssociatedStoreQueueItemsAsync(IEnumerable<StoreQueueItem> items) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CIReadOnlyList%3CStoreQueueItem%3E%3E%20StoreContext.SetInstallOrderForAssociatedStoreQueueItemsAsync%28IEnumerable%3CStoreQueueItem%3E%20items%29");
+		}
+		#endif
+		// Skipping already declared method Windows.Services.Store.StoreContext.GetDefault()
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public static global::Windows.Services.Store.StoreContext GetForUser( global::Windows.System.User user)
+		{
+			throw new global::System.NotImplementedException("The member StoreContext StoreContext.GetForUser(User user) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreContext%20StoreContext.GetForUser%28User%20user%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.Services.Store.StoreContext, object> OfflineLicensesChanged
+		{
+			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StoreContext", "event TypedEventHandler<StoreContext, object> StoreContext.OfflineLicensesChanged");
+			}
+			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StoreContext", "event TypedEventHandler<StoreContext, object> StoreContext.OfflineLicensesChanged");
+			}
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreContract.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreContract.cs
@@ -1,0 +1,12 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial struct StoreContract 
+	{
+		// Forced skipping of method Windows.Services.Store.StoreContract.StoreContract()
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreDurationUnit.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreDurationUnit.cs
@@ -1,0 +1,28 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StoreDurationUnit 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Minute = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Hour = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Day = 2,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Week = 3,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Month = 4,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Year = 5,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreImage.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreImage.cs
@@ -1,0 +1,66 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreImage 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Caption
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreImage.Caption is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreImage.Caption");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  uint Height
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member uint StoreImage.Height is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=uint%20StoreImage.Height");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ImagePurposeTag
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreImage.ImagePurposeTag is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreImage.ImagePurposeTag");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Uri Uri
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Uri StoreImage.Uri is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Uri%20StoreImage.Uri");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  uint Width
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member uint StoreImage.Width is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=uint%20StoreImage.Width");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreImage.Uri.get
+		// Forced skipping of method Windows.Services.Store.StoreImage.ImagePurposeTag.get
+		// Forced skipping of method Windows.Services.Store.StoreImage.Width.get
+		// Forced skipping of method Windows.Services.Store.StoreImage.Height.get
+		// Forced skipping of method Windows.Services.Store.StoreImage.Caption.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreLicense.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreLicense.cs
@@ -1,0 +1,66 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreLicense 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.DateTimeOffset ExpirationDate
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member DateTimeOffset StoreLicense.ExpirationDate is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=DateTimeOffset%20StoreLicense.ExpirationDate");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ExtendedJsonData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreLicense.ExtendedJsonData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreLicense.ExtendedJsonData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string InAppOfferToken
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreLicense.InAppOfferToken is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreLicense.InAppOfferToken");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsActive
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreLicense.IsActive is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreLicense.IsActive");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string SkuStoreId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreLicense.SkuStoreId is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreLicense.SkuStoreId");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreLicense.SkuStoreId.get
+		// Forced skipping of method Windows.Services.Store.StoreLicense.IsActive.get
+		// Forced skipping of method Windows.Services.Store.StoreLicense.ExpirationDate.get
+		// Forced skipping of method Windows.Services.Store.StoreLicense.ExtendedJsonData.get
+		// Forced skipping of method Windows.Services.Store.StoreLicense.InAppOfferToken.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageInstallOptions.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageInstallOptions.cs
@@ -1,0 +1,35 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StorePackageInstallOptions 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool AllowForcedAppRestart
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StorePackageInstallOptions.AllowForcedAppRestart is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StorePackageInstallOptions.AllowForcedAppRestart");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePackageInstallOptions", "bool StorePackageInstallOptions.AllowForcedAppRestart");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public StorePackageInstallOptions() 
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePackageInstallOptions", "StorePackageInstallOptions.StorePackageInstallOptions()");
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StorePackageInstallOptions.StorePackageInstallOptions()
+		// Forced skipping of method Windows.Services.Store.StorePackageInstallOptions.AllowForcedAppRestart.get
+		// Forced skipping of method Windows.Services.Store.StorePackageInstallOptions.AllowForcedAppRestart.set
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageLicense.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageLicense.cs
@@ -1,0 +1,66 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StorePackageLicense : global::System.IDisposable
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsValid
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StorePackageLicense.IsValid is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StorePackageLicense.IsValid");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.ApplicationModel.Package Package
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Package StorePackageLicense.Package is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Package%20StorePackageLicense.Package");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StorePackageLicense.LicenseLost.add
+		// Forced skipping of method Windows.Services.Store.StorePackageLicense.LicenseLost.remove
+		// Forced skipping of method Windows.Services.Store.StorePackageLicense.Package.get
+		// Forced skipping of method Windows.Services.Store.StorePackageLicense.IsValid.get
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  void ReleaseLicense()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePackageLicense", "void StorePackageLicense.ReleaseLicense()");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  void Dispose()
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePackageLicense", "void StorePackageLicense.Dispose()");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.Services.Store.StorePackageLicense, object> LicenseLost
+		{
+			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePackageLicense", "event TypedEventHandler<StorePackageLicense, object> StorePackageLicense.LicenseLost");
+			}
+			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePackageLicense", "event TypedEventHandler<StorePackageLicense, object> StorePackageLicense.LicenseLost");
+			}
+		}
+		#endif
+		// Processing: System.IDisposable
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageUpdate.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageUpdate.cs
@@ -1,0 +1,33 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StorePackageUpdate 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool Mandatory
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StorePackageUpdate.Mandatory is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StorePackageUpdate.Mandatory");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.ApplicationModel.Package Package
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Package StorePackageUpdate.Package is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Package%20StorePackageUpdate.Package");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StorePackageUpdate.Package.get
+		// Forced skipping of method Windows.Services.Store.StorePackageUpdate.Mandatory.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageUpdateResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageUpdateResult.cs
@@ -1,0 +1,44 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StorePackageUpdateResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StorePackageUpdateState OverallState
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StorePackageUpdateState StorePackageUpdateResult.OverallState is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StorePackageUpdateState%20StorePackageUpdateResult.OverallState");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StorePackageUpdateStatus> StorePackageUpdateStatuses
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<StorePackageUpdateStatus> StorePackageUpdateResult.StorePackageUpdateStatuses is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3CStorePackageUpdateStatus%3E%20StorePackageUpdateResult.StorePackageUpdateStatuses");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreQueueItem> StoreQueueItems
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<StoreQueueItem> StorePackageUpdateResult.StoreQueueItems is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3CStoreQueueItem%3E%20StorePackageUpdateResult.StoreQueueItems");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StorePackageUpdateResult.OverallState.get
+		// Forced skipping of method Windows.Services.Store.StorePackageUpdateResult.StorePackageUpdateStatuses.get
+		// Forced skipping of method Windows.Services.Store.StorePackageUpdateResult.StoreQueueItems.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageUpdateState.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageUpdateState.cs
@@ -1,0 +1,37 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StorePackageUpdateState 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Pending = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Downloading = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Deploying = 2,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Completed = 3,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Canceled = 4,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		OtherError = 5,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ErrorLowBattery = 6,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ErrorWiFiRecommended = 7,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ErrorWiFiRequired = 8,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageUpdateStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePackageUpdateStatus.cs
@@ -1,0 +1,30 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial struct StorePackageUpdateStatus 
+	{
+		// Forced skipping of method Windows.Services.Store.StorePackageUpdateStatus.StorePackageUpdateStatus()
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		public  string PackageFamilyName;
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		public  ulong PackageDownloadSizeInBytes;
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		public  ulong PackageBytesDownloaded;
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		public  double PackageDownloadProgress;
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		public  double TotalDownloadProgress;
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		public  global::Windows.Services.Store.StorePackageUpdateState PackageUpdateState;
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePrice.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePrice.cs
@@ -1,0 +1,77 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StorePrice 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string CurrencyCode
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StorePrice.CurrencyCode is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StorePrice.CurrencyCode");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string FormattedBasePrice
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StorePrice.FormattedBasePrice is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StorePrice.FormattedBasePrice");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string FormattedPrice
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StorePrice.FormattedPrice is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StorePrice.FormattedPrice");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string FormattedRecurrencePrice
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StorePrice.FormattedRecurrencePrice is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StorePrice.FormattedRecurrencePrice");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsOnSale
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StorePrice.IsOnSale is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StorePrice.IsOnSale");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.DateTimeOffset SaleEndDate
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member DateTimeOffset StorePrice.SaleEndDate is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=DateTimeOffset%20StorePrice.SaleEndDate");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StorePrice.FormattedBasePrice.get
+		// Forced skipping of method Windows.Services.Store.StorePrice.FormattedPrice.get
+		// Forced skipping of method Windows.Services.Store.StorePrice.IsOnSale.get
+		// Forced skipping of method Windows.Services.Store.StorePrice.SaleEndDate.get
+		// Forced skipping of method Windows.Services.Store.StorePrice.CurrencyCode.get
+		// Forced skipping of method Windows.Services.Store.StorePrice.FormattedRecurrencePrice.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProduct.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProduct.cs
@@ -1,0 +1,179 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if false || false || false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreProduct 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Description
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreProduct.Description is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreProduct.Description");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ExtendedJsonData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreProduct.ExtendedJsonData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreProduct.ExtendedJsonData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool HasDigitalDownload
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreProduct.HasDigitalDownload is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreProduct.HasDigitalDownload");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreImage> Images
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<StoreImage> StoreProduct.Images is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3CStoreImage%3E%20StoreProduct.Images");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string InAppOfferToken
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreProduct.InAppOfferToken is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreProduct.InAppOfferToken");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsInUserCollection
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreProduct.IsInUserCollection is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreProduct.IsInUserCollection");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<string> Keywords
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<string> StoreProduct.Keywords is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3Cstring%3E%20StoreProduct.Keywords");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Language
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreProduct.Language is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreProduct.Language");
+			}
+		}
+		#endif
+		// Skipping already declared property LinkUri
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StorePrice Price
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StorePrice StoreProduct.Price is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StorePrice%20StoreProduct.Price");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ProductKind
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreProduct.ProductKind is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreProduct.ProductKind");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreSku> Skus
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<StoreSku> StoreProduct.Skus is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3CStoreSku%3E%20StoreProduct.Skus");
+			}
+		}
+		#endif
+		// Skipping already declared property StoreId
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Title
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreProduct.Title is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreProduct.Title");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreVideo> Videos
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<StoreVideo> StoreProduct.Videos is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3CStoreVideo%3E%20StoreProduct.Videos");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreProduct.StoreId.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.Language.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.Title.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.Description.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.ProductKind.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.HasDigitalDownload.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.Keywords.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.Images.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.Videos.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.Skus.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.IsInUserCollection.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.Price.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.ExtendedJsonData.get
+		// Forced skipping of method Windows.Services.Store.StoreProduct.LinkUri.get
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<bool> GetIsAnySkuInstalledAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> StoreProduct.GetIsAnySkuInstalledAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3Cbool%3E%20StoreProduct.GetIsAnySkuInstalledAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StorePurchaseResult> RequestPurchaseAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StorePurchaseResult> StoreProduct.RequestPurchaseAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStorePurchaseResult%3E%20StoreProduct.RequestPurchaseAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StorePurchaseResult> RequestPurchaseAsync( global::Windows.Services.Store.StorePurchaseProperties storePurchaseProperties)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StorePurchaseResult> StoreProduct.RequestPurchaseAsync(StorePurchaseProperties storePurchaseProperties) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStorePurchaseResult%3E%20StoreProduct.RequestPurchaseAsync%28StorePurchaseProperties%20storePurchaseProperties%29");
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreProduct.InAppOfferToken.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProductOptions.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProductOptions.cs
@@ -1,0 +1,30 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreProductOptions 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IList<string> ActionFilters
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IList<string> StoreProductOptions.ActionFilters is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IList%3Cstring%3E%20StoreProductOptions.ActionFilters");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public StoreProductOptions() 
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StoreProductOptions", "StoreProductOptions.StoreProductOptions()");
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreProductOptions.StoreProductOptions()
+		// Forced skipping of method Windows.Services.Store.StoreProductOptions.ActionFilters.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProductPagedQueryResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProductPagedQueryResult.cs
@@ -1,0 +1,51 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreProductPagedQueryResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StoreProductPagedQueryResult.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StoreProductPagedQueryResult.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool HasMoreResults
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreProductPagedQueryResult.HasMoreResults is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreProductPagedQueryResult.HasMoreResults");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyDictionary<string, global::Windows.Services.Store.StoreProduct> Products
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyDictionary<string, StoreProduct> StoreProductPagedQueryResult.Products is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyDictionary%3Cstring%2C%20StoreProduct%3E%20StoreProductPagedQueryResult.Products");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreProductPagedQueryResult.Products.get
+		// Forced skipping of method Windows.Services.Store.StoreProductPagedQueryResult.HasMoreResults.get
+		// Forced skipping of method Windows.Services.Store.StoreProductPagedQueryResult.ExtendedError.get
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreProductPagedQueryResult> GetNextAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreProductPagedQueryResult> StoreProductPagedQueryResult.GetNextAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreProductPagedQueryResult%3E%20StoreProductPagedQueryResult.GetNextAsync%28%29");
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProductQueryResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProductQueryResult.cs
@@ -1,0 +1,33 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreProductQueryResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StoreProductQueryResult.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StoreProductQueryResult.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyDictionary<string, global::Windows.Services.Store.StoreProduct> Products
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyDictionary<string, StoreProduct> StoreProductQueryResult.Products is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyDictionary%3Cstring%2C%20StoreProduct%3E%20StoreProductQueryResult.Products");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreProductQueryResult.Products.get
+		// Forced skipping of method Windows.Services.Store.StoreProductQueryResult.ExtendedError.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProductResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreProductResult.cs
@@ -1,0 +1,15 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if false || false || false || false || false || false || false
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreProductResult 
+	{
+		// Skipping already declared property ExtendedError
+		// Skipping already declared property Product
+		// Forced skipping of method Windows.Services.Store.StoreProductResult.Product.get
+		// Forced skipping of method Windows.Services.Store.StoreProductResult.ExtendedError.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePurchaseProperties.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePurchaseProperties.cs
@@ -1,0 +1,59 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StorePurchaseProperties 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Name
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StorePurchaseProperties.Name is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StorePurchaseProperties.Name");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePurchaseProperties", "string StorePurchaseProperties.Name");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ExtendedJsonData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StorePurchaseProperties.ExtendedJsonData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StorePurchaseProperties.ExtendedJsonData");
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePurchaseProperties", "string StorePurchaseProperties.ExtendedJsonData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public StorePurchaseProperties( string name) 
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePurchaseProperties", "StorePurchaseProperties.StorePurchaseProperties(string name)");
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StorePurchaseProperties.StorePurchaseProperties(string)
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public StorePurchaseProperties() 
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StorePurchaseProperties", "StorePurchaseProperties.StorePurchaseProperties()");
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StorePurchaseProperties.StorePurchaseProperties()
+		// Forced skipping of method Windows.Services.Store.StorePurchaseProperties.Name.get
+		// Forced skipping of method Windows.Services.Store.StorePurchaseProperties.Name.set
+		// Forced skipping of method Windows.Services.Store.StorePurchaseProperties.ExtendedJsonData.get
+		// Forced skipping of method Windows.Services.Store.StorePurchaseProperties.ExtendedJsonData.set
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePurchaseResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePurchaseResult.cs
@@ -1,0 +1,33 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StorePurchaseResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StorePurchaseResult.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StorePurchaseResult.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StorePurchaseStatus Status
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StorePurchaseStatus StorePurchaseResult.Status is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StorePurchaseStatus%20StorePurchaseResult.Status");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StorePurchaseResult.Status.get
+		// Forced skipping of method Windows.Services.Store.StorePurchaseResult.ExtendedError.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePurchaseStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StorePurchaseStatus.cs
@@ -1,0 +1,25 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StorePurchaseStatus 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Succeeded = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		AlreadyPurchased = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		NotPurchased = 2,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		NetworkError = 3,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ServerError = 4,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItem.cs
@@ -1,0 +1,108 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreQueueItem 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreQueueItemKind InstallKind
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreQueueItemKind StoreQueueItem.InstallKind is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreQueueItemKind%20StoreQueueItem.InstallKind");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string PackageFamilyName
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreQueueItem.PackageFamilyName is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreQueueItem.PackageFamilyName");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ProductId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreQueueItem.ProductId is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreQueueItem.ProductId");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreQueueItem.ProductId.get
+		// Forced skipping of method Windows.Services.Store.StoreQueueItem.PackageFamilyName.get
+		// Forced skipping of method Windows.Services.Store.StoreQueueItem.InstallKind.get
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreQueueItemStatus GetCurrentStatus()
+		{
+			throw new global::System.NotImplementedException("The member StoreQueueItemStatus StoreQueueItem.GetCurrentStatus() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreQueueItemStatus%20StoreQueueItem.GetCurrentStatus%28%29");
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreQueueItem.Completed.add
+		// Forced skipping of method Windows.Services.Store.StoreQueueItem.Completed.remove
+		// Forced skipping of method Windows.Services.Store.StoreQueueItem.StatusChanged.add
+		// Forced skipping of method Windows.Services.Store.StoreQueueItem.StatusChanged.remove
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncAction CancelInstallAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncAction StoreQueueItem.CancelInstallAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncAction%20StoreQueueItem.CancelInstallAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncAction PauseInstallAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncAction StoreQueueItem.PauseInstallAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncAction%20StoreQueueItem.PauseInstallAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncAction ResumeInstallAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncAction StoreQueueItem.ResumeInstallAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncAction%20StoreQueueItem.ResumeInstallAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.Services.Store.StoreQueueItem, global::Windows.Services.Store.StoreQueueItemCompletedEventArgs> Completed
+		{
+			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StoreQueueItem", "event TypedEventHandler<StoreQueueItem, StoreQueueItemCompletedEventArgs> StoreQueueItem.Completed");
+			}
+			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StoreQueueItem", "event TypedEventHandler<StoreQueueItem, StoreQueueItemCompletedEventArgs> StoreQueueItem.Completed");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.Services.Store.StoreQueueItem, object> StatusChanged
+		{
+			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			add
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StoreQueueItem", "event TypedEventHandler<StoreQueueItem, object> StoreQueueItem.StatusChanged");
+			}
+			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			remove
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Services.Store.StoreQueueItem", "event TypedEventHandler<StoreQueueItem, object> StoreQueueItem.StatusChanged");
+			}
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemCompletedEventArgs.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemCompletedEventArgs.cs
@@ -1,0 +1,22 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreQueueItemCompletedEventArgs 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreQueueItemStatus Status
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreQueueItemStatus StoreQueueItemCompletedEventArgs.Status is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreQueueItemStatus%20StoreQueueItemCompletedEventArgs.Status");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreQueueItemCompletedEventArgs.Status.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemExtendedState.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemExtendedState.cs
@@ -1,0 +1,55 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StoreQueueItemExtendedState 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ActivePending = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ActiveStarting = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ActiveAcquiringLicense = 2,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ActiveDownloading = 3,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ActiveRestoringData = 4,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		ActiveInstalling = 5,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Completed = 6,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Canceled = 7,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Paused = 8,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Error = 9,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		PausedPackagesInUse = 10,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		PausedLowBattery = 11,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		PausedWiFiRecommended = 12,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		PausedWiFiRequired = 13,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		PausedReadyToInstall = 14,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemKind.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemKind.cs
@@ -1,0 +1,19 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StoreQueueItemKind 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Install = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Update = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Repair = 2,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemState.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemState.cs
@@ -1,0 +1,25 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StoreQueueItemState 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Active = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Completed = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Canceled = 2,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Error = 3,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Paused = 4,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreQueueItemStatus.cs
@@ -1,0 +1,55 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreQueueItemStatus 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StoreQueueItemStatus.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StoreQueueItemStatus.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreQueueItemExtendedState PackageInstallExtendedState
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreQueueItemExtendedState StoreQueueItemStatus.PackageInstallExtendedState is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreQueueItemExtendedState%20StoreQueueItemStatus.PackageInstallExtendedState");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreQueueItemState PackageInstallState
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreQueueItemState StoreQueueItemStatus.PackageInstallState is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreQueueItemState%20StoreQueueItemStatus.PackageInstallState");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StorePackageUpdateStatus UpdateStatus
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StorePackageUpdateStatus StoreQueueItemStatus.UpdateStatus is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StorePackageUpdateStatus%20StoreQueueItemStatus.UpdateStatus");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreQueueItemStatus.PackageInstallState.get
+		// Forced skipping of method Windows.Services.Store.StoreQueueItemStatus.PackageInstallExtendedState.get
+		// Forced skipping of method Windows.Services.Store.StoreQueueItemStatus.UpdateStatus.get
+		// Forced skipping of method Windows.Services.Store.StoreQueueItemStatus.ExtendedError.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreRateAndReviewResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreRateAndReviewResult.cs
@@ -1,0 +1,55 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreRateAndReviewResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StoreRateAndReviewResult.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StoreRateAndReviewResult.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ExtendedJsonData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreRateAndReviewResult.ExtendedJsonData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreRateAndReviewResult.ExtendedJsonData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreRateAndReviewStatus Status
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreRateAndReviewStatus StoreRateAndReviewResult.Status is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreRateAndReviewStatus%20StoreRateAndReviewResult.Status");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool WasUpdated
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreRateAndReviewResult.WasUpdated is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreRateAndReviewResult.WasUpdated");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreRateAndReviewResult.ExtendedError.get
+		// Forced skipping of method Windows.Services.Store.StoreRateAndReviewResult.ExtendedJsonData.get
+		// Forced skipping of method Windows.Services.Store.StoreRateAndReviewResult.WasUpdated.get
+		// Forced skipping of method Windows.Services.Store.StoreRateAndReviewResult.Status.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreRateAndReviewStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreRateAndReviewStatus.cs
@@ -1,0 +1,22 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StoreRateAndReviewStatus 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Succeeded = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		CanceledByUser = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		NetworkError = 2,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Error = 3,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreRequestHelper.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreRequestHelper.cs
@@ -1,0 +1,18 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public static partial class StoreRequestHelper 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public static global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StoreSendRequestResult> SendRequestAsync( global::Windows.Services.Store.StoreContext context,  uint requestKind,  string parametersAsJson)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StoreSendRequestResult> StoreRequestHelper.SendRequestAsync(StoreContext context, uint requestKind, string parametersAsJson) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStoreSendRequestResult%3E%20StoreRequestHelper.SendRequestAsync%28StoreContext%20context%2C%20uint%20requestKind%2C%20string%20parametersAsJson%29");
+		}
+		#endif
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreSendRequestResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreSendRequestResult.cs
@@ -1,0 +1,44 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreSendRequestResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StoreSendRequestResult.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StoreSendRequestResult.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Response
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreSendRequestResult.Response is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreSendRequestResult.Response");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Web.Http.HttpStatusCode HttpStatusCode
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member HttpStatusCode StoreSendRequestResult.HttpStatusCode is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=HttpStatusCode%20StoreSendRequestResult.HttpStatusCode");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreSendRequestResult.Response.get
+		// Forced skipping of method Windows.Services.Store.StoreSendRequestResult.ExtendedError.get
+		// Forced skipping of method Windows.Services.Store.StoreSendRequestResult.HttpStatusCode.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreSku.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreSku.cs
@@ -1,0 +1,208 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreSku 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreAvailability> Availabilities
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<StoreAvailability> StoreSku.Availabilities is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3CStoreAvailability%3E%20StoreSku.Availabilities");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<string> BundledSkus
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<string> StoreSku.BundledSkus is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3Cstring%3E%20StoreSku.BundledSkus");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreCollectionData CollectionData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreCollectionData StoreSku.CollectionData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreCollectionData%20StoreSku.CollectionData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string CustomDeveloperData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreSku.CustomDeveloperData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreSku.CustomDeveloperData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Description
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreSku.Description is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreSku.Description");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string ExtendedJsonData
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreSku.ExtendedJsonData is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreSku.ExtendedJsonData");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreImage> Images
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<StoreImage> StoreSku.Images is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3CStoreImage%3E%20StoreSku.Images");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsInUserCollection
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreSku.IsInUserCollection is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreSku.IsInUserCollection");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsSubscription
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreSku.IsSubscription is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreSku.IsSubscription");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool IsTrial
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreSku.IsTrial is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreSku.IsTrial");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Language
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreSku.Language is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreSku.Language");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StorePrice Price
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StorePrice StoreSku.Price is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StorePrice%20StoreSku.Price");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string StoreId
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreSku.StoreId is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreSku.StoreId");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreSubscriptionInfo SubscriptionInfo
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreSubscriptionInfo StoreSku.SubscriptionInfo is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreSubscriptionInfo%20StoreSku.SubscriptionInfo");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Title
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreSku.Title is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreSku.Title");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Collections.Generic.IReadOnlyList<global::Windows.Services.Store.StoreVideo> Videos
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member IReadOnlyList<StoreVideo> StoreSku.Videos is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IReadOnlyList%3CStoreVideo%3E%20StoreSku.Videos");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreSku.StoreId.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.Language.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.Title.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.Description.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.IsTrial.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.CustomDeveloperData.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.Images.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.Videos.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.Availabilities.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.Price.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.ExtendedJsonData.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.IsInUserCollection.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.BundledSkus.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.CollectionData.get
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<bool> GetIsInstalledAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<bool> StoreSku.GetIsInstalledAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3Cbool%3E%20StoreSku.GetIsInstalledAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StorePurchaseResult> RequestPurchaseAsync()
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StorePurchaseResult> StoreSku.RequestPurchaseAsync() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStorePurchaseResult%3E%20StoreSku.RequestPurchaseAsync%28%29");
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Foundation.IAsyncOperation<global::Windows.Services.Store.StorePurchaseResult> RequestPurchaseAsync( global::Windows.Services.Store.StorePurchaseProperties storePurchaseProperties)
+		{
+			throw new global::System.NotImplementedException("The member IAsyncOperation<StorePurchaseResult> StoreSku.RequestPurchaseAsync(StorePurchaseProperties storePurchaseProperties) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CStorePurchaseResult%3E%20StoreSku.RequestPurchaseAsync%28StorePurchaseProperties%20storePurchaseProperties%29");
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreSku.IsSubscription.get
+		// Forced skipping of method Windows.Services.Store.StoreSku.SubscriptionInfo.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreSubscriptionInfo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreSubscriptionInfo.cs
@@ -1,0 +1,66 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreSubscriptionInfo 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  uint BillingPeriod
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member uint StoreSubscriptionInfo.BillingPeriod is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=uint%20StoreSubscriptionInfo.BillingPeriod");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreDurationUnit BillingPeriodUnit
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreDurationUnit StoreSubscriptionInfo.BillingPeriodUnit is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreDurationUnit%20StoreSubscriptionInfo.BillingPeriodUnit");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  bool HasTrialPeriod
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member bool StoreSubscriptionInfo.HasTrialPeriod is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20StoreSubscriptionInfo.HasTrialPeriod");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  uint TrialPeriod
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member uint StoreSubscriptionInfo.TrialPeriod is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=uint%20StoreSubscriptionInfo.TrialPeriod");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreDurationUnit TrialPeriodUnit
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreDurationUnit StoreSubscriptionInfo.TrialPeriodUnit is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreDurationUnit%20StoreSubscriptionInfo.TrialPeriodUnit");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreSubscriptionInfo.BillingPeriod.get
+		// Forced skipping of method Windows.Services.Store.StoreSubscriptionInfo.BillingPeriodUnit.get
+		// Forced skipping of method Windows.Services.Store.StoreSubscriptionInfo.HasTrialPeriod.get
+		// Forced skipping of method Windows.Services.Store.StoreSubscriptionInfo.TrialPeriod.get
+		// Forced skipping of method Windows.Services.Store.StoreSubscriptionInfo.TrialPeriodUnit.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreUninstallStorePackageResult.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreUninstallStorePackageResult.cs
@@ -1,0 +1,33 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreUninstallStorePackageResult 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Exception ExtendedError
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Exception StoreUninstallStorePackageResult.ExtendedError is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Exception%20StoreUninstallStorePackageResult.ExtendedError");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreUninstallStorePackageStatus Status
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreUninstallStorePackageStatus StoreUninstallStorePackageResult.Status is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreUninstallStorePackageStatus%20StoreUninstallStorePackageResult.Status");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreUninstallStorePackageResult.ExtendedError.get
+		// Forced skipping of method Windows.Services.Store.StoreUninstallStorePackageResult.Status.get
+	}
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreUninstallStorePackageStatus.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreUninstallStorePackageStatus.cs
@@ -1,0 +1,25 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	public   enum StoreUninstallStorePackageStatus 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Succeeded = 0,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		CanceledByUser = 1,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		NetworkError = 2,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		UninstallNotApplicable = 3,
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		Error = 4,
+		#endif
+	}
+	#endif
+}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreVideo.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Services.Store/StoreVideo.cs
@@ -1,0 +1,77 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.Services.Store
+{
+	#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+	[global::Uno.NotImplemented]
+	#endif
+	public  partial class StoreVideo 
+	{
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string Caption
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreVideo.Caption is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreVideo.Caption");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  uint Height
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member uint StoreVideo.Height is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=uint%20StoreVideo.Height");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::Windows.Services.Store.StoreImage PreviewImage
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member StoreImage StoreVideo.PreviewImage is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=StoreImage%20StoreVideo.PreviewImage");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  global::System.Uri Uri
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member Uri StoreVideo.Uri is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=Uri%20StoreVideo.Uri");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  string VideoPurposeTag
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member string StoreVideo.VideoPurposeTag is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=string%20StoreVideo.VideoPurposeTag");
+			}
+		}
+		#endif
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		public  uint Width
+		{
+			get
+			{
+				throw new global::System.NotImplementedException("The member uint StoreVideo.Width is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=uint%20StoreVideo.Width");
+			}
+		}
+		#endif
+		// Forced skipping of method Windows.Services.Store.StoreVideo.Uri.get
+		// Forced skipping of method Windows.Services.Store.StoreVideo.VideoPurposeTag.get
+		// Forced skipping of method Windows.Services.Store.StoreVideo.Width.get
+		// Forced skipping of method Windows.Services.Store.StoreVideo.Height.get
+		// Forced skipping of method Windows.Services.Store.StoreVideo.Caption.get
+		// Forced skipping of method Windows.Services.Store.StoreVideo.PreviewImage.get
+	}
+}

--- a/src/Uno.UWP/Services/Store/StoreProduct.cs
+++ b/src/Uno.UWP/Services/Store/StoreProduct.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Windows.Services.Store
 {
-	public sealed class StoreProduct
+	public sealed partial class StoreProduct
 	{
 		internal StoreProduct() { }
 

--- a/src/Uno.UWP/Services/Store/StoreProductResult.cs
+++ b/src/Uno.UWP/Services/Store/StoreProductResult.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Windows.Services.Store
 {
-	public sealed class StoreProductResult
+	public sealed partial class StoreProductResult
 	{
 		internal StoreProductResult() { }
 

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -175,6 +175,7 @@ namespace Uno.UWPSyncGenerator
 						  || fileNameWithoutExtension.StartsWith("Windows.Phone.PhoneContract", StringComparison.Ordinal)
 						  || fileNameWithoutExtension.StartsWith("Windows.Networking.Connectivity.WwanContract", StringComparison.Ordinal)
 						  || fileNameWithoutExtension.StartsWith("Windows.ApplicationModel.Calls.CallsPhoneContract", StringComparison.Ordinal)
+						  || fileNameWithoutExtension.StartsWith("Windows.Services.Store.StoreContract", StringComparison.Ordinal)
 						  || fileNameWithoutExtension.StartsWith("Windows.UI.Xaml.Hosting.HostingContract", StringComparison.Ordinal)
 						  || fileNameWithoutExtension.StartsWith("Microsoft.Web.WebView2.Core", StringComparison.Ordinal)
 						  let asm = s_referenceCompilation.GetAssemblyOrModuleSymbol(externalRedfs) as IAssemblySymbol

--- a/src/Uno.UWPSyncGenerator/Program.cs
+++ b/src/Uno.UWPSyncGenerator/Program.cs
@@ -26,6 +26,7 @@ namespace Uno.UWPSyncGenerator
 				await new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.Phone.PhoneContract");
 				await new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.Networking.Connectivity.WwanContract");
 				await new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.ApplicationModel.Calls.CallsPhoneContract");
+				await new SyncGenerator().Build(@"..\..\..\Uno.UWP", "Uno", "Windows.Services.Store.StoreContract");
 
 				// When adding support for a new WinRT contract here, ensure to add it to the list of origins in Generator.cs
 				// and to the list of supported contracts in ApiInformation.shared.cs


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

API surface not present


## What is the new behavior?

Present

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 841813e</samp>

This pull request adds support for the `Windows.Services.Store` namespace in Uno applications by updating the `ApiInformation` class, adding a unit test, and generating the platform bindings.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification