### PR TITLE
fix: UI-vanishing `ItemsControl`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -520,7 +520,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			stackPanel.Children.Add(comboBox);
 			WindowHelper.WindowContent = stackPanel;
 			await WindowHelper.WaitForLoaded(stackPanel);
-			bool dataContextChangedRaised = false;
 			FrameworkElement itemContainer = null;
 
 			// Act
@@ -528,7 +527,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitFor(() => (itemContainer = comboBox.ContainerFromIndex(0) as ComboBoxItem) is not null);
 			itemContainer.DataContextChanged += (s, e) =>
 			{
-				dataContextChangedRaised = true;
 				// Assert
 				Assert.AreNotEqual(stackPanel.DataContext, itemContainer.DataContext);
 			};

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -508,6 +508,39 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public async Task When_ComboBoxItem_DataContext_Cleared()
+		{
+			// Arrange
+			var stackPanel = new StackPanel();
+			stackPanel.DataContext = Guid.NewGuid().ToString();
+			var comboBox = new ComboBox();
+			comboBox.ItemsSource = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+			comboBox.SelectedIndex = 0;
+			stackPanel.Children.Add(comboBox);
+			WindowHelper.WindowContent = stackPanel;
+			await WindowHelper.WaitForLoaded(stackPanel);
+			bool dataContextChangedRaised = false;
+			FrameworkElement itemContainer = null;
+
+			// Act
+			comboBox.IsDropDownOpen = true;
+			await WindowHelper.WaitFor(() => (itemContainer = comboBox.ContainerFromIndex(0) as ComboBoxItem) is not null);
+			itemContainer.DataContextChanged += (s, e) =>
+			{
+				dataContextChangedRaised = true;
+				// Assert
+				Assert.AreNotEqual(stackPanel.DataContext, itemContainer.DataContext);
+			};
+			comboBox.IsDropDownOpen = false;
+			await WindowHelper.WaitForIdle();
+			comboBox.IsDropDownOpen = true;
+			await WindowHelper.WaitForIdle();
+
+			// Assert
+			Assert.IsTrue(dataContextChangedRaised);
+		}
+
+		[TestMethod]
 		public async Task When_Binding_Change()
 		{
 			var SUT = new ComboBox();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -514,7 +514,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var stackPanel = new StackPanel();
 			stackPanel.DataContext = Guid.NewGuid().ToString();
 			var comboBox = new ComboBox();
-			comboBox.ItemsSource = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+			var originalSource = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+			comboBox.ItemsSource = originalSource;
 			comboBox.SelectedIndex = 0;
 			stackPanel.Children.Add(comboBox);
 			WindowHelper.WindowContent = stackPanel;
@@ -535,9 +536,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 			comboBox.IsDropDownOpen = true;
 			await WindowHelper.WaitForIdle();
-
-			// Assert
-			Assert.IsTrue(dataContextChangedRaised);
+			comboBox.IsDropDownOpen = false;
+			var updatedSource = new List<int>() { 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+			comboBox.ItemsSource = updatedSource;
+			await WindowHelper.WaitForIdle();
+			comboBox.IsDropDownOpen = true;
+			await WindowHelper.WaitForIdle();
+			comboBox.IsDropDownOpen = false;
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -1193,9 +1193,11 @@ namespace Windows.UI.Xaml.Controls
 					}
 				}
 
-				// We are clearing the DataContext last. Because if there is a binding set on any of the above properties, Content(Template(Selector)?)?,
-				// clearing the DC can cause the data-bound property to be unnecessarily re-evaluated with an inherited DC from the visual parent.
-				contentControl.ClearValue(DataContextProperty);
+				// We are changing the DataContext last. Because if there is a binding set on any of the above properties, Content(Template(Selector)?)?,
+				// changing the DC can cause the data-bound property to be unnecessarily re-evaluated with an inherited DC from the visual parent.
+				// We also need to set value to null explicitly, because just unsetting would cause the DataContext to be inherited from the visual parent,
+				// which then causes issues like #12845.
+				contentControl.SetValue(DataContextProperty, null);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12845

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Clearing `ItemsControl` item unsets the `DataContext`, making it gain the inherited `DataContext` from the parent.


## What is the new behavior?

We are explicitly `null`-ing out the `DataContext` when recycling.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02b42f4</samp>

This pull request adds a new test case and fixes a bug related to the `DataContext` inheritance of `ComboBoxItem` containers. It changes the `CleanUpContainer` method in `ItemsControl.cs` to explicitly clear the `DataContext` of recycled items, and verifies the expected behavior in `Given_ComboBox.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.