### PR TITLE
fix: Use fallback color for unsupported brushes

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Media/RevealBrush.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Media/RevealBrush.Android.cs
@@ -1,9 +1,11 @@
 ﻿using Android.Graphics;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 using Rect = Windows.Foundation.Rect;
 
-namespace Windows.UI.Xaml.Media;
+namespace Microsoft.UI.Xaml.Media;
 
-partial class RevealBrush
+public partial class RevealBrush : XamlCompositionBrushBase
 {
 	protected override Paint GetPaintInner(Rect destinationRect)
 	{

--- a/src/Uno.UI/UI/Xaml/Media/RevealBackgroundBrush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RevealBackgroundBrush.cs
@@ -1,11 +1,9 @@
 ﻿
-namespace Windows.UI.Xaml.Media
-{
-	public partial class RevealBackgroundBrush : RevealBrush
-	{
-		public RevealBackgroundBrush()
-		{
+namespace Windows.UI.Xaml.Media;
 
-		}
+public partial class RevealBackgroundBrush : RevealBrush
+{
+	public RevealBackgroundBrush()
+	{
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/RevealBorderBrush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RevealBorderBrush.cs
@@ -1,11 +1,8 @@
-﻿
-namespace Windows.UI.Xaml.Media
-{
-	public partial class RevealBorderBrush : RevealBrush
-	{
-		public RevealBorderBrush()
-		{
+﻿namespace Windows.UI.Xaml.Media;
 
-		}
+public partial class RevealBorderBrush : RevealBrush
+{
+	public RevealBorderBrush()
+	{
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/RevealBrush.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RevealBrush.cs
@@ -1,31 +1,29 @@
-﻿
-namespace Windows.UI.Xaml.Media
+﻿namespace Windows.UI.Xaml.Media;
+
+public partial class RevealBrush : XamlCompositionBrushBase
 {
-	public partial class RevealBrush : XamlCompositionBrushBase
+	public RevealBrush()
 	{
-		public RevealBrush()
-		{
 
-		}
-
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public global::Windows.UI.Color Color
-		{
-			get
-			{
-				return (global::Windows.UI.Color)this.GetValue(ColorProperty);
-			}
-			set
-			{
-				this.SetValue(ColorProperty, value);
-			}
-		}
-
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty ColorProperty { get; } =
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(Color), typeof(global::Windows.UI.Color),
-			typeof(global::Windows.UI.Xaml.Media.RevealBrush),
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 	}
+
+	[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+	public global::Windows.UI.Color Color
+	{
+		get
+		{
+			return (global::Windows.UI.Color)this.GetValue(ColorProperty);
+		}
+		set
+		{
+			this.SetValue(ColorProperty, value);
+		}
+	}
+
+	[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+	public static global::Windows.UI.Xaml.DependencyProperty ColorProperty { get; } =
+	Windows.UI.Xaml.DependencyProperty.Register(
+		nameof(Color), typeof(global::Windows.UI.Color),
+		typeof(global::Windows.UI.Xaml.Media.RevealBrush),
+		new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 }

--- a/src/Uno.UI/UI/Xaml/Media/SolidColorBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/SolidColorBrush.Android.cs
@@ -6,7 +6,6 @@ namespace Windows.UI.Xaml.Media
 	// Android partial for SolidColorBrush
 	public partial class SolidColorBrush : Brush
 	{
-
 		protected override Paint GetPaintInner(Rect destinationRect)
 		{
 			return new Paint() { Color = this.ColorWithOpacity, AntiAlias = true };

--- a/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.Android.cs
@@ -3,13 +3,12 @@ using Rect = Windows.Foundation.Rect;
 
 namespace Windows.UI.Xaml.Media;
 
-partial class RevealBrush
+public partial class XamlCompositionBrushBase : Brush
 {
 	protected override Paint GetPaintInner(Rect destinationRect)
 	{
-		var color = this.IsDependencyPropertySet(FallbackColorProperty) ?
-			GetColorWithOpacity(FallbackColor) :
-			GetColorWithOpacity(Color);
+		// By default fallback to FallbackColor, unless overridden by a derived class.
+		var color = GetColorWithOpacity(FallbackColor);
 		return new Paint() { Color = color, AntiAlias = true };
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.cs
+++ b/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.cs
@@ -1,42 +1,39 @@
-using Color = Windows.UI.Color;
+namespace Windows.UI.Xaml.Media;
 
-namespace Windows.UI.Xaml.Media
+public partial class XamlCompositionBrushBase : Brush
 {
-	public partial class XamlCompositionBrushBase : Brush
+	protected XamlCompositionBrushBase() : base()
 	{
-		protected XamlCompositionBrushBase() : base()
+	}
+
+	public Color FallbackColor
+	{
+		get
 		{
+			return (Color)this.GetValue(FallbackColorProperty);
 		}
-
-		public Color FallbackColor
+		set
 		{
-			get
-			{
-				return (Color)this.GetValue(FallbackColorProperty);
-			}
-			set
-			{
-				this.SetValue(FallbackColorProperty, value);
-			}
+			this.SetValue(FallbackColorProperty, value);
 		}
+	}
 
-		public static DependencyProperty FallbackColorProperty { get; } =
-			DependencyProperty.Register(
-				nameof(FallbackColor), typeof(Color),
-				typeof(XamlCompositionBrushBase),
-				new FrameworkPropertyMetadata(default(Color)));
+	public static DependencyProperty FallbackColorProperty { get; } =
+		DependencyProperty.Register(
+			nameof(FallbackColor), typeof(Color),
+			typeof(XamlCompositionBrushBase),
+			new FrameworkPropertyMetadata(default(Color)));
 
-		/// <summary>
-		/// Returns the fallback color mixed with opacity value.
-		/// </summary>
-		internal Color FallbackColorWithOpacity => FallbackColor.WithOpacity(Opacity);
+	/// <summary>
+	/// Returns the fallback color mixed with opacity value.
+	/// </summary>
+	internal Color FallbackColorWithOpacity => FallbackColor.WithOpacity(Opacity);
 
-		protected virtual void OnConnected()
-		{
-		}
+	protected virtual void OnConnected()
+	{
+	}
 
-		protected virtual void OnDisconnected()
-		{
-		}
+	protected virtual void OnDisconnected()
+	{
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Currently on Android trying to use MUX `RevealBrush` will cause an exception as it falls back to not implemented version of `GetPaintInner`.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
copilot:summary

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.