### PR TITLE
feat(Skia): Support `file://` uri scheme for images

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4913,7 +4913,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						}
 					}
 
-					return $"\"{rawValue}\"";
+					return $"@\"{rawValue}\"";
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
@@ -12,6 +12,7 @@ using Uno.Helpers;
 using Uno.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using Uno.UI;
+using System.Net;
 
 #if !IS_UNO
 using Uno.Web.Query;
@@ -247,9 +248,20 @@ namespace Windows.UI.Xaml.Media
 
 		private protected async Task<Stream> OpenStreamFromUriAsync(Uri uri, CancellationToken ct)
 		{
-			_httpClient ??= new HttpClient();
-			var response = await _httpClient.GetAsync(uri, HttpCompletionOption.ResponseContentRead, ct);
-			return await response.Content.ReadAsStreamAsync();
+			if (uri.IsFile)
+			{
+#pragma warning disable SYSLIB0014 // Type or member is obsolete - It suggests to use HttpClient, which doesn't work for file Uri scheme.
+				var request = WebRequest.Create(uri);
+#pragma warning restore SYSLIB0014 // Type or member is obsolete
+				var response = await request.GetResponseAsync();
+				return response.GetResponseStream();
+			}
+			else
+			{
+				_httpClient ??= new HttpClient();
+				var response = await _httpClient.GetAsync(uri, HttpCompletionOption.ResponseContentRead, ct);
+				return await response.Content.ReadAsStreamAsync();
+			}
 		}
 
 		internal void UnloadImageData()

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
@@ -250,18 +250,12 @@ namespace Windows.UI.Xaml.Media
 		{
 			if (uri.IsFile)
 			{
-#pragma warning disable SYSLIB0014 // Type or member is obsolete - It suggests to use HttpClient, which doesn't work for file Uri scheme.
-				var request = WebRequest.Create(uri);
-#pragma warning restore SYSLIB0014 // Type or member is obsolete
-				var response = await request.GetResponseAsync();
-				return response.GetResponseStream();
+				return File.Open(uri.LocalPath, FileMode.Open);
 			}
-			else
-			{
-				_httpClient ??= new HttpClient();
-				var response = await _httpClient.GetAsync(uri, HttpCompletionOption.ResponseContentRead, ct);
-				return await response.Content.ReadAsStreamAsync();
-			}
+
+			_httpClient ??= new HttpClient();
+			var response = await _httpClient.GetAsync(uri, HttpCompletionOption.ResponseContentRead, ct);
+			return await response.Content.ReadAsStreamAsync();
 		}
 
 		internal void UnloadImageData()

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/BitmapImage.skia.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -43,7 +44,8 @@ namespace Windows.UI.Xaml.Media.Imaging
 					}
 
 					if (UriSource.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ||
-						UriSource.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+						UriSource.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ||
+						UriSource.IsFile)
 					{
 						using var imageStream = await OpenStreamFromUriAsync(UriSource, ct);
 

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.skia.cs
@@ -20,7 +20,7 @@ partial class SvgImageSource
 			{
 				if (AbsoluteUri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ||
 					AbsoluteUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ||
-					AbsoluteUri.Isfile)
+					AbsoluteUri.IsFile)
 				{
 					using var imageStream = await OpenStreamFromUriAsync(UriSource, ct);
 					return await ReadFromStreamAsync(imageStream, ct);

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.skia.cs
@@ -19,7 +19,8 @@ partial class SvgImageSource
 			if (AbsoluteUri != null && AbsoluteUri.IsAbsoluteUri)
 			{
 				if (AbsoluteUri.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase) ||
-					AbsoluteUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+					AbsoluteUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ||
+					AbsoluteUri.Isfile)
 				{
 					using var imageStream = await OpenStreamFromUriAsync(UriSource, ct);
 					return await ReadFromStreamAsync(imageStream, ct);

--- a/src/Uno.UI/UI/Xaml/Style/mergedstyles.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/mergedstyles.xaml
@@ -11795,7 +11795,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
-              <FontIcon x:Name="CheckGlyph" FontFamily="{ThemeResource SymbolThemeFontFamily}" win:Glyph="&#xE001;" FontSize="16" not_win:Glyph="&#xE10B;" Foreground="{ThemeResource ToggleMenuFlyoutItemCheckGlyphForeground}" Opacity="0" Width="16" Margin="0,0,12,0" />
+              <FontIcon x:Name="CheckGlyph" FontFamily="{ThemeResource SymbolThemeFontFamily}" win:Glyph="&#xE001;" not_win:Glyph="&#xE10B;" FontSize="16" Foreground="{ThemeResource ToggleMenuFlyoutItemCheckGlyphForeground}" Opacity="0" Width="16" Margin="0,0,12,0" />
               <Viewbox x:Name="IconRoot" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Center" Width="16" Height="16" Visibility="Collapsed">
                 <ContentPresenter x:Name="IconContent" Content="{TemplateBinding Icon}" />
               </Viewbox>
@@ -14544,7 +14544,7 @@
       <Setter.Value>
         <ControlTemplate TargetType="FlyoutPresenter">
           <Border Background="{TemplateBinding Background}" BackgroundSizing="OuterBorderEdge" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}" Padding="{ThemeResource FlyoutBorderThemePadding}">
-            <ScrollViewer x:Name="ScrollViewer" win:ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}" not_win:ZoomMode="Disabled" HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" AutomationProperties.AccessibilityView="Raw">
+            <ScrollViewer x:Name="ScrollViewer" not_win:ZoomMode="Disabled" win:ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}" HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" AutomationProperties.AccessibilityView="Raw">
               <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" ContentTransitions="{TemplateBinding ContentTransitions}" Margin="{TemplateBinding Padding}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
             </ScrollViewer>
           </Border>
@@ -15325,7 +15325,7 @@
               <Grid.RenderTransform>
                 <TranslateTransform x:Name="ContentPresenterTranslateTransform" />
               </Grid.RenderTransform>
-              <ContentPresenter x:Name="ContentPresenter" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" not_win:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Margin="{TemplateBinding Padding}" />
+              <ContentPresenter x:Name="ContentPresenter" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" not_win:ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Margin="{TemplateBinding Padding}" />
             </Grid>
             <!-- The 'Xg' text simulates the amount of space one line of text will occupy.
 						  In the DataPlaceholder state, the Content is not loaded yet so we
@@ -15344,7 +15344,7 @@
               <Border.RenderTransform>
                 <TranslateTransform x:Name="MultiSelectCheckBoxTransform" />
               </Border.RenderTransform>
-              <FontIcon x:Name="MultiSelectCheck" FontFamily="{ThemeResource SymbolThemeFontFamily}" win:Glyph="&#xE73E;" FontSize="16" not_win:Glyph="&#xE081;" Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}" Visibility="Collapsed" Opacity="0" />
+              <FontIcon x:Name="MultiSelectCheck" FontFamily="{ThemeResource SymbolThemeFontFamily}" win:Glyph="&#xE73E;" not_win:Glyph="&#xE081;" FontSize="16" Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}" Visibility="Collapsed" Opacity="0" />
             </Border>
             <TextBlock x:Name="MultiArrangeOverlayText" Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DragItemsCount}" Foreground="{ThemeResource ListViewItemDragForegroundThemeBrush}" FontFamily="{ThemeResource ContentControlThemeFontFamily}" FontSize="26.667" IsHitTestVisible="False" Opacity="0" TextWrapping="Wrap" TextTrimming="WordEllipsis" Margin="18,9,0,0" AutomationProperties.AccessibilityView="Raw" Grid.ColumnSpan="2" />
           </Grid>
@@ -15588,7 +15588,7 @@
             <Rectangle x:Name="MultiArrangeOverlayBackground" IsHitTestVisible="False" Opacity="0" Fill="{ThemeResource ListViewItemDragBackgroundThemeBrush}" Grid.ColumnSpan="2" />
             <Rectangle x:Name="BorderRectangle" IsHitTestVisible="False" Stroke="{ThemeResource SystemControlHighlightListAccentLowBrush}" StrokeThickness="2" Opacity="0" />
             <Border x:Name="MultiSelectSquare" Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}" Width="20" Height="20" Margin="0,2,2,0" VerticalAlignment="Top" HorizontalAlignment="Right" Visibility="Collapsed">
-              <FontIcon x:Name="MultiSelectCheck" FontFamily="{ThemeResource SymbolThemeFontFamily}" win:Glyph="&#xE73E;" FontSize="16" not_win:Glyph="&#xE081;" Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}" Opacity="0" />
+              <FontIcon x:Name="MultiSelectCheck" FontFamily="{ThemeResource SymbolThemeFontFamily}" win:Glyph="&#xE73E;" not_win:Glyph="&#xE081;" FontSize="16" Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}" Opacity="0" />
             </Border>
             <Rectangle x:Name="FocusVisualWhite" IsHitTestVisible="False" Stroke="{ThemeResource SystemControlForegroundAltHighBrush}" StrokeEndLineCap="Square" StrokeDashArray="1.0,1.0" StrokeDashOffset="1.5" StrokeThickness="2" Opacity="0" />
             <Rectangle x:Name="FocusVisualBlack" IsHitTestVisible="False" Stroke="{ThemeResource SystemControlForegroundBaseHighBrush}" StrokeEndLineCap="Square" StrokeDashArray="1.0,1.0" StrokeDashOffset="0.5" StrokeThickness="2" Opacity="0" />
@@ -17157,7 +17157,7 @@
                             </VisualState>
                           </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <TextBlock x:Name="GlyphElement" Foreground="{ThemeResource SystemControlForegroundChromeBlackMediumBrush}" VerticalAlignment="Center" HorizontalAlignment="Center" FontStyle="Normal" FontSize="16" win:Text="&#xE052;" FontFamily="{ThemeResource SymbolThemeFontFamily}" not_win:Text="&#xE18B;" AutomationProperties.AccessibilityView="Raw" />
+                        <TextBlock x:Name="GlyphElement" Foreground="{ThemeResource SystemControlForegroundChromeBlackMediumBrush}" VerticalAlignment="Center" HorizontalAlignment="Center" FontStyle="Normal" FontSize="16" win:Text="&#xE052;" not_win:Text="&#xE18B;" FontFamily="{ThemeResource SymbolThemeFontFamily}" AutomationProperties.AccessibilityView="Raw" />
                       </Grid>
                     </ControlTemplate>
                   </Setter.Value>
@@ -17281,7 +17281,7 @@
                 </VisualState>
               </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
-            <TextBlock x:Name="GlyphElement" Foreground="{ThemeResource SystemControlForegroundChromeBlackMediumBrush}" VerticalAlignment="Center" HorizontalAlignment="Center" FontStyle="Normal" FontSize="16" win:Text="&#xE052;" FontFamily="{ThemeResource SymbolThemeFontFamily}" not_win:Text="&#xE18B;" AutomationProperties.AccessibilityView="Raw" />
+            <TextBlock x:Name="GlyphElement" Foreground="{ThemeResource SystemControlForegroundChromeBlackMediumBrush}" VerticalAlignment="Center" HorizontalAlignment="Center" FontStyle="Normal" FontSize="16" win:Text="&#xE052;" not_win:Text="&#xE18B;" FontFamily="{ThemeResource SymbolThemeFontFamily}" AutomationProperties.AccessibilityView="Raw" />
           </Grid>
         </ControlTemplate>
       </Setter.Value>


### PR DESCRIPTION
GitHub Issue (If applicable): Skia part of #13003

**Notes:**

- I'm not able to try on Android due to the VS bug.
- I'm not able to try on iOS/macOS as I don't have any Apple device.
- This is not going to work on Wasm due to security concerns (a website can't just open files from the local device)

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d20ab0c</samp>

This pull request adds support for loading images from file URIs in various classes that use the `ImageSource` class, such as `BitmapImage` and `SvgImageSource`. It also fixes a bug in the XAML generator that caused file URIs to be escaped incorrectly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
