### PR TITLE
fix: Implementing IDisposable and detaching event handlers

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -26,7 +26,7 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Uno.UI.RemoteControl.VS
 {
-	public class EntryPoint
+	public class EntryPoint : IDisposable
 	{
 		private const string UnoPlatformOutputPane = "Uno Platform";
 		private const string FolderKind = "{66A26720-8FB5-11D2-AA7E-00C04F688DDE}";
@@ -44,6 +44,11 @@ namespace Uno.UI.RemoteControl.VS
 
 		private int RemoteControlServerPort;
 		private bool _closing;
+		private bool _isDisposed;
+
+		private readonly _dispSolutionEvents_BeforeClosingEventHandler _closeHandler;
+		private readonly _dispBuildEvents_OnBuildDoneEventHandler _onBuildDoneHandler;
+		private readonly _dispBuildEvents_OnBuildProjConfigBeginEventHandler _onBuildProjConfigBeginHandler;
 
 		public EntryPoint(DTE2 dte2, string toolsPath, AsyncPackage asyncPackage, Action<Func<Task<Dictionary<string, string>>>> globalPropertiesProvider)
 		{
@@ -55,13 +60,14 @@ namespace Uno.UI.RemoteControl.VS
 
 			SetupOutputWindow();
 
-			_dte.Events.SolutionEvents.BeforeClosing += () => SolutionEvents_BeforeClosing();
+			_closeHandler = () => SolutionEvents_BeforeClosing();
+			_dte.Events.SolutionEvents.BeforeClosing += _closeHandler;
 
-			_dte.Events.BuildEvents.OnBuildDone +=
-				(s, a) => BuildEvents_OnBuildDone(s, a);
+			_onBuildDoneHandler = (s, a) => BuildEvents_OnBuildDone(s, a);
+			_dte.Events.BuildEvents.OnBuildDone += _onBuildDoneHandler;
 
-			_dte.Events.BuildEvents.OnBuildProjConfigBegin +=
-				(string project, string projectConfig, string platform, string solutionConfig) => _ = BuildEvents_OnBuildProjConfigBeginAsync(project, projectConfig, platform, solutionConfig);
+			_onBuildProjConfigBeginHandler = (string project, string projectConfig, string platform, string solutionConfig) => _ = BuildEvents_OnBuildProjConfigBeginAsync(project, projectConfig, platform, solutionConfig);
+			_dte.Events.BuildEvents.OnBuildProjConfigBegin += _onBuildProjConfigBeginHandler;
 
 			// Start the RC server early, as iOS and Android projects capture the globals early
 			// and don't recreate it unless out-of-process msbuild.exe instances are terminated.
@@ -202,6 +208,9 @@ namespace Uno.UI.RemoteControl.VS
 
 		private void SolutionEvents_BeforeClosing()
 		{
+			// Detach event handler to avoid this being called multiple times
+			_dte.Events.SolutionEvents.BeforeClosing -= _closeHandler;
+
 			if (_process != null)
 			{
 				try
@@ -218,6 +227,9 @@ namespace Uno.UI.RemoteControl.VS
 				{
 					_closing = true;
 					_process = null;
+
+					// Invoke Dispose to make sure other event handlers are detached
+					Dispose();
 				}
 			}
 		}
@@ -404,5 +416,25 @@ namespace Uno.UI.RemoteControl.VS
 				|| (ismacOSApp && isExe)
 				|| isWasm;
 		}
+
+		public void Dispose()
+		{
+			if (_isDisposed)
+			{
+				return;
+			}
+			_isDisposed = true;
+
+			try
+			{
+				_dte.Events.BuildEvents.OnBuildDone -= _onBuildDoneHandler;
+				_dte.Events.BuildEvents.OnBuildProjConfigBegin += _onBuildProjConfigBeginHandler;
+			}
+			catch (Exception e)
+			{
+				_debugAction($"Failed to dispose Remote Control server: {e}");
+			}
+		}
+
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12784 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Multiple instances of the remote control server launched if closing and reopening solutions in same instance of VS

## What is the new behavior?

Remove control server entrypoint class detaches event handlers

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d5acf3</samp>

Refactor `EntryPoint` class to implement `IDisposable` and detach event handlers. This improves memory and error handling for the remote control extension.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
