### PR TITLE
fix: Ensure `TextBox` recycling does not apply change for `TwoWay` binding

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -12,6 +12,10 @@ using Windows.UI;
 using FluentAssertions;
 using MUXControlsTestApp.Utilities;
 using System.Runtime.InteropServices;
+using Uno.UI.RuntimeTests.ListViewPages;
+using Uno.UI.RuntimeTests.TextBoxPages;
+
+
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -676,6 +680,28 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			textBox.SelectAll();
 
 			Assert.AreEqual(updatedText.Length, textBox.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Recycled_Text()
+		{
+			using var _ = FeatureConfigurationHelper.UseTemplatePooling();
+
+			var page = new RecyclingTextBoxPage();
+			var textBox = page.FindFirstChild<TextBox>();
+
+			WindowHelper.WindowContent = page;
+			await WindowHelper.WaitForLoaded(page);
+			await WindowHelper.WaitForIdle();
+
+			var vm = page.DataContext as RecyclingTextBoxPageItemViewModel;
+
+			Assert.IsFalse(string.IsNullOrEmpty(vm.Text));
+
+			textBox.OnTemplateRecycled();
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsFalse(string.IsNullOrEmpty(vm.Text));
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TextBox/RecyclingTextBoxPage.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TextBox/RecyclingTextBoxPage.xaml
@@ -1,0 +1,14 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.TextBoxPages.RecyclingTextBoxPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ListViewPages"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  x:Name="OuterPage"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<TextBox Text="{Binding Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TextBox/RecyclingTextBoxPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TextBox/RecyclingTextBoxPage.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI.Xaml.Controls;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.RuntimeTests.TextBoxPages
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class RecyclingTextBoxPage : Page
+	{
+		public RecyclingTextBoxPage()
+		{
+			this.InitializeComponent();
+
+			DataContext = new RecyclingTextBoxPageItemViewModel();
+		}
+	}
+
+	public class RecyclingTextBoxPageItemViewModel : INotifyPropertyChanged
+	{
+		private string _text = Guid.NewGuid().ToString();
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public string Text
+		{
+			get => _text; 
+			set
+			{
+				_text = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Text)));
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -1073,6 +1073,7 @@ namespace Windows.UI.Xaml.Controls
 		public void OnTemplateRecycled()
 		{
 			_suppressTextChanged = true;
+			ClearValue(TextProperty);
 			Text = string.Empty;
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe21790</samp>

This pull request adds a new unit test and a new UI page to verify the `UseTemplatePooling` feature for `TextBox` controls. It also fixes a potential issue with the `Text` property of recycled `TextBox` instances by clearing its local value.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.