### PR TITLE
test: Re-enable `When_CloseLast_Then_FileDeleted` test on Skia

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_TemporaryFile.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_TemporaryFile.cs
@@ -11,9 +11,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 	[TestClass]
 	public class Given_TemporaryFile
 	{
-#if __SKIA__
-		[Ignore("https://github.com/unoplatform/uno/issues/7271")]
-#endif
 		[TestMethod]
 		public void When_CloseLast_Then_FileDeleted()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): part of #7271

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR-->

- Tests

## What is the current behavior?
The `When_CloseLast_Then_FileDeleted` test is disabled on Skia.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Re-enabled the `When_CloseLast_Then_FileDeleted` test on Skia.

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 597dfdf</samp>

Enable a previously ignored test for the Skia platform. The test verifies the creation of temporary files using the `Windows.Storage` API.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
Tested on Skia - Gtk, Wpf + Uno Islands