### PR TITLE
fix: Fix TextDecoratios DP type and improve conversion to enum handling

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -6,6 +6,7 @@ using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI;
+using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
@@ -18,6 +19,21 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 	[TestClass]
 	public class Given_TextBlock
 	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Check_TextDecorations_Binding()
+		{
+			var SUT = new TextDecorationsBinding();
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(TextDecorations.Strikethrough, SUT.textBlock1.TextDecorations);
+			Assert.AreEqual(TextDecorations.Underline, SUT.textBlock2.TextDecorations);
+			Assert.AreEqual(TextDecorations.Strikethrough, SUT.textBlock3.TextDecorations);
+			Assert.AreEqual(TextDecorations.None, SUT.textBlock4.TextDecorations);
+			Assert.AreEqual(TextDecorations.Strikethrough, SUT.textBlock5.TextDecorations);
+			Assert.AreEqual(TextDecorations.None, SUT.textBlock6.TextDecorations);
+		}
+
 		[TestMethod]
 		[RunsOnUIThread]
 		public void Check_ActualWidth_After_Measure()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TextDecorationsBinding.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TextDecorationsBinding.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TextDecorationsBinding"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<StackPanel>
+		<TextBlock x:Name="textBlock1" x:FieldModifier="public" TextDecorations="{Binding P1}" />
+		<TextBlock x:Name="textBlock2" x:FieldModifier="public" TextDecorations="{Binding P2}" />
+		<TextBlock x:Name="textBlock3" x:FieldModifier="public" TextDecorations="{Binding P3}" />
+		<TextBlock x:Name="textBlock4" x:FieldModifier="public" TextDecorations="{Binding P4}" />
+		<TextBlock x:Name="textBlock5" x:FieldModifier="public" TextDecorations="{Binding P5}" />
+		<TextBlock x:Name="textBlock6" x:FieldModifier="public" TextDecorations="{Binding P6}" />
+	</StackPanel>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TextDecorationsBinding.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TextDecorationsBinding.xaml.cs
@@ -1,0 +1,20 @@
+﻿using Windows.UI.Text;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+public sealed partial class TextDecorationsBinding : Page
+{
+	public int P1 => (int)TextDecorations.Strikethrough;
+	public uint P2 => (uint)TextDecorations.Underline;
+	public TextDecorations P3 => TextDecorations.Strikethrough;
+	public TextDecorationsBinding P4 => null;
+	public string P5 => "Strikethrough";
+	public string P6 => "InvalidValue";
+
+	public TextDecorationsBinding()
+	{
+		this.InitializeComponent();
+		DataContext = this;
+	}
+}

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -1239,7 +1239,7 @@ namespace Uno.UI.DataBinding
 
 		private static object? ConvertToEnum(Type enumType, object value)
 		{
-			var valueString = value.ToString();
+			var valueString = Enum.GetName(enumType, value);
 
 			FieldInfo? defaultValue = null;
 			foreach (var field in enumType.GetFields())
@@ -1255,20 +1255,10 @@ namespace Uno.UI.DataBinding
 					if (descriptionAttribute.Description.Equals(valueString, StringComparison.CurrentCultureIgnoreCase) ||
 						descriptionAttribute.Description.Equals(valueString, StringComparison.InvariantCultureIgnoreCase))
 					{
-#if NET7_0_OR_GREATER
 						if (Enum.TryParse(enumType, field.Name, ignoreCase: true, out var enumValue))
 						{
 							return enumValue;
 						}
-#else
-						try
-						{
-							return Enum.Parse(enumType, field.Name, ignoreCase: true);
-						}
-						catch (Exception)
-						{
-						}
-#endif
 					}
 
 					if (descriptionAttribute.Description == "?")
@@ -1280,20 +1270,10 @@ namespace Uno.UI.DataBinding
 
 			if (defaultValue is not null)
 			{
-#if NET7_0_OR_GREATER
 				if (Enum.TryParse(enumType, defaultValue.Name, ignoreCase: true, out var enumValue))
 				{
 					return enumValue;
 				}
-#else
-				try
-				{
-					return Enum.Parse(enumType, defaultValue.Name, ignoreCase: true);
-				}
-				catch (Exception)
-				{
-				}
-#endif
 			}
 
 			return DependencyProperty.UnsetValue;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -655,8 +655,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public static DependencyProperty TextDecorationsProperty { get; } =
 			DependencyProperty.Register(
-				"TextDecorations",
-				typeof(uint),
+				nameof(TextDecorations),
+				typeof(TextDecorations),
 				typeof(TextBlock),
 				new FrameworkPropertyMetadata(
 					defaultValue: TextDecorations.None,

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
@@ -242,8 +242,8 @@ namespace Windows.UI.Xaml.Documents
 
 		public static DependencyProperty TextDecorationsProperty { get; } =
 			DependencyProperty.Register(
-				"TextDecorations",
-				typeof(uint),
+				nameof(TextDecorations),
+				typeof(TextDecorations),
 				typeof(TextElement),
 				new FrameworkPropertyMetadata(
 					defaultValue: TextDecorations.None,


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12929

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99dd854</samp>

This pull request implements the `TextDecorations` feature on Uno, which allows text elements to have strikethrough and underline decorations. It adds a new unit test for the feature, fixes a bug in the binding helper for enum properties, and updates the dependency properties to use the correct type and name.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
