### PR TITLE
perf: Faster ImmutableList.Add

### DIFF
--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Collections/ImmutableList.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Collections/ImmutableList.cs
@@ -1,3 +1,4 @@
+#if NET7_0_OR_GREATER
 // ******************************************************************
 // Copyright � 2015-2018 Uno Platform Inc. All rights reserved.
 //
@@ -14,13 +15,10 @@
 // limitations under the License.
 //
 // ******************************************************************
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
-using System.Linq;
-using System.Text;
+using System.Runtime.InteropServices;
 
 namespace Uno.Collections
 {
@@ -296,8 +294,10 @@ namespace Uno.Collections
 		public ImmutableList<T> Add(T value)
 		{
 			var newData = new T[_data.Length + 1];
-			Array.Copy(_data, newData, _data.Length);
-			newData[_data.Length] = value;
+			Span<T> newDataSpan = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(newData), newData.Length);
+			Span<T> dataSpan = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(_data), _data.Length); ;
+			dataSpan.CopyTo(newDataSpan);
+			newDataSpan[_data.Length] = value;
 			return new ImmutableList<T>(newData, copyData: false);
 		}
 
@@ -391,3 +391,4 @@ namespace Uno.Collections
 		public T this[int index] => _data[index];
 	}
 }
+#endif

--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Collections/ImmutableList.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Collections/ImmutableList.cs
@@ -295,7 +295,7 @@ namespace Uno.Collections
 		{
 			var newData = new T[_data.Length + 1];
 			Span<T> newDataSpan = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(newData), newData.Length);
-			Span<T> dataSpan = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(_data), _data.Length); ;
+			Span<T> dataSpan = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(_data), _data.Length);
 			dataSpan.CopyTo(newDataSpan);
 			newDataSpan[_data.Length] = value;
 			return new ImmutableList<T>(newData, copyData: false);


### PR DESCRIPTION
Benchmark:

```csharp
    private static readonly object[] s_arr = new object[] { new(), new(), new(), new(), new(), new(), new() };
    private static readonly object s_obj = new();
    [Benchmark(Baseline = true)]
    public void WithoutSpan()
    {
        var arr = new object[s_arr.Length + 1];
        Array.Copy(s_arr, arr, s_arr.Length);
        arr[s_arr.Length] = s_obj;
    }

    [Benchmark]
    public void WithSpan()
    {
        var arr = new object[s_arr.Length + 1];
        Span<object> arrSpan = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(arr), arr.Length);
        Span<object> span = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(s_arr), s_arr.Length);
        span.CopyTo(arrSpan);
        arrSpan[s_arr.Length] = s_obj;
    }
```

|      Method |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
| WithoutSpan | 14.83 ns | 0.344 ns | 0.970 ns | 14.35 ns |  1.00 |    0.00 | 0.0421 |     - |     - |      88 B |
|    WithSpan | 11.40 ns | 0.160 ns | 0.125 ns | 11.37 ns |  0.70 |    0.03 | 0.0421 |     - |     - |      88 B |
