### PR TITLE
fix(xamlreader): res-dict parsing

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
@@ -1,17 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.UI.RuntimeTests.Helpers;
-using Windows.UI;
+﻿using System.Linq;
+using Uno.UI.Helpers;
+using Uno.Xaml;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Markup;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Shapes;
-using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 {
@@ -22,10 +13,196 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 		[TestMethod]
 		public void When_Enum_HasNumericalValue()
 		{
-			XamlReader.Load("""
-				<StackPanel xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-					Orientation="0" />
-				""");
+			XamlHelper.LoadXaml<StackPanel>("""<StackPanel Orientation="0" />""");
 		}
+
+		[TestMethod]
+		public void When_ResDict_ComprehensiveSetup()
+		{
+			var sut = XamlHelper.LoadXaml<ResourceDictionary>("""
+				<ResourceDictionary>
+
+					<ResourceDictionary.ThemeDictionaries>
+						<ResourceDictionary x:Key="Light">
+							<Color x:Key="Color1">Red</Color>
+						</ResourceDictionary>
+						<ResourceDictionary x:Key="Dark">
+							<Color x:Key="Color1">Green</Color>
+						</ResourceDictionary>
+					</ResourceDictionary.ThemeDictionaries>
+					<ResourceDictionary.MergedDictionaries>
+						<ResourceDictionary>
+							<Color x:Key="Color2">Blue</Color>
+						</ResourceDictionary>
+					</ResourceDictionary.MergedDictionaries>
+					<Color x:Key="Color3">White</Color>
+
+				</ResourceDictionary>
+			""");
+
+			Assert.AreEqual(2, sut.ThemeDictionaries.Count);
+			Assert.AreEqual(1, sut.MergedDictionaries.Count);
+			Assert.IsTrue(sut.TryGetValue("Color1", out var _, shouldCheckSystem: false), "Failed to resolve key: Color1");
+			Assert.IsTrue(sut.TryGetValue("Color2", out var _, shouldCheckSystem: false), "Failed to resolve key: Color2");
+			Assert.IsTrue(sut.TryGetValue("Color3", out var _, shouldCheckSystem: false), "Failed to resolve key: Color3");
+		}
+
+		[TestMethod]
+		public void When_FrameworkElement_Resources_ComprehensiveSetup()
+		{
+			var setup = XamlHelper.LoadXaml<Border>("""
+				<Border>
+					<Border.Resources>
+						<ResourceDictionary>
+			
+							<ResourceDictionary.ThemeDictionaries>
+								<ResourceDictionary x:Key="Light">
+									<Color x:Key="Color1">Red</Color>
+								</ResourceDictionary>
+								<ResourceDictionary x:Key="Dark">
+									<Color x:Key="Color1">Green</Color>
+								</ResourceDictionary>
+							</ResourceDictionary.ThemeDictionaries>
+							<ResourceDictionary.MergedDictionaries>
+								<ResourceDictionary>
+									<Color x:Key="Color2">Blue</Color>
+								</ResourceDictionary>
+							</ResourceDictionary.MergedDictionaries>
+							<Color x:Key="Color3">White</Color>
+
+						</ResourceDictionary>
+					</Border.Resources>
+				</Border>
+			""");
+			var sut = setup.Resources;
+
+			Assert.AreEqual(2, sut.ThemeDictionaries.Count);
+			Assert.AreEqual(1, sut.MergedDictionaries.Count);
+			Assert.IsTrue(sut.TryGetValue("Color1", out var _, shouldCheckSystem: false), "Failed to resolve key: Color1");
+			Assert.IsTrue(sut.TryGetValue("Color2", out var _, shouldCheckSystem: false), "Failed to resolve key: Color2");
+			Assert.IsTrue(sut.TryGetValue("Color3", out var _, shouldCheckSystem: false), "Failed to resolve key: Color3");
+		}
+
+		// winui observation: FrameworkElement.Resources
+		// - can directly nested res-dict which will replace the .Resources instance
+		//		^ x:Key'ing this res-dict or not, has no effect on the outcome (except theme-dict ofc)
+		// - can directly nested children resources
+		//		^ however each item must be x:Key'd, else: XamlCompiler error WMC0060: Dictionary Item 'Color' must have a Key attribute
+		// - but, not both a res-dict AND (any child resource OR another res-dict)
+		//		^ doing so resulting in: Xaml Internal Error error WMC9999: This Member 'Resources' has more than one item, use the Items property
+
+		[TestMethod]
+		public void When_FrameworkElement_Resources_Nest_ResDict()
+		{
+			var sut = XamlHelper.LoadXaml<Border>("""
+				<Border>
+					<Border.Resources>
+
+						<ResourceDictionary x:Key="DontCare_And_ShouldntWork">
+							<Color x:Key="Asd">SkyBlue</Color>
+						</ResourceDictionary>
+
+					</Border.Resources>
+				</Border>
+			""");
+
+			Assert.IsFalse(sut.Resources.ContainsKey("DontCare_And_ShouldntWork"), "x:Key on res-dict should not work here.");
+			Assert.IsTrue(sut.Resources.ContainsKey("Asd"), "Failed to resolve key: Asd");
+		}
+
+		[TestMethod]
+		public void When_FrameworkElement_Resources_Nest_Resources()
+		{
+			var sut = XamlHelper.LoadXaml<Border>("""
+				<Border>
+					<Border.Resources>
+
+						<Color x:Key="Asd">SkyBlue</Color>
+						<Color x:Key="Asd2">SkyBlue</Color>
+
+					</Border.Resources>
+				</Border>
+			""");
+
+			Assert.IsTrue(sut.Resources.ContainsKey("Asd"), "Failed to resolve key: Asd");
+			Assert.IsTrue(sut.Resources.ContainsKey("Asd2"), "Failed to resolve key: Asd2");
+		}
+
+		[TestMethod]
+		public void When_FrameworkElement_Resources_Nest_ResDictAndRes()
+		{
+			Assert.ThrowsException<XamlParseException>(() => XamlHelper.LoadXaml<Border>("""
+				<Border>
+					<Border.Resources>
+			
+						<ResourceDictionary x:Key="DontCare_And_ShouldntWork">
+							<Color x:Key="Asd">SkyBlue</Color>
+						</ResourceDictionary>
+						<Color x:Key="Asd2">SkyBlue</Color>
+
+					</Border.Resources>
+				</Border>
+			"""), "FE.Resources nested both a res-dict and any resource should throw");
+		}
+
+		[TestMethod]
+		public void When_FrameworkElement_Resources_Nest_ManyResDicts()
+		{
+			Assert.ThrowsException<XamlParseException>(() => XamlHelper.LoadXaml<Border>("""
+				<Border>
+					<Border.Resources>
+			
+						<ResourceDictionary x:Key="DontCare_And_ShouldntWork">
+							<Color x:Key="Asd">SkyBlue</Color>
+						</ResourceDictionary>
+						<ResourceDictionary x:Key="DontCare_And_ShouldntWork2">
+							<Color x:Key="Asd2">SkyBlue</Color>
+						</ResourceDictionary>
+
+					</Border.Resources>
+				</Border>
+			"""), "FE.Resources nested multiple res-dicts should throw");
+		}
+
+		[TestMethod]
+		public void When_ResDict_MergedDict() // uno#13100
+		{
+			var sut = XamlHelper.LoadXaml<ResourceDictionary>("""
+				<ResourceDictionary>
+					<ResourceDictionary.MergedDictionaries>
+			
+						<ResourceDictionary>
+							<Color x:Key="Asd">SkyBlue</Color>
+						</ResourceDictionary>
+
+					</ResourceDictionary.MergedDictionaries>
+				</ResourceDictionary>
+			""");
+
+			Assert.IsTrue(sut.MergedDictionaries.FirstOrDefault()?.ContainsKey("Asd"), "Failed to resolve key: Asd");
+		}
+
+		[TestMethod]
+		public void When_CustomResDict_NormalProperty() // uno#13099
+		{
+			var sut = XamlHelper.LoadXaml<Given_XamlReader_CustomResDict>("""
+				<local:Given_XamlReader_CustomResDict xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup">
+
+					<local:Given_XamlReader_CustomResDict.MemberDict>
+						<ResourceDictionary>
+							<Color x:Key="Asd">SkyBlue</Color>
+						</ResourceDictionary>
+					</local:Given_XamlReader_CustomResDict.MemberDict>
+
+				</local:Given_XamlReader_CustomResDict>
+			""");
+
+			Assert.IsTrue(sut.MemberDict?.ContainsKey("Asd"), "Failed to resolve key: Asd");
+		}
+	}
+
+	public class Given_XamlReader_CustomResDict : ResourceDictionary
+	{
+		public ResourceDictionary MemberDict { get; set; }
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions;
+using Uno.UI.Helpers;
 using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -1622,77 +1623,6 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 				{
 					return streamReader.ReadToEnd();
 				}
-			}
-		}
-
-		private static class XamlHelper
-		{
-			/// <summary>
-			/// Matches right before the &gt; or \&gt; tail of any tag.
-			/// </summary>
-			/// <remarks>
-			/// It will match an opening or closing or self-closing tag.
-			/// </remarks>
-			private static readonly Regex EndOfTagRegex = new Regex(@"(?=( ?/)?>)");
-
-			/// <summary>
-			/// Matches any tag without xmlns prefix.
-			/// </summary>
-			private static readonly Regex NonXmlnsTagRegex = new Regex(@"<\w+[ />]");
-
-			private static readonly IReadOnlyDictionary<string, string> KnownXmlnses = new Dictionary<string, string>
-			{
-				[string.Empty] = "http://schemas.microsoft.com/winfx/2006/xaml/presentation",
-				["x"] = "http://schemas.microsoft.com/winfx/2006/xaml",
-				["local"] = "Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests",
-				["toolkit"] = "using:Uno.UI.Toolkit",
-				["muxc"] = "using:Microsoft.UI.Xaml.Controls",
-			};
-
-			/// <summary>
-			/// XamlReader.Load the xaml and type-check result.
-			/// </summary>
-			/// <param name="xaml">Xaml with single or double quotes</param>
-			/// <param name="autoInjectXmlns">Toggle automatic detection of xmlns required and inject to the xaml</param>
-			public static T LoadXaml<T>(string xaml, bool autoInjectXmlns = true) where T : class
-			{
-				var xmlnses = new Dictionary<string, string>();
-
-				if (autoInjectXmlns)
-				{
-					foreach (var xmlns in KnownXmlnses)
-					{
-						var match = xmlns.Key == string.Empty
-							? NonXmlnsTagRegex.IsMatch(xaml)
-							: xaml.Contains($"<{xmlns.Key}:");
-						if (match)
-						{
-							xmlnses.Add(xmlns.Key, xmlns.Value);
-						}
-					}
-				}
-
-				return LoadXaml<T>(xaml, xmlnses);
-			}
-
-			/// <summary>
-			/// XamlReader.Load the xaml and type-check result.
-			/// </summary>
-			/// <param name="xaml">Xaml with single or double quotes</param>
-			/// <param name="xmlnses">Xmlns to inject; use string.Empty for the default xmlns' key</param>
-			public static T LoadXaml<T>(string xaml, Dictionary<string, string> xmlnses) where T : class
-			{
-				var injection = " " + string.Join(" ", xmlnses
-					.Select(x => $"xmlns{(string.IsNullOrEmpty(x.Key) ? "" : $":{x.Key}")}=\"{x.Value}\"")
-				);
-
-				xaml = EndOfTagRegex.Replace(xaml, injection.TrimEnd(), 1);
-
-				var result = Windows.UI.Xaml.Markup.XamlReader.Load(xaml);
-				Assert.IsNotNull(result, "XamlReader.Load returned null");
-				Assert.IsInstanceOfType(result, typeof(T), "XamlReader.Load did not return the expected type");
-
-				return (T)result;
 			}
 		}
 	}

--- a/src/Uno.UI/Helpers/XamlHelper.cs
+++ b/src/Uno.UI/Helpers/XamlHelper.cs
@@ -14,7 +14,7 @@ internal static partial class XamlHelper
 	/// It will match an opening or closing or self-closing tag.
 	/// </remarks>
 #if DISABLE_GENERATED_REGEX
-	private static Regex EndOfTagRegex() = new Regex(@"(?=( ?/)?>)");
+	private static Regex EndOfTagRegex() => new Regex(@"(?=( ?/)?>)");
 #else
 	[GeneratedRegex(@"(?=( ?/)?>)")]
 	private static partial Regex EndOfTagRegex();
@@ -24,7 +24,7 @@ internal static partial class XamlHelper
 	/// Matches any tag without xmlns prefix.
 	/// </summary>
 #if DISABLE_GENERATED_REGEX
-	private static Regex NonXmlnsTagRegex() = new Regex(@"<\w+[ />]");
+	private static Regex NonXmlnsTagRegex() => new Regex(@"<\w+[ />]");
 #else
 	[GeneratedRegex(@"<\w+[ />]")]
 	private static partial Regex NonXmlnsTagRegex();

--- a/src/Uno.UI/Helpers/XamlHelper.cs
+++ b/src/Uno.UI/Helpers/XamlHelper.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Windows.UI.Xaml.Markup;
+
+namespace Uno.UI.Helpers;
+
+internal static partial class XamlHelper
+{
+	/// <summary>
+	/// Matches right before the &gt; or \&gt; tail of any tag.
+	/// </summary>
+	/// <remarks>
+	/// It will match an opening or closing or self-closing tag.
+	/// </remarks>
+#if DISABLE_GENERATED_REGEX
+	private static Regex EndOfTagRegex() = new Regex(@"(?=( ?/)?>)");
+#else
+	[GeneratedRegex(@"(?=( ?/)?>)")]
+	private static partial Regex EndOfTagRegex();
+#endif
+
+	/// <summary>
+	/// Matches any tag without xmlns prefix.
+	/// </summary>
+#if DISABLE_GENERATED_REGEX
+	private static Regex NonXmlnsTagRegex() = new Regex(@"<\w+[ />]");
+#else
+	[GeneratedRegex(@"<\w+[ />]")]
+	private static partial Regex NonXmlnsTagRegex();
+#endif
+
+	private static readonly IReadOnlyDictionary<string, string> KnownXmlnses = new Dictionary<string, string>
+	{
+		[string.Empty] = "http://schemas.microsoft.com/winfx/2006/xaml/presentation",
+		["x"] = "http://schemas.microsoft.com/winfx/2006/xaml",
+		["toolkit"] = "using:Uno.UI.Toolkit", // uno utilities
+		["muxc"] = "using:Microsoft.UI.Xaml.Controls",
+	};
+
+	/// <summary>
+	/// XamlReader.Load the xaml with automatic xmlns injection.
+	/// </summary>
+	/// <param name="xaml">Xaml with single or double quotes</param>
+	/// <param name="autoInjectXmlns">Toggle automatic detection of xmlns required and inject to the xaml</param>
+	public static T LoadXaml<T>(string xaml, bool autoInjectXmlns = true) where T : class
+	{
+		var xmlnses = new Dictionary<string, string>();
+
+		if (autoInjectXmlns)
+		{
+			foreach (var xmlns in KnownXmlnses)
+			{
+				var match = xmlns.Key == string.Empty
+					? NonXmlnsTagRegex().IsMatch(xaml)
+					// naively match the xmlns-prefix regardless if it is quoted,
+					// since false positive doesn't matter.
+					: xaml.Contains($"{xmlns.Key}:");
+				if (match)
+				{
+					xmlnses.Add(xmlns.Key, xmlns.Value);
+				}
+			}
+		}
+
+		return LoadXaml<T>(xaml, xmlnses);
+	}
+
+	/// <summary>
+	/// XamlReader.Load the xaml with the provided xmlnses.
+	/// </summary>
+	/// <param name="xaml">Xaml with single or double quotes</param>
+	/// <param name="xmlnses">Xmlns to inject; use string.Empty for the default xmlns' key</param>
+	public static T LoadXaml<T>(string xaml, Dictionary<string, string> xmlnses) where T : class
+	{
+		var injection = " " + string.Join(" ", xmlnses
+			.Select(x => $"xmlns{(string.IsNullOrEmpty(x.Key) ? "" : $":{x.Key}")}=\"{x.Value}\"")
+		);
+
+		xaml = EndOfTagRegex().Replace(xaml, injection.TrimEnd(), 1);
+
+		return XamlReader.Load(xaml) as T;
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -136,32 +136,20 @@ namespace Windows.UI.Xaml.Markup.Reader
 
 				return created;
 			}
-			else if (type.Is<ResourceDictionary>() && unknownContent != null)
+			else if (type.Is<ResourceDictionary>())
 			{
 				var contentOwner = unknownContent;
 
 				if (Activator.CreateInstance(type) is ResourceDictionary rd)
 				{
-					foreach (var xamlObjectDefinition in contentOwner.Objects)
+					if (unknownContent is { })
 					{
-						var key = xamlObjectDefinition.Members.FirstOrDefault(m => m.Member.Name == "Key")?.Value;
-
-						var instance = LoadObject(xamlObjectDefinition, rootInstance: rootInstance);
-
-						if (key != null)
-						{
-							rd.Add(key, instance);
-						}
+						ProcessResourceDictionaryContent(rd, unknownContent, rootInstance);
 					}
 
-					if (rootInstance is null)
+					foreach (var member in control.Members.Where(m => m != unknownContent))
 					{
-						// This is a top level dictionary, where explicit members need to
-						// be process explicitly (other types are processed below).
-						foreach (var member in control.Members.Where(m => m != unknownContent))
-						{
-							ProcessNamedMember(control, rd, member, rd);
-						}
+						ProcessNamedMember(control, rd, member, rd);
 					}
 
 					return rd;
@@ -586,6 +574,29 @@ namespace Windows.UI.Xaml.Markup.Reader
 			}
 		}
 
+		private void ProcessResourceDictionaryContent(ResourceDictionary rd, XamlMemberDefinition unknownContent, object? rootInstance)
+		{
+			foreach (var child in unknownContent.Objects)
+			{
+				var childInstance = LoadObject(child, rootInstance);
+				var resourceKey = GetResourceKey(child);
+				var styleTargetType = childInstance is Style
+					? GetResourceTargetType(child) ?? throw new InvalidOperationException($"No target type was specified (Line {child.LineNumber}:{child.LinePosition}")
+					: default;
+
+				if ((resourceKey ?? styleTargetType) is { } key)
+				{
+					rd.Add(key, childInstance);
+				}
+
+				if (HasAnyResourceMarkup(child) && childInstance is IDependencyObjectStoreProvider provider)
+				{
+					// Delay resolve static resources
+					provider.Store.UpdateResourceBindings(ResourceUpdateReason.StaticResourceLoading, rd);
+				}
+			}
+		}
+
 		private void ProcessMemberElements(DependencyObject instance, XamlMemberDefinition member, DependencyProperty property, object rootInstance)
 		{
 			if (TypeResolver.IsCollectionOrListType(property.Type))
@@ -618,96 +629,69 @@ namespace Windows.UI.Xaml.Markup.Reader
 		{
 			if (TypeResolver.IsCollectionOrListType(propertyInfo.PropertyType))
 			{
-				if (propertyInfo.PropertyType == typeof(ResourceDictionary)
-					|| (
-						propertyInfo.DeclaringType == typeof(ResourceDictionary)
-						&& (
-							propertyInfo.Name == nameof(ResourceDictionary.ThemeDictionaries)
-							|| propertyInfo.Name == nameof(ResourceDictionary.MergedDictionaries)
-						)
-					)
-				)
+				if (propertyInfo.PropertyType == typeof(ResourceDictionary))
 				{
-					var methods = propertyInfo.PropertyType.GetMethods();
-					var addMethod = propertyInfo.PropertyType.GetMethod("Add", new[] { typeof(object), typeof(object) })
-						?? throw new InvalidOperationException($"The property {propertyInfo} type does not provide an Add method (Line {member.LineNumber}:{member.LinePosition}");
+					// A resource-dictionary property (typically FE.Resources) can only have two types of nested scenarios:
+					// 1. a single res-dict
+					// 2. zero-to-many non-res-dict resources
+					// Nesting multiple res-dict or a mix of (res-dict(s) + resource(s)) will throw:
+					// > Xaml Internal Error error WMC9999: This Member 'Resources' has more than one item, use the Items property
+					// It is also illegal to nested Page.Resources\ResourceDictionary.MergedDictionary without a ResourceDictionary node in between.
+					// > Xaml Xml Parsing Error error WMC9997: 'Unexpected 'PROPERTYELEMENT' in parse rule 'NonemptyPropertyElement ::= . PROPERTYELEMENT Content? ENDTAG.'.' Line number '13' and line position '5'.
 
-					if (propertyInfo.GetMethod == null)
+					// Case 1: a single res-dict
+					if (member.Objects is [var singleChild] &&
+						TypeResolver.FindType(singleChild.Type)?.IsAssignableTo(typeof(ResourceDictionary)) == true)
 					{
-						throw new InvalidOperationException($"The property {propertyInfo} does not provide a getter (Line {member.LineNumber}:{member.LinePosition}");
-					}
-
-					var targetDictionary = (ResourceDictionary)propertyInfo.GetMethod.Invoke(instance, null)!;
-
-					var dictionaryObjects = member.Objects;
-
-					if (member.Objects.Count == 1
-						&& member.Objects.First() is { } innerDictionary
-						&& TypeResolver.FindType(innerDictionary.Type) == typeof(ResourceDictionary))
-					{
-						if (innerDictionary.Members.FirstOrDefault(m => m.Member.Name == "ThemeDictionaries") is { } themeDictionaries)
+						if (propertyInfo.SetMethod == null)
 						{
-							foreach (var themeDictionary in themeDictionaries.Objects)
-							{
-								targetDictionary.ThemeDictionaries.Add(
-									GetResourceKey(themeDictionary),
-									LoadObject(themeDictionary, rootInstance));
-							}
+							throw new InvalidOperationException($"The property {propertyInfo} does not provide a setter (Line {member.LineNumber}:{member.LinePosition}");
 						}
 
-						if (innerDictionary.Members.FirstOrDefault(m => m.Member.Name == "MergedDictionaries") is { } mergedDictionaries)
+						var rd = (ResourceDictionary)LoadObject(singleChild, rootInstance)!;
+						if (IsFrameworkElementResources(propertyInfo))
 						{
-							foreach (var mergedDictionary in mergedDictionaries.Objects)
-							{
-								var newInstance = LoadObject(mergedDictionary, rootInstance);
-								if (newInstance is ResourceDictionary instanceAsDictionary)
-								{
-									targetDictionary.MergedDictionaries.Add(instanceAsDictionary);
-								}
-								else
-								{
-									throw new InvalidOperationException($"An object of type {newInstance?.GetType()} is not supported on MergedDictionaries");
-								}
-							}
+							((FrameworkElement)instance).Resources = rd;
 						}
-
-						if (innerDictionary.Members.FirstOrDefault(m => m.Member.Name == "_UnknownContent") is { } unknownContent)
+						else
 						{
-							dictionaryObjects = unknownContent.Objects;
+							propertyInfo.SetMethod.Invoke(instance, new[] { rd });
 						}
 					}
-
-					List<IDependencyObjectStoreProvider> delayResolutionList = new();
-					foreach (var child in dictionaryObjects)
+					// Case 2: zero-to-many non-res-dict resources
+					else if (member.Objects.All(x => TypeResolver.FindType(x.Type)?.IsAssignableTo(typeof(ResourceDictionary)) != true))
 					{
-						var item = LoadObject(child, rootInstance: rootInstance);
-
-						var resourceKey = GetResourceKey(child);
-						var resourceTargetType = GetResourceTargetType(child);
-
-						if (
-							item?.GetType() == typeof(Style)
-							&& resourceTargetType == null
-						)
+						if (propertyInfo.GetMethod == null)
 						{
-							throw new InvalidOperationException($"No target type was specified (Line {member.LineNumber}:{member.LinePosition}");
+							throw new InvalidOperationException($"The property {propertyInfo} does not provide a getter (Line {member.LineNumber}:{member.LinePosition}");
 						}
 
-						if ((resourceKey ?? resourceTargetType) is { } key)
-						{
-							targetDictionary.Add(key, item);
-						}
-
-						if (HasAnyResourceMarkup(child) && item is IDependencyObjectStoreProvider provider)
-						{
-							delayResolutionList.Add(provider);
-						}
+						var rd = (ResourceDictionary)propertyInfo.GetMethod.Invoke(instance, null)!;
+						ProcessResourceDictionaryContent(rd, member, rootInstance);
+					}
+					else
+					{
+						throw new XamlParseException($"This Member '{propertyInfo.DeclaringType}.{propertyInfo.Name}' has more than one item, use the Items property");
 					}
 
-					// Delay resolve static resources
-					foreach (var delayedItem in delayResolutionList)
+					bool IsFrameworkElementResources(PropertyInfo propertyInfo) =>
+						propertyInfo.DeclaringType == typeof(FrameworkElement) &&
+						propertyInfo.Name == nameof(FrameworkElement.Resources);
+				}
+				else if (propertyInfo.DeclaringType == typeof(ResourceDictionary) &&
+					propertyInfo.Name is nameof(ResourceDictionary.ThemeDictionaries) or nameof(ResourceDictionary.MergedDictionaries))
+				{
+					foreach (var child in member.Objects)
 					{
-						delayedItem.Store.UpdateResourceBindings(ResourceUpdateReason.StaticResourceLoading, targetDictionary);
+						var rd = (ResourceDictionary)LoadObject(child, rootInstance)!;
+						if (propertyInfo.Name is nameof(ResourceDictionary.ThemeDictionaries))
+						{
+							((ResourceDictionary)instance).ThemeDictionaries.Add(GetResourceKey(child), rd);
+						}
+						else
+						{
+							((ResourceDictionary)instance).MergedDictionaries.Add(rd);
+						}
 					}
 				}
 				else if (propertyInfo.SetMethod?.IsPublic == true &&
@@ -1159,19 +1143,19 @@ namespace Windows.UI.Xaml.Markup.Reader
 
 		private object? GetResourceKey(XamlObjectDefinition child) =>
 			child.Members.FirstOrDefault(m =>
-				string.Equals(m.Member.Name, "Name", StringComparison.OrdinalIgnoreCase)
-				|| string.Equals(m.Member.Name, "Key", StringComparison.OrdinalIgnoreCase)
+				string.Equals(m.Member.Name, "Name", StringComparison.OrdinalIgnoreCase) ||
+				string.Equals(m.Member.Name, "Key", StringComparison.OrdinalIgnoreCase)
 			)
 			?.Value
 			?.ToString();
 
-		private Type? GetResourceTargetType(XamlObjectDefinition child) =>
-				TypeResolver.FindType(child.Members.FirstOrDefault(m =>
-					string.Equals(m.Member.Name, "TargetType", StringComparison.OrdinalIgnoreCase)
-				)
+		private Type? GetResourceTargetType(XamlObjectDefinition child) => TypeResolver.FindType(
+			child.Members
+				.FirstOrDefault(m => string.Equals(m.Member.Name, "TargetType", StringComparison.OrdinalIgnoreCase))
 				?.Value
-				?.ToString() ?? ""
-			);
+				?.ToString() ??
+			""
+		);
 
 		private PropertyInfo? GetMemberProperty(XamlObjectDefinition control, XamlMemberDefinition member)
 		{

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -142,14 +142,14 @@ namespace Windows.UI.Xaml.Markup.Reader
 
 				if (Activator.CreateInstance(type) is ResourceDictionary rd)
 				{
-					if (unknownContent is { })
-					{
-						ProcessResourceDictionaryContent(rd, unknownContent, rootInstance);
-					}
-
 					foreach (var member in control.Members.Where(m => m != unknownContent))
 					{
 						ProcessNamedMember(control, rd, member, rd);
+					}
+
+					if (unknownContent is { })
+					{
+						ProcessResourceDictionaryContent(rd, unknownContent, rootInstance);
 					}
 
 					return rd;
@@ -576,6 +576,11 @@ namespace Windows.UI.Xaml.Markup.Reader
 
 		private void ProcessResourceDictionaryContent(ResourceDictionary rd, XamlMemberDefinition unknownContent, object? rootInstance)
 		{
+			// note: In order for static resolution to work, the referenced resources must be already parsed & added, which means:
+			// - MergedDictionaries should be processed before this method call.
+			// - Member resources should be all processed prior the resolution can began.
+			var delayedResolutionList = new List<IDependencyObjectStoreProvider>();
+
 			foreach (var child in unknownContent.Objects)
 			{
 				var childInstance = LoadObject(child, rootInstance);
@@ -591,9 +596,14 @@ namespace Windows.UI.Xaml.Markup.Reader
 
 				if (HasAnyResourceMarkup(child) && childInstance is IDependencyObjectStoreProvider provider)
 				{
-					// Delay resolve static resources
-					provider.Store.UpdateResourceBindings(ResourceUpdateReason.StaticResourceLoading, rd);
+					delayedResolutionList.Add(provider);
 				}
+			}
+
+			// Delay resolve static resources
+			foreach (var provider in delayedResolutionList)
+			{
+				provider.Store.UpdateResourceBindings(ResourceUpdateReason.StaticResourceLoading, rd);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -180,7 +180,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 			}
 		}
 
-		public DependencyProperty? FindDependencyProperty(Type propertyOwner, string? propertyName)
+		public DependencyProperty? FindDependencyProperty(Type? propertyOwner, string? propertyName)
 		{
 			var propertyDependencyPropertyQuery = GetAllProperties(propertyOwner)
 								.Where(p => p.Name == propertyName + "Property")
@@ -196,7 +196,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 			) as DependencyProperty;
 		}
 
-		private static IEnumerable<PropertyInfo> GetAllProperties(Type type)
+		private static IEnumerable<PropertyInfo> GetAllProperties(Type? type)
 		{
 			Type? currentType = type;
 
@@ -211,7 +211,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 			}
 		}
 
-		private static IEnumerable<FieldInfo> GetAllFields(Type type)
+		private static IEnumerable<FieldInfo> GetAllFields(Type? type)
 		{
 			Type? currentType = type;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13099, closes #13100, re: #13121

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

## What is the new behavior?
- fixed two instances of crashes when parsing res-dict
- fixed one instance of crash when parsing setter with attached property

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82e43c6</samp>

This pull request enhances the xaml parsing and loading functionality in Uno.UI, by refactoring the test code, fixing some bugs, and adding new features. It introduces the `XamlHelper` class as a shared utility for xaml loading, and improves the handling of `ResourceDictionary` elements and dependency properties in the `XamlObjectBuilder` class. It also simplifies and reorders some using directives in the test files.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
n/a