### PR TITLE
fix: Ensure initial measure occurs only after Window size is initialized

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using SampleControl.Presentation;
+using Windows.Foundation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 #if NETFX_CORE
 using Windows.Foundation;
 using Windows.Foundation.Collections;
@@ -23,9 +25,32 @@ namespace Uno.UI.Samples.Controls
 {
 	public sealed partial class SampleChooserControl : UserControl
 	{
+		private bool _initialMeasure = true;
+		private bool _initialArrange = true;
+
 		public SampleChooserControl()
 		{
 			this.InitializeComponent();
+		}
+
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			if (_initialMeasure && availableSize == default)
+			{
+				_initialMeasure = false;
+				Assert.Fail("Initial Measure should not be called with empty size");
+			}
+			return base.MeasureOverride(availableSize);
+		}
+
+		protected override Size ArrangeOverride(Size availableSize)
+		{
+			if (_initialArrange && availableSize == default)
+			{
+				_initialArrange = false;
+				Assert.Fail("Initial Arrange should not be called with empty size");
+			}
+			return base.ArrangeOverride(availableSize);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkWindow.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkWindow.cs
@@ -27,7 +27,7 @@ internal class UnoGtkWindow : Gtk.Window
 	public UnoGtkWindow(WinUIWindow winUIWindow) : base(WindowType.Toplevel)
 	{
 		_winUIWindow = winUIWindow ?? throw new ArgumentNullException(nameof(winUIWindow));
-		_winUIWindow.Shown += OnShown;
+		_winUIWindow.Showing += OnShowing;
 
 		Size preferredWindowSize = ApplicationView.PreferredLaunchViewSize;
 		if (preferredWindowSize != Size.Empty)
@@ -57,12 +57,19 @@ internal class UnoGtkWindow : Gtk.Window
 
 	internal UnoGtkWindowHost Host { get; }
 
-	private async void OnShown(object? sender, EventArgs e)
+	private async void OnShowing(object? sender, EventArgs e)
 	{
-		await Host.InitializeAsync();
-		ShowAll();
-		_wasShown = true;
-		ReplayPendingWindowStateChanges();
+		try
+		{
+			await Host.InitializeAsync();
+			ShowAll();
+			_wasShown = true;
+			ReplayPendingWindowStateChanges();
+		}
+		catch (Exception ex)
+		{
+			this.Log().Error("Failed to initialize the UnoGtkWindow", ex);
+		}
 	}
 
 	private void WindowClosing(object sender, DeleteEventArgs args)

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkWindowHost.cs
@@ -24,6 +24,7 @@ internal class UnoGtkWindowHost : IGtkXamlRootHost
 
 	private Widget? _area;
 	private IGtkRenderer? _renderer;
+	private bool _firstSizeAllocated;
 
 	public UnoGtkWindowHost(Gtk.Window gtkWindow, WinUIWindow winUIWindow)
 	{
@@ -63,6 +64,11 @@ internal class UnoGtkWindowHost : IGtkXamlRootHost
 		_area.SizeAllocated += (s, e) =>
 		{
 			_winUIWindow.OnNativeSizeChanged(new Windows.Foundation.Size(e.Allocation.Width, e.Allocation.Height));
+			if (!_firstSizeAllocated)
+			{
+				_firstSizeAllocated = true;
+				_winUIWindow.OnNativeWindowCreated();
+			}
 		};
 
 		overlay.Add(_area);

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
@@ -21,6 +21,7 @@ namespace Uno.UI.Runtime.Skia
 		private bool _needsScanlineCopy;
 		private int renderCount;
 		private DisplayInformation? _displayInformation;
+		private bool _isWindowInitialized;
 
 		public Renderer(IXamlRootHost host)
 		{
@@ -61,6 +62,12 @@ namespace Uno.UI.Runtime.Skia
 				_needsScanlineCopy = _fbDev.RowBytes != _bitmap.BytesPerPixel * width;
 
 				WUX.Window.Current.OnNativeSizeChanged(new Size(rawScreenSize.Width / scale, rawScreenSize.Height / scale));
+
+				if (!_isWindowInitialized)
+				{
+					_isWindowInitialized = true;
+					WUX.Window.Current.OnNativeWindowCreated();
+				}
 			}
 
 			using (var surface = SKSurface.Create(info, _bitmap.GetPixels(out _)))

--- a/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoWpfWindow.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoWpfWindow.cs
@@ -21,7 +21,7 @@ internal class UnoWpfWindow : WpfWindow
 	public UnoWpfWindow(WinUI.Window winUIWindow)
 	{
 		_winUIWindow = winUIWindow ?? throw new ArgumentNullException(nameof(winUIWindow));
-		_winUIWindow.Shown += OnShown;
+		_winUIWindow.Showing += OnShowing;
 
 		Windows.Foundation.Size preferredWindowSize = ApplicationView.PreferredLaunchViewSize;
 		if (preferredWindowSize != Windows.Foundation.Size.Empty)
@@ -38,9 +38,11 @@ internal class UnoWpfWindow : WpfWindow
 		StateChanged += OnStateChanged;
 
 		ApplicationView.GetForCurrentView().PropertyChanged += OnApplicationViewPropertyChanged;
+
+		winUIWindow.OnNativeWindowCreated();
 	}
 
-	private void OnShown(object? sender, EventArgs e) => Show();
+	private void OnShowing(object? sender, EventArgs e) => Show();
 
 	private void OnClosing(object? sender, CancelEventArgs e)
 	{

--- a/src/Uno.UI/UI/Xaml/Hosting/DesktopWindowXamlSource.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/Hosting/DesktopWindowXamlSource.crossruntime.cs
@@ -11,6 +11,10 @@ partial class DesktopWindowXamlSource
 	{
 		// Ensure the root element of the XamlIsland is loaded.
 		UIElement.LoadingRootElement(_root);
+
+		_root.XamlRoot.InvalidateMeasure();
+		_root.XamlRoot.InvalidateArrange();
+
 		UIElement.RootElementLoaded(_root);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/XamlRoot.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/XamlRoot.crossruntime.cs
@@ -55,6 +55,12 @@ public sealed partial class XamlRoot
 
 	internal void ScheduleInvalidateMeasureOrArrange(bool invalidateMeasure)
 	{
+		if (VisualTree.RootElement is not UIElement rootElement || !(rootElement.IsLoading || rootElement.IsLoaded))
+		{
+			// The root element is not loaded, no need to schedule anything.
+			return;
+		}
+
 		if (invalidateMeasure)
 		{
 			if (_isMeasureWaiting)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Previously the initial measure/arrange could occur before the Window size is non-zero. This does not happen in WinUI/UWP


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98b6558</samp>

This pull request fixes various issues related to the initial window size and layout on different Skia platforms, such as Linux, GTK, WPF, and WinUI Desktop. It modifies the `Window`, `XamlRoot`, and `DesktopWindowXamlSource` classes, as well as the platform-specific window classes, to ensure that the layout passes run at the right time and with the correct window size. It also adds some unit tests for the `SampleChooserControl` class.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
