### PR TITLE
[Android][MediaPlayerElement] Blank space in MediaControlsCommandBar and Missing or cut icon

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -1599,18 +1599,6 @@ namespace Windows.UI.Xaml.Controls
 				if (m_tpCommandBar as FrameworkElement is { } cmElementy)
 				{
 					cmElementy.HorizontalAlignment = HorizontalAlignment.Stretch;
-					//var spPrimaryCommandObsVec = m_tpCommandBar.PrimaryCommands;
-					//var spPrimaryButtons = spPrimaryCommandObsVec.ToArray();
-					//for (int i = 0; i < spPrimaryButtons.Length; i++)
-					//{
-					//	var spCommandElement = spPrimaryButtons[i];
-					//	if (spCommandElement as FrameworkElement is { } spElement && spElement.Margin.Right > 0)
-					//	{
-					//		var extraMargin = new Thickness(0, 0, spElement.Margin.Right, 0);
-					//		cmElementy.Margin = extraMargin;
-					//		return;
-					//	}
-					//}
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -16,6 +16,7 @@ using Windows.UI.Xaml.Media;
 using DirectUI;
 using Uno.Disposables;
 using Uno.Extensions;
+using System.Threading;
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;
@@ -23,7 +24,6 @@ using PointerDeviceType = Microsoft.UI.Input.PointerDeviceType;
 #else
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 using Uno.UI.Xaml.Core;
-using System.Threading;
 
 #endif
 #if __IOS__


### PR DESCRIPTION
GitHub Issue (If applicable): 
closes #13123 
closes #12660
closes #12661


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Space 
![image](https://github.com/unoplatform/uno/assets/116665025/1f5891f1-e9c4-44e6-a9b3-a8fc55605daf)

Cut icon
![image](https://github.com/unoplatform/uno/assets/116665025/683e625e-cf29-4e1c-b501-4d481993e9fa)

Missing icon
![image](https://github.com/unoplatform/uno/assets/116665025/cc3b88bf-7ccc-40cd-b9d7-f6253c872401)


## What is the new behavior?

![image](https://github.com/unoplatform/uno/assets/116665025/9a31832a-3761-4553-b412-1e78a6a1a3fc)

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9d3520</samp>

Improve the layout and resizing of media player controls. Prevent concurrent calls to `MeasureCommandBar` and use events and fields to track and adjust the command bar size and visibility. Modify `MediaTransportControls.cs` to implement these changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information


Internal Issue (If applicable):
