### PR TITLE
fix: Assert DisplayName value instead of Title

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -653,17 +653,17 @@ namespace SamplesApp
 		}
 
 		/// <summary>
-		/// Asserts that the App Title was found in manifest and loaded from resources.
+		/// Assert that the App DisplayName was found in manifest and loaded from resources
 		/// </summary>
 		public void AssertIssue12936()
 		{
-			//ApplicationView Title is currently not supported on iOS
-#if !__IOS__
-			var title = ApplicationView.GetForCurrentView().Title;
+			//On Wasm the DisplayName is currently empty, as it is not being load from manifest
+#if !__WASM__
+			var displayName = Package.Current.DisplayName;
 
-			Assert.IsFalse(string.IsNullOrEmpty(title), "App Title is empty.");
+			Assert.IsFalse(string.IsNullOrEmpty(displayName), "DisplayName is empty.");
 
-			Assert.IsFalse(title.Contains("ms-resource:"), $"'{title}' wasn't found in resources.");
+			Assert.IsFalse(displayName.Contains("ms-resource:"), $"'{displayName}' wasn't found in resources.");
 #endif
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13186 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?
Currently the `AssertIssue12936` fails on Windows as the `Title` is being loaded from resources much later on UWP.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
It now Asserts the `DisplayName` instead of `Title` on all platforms, except Wasm (where it's not implemented at the moment). 

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a875c41</samp>

Fixed a bug where the app title was not loaded correctly on some platforms. Updated `AssertIssue12936` to use `Package.Current.DisplayName` instead of `ApplicationView.GetForCurrentView().Title`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.