### PR TITLE
fix: Properly update `WebView` history properties

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
@@ -94,7 +94,7 @@ public class Given_WebView2
 		Assert.IsFalse(webView.CanGoForward);
 
 		webView.NavigationCompleted += (sender, e) => navigated = true;
-		webView.CoreWebView2.Navigate("https://www.google.com/");
+		webView.CoreWebView2.Navigate("https://example.com/1");
 		await TestServices.WindowHelper.WaitFor(() => navigated);
 
 		Assert.IsFalse(webView.CoreWebView2.CanGoBack);
@@ -103,7 +103,7 @@ public class Given_WebView2
 		Assert.IsFalse(webView.CanGoForward);
 
 		navigated = false;
-		webView.CoreWebView2.Navigate("https://www.bing.com/");
+		webView.CoreWebView2.Navigate("https://example.com/2");
 		await TestServices.WindowHelper.WaitFor(() => navigated);
 
 		Assert.IsTrue(webView.CoreWebView2.CanGoBack);

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
@@ -69,7 +69,54 @@ public class Given_WebView2
 		navigationDone = false;
 		webView.NavigateToString("<html></html>");
 		await TestServices.WindowHelper.WaitFor(() => navigationDone, 3000);
+#if HAS_UNO
 		Assert.AreEqual(CoreWebView2.BlankUri, webView.Source);
+#endif
+	}
+
+
+	[TestMethod]
+	public async Task When_GoBack()
+	{
+		var border = new Border();
+		var webView = new WebView2();
+		webView.Width = 200;
+		webView.Height = 200;
+		border.Child = webView;
+		TestServices.WindowHelper.WindowContent = border;
+		bool navigated = false;
+		await TestServices.WindowHelper.WaitForLoaded(border);
+		await webView.EnsureCoreWebView2Async();
+
+		Assert.IsFalse(webView.CoreWebView2.CanGoBack);
+		Assert.IsFalse(webView.CanGoBack);
+		Assert.IsFalse(webView.CoreWebView2.CanGoForward);
+		Assert.IsFalse(webView.CanGoForward);
+
+		webView.NavigationCompleted += (sender, e) => navigated = true;
+		webView.CoreWebView2.Navigate("https://www.google.com/");
+		await TestServices.WindowHelper.WaitFor(() => navigated);
+
+		Assert.IsFalse(webView.CoreWebView2.CanGoBack);
+		Assert.IsFalse(webView.CanGoBack);
+		Assert.IsFalse(webView.CoreWebView2.CanGoForward);
+		Assert.IsFalse(webView.CanGoForward);
+
+		navigated = false;
+		webView.CoreWebView2.Navigate("https://www.bing.com/");
+		await TestServices.WindowHelper.WaitFor(() => navigated);
+
+		Assert.IsTrue(webView.CoreWebView2.CanGoBack);
+		Assert.IsTrue(webView.CanGoBack);
+
+		navigated = false;
+		webView.GoBack();
+		await TestServices.WindowHelper.WaitFor(() => navigated);
+
+		Assert.IsFalse(webView.CoreWebView2.CanGoBack);
+		Assert.IsFalse(webView.CanGoBack);
+		Assert.IsTrue(webView.CoreWebView2.CanGoForward);
+		Assert.IsTrue(webView.CanGoForward);
 	}
 
 #if __ANDROID__ || __IOS__
@@ -227,7 +274,6 @@ public class Given_WebView2
 
 		await TestHelper.RetryAssert(Do, 3);
 	}
-
 
 	[TestMethod]
 	public async Task When_ExecuteScriptAsync_Non_String()

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
@@ -95,7 +95,7 @@ public class Given_WebView2
 
 		webView.NavigationCompleted += (sender, e) => navigated = true;
 		webView.CoreWebView2.Navigate("https://example.com/1");
-		await TestServices.WindowHelper.WaitFor(() => navigated);
+		await TestServices.WindowHelper.WaitFor(() => navigated, 3000);
 
 		Assert.IsFalse(webView.CoreWebView2.CanGoBack);
 		Assert.IsFalse(webView.CanGoBack);
@@ -104,14 +104,14 @@ public class Given_WebView2
 
 		navigated = false;
 		webView.CoreWebView2.Navigate("https://example.com/2");
-		await TestServices.WindowHelper.WaitFor(() => navigated);
+		await TestServices.WindowHelper.WaitFor(() => navigated, 3000);
 
 		Assert.IsTrue(webView.CoreWebView2.CanGoBack);
 		Assert.IsTrue(webView.CanGoBack);
 
 		navigated = false;
 		webView.GoBack();
-		await TestServices.WindowHelper.WaitFor(() => navigated);
+		await TestServices.WindowHelper.WaitFor(() => navigated, 3000);
 
 		Assert.IsFalse(webView.CoreWebView2.CanGoBack);
 		Assert.IsFalse(webView.CanGoBack);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_WebView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_WebView.cs
@@ -3,10 +3,12 @@ using System.Threading.Tasks;
 using Private.Infrastructure;
 using Windows.UI.Xaml.Controls;
 using System.Linq;
+using Microsoft.UI.Xaml.Controls;
+
+
 #if HAS_UNO
 using Uno.UI.Xaml.Controls;
 #endif
-
 #if __IOS__
 using UIKit;
 using _View = UIKit.UIView;
@@ -102,6 +104,42 @@ public class Given_WebView
 
 	}
 #endif
+
+	[TestMethod]
+	public async Task When_GoBack()
+	{
+		var border = new Border();
+		var webView = new WebView();
+		webView.Width = 200;
+		webView.Height = 200;
+		border.Child = webView;
+		TestServices.WindowHelper.WindowContent = border;
+		bool navigated = false;
+		await TestServices.WindowHelper.WaitForLoaded(border);
+
+		Assert.IsFalse(webView.CanGoBack);
+		Assert.IsFalse(webView.CanGoForward);
+
+		webView.NavigationCompleted += (sender, e) => navigated = true;
+		webView.Navigate(new Uri("https://www.google.com/"));
+		await TestServices.WindowHelper.WaitFor(() => navigated, 3000);
+
+		Assert.IsFalse(webView.CanGoBack);
+		Assert.IsFalse(webView.CanGoForward);
+
+		navigated = false;
+		webView.Navigate(new Uri("https://www.bing.com/"));
+		await TestServices.WindowHelper.WaitFor(() => navigated, 3000);
+
+		Assert.IsTrue(webView.CanGoBack);
+
+		navigated = false;
+		webView.GoBack();
+		await TestServices.WindowHelper.WaitFor(() => navigated, 3000);
+
+		Assert.IsFalse(webView.CanGoBack);
+		Assert.IsTrue(webView.CanGoForward);
+	}
 
 #if !HAS_UNO
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_WebView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_WebView.cs
@@ -121,14 +121,14 @@ public class Given_WebView
 		Assert.IsFalse(webView.CanGoForward);
 
 		webView.NavigationCompleted += (sender, e) => navigated = true;
-		webView.Navigate(new Uri("https://www.google.com/"));
+		webView.Navigate(new Uri("https://example.com/1"));
 		await TestServices.WindowHelper.WaitFor(() => navigated, 3000);
 
 		Assert.IsFalse(webView.CanGoBack);
 		Assert.IsFalse(webView.CanGoForward);
 
 		navigated = false;
-		webView.Navigate(new Uri("https://www.bing.com/"));
+		webView.Navigate(new Uri("https://example.com/2"));
 		await TestServices.WindowHelper.WaitFor(() => navigated, 3000);
 
 		Assert.IsTrue(webView.CanGoBack);

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.cs
@@ -163,6 +163,12 @@ public partial class CoreWebView2
 
 	internal void RaiseHistoryChanged() => HistoryChanged?.Invoke(this, null);
 
+	internal void SetHistoryProperties(bool canGoBack, bool canGoForward)
+	{
+		CanGoBack = canGoBack;
+		CanGoForward = canGoForward;
+	}
+
 	internal void RaiseWebMessageReceived(string message) => WebMessageReceived?.Invoke(this, new(message));
 
 	internal void RaiseUnsupportedUriSchemeIdentified(Uri targetUri, out bool handled)
@@ -171,13 +177,6 @@ public partial class CoreWebView2
 		UnsupportedUriSchemeIdentified?.Invoke(this, args);
 
 		handled = args.Handled;
-	}
-
-	internal void SetHistoryProperties(bool canGoBack, bool canGoForward)
-	{
-		CanGoBack = canGoBack;
-		CanGoForward = canGoForward;
-		RaiseHistoryChanged();
 	}
 
 	internal static bool GetIsHistoryEntryValid(string url) =>

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/InternalWebClient.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/InternalWebClient.Android.cs
@@ -62,6 +62,7 @@ internal class InternalClient : Android.Webkit.WebViewClient
 	{
 		_coreWebView.DocumentTitle = view.Title;
 
+		_nativeWebViewWrapper.RefreshHistoryProperties();
 		_coreWebView.RaiseHistoryChanged();
 
 		var uri = !_nativeWebViewWrapper._wasLoadedFromString && !string.IsNullOrEmpty(url) ? new Uri(url) : null;

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebViewWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebViewWrapper.Android.cs
@@ -191,7 +191,7 @@ internal class NativeWebViewWrapper : INativeWebView
 	// Because Android doesn't let you modify the navigation history, 
 	// we need CanGoBack, CanGoForward, GoBack and GoForward to take the above condition into consideration.
 
-	internal void OnNavigationHistoryChanged()
+	internal void RefreshHistoryProperties()
 	{
 		// A non-zero number of steps to the nearest valid history entry means that navigation in the given direction is allowed
 		var canGoBack = GetStepsToNearestValidHistoryEntry(direction: -1 /* backward */) != 0;

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/UnoWKWebView.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/UnoWKWebView.iOSmacOS.cs
@@ -423,6 +423,7 @@ public partial class UnoWKWebView : WKWebView, INativeWebView, IWKScriptMessageH
 	private void RaiseNavigationCompleted(Uri uri, bool isSuccess, int httpStatusCode, CoreWebView2WebErrorStatus errorStatus)
 	{
 		_coreWebView.SetHistoryProperties(CanGoBack, CanGoForward);
+		_coreWebView.RaiseHistoryChanged();
 		_coreWebView.RaiseNavigationCompleted(uri, isSuccess, httpStatusCode, errorStatus);
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/nventive-private/issues/496

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96999a8</samp>

This pull request updates the `WebView` and `WebView2` controls to use the WinUI 3 namespace and to improve the history management of the `CoreWebView2` class. It adds or modifies tests for the navigation history methods of both controls. It also changes the names and calls of some methods in the native web view wrappers for Android, iOS, and macOS to reflect the history state changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
