### PR TITLE
chore: Trace information was being logged as an error

### DIFF
--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -388,9 +388,9 @@ namespace Uno.UI.RemoteControl
 
 		public async Task SendMessage(IMessage message)
 		{
-			if (this.Log().IsEnabled(LogLevel.Error))
+			if (this.Log().IsEnabled(LogLevel.Trace))
 			{
-				this.Log().LogError($"Sending message: {message} {message.Name}");
+				this.Log().Trace($"Sending message: {message} {message.Name}");
 			}
 
 			if (_webSocket != null)


### PR DESCRIPTION
GitHub Issue (If applicable): none

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

RemoteControl Client was logging every sent message as an error.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

RemoteControl Client now logs sent messages with `Trace` priority

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b1d2c1</samp>

Lowered log level for remote control message sending in `RemoteControlClient.cs`. This improves the log output and aligns with the message receiving log level. The change is part of a fix for the remote control feature of Uno Platform.

## PR Checklist

Please check if your PR fulfills the following requirements:

-  ~Docs have been added/updated which fit [documentation template] (https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)~ n/a
-  ~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~ n/a
- ~Validated PR `Screenshots Compare Test Run` results.~ n/a (non-visual)
- [x] Contains **NO** breaking changes
- ~Associated with an issue (GitHub or internal) and uses the [automatic close keywords(https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).~ see below
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Just a quick fix with no issue so that this can be addressed quickly rather than wait for inclusion as part of other changes. 

Internal Issue (If applicable): _n/a_
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
