### PR TITLE
fix(ios): an instance of ListView crash during layout

### DIFF
--- a/src/Uno.UI/Extensions/EnumerableExtensions.cs
+++ b/src/Uno.UI/Extensions/EnumerableExtensions.cs
@@ -34,5 +34,43 @@ namespace Uno.UI.Extensions
 
 			return output;
 		}
+
+		/// <summary>
+		/// ToDictionary that doesn't throw on duplicated key. The first value is kept per key.
+		/// </summary>
+		public static Dictionary<TKey, TElement> ToDictionaryKeepFirst<TSource, TKey, TElement>(
+			this IEnumerable<TSource> source,
+			Func<TSource, TKey> keySelector,
+			Func<TSource, TElement> elementSelector
+		) where TKey : notnull
+		{
+			var result = new Dictionary<TKey, TElement>();
+
+			foreach (var item in source)
+			{
+				result.TryAdd(keySelector(item), elementSelector(item));
+			}
+
+			return result;
+		}
+
+		/// <summary>
+		/// ToDictionary that doesn't throw on duplicated key. The last value is kept per key.
+		/// </summary>
+		public static Dictionary<TKey, TElement> ToDictionaryKeepLast<TSource, TKey, TElement>(
+			this IEnumerable<TSource> source,
+			Func<TSource, TKey> keySelector,
+			Func<TSource, TElement> elementSelector
+		) where TKey : notnull
+		{
+			var result = new Dictionary<TKey, TElement>();
+
+			foreach (var item in source)
+			{
+				result[keySelector(item)] = elementSelector(item);
+			}
+
+			return result;
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -591,13 +591,13 @@ namespace Windows.UI.Xaml.Controls
 				// We are layouting after an INotifyCollectionChanged operation(s). Cache the previous element sizes, under their new index 
 				// paths, so we can reuse them in order not to have to lay out elements with different databound sizes with their static size.
 				oldItemSizes = _itemLayoutInfos.SelectMany(kvp => kvp.Value)
-					.ToDictionary(
+					.ToDictionaryKeepLast(
 						kvp => OffsetIndexForPendingChanges(kvp.Key, NativeListViewBase.ListViewItemElementKind),
 						kvp => (CGSize?)kvp.Value.Size
 					);
 				oldGroupHeaderSizes = _supplementaryLayoutInfos
 					.UnoGetValueOrDefault(NativeListViewBase.ListViewSectionHeaderElementKind)?
-					.ToDictionary(
+					.ToDictionaryKeepLast(
 						kvp => OffsetIndexForPendingChanges(kvp.Key, NativeListViewBase.ListViewSectionHeaderElementKind).Section,
 						kvp => (CGSize?)kvp.Value.Size
 					);


### PR DESCRIPTION
GitHub Issue (If applicable): (referenced from the private issue)

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
fix(ios): an instance of ListView crash during layout

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4198216</samp>

Added `ToDictionaryKeepFirst` and `ToDictionaryKeepLast` extension methods to handle duplicate keys in `ToDictionary` calls. Used them in `VirtualizingPanelLayout` to avoid exceptions and update layout sizes for list view items and group headers.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Just a failsafe measure.