### PR TITLE
perf: Avoid pooling for long-living `HashtableEx`es

### DIFF
--- a/src/SamplesApp/Benchmarks.Shared/Benchmarks.Shared.projitems
+++ b/src/SamplesApp/Benchmarks.Shared/Benchmarks.Shared.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Suite\SpanBench\SimpleSpanBenchmark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\BenchmarkDotNetControl.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\BenchmarkDotNetTestsPage.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Suite\Collections\HashtableBench.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Suite\Windows_UI\ColorBench\XamlControlsResourcesCreationBenchmark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Suite\Windows_UI_Xaml\ResourceDictionaryBench\XamlControlsResourcesCreationBenchmark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Suite\Windows_UI_Xaml\ResourceDictionaryBench\XamlControlsResourcesReadBenchmark.cs" />

--- a/src/SamplesApp/Benchmarks.Shared/Suite/Collections/HashtableBench.cs
+++ b/src/SamplesApp/Benchmarks.Shared/Suite/Collections/HashtableBench.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Uno.Collections;
+
+namespace SamplesApp.Benchmarks.Suite.SpanBench;
+
+public class HashtableBench
+{
+	[Benchmark(Baseline = true)]
+	public void HashtableEx()
+	{
+		var x = new HashtableEx();
+		for (int i = 0; i < 10; i++)
+		{
+			x.Add(new(), new());
+		}
+	}
+
+
+	[Benchmark]
+	public void Hashtable()
+	{
+		var x = new Hashtable();
+		for (int i = 0; i < 10; i++)
+		{
+			x.Add(new(), new());
+		}
+	}
+
+	[Benchmark]
+	public void Dictionary()
+	{
+		var x = new Dictionary<object, object>();
+		for (int i = 0; i < 10; i++)
+		{
+			x.Add(new(), new());
+		}
+	}
+}
+

--- a/src/SamplesApp/Benchmarks.Shared/Suite/Collections/HashtableBench.cs
+++ b/src/SamplesApp/Benchmarks.Shared/Suite/Collections/HashtableBench.cs
@@ -1,3 +1,4 @@
+#if !WINDOWS_UWP
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -42,3 +43,4 @@ public class HashtableBench
 	}
 }
 
+#endif

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.FrameworkPropertiesForType.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.FrameworkPropertiesForType.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using Uno.Collections;
 
 using _Key = Uno.CachedTuple<System.Type, Windows.UI.Xaml.FrameworkPropertyMetadataOptions>;
+using System.Collections;
 
 namespace Windows.UI.Xaml
 {
@@ -20,11 +21,11 @@ namespace Windows.UI.Xaml
 	{
 		private class FrameworkPropertiesForTypeDictionary
 		{
-			private readonly HashtableEx _entries = new HashtableEx();
+			private readonly Hashtable _entries = new Hashtable();
 
 			internal bool TryGetValue(_Key key, out DependencyProperty[]? result)
 			{
-				if (_entries.TryGetValue(key, out var value))
+				if (_entries[key] is { } value)
 				{
 					result = (DependencyProperty[])value!;
 
@@ -39,9 +40,6 @@ namespace Windows.UI.Xaml
 				=> _entries.Add(key, value);
 
 			internal void Clear() => _entries.Clear();
-
-			internal void Dispose()
-				=> _entries.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.FrameworkPropertiesForType.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.FrameworkPropertiesForType.cs
@@ -21,11 +21,13 @@ namespace Windows.UI.Xaml
 	{
 		private class FrameworkPropertiesForTypeDictionary
 		{
-			private readonly Hashtable _entries = new Hashtable();
+			// This dictionary has a single static instance that is kept for the lifetime of the whole app.
+			// So we don't use pooling to not cause pool exhaustion by renting without returning.
+			private readonly HashtableEx _entries = new HashtableEx(usePooling: false);
 
 			internal bool TryGetValue(_Key key, out DependencyProperty[]? result)
 			{
-				if (_entries[key] is { } value)
+				if (_entries.TryGetValue(key, out var value))
 				{
 					result = (DependencyProperty[])value!;
 

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.NameToProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.NameToProperty.cs
@@ -28,12 +28,20 @@ namespace Windows.UI.Xaml
 		private class NameToPropertyDictionary
 		{
 			private readonly Hashtable _entries = new Hashtable(PropertyCacheEntry.DefaultComparer);
+			private static readonly object _nullSentinel = new();
 
 			internal bool TryGetValue(PropertyCacheEntry key, out DependencyProperty? result)
 			{
 				if (_entries[key] is { } value)
 				{
-					result = (DependencyProperty)value!;
+					if (object.ReferenceEquals(value, _nullSentinel))
+					{
+						result = null;
+					}
+					else
+					{
+						result = (DependencyProperty?)value;
+					}
 
 					return true;
 				}
@@ -42,8 +50,8 @@ namespace Windows.UI.Xaml
 				return false;
 			}
 
-			internal void Add(PropertyCacheEntry key, DependencyProperty dependencyProperty)
-				=> _entries.Add(key, dependencyProperty);
+			internal void Add(PropertyCacheEntry key, DependencyProperty? dependencyProperty)
+				=> _entries.Add(key, dependencyProperty ?? _nullSentinel);
 
 			internal void Remove(PropertyCacheEntry propertyCacheEntry)
 				=> _entries.Remove(propertyCacheEntry);

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.NameToProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.NameToProperty.cs
@@ -11,6 +11,7 @@ using System.Runtime.CompilerServices;
 using Uno;
 using System.Threading;
 using Uno.Collections;
+using System.Collections;
 
 #if __ANDROID__
 using _View = Android.Views.View;
@@ -26,11 +27,11 @@ namespace Windows.UI.Xaml
 	{
 		private class NameToPropertyDictionary
 		{
-			private readonly HashtableEx _entries = new HashtableEx(PropertyCacheEntry.DefaultComparer);
+			private readonly Hashtable _entries = new Hashtable(PropertyCacheEntry.DefaultComparer);
 
 			internal bool TryGetValue(PropertyCacheEntry key, out DependencyProperty? result)
 			{
-				if (_entries.TryGetValue(key, out var value))
+				if (_entries[key] is { } value)
 				{
 					result = (DependencyProperty)value!;
 
@@ -50,9 +51,6 @@ namespace Windows.UI.Xaml
 			internal int Count => _entries.Count;
 
 			internal void Clear() => _entries.Clear();
-
-			internal void Dispose()
-				=> _entries.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.PropertiesRegistry.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.PropertiesRegistry.cs
@@ -12,6 +12,7 @@ using Uno;
 using System.Threading;
 using Uno.Collections;
 using Uno.UI.Helpers;
+using System.Collections;
 
 namespace Windows.UI.Xaml
 {
@@ -19,13 +20,13 @@ namespace Windows.UI.Xaml
 	{
 		private class DependencyPropertyRegistry
 		{
-			private readonly HashtableEx _entries = new HashtableEx(FastTypeComparer.Default);
+			private readonly Hashtable _entries = new Hashtable(FastTypeComparer.Default);
 
 			internal bool TryGetValue(Type type, string name, out DependencyProperty? result)
 			{
 				if (TryGetTypeTable(type, out var typeTable))
 				{
-					if (typeTable!.TryGetValue(name, out var propertyObject))
+					if (typeTable![name] is { } propertyObject)
 					{
 						result = (DependencyProperty)propertyObject!;
 						return true;
@@ -42,7 +43,7 @@ namespace Windows.UI.Xaml
 			{
 				if (!TryGetTypeTable(type, out var typeTable))
 				{
-					typeTable = new HashtableEx();
+					typeTable = new Hashtable();
 					_entries[type] = typeTable;
 				}
 
@@ -60,20 +61,17 @@ namespace Windows.UI.Xaml
 				}
 			}
 
-			private bool TryGetTypeTable(Type type, out HashtableEx? table)
+			private bool TryGetTypeTable(Type type, out Hashtable? table)
 			{
-				if (_entries.TryGetValue(type, out var dictionaryObject))
+				if (_entries[type] is { } dictionaryObject)
 				{
-					table = (HashtableEx)dictionaryObject!;
+					table = (Hashtable)dictionaryObject!;
 					return true;
 				}
 
 				table = null;
 				return false;
 			}
-
-			internal void Dispose()
-				=> _entries.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
@@ -24,11 +24,13 @@ namespace Windows.UI.Xaml
 
 		private class TypeNullableDictionary
 		{
-			private readonly Hashtable _entries = new Hashtable(FastTypeComparer.Default);
+			// This dictionary has a single static instance that is kept for the lifetime of the whole app.
+			// So we don't use pooling to not cause pool exhaustion by renting without returning.
+			private readonly HashtableEx _entries = new HashtableEx(FastTypeComparer.Default, usePooling: false);
 
 			internal bool TryGetValue(Type key, out bool result)
 			{
-				if (_entries[key] is { } value)
+				if (_entries.TryGetValue(key, out var value))
 				{
 					result = (bool)value!;
 					return true;

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeNullableDictionary.cs
@@ -4,6 +4,7 @@ using System;
 using Uno.Collections;
 using Uno.UI.Helpers;
 using Uno.Extensions;
+using System.Collections;
 
 namespace Windows.UI.Xaml
 {
@@ -23,11 +24,11 @@ namespace Windows.UI.Xaml
 
 		private class TypeNullableDictionary
 		{
-			private readonly HashtableEx _entries = new HashtableEx(FastTypeComparer.Default);
+			private readonly Hashtable _entries = new Hashtable(FastTypeComparer.Default);
 
 			internal bool TryGetValue(Type key, out bool result)
 			{
-				if (_entries.TryGetValue(key, out var value))
+				if (_entries[key] is { } value)
 				{
 					result = (bool)value!;
 					return true;
@@ -42,9 +43,6 @@ namespace Windows.UI.Xaml
 
 			internal void Clear()
 				=> _entries.Clear();
-
-			internal void Dispose()
-				=> _entries.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeToProperties.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeToProperties.cs
@@ -11,11 +11,13 @@ namespace Windows.UI.Xaml
 	{
 		private class TypeToPropertiesDictionary
 		{
-			private readonly Hashtable _entries = new Hashtable(FastTypeComparer.Default);
+			// This dictionary has a single static instance that is kept for the lifetime of the whole app.
+			// So we don't use pooling to not cause pool exhaustion by renting without returning.
+			private readonly HashtableEx _entries = new HashtableEx(FastTypeComparer.Default, usePooling: false);
 
 			internal bool TryGetValue(Type key, out DependencyProperty[]? result)
 			{
-				if (_entries[key] is { } value)
+				if (_entries.TryGetValue(key, out var value))
 				{
 					result = (DependencyProperty[])value!;
 

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeToProperties.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.Dictionary.TypeToProperties.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Collections;
 using Uno.Collections;
 using Uno.UI.Helpers;
 
@@ -10,11 +11,11 @@ namespace Windows.UI.Xaml
 	{
 		private class TypeToPropertiesDictionary
 		{
-			private readonly HashtableEx _entries = new HashtableEx(FastTypeComparer.Default);
+			private readonly Hashtable _entries = new Hashtable(FastTypeComparer.Default);
 
 			internal bool TryGetValue(Type key, out DependencyProperty[]? result)
 			{
-				if (_entries.TryGetValue(key, out var value))
+				if (_entries[key] is { } value)
 				{
 					result = (DependencyProperty[])value!;
 
@@ -30,9 +31,6 @@ namespace Windows.UI.Xaml
 
 			internal void Clear()
 				=> _entries.Clear();
-
-			internal void Dispose()
-				=> _entries.Dispose();
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -484,7 +484,6 @@ namespace Windows.UI.Xaml
 				}
 			}
 
-			// TODO: Lazily allocate the list and return empty array.
 			return output.ToArray();
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -484,6 +484,7 @@ namespace Windows.UI.Xaml
 				}
 			}
 
+			// TODO: Lazily allocate the list and return empty array.
 			return output.ToArray();
 		}
 

--- a/src/Uno.UI/UI/Xaml/PropertyMetadataDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/PropertyMetadataDictionary.cs
@@ -20,17 +20,16 @@ namespace Windows.UI.Xaml
 		/// This implementation of PropertyMetadataDictionary uses HashTable because it's generally faster than
 		/// Dictionary`ref/ref. 
 		/// </summary>
-		private readonly HashtableEx _table = new HashtableEx();
+		private readonly Hashtable _table = new Hashtable();
 
 		internal void Add(Type ownerType, PropertyMetadata ownerTypeMetadata)
 			=> _table.Add(ownerType, ownerTypeMetadata);
 
 		internal bool TryGetValue(Type ownerType, out PropertyMetadata? metadata)
 		{
-			if (_table.TryGetValue(ownerType, out var value))
+			if (_table[ownerType] is { } value)
 			{
-				metadata = (PropertyMetadata)value!;
-
+				metadata = (PropertyMetadata)value;
 				return true;
 			}
 
@@ -46,9 +45,9 @@ namespace Windows.UI.Xaml
 
 		internal PropertyMetadata FindOrCreate(Type ownerType, Type baseType, DependencyProperty property)
 		{
-			if (_table.TryGetValue(ownerType, out var value))
+			if (_table[ownerType] is { } value)
 			{
-				return (PropertyMetadata)value!;
+				return (PropertyMetadata)value;
 			}
 
 			var metadata = property.GetMetadata(baseType);
@@ -57,8 +56,5 @@ namespace Windows.UI.Xaml
 
 			return metadata;
 		}
-
-		internal void Dispose()
-			=> _table.Dispose();
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 29883f5</samp>

This pull request introduces a new benchmark for hash table implementations and changes the `PropertyMetadataDictionary` class to use the standard `Hashtable` instead of the custom `HashtableEx`. The goal is to evaluate the performance and memory impact of different hash table options in the Uno platform.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
