### PR TITLE
fix: Fix toggle switch knob translation

### DIFF
--- a/src/Uno.UI/UI/Xaml/Duration.cs
+++ b/src/Uno.UI/UI/Xaml/Duration.cs
@@ -28,8 +28,7 @@ namespace Windows.UI.Xaml
 		{
 			get
 			{
-				return this.Type == DurationType.TimeSpan &&
-					this.TimeSpan.CompareTo(TimeSpan.Zero) > 0;
+				return this.Type == DurationType.TimeSpan;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.cs
@@ -14,6 +14,11 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// </summary>
 		internal static IValueAnimator Create<T>(Timeline timeline, T startingValue, T targetValue) where T : struct
 		{
+			if (timeline.Duration.HasTimeSpan && timeline.Duration.TimeSpan == TimeSpan.Zero)
+			{
+				return new ImmediateAnimator<T>(targetValue);
+			}
+
 			if (startingValue is float startingFloat && targetValue is float targetFloat)
 			{
 				return CreateDouble(timeline, startingFloat, targetFloat);

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.skia.cs
@@ -17,6 +17,6 @@ namespace Windows.UI.Xaml.Media.Animation
 			=> new DispatcherDoubleAnimator(startingValue, targetValue);
 
 		private static IValueAnimator CreateColor(Timeline timeline, ColorOffset startingValue, ColorOffset targetValue)
-			=> new ImmediateAnimator<ColorOffset>(startingValue, targetValue);
+			=> new ImmediateAnimator<ColorOffset>(targetValue);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.wasm.cs
@@ -29,7 +29,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			if (timeline.GetIsDurationZero())
 			{
 				// Avoid unnecessary JS interop in the case of a zero-duration animation
-				return new ImmediateAnimator<ColorOffset>(startingValue, targetValue);
+				return new ImmediateAnimator<ColorOffset>(targetValue);
 			}
 
 			// TODO: GPU-bound color animations - https://github.com/unoplatform/uno/issues/2947

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.wasm.cs
@@ -18,7 +18,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			if (timeline.GetIsDurationZero())
 			{
 				// Avoid unnecessary JS interop in the case of a zero-duration animation
-				return new ImmediateAnimator<double>(startingValue, targetValue);
+				return new ImmediateAnimator<double>(targetValue);
 			}
 
 			return new RenderingLoopFloatAnimator((float)startingValue, (float)targetValue);

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/ImmediateAnimator.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/ImmediateAnimator.cs
@@ -6,14 +6,12 @@ namespace Windows.UI.Xaml.Media.Animation
 {
 	internal sealed class ImmediateAnimator<T> : IValueAnimator, IDisposable where T : struct
 	{
-		private T _from;
 		private T _to;
 		private long _duration;
 
-		public ImmediateAnimator(T from, T to)
+		public ImmediateAnimator(T to)
 		{
 			_to = to;
-			_from = from;
 
 			StartDelay = 0;
 			CurrentPlayTime = 0;

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.Android.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Diagnostics;
 
 namespace Windows.UI.Xaml.Media.Animation
 {
@@ -22,6 +23,13 @@ namespace Windows.UI.Xaml.Media.Animation
 				}
 
 				// TODO: apply easing function - https://github.com/unoplatform/uno/issues/2948
+
+				if (Duration.HasTimeSpan && Duration.TimeSpan == TimeSpan.Zero)
+				{
+					Debug.Assert(_animator is ImmediateAnimator<T>);
+					SetValue(_endValue.Value);
+					return;
+				}
 
 				var totalDiff = AnimationOwner.Subtract(_endValue.Value, _startingValue.Value);
 				var currentDiff = AnimationOwner.Multiply(((NativeValueAnimatorAdapter)_animator).AnimatedFraction, totalDiff);

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
@@ -283,22 +283,32 @@ namespace Windows.UI.Xaml.Media.Animation
 			private void Play()
 			{
 				_animator?.Dispose();
-				InitializeAnimator(); // Create the animator
 
-				if (!EnableDependentAnimation && _owner.GetIsDependantAnimation())
-				{ // Don't start the animator its a dependent animation
-					return;
+				if (Duration.HasTimeSpan && Duration.TimeSpan == TimeSpan.Zero)
+				{
+					State = TimelineState.Active;
+					SetValue(ComputeToValue());
+					State = TimelineState.Stopped;
 				}
+				else
+				{
+					InitializeAnimator(); // Create the animator
 
-				UseHardware();//Ensure that the GPU is used for animations
+					if (!EnableDependentAnimation && _owner.GetIsDependantAnimation())
+					{ // Don't start the animator its a dependent animation
+						return;
+					}
 
-				if (BeginTime.HasValue)
-				{ // Set the start delay
-					_animator.StartDelay = (long)BeginTime.Value.TotalMilliseconds;
+					UseHardware();//Ensure that the GPU is used for animations
+
+					if (BeginTime.HasValue)
+					{ // Set the start delay
+						_animator.StartDelay = (long)BeginTime.Value.TotalMilliseconds;
+					}
+
+					_animator.Start();
+					State = TimelineState.Active;
 				}
-
-				_animator.Start();
-				State = TimelineState.Active;
 
 #if __IOS__
 				// On iOS, animations started while the app is in the background will lead to properties in an incoherent state (native static

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
@@ -284,31 +284,22 @@ namespace Windows.UI.Xaml.Media.Animation
 			{
 				_animator?.Dispose();
 
-				if (Duration.HasTimeSpan && Duration.TimeSpan == TimeSpan.Zero)
-				{
-					State = TimelineState.Active;
-					SetValue(ComputeToValue());
-					State = TimelineState.Stopped;
+				InitializeAnimator(); // Create the animator
+
+				if (!EnableDependentAnimation && _owner.GetIsDependantAnimation())
+				{ // Don't start the animator its a dependent animation
+					return;
 				}
-				else
-				{
-					InitializeAnimator(); // Create the animator
 
-					if (!EnableDependentAnimation && _owner.GetIsDependantAnimation())
-					{ // Don't start the animator its a dependent animation
-						return;
-					}
+				UseHardware();//Ensure that the GPU is used for animations
 
-					UseHardware();//Ensure that the GPU is used for animations
-
-					if (BeginTime.HasValue)
-					{ // Set the start delay
-						_animator.StartDelay = (long)BeginTime.Value.TotalMilliseconds;
-					}
-
-					_animator.Start();
-					State = TimelineState.Active;
+				if (BeginTime.HasValue)
+				{ // Set the start delay
+					_animator.StartDelay = (long)BeginTime.Value.TotalMilliseconds;
 				}
+
+				_animator.Start();
+				State = TimelineState.Active;
 
 #if __IOS__
 				// On iOS, animations started while the app is in the background will lead to properties in an incoherent state (native static


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12643

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When a ToggleSwitch has `IsOn` set to true, pressing on it (without releasing) shows the knob shifted to the left by 24.

On the ToggleSwitch-level, things go wrong here:

https://github.com/unoplatform/uno/blob/33b35eb25900ef461a2b98253255e5dc47acc8a5/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs#L586


Specifically, `_maxKnobTranslation` and `_minKnobTranslation` end up having the wrong value. The problem is specifically on line 617. The ToggleSwitch is in "On" state, and so _spKnobTransform.X is supposed to be 24, but it reads 0. The root cause is how the animations work.

The correct sequence is:

1. visual states are updated in OnApplyTemplate
1. We go to "On" state
1. "On" state should set the translation to 24
1. During arrange, SizeChangedHandler is invoked reading 24

What happens in reality is:

1. visual states are updated in OnApplyTemplate
1. We go to "On" state
1. Setting the translation to 24 is dispatched
1. During arrange, SizeChangedHandler is invoked reading 0
1. the translation is actually set to 24, but it's too late now.


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
When an animation duration is zero, we execute it directly without dispatching

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b1215b</samp>

This pull request improves the performance and correctness of zero duration animations and simplifies the logic of the `Duration` struct. It changes the `Play` method of the `Timeline` class and the `HasTimeSpan` property of the `Duration` struct in the files `Timeline.animation.cs` and `Duration.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
