### PR TITLE
fix: `ThemeResource` bindings are not scope-updated on `Style` switch

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_ThemeResource_Style_Switch_Page.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_ThemeResource_Style_Switch_Page.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl x:Class="Uno.UI.RuntimeTests.When_ThemeResource_Style_Switch_Page"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<Style x:Key="FirstButtonStyle" TargetType="Button">
+			<Setter Property="Background" Value="{ThemeResource ButtonBackground}" />
+		</Style>
+		<Style x:Key="SecondButtonStyle" TargetType="Button">
+			<Setter Property="Background" Value="{ThemeResource ButtonBackgroundPressed}" />
+		</Style>
+	</UserControl.Resources>
+	<StackPanel>
+		<Border>
+			<Border.Resources>
+				<SolidColorBrush x:Key="ButtonBackground" Color="Blue" />
+				<SolidColorBrush x:Key="ButtonBackgroundPressed" Color="Red" />
+			</Border.Resources>
+			<Button x:Name="TestBtn" Style="{StaticResource FirstButtonStyle}" Width="100" Height="100" />
+		</Border>
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_ThemeResource_Style_Switch_Page.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_ThemeResource_Style_Switch_Page.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests;
+
+public sealed partial class When_ThemeResource_Style_Switch_Page : UserControl
+{
+	public When_ThemeResource_Style_Switch_Page()
+	{
+		this.InitializeComponent();
+	}
+
+	public Button TestButton => TestBtn;
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -136,6 +136,29 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			}
 		}
 
+		[TestMethod]
+		public async Task When_ThemeResource_Style_Switch()
+		{
+			using (StyleHelper.UseFluentStyles())
+			{
+				var SUT = new When_ThemeResource_Style_Switch_Page();
+				WindowHelper.WindowContent = SUT;
+				await WindowHelper.WaitForLoaded(SUT);
+
+				var color = ((SolidColorBrush)SUT.TestButton.Background).Color;
+
+				Assert.AreEqual(Colors.Blue, color);
+
+				SUT.TestButton.Style = (Style)SUT.Resources["SecondButtonStyle"];
+
+				await WindowHelper.WaitForIdle();
+
+				color = ((SolidColorBrush)SUT.TestButton.Background).Color;
+
+				Assert.AreEqual(Colors.Red, color);
+			}
+		}
+
 		private async Task When_DefaultForeground(Color lightThemeColor, Color darkThemeColor)
 		{
 			var run = new Run()

--- a/src/Uno.UI/UI/Xaml/Style/Style.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Style.cs
@@ -73,7 +73,7 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
-			IDisposable? localPrecedenceDisposable = DependencyObjectExtensions.OverrideLocalPrecedence(o, precedence);
+			IDisposable? localPrecedenceDisposable = null;
 
 			EnsureSetterMap();
 
@@ -82,7 +82,8 @@ namespace Windows.UI.Xaml
 #endif
 			{
 				ResourceResolver.PushNewScope(_xamlScope);
-
+				localPrecedenceDisposable = DependencyObjectExtensions.OverrideLocalPrecedence(o, precedence);
+				
 				if (_flattenedSetters != null)
 				{
 					for (var i = 0; i < _flattenedSetters.Length; i++)

--- a/src/Uno.UI/UI/Xaml/Style/Style.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Style.cs
@@ -92,6 +92,7 @@ namespace Windows.UI.Xaml
 				}
 
 				localPrecedenceDisposable?.Dispose();
+				localPrecedenceDisposable = null;
 
 				// Check tree for resource binding values, since some Setters may have set ThemeResource-backed values
 				(o as IDependencyObjectStoreProvider)!.Store.UpdateResourceBindings(ResourceUpdateReason.ResolvedOnLoading);

--- a/src/Uno.UI/UI/Xaml/Style/Style.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Style.cs
@@ -4,8 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-
-using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI;
 using Windows.UI.Xaml.Data;
@@ -83,7 +81,7 @@ namespace Windows.UI.Xaml
 			{
 				ResourceResolver.PushNewScope(_xamlScope);
 				localPrecedenceDisposable = DependencyObjectExtensions.OverrideLocalPrecedence(o, precedence);
-				
+
 				if (_flattenedSetters != null)
 				{
 					for (var i = 0; i < _flattenedSetters.Length; i++)

--- a/src/Uno.UI/UI/Xaml/Style/Style.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Style.cs
@@ -73,7 +73,7 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
-			var localPrecedenceDisposable = DependencyObjectExtensions.OverrideLocalPrecedence(o, precedence);
+			IDisposable? localPrecedenceDisposable = DependencyObjectExtensions.OverrideLocalPrecedence(o, precedence);
 
 			EnsureSetterMap();
 
@@ -91,15 +91,17 @@ namespace Windows.UI.Xaml
 					}
 				}
 
+				localPrecedenceDisposable?.Dispose();
+
 				// Check tree for resource binding values, since some Setters may have set ThemeResource-backed values
-				(o as IDependencyObjectStoreProvider)!.Store.UpdateResourceBindings(ResourceUpdateReason.StaticResourceLoading);
+				(o as IDependencyObjectStoreProvider)!.Store.UpdateResourceBindings(ResourceUpdateReason.ResolvedOnLoading);
 			}
 #if !HAS_EXPENSIVE_TRYFINALLY
 			finally
 #endif
 			{
-				ResourceResolver.PopScope();
 				localPrecedenceDisposable?.Dispose();
+				ResourceResolver.PopScope();
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12496 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Previously only `StaticResource` bindings were re-evaluated when `Style` was applied. This is not enough as `ThemeResources` also need to be sourced from the current scope. In addition, the precedence override needs to be applied only while the setters are being applied, but not for the resource bindings update, otherwise it could also apply base control bindings with `ExplicitStyle` precedence, even though the bindings have just `ImplicitStyle` precedence.

## What is the new behavior?

Fixed!

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e51e120</samp>

This pull request fixes a bug and adds a test for theme resource resolution in styles. It refactors the `Style.ApplyTo` method to make it more clear and consistent. It also creates a new user control with two styles for a button, one using a theme resource and one using a static resource, and a new test method that asserts that the button's background color changes correctly when the style is switched at runtime.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.