### PR TITLE
feat: Adding hot reload mapping dictionary for replaced types

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -208,14 +208,12 @@ namespace Uno.UI.RemoteControl.HotReload
 
 		public static void UpdateApplication(Type[] types)
 		{
-			var meta = (from t in types
-						let update = t.GetCustomAttribute<System.Runtime.CompilerServices.MetadataUpdateOriginalTypeAttribute>()
-						where update is not null
-						select (Type: t, OriginalType: update.OriginalType)).ToArray();
-
-			foreach (var t in meta)
+			foreach (var t in types)
 			{
-				TypeMappingHelper.RegisterMapping(t.Type, t.OriginalType);
+				if (t.GetCustomAttribute<System.Runtime.CompilerServices.MetadataUpdateOriginalTypeAttribute>() is { } update)
+				{
+					TypeMappingHelper.RegisterMapping(t, update.OriginalType);
+				}
 			}
 
 			if (_log.IsEnabled(LogLevel.Trace))

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -208,6 +208,16 @@ namespace Uno.UI.RemoteControl.HotReload
 
 		public static void UpdateApplication(Type[] types)
 		{
+			var meta = (from t in types
+						let update = t.GetCustomAttribute<System.Runtime.CompilerServices.MetadataUpdateOriginalTypeAttribute>()
+						where update is not null
+						select (Type: t, OriginalType: update.OriginalType)).ToArray();
+
+			foreach (var t in meta)
+			{
+				TypeMappingHelper.RegisterMapping(t.Type, t.OriginalType);
+			}
+
 			if (_log.IsEnabled(LogLevel.Trace))
 			{
 				_log.Trace($"UpdateApplication (changed types: {string.Join(", ", types.Select(s => s.ToString()))})");

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
+using Uno.UI.Helpers;
 using Uno.UI.RemoteControl.HotReload.Messages;
 using Uno.UI.RemoteControl.HotReload.MetadataUpdater;
 using Windows.UI.Xaml;

--- a/src/Uno.UI/Helpers/TypeMappingHelper.cs
+++ b/src/Uno.UI/Helpers/TypeMappingHelper.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Uno.UI.Helpers
+{
+	/// <summary>
+	/// Helper class to map types to their original types and vice versa as part of hot reload
+	/// </summary>
+	public static class TypeMappingHelper
+	{
+		/// <summary>
+		/// This maps a replacement type to the original type. This dictionary will grow with each iteration 
+		/// of the original type.
+		/// </summary>
+		private static IDictionary<Type, Type> MappedTypeToOrignalTypeMapings { get; } = new Dictionary<Type, Type>();
+
+		/// <summary>
+		/// This maps an original type to the most recent replacement type. This dictionary will only grow when
+		/// a different original type is modified.
+		/// </summary>
+		private static IDictionary<Type, Type> OriginalTypeToMappedType { get; } = new Dictionary<Type, Type>();
+
+		/// <summary>
+		/// Extension method to return the replacement type for a given instance type
+		/// </summary>
+		/// <param name="instanceType">This is the type that may have been replaced</param>
+		/// <returns>If instanceType has been replaced, then the replacement type, otherwise the instanceType</returns>
+		public static Type GetReplacementType(this Type instanceType)
+		{
+			// Two scenarios:
+			// 1. The instance type is a mapped type, in which case we need to get the original type
+			// 2. The instance type is an original type, in which case we need to get the mapped type
+			var originalType = GetOriginalType(instanceType) ?? instanceType;
+			return originalType.GetMappedType() ?? instanceType;
+		}
+
+		internal static Type GetMappedType(this Type originalType) =>
+			OriginalTypeToMappedType.TryGetValue(originalType, out var mappedType) ? mappedType : default;
+
+		internal static Type GetOriginalType(this Type mappedType) =>
+			MappedTypeToOrignalTypeMapings.TryGetValue(mappedType, out var originalType) ? originalType : default;
+
+		internal static bool IsReplacedBy(this Type sourceType, Type mappedType)
+		{
+			if (mappedType.GetOriginalType() is { } originalType)
+			{
+				if (originalType == sourceType)
+				{
+					return true;
+				}
+				return sourceType.GetOriginalType()?.GetMappedType() == mappedType;
+			}
+
+			return false;
+		}
+
+		internal static void RegisterMapping(Type mappedType, Type originalType)
+		{
+			MappedTypeToOrignalTypeMapings[mappedType] = originalType;
+			OriginalTypeToMappedType[originalType] = mappedType;
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #https://github.com/unoplatform/uno/issues/12790

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

When types are replaced the UpdateApplication method in the ClientHotReloadProcessor is already called but there's no tracking of the replacement types

## What is the new behavior?

This change creates two mapping dictionaries to allow for mapping between original types and their replacements.
The TypeMappingHelper exposes a single public method, GetReplacementType, for retrieving the current replacement type for a particular type (instanceType). The instanceType could be the original type (if no prior replacements), or it could be an existing replacement type.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8697db</samp>

This pull request adds support for hot reload with XAML bindings and resources by mapping the updated types to their original types using a new `TypeMappingHelper` class and a custom attribute. It modifies the `ClientHotReloadProcessor` class and the `ClientHotReloadProcessor.MetadataUpdate.cs` file to use the type mapping feature.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [N/A] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [N/A] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

