### PR TITLE
fix(ListView): Fix element not placed properly when re-ordering

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
@@ -1,4 +1,5 @@
-﻿using Uno.Extensions;
+﻿//#define USE_CUSTOM_LAYOUT_ATTRIBUTES (cf. VirtualizingPanelLayout.iOS.cs for more info)
+using Uno.Extensions;
 using Windows.UI.Xaml;
 using System;
 using System.Collections.Generic;
@@ -14,6 +15,12 @@ using Foundation;
 using UIKit;
 using CoreGraphics;
 using LayoutInfo = System.Collections.Generic.Dictionary<Foundation.NSIndexPath, UIKit.UICollectionViewLayoutAttributes>;
+
+#if USE_CUSTOM_LAYOUT_ATTRIBUTES
+using _LayoutAttributes = Windows.UI.Xaml.Controls.UnoUICollectionViewLayoutAttributes;
+#else
+using _LayoutAttributes = UIKit.UICollectionViewLayoutAttributes;
+#endif
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -60,7 +67,7 @@ namespace Windows.UI.Xaml.Controls
 			return measuredBreadth;
 		}
 
-		private protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem, bool shouldRecurse)
+		private protected override void UpdateLayoutAttributesForItem(_LayoutAttributes updatingItem, bool shouldRecurse)
 		{
 			while (updatingItem != null)
 			{
@@ -69,12 +76,12 @@ namespace Windows.UI.Xaml.Controls
 				var nextIndexInGroup = GetNSIndexPathFromRowSection(currentIndex.Row + 1, currentIndex.Section);
 
 				// Get next item in current group
-				var elementToAdjust = LayoutAttributesForItem(nextIndexInGroup);
+				var elementToAdjust = (_LayoutAttributes)LayoutAttributesForItem(nextIndexInGroup);
 
-				if (elementToAdjust == null)
+				if (elementToAdjust is null)
 				{
 					// No more items in current group, get group header of next group
-					elementToAdjust = LayoutAttributesForSupplementaryView(
+					elementToAdjust = (_LayoutAttributes)LayoutAttributesForSupplementaryView(
 						NativeListViewBase.ListViewSectionHeaderElementKindNS,
 						GetNSIndexPathFromRowSection(0, currentIndex.Section + 1));
 
@@ -82,15 +89,15 @@ namespace Windows.UI.Xaml.Controls
 					_sectionEnd[currentIndex.Section] = GetExtentEnd(updatingItem.Frame);
 				}
 
-				if (elementToAdjust == null)
+				if (elementToAdjust is null)
 				{
 					// No more groups in source, get footer
-					elementToAdjust = LayoutAttributesForSupplementaryView(
+					elementToAdjust = (_LayoutAttributes)LayoutAttributesForSupplementaryView(
 						NativeListViewBase.ListViewFooterElementKindNS,
 						GetNSIndexPathFromRowSection(0, 0));
 				}
 
-				if (elementToAdjust == null)
+				if (elementToAdjust is null)
 				{
 					break;
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -1,3 +1,4 @@
+//#define USE_CUSTOM_LAYOUT_ATTRIBUTES (cf. VirtualizingPanelLayout.iOS.cs for more info)
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -31,6 +32,12 @@ using NativeHandle = System.IntPtr;
 using Foundation;
 using UIKit;
 using CoreGraphics;
+
+#if USE_CUSTOM_LAYOUT_ATTRIBUTES
+using _LayoutAttributes = Windows.UI.Xaml.Controls.UnoUICollectionViewLayoutAttributes;
+#else
+using _LayoutAttributes = UIKit.UICollectionViewLayoutAttributes;
+#endif
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -842,9 +849,9 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		internal void ClearMeasuredSize() => _measuredContentSize = null;
 
-		public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(UICollectionViewLayoutAttributes layoutAttributes)
+		public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(UICollectionViewLayoutAttributes nativeLayoutAttributes)
 		{
-			if (!(((object)layoutAttributes) is UICollectionViewLayoutAttributes))
+			if (((object)nativeLayoutAttributes) is not _LayoutAttributes)
 			{
 				// This case happens for a yet unknown GC issue, where the layoutAttribute instance passed the current
 				// method maps to another object. The repro steps are not clear, and it may be related to ListView/GridView
@@ -853,6 +860,7 @@ namespace Windows.UI.Xaml.Controls
 				return null;
 			}
 
+			var layoutAttributes = (_LayoutAttributes)nativeLayoutAttributes;
 			if (Content == null)
 			{
 				this.Log().Error("Empty ListViewBaseInternalContainer content.");
@@ -916,6 +924,7 @@ namespace Windows.UI.Xaml.Controls
 							//to use stale layoutAttributes for deciding if items should be visible, leading to them popping out of view mid-viewport.
 							Owner?.NativeLayout?.RefreshLayout();
 						}
+
 						layoutAttributes.Frame = frame;
 						if (sizesAreDifferent)
 						{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿//#define USE_CUSTOM_LAYOUT_ATTRIBUTES // Use this to debug the frame of the attributes (This also has to be set in the ListViewBaseSource.iOS.cs and ItemsStackPanaleLayout.iOS.cs)
+using System;
 using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Uno.Extensions;
@@ -7,7 +8,6 @@ using Uno.Disposables;
 using Foundation;
 using UIKit;
 using CoreGraphics;
-using LayoutInfoDictionary = System.Collections.Generic.Dictionary<Foundation.NSIndexPath, UIKit.UICollectionViewLayoutAttributes>;
 using Uno.Diagnostics.Eventing;
 using Uno;
 using Uno.UI.DataBinding;
@@ -15,6 +15,7 @@ using System.Linq;
 using Uno.Foundation.Logging;
 
 using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
 using Windows.UI.Xaml.Controls.Primitives;
 using Uno.UI;
 using Windows.Foundation;
@@ -23,8 +24,40 @@ using Windows.Foundation;
 using ObjCRuntime;
 #endif
 
+#if USE_CUSTOM_LAYOUT_ATTRIBUTES
+using _LayoutAttributes = Microsoft.UI.Xaml.Controls.UnoUICollectionViewLayoutAttributes;
+using LayoutInfoDictionary = System.Collections.Generic.Dictionary<Foundation.NSIndexPath, Microsoft.UI.Xaml.Controls.UnoUICollectionViewLayoutAttributes>;
+#else
+using _LayoutAttributes = UIKit.UICollectionViewLayoutAttributes;
+using LayoutInfoDictionary = System.Collections.Generic.Dictionary<Foundation.NSIndexPath, UIKit.UICollectionViewLayoutAttributes>;
+#endif
+
+
 namespace Windows.UI.Xaml.Controls
 {
+#if USE_CUSTOM_LAYOUT_ATTRIBUTES
+	public class UnoUICollectionViewLayoutAttributes : UICollectionViewLayoutAttributes
+	{
+		/// <inheritdoc />
+		public override CGRect Frame
+		{
+			get => base.Frame;
+			set
+			{
+				
+				var was = base.Frame;
+				base.Frame = value;
+				var index = IndexPath;
+
+				this.Log().Debug($"////////////// ALTERING FRAME OF ATTRIBUTES: {GetHashCode():X8} {index.Section}-{index.Row} from {ToString(was)} TO {ToString(value)}");
+				
+				static string ToString(CGRect frame)
+					=> $" {((int)frame.Width)}x{((int)frame.Height)}@{((int)frame.X)},{((int)frame.Y)}";
+			}
+		}
+	}
+#endif
+
 	public abstract partial class VirtualizingPanelLayout : UICollectionViewLayout, DependencyObject
 	{
 		private readonly static IEventProvider _trace = Tracing.Get(TraceProvider.Id);
@@ -82,7 +115,7 @@ namespace Windows.UI.Xaml.Controls
 		/// The last element in the list. This is set when the layout is created (and will point to the databound size and position of 
 		/// the element, once it has been materialized).
 		/// </summary>
-		private UICollectionViewLayoutAttributes _lastElement;
+		private _LayoutAttributes _lastElement;
 
 		/// <summary>
 		/// Locations of group header frames if they were to appear inline with items (ie not 'sticky').
@@ -92,7 +125,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private Thickness _padding;
 		private Dictionary<CachedTuple<int, int>, NSIndexPath> _indexPaths = new Dictionary<CachedTuple<int, int>, NSIndexPath>(CachedTuple<int, int>.Comparer);
-		private Dictionary<CachedTuple<int, int>, UICollectionViewLayoutAttributes> _layoutAttributesForIndexPaths = new Dictionary<CachedTuple<int, int>, UICollectionViewLayoutAttributes>(CachedTuple<int, int>.Comparer);
+		private Dictionary<CachedTuple<int, int>, _LayoutAttributes> _layoutAttributesForIndexPaths = new Dictionary<CachedTuple<int, int>, _LayoutAttributes>(CachedTuple<int, int>.Comparer);
 		private DirtyState _dirtyState;
 		/// <summary>
 		/// The most recently returned desired size.
@@ -116,7 +149,7 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		private UICollectionViewUpdateItem[] _updateItems;
 
-		private (Point Location, object Item, UICollectionViewLayoutAttributes LayoutAttributes)? _reorderingState;
+		private (Point Location, object Item, _LayoutAttributes LayoutAttributes)? _reorderingState;
 		private NSIndexPath _reorderingDropTarget;
 		/// <summary>
 		/// Pre-reorder item positions, stored while applying provisional positions during drag-to-reorder
@@ -223,7 +256,7 @@ namespace Windows.UI.Xaml.Controls
 		#region Overrides
 		public override UICollectionViewLayoutAttributes[] LayoutAttributesForElementsInRect(CGRect rect)
 		{
-			var allAttributes = new List<UICollectionViewLayoutAttributes>();
+			var allAttributes = new List<_LayoutAttributes>();
 
 			foreach (var cellLayoutInfo in _itemLayoutInfos.Values.Concat(_supplementaryLayoutInfos.Values))
 			{
@@ -233,9 +266,13 @@ namespace Windows.UI.Xaml.Controls
 					// Alias to avoid paying the price of interop twice.
 					var frame = layoutAttributes.Frame;
 
-					if (SupportsDynamicItemSizes && HasDynamicElementSizes && areItems)
+					if (SupportsDynamicItemSizes && HasDynamicElementSizes && areItems && _reorderingState is null)
 					{
 						//Propagate layout changes for materialized items that may have a different size to the non-databound template.
+						// Note: If there is pending re-ordering (_reorderingState is not null), we don't want to update the layout attributes,
+						//		 as this will cause the item to jump to the wrong position.
+						//		 Anyway in that case item should already have the correct size.
+
 						UpdateLayoutAttributesForItem(layoutAttributes, shouldRecurse: false);
 					}
 
@@ -650,7 +687,7 @@ namespace Windows.UI.Xaml.Controls
 				//Ensure container for group exists even if group contains no items, to simplify subsequent logic
 				if (createLayoutInfo)
 				{
-					_itemLayoutInfos[section] = new Dictionary<NSIndexPath, UICollectionViewLayoutAttributes>();
+					_itemLayoutInfos[section] = new Dictionary<NSIndexPath, _LayoutAttributes>();
 				}
 				//b. Layout items in group
 				var itemsBreadth = LayoutItemsInGroup(section, availableGroupBreadth, ref frame, createLayoutInfo, oldItemSizes);
@@ -780,7 +817,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var container = _supplementaryLayoutInfos.FindOrCreate(kind, () => new LayoutInfoDictionary());
 			var indexPath = GetNSIndexPathFromRowSection(row, section);
-			var layout = UICollectionViewLayoutAttributes.CreateForSupplementaryView(kind, indexPath);
+			var layout = UICollectionViewLayoutAttributes.CreateForSupplementaryView<_LayoutAttributes>(kind, indexPath);
 			layout.Frame = frame;
 			container[indexPath] = layout;
 			_lastElement = layout;
@@ -788,7 +825,7 @@ namespace Windows.UI.Xaml.Controls
 
 		protected void CreateItemLayoutInfo(int row, int section, CGRect frame)
 		{
-			var layout = GetLayoutAttributesForIndexPath(row, section);
+			var layout = (_LayoutAttributes)GetLayoutAttributesForIndexPath(row, section);
 			layout.Frame = frame;
 			var container = _itemLayoutInfos.FindOrCreate(section, () => new LayoutInfoDictionary());
 			container[GetNSIndexPathFromRowSection(row, section)] = layout;
@@ -887,7 +924,7 @@ namespace Windows.UI.Xaml.Controls
 				0 :
 				1;
 			var offset = CollectionView.ContentOffset.GetXOrY(axisIndex);
-			Dictionary<NSIndexPath, UIKit.UICollectionViewLayoutAttributes> headerAttributes;
+			Dictionary<NSIndexPath, _LayoutAttributes> headerAttributes;
 			if (_supplementaryLayoutInfos.TryGetValue(NativeListViewBase.ListViewSectionHeaderElementKind, out headerAttributes))
 			{
 				foreach (var kvp in headerAttributes)
@@ -1091,12 +1128,12 @@ namespace Windows.UI.Xaml.Controls
 		protected UICollectionViewLayoutAttributes GetLayoutAttributesForIndexPath(int row, int section)
 		{
 			var key = CachedTuple.Create(row, section);
-			UICollectionViewLayoutAttributes attributes;
+			_LayoutAttributes attributes;
 
 			if (!_layoutAttributesForIndexPaths.TryGetValue(key, out attributes))
 			{
 				var indexPath = GetNSIndexPathFromRowSection(row, section);
-				_layoutAttributesForIndexPaths.Add(key, attributes = UICollectionViewLayoutAttributes.CreateForCell<UICollectionViewLayoutAttributes>(indexPath));
+				_layoutAttributesForIndexPaths.Add(key, attributes = UICollectionViewLayoutAttributes.CreateForCell<_LayoutAttributes>(indexPath));
 			}
 
 			return attributes;
@@ -1132,7 +1169,7 @@ namespace Windows.UI.Xaml.Controls
 		/// <summary>
 		/// Update cached layout attributes for an element after the materialized, databound element has been measured.
 		/// </summary>
-		public void UpdateLayoutAttributesForElement(UICollectionViewLayoutAttributes layoutAttributes)
+		public void UpdateLayoutAttributesForElement(_LayoutAttributes layoutAttributes)
 		{
 			//Update frame of target layoutAttributes
 			var identifier = layoutAttributes.RepresentedElementKind;
@@ -1268,7 +1305,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected void UpdateLayoutAttributesForGroupHeader(UICollectionViewLayoutAttributes groupHeaderLayout, nfloat extentDifference, bool applyOffsetToThis)
+		protected void UpdateLayoutAttributesForGroupHeader(_LayoutAttributes groupHeaderLayout, nfloat extentDifference, bool applyOffsetToThis)
 		{
 			if (applyOffsetToThis)
 			{
@@ -1296,7 +1333,7 @@ namespace Windows.UI.Xaml.Controls
 			_sectionEnd[groupHeaderLayout.IndexPath.Section] += extentDifference;
 		}
 
-		private protected virtual void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes layoutAttributes, bool shouldRecurse)
+		private protected virtual void UpdateLayoutAttributesForItem(_LayoutAttributes layoutAttributes, bool shouldRecurse)
 		{
 			throw new NotSupportedException($"This should be overridden by types which set {nameof(SupportsDynamicItemSizes)} to true.");
 		}
@@ -1445,7 +1482,7 @@ namespace Windows.UI.Xaml.Controls
 		/// <summary>
 		/// Get all LayoutAttributes for every display element.
 		/// </summary>
-		private IEnumerable<UICollectionViewLayoutAttributes> GetAllElementLayouts()
+		private IEnumerable<_LayoutAttributes> GetAllElementLayouts()
 		{
 			foreach (var kvp in _itemLayoutInfos)
 			{
@@ -1485,7 +1522,8 @@ namespace Windows.UI.Xaml.Controls
 		internal void UpdateReorderingItem(Point location, FrameworkElement element, object item)
 		{
 			var indexPath = XamlParent.GetIndexPathFromItem(item);
-			var layoutAttributes = LayoutAttributesForItem(indexPath.ToNSIndexPath());
+			var layoutAttributes = (_LayoutAttributes)LayoutAttributesForItem(indexPath.ToNSIndexPath());
+
 			_reorderingState = (location, item, layoutAttributes);
 			if (layoutAttributes != null && !DoesLayoutAttributesContainDraggedPoint(location, layoutAttributes))
 			{
@@ -1566,7 +1604,7 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
-			CGRect ApplyTemporaryFrame(UICollectionViewLayoutAttributes layoutAttributes, nfloat adjustValue, AdjustFrame adjustFrame)
+			CGRect ApplyTemporaryFrame(_LayoutAttributes layoutAttributes, nfloat adjustValue, AdjustFrame adjustFrame)
 			{
 				var frame = layoutAttributes.Frame;
 				_preReorderFrames[layoutAttributes.IndexPath] = frame;
@@ -1592,12 +1630,12 @@ namespace Windows.UI.Xaml.Controls
 			_preReorderFrames.Clear();
 		}
 
-		private UICollectionViewLayoutAttributes FindLayoutAttributesClosestOfPoint(Point point)
+		private _LayoutAttributes FindLayoutAttributesClosestOfPoint(Point point)
 		{
 			var adjustedPoint = AdjustExtentOffset(point, GetExtent(Owner.ContentOffset));
 
 			var closestDistance = double.MaxValue;
-			var closestElement = default(UICollectionViewLayoutAttributes);
+			var closestElement = default(_LayoutAttributes);
 
 			foreach (var dict in _itemLayoutInfos.Values)
 			{
@@ -1621,7 +1659,7 @@ namespace Windows.UI.Xaml.Controls
 			return closestElement;
 		}
 
-		private bool DoesLayoutAttributesContainDraggedPoint(Point point, UICollectionViewLayoutAttributes layoutAttributes)
+		private bool DoesLayoutAttributesContainDraggedPoint(Point point, _LayoutAttributes layoutAttributes)
 		{
 			var adjustedPoint = AdjustExtentOffset(point, GetExtent(Owner.ContentOffset));
 			return layoutAttributes.Frame.Contains(adjustedPoint);
@@ -1894,7 +1932,28 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 #if DEBUG
-		UICollectionViewLayoutAttributes[] AllItemLayoutAttributes => _itemLayoutInfos?.SelectMany(kvp => kvp.Value.Values).ToArray();
+		_LayoutAttributes[] AllItemLayoutAttributes => _itemLayoutInfos?.SelectMany(kvp => kvp.Value.Values).ToArray();
+
+		private void DumpFrames(string header, [CallerMemberName] string caller = "", [CallerLineNumber] int line = -1)
+		{
+			Console.WriteLine($"********************* {caller}@{line}: {header}");
+			foreach (var dict in _itemLayoutInfos.Values)
+			{
+				var i = 0;
+				foreach (var layoutAttributes in dict.Values)
+				{
+					Console.WriteLine($"*********************   - {i++} {ToString(layoutAttributes)}");
+				}
+			}
+		}
+
+		private string ToString(UICollectionViewLayoutAttributes layoutAttributes)
+		{
+			var index = layoutAttributes.IndexPath;
+			var data = (CollectionView?.CellForItem(index)?.ContentView?.Subviews?.FirstOrDefault() as FrameworkElement)?.DataContext?.ToString() ?? "--undef--";
+
+			return $"{layoutAttributes.GetHashCode():X8} {index.Section}-{index.Row} {((int)layoutAttributes.Frame.Width)}x{((int)layoutAttributes.Frame.Height)}@{((int)layoutAttributes.Frame.X)},{((int)layoutAttributes.Frame.Y)} {data}";
+		}
 
 #pragma warning disable IDE0051 // Remove unused private members
 		CGRect[] AllItemFrames => AllItemLayoutAttributes?.Select(l => l.Frame).ToArray();


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/12207

## Bugfix
Fix element not placed properly when re-ordering

## What is the current behavior?
When re-ordering items the logic that adjust the size of the items in order to support dynamically sized items ignores the re-ordering state.

## What is the new behavior?
As when we re-order items, they already have the valid size, we disable the `Frame` update for dynamically sized items.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
copilot:summary

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- ~~[ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This cannot be tested properly using automated tests since we don't have support yet to take screenshots while manipulating items.