### PR TITLE
fix: Fix ListView selection when items are duplicated

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1614,6 +1614,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_DuplicateItem.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Snap_Rubberband.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5729,6 +5733,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_BringIntoView.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\SvgImageSource_FromMsAppData.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_DuplicateItem.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Snap_Rubberband.xaml.cs">
       <DependentUpon>ListView_Snap_Rubberband.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DuplicateItem.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DuplicateItem.xaml
@@ -1,0 +1,22 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.ListView.ListView_DuplicateItem"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ListView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<ListView x:Name="listView">
+		<ListView.ItemTemplate>
+			<DataTemplate>
+				<TextBlock
+                    HorizontalAlignment="Stretch"
+                    Text="{Binding}"
+                    TextWrapping="Wrap" />
+			</DataTemplate>
+		</ListView.ItemTemplate>
+	</ListView>
+
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DuplicateItem.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DuplicateItem.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.ObjectModel;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.ListView
+{
+	[Sample("ListView")]
+	public sealed partial class ListView_DuplicateItem : Page
+	{
+		public ListView_DuplicateItem()
+		{
+			this.InitializeComponent();
+			var items = new ObservableCollection<string>(new[]
+			{
+				"String 1",
+				"String 1",
+				"String 1",
+				"String 2",
+				"String 2",
+				"String 2",
+				"String 3",
+				"String 3",
+				"String 3",
+				"String 1",
+				"String 1",
+				"String 1",
+				"String 2",
+				"String 2",
+				"String 2",
+				"String 3",
+				"String 3",
+				"String 3",
+			});
+			listView.ItemsSource = items;
+
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -2854,7 +2854,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Items_Have_Duplicates_FlipView() => await When_Items_Have_Duplicates_Common(new FlipView());
 
-		private async Task When_Items_Have_Duplicates_Common(ListViewBase sut)
+		private async Task When_Items_Have_Duplicates_Common(Selector sut)
 		{
 			var items = new ObservableCollection<string>(new[]
 			{
@@ -2925,7 +2925,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Items_Are_Equal_But_Different_References_FlipView() => await When_Items_Are_Equal_But_Different_References_Common(new FlipView());
 
-		private async Task When_Items_Are_Equal_But_Different_References_Common(ListViewBase sut)
+		private async Task When_Items_Are_Equal_But_Different_References_Common(Selector sut)
 		{
 			var obj1 = new AlwaysEqualClass();
 			var obj2 = new AlwaysEqualClass();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -2843,9 +2843,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-		public async Task When_Items_Have_Duplicates()
+		public async Task When_Items_Have_Duplicates_ListView() => await When_Items_Have_Duplicates_Common(new ListView());
+
+		[TestMethod]
+		public async Task When_Items_Have_Duplicates_GridView() => await When_Items_Have_Duplicates_Common(new GridView());
+
+		[TestMethod]
+		public async Task When_Items_Have_Duplicates_ComboBox() => await When_Items_Have_Duplicates_Common(new ComboBox());
+
+		[TestMethod]
+		public async Task When_Items_Have_Duplicates_FlipView() => await When_Items_Have_Duplicates_Common(new FlipView());
+
+		private async Task When_Items_Have_Duplicates_Common(ListViewBase sut)
 		{
-			var sut = new ListView();
 			var items = new ObservableCollection<string>(new[]
 			{
 				"String 1",
@@ -2904,11 +2914,21 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-		public async Task When_Items_Are_Equal_But_Different_References()
+		public async Task When_Items_Are_Equal_But_Different_References_ListView() => await When_Items_Are_Equal_But_Different_References_Common(new ListView());
+
+		[TestMethod]
+		public async Task When_Items_Are_Equal_But_Different_References_GridView() => await When_Items_Are_Equal_But_Different_References_Common(new GridView());
+
+		[TestMethod]
+		public async Task When_Items_Are_Equal_But_Different_References_ComboBox() => await When_Items_Are_Equal_But_Different_References_Common(new ComboBox());
+
+		[TestMethod]
+		public async Task When_Items_Are_Equal_But_Different_References_FlipView() => await When_Items_Are_Equal_But_Different_References_Common(new FlipView());
+
+		private async Task When_Items_Are_Equal_But_Different_References_Common(ListViewBase sut)
 		{
 			var obj1 = new AlwaysEqualClass();
 			var obj2 = new AlwaysEqualClass();
-			var sut = new ListView();
 			var items = new ObservableCollection<AlwaysEqualClass>(new[]
 			{
 				obj1, obj2

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -2896,7 +2896,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var added2 = list[1].AddedItems;
 			var added3 = list[2].AddedItems;
 
-			Assert.AreEqual(0, removed1.Count);
+			if (sut is FlipView)
+			{
+				Assert.AreEqual("String 1", (string)removed1.Single());
+			}
+			else
+			{
+				Assert.AreEqual(0, removed1.Count);
+			}
+
 			Assert.AreEqual("String 1", (string)added1.Single());
 
 			Assert.AreEqual("String 1", (string)removed2.Single());
@@ -2950,7 +2958,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var added1 = list[0].AddedItems;
 			var added2 = list[1].AddedItems;
 
-			Assert.AreEqual(0, removed1.Count);
+			if (sut is FlipView)
+			{
+				Assert.AreSame(obj1, removed1.Single());
+			}
+			else
+			{
+				Assert.AreEqual(0, removed1.Count);
+			}
 			Assert.AreSame(obj2, added1.Single());
 
 			Assert.AreSame(obj2, removed2.Single());

--- a/src/Uno.UI/UI/Xaml/Controls/FlipView/FlipView.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/FlipView/FlipView.managed.cs
@@ -1432,12 +1432,6 @@ namespace Windows.UI.Xaml.Controls
 				case "Visibility":
 					OnVisibilityChanged();
 					break;
-
-				case "SelectedIndex":
-					{
-						OnSelectedIndexChanged((int)args.OldValue, (int)args.NewValue);
-					}
-					break;
 			}
 
 			base.OnPropertyChanged2(args);

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -263,6 +263,11 @@ namespace Windows.UI.Xaml.Controls
 					case ListViewSelectionMode.None:
 						break;
 					case ListViewSelectionMode.Single:
+						if (_changingSelectedIndex)
+						{
+							break;
+						}
+
 						var index = IndexFromItem(item);
 						if (!newIsSelected)
 						{
@@ -381,8 +386,16 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnSelectedIndexChanged(oldSelectedIndex, newSelectedIndex);
 
-			//SetSelectedState(oldSelectedIndex, false);
-			//SetSelectedState(newSelectedIndex, true);
+			try
+			{
+				_changingSelectedIndex = true;
+				SetSelectedState(oldSelectedIndex, false);
+				SetSelectedState(newSelectedIndex, true);
+			}
+			finally
+			{
+				_changingSelectedIndex = false;
+			}
 		}
 
 		public event ItemClickEventHandler ItemClick;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -200,7 +200,7 @@ namespace Windows.UI.Xaml.Controls
 			try
 			{
 				_modifyingSelectionInternally = true;
-				_isSelectionActive = true;
+				_isUpdatingSelection = true;
 				var itemIndex = SelectedItems.Select(item => (int?)items.IndexOf(item)).FirstOrDefault(index => index > -1);
 				if (itemIndex != null)
 				{
@@ -219,7 +219,7 @@ namespace Windows.UI.Xaml.Controls
 			finally
 			{
 				_modifyingSelectionInternally = false;
-				_isSelectionActive = false;
+				_isUpdatingSelection = false;
 			}
 			if (validAdditions.Any() || validRemovals.Any())
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -200,7 +200,7 @@ namespace Windows.UI.Xaml.Controls
 			try
 			{
 				_modifyingSelectionInternally = true;
-
+				_isSelectionActive = true;
 				var itemIndex = SelectedItems.Select(item => (int?)items.IndexOf(item)).FirstOrDefault(index => index > -1);
 				if (itemIndex != null)
 				{
@@ -219,6 +219,7 @@ namespace Windows.UI.Xaml.Controls
 			finally
 			{
 				_modifyingSelectionInternally = false;
+				_isSelectionActive = false;
 			}
 			if (validAdditions.Any() || validRemovals.Any())
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -303,9 +303,13 @@ namespace Windows.UI.Xaml.Controls.Primitives
 					collectionView.MoveCurrentToPosition(newSelectedIndex);
 					//TODO: we should check if CurrentPosition actually changes, and set SelectedIndex back if not.
 				}
-				if (!object.Equals(SelectedItem, newSelectedItem))
+				if (!object.ReferenceEquals(SelectedItem, newSelectedItem))
 				{
 					SelectedItem = newSelectedItem;
+				}
+				else
+				{
+					InvokeSelectionChanged(new[] { SelectedItem }, new[] { newSelectedItem });
 				}
 
 				SelectedIndexPath = GetIndexPathFromIndex(SelectedIndex);

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 	public partial class Selector : ItemsControl
 	{
 		private protected ScrollViewer m_tpScrollViewer;
-		protected bool _changingSelectedIndex;
+		private protected bool _changingSelectedIndex;
 
 		private protected IVirtualizingPanel VirtualizingPanel => ItemsPanelRoot as IVirtualizingPanel;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -22,7 +22,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 	{
 		private protected ScrollViewer m_tpScrollViewer;
 		private protected bool _changingSelectedIndex;
-		private protected bool _isSelectionActive;
+		private protected bool _isUpdatingSelection;
 
 		private protected IVirtualizingPanel VirtualizingPanel => ItemsPanelRoot as IVirtualizingPanel;
 
@@ -146,8 +146,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				}
 			}
 
-			var shouldRaiseSelectionChanged = !_isSelectionActive;
-			_isSelectionActive = true;
+			var shouldRaiseSelectionChanged = !_isUpdatingSelection;
+			_isUpdatingSelection = true;
 
 			// If SelectedIndex is -1 and SelectedItem is being changed from non-null to null, this indicates that we're desetting
 			// SelectedItem, not setting a null inside the collection as selected. Little edge case there. (Note that this relies
@@ -176,12 +176,13 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				TryUpdateSelectorItemIsSelected(selectedItem, true);
 			}
 
-			_isSelectionActive = false;
+			_isUpdatingSelection = false;
 
 			if (shouldRaiseSelectionChanged)
 			{
 				// Setting SelectedIndex above will have already invoked the SelectionChanged.
-				InvokeSelectionChanged(wasSelectionUnset ? Array.Empty<object>() : new[] { oldSelectedItem },
+				InvokeSelectionChanged(
+					wasSelectionUnset ? Array.Empty<object>() : new[] { oldSelectedItem },
 					isSelectionUnset ? Array.Empty<object>() : new[] { selectedItem }
 				);
 			}
@@ -306,8 +307,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			try
 			{
 				_changingSelectedIndex = true;
-				var shouldRaiseSelectionChanged = !_isSelectionActive;
-				_isSelectionActive = true;
+				var shouldRaiseSelectionChanged = !_isUpdatingSelection;
+				_isUpdatingSelection = true;
 				var oldSelectedItem = SelectedItem;
 				var newSelectedItem = ItemFromIndex(newSelectedIndex);
 
@@ -322,7 +323,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				}
 
 				SelectedIndexPath = GetIndexPathFromIndex(SelectedIndex);
-				_isSelectionActive = false;
+				_isUpdatingSelection = false;
 				if (shouldRaiseSelectionChanged)
 				{
 					InvokeSelectionChanged(

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -63,10 +63,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 			if (args.Property == SelectedItemProperty)
 			{
-				if (!_changingSelectedIndex)
-				{
-					OnSelectedItemChanged(args.OldValue, args.NewValue, updateItemSelectedState: true);
-				}
+				OnSelectedItemChanged(args.OldValue, args.NewValue, updateItemSelectedState: true);
 			}
 			else if (args.Property == SelectedIndexProperty)
 			{
@@ -156,17 +153,20 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				isSelectionUnset = true;
 			}
 
-			var newIndex = IndexFromItem(selectedItem);
-			if (SelectedIndex != newIndex)
+			if (!_changingSelectedIndex)
 			{
-				SelectedIndex = newIndex;
+				var newIndex = IndexFromItem(selectedItem);
+				if (SelectedIndex != newIndex)
+				{
+					SelectedIndex = newIndex;
+				}
 			}
 
 			OnSelectedItemChangedPartial(oldSelectedItem, selectedItem);
 
 			UpdateSelectedValue();
 
-			if (updateItemSelectedState)
+			if (updateItemSelectedState && !_changingSelectedIndex)
 			{
 				TryUpdateSelectorItemIsSelected(oldSelectedItem, false);
 				TryUpdateSelectorItemIsSelected(selectedItem, true);
@@ -346,6 +346,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		private void OnSelectedValueChanged(object oldValue, object newValue)
 		{
+			if (_changingSelectedIndex)
+			{
+				return;
+			}
 
 			var (indexOfItemWithValue, itemWithValue) = FindIndexOfItemWithValue(newValue);
 			SelectedIndex = indexOfItemWithValue;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12783

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d92648</samp>

This pull request adds a new UI test for `ListView` with duplicate items, and improves the selection logic and debugging output of the `ListView` and `Selector` classes. It modifies the files `ListView.cs`, `ListViewBase.cs`, and `Selector.cs` in the Uno.UI project, and creates the files `ListView_DuplicateItem.xaml` and `ListView_DuplicateItem.xaml.cs` in the UITests.Shared project.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
