### PR TITLE
Allow RCServer to load processors in specific Assem…

### DIFF
--- a/src/Uno.UI.RemoteControl/Messages/ProcessorsDiscovery.cs
+++ b/src/Uno.UI.RemoteControl/Messages/ProcessorsDiscovery.cs
@@ -1,6 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Runtime.Remoting.Messaging;
 
 namespace Uno.UI.RemoteControl.Messages
 {
@@ -8,9 +6,10 @@ namespace Uno.UI.RemoteControl.Messages
 	{
 		public const string Name = nameof(ProcessorsDiscovery);
 
-		public ProcessorsDiscovery(string basePath)
+		public ProcessorsDiscovery(string basePath, string appInstanceId = "")
 		{
 			BasePath = basePath;
+			AppInstanceId = appInstanceId;
 		}
 
 		public string Scope => "RemoteControlServer";
@@ -18,5 +17,7 @@ namespace Uno.UI.RemoteControl.Messages
 		string IMessage.Name => Name;
 
 		public string BasePath { get; }
+
+		public string AppInstanceId { get; }
 	}
 }


### PR DESCRIPTION
…blyLoadContext

GitHub Issue (If applicable): _none_

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Refactoring

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Each RemoteControlServer instance uses a separate AssemblyLoadContext.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

`AssemblyLoadContext`s are now pooled and grouped by `appInstanceId`.
This allows for the registering of multiple Processors with the same Id which can access the same static instances of types.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
copilot:summary

## PR Checklist

Please check if your PR fulfills the following requirements:

-  Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
-  [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
-  Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
-  Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Created as an alternative to and in response to feedback on #12707

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
