### PR TITLE
fix: Use LogicalParentOverride for PopupPanel everywhere

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -78,7 +78,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 		}
 
 		[TestMethod]
-		public async Task When_Child_Visual_Parents_Include_Popup()
+		public async Task When_Child_Visual_Parents_Does_Not_Include_Popup()
 		{
 			var popup = new Popup();
 			popup.XamlRoot = TestServices.WindowHelper.XamlRoot;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Private.Infrastructure;
-using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives.PopupPages;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Media;
-using static Private.Infrastructure.TestServices;
-using Windows.Media.Capture.Core;
-using Windows.System;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives.PopupPages;
+using Windows.System;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 {
@@ -74,6 +73,68 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 			var popup = new Popup();
 			popup.XamlRoot = TestServices.WindowHelper.XamlRoot;
 			popup.IsOpen = true;
+			// Should not throw
+			popup.IsOpen = false;
+		}
+
+		[TestMethod]
+		public async Task When_Child_Visual_Parents_Include_Popup()
+		{
+			var popup = new Popup();
+			popup.XamlRoot = TestServices.WindowHelper.XamlRoot;
+			var button = new Button()
+			{
+				Content = "test"
+			};
+			popup.Child = button;
+			popup.IsOpen = true;
+			await WindowHelper.WaitForLoaded(button);
+			bool found = false;
+			DependencyObject current = popup.Child;
+			while (current != null)
+			{
+				if (current == popup)
+				{
+					found = true;
+					break;
+				}
+
+				current = VisualTreeHelper.GetParent(current);
+			}
+
+			Assert.IsFalse(found);
+
+			// Should not throw
+			popup.IsOpen = false;
+		}
+
+		[TestMethod]
+		public async Task When_Child_Logical_Parents_Include_Popup()
+		{
+			var popup = new Popup();
+			popup.XamlRoot = TestServices.WindowHelper.XamlRoot;
+			var button = new Button()
+			{
+				Content = "test"
+			};
+			popup.Child = button;
+			popup.IsOpen = true;
+			await WindowHelper.WaitForLoaded(button);
+			bool found = false;
+			DependencyObject current = button;
+			while (current != null)
+			{
+				if (current == popup)
+				{
+					found = true;
+					break;
+				}
+
+				current = (current as FrameworkElement)?.Parent;
+			}
+
+			Assert.IsTrue(found);
+
 			// Should not throw
 			popup.IsOpen = false;
 		}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -152,17 +152,12 @@ namespace Microsoft.UI.Xaml
 
 		internal static void SetLogicalParent(this FrameworkElement element, DependencyObject logicalParent)
 		{
-#if UNO_HAS_MANAGED_POINTERS || __WASM__ // WASM has managed-esque pointers
-
 			// UWP distinguishes between the 'logical parent' (or inheritance parent) and the 'visual parent' of an element. Uno already
 			// recognises this distinction on some targets, but for targets using CoerceHitTestVisibility() for hit testing, the pointer
 			// implementation depends upon the logical parent (ie DepObjStore.Parent) being identical to the visual parent, because it
 			// piggybacks on the DP inheritance mechanism. Therefore we use LogicalParentOverride as a workaround to modify the publicly-visible
 			// FrameworkElement.Parent without affecting DP propagation.
 			element.LogicalParentOverride = logicalParent;
-#else
-			SetParent(element, logicalParent);
-#endif
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -271,9 +271,7 @@ namespace Microsoft.UI.Xaml
 		new
 #endif
 		DependencyObject Parent =>
-#if UNO_HAS_MANAGED_POINTERS || __WASM__
 			LogicalParentOverride ??
-#endif
 			((IDependencyObjectStoreProvider)this).Store.Parent as DependencyObject;
 
 		public global::System.Uri BaseUri
@@ -289,12 +287,10 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-#if UNO_HAS_MANAGED_POINTERS || __WASM__
 		/// <summary>
 		/// Allows to override the publicly-visible <see cref="Parent"/> without modifying DP propagation.
 		/// </summary>
 		internal DependencyObject LogicalParentOverride { get; set; }
-#endif
 
 		/// <summary>
 		/// Provides the managed visual parent of the element. This property can be overriden for specific


### PR DESCRIPTION
Previously it was used only on WASM and Skia, but that caused odd issues, because routed events got propagated from Popups to the logical parents

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4964759</samp>

This pull request refactors the logical parent logic for UI elements by moving it from `FrameworkElement` to `DependencyObjectExtensions`. This simplifies the code and improves cross-platform consistency.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
