### PR TITLE
fix(svg): Use StorageFile for reading the SVG payload

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/SvgImageSource_Basic.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/SvgImageSource_Basic.xaml.cs
@@ -38,6 +38,7 @@ public sealed partial class SvgImageSource_Basic : Page
 
 	public SampleSvgSource[] Sources { get; } = new SampleSvgSource[]
 	{
+		new("Couch (ms-appx library)", new Uri("ms-appx:///Uno.UI.RuntimeTests/Assets/couch.svg")),
 		new("Couch (ms-appx)", new Uri("ms-appx:///Assets/Formats/couch.svg")),
 		new("Calendar (ms-appx)", new Uri("ms-appx:///Assets/Formats/czcalendar.svg")),
 		new("Home (ms-appx)", new Uri("ms-appx:///Assets/Formats/home.svg")),

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -463,6 +463,20 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForLoaded(image);
 		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_SVGImageSource_From_Library()
+		{
+			if (!ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
+			}
+
+			var svgImageSource = new SvgImageSource(new Uri("ms-appx:///Uno.UI.RuntimeTests/Assets/couch.svg"));
+			var image = new Image() { Source = svgImageSource, Width = 100, Height = 100 };
+			TestServices.WindowHelper.WindowContent = image;
+			await WindowHelper.WaitForLoaded(image);
+		}
 
 		[TestMethod]
 		[RunsOnUIThread]

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
@@ -114,9 +114,17 @@ namespace Windows.UI.Xaml.Media
 
 		partial void InitFromResource(Uri uri)
 		{
-			ResourceString = uri.PathAndQuery.TrimStart(new[] { '/' });
+			if (uri.OriginalString.EndsWith(".svg", StringComparison.Ordinal))
+			{
+				// SVGs do not support direct assets reading so we use uri based loading
+				AbsoluteUri = uri;
+			}
+			else
+			{
+				ResourceString = uri.PathAndQuery.TrimStart(new[] { '/' });
 
-			ResourceId = Uno.Helpers.DrawableHelper.FindResourceIdFromPath(ResourceString);
+				ResourceId = Uno.Helpers.DrawableHelper.FindResourceIdFromPath(ResourceString);
+			}
 		}
 
 		partial void CleanupResource()

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.Android.cs
@@ -33,16 +33,6 @@ partial class SvgImageSource
 	{
 		try
 		{
-			if (ResourceId.HasValue)
-			{
-				return await FetchSvgResource(ct, ResourceId.Value);
-			}
-
-			if (ResourceString is not null)
-			{
-				return await FetchSvgAssetAsync(ct, ResourceString);
-			}
-
 			if (Stream is not null)
 			{
 				return await ReadFromStreamAsync(Stream, ct);
@@ -65,6 +55,15 @@ partial class SvgImageSource
 					}
 
 					return await ReadFromStreamAsync(stream, ct);
+				}
+
+				if (AbsoluteUri.IsLocalResource())
+				{
+					var file = await StorageFile.GetFileFromApplicationUriAsync(AbsoluteUri);
+
+					using var fileStream = await file.OpenAsync(FileAccessMode.Read);
+					using var ioStream = fileStream.AsStream();
+					return await ReadFromStreamAsync(ioStream, ct);
 				}
 
 				if (Downloader is not null)
@@ -92,26 +91,5 @@ partial class SvgImageSource
 		{
 			return ImageData.FromError(ex);
 		}
-	}
-
-	private async Task<ImageData> FetchSvgResource(CancellationToken ct, int resourceId)
-	{
-		if (ContextHelper.Current.Resources?.OpenRawResource(resourceId) is not { } rawResourceStream)
-		{
-			return ImageData.Empty;
-		}
-
-		return await ReadFromStreamAsync(rawResourceStream, ct);
-	}
-
-	private async Task<ImageData> FetchSvgAssetAsync(CancellationToken ct, string assetPath)
-	{
-		if (ContextHelper.Current.Assets is not AssetManager assets)
-		{
-			return ImageData.Empty;
-		}
-
-		using var stream = assets.Open(assetPath);
-		return await ReadFromStreamAsync(stream, ct);
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/12667

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change aligns the assets resolution, particularly when using paths that contain library assets.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
copilot:summary

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
