### PR TITLE
fix: Correcting startup location for remote control service

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -260,7 +260,8 @@ namespace Uno.UI.RemoteControl.VS
 			{
 				RemoteControlServerPort = GetTcpPort();
 
-				var runtimeVersionPath = GetDotnetMajorVersion() > 5 ? "netcoreapp3.1" : "net6.0";
+				var version = GetDotnetMajorVersion();
+				var runtimeVersionPath = version <= 5 ? "netcoreapp3.1" : $"net{version}.0";
 
 				var sb = new StringBuilder();
 

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -428,7 +428,7 @@ namespace Uno.UI.RemoteControl.VS
 			try
 			{
 				_dte.Events.BuildEvents.OnBuildDone -= _onBuildDoneHandler;
-				_dte.Events.BuildEvents.OnBuildProjConfigBegin += _onBuildProjConfigBeginHandler;
+				_dte.Events.BuildEvents.OnBuildProjConfigBegin -= _onBuildProjConfigBeginHandler;
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12800 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Remote control service looks for the host library in wrong folder (netcoreapp3.1 folder instead of net7/8)

## What is the new behavior?

Remote control service look for the correct folder

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9680d9</samp>

Fix remote control server issues for Uno Platform. Improve compatibility with `dotnet 6` and prevent memory leak from event handler in `EntryPoint.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [N/A] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [N/A] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

