### PR TITLE
fix(ItemsRepeater): Fix ItemWrapGrid not sizing dynamic items properly

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
@@ -7,7 +7,6 @@ using SampleControl.Presentation;
 using Windows.Foundation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #if NETFX_CORE
-using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/UniformGridLayout/Given_UniformGridLayout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/UniformGridLayout/Given_UniformGridLayout.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using FluentAssertions;
+using Microsoft.UI.Xaml.Controls;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater;
+
+[TestClass]
+public class Given_UniformGridLayout
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_AdaptiveChildren_Then_DoesNotConstraintsThem()
+	{
+		using var template = new DynamicDataTemplate(() => new TextBlock
+		{
+			Text = string.Join(' ', Enumerable.Range(0, 16).Select(i => $"some_text_{i:D2}")), // A dynamically sizable item
+			TextWrapping = TextWrapping.Wrap
+		});
+		var sut = new ItemsRepeater
+		{
+			Width = 400,
+			ItemsSource = Enumerable.Range(0, 10),
+			ItemTemplate = template.Value,
+			Layout = new UniformGridLayout
+			{
+				ItemsStretch = UniformGridLayoutItemsStretch.Fill,
+				MaximumRowsOrColumns = 2,
+				MinColumnSpacing = 10,
+				MinItemWidth = 75,
+				MinRowSpacing = 10,
+			}
+		};
+
+		await UITestHelper.Load(sut);
+
+		var firstItem = VisualTreeHelper.GetChild(sut, 0) as UIElement;
+		var originalHeight = firstItem!.ActualSize.Y;
+
+		// Force a resize just to validate that size is coherent
+		sut.Width = 200;
+		sut.UpdateLayout();
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var newHeight = firstItem.ActualSize.Y;
+
+		originalHeight.Should().BeGreaterThan(50);
+		newHeight.Should().BeGreaterThan(originalHeight);
+
+		Math.Abs(originalHeight * 2 - newHeight).Should().BeLessThan(20, "we devided the width by 2, so the height of each should be about the double of the original"); // We allow about a line of difference for wrapping consideration
+	}
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/UniformGridLayout/UniformGridLayoutState.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/UniformGridLayout/UniformGridLayoutState.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+// UniformGridLayoutState.cpp, commit a4dcfc96267edb80fe9cc346eb24c0dfac21b40d
 
 #nullable enable
 
@@ -29,7 +30,7 @@ namespace Microsoft.UI.Xaml.Controls
 			Size availableSize,
 			VirtualizingLayoutContext context,
 			double layoutItemWidth,
-			double LayoutItemHeight,
+			double layoutItemHeight,
 			UniformGridLayoutItemsStretch stretch,
 			Orientation orientation,
 			double minRowSpacing,
@@ -47,8 +48,8 @@ namespace Microsoft.UI.Xaml.Controls
 				var realizedElement = m_flowAlgorithm.GetElementIfRealized(0);
 				if (realizedElement is { })
 				{
-					realizedElement.Measure(availableSize);
-					SetSize(realizedElement.DesiredSize, layoutItemWidth, LayoutItemHeight, availableSize, stretch,
+					realizedElement.Measure(CalculateAvailableSize(availableSize, orientation, stretch, maxItemsPerLine, layoutItemWidth, layoutItemHeight, minRowSpacing, minColumnSpacing));
+					SetSize(realizedElement.DesiredSize, layoutItemWidth, layoutItemHeight, availableSize, stretch,
 						orientation, minRowSpacing, minColumnSpacing, maxItemsPerLine);
 				}
 				else
@@ -58,8 +59,8 @@ namespace Microsoft.UI.Xaml.Controls
 
 					if (firstElement is { })
 					{
-						firstElement.Measure(availableSize);
-						SetSize(firstElement.DesiredSize, layoutItemWidth, LayoutItemHeight, availableSize, stretch,
+						firstElement.Measure(CalculateAvailableSize(availableSize, orientation, stretch, maxItemsPerLine, layoutItemWidth, layoutItemHeight, minRowSpacing, minColumnSpacing));
+						SetSize(firstElement.DesiredSize, layoutItemWidth, layoutItemHeight, availableSize, stretch,
 							orientation, minRowSpacing, minColumnSpacing, maxItemsPerLine);
 						context.RecycleElement(firstElement);
 					}
@@ -67,10 +68,78 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		private Size CalculateAvailableSize(
+			Size availableSize,
+			Orientation orientation,
+			UniformGridLayoutItemsStretch stretch,
+			uint maxItemsPerLine,
+			double itemWidth,
+			double itemHeight,
+			double minRowSpacing,
+			double minColumnSpacing)
+		{
+			// Since some controls might have certain requirements when rendering (e.g. maintaining an aspect ratio),
+			// we will let elements know the actual size they will get within our layout and let them measure based on that assumption.
+			// That way we ensure that no gaps will be created within our layout because of a control deciding it doesn't need as much height (or width)
+			// for the column width (or row height) being provided.
+			if (orientation == Orientation.Horizontal)
+			{
+				if (!itemWidth.IsNaN())
+				{
+					double allowedColumnWidth = itemWidth;
+					if (stretch != UniformGridLayoutItemsStretch.None)
+					{
+						allowedColumnWidth += CalculateExtraPixelsInLine(maxItemsPerLine, (float)availableSize.Width, itemWidth, minColumnSpacing);
+					}
+
+					return new Size((float)allowedColumnWidth, availableSize.Height);
+				}
+			}
+			else
+			{
+				if (!itemHeight.IsNaN())
+				{
+					double allowedRowHeight = itemHeight;
+					if (stretch != UniformGridLayoutItemsStretch.None)
+					{
+						allowedRowHeight += CalculateExtraPixelsInLine(maxItemsPerLine, (float)availableSize.Height, itemHeight, minRowSpacing);
+					}
+
+					return new Size(availableSize.Width, (float)itemHeight);
+				}
+			}
+
+			return availableSize;
+		}
+
+		double CalculateExtraPixelsInLine(
+			uint maxItemsPerLine,
+			float availableSizeMinor,
+			double itemSizeMinor,
+			double minorItemSpacing)
+		{
+			uint numItemsPerColumn;
+			uint numItemsBasedOnSize = (uint)(Math.Max(1.0, availableSizeMinor / (itemSizeMinor + minorItemSpacing)));
+			if (numItemsBasedOnSize == 0)
+			{
+				numItemsPerColumn = maxItemsPerLine;
+			}
+			else
+			{
+				numItemsPerColumn = Math.Min(
+					maxItemsPerLine,
+					numItemsBasedOnSize);
+			}
+
+			var usedSpace = (numItemsPerColumn * (itemSizeMinor + minorItemSpacing)) - minorItemSpacing;
+			var remainingSpace = ((int)(availableSizeMinor - usedSpace));
+			return remainingSpace / ((int)numItemsPerColumn);
+		}
+
 		void SetSize(
 			Size desiredItemSize,
 			double layoutItemWidth,
-			double LayoutItemHeight,
+			double layoutItemHeight,
 			Size availableSize,
 			UniformGridLayoutItemsStretch stretch,
 			Orientation orientation,
@@ -84,7 +153,7 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 
 			m_effectiveItemWidth = (layoutItemWidth.IsNaN() ? desiredItemSize.Width : layoutItemWidth);
-			m_effectiveItemHeight = (LayoutItemHeight.IsNaN() ? desiredItemSize.Height : LayoutItemHeight);
+			m_effectiveItemHeight = (layoutItemHeight.IsNaN() ? desiredItemSize.Height : layoutItemHeight);
 
 			var availableSizeMinor =
 				orientation == Orientation.Horizontal ? availableSize.Width : availableSize.Height;
@@ -96,12 +165,7 @@ namespace Microsoft.UI.Xaml.Controls
 			double extraMinorPixelsForEachItem = 0.0;
 			if (availableSizeMinor.IsFinite())
 			{
-				var numItemsPerColumn = Math.Min(
-					maxItemsPerLine,
-					(uint)(Math.Max(1.0, availableSizeMinor / (itemSizeMinor + minorItemSpacing))));
-				var usedSpace = (numItemsPerColumn * (itemSizeMinor + minorItemSpacing)) - minorItemSpacing;
-				var remainingSpace = ((int)(availableSizeMinor - usedSpace));
-				extraMinorPixelsForEachItem = remainingSpace / ((int)numItemsPerColumn);
+				extraMinorPixelsForEachItem = CalculateExtraPixelsInLine(maxItemsPerLine, (float)availableSizeMinor, itemSizeMinor, minorItemSpacing);
 			}
 
 			if (stretch == UniformGridLayoutItemsStretch.Fill)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/12881

## Bugfix
Fix ItemWrapGrid not sizing dynamic items properly

## What is the current behavior?
When using an `ItemsRepeater` with a `UniformGridLayout`, items are dynamically sizing them based on parent's sizing constraints, they are not able use as much space as they would.

## What is the new behavior?
Sizing made by the `UniformGridLayout` no longer assume that the size returned by the child is the exact one.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afed695</samp>

This pull request adds helper classes and methods for creating and testing DataTemplates and ItemsRepeater layouts, improves the porting of the UniformGridLayoutState class, and removes an unused using directive. It affects the files `UITestHelper.cs`, `UniformGridLayoutState.cs`, `SampleChooserControl.xaml.cs`, and `Given_UniformGridLayout.cs`.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This imports the changes made by https://github.com/microsoft/microsoft-ui-xaml/pull/5359.