### PR TITLE
test: Enable DoubleAnimation_Tests

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Opacity.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Opacity.cs
@@ -14,10 +14,6 @@ using Uno.UITest.Helpers.Queries;
 namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 {
 	[TestFixture]
-
-	// Disabled for Android: https://github.com/unoplatform/uno/issues/9080
-	// Disabled for iOS: https://github.com/unoplatform/uno/issues/1955
-	[ActivePlatforms(Platform.Browser)]
 	public partial class DoubleAnimation_Tests : SampleControlUITestBase
 	{
 		private const string _finalStateOpacityTestControl = "UITests.Windows_UI_Xaml_Media_Animation.DoubleAnimation_FinalState_Opacity";

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Opacity.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Opacity.cs
@@ -14,6 +14,8 @@ using Uno.UITest.Helpers.Queries;
 namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 {
 	[TestFixture]
+	// Disabled for iOS: https://github.com/unoplatform/uno/issues/1955
+	[ActivePlatforms(Platform.Browser, Platform.Android)]
 	public partial class DoubleAnimation_Tests : SampleControlUITestBase
 	{
 		private const string _finalStateOpacityTestControl = "UITests.Windows_UI_Xaml_Media_Animation.DoubleAnimation_FinalState_Opacity";

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Transforms.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Tests.FinalState_Transforms.cs
@@ -22,7 +22,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Media_Animation
 
 		[Test]
 		[AutoRetry]
-		[ActivePlatforms(Platform.Browser)] // Disabled for Android and iOS: https://github.com/unoplatform/uno/issues/9080
 		public void When_Transforms_Paused_With_FillBehaviorStop_Then_Hold() => TestTransformsFinalState();
 
 		[Test][AutoRetry] public void When_Transforms_Paused_With_FillBehaviorHold_Then_Hold() => TestTransformsFinalState();


### PR DESCRIPTION
GitHub Issue (If applicable): #9080

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18896b5</samp>

This pull request enables two UI tests for double animations on opacity and transforms that were previously disabled for Android. The tests verify that the final state of the animations is correct when the animations are paused with `FillBehavior.Stop`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
