### PR TITLE
Adjust hotrestart generator

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/HotRestart/HotRestartGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/HotRestart/HotRestartGenerator.cs
@@ -94,7 +94,7 @@ public partial class HotRestartGenerator : ISourceGenerator
 		}
 
 		private bool IsGenerationEnabled()
-			=> bool.TryParse(_context.GetMSBuildPropertyValue("UnoDisableHotRestartHelperGeneration", "false"), out var result) ? result : true;
+			=> bool.TryParse(_context.GetMSBuildPropertyValue("UnoDisableHotRestartHelperGeneration", "false"), out var result) ? !result : true;
 
 		private string? GetApplicationDefinitionType()
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/HotRestart/HotRestartGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/HotRestart/HotRestartGenerator.cs
@@ -46,7 +46,14 @@ public partial class HotRestartGenerator : ISourceGenerator
 			}
 
 			var mauiAppDelegate = _context.Compilation.GetTypeByMetadataName("Microsoft.Maui.MauiUIApplicationDelegate");
-			var shouldDefineAppDelegate = (mauiAppDelegate is null).ToString().ToLowerInvariant();
+
+			if (mauiAppDelegate is not null)
+			{
+				// Support for hot restart is disabled, since the app cannot be started from
+				// the MauiUIApplicationDelegate as the CreateMaui override cannot be implemented
+				// in an Uno context.
+				return;
+			}
 
 			var appType = GetApplicationDefinitionType();
 
@@ -63,7 +70,6 @@ public partial class HotRestartGenerator : ISourceGenerator
 				// *************************************************************
 				// </auto-generated>
 
-				#if {{shouldDefineAppDelegate}}
 				namespace Microsoft.Maui
 				{
 					[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -71,7 +77,6 @@ public partial class HotRestartGenerator : ISourceGenerator
 					{
 					}
 				}
-				#endif
 
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				internal class __UnoHotRestartDelegate : global::Microsoft.Maui.MauiUIApplicationDelegate


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/13018

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Disable HR generation when MAUI is present
- Adjust disable feature property reading

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35b32c2</samp>

This pull request improves the hot restart feature for .NET MAUI projects and fixes a bug in the `HotRestartGenerator`. It adds a new condition to skip generation for MAUI apps and removes an unused directive from `HotRestartGenerator.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
