### PR TITLE
fix: Ensure `_UnoAssetsGetCopyToPublishDirectory` is run before `_UnoGeneratePriMarker`

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -7,6 +7,7 @@
 	<PropertyGroup>
 		<_UnoDirectorySeparator Condition="'$(OS)' == 'Unix'">/</_UnoDirectorySeparator>
 		<_UnoDirectorySeparator Condition="'$(OS)' == 'Windows_NT'">\</_UnoDirectorySeparator>
+		<_WasUnoAssetsGetCopyToPublishDirectoryRun>false</_WasUnoAssetsGetCopyToPublishDirectoryRun>
 	</PropertyGroup>
 
 	<Target Name="_DefineUnoPriProperties">
@@ -43,8 +44,14 @@
 	<Target Name="_UnoGeneratePriMarker"
 			Condition="'$(GenerateLibraryLayout)' == 'true' AND '$(SDKIdentifier)' != 'Windows'"
 			BeforeTargets="PrepareForRun"
-			DependsOnTargets="_DefineUnoPriProperties;_UnoAssetsGetCopyToPublishDirectory">
-		
+			DependsOnTargets="_DefineUnoPriProperties">
+
+		<ItemGroup Condition="'$(_WasUnoAssetsGetCopyToPublishDirectoryRun)'!='true'">
+			<ContentWithTargetPath Include="@(_TransitiveItemsToCopyToOutputDirectory)">
+				<TargetPath>%(TargetPath)</TargetPath>
+				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			</ContentWithTargetPath>
+		</ItemGroup>
 		<WriteLinesToFile File="$(ProjectUnoPriFullPath)"
 						  Lines="@(ContentWithTargetPath)"
 						  Condition="'@(ContentWithTargetPath)'!=''"
@@ -198,7 +205,10 @@
 	as nuget packages content.
 	-->
 	<Target Name="_UnoAssetsGetCopyToPublishDirectory"
-	BeforeTargets="GetCopyToPublishDirectoryItems">
+			BeforeTargets="GetCopyToPublishDirectoryItems">
+		<PropertyGroup>
+			<_WasUnoAssetsGetCopyToPublishDirectoryRun>true</_WasUnoAssetsGetCopyToPublishDirectoryRun>
+		</PropertyGroup>
 		<ItemGroup>
 			<ContentWithTargetPath Include="@(_TransitiveItemsToCopyToOutputDirectory)">
 				<TargetPath>%(TargetPath)</TargetPath>

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -43,7 +43,7 @@
 	<Target Name="_UnoGeneratePriMarker"
 			Condition="'$(GenerateLibraryLayout)' == 'true' AND '$(SDKIdentifier)' != 'Windows'"
 			BeforeTargets="PrepareForRun"
-			DependsOnTargets="_DefineUnoPriProperties">
+			DependsOnTargets="_DefineUnoPriProperties;_UnoAssetsGetCopyToPublishDirectory">
 		
 		<WriteLinesToFile File="$(ProjectUnoPriFullPath)"
 						  Lines="@(ContentWithTargetPath)"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e413fdb</samp>

Fixed a bug in `uno.ui.tasks.assets.targets` that caused some assets to be missing from the .pri file when publishing a Uno library project. Modified the `WriteLinesToFile` task to depend on a new target that ensures the assets are copied to the publish directory.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
