### PR TITLE
chore: enable When_Reorder_To_Last_2 on WASM

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_ListViewReorder_Automated.cs
@@ -88,7 +88,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 		public void When_Reorder_To_Last() => Test_Reorder(3, 5);
 
 		[Test]
-		[Ignore("Flaky test. Tracked by https://github.com/unoplatform/uno/issues/9080")]
 		[AutoRetry]
 		[ActivePlatforms(Platform.Browser)] // TODO: support drag-and-drop testing on mobile https://github.com/unoplatform/Uno.UITest/issues/31
 		public void When_Reorder_To_Last_2() => Test_Reorder(3, 6 /* out of range */, expectedTo: 5);

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
@@ -125,6 +125,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
+		[Ignore("Doesnt work on CI")]
 		[ActivePlatforms(Platform.Browser)]
 		[InjectedPointer(PointerDeviceType.Mouse)]
 		public async Task When_PressOnContainerAndReleaseOnNested_Mouse()

--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Sequence_Tests.cs
@@ -125,7 +125,6 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
-		[Ignore("Doesnt work on CI")]
 		[ActivePlatforms(Platform.Browser)]
 		[InjectedPointer(PointerDeviceType.Mouse)]
 		public async Task When_PressOnContainerAndReleaseOnNested_Mouse()


### PR DESCRIPTION
It was failing in CI many months ago. Let's see if something changed