### PR TITLE
fix: Ensure that clipping changes are applied

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
@@ -24,6 +24,8 @@ using UIKit;
 using AppKit;
 #else
 using Uno.UI;
+using Windows.UI;
+using Windows.ApplicationModel.Appointments;
 #endif
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
@@ -644,6 +646,24 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				sut.IsArrangeDirty.Should().BeFalse("IsArrangeDirty");
 				sut.IsArrangeDirtyPath.Should().BeFalse("IsArrangeDirtyPath");
 			}
+		}
+#endif
+
+#if __SKIA__
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Explicit_Size_Clip_Changes()
+		{
+			var sut = new UIElement();
+
+			var rect = new Rect(0, 0, 100, 100);
+			var clip = new Rect(0, 0, 50, 50);
+
+			sut.ArrangeVisual(rect, clip);
+			Assert.IsNotNull(sut.Visual.Clip);
+
+			sut.ArrangeVisual(rect, null);
+			Assert.IsNull(sut.Visual.Clip);
 		}
 #endif
 	}

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -27,6 +27,7 @@ namespace Windows.UI.Xaml
 		internal double _canvasTop;
 		internal double _canvasLeft;
 		private Rect _currentFinalRect;
+		private Rect? _currentClippedFrame;
 
 		public UIElement()
 		{
@@ -263,11 +264,16 @@ namespace Windows.UI.Xaml
 			LayoutSlotWithMarginsAndAlignments = finalRect;
 
 			var oldFinalRect = _currentFinalRect;
+			var oldClippedFrame = _currentClippedFrame;
 			_currentFinalRect = finalRect;
+			_currentClippedFrame = clippedFrame;
 
 			var oldRect = oldFinalRect;
 			var newRect = finalRect;
-			if (oldRect != newRect)
+
+			var oldClip = oldClippedFrame;
+			var newClip = clippedFrame;
+			if (oldRect != newRect || oldClip != newClip)
 			{
 				if (
 					newRect.Width < 0


### PR DESCRIPTION

GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/12885

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Previously the UIElement arrange stopped when it recognized the previous arrange rect was the same as the current one, while ignoring potential changes in clipping.


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98aee9a</samp>

Improved clipping support and performance for Skia-based UI elements. Added a `ClippedFrame` field and updated `InvalidateRender` in `UIElement.skia.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
