### PR TITLE
fix(menuflyout): properly change the DataContext of a MenuFlyout and MenuFlyoutPresenter during opening

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_MenuFlyout_DataContext_Changes_In_Opening.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_MenuFlyout_DataContext_Changes_In_Opening.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl x:Class="Uno.UI.RuntimeTests.When_MenuFlyout_DataContext_Changes_In_Opening"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:local="using:Uno.UI.RuntimeTests"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d">
+
+	<UserControl.Resources>
+		<MenuFlyout x:Key="sharedFlyout" Opening="MenuFlyout_Opening">
+			<MenuFlyoutItem Text="{Binding Text}" />
+		</MenuFlyout>
+	</UserControl.Resources>
+
+	<StackPanel
+		HorizontalAlignment="Center"
+		VerticalAlignment="Center"
+		Spacing="12">
+		<Button
+			x:Name="btn"
+			Width="220"
+			Flyout="{StaticResource sharedFlyout}" />
+		<Button
+			x:Name="btn2"
+			Width="220"
+			Flyout="{StaticResource sharedFlyout}" />
+	</StackPanel>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_MenuFlyout_DataContext_Changes_In_Opening.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_MenuFlyout_DataContext_Changes_In_Opening.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests
+{
+	public sealed partial class When_MenuFlyout_DataContext_Changes_In_Opening : UserControl
+	{
+		public When_MenuFlyout_DataContext_Changes_In_Opening()
+		{
+			InitializeComponent();
+
+			btn.DataContext = new DataContextClass() { Text = "1" };
+			btn2.DataContext = new DataContextClass() { Text = "2" };
+		}
+
+		private void MenuFlyout_Opening(object sender, object e)
+		{
+			if (sender is MenuFlyout flyout && flyout.Target is FrameworkElement elem)
+			{
+#if HAS_UNO
+				flyout.DataContext = elem.DataContext;
+#endif
+			}
+		}
+
+		private class DataContextClass
+		{
+			public string Text { get; set; }
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -325,5 +325,35 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 #endif
+
+		[TestMethod]
+		public async Task When_MenuFlyout_DataContext_Changes_In_Opening()
+		{
+			var SUT = new When_MenuFlyout_DataContext_Changes_In_Opening();
+
+
+			MenuFlyout flyout = null;
+			try
+			{
+				WindowHelper.WindowContent = SUT;
+				await WindowHelper.WaitForLoaded(SUT);
+
+
+				var button = SUT.FindFirstChild<Button>();
+				flyout = (MenuFlyout)button.Flyout;
+
+				flyout.ShowAt(button);
+				await WindowHelper.WaitForIdle();
+
+				Assert.AreEqual((flyout.Items[0] as MenuFlyoutItem)!.Text, "1");
+			}
+			finally
+			{
+				if (flyout?.IsOpen == true)
+				{
+					flyout.Hide();
+				}
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyValuePrecedences.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyValuePrecedences.cs
@@ -28,6 +28,11 @@ namespace Windows.UI.Xaml
 		Local,
 
 		/// <summary>
+		/// Values set by a Popup to its child
+		/// </summary>
+		Popup,
+
+		/// <summary>
 		/// Values inherited from the templated parent
 		/// </summary>
 		TemplatedParent,

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyValuePrecedences.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyValuePrecedences.cs
@@ -28,11 +28,6 @@ namespace Windows.UI.Xaml
 		Local,
 
 		/// <summary>
-		/// Values set by a Popup to its child
-		/// </summary>
-		Popup,
-
-		/// <summary>
 		/// Values inherited from the templated parent
 		/// </summary>
 		TemplatedParent,


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12490, closes #12494

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2917c2</samp>

This pull request adds a new precedence level for the `DataContext` property of the `Popup` child element, to enable data context propagation and avoid conflicts with the local value. It also simplifies the logic for checking the local value in the `Popup` class and updates the `DependencyPropertyValuePrecedences` enum accordingly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
