### PR TITLE
fix(net8): Ensure that roslyn generators can be used when `LangVersion` is empty

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -14,6 +14,11 @@
 							Or '$(LangVersion)' == 'latestMajor'
 							Or '$(LangVersion)' == 'default'
 							Or (
+								'$(LangVersion)' == ''
+								and '$(BundledNETCoreAppTargetFrameworkVersion)' != ''
+								and '$(BundledNETCoreAppTargetFrameworkVersion)' &gt;= '8.0'
+							)
+							Or (
 								'$(LangVersion)'!=''
 								and '$(LangVersion)' &gt; '9.0'
 							)">true</_canUseRoslynAnalyzer>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/12862

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensure that building when the .NET 8 SDK is installed, where `LangVersion` is not defined by default.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0705a8</samp>

This change allows the source generators project to use C# 8.0 features by setting the `LangVersion` property conditionally based on the target framework version in `Uno.UI.SourceGenerators.props`.