### PR TITLE
fix!: Make DataContext available only on FrameworkElement

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Helpers/FlyoutHelper.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Helpers/FlyoutHelper.cs
@@ -29,21 +29,13 @@ namespace Uno.UI.RuntimeTests.MUX.Helpers
 		public static void HideFlyout<T>(T flyoutControl)
 			where T : FlyoutBase
 		{
-#if WINDOWS_UWP
 			flyoutControl.Hide();
-#else
-			flyoutControl.Close();
-#endif
 		}
 
 		internal static void OpenFlyout<T>(T flyoutControl, FrameworkElement target, FlyoutOpenMethod openMethod)
 			where T : FlyoutBase
 		{
-#if WINDOWS_UWP
 			flyoutControl.ShowAt(target);
-#else
-			flyoutControl.Open();
-#endif
 		}
 
 		public static void ValidateOpenFlyoutOverlayBrush(string name)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarDatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarDatePicker.cs
@@ -24,14 +24,14 @@ public class Given_CalendarDatePicker
 		var root = (Grid)SUT.FindName("Root");
 		var flyout = (Flyout)FlyoutBase.GetAttachedFlyout(root);
 		flyout.XamlRoot = SUT.XamlRoot;
-		flyout.Open();
+		flyout.ShowAt(SUT);
 
 		await WindowHelper.WaitForIdle();
 		var calendarView = (CalendarView)flyout.Content;
 
 		Assert.IsTrue(calendarView.ActualHeight > 300);
 
-		flyout.Close();
+		flyout.Hide();
 	}
 #endif
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -555,12 +555,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			FlyoutBase.ShowAttachedFlyout(b1);
 			await TestServices.WindowHelper.WaitForLoaded(tb);
 			Assert.AreEqual("41", tb.Text);
-			SUT.Close();
+			SUT.Hide();
 
 			FlyoutBase.ShowAttachedFlyout(b2);
 			await TestServices.WindowHelper.WaitForLoaded(tb);
 			Assert.AreEqual("42", tb.Text);
-			SUT.Close();
+			SUT.Hide();
 		}
 #endif
 
@@ -656,9 +656,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 			finally
 			{
-#if HAS_UNO
-				SUT.contextFlyout.Close();
-#endif
+				SUT.contextFlyout.Hide();
 			}
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -172,10 +172,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 				sv.ChangeView(null, sv.ExtentHeight / 2, null, disableAnimation: true);
 				await TestServices.WindowHelper.WaitForIdle();
 
-				var groupView = sut.Children.Single(g => g.DataContext as string == "Group #05");
+				var groupView = sut.Children.Single(g => ((FrameworkElement)g).DataContext as string == "Group #05");
 				var groupIr = (ItemsRepeater)((StackPanel)groupView).Children[1];
 
-				var beforeVisibleItems = groupIr.Children.Select(i => i.DataContext?.ToString()).OrderBy(i => i).ToArray();
+				var beforeVisibleItems = groupIr.Children.Select(i => ((FrameworkElement)i).DataContext?.ToString()).OrderBy(i => i).ToArray();
 
 				// Scroll by baby step to not be above the threshold which would cause a complete redraw
 				const int step = 10;
@@ -185,7 +185,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 					await TestServices.WindowHelper.WaitForIdle();
 				}
 
-				var afterVisibleItems = groupIr.Children.Select(i => i.DataContext?.ToString()).OrderBy(i => i).ToArray();
+				var afterVisibleItems = groupIr.Children.Select(i => ((FrameworkElement)i).DataContext?.ToString()).OrderBy(i => i).ToArray();
 
 				afterVisibleItems.Should().NotContain(beforeVisibleItems);
 			}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBarItem.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBarItem.cs
@@ -82,11 +82,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private void SetFlyoutDataContext()
 		{
 			// This is present to force the dataContext to be passed to the popup of the flyout since it is not directly a child in the visual tree of the flyout.
-			m_flyout?.SetValue(
-				MenuFlyout.DataContextProperty,
-				this.DataContext,
-				precedence: DependencyPropertyValuePrecedences.Inheritance
-			);
+			m_flyout.SetFlyoutItemsDataContext(DataContext);
 		}
 
 		private void PopulateContent()

--- a/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/Button.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnUnloaded();
 
-			Flyout?.Close();
+			Flyout?.Hide();
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -417,11 +417,11 @@ namespace Windows.UI.Xaml.Controls
 				{
 					if ((ContentTemplateRoot is IDependencyObjectStoreProvider provider) &&
 						// The DataContext may be set directly on the template root
-						(_localContentDataContextOverride || !(provider as DependencyObject).IsDependencyPropertyLocallySet(provider.Store.DataContextProperty))
+						(_localContentDataContextOverride || !(provider as DependencyObject).IsDependencyPropertyLocallySet(FrameworkElement.DataContextProperty))
 					)
 					{
 						_localContentDataContextOverride = true;
-						provider.Store.SetValue(provider.Store.DataContextProperty, Content, DependencyPropertyValuePrecedences.Local);
+						provider.Store.SetValue(FrameworkElement.DataContextProperty, Content, DependencyPropertyValuePrecedences.Local);
 					}
 				}
 			}
@@ -436,7 +436,7 @@ namespace Windows.UI.Xaml.Controls
 			if (_localContentDataContextOverride && ContentTemplateRoot is IDependencyObjectStoreProvider provider)
 			{
 				_localContentDataContextOverride = false;
-				provider.Store.ClearValue(provider.Store.DataContextProperty, DependencyPropertyValuePrecedences.Local);
+				provider.Store.ClearValue(FrameworkElement.DataContextProperty, DependencyPropertyValuePrecedences.Local);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout_Partial.cs
@@ -62,7 +62,7 @@ namespace Windows.UI.Xaml.Controls
 
 			_datePicked?.Invoke(this, new DatePickedEventArgs(newDateTime, oldDateTime));
 
-			Close();
+			Hide();
 		}
 
 		//// -----

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
@@ -129,16 +129,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected internal override void OnDataContextChanged(DependencyPropertyChangedEventArgs e)
-		{
-			base.OnDataContextChanged(e);
-
-			if (Content is IDependencyObjectStoreProvider binder)
-			{
-				binder.Store.SetValue(binder.Store.DataContextProperty, DataContext, DependencyPropertyValuePrecedences.Local);
-			}
-		}
-
 		protected override Control CreatePresenter()
 		{
 			_presenter = new FlyoutPresenter();

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
@@ -107,18 +107,6 @@ namespace Windows.UI.Xaml.Controls
 		{
 		}
 
-		protected internal override void Close()
-		{
-			// This overload is required for binary compatibility
-			base.Close();
-		}
-
-		protected internal override void Open()
-		{
-			// This overload is required for binary compatibility
-			base.Open();
-		}
-
 		protected internal override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
 		{
 			base.OnTemplatedParentChanged(e);

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -482,7 +482,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			_sizeChangedDisposable.Disposable = null;
 		}
 
-		protected internal virtual void Close()
+		private void Close()
 		{
 			if (_popup != null)
 			{
@@ -490,7 +490,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			}
 		}
 
-		protected internal virtual void Open()
+		private void Open()
 		{
 			EnsurePopupCreated(Target.DataContext);
 

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
@@ -47,19 +47,12 @@ namespace Windows.UI.Xaml.Controls
 
 		internal FocusInputDeviceKind InputDeviceTypeUsedToOpen { get; set; }
 
-		internal protected override void OnDataContextChanged(DependencyPropertyChangedEventArgs e)
-		{
-			base.OnDataContextChanged(e);
-
-			SetFlyoutItemsDataContext();
-		}
-
-		private void SetFlyoutItemsDataContext()
+		internal void SetFlyoutItemsDataContext(object dataContext)
 		{
 			// This is present to force the dataContext to be passed to the popup of the flyout since it is not directly a child in the visual tree of the flyout.
 			Items?.ForEach(item => item?.SetValue(
-				UIElement.DataContextProperty,
-				this.DataContext,
+				FrameworkElement.DataContextProperty,
+				dataContext,
 				precedence: DependencyPropertyValuePrecedences.Inheritance
 			));
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Base.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Base.cs
@@ -142,7 +142,7 @@ public partial class Popup : FrameworkElement, IPopup
 	{
 		if (oldChild is IDependencyObjectStoreProvider provider && !_childHasOwnDataContext)
 		{
-			provider.Store.ClearValue(provider.Store.DataContextProperty, DependencyPropertyValuePrecedences.Local);
+			provider.Store.ClearValue(FrameworkElement.DataContextProperty, DependencyPropertyValuePrecedences.Local);
 			provider.Store.ClearValue(provider.Store.TemplatedParentProperty, DependencyPropertyValuePrecedences.Local);
 			provider.Store.ClearValue(AllowFocusOnInteractionProperty, DependencyPropertyValuePrecedences.Local);
 			provider.Store.ClearValue(AllowFocusWhenDisabledProperty, DependencyPropertyValuePrecedences.Local);
@@ -172,14 +172,14 @@ public partial class Popup : FrameworkElement, IPopup
 		_childHasOwnDataContext = false;
 		if (PropagatesDataContextToChild && Child is IDependencyObjectStoreProvider provider)
 		{
-			var dataContextProperty = provider.Store.ReadLocalValue(provider.Store.DataContextProperty);
+			var dataContextProperty = provider.Store.ReadLocalValue(FrameworkElement.DataContextProperty);
 
 			var shouldClearValue = e != null && e.NewValue == null && dataContextProperty == e.OldValue;
 			if (shouldClearValue)
 			{
 				//In this case we are clearing the DataContext that was previously set by the Popup
 				//This usually occurs when the owner of the Popup is removed from the Visual Tree
-				provider.Store.ClearValue(provider.Store.DataContextProperty, DependencyPropertyValuePrecedences.Local);
+				provider.Store.ClearValue(FrameworkElement.DataContextProperty, DependencyPropertyValuePrecedences.Local);
 			}
 			else if (dataContextProperty != null && dataContextProperty != DependencyProperty.UnsetValue)
 			{
@@ -188,7 +188,7 @@ public partial class Popup : FrameworkElement, IPopup
 			}
 			else
 			{
-				provider.Store.SetValue(provider.Store.DataContextProperty, this.DataContext, DependencyPropertyValuePrecedences.Local);
+				provider.Store.SetValue(FrameworkElement.DataContextProperty, this.DataContext, DependencyPropertyValuePrecedences.Local);
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -41,7 +41,6 @@ namespace Windows.UI.Xaml
 		private bool _isApplyingTemplateBindings;
 		private bool _isApplyingDataContextBindings;
 		private bool _bindingsSuspended;
-		private readonly DependencyProperty _dataContextProperty;
 		private readonly DependencyProperty _templatedParentProperty;
 
 		/// <summary>
@@ -102,7 +101,7 @@ namespace Windows.UI.Xaml
 				{
 					provider.Store.SetInheritedTemplatedParent(inheritedValue);
 				}
-				else
+				else if (provider.Store.ActualInstance is FrameworkElement)
 				{
 					provider.Store.SetInheritedDataContext(inheritedValue);
 				}
@@ -171,7 +170,7 @@ namespace Windows.UI.Xaml
 			=> SetValue(_templatedParentProperty!, templatedParent, DependencyPropertyValuePrecedences.Inheritance, _properties.TemplatedParentPropertyDetails);
 
 		private void SetInheritedDataContext(object? dataContext)
-			=> SetValue(_dataContextProperty!, dataContext, DependencyPropertyValuePrecedences.Inheritance, _properties.DataContextPropertyDetails);
+			=> SetValue(FrameworkElement.DataContextProperty, dataContext, DependencyPropertyValuePrecedences.Inheritance, _properties.DataContextPropertyDetails);
 
 		/// <summary>
 		/// Apply load-time binding updates. Processes the x:Bind markup for the current FrameworkElement, applies load-time ElementName bindings, and updates ResourceBindings.
@@ -191,7 +190,6 @@ namespace Windows.UI.Xaml
 			BindingPath.RegisterPropertyChangedRegistrationHandler(new BindingPathPropertyChangedRegistrationHandler());
 		}
 
-		internal DependencyProperty DataContextProperty => _dataContextProperty!;
 		internal DependencyProperty TemplatedParentProperty => _templatedParentProperty!;
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -27,7 +27,6 @@ namespace Windows.UI.Xaml
 		private readonly Type _ownerType;
 		private readonly ManagedWeakReference _ownerReference;
 		private object? _hardOwnerReference;
-		private readonly DependencyProperty _dataContextProperty;
 		private readonly DependencyProperty _templatedParentProperty;
 
 		private DependencyPropertyDetails? _dataContextPropertyDetails;
@@ -46,12 +45,11 @@ namespace Windows.UI.Xaml
 		/// Creates an instance using the specified DependencyObject <see cref="Type"/>
 		/// </summary>
 		/// <param name="ownerType">The owner type</param>
-		public DependencyPropertyDetailsCollection(Type ownerType, ManagedWeakReference ownerReference, DependencyProperty dataContextProperty, DependencyProperty templatedParentProperty)
+		public DependencyPropertyDetailsCollection(Type ownerType, ManagedWeakReference ownerReference, DependencyProperty templatedParentProperty)
 		{
 			_ownerType = ownerType;
 			_ownerReference = ownerReference;
 
-			_dataContextProperty = dataContextProperty;
 			_templatedParentProperty = templatedParentProperty;
 		}
 
@@ -99,7 +97,7 @@ namespace Windows.UI.Xaml
 		}
 
 		public DependencyPropertyDetails DataContextPropertyDetails
-			=> _dataContextPropertyDetails ??= GetPropertyDetails(_dataContextProperty);
+			=> _dataContextPropertyDetails ??= GetPropertyDetails(FrameworkElement.DataContextProperty);
 
 		public DependencyPropertyDetails TemplatedParentPropertyDetails
 			=> _templatedParentPropertyDetails ??= GetPropertyDetails(_templatedParentProperty);
@@ -204,7 +202,7 @@ namespace Windows.UI.Xaml
 			out bool hasValueDoesNotInherit)
 		{
 			if (property == _templatedParentProperty
-				|| property == _dataContextProperty)
+				|| property == FrameworkElement.DataContextProperty)
 			{
 				// TemplatedParent is a DependencyObject but does not propagate datacontext
 				hasValueInherits = false;

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -147,6 +147,35 @@ namespace Windows.UI.Xaml
 
 		#endregion
 
+		#region DataContext DependencyProperty
+
+		public event Windows.Foundation.TypedEventHandler<FrameworkElement, DataContextChangedEventArgs> DataContextChanged;
+
+		public object DataContext
+		{
+			get => GetValue(DataContextProperty);
+			set => SetValue(DataContextProperty, value);
+		}
+
+		public static DependencyProperty DataContextProperty { get; } =
+			DependencyProperty.Register(
+				name: nameof(DataContext),
+				propertyType: typeof(object),
+				ownerType: typeof(FrameworkElement),
+				typeMetadata: new FrameworkPropertyMetadata(
+					defaultValue: null,
+					options: FrameworkPropertyMetadataOptions.Inherits,
+					propertyChangedCallback: (s, e) => ((FrameworkElement)s).OnDataContextChanged(e)
+		)
+);
+
+
+		internal protected virtual void OnDataContextChanged(DependencyPropertyChangedEventArgs e)
+		{
+			DataContextChanged?.Invoke(this, new DataContextChangedEventArgs(DataContext));
+		}
+
+		#endregion
 
 		partial void Initialize()
 		{

--- a/src/Uno.UI/UI/Xaml/Media/Brush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.cs
@@ -43,7 +43,7 @@ namespace Windows.UI.Xaml.Media
 
 		internal virtual void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
 		{
-			if (args.Property == DataContextProperty || args.Property == TemplatedParentProperty)
+			if (args.Property == TemplatedParentProperty)
 			{
 				return;
 			}

--- a/src/Uno.UI/UI/Xaml/SetterBase.cs
+++ b/src/Uno.UI/UI/Xaml/SetterBase.cs
@@ -24,11 +24,6 @@ namespace Windows.UI.Xaml
 
 		internal virtual void OnStringPropertyChanged(string name) { }
 
-		partial void OnDataContextChangedPartial(DependencyPropertyChangedEventArgs e)
-		{
-			this.Log().Debug("SetterBase.DataContextChanged");
-		}
-
 		public bool IsSealed
 		{
 			get; private set;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13201

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b13198a</samp>

This pull request refactors the data context inheritance logic in the Uno Platform and aligns it with the UWP behavior. It removes the `DataContextProperty` and the `DataContextChanged` event from the `DependencyObject` class and moves them to the `FrameworkElement` class, which is the only type that should have them. It also updates the classes that inherit from `FlyoutBase` and `Popup` to use the data context of their placement targets or owners, and to propagate it to their content. It simplifies the `DependencyObjectStore` and the `DependencyPropertyDetailsCollection` classes by removing the dependency on the data context property of the dependency object type. It adapts the `Brush` and the `SetterBase` classes to the new behavior of the `DependencyObject` class. It modifies the `MenuBarItem` and the `MenuFlyout` classes to use a new method to set the data context on their items.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
