### PR TITLE
fix: Fix ScrollBarVisibility regression on Wasm

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
@@ -255,6 +255,33 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		}
 
+#if __WASM__
+		[TestMethod]
+		public async Task When_Multiple_Items_Should_Not_Scroll()
+		{
+			var itemsSource = new ObservableCollection<string>();
+			AddItem(itemsSource);
+			AddItem(itemsSource);
+			AddItem(itemsSource);
+
+			var flipView = new FlipView
+			{
+				Width = 100,
+				Height = 100,
+				ItemsSource = itemsSource,
+			};
+
+			WindowHelper.WindowContent = flipView;
+			await WindowHelper.WaitForLoaded(flipView);
+			var scrollViewer = (ScrollViewer)flipView.GetTemplateChild("ScrollingHost");
+			var border = (Border)VisualTreeHelper.GetChildren(scrollViewer).Single();
+			var grid = (Grid)VisualTreeHelper.GetChildren(border).Single();
+			var scrollContentPresenter = (ScrollContentPresenter)VisualTreeHelper.GetChildren(grid).First();
+			var classes = Uno.Foundation.WebAssemblyRuntime.InvokeJS($"document.getElementById({scrollContentPresenter.HtmlId}).classList").Split(' ');
+			Assert.IsTrue(classes.Contains("scroll-x-disabled"));
+			Assert.IsTrue(classes.Contains("scroll-y-disabled"));
+		}
+#endif
 	}
 
 #if __SKIA__ || __WASM__

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -19,8 +19,14 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class ScrollContentPresenter : ContentPresenter, IScrollContentPresenter
 	{
-		private ScrollBarVisibility _verticalScrollBarVisibility;
-		private ScrollBarVisibility _horizontalScrollBarVisibility;
+		// On wasm, the default of "overflow" property is "visible".
+		// This doesn't match any of our scroll-[x|y]-[auto|disabled|hidden|visible] defined in Uno.UI.css
+		// (see https://github.com/unoplatform/uno/blob/dca49dadd6feaf0b3addd2ec2195c3af1b6ac9f4/src/Uno.UI/WasmCSS/Uno.UI.css#L183-L223)
+		// So, we want the first setter call to be executed, regardless of the value being set.
+		// The logic in the setter is done under "if (_[vertical|horizontal]ScrollBarVisibility != value)"
+		// So, to make sure this condition is always true for the first call of the setter, we set the initial value to -1, which isn't a valid value for ScrollBarVisibility.
+		private ScrollBarVisibility _verticalScrollBarVisibility = (ScrollBarVisibility)(-1);
+		private ScrollBarVisibility _horizontalScrollBarVisibility = (ScrollBarVisibility)(-1);
 		private bool _eventsRegistered;
 
 		private (double? horizontal, double? vertical)? _pendingScrollTo;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.wasm.cs
@@ -112,7 +112,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private static readonly string[] VerticalVisibilityClasses = { "scroll-y-auto", "scroll-y-disabled", "scroll-y-hidden", "scroll-y-visible" };
+		private static readonly string[] VerticalVisibilityClasses = { "scroll-y-disabled", "scroll-y-auto", "scroll-y-hidden", "scroll-y-visible" };
 
 		ScrollBarVisibility IScrollContentPresenter.NativeVerticalScrollBarVisibility { set => VerticalScrollBarVisibility = value; }
 		internal ScrollBarVisibility VerticalScrollBarVisibility
@@ -130,7 +130,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private static readonly string[] HorizontalVisibilityClasses = { "scroll-x-auto", "scroll-x-disabled", "scroll-x-hidden", "scroll-x-visible" };
+		private static readonly string[] HorizontalVisibilityClasses = { "scroll-x-disabled", "scroll-x-auto", "scroll-x-hidden", "scroll-x-visible" };
 
 		ScrollBarVisibility IScrollContentPresenter.NativeHorizontalScrollBarVisibility { set => HorizontalScrollBarVisibility = value; }
 		internal ScrollBarVisibility HorizontalScrollBarVisibility


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12889

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 992d22c</samp>

Fixed a bug in WASM that caused incorrect visibility of scroll bars in `ScrollContentPresenter`. Updated the CSS class logic to match the `ScrollBarVisibility` enum values.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
