### PR TITLE
feat(flyout): Implement FlyoutBase.OverlayInputPassThroughElement

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1670,6 +1670,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_OverlayInputPassThroughElement.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FlipView\FlipView_Images.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5722,6 +5726,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FlipView\FlipView_Background.xaml.cs">
       <DependentUpon>FlipView_Background.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_OverlayInputPassThroughElement.xaml.cs">
+      <DependentUpon>Flyout_OverlayInputPassThroughElement.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\ImageSourceWriteableBitmapInvalidate_Stretch.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\IconSourceTests\IconSourceElementTests.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_OverlayInputPassThroughElement.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_OverlayInputPassThroughElement.xaml
@@ -1,0 +1,27 @@
+﻿<Page
+	x:Name="ThePage"
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Flyout.Flyout_OverlayInputPassThroughElement"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<StackPanel x:Name="stackPanel" HorizontalAlignment="Center" VerticalAlignment="Center">
+			<TextBlock x:Name="textBlock" Text="Initial" />
+			<Button Content="Open Flyout">
+				<Button.Flyout>
+					<Flyout OverlayInputPassThroughElement="{x:Bind ThePage}" Closing="FlyoutBase_OnClosing" Closed="FlyoutBase_OnClosed">
+						<TextBlock Text="Flyout Yay" />
+					</Flyout>
+				</Button.Flyout>
+			</Button>
+			<Button
+				Margin="0,100,0,0"
+				Click="Button_Click"
+				Content="Click With Flyout Open" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_OverlayInputPassThroughElement.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_OverlayInputPassThroughElement.xaml.cs
@@ -1,0 +1,41 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Flyout
+{
+	[Sample("Flyouts", "Flyout_ButtonInContent")]
+	public sealed partial class Flyout_OverlayInputPassThroughElement : Page
+	{
+		public Flyout_OverlayInputPassThroughElement()
+		{
+			this.InitializeComponent();
+
+			stackPanel.Loaded += (_, _) =>
+			{
+				stackPanel.AddHandler(PointerPressedEvent, new PointerEventHandler(StackPanel_Click), true);
+			};
+		}
+
+		private void Button_Click(object sender, RoutedEventArgs e)
+		{
+			textBlock.Text += " Button_Click";
+		}
+
+		private void FlyoutBase_OnClosed(object sender, object e)
+		{
+			textBlock.Text += " FlyoutBase_OnClosed";
+		}
+		private void FlyoutBase_OnClosing(FlyoutBase sender, FlyoutBaseClosingEventArgs args)
+		{
+			textBlock.Text += " FlyoutBase_OnClosing";
+		}
+
+		private void StackPanel_Click(object sender, RoutedEventArgs e)
+		{
+			textBlock.Text += " StackPanel_Click";
+		}
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/FlyoutBase.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		// Skipping already declared property AllowFocusWhenDisabled
 		// Skipping already declared property AllowFocusOnInteraction
 		// Skipping already declared property Target
-		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public  global::Windows.UI.Xaml.DependencyObject OverlayInputPassThroughElement
 		{
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			new Windows.UI.Xaml.FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.ElementSoundMode)));
 		#endif
 		// Skipping already declared property LightDismissOverlayModeProperty
-		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+		#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty OverlayInputPassThroughElementProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -197,6 +197,15 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		internal static DependencyProperty LightDismissOverlayBackgroundProperty { get; } =
 			DependencyProperty.Register("LightDismissOverlayBackground", typeof(Brush), typeof(FlyoutBase), new FrameworkPropertyMetadata(null));
+		
+		internal static DependencyProperty OverlayInputPassThroughElementProperty { get; } = 
+			DependencyProperty.Register("OverlayInputPassThroughElement", typeof(DependencyObject), typeof(FlyoutBase), new FrameworkPropertyMetadata(null));
+		
+		public DependencyObject OverlayInputPassThroughElement
+		{
+			get { return (DependencyObject)GetValue(OverlayInputPassThroughElementProperty); }
+			set { SetValue(OverlayInputPassThroughElementProperty, value); }
+		}
 
 		/// <summary>
 		/// Gets or sets whether a disabled control can receive focus.

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -199,12 +199,12 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			DependencyProperty.Register("LightDismissOverlayBackground", typeof(Brush), typeof(FlyoutBase), new FrameworkPropertyMetadata(null));
 		
 		internal static DependencyProperty OverlayInputPassThroughElementProperty { get; } = 
-			DependencyProperty.Register("OverlayInputPassThroughElement", typeof(DependencyObject), typeof(FlyoutBase), new FrameworkPropertyMetadata(null));
+			DependencyProperty.Register(nameof(OverlayInputPassThroughElement), typeof(DependencyObject), typeof(FlyoutBase), new FrameworkPropertyMetadata(null));
 		
 		public DependencyObject OverlayInputPassThroughElement
 		{
-			get { return (DependencyObject)GetValue(OverlayInputPassThroughElementProperty); }
-			set { SetValue(OverlayInputPassThroughElementProperty, value); }
+			get => (DependencyObject)GetValue(OverlayInputPassThroughElementProperty);
+			set => SetValue(OverlayInputPassThroughElementProperty, value);
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPopupPanel.cs
@@ -39,7 +39,7 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override int PopupPlacementTargetMargin => 5;
 
-		protected override void OnPointerPressed(object sender, PointerRoutedEventArgs args)
+		private protected override void OnPointerPressed(object sender, PointerRoutedEventArgs args)
 		{
 			base.OnPointerPressed(sender, args);
 
@@ -53,11 +53,11 @@ namespace Windows.UI.Xaml.Controls
 						passThroughElement.XamlRoot.VisualTree.RootElement,
 						VisualTreeHelper.DefaultGetTestability,
 						childrenFilter: elements => elements.Where(e => e != this));
-					
+
 					var eventArgs = new PointerRoutedEventArgs(
 						new PointerEventArgs(args.GetCurrentPoint(null), args.KeyModifiers),
 						args.OriginalSource as UIElement);
-					
+
 					elementToBeHit.OnPointerDown(eventArgs);
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPopupPanel.cs
@@ -1,11 +1,14 @@
 #if !__UWP__
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Uno.UI;
 using Windows.Foundation;
+using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
@@ -35,6 +38,30 @@ namespace Windows.UI.Xaml.Controls
 		internal override FlyoutBase Flyout => _flyout;
 
 		protected override int PopupPlacementTargetMargin => 5;
+
+		protected override void OnPointerPressed(object sender, PointerRoutedEventArgs args)
+		{
+			base.OnPointerPressed(sender, args);
+
+			// Make sure we are the original source.  We do not want to handle PointerPressed on the Popup itself.
+			if (args.OriginalSource == this)
+			{
+				if (Flyout.OverlayInputPassThroughElement is UIElement passThroughElement)
+				{
+					var (elementToBeHit, _) = VisualTreeHelper.SearchDownForTopMostElementAt(
+						args.GetCurrentPoint(null).Position,
+						passThroughElement.XamlRoot.VisualTree.RootElement,
+						VisualTreeHelper.DefaultGetTestability,
+						childrenFilter: elements => elements.Where(e => e != this));
+					
+					var eventArgs = new PointerRoutedEventArgs(
+						new PointerEventArgs(args.GetCurrentPoint(null), args.KeyModifiers),
+						args.OriginalSource as UIElement);
+					
+					elementToBeHit.OnPointerDown(eventArgs);
+				}
+			}
+		}
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -238,7 +238,7 @@ internal partial class PopupPanel : Panel
 
 	// TODO: pointer handling should really go on PopupRoot. For now it's easier to put here because PopupRoot doesn't track open popups, and also we
 	// need to support native popups on Android that don't use PopupRoot.
-	private void OnPointerPressed(object sender, PointerRoutedEventArgs args)
+	protected virtual void OnPointerPressed(object sender, PointerRoutedEventArgs args)
 	{
 		// Make sure we are the original source.  We do not want to handle PointerPressed on the Popup itself.
 		if (args.OriginalSource == this && Popup is { } popup

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -238,7 +238,7 @@ internal partial class PopupPanel : Panel
 
 	// TODO: pointer handling should really go on PopupRoot. For now it's easier to put here because PopupRoot doesn't track open popups, and also we
 	// need to support native popups on Android that don't use PopupRoot.
-	protected virtual void OnPointerPressed(object sender, PointerRoutedEventArgs args)
+	private protected virtual void OnPointerPressed(object sender, PointerRoutedEventArgs args)
 	{
 		// Make sure we are the original source.  We do not want to handle PointerPressed on the Popup itself.
 		if (args.OriginalSource == this && Popup is { } popup

--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
@@ -371,7 +371,7 @@ namespace Windows.UI.Xaml.Media
 			return default;
 		}
 
-		private static (UIElement? element, Branch? stale) SearchDownForTopMostElementAt(
+		internal static (UIElement? element, Branch? stale) SearchDownForTopMostElementAt(
 			Point posRelToParent,
 			UIElement element,
 			GetHitTestability getVisibility,
@@ -469,7 +469,7 @@ namespace Windows.UI.Xaml.Media
 			var isChildStale = isStale;
 			while (child.MoveNext())
 			{
-				var childResult = SearchDownForTopMostElementAt(posRelToElement, child.Current!, getVisibility, isChildStale);
+				var childResult = SearchDownForTopMostElementAt(posRelToElement, child.Current!, getVisibility, isChildStale, childrenFilter);
 
 				// If we found a stale element in child sub-tree, keep it and stop looking for stale elements
 				if (childResult.stale is not null)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12681

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4096839</samp>

This pull request adds a new feature to the `Flyout` control that allows it to ignore pointer input on a specified element. It also improves the pointer input handling for `Flyout` controls and makes some methods more accessible and flexible for reuse. It affects the files `FlyoutBase.cs`, `FlyoutPopupPanel.cs`, `PopupPanel.cs`, `VisualTreeHelper.cs`, and `UITests.Shared.projitems`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
