### PR TITLE
fix: Use the correct default value for string DPs

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/AnimatedIcon/AnimatedIcon.Properties.cs
@@ -46,7 +46,7 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty StateProperty { get; } =
-			DependencyProperty.RegisterAttached("State", typeof(string), typeof(AnimatedIcon), new FrameworkPropertyMetadata(null, OnAnimatedIconStatePropertyChanged));
+			DependencyProperty.RegisterAttached("State", typeof(string), typeof(AnimatedIcon), new FrameworkPropertyMetadata(string.Empty, OnAnimatedIconStatePropertyChanged));
 
 		private static void OnFallbackIconSourcePropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs args)
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBar.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBar.Properties.cs
@@ -189,7 +189,7 @@ namespace Microsoft.UI.Xaml.Controls
 		/// Identifies the Message dependency property.
 		/// </summary>
 		public static DependencyProperty MessageProperty { get; } =
-			DependencyProperty.Register(nameof(Message), typeof(string), typeof(InfoBar), new FrameworkPropertyMetadata(null));
+			DependencyProperty.Register(nameof(Message), typeof(string), typeof(InfoBar), new FrameworkPropertyMetadata(string.Empty));
 
 		/// <summary>
 		/// Gets or sets the type of the InfoBar to apply consistent status color, icon,
@@ -232,7 +232,7 @@ namespace Microsoft.UI.Xaml.Controls
 		/// Identifies the Title dependency property.
 		/// </summary>
 		public static DependencyProperty TitleProperty { get; } =
-			DependencyProperty.Register(nameof(Title), typeof(string), typeof(InfoBar), new FrameworkPropertyMetadata(null));
+			DependencyProperty.Register(nameof(Title), typeof(string), typeof(InfoBar), new FrameworkPropertyMetadata(string.Empty));
 
 		private static void OnIconSourcePropertyChanged(
 			DependencyObject sender,

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBarItem.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBarItem.Properties.cs
@@ -36,6 +36,6 @@ namespace Microsoft.UI.Xaml.Controls
 				"Title",
 				typeof(string),
 				typeof(MenuBarItem),
-				new FrameworkPropertyMetadata(default(string)));
+				new FrameworkPropertyMetadata(string.Empty));
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.Properties.cs
@@ -492,7 +492,7 @@ namespace Microsoft.UI.Xaml.Controls
 		/// Identifies the PaneTitle dependency property.
 		/// </summary>
 		public static DependencyProperty PaneTitleProperty { get; } =
-			DependencyProperty.Register(nameof(PaneTitle), typeof(string), typeof(NavigationView), new FrameworkPropertyMetadata(string.Empty, OnPropertyChanged)); //TODO: Empty string or null?
+			DependencyProperty.Register(nameof(PaneTitle), typeof(string), typeof(NavigationView), new FrameworkPropertyMetadata(string.Empty, OnPropertyChanged));
 
 		/// <summary>
 		/// Gets or sets the Style that defines the look of the menu toggle button.

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.Properties.cs
@@ -120,7 +120,7 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty PlaceholderTextProperty { get; } =
-			DependencyProperty.Register(nameof(PlaceholderText), typeof(string), typeof(NumberBox), new FrameworkPropertyMetadata(null));
+			DependencyProperty.Register(nameof(PlaceholderText), typeof(string), typeof(NumberBox), new FrameworkPropertyMetadata(string.Empty));
 
 		[Uno.NotImplemented] // TODO:
 		public FlyoutBase SelectionFlyout

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PagerControl/PagerControl.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PagerControl/PagerControl.Properties.cs
@@ -123,7 +123,7 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty PrefixTextProperty { get; } =
-			DependencyProperty.Register(nameof(PrefixText), typeof(string), typeof(PagerControl), new FrameworkPropertyMetadata(null, OnPropertyChanged));
+			DependencyProperty.Register(nameof(PrefixText), typeof(string), typeof(PagerControl), new FrameworkPropertyMetadata(string.Empty, OnPropertyChanged));
 
 		public ICommand PreviousButtonCommand
 		{
@@ -168,7 +168,7 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty SuffixTextProperty { get; } =
-			DependencyProperty.Register(nameof(SuffixText), typeof(string), typeof(PagerControl), new FrameworkPropertyMetadata(null, OnPropertyChanged));
+			DependencyProperty.Register(nameof(SuffixText), typeof(string), typeof(PagerControl), new FrameworkPropertyMetadata(string.Empty, OnPropertyChanged));
 
 		public PagerControlTemplateSettings TemplateSettings
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PersonPicture/PersonPicture.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PersonPicture/PersonPicture.Properties.cs
@@ -105,7 +105,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(BadgeText),
 				typeof(string),
 				typeof(PersonPicture),
-				new FrameworkPropertyMetadata(default(string), OnPropertyChanged));
+				new FrameworkPropertyMetadata(string.Empty, OnPropertyChanged));
 
 		public static DependencyProperty ContactProperty { get; } =
 			DependencyProperty.Register(

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/RatingControl/RatingItemFontInfo.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/RatingControl/RatingItemFontInfo.cs
@@ -31,7 +31,7 @@ public partial class RatingItemFontInfo : RatingItemInfo
 	/// Identifies the DisabledGlyph dependency property.
 	/// </summary>
 	public static DependencyProperty DisabledGlyphProperty { get; } =
-		DependencyProperty.Register(nameof(DisabledGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(null));
+		DependencyProperty.Register(nameof(DisabledGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(string.Empty));
 
 	/// <summary>
 	/// Gets or sets a Segoe MDL2 Assets font glyph that represents a rating element that has been set by the user.
@@ -46,7 +46,7 @@ public partial class RatingItemFontInfo : RatingItemInfo
 	/// Identifies the Glyph dependency property.
 	/// </summary>
 	public static DependencyProperty GlyphProperty { get; } =
-		DependencyProperty.Register(nameof(Glyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(null));
+		DependencyProperty.Register(nameof(Glyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(string.Empty));
 
 	/// <summary>
 	/// Gets or sets a Segoe MDL2 Assets font glyph that represents a rating element that is showing a placeholder value.
@@ -61,7 +61,7 @@ public partial class RatingItemFontInfo : RatingItemInfo
 	/// Identifies the PlaceholderGlyph dependency property.
 	/// </summary>
 	public static DependencyProperty PlaceholderGlyphProperty { get; } =
-		DependencyProperty.Register(nameof(PlaceholderGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(null));
+		DependencyProperty.Register(nameof(PlaceholderGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(string.Empty));
 
 	/// <summary>
 	/// Gets or sets a Segoe MDL2 Assets font glyph that represents a rating element that has the pointer over it.
@@ -76,7 +76,7 @@ public partial class RatingItemFontInfo : RatingItemInfo
 	/// Identifies the PointerOverGlyph dependency property.
 	/// </summary>
 	public static DependencyProperty PointerOverGlyphProperty { get; } =
-		DependencyProperty.Register(nameof(PointerOverGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(null));
+		DependencyProperty.Register(nameof(PointerOverGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(string.Empty));
 
 	/// <summary>
 	/// Gets or sets a Segoe MDL2 Assets font glyph that represents a rating element showing a placeholder value with the pointer over it.
@@ -91,7 +91,7 @@ public partial class RatingItemFontInfo : RatingItemInfo
 	/// Identifies the PointerOverPlaceholderGlyph dependency property.
 	/// </summary>
 	public static DependencyProperty PointerOverPlaceholderGlyphProperty { get; } =
-		DependencyProperty.Register(nameof(PointerOverPlaceholderGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(null));
+		DependencyProperty.Register(nameof(PointerOverPlaceholderGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(string.Empty));
 
 	/// <summary>
 	/// Gets or sets a Segoe MDL2 Assets font glyph that represents a rating element that has not been set.
@@ -106,5 +106,5 @@ public partial class RatingItemFontInfo : RatingItemInfo
 	/// Identifies the UnsetGlyph dependency property.
 	/// </summary>
 	public static DependencyProperty UnsetGlyphProperty { get; } =
-		DependencyProperty.Register(nameof(UnsetGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(null));
+		DependencyProperty.Register(nameof(UnsetGlyph), typeof(string), typeof(RatingItemFontInfo), new FrameworkPropertyMetadata(string.Empty));
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/SwipeControl/SwipeItem.properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/SwipeControl/SwipeItem.properties.cs
@@ -310,7 +310,7 @@ namespace Microsoft.UI.Xaml.Controls
 		//}
 
 		public static DependencyProperty TextProperty { get; } = DependencyProperty.Register(
-			"Text", typeof(string), typeof(SwipeItem), new FrameworkPropertyMetadata(default(string), OnTextPropertyChanged));
+			"Text", typeof(string), typeof(SwipeItem), new FrameworkPropertyMetadata(string.Empty, OnTextPropertyChanged));
 
 		public string Text
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/AppBar/AppBarToggleButton.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AppBar/AppBarToggleButton.Properties.cs
@@ -23,7 +23,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public string Label
 		{
-			get => (string)GetValue(LabelProperty);
+			get => (string)GetValue(LabelProperty) ?? string.Empty;
 			set => SetValue(LabelProperty, value);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.Properties.cs
@@ -44,7 +44,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public string TextMemberPath
 		{
-			get => (string)this.GetValue(TextMemberPathProperty);
+			get => (string)this.GetValue(TextMemberPathProperty) ?? "";
 			set => this.SetValue(TextMemberPathProperty, value);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarDatePicker.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarDatePicker.Properties.cs
@@ -40,7 +40,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public string DateFormat
 		{
-			get => (string)GetValue(DateFormatProperty);
+			get => (string)GetValue(DateFormatProperty) ?? "";
 			set => SetValue(DateFormatProperty, value);
 		}
 
@@ -49,7 +49,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public string DayOfWeekFormat
 		{
-			get => (string)GetValue(DayOfWeekFormatProperty);
+			get => (string)GetValue(DayOfWeekFormatProperty) ?? "";
 			set => SetValue(DayOfWeekFormatProperty, value);
 		}
 
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty PlaceholderTextProperty { get; } = DependencyProperty.Register(
-			"PlaceholderText", typeof(string), typeof(CalendarDatePicker), new FrameworkPropertyMetadata(default(string)));
+			"PlaceholderText", typeof(string), typeof(CalendarDatePicker), new FrameworkPropertyMetadata("select a date")); // TODO: Localize?
 
 		public string PlaceholderText
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView.Properties.cs
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			get
 			{
-				return (string)this.GetValue(DayOfWeekFormatProperty);
+				return (string)this.GetValue(DayOfWeekFormatProperty) ?? "";
 			}
 			set
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/Primitives/CalendarViewTemplateSettings.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/Primitives/CalendarViewTemplateSettings.cs
@@ -34,7 +34,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"HeaderText",
 			typeof(string),
 			typeof(CalendarViewTemplateSettings),
-			new FrameworkPropertyMetadata(default(string)));
+			new FrameworkPropertyMetadata(string.Empty));
 
 		/// <summary>Gets the first day of the week.</summary>
 		/// <returns>The first day of the week.</returns>
@@ -48,7 +48,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"WeekDay1",
 			typeof(string),
 			typeof(CalendarViewTemplateSettings),
-			new FrameworkPropertyMetadata(default(string)));
+			new FrameworkPropertyMetadata(string.Empty));
 
 		/// <summary>Gets the second day of the week.</summary>
 		/// <returns>The second day of the week.</returns>
@@ -62,7 +62,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"WeekDay2",
 			typeof(string),
 			typeof(CalendarViewTemplateSettings),
-			new FrameworkPropertyMetadata(default(string)));
+			new FrameworkPropertyMetadata(string.Empty));
 
 		/// <summary>Gets the third day of the week.</summary>
 		/// <returns>The third day of the week.</returns>
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"WeekDay3",
 			typeof(string),
 			typeof(CalendarViewTemplateSettings),
-			new FrameworkPropertyMetadata(default(string)));
+			new FrameworkPropertyMetadata(string.Empty));
 
 		/// <summary>Gets the fourth day of the week.</summary>
 		/// <returns>The fourth day of the week.</returns>
@@ -90,7 +90,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"WeekDay4",
 			typeof(string),
 			typeof(CalendarViewTemplateSettings),
-			new FrameworkPropertyMetadata(default(string)));
+			new FrameworkPropertyMetadata(string.Empty));
 
 		/// <summary>Gets the fifth day of the week.</summary>
 		/// <returns>The fifth day of the week.</returns>
@@ -104,7 +104,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"WeekDay5",
 			typeof(string),
 			typeof(CalendarViewTemplateSettings),
-			new FrameworkPropertyMetadata(default(string)));
+			new FrameworkPropertyMetadata(string.Empty));
 
 		/// <summary>Gets the sixth day of the week.</summary>
 		/// <returns>The sixth day of the week.</returns>
@@ -118,7 +118,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"WeekDay6",
 			typeof(string),
 			typeof(CalendarViewTemplateSettings),
-			new FrameworkPropertyMetadata(default(string)));
+			new FrameworkPropertyMetadata(string.Empty));
 
 		/// <summary>Gets the seventh day of the week.</summary>
 		/// <returns>The seventh day of the week.</returns>
@@ -132,7 +132,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			"WeekDay7",
 			typeof(string),
 			typeof(CalendarViewTemplateSettings),
-			new FrameworkPropertyMetadata(default(string)));
+			new FrameworkPropertyMetadata(string.Empty));
 
 		/// <summary>Gets a value that indicates whether the CalendarView has more content after the displayed content.</summary>
 		/// <returns>**true** if the CalendarView has more content after the displayed content; otherwise, **false**.</returns>

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutItem.cs
@@ -93,7 +93,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public string Text
 		{
-			get { return (string)GetValue(TextProperty); }
+			get { return (string)GetValue(TextProperty) ?? ""; }
 			set { SetValue(TextProperty, value); }
 		}
 
@@ -121,7 +121,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public string KeyboardAcceleratorTextOverride
 		{
-			get => (string)this.GetValue(KeyboardAcceleratorTextOverrideProperty);
+			get => (string)this.GetValue(KeyboardAcceleratorTextOverrideProperty) ?? "";
 			set => this.SetValue(KeyboardAcceleratorTextOverrideProperty, value);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutSubItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutSubItem.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 
 		public string Text
 		{
-			get => (string)this.GetValue(TextProperty);
+			get => (string)this.GetValue(TextProperty) ?? "";
 			set => SetValue(TextProperty, value);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Properties.cs
@@ -530,7 +530,7 @@ namespace Windows.UI.Xaml.Controls
 			nameof(PaneTitle),
 			typeof(string),
 			typeof(NavigationView),
-			new FrameworkPropertyMetadata(default(string),
+			new FrameworkPropertyMetadata(string.Empty,
 				propertyChangedCallback: (s, e) => (s as NavigationView)?.OnPropertyChanged(e)));
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/PickerFlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/PickerFlyoutBase.cs
@@ -12,9 +12,17 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				typeof(PickerFlyoutBase),
 				new FrameworkPropertyMetadata(default(string)));
 
-		public static string GetTitle(DependencyObject element) => (string)element.GetValue(TitleProperty);
+		public static string GetTitle(DependencyObject element) => (string)element.GetValue(TitleProperty) ?? "";
 
-		public static void SetTitle(DependencyObject element, string value) => element.SetValue(TitleProperty, value);
+		public static void SetTitle(DependencyObject element, string value)
+		{
+			if (value == null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			element.SetValue(TitleProperty, value);
+		}
 
 		protected virtual void OnConfirmed() => throw new InvalidOperationException();
 

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView1/WebView.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView1/WebView.Properties.cs
@@ -63,7 +63,7 @@ public partial class WebView : Control
 	/// </summary>
 	public string DocumentTitle
 	{
-		get => (string)GetValue(DocumentTitleProperty);
+		get => (string)GetValue(DocumentTitleProperty) ?? "";
 		private set => SetValue(DocumentTitleProperty, value);
 	}
 
@@ -71,7 +71,7 @@ public partial class WebView : Control
 	/// Identifies the DocumentTitle dependency property.
 	/// </summary>
 	public static DependencyProperty DocumentTitleProperty { get; } =
-		DependencyProperty.Register(nameof(DocumentTitle), typeof(string), typeof(WebView), new FrameworkPropertyMetadata(null));
+		DependencyProperty.Register(nameof(DocumentTitle), typeof(string), typeof(WebView), new FrameworkPropertyMetadata(string.Empty));
 
 	public bool IsScrollEnabled
 	{

--- a/src/Uno.UI/UI/Xaml/DragDrop/DragView.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragView.cs
@@ -16,7 +16,7 @@ namespace Windows.UI.Xaml
 	{
 		#region Glyph
 		public static readonly DependencyProperty GlyphProperty = DependencyProperty.Register(
-			"Glyph", typeof(string), typeof(DragView), new FrameworkPropertyMetadata(default(string)));
+			"Glyph", typeof(string), typeof(DragView), new FrameworkPropertyMetadata(string.Empty));
 
 		public string Glyph
 		{
@@ -38,7 +38,7 @@ namespace Windows.UI.Xaml
 
 		#region Caption
 		public static readonly DependencyProperty CaptionProperty = DependencyProperty.Register(
-			"Caption", typeof(string), typeof(DragView), new FrameworkPropertyMetadata(default(string)));
+			"Caption", typeof(string), typeof(DragView), new FrameworkPropertyMetadata(string.Empty));
 
 		public string Caption
 		{

--- a/src/Uno.UI/UI/Xaml/Input/XamlUICommand.cs
+++ b/src/Uno.UI/UI/Xaml/Input/XamlUICommand.cs
@@ -33,7 +33,7 @@ namespace Windows.UI.Xaml.Input
 		/// </summary>
 		public string Label
 		{
-			get => (string)GetValue(LabelProperty);
+			get => (string)GetValue(LabelProperty) ?? "";
 			set => SetValue(LabelProperty, value);
 		}
 
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Input
 		/// </summary>
 		public string Description
 		{
-			get => (string)GetValue(DescriptionProperty);
+			get => (string)GetValue(DescriptionProperty) ?? "";
 			set => SetValue(DescriptionProperty, value);
 		}
 
@@ -71,7 +71,7 @@ namespace Windows.UI.Xaml.Input
 		/// </summary>
 		public string AccessKey
 		{
-			get => (string)GetValue(AccessKeyProperty);
+			get => (string)GetValue(AccessKeyProperty) ?? "";
 			set => SetValue(AccessKeyProperty, value);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Maps/MapControl.cs
+++ b/src/Uno.UI/UI/Xaml/Maps/MapControl.cs
@@ -92,7 +92,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 
 		public string MapServiceToken
 		{
-			get => (string)this.GetValue(MapServiceTokenProperty);
+			get => (string)this.GetValue(MapServiceTokenProperty) ?? "";
 			set => this.SetValue(MapServiceTokenProperty, value);
 		}
 
@@ -203,7 +203,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 		}
 		public string Region
 		{
-			get => (string)this.GetValue(RegionProperty);
+			get => (string)this.GetValue(RegionProperty) ?? "";
 			set => this.SetValue(RegionProperty, value);
 		}
 		public static DependencyProperty CenterProperty { get; } =

--- a/src/Uno.UI/UI/Xaml/Media/Animation/FadeInThemeAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/FadeInThemeAnimation.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		}
 
 		public static DependencyProperty TargetNameProperty { get; } = DependencyProperty.Register(
-			"TargetName", typeof(string), typeof(FadeInThemeAnimation), new FrameworkPropertyMetadata(null));
+			"TargetName", typeof(string), typeof(FadeInThemeAnimation), new FrameworkPropertyMetadata(string.Empty));
 
 		public string TargetName
 		{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/FadeOutThemeAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/FadeOutThemeAnimation.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		}
 
 		public static DependencyProperty TargetNameProperty { get; } = DependencyProperty.Register(
-			"TargetName", typeof(string), typeof(FadeOutThemeAnimation), new FrameworkPropertyMetadata(null));
+			"TargetName", typeof(string), typeof(FadeOutThemeAnimation), new FrameworkPropertyMetadata(string.Empty));
 
 		public string TargetName
 		{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
@@ -50,7 +50,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		// Using a DependencyProperty as the backing store for TargetName.  This enables animation, styling, binding, etc...
 		public static DependencyProperty TargetNameProperty { get; } =
-			DependencyProperty.RegisterAttached("TargetName", typeof(string), typeof(Storyboard), new FrameworkPropertyMetadata(null));
+			DependencyProperty.RegisterAttached("TargetName", typeof(string), typeof(Storyboard), new FrameworkPropertyMetadata(string.Empty));
 		#endregion
 
 		#region TargetProperty Attached Property
@@ -60,7 +60,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		// Using a DependencyProperty as the backing store for TargetProperty.  This enables animation, styling, binding, etc...
 		public static DependencyProperty TargetPropertyProperty { get; } =
-			DependencyProperty.RegisterAttached("TargetProperty", typeof(string), typeof(Storyboard), new FrameworkPropertyMetadata(null));
+			DependencyProperty.RegisterAttached("TargetProperty", typeof(string), typeof(Storyboard), new FrameworkPropertyMetadata(string.Empty));
 		#endregion
 
 		public static void SetTarget(Timeline timeline, DependencyObject target) => timeline.Target = target;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7085, replaces #7087

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10e7733</samp>

This pull request updates the default values and getters of several string properties of various controls to match the WinUI behavior and prevent null reference exceptions. It mainly changes `null` values to `string.Empty` or vice versa, depending on the WinUI specification. It affects the files `InfoBar.Properties.cs`, `PagerControl.Properties.cs`, `RatingItemFontInfo.cs`, `CalendarDatePicker.Properties.cs`, `CalendarViewTemplateSettings.cs`, `MenuFlyoutItem.cs`, `WebView.Properties.cs`, `DragView.cs`, `AnimatedIcon.Properties.cs`, `MenuBarItem.Properties.cs`, `NavigationView.Properties.cs`, `NumberBox.Properties.cs`, `PersonPicture.Properties.cs`, `SwipeItem.properties.cs`, `AppBarToggleButton.Properties.cs`, `AutoSuggestBox.Properties.cs`, `CalendarView.Properties.cs`, `MenuFlyoutSubItem.cs`, and `PickerFlyoutBase.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
