### PR TITLE
fix: Align Duration behavior with WinUI

### DIFF
--- a/src/Uno.UI.Tests/Animations/Given_Duration.cs
+++ b/src/Uno.UI.Tests/Animations/Given_Duration.cs
@@ -84,5 +84,78 @@ namespace Uno.UI.Tests.Animations
 			Assert.AreEqual(new Duration(TimeSpan.FromSeconds(48)), duration.Add(new Duration(TimeSpan.FromSeconds(24))));
 			Assert.AreEqual(new Duration(TimeSpan.FromSeconds(1)), duration.Subtract(new Duration(TimeSpan.FromSeconds(23))));
 		}
+
+		[TestMethod]
+		[DataRow("00:00:05", "00:00:03", "00:00:08")]
+		[DataRow("00:00:05", "Automatic", "Automatic")]
+		[DataRow("00:00:05", "Forever", "Forever")]
+		[DataRow("Automatic", "00:00:03", "Automatic")]
+		[DataRow("Automatic", "Automatic", "Automatic")]
+		[DataRow("Automatic", "Forever", "Automatic")]
+		[DataRow("Forever", "00:00:03", "Forever")]
+		[DataRow("Forever", "Automatic", "Automatic")]
+		[DataRow("Forever", "Forever", "Forever")]
+		public void When_Adding_Durations(string d1, string d2, string expected)
+		{
+			var duration1 = StringToDuration(d1);
+			var duration2 = StringToDuration(d2);
+			var expectedDuration = StringToDuration(expected);
+			Assert.AreEqual(expectedDuration, duration1 + duration2);
+			Assert.AreEqual(expectedDuration, duration1.Add(duration2));
+			Assert.AreEqual(expectedDuration, duration2.Add(duration1));
+		}
+
+		[TestMethod]
+		[DataRow("00:00:05", "00:00:03", "00:00:02")]
+		[DataRow("00:00:05", "Automatic", "Automatic")]
+		[DataRow("00:00:05", "Forever", "Automatic")]
+		[DataRow("Automatic", "00:00:03", "Automatic")]
+		[DataRow("Automatic", "Automatic", "Automatic")]
+		[DataRow("Automatic", "Forever", "Automatic")]
+		[DataRow("Forever", "00:00:03", "Forever")]
+		[DataRow("Forever", "Automatic", "Automatic")]
+		[DataRow("Forever", "Forever", "Automatic")]
+		public void When_Subtracting_Durations(string d1, string d2, string expected)
+		{
+			var duration1 = StringToDuration(d1);
+			var duration2 = StringToDuration(d2);
+			var expectedDuration = StringToDuration(expected);
+			Assert.AreEqual(expectedDuration, duration1 - duration2);
+			Assert.AreEqual(expectedDuration, duration1.Subtract(duration2));
+		}
+
+		[TestMethod]
+		[DataRow("00:00:05", "00:00:03", 1, true, true, false, false)]
+		[DataRow("00:00:03", "00:00:05", -1, false, false, true, true)]
+		[DataRow("00:00:03", "00:00:03", 0, false, true, false, true)]
+		[DataRow("00:00:05", "Automatic", 1, false, false, false, false)]
+		[DataRow("00:00:05", "Forever", -1, false, false, true, true)]
+		[DataRow("Automatic", "00:00:03", -1, false, false, false, false)]
+		[DataRow("Automatic", "Automatic", 0, false, true, false, true)]
+		[DataRow("Automatic", "Forever", -1, false, false, false, false)]
+		[DataRow("Forever", "00:00:03", 1, true, true, false, false)]
+		[DataRow("Forever", "Automatic", 1, false, false, false, false)]
+		[DataRow("Forever", "Forever", 0, false, true, false, true)]
+		public void When_Comparing_Durations(string d1, string d2, int expectedCompare, bool isGreaterThan, bool isGreaterThanOrEquals, bool isLessThan, bool isLessThanOrEquals)
+		{
+			var duration1 = StringToDuration(d1);
+			var duration2 = StringToDuration(d2);
+			Assert.AreEqual(expectedCompare, duration1.CompareTo(duration2));
+			Assert.AreEqual(expectedCompare, Duration.Compare(duration1, duration2));
+			Assert.AreEqual(isGreaterThan, duration1 > duration2);
+			Assert.AreEqual(isGreaterThanOrEquals, duration1 >= duration2);
+			Assert.AreEqual(isLessThan, duration1 < duration2);
+			Assert.AreEqual(isLessThanOrEquals, duration1 <= duration2);
+		}
+
+		private Duration StringToDuration(string s)
+		{
+			return s switch
+			{
+				"Automatic" => Duration.Automatic,
+				"Forever" => Duration.Forever,
+				_ => new Duration(TimeSpan.Parse(s)),
+			};
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Duration.cs
+++ b/src/Uno.UI/UI/Xaml/Duration.cs
@@ -1,8 +1,6 @@
 ﻿using Uno.UI.Extensions;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 
 namespace Windows.UI.Xaml
 {
@@ -10,7 +8,6 @@ namespace Windows.UI.Xaml
 	{
 		private static readonly string __automatic = "Automatic";
 		private static readonly string __forever = "Forever";
-
 
 		public Duration(TimeSpan timeSpan)
 		{
@@ -24,48 +21,67 @@ namespace Windows.UI.Xaml
 		public static implicit operator Duration(string timeSpan)
 			=> timeSpan != null ? new Duration(TimeSpan.Parse(timeSpan, CultureInfo.InvariantCulture)) : new Duration(TimeSpan.Zero);
 
-		public bool HasTimeSpan
-		{
-			get
-			{
-				return this.Type == DurationType.TimeSpan;
-			}
-		}
+		public bool HasTimeSpan => Type == DurationType.TimeSpan;
 
-		public static Duration Forever
-		{
-			get
-			{
-				return new Duration() { Type = DurationType.Forever };
-			}
-		}
+		public static Duration Forever => new Duration() { Type = DurationType.Forever };
 
-		public static Duration Automatic
-		{
-			get
-			{
-				return new Duration() { Type = DurationType.Automatic };
-			}
-		}
+		public static Duration Automatic => new Duration() { Type = DurationType.Automatic };
 
 		public Duration Add(Duration duration)
 		{
+			// We have 9 cases:
+			// (1) TimeSpan + TimeSpan
+			// (2) TimeSpan + Automatic
+			// (3) TimeSpan + Forever
+			// (4) Automatic + TimeSpan
+			// (5) Automatic + Automatic
+			// (6) Automatic + Forever
+			// (7) Forever + TimeSpan
+			// (8) Forever + Automatic
+			// (9) Forever + Forever
+
+			// Case (1)
 			if (this.Type == DurationType.TimeSpan && duration.Type == DurationType.TimeSpan)
 			{
 				return new Duration(this.TimeSpan.Add(duration.TimeSpan));
 			}
 
-			return this;
+			// Case (2), (4), (5), (6), (8)
+			if (this.Type == DurationType.Automatic || duration.Type == DurationType.Automatic)
+			{
+				return Automatic;
+			}
+
+			// Case (3), (7), (9)
+			return Forever;
 		}
 
 		public Duration Subtract(Duration duration)
 		{
+			// We have 9 cases:
+			// (1) TimeSpan - TimeSpan     ===> Subtract spans
+			// (2) TimeSpan - Automatic    ===> Automatic
+			// (3) TimeSpan - Forever	   ===> Automatic
+			// (4) Automatic - TimeSpan    ===> Automatic
+			// (5) Automatic - Automatic   ===> Automatic
+			// (6) Automatic - Forever	   ===> Automatic
+			// (7) Forever - TimeSpan      ===> Forever
+			// (8) Forever - Automatic     ===> Automatic
+			// (9) Forever - Forever       ===> Automatic
+
+			// Case (1)
 			if (this.Type == DurationType.TimeSpan && duration.Type == DurationType.TimeSpan)
 			{
 				return new Duration(this.TimeSpan.Subtract(duration.TimeSpan));
 			}
 
-			return this;
+			// Case (7)
+			if (this.Type == DurationType.Forever && duration.Type == DurationType.TimeSpan)
+			{
+				return Forever;
+			}
+
+			return Automatic;
 		}
 
 		#region Operator overrides
@@ -82,22 +98,67 @@ namespace Windows.UI.Xaml
 
 		public static bool operator >(Duration t1, Duration t2)
 		{
-			return Compare(t1, t2) > 0;
+			if (t1.HasTimeSpan && t2.HasTimeSpan)
+			{
+				return t1.TimeSpan > t2.TimeSpan;
+			}
+
+			if (t1.HasTimeSpan && t2.Type == DurationType.Forever)
+			{
+				return false;
+			}
+
+			if (t1.Type == DurationType.Forever && t2.HasTimeSpan)
+			{
+				return true;
+			}
+
+			return false;
 		}
 
 		public static bool operator >=(Duration t1, Duration t2)
 		{
-			return Compare(t1, t2) >= 0;
+			if (t1.Type == DurationType.Automatic && t2.Type == DurationType.Automatic)
+			{
+				return true;
+			}
+
+			if (t1.Type == DurationType.Automatic || t2.Type == DurationType.Automatic)
+			{
+				return false;
+			}
+
+			return !(t1 < t2);
 		}
 
 		public static bool operator <(Duration t1, Duration t2)
 		{
-			return Compare(t1, t2) < 0;
+			if (t1.HasTimeSpan && t2.HasTimeSpan)
+			{
+				return t1.TimeSpan < t2.TimeSpan;
+			}
+
+			if (t1.HasTimeSpan && t2.Type == DurationType.Forever)
+			{
+				return true;
+			}
+
+			return false;
 		}
 
 		public static bool operator <=(Duration t1, Duration t2)
 		{
-			return Compare(t1, t2) <= 0;
+			if (t1.Type == DurationType.Automatic && t2.Type == DurationType.Automatic)
+			{
+				return true;
+			}
+
+			if (t1.Type == DurationType.Automatic || t2.Type == DurationType.Automatic)
+			{
+				return false;
+			}
+
+			return !(t1 > t2);
 		}
 
 		public static Duration operator +(Duration t1, Duration t2)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13039

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ba972b</samp>

This pull request enhances the `Duration` struct that represents a time interval in XAML animations. It refactors the code to make it more concise and readable, and adds unit tests to verify the behavior of the arithmetic and comparison operators. It affects the files `Duration.cs` and `Given_Duration.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
