### PR TITLE
perf: Use Span CopyTo instead of Array CopyTo for better performance

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using Uno.Buffers;
 using Uno.UI.DataBinding;
@@ -358,7 +359,7 @@ namespace Windows.UI.Xaml
 				{
 					_stack = _pool.Rent(_stackLength);
 
-					Array.Copy(_unsetStack, _stack, _stackLength);
+					MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(_unsetStack), _stackLength).CopyTo(MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(_stack)!, _stackLength));
 
 					var defaultValue = GetDefaultValue();
 


### PR DESCRIPTION
Benchmark:

```csharp

    private static object UnsetValue = new();

    private static object[] _unsetStack = new object[10] { UnsetValue, UnsetValue, UnsetValue, UnsetValue, UnsetValue, UnsetValue, UnsetValue, UnsetValue, UnsetValue, UnsetValue };

    [Benchmark(Baseline = true)]
    public void ArrayCopy()
    {
        var arr = new object[10];
        Array.Copy(_unsetStack, arr, 10);
    }

    [Benchmark]
    public void SpanCopyToSpan()
    {
        var arr = new object[10];
        MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(_unsetStack), 10).CopyTo(MemoryMarshal.CreateSpan(ref MemoryMarshal.GetArrayDataReference(arr), 10));
    }

    [Benchmark]
    public void ArrayFill()
    {
        var arr = new object[10];
        Array.Fill(arr, UnsetValue);
    }
```

Outcome:

|         Method |     Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|      ArrayCopy | 14.60 ns | 0.115 ns | 0.096 ns |  1.00 |    0.00 | 0.0497 |     - |     - |     104 B |
| SpanCopyToSpan | 10.68 ns | 0.071 ns | 0.063 ns |  0.73 |    0.00 | 0.0497 |     - |     - |     104 B |
|      ArrayFill | 30.13 ns | 0.355 ns | 0.332 ns |  2.06 |    0.02 | 0.0497 |     - |     - |     104 B |
