### PR TITLE
test(clipping): Added a UI test for clipping change on Android

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
@@ -1,4 +1,7 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using FluentAssertions;
 using FluentAssertions.Execution;
 using NUnit.Framework;
 using SamplesApp.UITests.TestFramework;
@@ -156,6 +159,52 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
 						.At("bottom-right " + s, rectCtl.Right - 1, rectCtl.Bottom - 1)
 						.Pixel(green)
 				);
+			}
+		}
+
+		// Check that the clipping is applied to the child element using the UIElement_Clipping sample
+		[Test]
+		[AutoRetry]
+		public void When_Clip_Is_Set_On_Child_Element()
+		{
+			Run("UITests.Windows_UI_Xaml.UIElementTests.UIElement_Clipping");
+
+			var squares = new[]
+			{
+				_app.Marked("Square1"),
+				_app.Marked("Square2"),
+				_app.Marked("Square3"),
+				_app.Marked("Square4"),
+				_app.Marked("Square5")
+			};
+
+			_app.WaitForElement(squares[0]);
+			_app.WaitForElement(squares[4]);
+
+			var rects = squares
+				.Select(s => s.FirstResult().Rect)
+				.ToArray();
+
+			// Check that all rects are similar
+			for (var i = 1; i < rects.Length; i++)
+			{
+				rects[i].Width.Should().BeApproximately(rects[0].Width, 2, "all squares should have the same width");
+				rects[i].Height.Should().BeApproximately(rects[0].Height, 2, "all squares should have the same height");
+			}
+
+			using var snapshot1 = this.TakeScreenshot("original", ignoreInSnapshotCompare: false);
+			using var snapshot2 = this.TakeScreenshot("validation", ignoreInSnapshotCompare: false);
+
+			// Check that the square bitmaps are similar
+			for (var i = 1; i < squares.Length; i++)
+			{
+				Console.WriteLine($"Checking square #{i + 1} against the first one");
+				ImageAssert.AreAlmostEqual(
+					snapshot1,
+					squares[0].FirstResult().Rect,
+					snapshot2,
+					squares[i].FirstResult().Rect,
+					20);
 			}
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/ClippingTests/ClippingTests_Tests.cs
@@ -165,6 +165,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.ClippingTests
 		// Check that the clipping is applied to the child element using the UIElement_Clipping sample
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // The sample is not working well on WASM
 		public void When_Clip_Is_Set_On_Child_Element()
 		{
 			Run("UITests.Windows_UI_Xaml.UIElementTests.UIElement_Clipping");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1106,6 +1106,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Clipping.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_ContextFlyout.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -3346,10 +3350,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-	<Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_ManualTest.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_ManualTest.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
-    </Page>	
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5740,9 +5744,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping652.xaml.cs">
       <DependentUpon>Clipping652.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_SoftKeboard.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Clipping.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_SoftKeboard.xaml.cs">
       <DependentUpon>AutoSuggestBox_SoftKeboard.xaml</DependentUpon>
-    </Compile>    
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Monochromatic.xaml.cs">
       <DependentUpon>BitmapIcon_Monochromatic.xaml</DependentUpon>
     </Compile>
@@ -5768,7 +5773,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_BringIntoView.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\SvgImageSource_FromMsAppData.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_DuplicateItem.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_DeleteItem.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_DeleteItem.xaml.cs">
       <DependentUpon>ListView_DeleteItem.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Snap_Rubberband.xaml.cs">
@@ -7226,7 +7231,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Original.xaml.cs">
       <DependentUpon>MediaPlayerElement_Original.xaml</DependentUpon>
     </Compile>
-	<Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_ManualTest.xaml.cs">
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_ManualTest.xaml.cs">
       <DependentUpon>MediaPlayerElement_ManualTest.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Original_MsAppxSource.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Clipping.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Clipping.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml.UIElementTests
+{
+	[Sample("UIElement", "Clipping")]
+	public sealed partial class UIElement_Clipping : UserControl
+	{
+		public UIElement_Clipping()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Clipping.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/UIElement_Clipping.xaml
@@ -1,0 +1,57 @@
+<UserControl
+    x:Class="UITests.Windows_UI_Xaml.UIElementTests.UIElement_Clipping"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml.UIElementTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<TextBlock FontSize="20" Margin="5">All following squares MUST BE identical</TextBlock>
+	    <StackPanel Spacing="10" Orientation="Horizontal" HorizontalAlignment="Left" Grid.Row="1">
+	        <Border Background="Orange" Padding="10" Width="75" Height="75" x:Name="Square1">
+	            <Rectangle Fill="Green" />
+	        </Border>
+	        <Border Background="Orange" Padding="10" Width="75" Height="75" x:Name="Square2">
+	            <Rectangle Fill="Green" Width="2000" Height="2000" />
+	        </Border>
+	        <Canvas Background="Orange" Width="75" Height="75" x:Name="Square3">
+	            <Rectangle Fill="Green" Canvas.Top="10" Canvas.Left="10" Width="55" Height="55" />
+	        </Canvas>
+	        <Canvas Width="75" Height="75" x:Name="Square4">
+	            <Rectangle Fill="Orange" Width="75" Height="75" />
+	            <Rectangle Fill="Green" Width="1" Height="1" Canvas.Top="-1000" Canvas.Left="-1000">
+	                <Rectangle.RenderTransform>
+	                    <CompositeTransform ScaleX="55" ScaleY="55" TranslateX="1010" TranslateY="1010" />
+	                </Rectangle.RenderTransform>
+	            </Rectangle>
+	        </Canvas>
+	        <Border Background="Orange" Padding="10" Width="75" Height="75" x:Name="Square5">
+	            <StackPanel Spacing="10">
+	                <Rectangle Fill="Green" Height="10">
+	                    <Rectangle.RenderTransform>
+	                        <ScaleTransform ScaleY="2" />
+	                    </Rectangle.RenderTransform>
+	                </Rectangle>
+	                <Rectangle Fill="Green" Height="10">
+	                    <Rectangle.RenderTransform>
+	                        <ScaleTransform ScaleY="2" />
+	                    </Rectangle.RenderTransform>
+	                </Rectangle>
+	                <Rectangle Fill="Green" Height="10">
+	                    <Rectangle.RenderTransform>
+	                        <ScaleTransform ScaleY="1.5" />
+	                    </Rectangle.RenderTransform>
+	                </Rectangle>
+	            </StackPanel>
+	        </Border>
+	    </StackPanel>
+	</Grid>
+</UserControl>

--- a/src/Uno.UI/Extensions/ViewExtensions.Android.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.Android.cs
@@ -635,6 +635,8 @@ namespace Uno.UI
 					.Append(fe != null && fe.TryGetPadding(out var p) && p != default ? $" Padding={p}" : "")
 					.Append(u != null ? $" DesiredSize={u.DesiredSize.ToString("F1")}" : "")
 					.Append(u != null && u.NeedsClipToSlot ? " CLIPPED_TO_SLOT" : "")
+					.Append(vg?.ClipChildren is true ? " vg.CLIP_CHILDREN" : "")
+					.Append(vg?.ClipToPadding is true ? " vg.CLIP_TO_PADDING" : "")
 					.Append(u?.Clip != null ? $" Clip={u.Clip.Rect}" : "")
 					.Append(u == null && vg != null ? $" ClipChildren={vg.ClipChildren}" : "")
 					.Append(fe?.Background != null ? $" Background={fe.Background}" : "")

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -583,12 +583,13 @@ namespace Uno.UI
 			/// </summary>
 			public static bool UseInvalidateArrangePath { get; set; } = true;
 
+#if __ANDROID__
 			/// <summary>
-			/// [DEPRECATED]
-			/// Not used anymore, does nothing.
+			/// On Android, rollback the clipping to the previous behavior, which was to apply the clipping
+			/// on the assigned children bounds instead of the parent bounds. 
 			/// </summary>
-			[NotImplemented]
-			public static bool UseLegacyClipping { get; set; } = true;
+			public static bool UseLegacyClipping { get; set; }
+#endif
 
 			/// <summary>
 			/// Enable the visualization of clipping bounds (intended for diagnostic purposes).

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -170,7 +170,18 @@ namespace Windows.UI.Xaml
 
 			ViewCompat.SetClipBounds(this, physicalRect);
 
-			SetClipToPadding(NeedsClipToSlot);
+			if (FeatureConfiguration.UIElement.UseLegacyClipping)
+			{
+				// Old way: apply the clipping for each child on their assigned slot
+				SetClipChildren(NeedsClipToSlot);
+			}
+			else
+			{
+				// "New" correct way: apply the clipping on the parent,
+				// and let the children overflow inside the parent's bounds
+				// This is closer to the XAML way of doing clipping.
+				SetClipToPadding(NeedsClipToSlot);
+			}
 		}
 
 		/// <summary>

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.Android.cs
@@ -212,7 +212,7 @@ namespace Windows.Graphics.Display
 		{
 			if (ContextHelper.Current.GetSystemService(Context.WindowService) is { } windowService)
 			{
-				return windowService.JavaCast<IWindowManager>(); ;
+				return windowService.JavaCast<IWindowManager>();
 			}
 
 			throw new InvalidOperationException("Failed to get the system Window Service");


### PR DESCRIPTION
This is tests after the PR https://github.com/unoplatform/uno/pull/13010

# UI Tests for PR #13010

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85008db</samp>

This pull request enhances the UI clipping feature on Android and adds a new sample page to demonstrate it. It also improves the unit testing and debugging of UI clipping on all platforms. It deprecates the `FeatureConfiguration.UIElement.UseLegacyClipping` flag and adds some comments to explain the new clipping behavior. It fixes some minor formatting and syntax issues in some files.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
