### PR TITLE
fix: property inheritance for Control.IsEnabledProperty

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2734,6 +2734,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ControlTests\Button_Enabled_Control_Disabled.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_IsEnabled_Automated.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -8358,6 +8362,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_IsEnabled.xaml.cs">
       <DependentUpon>Button_IsEnabled.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ControlTests\Button_Enabled_Control_Disabled.xaml.cs">
+      <DependentUpon>Button_Enabled_Control_Disabled.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button.xaml.cs">
       <DependentUpon>CheckBox_Button.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml
@@ -48,12 +48,19 @@
 				<Button x:Name="btn" IsEnabled="true" Content="Try to click me" />
 			</ContentControl>
 			<StackPanel Grid.Row="4" Grid.Column="1">
-				<TextBlock  Text="ContentControl disabled in source, IsEnabled =" />	
-				<TextBlock  Text="{Binding IsEnabled, ElementName=cc1}" />	
-				<TextBlock  Text="Button enabled in source, IsEnabled =" />	
-				<TextBlock  Text="{Binding IsEnabled, ElementName=btn}" />	
+				<StackPanel Orientation="Horizontal">
+					<TextBlock  Text="ContentControl disabled in source, IsEnabled =" />
+					<TextBlock  Text="{Binding IsEnabled, ElementName=cc1}" />
+				</StackPanel>
+				<StackPanel Orientation="Horizontal">
+					<TextBlock  Text="Button enabled in source, IsEnabled =" />
+					<TextBlock  Text="{Binding IsEnabled, ElementName=btn}" />
+				</StackPanel>
 			</StackPanel>
-			<Button Grid.Row="4" Grid.Column="2" Click="ButtonBase_OnClick">Change ContentControl IsEnabled</Button>
+			<StackPanel Grid.Row="4" Grid.Column="2">
+				<Button Click="Button_OnClick">Change ContentControl IsEnabled</Button>
+				<Button Click="Button2_OnClick">Change Button IsEnabled</Button>
+			</StackPanel>
 		</Grid>
 	</StackPanel>
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml
@@ -15,7 +15,7 @@
 				<ColumnDefinition Width="*" />
 				<ColumnDefinition Width="*" />
 			</Grid.ColumnDefinitions>
-			
+
 			<Grid.RowDefinitions>
 				<RowDefinition Height="100" />
 				<RowDefinition Height="100" />
@@ -23,27 +23,27 @@
 				<RowDefinition Height="100" />
 				<RowDefinition Height="100" />
 			</Grid.RowDefinitions>
-			
+
 			<ContentControl Grid.Row="0" Grid.Column="0" IsEnabled="false">
 				<Button IsEnabled="true" Content="Try to click me" />
 			</ContentControl>
 			<TextBlock Grid.Row="0" Grid.Column="1" Text="ContentControl disabled, Button enabled" />
-			
+
 			<ContentControl Grid.Row="1" Grid.Column="0" IsEnabled="true">
 				<Button IsEnabled="false" Content="Try to click me" />
 			</ContentControl>
 			<TextBlock Grid.Row="1" Grid.Column="1" Text="ContentControl enabled, Button disabled" />
-			
+
 			<ContentControl Grid.Row="2" Grid.Column="0">
 				<Button IsEnabled="false" Content="Try to click me" />
 			</ContentControl>
 			<TextBlock Grid.Row="2" Grid.Column="1" Text="ContentControl default, Button disabled" />
-			
+
 			<ContentControl Grid.Row="3" Grid.Column="0" IsEnabled="true">
 				<Button IsEnabled="true" Content="Try to click me" />
 			</ContentControl>
 			<TextBlock Grid.Row="3" Grid.Column="1" Text="ContentControl enabled, Button enabled" />
-			
+
 			<ContentControl Grid.Row="4" Grid.Column="0" IsEnabled="false" x:Name="cc1">
 				<Button x:Name="btn" IsEnabled="true" Content="Try to click me" />
 			</ContentControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml
@@ -1,0 +1,60 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Button_Enabled_Control_Disabled"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<Grid>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="150" />
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+			
+			<Grid.RowDefinitions>
+				<RowDefinition Height="100" />
+				<RowDefinition Height="100" />
+				<RowDefinition Height="100" />
+				<RowDefinition Height="100" />
+				<RowDefinition Height="100" />
+			</Grid.RowDefinitions>
+			
+			<ContentControl Grid.Row="0" Grid.Column="0" IsEnabled="false">
+				<Button IsEnabled="true" Content="Try to click me" />
+			</ContentControl>
+			<TextBlock Grid.Row="0" Grid.Column="1" Text="ContentControl disabled, Button enabled" />
+			
+			<ContentControl Grid.Row="1" Grid.Column="0" IsEnabled="true">
+				<Button IsEnabled="false" Content="Try to click me" />
+			</ContentControl>
+			<TextBlock Grid.Row="1" Grid.Column="1" Text="ContentControl enabled, Button disabled" />
+			
+			<ContentControl Grid.Row="2" Grid.Column="0">
+				<Button IsEnabled="false" Content="Try to click me" />
+			</ContentControl>
+			<TextBlock Grid.Row="2" Grid.Column="1" Text="ContentControl default, Button disabled" />
+			
+			<ContentControl Grid.Row="3" Grid.Column="0" IsEnabled="true">
+				<Button IsEnabled="true" Content="Try to click me" />
+			</ContentControl>
+			<TextBlock Grid.Row="3" Grid.Column="1" Text="ContentControl enabled, Button enabled" />
+			
+			<ContentControl Grid.Row="4" Grid.Column="0" IsEnabled="false" x:Name="cc1">
+				<Button x:Name="btn" IsEnabled="true" Content="Try to click me" />
+			</ContentControl>
+			<StackPanel Grid.Row="4" Grid.Column="1">
+				<TextBlock  Text="ContentControl disabled in source, IsEnabled =" />	
+				<TextBlock  Text="{Binding IsEnabled, ElementName=cc1}" />	
+				<TextBlock  Text="Button enabled in source, IsEnabled =" />	
+				<TextBlock  Text="{Binding IsEnabled, ElementName=btn}" />	
+			</StackPanel>
+			<Button Grid.Row="4" Grid.Column="2" Click="ButtonBase_OnClick">Change ContentControl IsEnabled</Button>
+		</Grid>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Linq;
+using System.Windows.Input;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+using System.Collections.Generic;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[Sample("Control", Name = "Button_Enabled_Control_Disabled",
+		Description = "A control should be disabled if the surrounding control is disabled even if it's explicity set to enabled.")]
+	public sealed partial class Button_Enabled_Control_Disabled : UserControl
+	{
+		public Button_Enabled_Control_Disabled()
+		{
+			this.InitializeComponent();
+		}
+		private void ButtonBase_OnClick(object sender, RoutedEventArgs e)
+		{
+			cc1.IsEnabled = !cc1.IsEnabled;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ControlTests/Button_Enabled_Control_Disabled.xaml.cs
@@ -19,9 +19,14 @@ namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
 		{
 			this.InitializeComponent();
 		}
-		private void ButtonBase_OnClick(object sender, RoutedEventArgs e)
+		private void Button_OnClick(object sender, RoutedEventArgs e)
 		{
 			cc1.IsEnabled = !cc1.IsEnabled;
+		}
+
+		private void Button2_OnClick(object sender, RoutedEventArgs e)
+		{
+			btn.IsEnabled = !btn.IsEnabled;
 		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/DependencyObject/DependencyPropertyGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/DependencyObject/DependencyPropertyGenerator.cs
@@ -467,7 +467,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				{
 					builder.AppendLineIndented($"\t\t, coerceValueCallback: (instance, baseValue, precedence) => (({containingTypeName})instance).Coerce{propertyName}(baseValue, precedence)");
 				}
-				else // data.CoerceCallbackMethod.Parameters.Length == 1
+				else
 				{
 					builder.AppendLineIndented($"\t\t, coerceValueCallback: (instance, baseValue, precedence) => (({containingTypeName})instance).Coerce{propertyName}(baseValue)");
 				}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/DependencyObject/DependencyPropertyGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Internal/DependencyObject/DependencyPropertyGenerator.cs
@@ -110,7 +110,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 			public string PropertyName { get; }
 			public bool HasPropertySuffix { get; }
 
-			public IMethodSymbol? CoerceCallbackMethod { get; }
+			public int? CoerceCallbackMethodParameterLength { get; }
 
 			public bool IsCallbackWithDPChangedArgs { get; }
 			public bool IsCallbackWithDPChangedArgsOnly { get; }
@@ -143,7 +143,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				ContainingTypeFullyQualifiedName = dpSymbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 				ContainingTypeHintName = HashBuilder.BuildIDFromSymbol(dpSymbol.ContainingType);
 				ContainingTypeHasGetDefaultValueMethod = dpSymbol.ContainingType.GetFirstMethodWithName($"Get{PropertyName}DefaultValue") is not null;
-				CoerceCallbackMethod = dpSymbol.ContainingType.GetFirstMethodWithName("Coerce" + PropertyName);
+				CoerceCallbackMethodParameterLength = dpSymbol.ContainingType.GetFirstMethodWithName("Coerce" + PropertyName)?.Parameters.Length;
 
 				MemberSymbolNodeContent = SymbolToNodeString(dpSymbol);
 
@@ -363,13 +363,13 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				}
 			}
 
-			if (coerceCallback)
+			if (coerceCallback || data.CoerceCallbackMethodParameterLength is not null)
 			{
-				if (data.CoerceCallbackMethod is { } m && m.Parameters.Length == 2)
+				if (data.CoerceCallbackMethodParameterLength is 2)
 				{
 					builder.AppendLineIndented($"\t\t, coerceValueCallback: (instance, baseValue, precedence) => Coerce{propertyName}(instance, ({propertyTypeName})baseValue, precedence)");
 				}
-				else // data.CoerceCallbackMethod.Parameters.Length == 1
+				else
 				{
 					builder.AppendLineIndented($"\t\t, coerceValueCallback: (instance, baseValue, precedence) => Coerce{propertyName}(instance, ({propertyTypeName})baseValue)");
 				}
@@ -461,9 +461,9 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				builder.AppendLineIndented($"\t\t, backingFieldUpdateCallback: On{propertyName}BackingFieldUpdate");
 			}
 
-			if (coerceCallback)
+			if (coerceCallback || data.CoerceCallbackMethodParameterLength is not null)
 			{
-				if (data.CoerceCallbackMethod is { } m && m.Parameters.Length == 2)
+				if (data.CoerceCallbackMethodParameterLength is 2)
 				{
 					builder.AppendLineIndented($"\t\t, coerceValueCallback: (instance, baseValue, precedence) => (({containingTypeName})instance).Coerce{propertyName}(baseValue, precedence)");
 				}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -18,6 +18,64 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 	public class Given_Button
 	{
 		[TestMethod]
+		public async Task When_Enabled_Inside_Disabled_Control()
+		{
+			var SUT = new Button()
+			{
+				IsEnabled = true
+			};
+
+			var cc = new ContentControl()
+			{
+				IsEnabled = false,
+				Content = SUT
+			};
+
+			WindowHelper.WindowContent = cc;
+
+			await WindowHelper.WaitForIdle();
+
+			// The button should be disabled because the outer control is disabled
+			Assert.AreEqual(cc.IsEnabled, false);
+			Assert.AreEqual(SUT.IsEnabled, false);
+
+			// Once the outer control is enabled, the button can control its own IsEnabled
+			cc.IsEnabled = true;
+			Assert.AreEqual(cc.IsEnabled, true);
+			Assert.AreEqual(SUT.IsEnabled, true);
+
+			// We test once again to test behaviour when the value is set while running
+			// instead of during initialization
+			cc.IsEnabled = false;
+			Assert.AreEqual(cc.IsEnabled, false);
+			Assert.AreEqual(SUT.IsEnabled, false);
+
+			// Now let's make sure Button.IsEnabled doesn't
+			// affect the outer ContentControl.IsEnabled
+
+			// cc.IsEnbaled is false
+			SUT.IsEnabled = true;
+			Assert.AreEqual(cc.IsEnabled, false);
+			Assert.AreEqual(SUT.IsEnabled, false);
+
+			SUT.IsEnabled = false;
+			Assert.AreEqual(cc.IsEnabled, false);
+			Assert.AreEqual(SUT.IsEnabled, false);
+
+			cc.IsEnabled = true;
+			Assert.AreEqual(cc.IsEnabled, true);
+			Assert.AreEqual(SUT.IsEnabled, false);
+
+			SUT.IsEnabled = true;
+			Assert.AreEqual(cc.IsEnabled, true);
+			Assert.AreEqual(SUT.IsEnabled, true);
+
+			SUT.IsEnabled = false;
+			Assert.AreEqual(cc.IsEnabled, true);
+			Assert.AreEqual(SUT.IsEnabled, false);
+		}
+
+		[TestMethod]
 		public async Task When_Command_Executing_IsEnabled()
 		{
 			var command = new IsExecutingCommand(true);

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.cs
@@ -627,7 +627,7 @@ namespace Uno.UI.Tests.BinderTests
 
 			Action callback = null;
 
-			object Coerce(object dependencyObject, object baseValue)
+			object Coerce(object dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 			{
 				callback?.Invoke();
 
@@ -928,45 +928,45 @@ namespace Uno.UI.Tests.BinderTests
 
 		#region CoerceValueCallbacks
 
-		private object PreventSet(object dependencyObject, object baseValue)
+		private object PreventSet(object dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			return DependencyProperty.UnsetValue;
 		}
 
-		private object DoNothing(object dependencyObject, object baseValue)
+		private object DoNothing(object dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			return baseValue;
 		}
 
-		private object ReturnNull(object dependencyObject, object baseValue)
+		private object ReturnNull(object dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			return null;
 		}
 
-		private object AbsoluteInteger(object dependencyObject, object baseValue)
+		private object AbsoluteInteger(object dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			return Math.Abs((int)baseValue);
 		}
 
-		private object IgnoreNegative(object dependencyObject, object baseValue)
+		private object IgnoreNegative(object dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			return (int)baseValue < 0
 				? DependencyProperty.UnsetValue
 				: baseValue;
 		}
 
-		private object StringTake10(object dependencyObject, object baseValue)
+		private object StringTake10(object dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			return new string(((string)baseValue).Take(10).ToArray());
 		}
 
-		private object Now(object dependencyObject, object baseValue)
+		private object Now(object dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			return DateTime.Now;
 		}
 
 		private static object _customCoercion;
-		private object Custom(object dependencyObject, object baseValue)
+		private object Custom(object dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			if (_customCoercion != null)
 			{
@@ -2029,8 +2029,7 @@ namespace Uno.UI.Tests.BinderTests
 				new PropertyMetadata(
 					"default1",
 					(s, e) => { (s as MyDependencyObject1).PropertyChangedCallbacks.Add("changed1: " + e.NewValue); },
-					(s, baseValue) => { (s as MyDependencyObject1).CoerceValueCallbackCount++; return "coercion1: " + baseValue; }
-
+					(s, baseValue, _) => { (s as MyDependencyObject1).CoerceValueCallbackCount++; return "coercion1: " + baseValue; }
 				)
 			);
 
@@ -2046,7 +2045,7 @@ namespace Uno.UI.Tests.BinderTests
 				"default2",
 				FrameworkPropertyMetadataOptions.Inherits,
 				(s, e) => { (s as MyDependencyObject1).PropertyChangedCallbacks.Add("changed2: " + e.NewValue); },
-				(s, baseValue) => { (s as MyDependencyObject1).CoerceValueCallbackCount++; return "coercion2: " + baseValue; }
+				(s, baseValue, _) => { (s as MyDependencyObject1).CoerceValueCallbackCount++; return "coercion2: " + baseValue; }
 			);
 
 			MyPropertyProperty.OverrideMetadata(typeof(MyDependencyObject2), metadata);
@@ -2062,7 +2061,7 @@ namespace Uno.UI.Tests.BinderTests
 			var metadata = new FrameworkPropertyMetadata(
 				"default3",
 				(s, e) => { (s as MyDependencyObject1).PropertyChangedCallbacks.Add("changed3: " + e.NewValue); },
-				(s, baseValue) => { (s as MyDependencyObject1).CoerceValueCallbackCount++; return "coercion3: " + baseValue; }
+				(s, baseValue, _) => { (s as MyDependencyObject1).CoerceValueCallbackCount++; return "coercion3: " + baseValue; }
 			);
 
 			MyPropertyProperty.OverrideMetadata(typeof(MyDependencyObject3), metadata);

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/RecyclePoolFactory.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/RecyclePoolFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.UI.Xaml.Controls
 			"OriginTemplate",
 			typeof(DataTemplate),
 			typeof(RecyclePool),
-			new FrameworkPropertyMetadata(null /* defaultValue */, null /* propertyChangedCallback */));
+			new FrameworkPropertyMetadata(defaultValue: null, propertyChangedCallback: null));
 
 
 		#region IRecyclePoolStatics

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -189,10 +189,10 @@ namespace Windows.UI.Xaml.Controls
 			// otherwise use the more local value
 			var (localValue, localPrecedence) = this.GetValueUnderPrecedence(IsEnabledProperty, DependencyPropertyValuePrecedences.Coercion);
 
-			if (localPrecedence == precedence)
+			if (localPrecedence >= precedence) // > means weaker precedence
 			{
 				// The baseValue hasn't been set inside PropertyDetails yet, so we need to make sure we're not
-				// reading soon-to-be-outdated values
+				// using the old weaker value when a new stronger value is being set
 				localValue = baseValue;
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -115,11 +115,10 @@ namespace Windows.UI.Xaml.Controls
 			DependencyProperty.Register(name: "IsEnabled", propertyType: typeof(bool), ownerType: typeof(Control),
 				typeMetadata: new FrameworkPropertyMetadata(
 					defaultValue: true
-					, options: FrameworkPropertyMetadataOptions.Inherits
+					, options: FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.KeepCoercedWhenEquals
 					, backingFieldUpdateCallback: OnIsEnabledBackingFieldUpdate
 					, coerceValueCallback: (instance, baseValue) => ((Control)instance).CoerceIsEnabled(baseValue)
 					, propertyChangedCallback: (instance, args) => ((Control)instance).OnIsEnabledChanged(args)
-					, keepCoercedWhenEquals: true
 				));
 		
 		private static void OnIsEnabledBackingFieldUpdate(object instance, object newValue)

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -181,7 +181,7 @@ namespace Windows.UI.Xaml.Controls
 				this.GetValue(IsEnabledProperty, DependencyPropertyValuePrecedences.Inheritance);
 
 			// If the parent is disabled, this control must be disabled as well
-			if (parentValue != DependencyProperty.UnsetValue && !(bool)parentValue!)
+			if (parentValue is false)
 			{
 				return false;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -172,7 +172,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				return false;
 			}
-			
+
 			// The baseValue hasn't been set yet, so we need to make sure we're not
 			// reading soon-to-be-outdated values
 			var localValue = precedence < DependencyPropertyValuePrecedences.Inheritance ? // < actually means higher precedence
@@ -181,13 +181,13 @@ namespace Windows.UI.Xaml.Controls
 			var parentValue = precedence == DependencyPropertyValuePrecedences.Inheritance ?
 				baseValue :
 				((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty).GetValue(DependencyPropertyValuePrecedences.Inheritance);
-			
+
 			// If the parent is disabled, this control must be disabled as well
 			if (parentValue != DependencyProperty.UnsetValue && !(bool)parentValue!)
 			{
 				return false;
 			}
-			
+
 			return localValue;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -176,14 +176,9 @@ namespace Windows.UI.Xaml.Controls
 			// The baseValue hasn't been set inside PropertyDetails yet, so we need to make sure we're not
 			// reading soon-to-be-outdated values
 
-			var parentValue = baseValue;
-			DependencyPropertyDetails propertyDetails = null;
-
-			if (precedence != DependencyPropertyValuePrecedences.Inheritance)
-			{
-				propertyDetails = ((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty);
-				parentValue = propertyDetails.GetValue(DependencyPropertyValuePrecedences.Inheritance);
-			}
+			var parentValue = precedence == DependencyPropertyValuePrecedences.Inheritance ?
+				baseValue :
+				this.GetValue(IsEnabledProperty, DependencyPropertyValuePrecedences.Inheritance);
 
 			// If the parent is disabled, this control must be disabled as well
 			if (parentValue != DependencyProperty.UnsetValue && !(bool)parentValue!)
@@ -194,7 +189,7 @@ namespace Windows.UI.Xaml.Controls
 			// otherwise use the more local value
 			return precedence < DependencyPropertyValuePrecedences.Inheritance ? // < actually means higher precedence
 				baseValue :
-				(propertyDetails ?? ((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty)).GetValueUnderPrecedence(DependencyPropertyValuePrecedences.Coercion).value;
+				this.GetValueUnderPrecedence(IsEnabledProperty, DependencyPropertyValuePrecedences.Coercion).value;
 		}
 
 

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -187,9 +187,16 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			// otherwise use the more local value
-			return precedence < DependencyPropertyValuePrecedences.Inheritance ? // < actually means higher precedence
-				baseValue :
-				this.GetValueUnderPrecedence(IsEnabledProperty, DependencyPropertyValuePrecedences.Coercion).value;
+			var (localValue, localPrecedence) = this.GetValueUnderPrecedence(IsEnabledProperty, DependencyPropertyValuePrecedences.Coercion);
+
+			if (localPrecedence == precedence)
+			{
+				// The baseValue hasn't been set inside PropertyDetails yet, so we need to make sure we're not
+				// reading soon-to-be-outdated values
+				localValue = baseValue;
+			}
+
+			return localValue;
 		}
 
 

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -42,8 +42,6 @@ namespace Windows.UI.Xaml.Controls
 		private View _templatedRoot;
 		private bool _updateTemplate;
 		private bool _suppressIsEnabled;
-		private bool _IsEnabledPropertyBackingFieldSet;
-		private bool _IsEnabledPropertyBackingField;
 
 		private void InitializeControl()
 		{
@@ -111,33 +109,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public event DependencyPropertyChangedEventHandler IsEnabledChanged;
 
-		public static DependencyProperty IsEnabledProperty { get; } = 
-			DependencyProperty.Register(name: "IsEnabled", propertyType: typeof(bool), ownerType: typeof(Control),
-				typeMetadata: new FrameworkPropertyMetadata(
-					defaultValue: true
-					, options: FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.KeepCoercedWhenEquals
-					, backingFieldUpdateCallback: OnIsEnabledBackingFieldUpdate
-					, coerceValueCallback: (instance, baseValue) => ((Control)instance).CoerceIsEnabled(baseValue)
-					, propertyChangedCallback: (instance, args) => ((Control)instance).OnIsEnabledChanged(args)
-				));
-		
-		private static void OnIsEnabledBackingFieldUpdate(object instance, object newValue)
-		{
-			var typedInstance = instance as Control;
-			typedInstance!._IsEnabledPropertyBackingField = (bool)newValue;
-			typedInstance!._IsEnabledPropertyBackingFieldSet = true;
-		}
-		
-		private bool GetIsEnabledValue()
-		{
-			if (!_IsEnabledPropertyBackingFieldSet)
-			{
-				_IsEnabledPropertyBackingField = (bool)GetValue(IsEnabledProperty);
-				_IsEnabledPropertyBackingFieldSet = true;
-			}
-			return _IsEnabledPropertyBackingField;
-		}
-		private void SetIsEnabledValue(bool value) => SetValue(IsEnabledProperty, value);
+		[GeneratedDependencyProperty(DefaultValue = true, ChangedCallback = true, CoerceCallback = true, Options = FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.KeepCoercedWhenEquals)]
+		public static DependencyProperty IsEnabledProperty { get; } = CreateIsEnabledProperty();
 
 		public bool IsEnabled
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -166,15 +166,21 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private protected virtual object CoerceIsEnabled(object baseValue)
+		private protected virtual object CoerceIsEnabled(object baseValue, DependencyPropertyValuePrecedences precedence)
 		{
 			if (_suppressIsEnabled)
 			{
 				return false;
 			}
 			
-			var (localValue, _) = ((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty).GetValueUnderPrecedence(DependencyPropertyValuePrecedences.Coercion);
-			var parentValue = ((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty).GetValue(DependencyPropertyValuePrecedences.Inheritance);
+			// The baseValue hasn't been set yet, so we need to make sure we're not
+			// reading soon-to-be-outdated values
+			var localValue = precedence < DependencyPropertyValuePrecedences.Inheritance ? // < actually means higher precedence
+				baseValue :
+				((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty).GetValueUnderPrecedence(DependencyPropertyValuePrecedences.Coercion).value;
+			var parentValue = precedence == DependencyPropertyValuePrecedences.Inheritance ?
+				baseValue :
+				((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty).GetValue(DependencyPropertyValuePrecedences.Inheritance);
 			
 			// If the parent is disabled, this control must be disabled as well
 			if (parentValue != DependencyProperty.UnsetValue && !(bool)parentValue!)

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -173,14 +173,17 @@ namespace Windows.UI.Xaml.Controls
 				return false;
 			}
 
-			// The baseValue hasn't been set yet, so we need to make sure we're not
+			// The baseValue hasn't been set inside PropertyDetails yet, so we need to make sure we're not
 			// reading soon-to-be-outdated values
-			var localValue = precedence < DependencyPropertyValuePrecedences.Inheritance ? // < actually means higher precedence
-				baseValue :
-				((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty).GetValueUnderPrecedence(DependencyPropertyValuePrecedences.Coercion).value;
-			var parentValue = precedence == DependencyPropertyValuePrecedences.Inheritance ?
-				baseValue :
-				((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty).GetValue(DependencyPropertyValuePrecedences.Inheritance);
+
+			var parentValue = baseValue;
+			DependencyPropertyDetails propertyDetails = null;
+
+			if (precedence != DependencyPropertyValuePrecedences.Inheritance)
+			{
+				propertyDetails = ((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty);
+				parentValue = propertyDetails.GetValue(DependencyPropertyValuePrecedences.Inheritance);
+			}
 
 			// If the parent is disabled, this control must be disabled as well
 			if (parentValue != DependencyProperty.UnsetValue && !(bool)parentValue!)
@@ -188,7 +191,10 @@ namespace Windows.UI.Xaml.Controls
 				return false;
 			}
 
-			return localValue;
+			// otherwise use the more local value
+			return precedence < DependencyPropertyValuePrecedences.Inheritance ? // < actually means higher precedence
+				baseValue :
+				(propertyDetails ?? ((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(IsEnabledProperty)).GetValueUnderPrecedence(DependencyPropertyValuePrecedences.Coercion).value;
 		}
 
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
@@ -27,18 +27,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 {
 	public partial class ButtonBase : ContentControl
 	{
-		static ButtonBase()
-		{
-			IsEnabledProperty.OverrideMetadata(
-				typeof(ButtonBase),
-				new FrameworkPropertyMetadata(
-					defaultValue: true,
-					propertyChangedCallback: null,
-					coerceValueCallback: CoerceIsEnabled
-				)
-			);
-		}
-
 		public
 #if __ANDROID__
 			new
@@ -160,16 +148,15 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		}
 #endif
 
-		private static object CoerceIsEnabled(DependencyObject dependencyObject, object baseValue)
+		private protected override object CoerceIsEnabled(object baseValue)
 		{
-			if (dependencyObject is ButtonBase buttonBase
-				&& buttonBase.Command != null
-				&& !buttonBase.Command.CanExecute(buttonBase.CommandParameter))
+			if (Command != null
+				&& !Command.CanExecute(CommandParameter))
 			{
 				return false;
 			}
 
-			return baseValue;
+			return base.CoerceIsEnabled(baseValue);
 		}
 
 		private protected override void OnContentTemplateRootSet() => RegisterEvents();

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
@@ -148,7 +148,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		}
 #endif
 
-		private protected override object CoerceIsEnabled(object baseValue)
+		private protected override object CoerceIsEnabled(object baseValue, DependencyPropertyValuePrecedences precedence)
 		{
 			if (Command != null
 				&& !Command.CanExecute(CommandParameter))
@@ -156,7 +156,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				return false;
 			}
 
-			return base.CoerceIsEnabled(baseValue);
+			return base.CoerceIsEnabled(baseValue, precedence);
 		}
 
 		private protected override void OnContentTemplateRootSet() => RegisterEvents();

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/RangeBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/RangeBase.cs
@@ -18,17 +18,17 @@ public partial class RangeBase : Control
 
 	// Uno specific: Coercion for properties to call RangeBase Core
 
-	private static object CoerceValue(DependencyObject dependencyObject, object baseValue)
+	private static object CoerceValue(DependencyObject dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 	{
 		return ((RangeBase)dependencyObject).SetRangeBaseValue(ValueProperty, baseValue);
 	}
 
-	private static object CoerceMinimum(DependencyObject dependencyObject, object baseValue)
+	private static object CoerceMinimum(DependencyObject dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 	{
 		return ((RangeBase)dependencyObject).SetRangeBaseValue(MinimumProperty, baseValue);
 	}
 
-	private static object CoerceMaximum(DependencyObject dependencyObject, object baseValue)
+	private static object CoerceMaximum(DependencyObject dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 	{
 		return ((RangeBase)dependencyObject).SetRangeBaseValue(MaximumProperty, baseValue);
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -258,7 +258,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		private int _uncoercedSelectedIndex = -1;
 
-		private static object CoerceSelectedIndex(DependencyObject dependencyObject, object baseValue)
+		private static object CoerceSelectedIndex(DependencyObject dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			if (baseValue is not int desiredIndex)
 			{
@@ -376,7 +376,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			SelectedIndex = indexOfItemWithValue;
 		}
 
-		private static object SelectedValueCoerce(DependencyObject snd, object baseValue)
+		private static object SelectedValueCoerce(DependencyObject snd, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			var selector = (Selector)snd;
 			if (selector?._selectedValueBindingPath != null)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -235,7 +235,7 @@ namespace Windows.UI.Xaml.Controls
 				)
 			);
 
-		internal static object CoerceText(DependencyObject dependencyObject, object baseValue) =>
+		internal static object CoerceText(DependencyObject dependencyObject, object baseValue, DependencyPropertyValuePrecedences _) =>
 			baseValue is string
 				? baseValue
 				: string.Empty;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -135,7 +135,7 @@ namespace Windows.UI.Xaml.Controls
 				)
 			);
 
-		private static object CoerceImeOptions(DependencyObject dependencyObject, object baseValue)
+		private static object CoerceImeOptions(DependencyObject dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			return dependencyObject is TextBox textBox && textBox.InputScope?.GetFirstInputScopeNameValue() == InputScopeNameValue.Search
 				? ImeAction.Search

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -242,7 +242,7 @@ namespace Windows.UI.Xaml.Controls
 					defaultValue: string.Empty,
 					options: FrameworkPropertyMetadataOptions.CoerceWhenUnchanged,
 					propertyChangedCallback: (s, e) => ((TextBox)s)?.OnTextChanged(e),
-					coerceValueCallback: (d, v) => ((TextBox)d)?.CoerceText(v),
+					coerceValueCallback: (d, v, _) => ((TextBox)d)?.CoerceText(v),
 					defaultUpdateSourceTrigger: UpdateSourceTrigger.Explicit
 				)
 			);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -240,14 +240,11 @@ namespace Windows.UI.Xaml.Controls
 				typeof(TextBox),
 				new FrameworkPropertyMetadata(
 					defaultValue: string.Empty,
-					options: FrameworkPropertyMetadataOptions.None,
+					options: FrameworkPropertyMetadataOptions.CoerceWhenUnchanged,
 					propertyChangedCallback: (s, e) => ((TextBox)s)?.OnTextChanged(e),
 					coerceValueCallback: (d, v) => ((TextBox)d)?.CoerceText(v),
 					defaultUpdateSourceTrigger: UpdateSourceTrigger.Explicit
 				)
-				{
-					CoerceWhenUnchanged = false
-				}
 			);
 
 		protected virtual void OnTextChanged(DependencyPropertyChangedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -240,7 +240,7 @@ namespace Windows.UI.Xaml.Controls
 				typeof(TextBox),
 				new FrameworkPropertyMetadata(
 					defaultValue: string.Empty,
-					options: FrameworkPropertyMetadataOptions.CoerceWhenUnchanged,
+					options: FrameworkPropertyMetadataOptions.CoerceOnlyWhenChanged,
 					propertyChangedCallback: (s, e) => ((TextBox)s)?.OnTextChanged(e),
 					coerceValueCallback: (d, v, _) => ((TextBox)d)?.CoerceText(v),
 					defaultUpdateSourceTrigger: UpdateSourceTrigger.Explicit

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -291,13 +291,13 @@ namespace Windows.UI.Xaml.Controls
 				typeof(TextBox),
 				new FrameworkPropertyMetadata(
 					UIReturnKeyType.Default,
-					(s, e) => ((TextBox)s)?.OnReturnKeyTypeChanged((UIReturnKeyType)e.NewValue),
+					(s, e, _) => ((TextBox)s)?.OnReturnKeyTypeChanged((UIReturnKeyType)e.NewValue),
 					coerceValueCallback: CoerceReturnKeyType
 				)
 			);
 
 
-		private static object CoerceReturnKeyType(DependencyObject dependencyObject, object baseValue)
+		private static object CoerceReturnKeyType(DependencyObject dependencyObject, object baseValue, DependencyPropertyValuePrecedences _)
 		{
 			return dependencyObject is TextBox textBox && textBox.InputScope.GetFirstInputScopeNameValue() == InputScopeNameValue.Search
 				? UIReturnKeyType.Search

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.iOS.cs
@@ -291,7 +291,7 @@ namespace Windows.UI.Xaml.Controls
 				typeof(TextBox),
 				new FrameworkPropertyMetadata(
 					UIReturnKeyType.Default,
-					(s, e, _) => ((TextBox)s)?.OnReturnKeyTypeChanged((UIReturnKeyType)e.NewValue),
+					(s, e) => ((TextBox)s)?.OnReturnKeyTypeChanged((UIReturnKeyType)e.NewValue),
 					coerceValueCallback: CoerceReturnKeyType
 				)
 			);

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -68,7 +68,7 @@ namespace Windows.UI.Xaml.Controls
 					defaultValue: new TimeSpan(-1),
 					options: FrameworkPropertyMetadataOptions.None,
 					propertyChangedCallback: (s, e) => ((TimePicker)s)?.OnTimeChanged((TimeSpan)e.OldValue, (TimeSpan)e.NewValue),
-					coerceValueCallback: (s, e) => ((TimePicker)s)?.CoerceTime((TimeSpan)e))
+					coerceValueCallback: (s, e, _) => ((TimePicker)s)?.CoerceTime((TimeSpan)e))
 				);
 
 		private static void ValidateTimeSpanForTimeProperty(TimeSpan span)
@@ -110,7 +110,7 @@ namespace Windows.UI.Xaml.Controls
 					defaultValue: null,
 					FrameworkPropertyMetadataOptions.None,
 					propertyChangedCallback: (s, e) => ((TimePicker)s)?.OnSelectedTimeChanged((TimeSpan?)e.OldValue, (TimeSpan?)e.NewValue),
-					coerceValueCallback: (s, e) => ((TimePicker)s)?.CoerceSelectedTime((TimeSpan?)e))
+					coerceValueCallback: (s, e, _) => ((TimePicker)s)?.CoerceSelectedTime((TimeSpan?)e))
 				);
 
 		private static void ValidateTimeSpanForSelectedTimeProperty(TimeSpan? span)
@@ -145,7 +145,7 @@ namespace Windows.UI.Xaml.Controls
 					defaultValue: 1,
 					options: FrameworkPropertyMetadataOptions.None,
 					propertyChangedCallback: (s, e) => ((TimePicker)s)?.OnMinuteIncrementChanged((int)e.OldValue, (int)e.NewValue),
-					coerceValueCallback: (s, e) =>
+					coerceValueCallback: (s, e, _) =>
 					{
 						var value = (int)e;
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -17,7 +17,6 @@ using Uno.UI;
 using System.Collections;
 using System.Globalization;
 using Windows.ApplicationModel.Calls;
-using Windows.UI.Xaml.Controls;
 
 #if __ANDROID__
 using View = Android.Views.View;
@@ -469,16 +468,10 @@ namespace Windows.UI.Xaml
 					var previousValue = GetValue(propertyDetails);
 					var previousPrecedence = GetCurrentHighestValuePrecedence(propertyDetails);
 
-					ApplyCoercion(actualInstanceAlias, propertyDetails, previousValue, value);
-
-					// Set even if they are different to make sure the value is now set on the right precedence
+					// Set at precedence before setting at coercion as some elements use this value to determine how to coerce
 					SetValueInternal(value, precedence, propertyDetails);
-					
-					if (property == Control.IsEnabledProperty &&
-						GetValue(propertyDetails, DependencyPropertyValuePrecedences.Inheritance) is false)
-					{
-						SetValueInternal(false, DependencyPropertyValuePrecedences.Coercion, propertyDetails);
-					}
+
+					ApplyCoercion(actualInstanceAlias, propertyDetails, previousValue, value);
 
 					if (!isPersistentResourceBinding && !_isSettingPersistentResourceBinding)
 					{
@@ -659,7 +652,7 @@ namespace Windows.UI.Xaml
 				// Source: https://msdn.microsoft.com/en-us/library/ms745795%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
 				SetValueInternal(previousValue, DependencyPropertyValuePrecedences.Coercion, propertyDetails);
 			}
-			else if (!Equals(coercedValue, baseValue))
+			else if (!Equals(coercedValue, baseValue) || propertyDetails.Metadata.KeepCoercedWhenEquals)
 			{
 				// The base value and the coerced value are different, which means that coercion must be applied.
 				// Set value using DependencyPropertyValuePrecedences.Coercion, which has the highest precedence.

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -17,6 +17,7 @@ using Uno.UI;
 using System.Collections;
 using System.Globalization;
 using Windows.ApplicationModel.Calls;
+using Windows.UI.Xaml.Controls;
 
 #if __ANDROID__
 using View = Android.Views.View;
@@ -472,6 +473,12 @@ namespace Windows.UI.Xaml
 
 					// Set even if they are different to make sure the value is now set on the right precedence
 					SetValueInternal(value, precedence, propertyDetails);
+					
+					if (property == Control.IsEnabledProperty &&
+						GetValue(propertyDetails, DependencyPropertyValuePrecedences.Inheritance) is false)
+					{
+						SetValueInternal(false, DependencyPropertyValuePrecedences.Coercion, propertyDetails);
+					}
 
 					if (!isPersistentResourceBinding && !_isSettingPersistentResourceBinding)
 					{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -636,8 +636,9 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
-			if (Equals(previousValue, baseValue) &&
-				propertyDetails.Metadata is FrameworkPropertyMetadata fpmd && !fpmd.Options.HasFlag(FrameworkPropertyMetadataOptions.CoerceWhenUnchanged))
+			var options = (propertyDetails.Metadata as FrameworkPropertyMetadata)?.Options ?? FrameworkPropertyMetadataOptions.Default;
+
+			if (Equals(previousValue, baseValue) && !options.HasFlag(FrameworkPropertyMetadataOptions.CoerceWhenUnchanged))
 			{
 				// Value hasn't changed, don't coerce.
 				return;
@@ -653,8 +654,7 @@ namespace Windows.UI.Xaml
 				// Source: https://msdn.microsoft.com/en-us/library/ms745795%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
 				SetValueInternal(previousValue, DependencyPropertyValuePrecedences.Coercion, propertyDetails);
 			}
-			else if (!Equals(coercedValue, baseValue) ||
-				(propertyDetails.Metadata is FrameworkPropertyMetadata fpmd2 && fpmd2.Options.HasFlag(FrameworkPropertyMetadataOptions.KeepCoercedWhenEquals)))
+			else if (!Equals(coercedValue, baseValue) || options.HasFlag(FrameworkPropertyMetadataOptions.KeepCoercedWhenEquals))
 			{
 				// The base value and the coerced value are different, which means that coercion must be applied.
 				// Set value using DependencyPropertyValuePrecedences.Coercion, which has the highest precedence.

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -636,7 +636,8 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
-			if (!propertyDetails.Metadata.CoerceWhenUnchanged && Equals(previousValue, baseValue))
+			if (Equals(previousValue, baseValue) &&
+				propertyDetails.Metadata is FrameworkPropertyMetadata fpmd && (fpmd.Options & FrameworkPropertyMetadataOptions.CoerceWhenUnchanged) == 0)
 			{
 				// Value hasn't changed, don't coerce.
 				return;
@@ -652,7 +653,8 @@ namespace Windows.UI.Xaml
 				// Source: https://msdn.microsoft.com/en-us/library/ms745795%28v=vs.110%29.aspx?f=255&MSPPError=-2147217396
 				SetValueInternal(previousValue, DependencyPropertyValuePrecedences.Coercion, propertyDetails);
 			}
-			else if (!Equals(coercedValue, baseValue) || propertyDetails.Metadata.KeepCoercedWhenEquals)
+			else if (!Equals(coercedValue, baseValue) ||
+				(propertyDetails.Metadata is FrameworkPropertyMetadata fpmd2 && (fpmd2.Options & FrameworkPropertyMetadataOptions.KeepCoercedWhenEquals) != 0))
 			{
 				// The base value and the coerced value are different, which means that coercion must be applied.
 				// Set value using DependencyPropertyValuePrecedences.Coercion, which has the highest precedence.

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -640,7 +640,7 @@ namespace Windows.UI.Xaml
 
 			var options = (propertyDetails.Metadata as FrameworkPropertyMetadata)?.Options ?? FrameworkPropertyMetadataOptions.Default;
 
-			if (Equals(previousValue, baseValue) && !options.HasFlag(FrameworkPropertyMetadataOptions.CoerceWhenUnchanged))
+			if (Equals(previousValue, baseValue) && options.HasFlag(FrameworkPropertyMetadataOptions.CoerceOnlyWhenChanged))
 			{
 				// Value hasn't changed, don't coerce.
 				return;

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -637,7 +637,7 @@ namespace Windows.UI.Xaml
 			}
 
 			if (Equals(previousValue, baseValue) &&
-				propertyDetails.Metadata is FrameworkPropertyMetadata fpmd && (fpmd.Options & FrameworkPropertyMetadataOptions.CoerceWhenUnchanged) == 0)
+				propertyDetails.Metadata is FrameworkPropertyMetadata fpmd && !fpmd.Options.HasFlag(FrameworkPropertyMetadataOptions.CoerceWhenUnchanged))
 			{
 				// Value hasn't changed, don't coerce.
 				return;
@@ -654,7 +654,7 @@ namespace Windows.UI.Xaml
 				SetValueInternal(previousValue, DependencyPropertyValuePrecedences.Coercion, propertyDetails);
 			}
 			else if (!Equals(coercedValue, baseValue) ||
-				(propertyDetails.Metadata is FrameworkPropertyMetadata fpmd2 && (fpmd2.Options & FrameworkPropertyMetadataOptions.KeepCoercedWhenEquals) != 0))
+				(propertyDetails.Metadata is FrameworkPropertyMetadata fpmd2 && fpmd2.Options.HasFlag(FrameworkPropertyMetadataOptions.KeepCoercedWhenEquals)))
 			{
 				// The base value and the coerced value are different, which means that coercion must be applied.
 				// Set value using DependencyPropertyValuePrecedences.Coercion, which has the highest precedence.

--- a/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
@@ -33,9 +33,8 @@ namespace Windows.UI.Xaml
 		internal FrameworkPropertyMetadata(
 			object defaultValue,
 			CoerceValueCallback coerceValueCallback
-		) : base(defaultValue)
+		) : base(defaultValue, coerceValueCallback)
 		{
-			CoerceValueCallback = coerceValueCallback;
 		}
 
 		public FrameworkPropertyMetadata(

--- a/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
@@ -98,18 +98,6 @@ namespace Windows.UI.Xaml
 		{
 			Options = options.WithDefault();
 		}
-		
-		internal FrameworkPropertyMetadata(
-			object defaultValue,
-			FrameworkPropertyMetadataOptions options,
-			PropertyChangedCallback propertyChangedCallback,
-			CoerceValueCallback coerceValueCallback,
-			BackingFieldUpdateCallback backingFieldUpdateCallback,
-			bool keepCoercedWhenEquals
-		) : base(defaultValue, propertyChangedCallback, coerceValueCallback, backingFieldUpdateCallback, keepCoercedWhenEquals)
-		{
-			Options = options.WithDefault();
-		}
 
 		internal FrameworkPropertyMetadata(
 			object defaultValue,

--- a/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadata.cs
@@ -98,6 +98,18 @@ namespace Windows.UI.Xaml
 		{
 			Options = options.WithDefault();
 		}
+		
+		internal FrameworkPropertyMetadata(
+			object defaultValue,
+			FrameworkPropertyMetadataOptions options,
+			PropertyChangedCallback propertyChangedCallback,
+			CoerceValueCallback coerceValueCallback,
+			BackingFieldUpdateCallback backingFieldUpdateCallback,
+			bool keepCoercedWhenEquals
+		) : base(defaultValue, propertyChangedCallback, coerceValueCallback, backingFieldUpdateCallback, keepCoercedWhenEquals)
+		{
+			Options = options.WithDefault();
+		}
 
 		internal FrameworkPropertyMetadata(
 			object defaultValue,

--- a/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadataOptions.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadataOptions.cs
@@ -60,6 +60,19 @@ namespace Windows.UI.Xaml
 		AffectsRender = 1 << 8, // 256
 
 		/// <summary>
+		/// Should <see cref="CoerceValueCallback"/> be raised even if value has not changed?
+		/// </summary>
+		CoerceWhenUnchanged = 1 << 9, // 512
+
+		/// <summary>
+		/// Normally, when a property is updated and the coerced value is equal to
+		/// the value being updated to, the coerced value is thrown away. <seealso cref="DependencyObjectStore.ApplyCoercion"/>
+		/// This property is added specifically for Control.IsEnabledProperty in order
+		/// to override this behaviour.
+		/// </summary>
+		KeepCoercedWhenEquals = 1 << 10, // 1024
+
+		/// <summary>
 		/// The default options set when creating a <see cref="FrameworkPropertyMetadata"/>.
 		/// </summary>
 		/// <remarks>

--- a/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadataOptions.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkPropertyMetadataOptions.cs
@@ -60,9 +60,9 @@ namespace Windows.UI.Xaml
 		AffectsRender = 1 << 8, // 256
 
 		/// <summary>
-		/// Should <see cref="CoerceValueCallback"/> be raised even if value has not changed?
+		/// Should <see cref="CoerceValueCallback"/> be raised only when value has changed?
 		/// </summary>
-		CoerceWhenUnchanged = 1 << 9, // 512
+		CoerceOnlyWhenChanged = 1 << 9, // 512
 
 		/// <summary>
 		/// Normally, when a property is updated and the coerced value is equal to

--- a/src/Uno.UI/UI/Xaml/PropertyMetadata.cs
+++ b/src/Uno.UI/UI/Xaml/PropertyMetadata.cs
@@ -16,14 +16,15 @@ namespace Windows.UI.Xaml
 	/// Provides a template for a method that is called whenever a dependency property value is being re-evaluated, or coercion is specifically requested.
 	/// </summary>
 	/// <param name="dependencyObject">The object that the property exists on. When the callback is invoked, the property system will pass this value.</param>
-	/// <param name="args">The new value of the property, prior to any coercion attempt.</param>
-	internal delegate object CoerceValueCallback(DependencyObject dependencyObject, object baseValue);
+	/// <param name="baseValue">The new value of the property, prior to any coercion attempt.</param>
+	/// <param name="precedence">The precedence at which the new value is being set.</param>
+	internal delegate object CoerceValueCallback(DependencyObject dependencyObject, object baseValue, DependencyPropertyValuePrecedences precedence);
 
 	/// <summary>
 	/// Provides a delegate for a method used to update backing fields of a dependency property
 	/// </summary>
 	/// <param name="dependencyObject">The object that the property exists on.</param>
-	/// <param name="args">The new value of the property</param>
+	/// <param name="newValue">The new value of the property</param>
 	internal delegate void BackingFieldUpdateCallback(DependencyObject dependencyObject, object newValue);
 
 	/// <summary>
@@ -44,6 +45,15 @@ namespace Windows.UI.Xaml
 		)
 		{
 			DefaultValue = defaultValue;
+		}
+
+		internal PropertyMetadata(
+			object defaultValue,
+			CoerceValueCallback coerceValueCallback
+		)
+		{
+			DefaultValue = defaultValue;
+			CoerceValueCallback = coerceValueCallback;
 		}
 
 		internal PropertyMetadata(

--- a/src/Uno.UI/UI/Xaml/PropertyMetadata.cs
+++ b/src/Uno.UI/UI/Xaml/PropertyMetadata.cs
@@ -37,19 +37,6 @@ namespace Windows.UI.Xaml
 		private bool _isCoerceValueCallbackSet;
 		private CoerceValueCallback _coerceValueCallback;
 
-		/// <summary>
-		/// Should <see cref="CoerceValueCallback"/> be raised even if value has not changed?
-		/// </summary>
-		internal bool CoerceWhenUnchanged { get; set; } = true;
-
-		/// <summary>
-		/// Normally, when a property is updated and the coerced value is equal to
-		/// the value being updated to, the coerced value is thrown away. <seealso cref="DependencyObjectStore.ApplyCoercion"/>
-		/// This property is added specifically for Control.IsEnabledProperty in order
-		/// to override this behaviour.
-		/// </summary>
-		internal bool KeepCoercedWhenEquals { get; set; }
-
 		internal PropertyMetadata() { }
 
 		public PropertyMetadata(
@@ -126,21 +113,6 @@ namespace Windows.UI.Xaml
 			PropertyChangedCallback = propertyChangedCallback;
 			CoerceValueCallback = coerceValueCallback;
 			BackingFieldUpdateCallback = backingFieldUpdateCallback;
-		}
-
-		internal PropertyMetadata(
-			object defaultValue,
-			PropertyChangedCallback propertyChangedCallback,
-			CoerceValueCallback coerceValueCallback,
-			BackingFieldUpdateCallback backingFieldUpdateCallback,
-			bool keepCoercedWhenEquals
-		)
-		{
-			DefaultValue = defaultValue;
-			PropertyChangedCallback = propertyChangedCallback;
-			CoerceValueCallback = coerceValueCallback;
-			BackingFieldUpdateCallback = backingFieldUpdateCallback;
-			KeepCoercedWhenEquals = keepCoercedWhenEquals;
 		}
 
 		public object DefaultValue

--- a/src/Uno.UI/UI/Xaml/PropertyMetadata.cs
+++ b/src/Uno.UI/UI/Xaml/PropertyMetadata.cs
@@ -42,6 +42,14 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		internal bool CoerceWhenUnchanged { get; set; } = true;
 
+		/// <summary>
+		/// Normally, when a property is updated and the coerced value is equal to
+		/// the value being updated to, the coerced value is thrown away. <seealso cref="DependencyObjectStore.ApplyCoercion"/>
+		/// This property is added specifically for Control.IsEnabledProperty in order
+		/// to override this behaviour.
+		/// </summary>
+		internal bool KeepCoercedWhenEquals { get; set; }
+
 		internal PropertyMetadata() { }
 
 		public PropertyMetadata(
@@ -118,6 +126,21 @@ namespace Windows.UI.Xaml
 			PropertyChangedCallback = propertyChangedCallback;
 			CoerceValueCallback = coerceValueCallback;
 			BackingFieldUpdateCallback = backingFieldUpdateCallback;
+		}
+
+		internal PropertyMetadata(
+			object defaultValue,
+			PropertyChangedCallback propertyChangedCallback,
+			CoerceValueCallback coerceValueCallback,
+			BackingFieldUpdateCallback backingFieldUpdateCallback,
+			bool keepCoercedWhenEquals
+		)
+		{
+			DefaultValue = defaultValue;
+			PropertyChangedCallback = propertyChangedCallback;
+			CoerceValueCallback = coerceValueCallback;
+			BackingFieldUpdateCallback = backingFieldUpdateCallback;
+			KeepCoercedWhenEquals = keepCoercedWhenEquals;
 		}
 
 		public object DefaultValue

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
@@ -60,10 +60,13 @@ namespace Windows.UI.Xaml
 		/// <returns></returns>
 		private object CoerceHitTestVisibility(object baseValue)
 		{
-			var parentValue = ((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(HitTestVisibilityProperty).GetValue(DependencyPropertyValuePrecedences.Inheritance);
+			// The HitTestVisibilityProperty is never set directly. This means that baseValue is always the result of the parent's CoerceHitTestVisibility.
+			var parentValue = baseValue == DependencyProperty.UnsetValue 
+				? HitTestability.Collapsed
+				: (HitTestability)baseValue;
 
 			// If the parent is collapsed, we should be collapsed as well. This takes priority over everything else, even if we would be visible otherwise.
-			if (parentValue != DependencyProperty.UnsetValue && (HitTestability)parentValue! == HitTestability.Collapsed)
+			if (parentValue == HitTestability.Collapsed)
 			{
 				return HitTestability.Collapsed;
 			}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
@@ -61,7 +61,7 @@ namespace Windows.UI.Xaml
 		private object CoerceHitTestVisibility(object baseValue)
 		{
 			// The HitTestVisibilityProperty is never set directly. This means that baseValue is always the result of the parent's CoerceHitTestVisibility.
-			var parentValue = baseValue == DependencyProperty.UnsetValue 
+			var parentValue = baseValue == DependencyProperty.UnsetValue
 				? HitTestability.Collapsed
 				: (HitTestability)baseValue;
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Managed.cs
@@ -60,11 +60,10 @@ namespace Windows.UI.Xaml
 		/// <returns></returns>
 		private object CoerceHitTestVisibility(object baseValue)
 		{
-			// The HitTestVisibilityProperty is never set directly. This means that baseValue is always the result of the parent's CoerceHitTestVisibility.
-			var baseHitTestVisibility = (HitTestability)baseValue;
+			var parentValue = ((IDependencyObjectStoreProvider)this).Store.GetPropertyDetails(HitTestVisibilityProperty).GetValue(DependencyPropertyValuePrecedences.Inheritance);
 
 			// If the parent is collapsed, we should be collapsed as well. This takes priority over everything else, even if we would be visible otherwise.
-			if (baseHitTestVisibility == HitTestability.Collapsed)
+			if (parentValue != DependencyProperty.UnsetValue && (HitTestability)parentValue! == HitTestability.Collapsed)
 			{
 				return HitTestability.Collapsed;
 			}

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -189,7 +189,7 @@ namespace Windows.UI.Xaml
 				RoutedEventFlag.None,
 				FrameworkPropertyMetadataOptions.Inherits)
 			{
-				CoerceValueCallback = CoerceRoutedEventFlag
+				CoerceValueCallback = (dependencyObject, value, _) => CoerceRoutedEventFlag(dependencyObject, value)
 			}
 		);
 
@@ -212,7 +212,7 @@ namespace Windows.UI.Xaml
 					RoutedEventFlag.None,
 					FrameworkPropertyMetadataOptions.Inherits)
 				{
-					CoerceValueCallback = CoerceRoutedEventFlag
+					CoerceValueCallback = (dependencyObject, value, _) => CoerceRoutedEventFlag(dependencyObject, value)
 				}
 			);
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12758

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea88803</samp>

This pull request adds a new UI test for the `IsEnabled` property of buttons inside content controls, and fixes a bug in the `DependencyObjectStore` class that prevented the correct coercion of the property. It modifies the `UITests.Shared` project and the `DependencyObjectStore` class, and adds new XAML and code-behind files for the test page.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
