### PR TITLE
perf: adjust when_disabled test because sometimes it fails

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -35,10 +35,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			// Disable re-ordering
 			mode.SetDependencyPropertyValue("IsChecked", "False");
 
+			// Tap outside the ListView to get rid of PointerOver visual from the step above
+			var sutBounds = _app.Query(sut).Single().Rect;
+			_app.TapCoordinates(sutBounds.CenterX, sutBounds.Bottom + 10);
+
 			var before = TakeScreenshot("Before", ignoreInSnapshotCompare: true);
 
 			// Attempt to re-order by dragging from item1 (orange) to item3 (green)
-			var sutBounds = _app.Query(sut).Single().Rect;
 			var x = sutBounds.X + 50;
 			var srcY = Item(sutBounds, 1);
 			var dstY = Item(sutBounds, 3);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Refactoring (no functional changes, no api changes)
## What is the current behavior?
When running CI, When_Disabled test fails frequently. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb2cd06</samp>

Fix a bug in ListView drag and drop on Windows by tapping outside the control before taking a screenshot. This avoids capturing the PointerOver state of the last tapped item in `DragDrop_ListViewReorder_Automated.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
