### PR TITLE
test: Unskip `Basics_AutomatedTransformation` on Android

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_BasicAutomatedTransformation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_BasicAutomatedTransformation.cs
@@ -8,9 +8,6 @@ using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 {
-#if __ANDROID__
-	[Ignore("Currently fails on Android https://github.com/unoplatform/uno/issues/9080")]
-#endif
 	[TestClass]
 	[RunsOnUIThread]
 	public class Basics_AutomatedTransformation
@@ -194,6 +191,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 
 		private async Task<RawBitmap> Arrange(FrameworkElement SUT)
 		{
+#if __ANDROID__
+			if (SUT is Android.Views.View view && view.Parent is Controls.BindableView bindableView)
+			{
+				bindableView.RemoveView(view);
+			}
+#endif
 			WindowHelper.WindowContent = SUT;
 			await WindowHelper.WaitForLoaded(SUT);
 			var renderer = new RenderTargetBitmap();


### PR DESCRIPTION
GitHub Issue (If applicable): #9080

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Test is failing on Android. The reason is that `SUT` already has a parent, and then we try to set it to ContentControl.Content. The test actually already fails on Windows, so I didn't attempt to gracefully handle this case in `ContentControl.RegisterContentTemplateRoot`.

## What is the new behavior?

A little test hack to remove the parent to allow the test to run successfully.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
