### PR TITLE
fix: Detach native element on host unload

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/GtkCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/GtkCoreWindowExtension.cs
@@ -66,6 +66,12 @@ namespace Uno.UI.Runtime.Skia
 			}
 		}
 
+		public bool IsNativeElementAttached(object owner, object nativeElement) =>
+			nativeElement is Widget widget
+				&& owner is XamlRoot xamlRoot
+				&& GetOverlayLayer(xamlRoot) is { } overlay
+				&& widget.Parent == overlay;
+
 		public void ArrangeNativeElement(object owner, object content, Windows.Foundation.Rect arrangeRect)
 		{
 			if (content is Widget widget

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/CoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/CoreWindowExtension.cs
@@ -134,6 +134,7 @@ unsafe internal partial class CoreWindowExtension : ICoreWindowExtension, IDispo
 	public void ArrangeNativeElement(object owner, object content, Rect arrangeRect) { }
 	public Size MeasureNativeElement(object owner, object content, Size size)
 		=> size;
+	public bool IsNativeElementAttached(object owner, object nativeElement) => false;
 
 	private bool TryGetPointers(/*[NotNullWhen(true)] */out FrameBufferPointerInputSource? pointers)
 	{

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/WpfCoreWindowExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/WpfCoreWindowExtension.cs
@@ -6,6 +6,7 @@ using Uno.UI.Runtime.Skia.Wpf;
 using Uno.UI.Skia.Platform.Extensions;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
+using static Windows.UI.Xaml.Shapes.BorderLayerRenderer;
 using WpfCanvas = System.Windows.Controls.Canvas;
 using WpfUIElement = System.Windows.UIElement;
 
@@ -80,9 +81,9 @@ namespace Uno.UI.Skia.Platform
 			if (owner is XamlRoot xamlRoot
 				&& GetOverlayLayer(xamlRoot) is { } layer
 				&& content is System.Windows.FrameworkElement contentAsFE
-				&& contentAsFE.Parent != layer)
+				&& contentAsFE.Parent == layer)
 			{
-				layer.Children.Add(contentAsFE);
+				layer.Children.Remove(contentAsFE);
 			}
 			else
 			{
@@ -92,6 +93,12 @@ namespace Uno.UI.Skia.Platform
 				}
 			}
 		}
+
+		public bool IsNativeElementAttached(object owner, object nativeElement) =>
+			nativeElement is System.Windows.FrameworkElement contentAsFE
+				&& owner is XamlRoot xamlRoot
+				&& GetOverlayLayer(xamlRoot) is { } layer
+				&& contentAsFE.Parent == layer;
 
 		public void ArrangeNativeElement(object owner, object content, Windows.Foundation.Rect arrangeRect)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.NativeElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.NativeElement.cs
@@ -1,24 +1,15 @@
-﻿using System;
+﻿#if __SKIA__
+using System;
 using System.Threading.Tasks;
 using Private.Infrastructure;
 using Uno.UI.Xaml;
 using Windows.UI.Core;
 using Windows.UI.Xaml.Controls;
 
-#if NETFX_CORE
-using Uno.UI.Extensions;
-#elif __IOS__
-using UIKit;
-#elif __MACOS__
-using AppKit;
-#else
-#endif
-
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
 	public partial class Given_ContentControl
 	{
-#if __SKIA__
 		[TestMethod]
 		public void When_Native_Element()
 		{
@@ -65,6 +56,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.IsFalse(coreWindow.IsNativeElementAttached(SUT.XamlRoot, nativeControl));
 		}
-#endif
 	}
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.NativeElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.NativeElement.cs
@@ -1,19 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
-using Uno.Extensions;
-using Windows.UI.Xaml;
+using Uno.UI.Xaml;
+using Windows.UI.Core;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Controls.Primitives;
-using System.Linq;
-using static Private.Infrastructure.TestServices;
-using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ContentControlPages;
-using Windows_UI_Xaml_Controls;
 
 #if NETFX_CORE
 using Uno.UI.Extensions;
@@ -22,7 +12,6 @@ using UIKit;
 #elif __MACOS__
 using AppKit;
 #else
-using Uno.UI;
 #endif
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -45,6 +34,36 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.Content = nativeControl;
 
 			TestServices.WindowHelper.WindowContent = SUT;
+
+			var coreWindow = CoreWindow.GetForCurrentThread();
+			Assert.IsTrue(coreWindow.IsNativeElementAttached(SUT.XamlRoot, nativeControl));
+		}
+
+		[TestMethod]
+		public async Task When_Native_Element_Detached()
+		{
+			var checkButtonType =
+				Type.GetType("Gtk.CheckButton, GtkSharp", false)
+				?? Type.GetType("System.Windows.Controls.CheckBox, PresentationFramework", false);
+
+			Assert.IsNotNull(checkButtonType);
+
+			var nativeControl = Activator.CreateInstance(checkButtonType);
+
+			ContentPresenter SUT = new();
+			SUT.Content = nativeControl;
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var coreWindow = CoreWindow.GetForCurrentThread();
+
+			Assert.IsTrue(coreWindow.IsNativeElementAttached(SUT.XamlRoot, nativeControl));
+
+			TestServices.WindowHelper.WindowContent = null;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(coreWindow.IsNativeElementAttached(SUT.XamlRoot, nativeControl));
 		}
 #endif
 	}

--- a/src/Uno.UWP/UI/Core/CoreWindow.skia.cs
+++ b/src/Uno.UWP/UI/Core/CoreWindow.skia.cs
@@ -37,6 +37,9 @@ namespace Windows.UI.Core
 		internal Size MeasureNativeElement(object owner, object content, Size size)
 			=> _coreWindowExtension.MeasureNativeElement(owner, content, size);
 
+		internal bool IsNativeElementAttached(object owner, object nativeElement)
+			=> _coreWindowExtension.IsNativeElementAttached(owner, nativeElement);
+
 		internal void RaiseNativeKeyDownReceived(KeyEventArgs args)
 		{
 			NativeKeyDownReceived?.Invoke(this, args);

--- a/src/Uno.UWP/UI/Core/ICoreWindowExtension.cs
+++ b/src/Uno.UWP/UI/Core/ICoreWindowExtension.cs
@@ -17,5 +17,7 @@ internal interface ICoreWindowExtension
 	void ArrangeNativeElement(object owner, object content, Rect arrangeRect);
 
 	Size MeasureNativeElement(object owner, object content, Size size);
+
+	bool IsNativeElementAttached(object owner, object nativeElement);
 #endif
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Native elements are not detached when host is unloaded on WPF

## What is the new behavior?

Detaching occurs properly

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddfb47f</samp>

This pull request adds a feature to support native elements in Xaml content on Skia platforms. It fixes a bug, adds tests, and implements the `IsNativeElementAttached` method on Skia.Wpf, Skia.Gtk, and Linux.FrameBuffer platforms. It also exposes the `IsNativeElementAttached` method on the `CoreWindow` class and the `ICoreWindowExtension` interface.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
