### PR TITLE
fix(listview): account for panel orientation

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -990,7 +990,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		[RunsOnUIThread]
 #if !__SKIA__
-        [Ignore("InputInjector is only supported on skia")]
+		[Ignore("InputInjector is only supported on skia")]
 #endif
 		public async Task When_Extended_Selection_SelectedIndex_Changed_Mixed()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -14,6 +14,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -642,11 +643,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 #if HAS_UNO
-#if !__SKIA__
-		[Ignore("InputInjector is only supported on skia")]
-#else
 		[TestMethod]
 		[RunsOnUIThread]
+#if !__SKIA__
+		[Ignore("InputInjector is only supported on skia")]
 #endif
 		public async Task When_Multiple_Selection_Pointer()
 		{
@@ -715,12 +715,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 
 #if HAS_UNO
-#if !__SKIA__
-		[Ignore("InputInjector is only supported on skia")]
-#else
 		[TestMethod]
 		[RunsOnUIThread]
-#endif
 		public async Task When_Multiple_Selection_Keyboard()
 		{
 			var items = Enumerable.Range(0, 10).Select(i => new ListViewItem { Content = i }).ToArray();
@@ -734,14 +730,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForIdle();
 
-			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
-			using var mouse = injector.GetMouse();
-
 			var selected = new List<ListViewItem>();
 			await AssertSelected();
 
-			mouse.Press(items[1].GetAbsoluteBounds().GetCenter());
-			mouse.Release();
+			list.SelectedIndex = 1;
+			var result = await FocusManager.TryFocusAsync(list.ContainerFromIndex(1), FocusState.Pointer);
+			Assert.IsTrue(result.Succeeded);
 
 			selected.Add(items[1]);
 			await AssertSelected();
@@ -782,11 +776,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 
 #if HAS_UNO
-#if !__SKIA__
-		[Ignore("InputInjector is only supported on skia")]
-#else
 		[TestMethod]
 		[RunsOnUIThread]
+#if !__SKIA__
+		[Ignore("InputInjector is only supported on skia")]
 #endif
 		public async Task When_Extended_Selection_Pointer()
 		{
@@ -864,12 +857,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 
 #if HAS_UNO
-#if !__SKIA__
-		[Ignore("InputInjector is only supported on skia")]
-#else
 		[TestMethod]
 		[RunsOnUIThread]
-#endif
 		public async Task When_Extended_Selection_Keyboard()
 		{
 			var items = Enumerable.Range(0, 10).Select(i => new ListViewItem { Content = i }).ToArray();
@@ -883,14 +872,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = list;
 			await WindowHelper.WaitForIdle();
 
-			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
-			using var mouse = injector.GetMouse();
-
 			var selected = new List<ListViewItem>();
 			await AssertSelected();
 
-			mouse.Press(items[1].GetAbsoluteBounds().GetCenter());
-			mouse.Release();
+			list.SelectedIndex = 1;
+			var result = await FocusManager.TryFocusAsync(list.ContainerFromIndex(1), FocusState.Pointer);
+			Assert.IsTrue(result.Succeeded);
 
 			selected.Add(items[1]);
 			await AssertSelected();
@@ -946,6 +933,162 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 #endif
+
+#if HAS_UNO
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Extended_Selection_SelectedIndex_Changed_Keyboard()
+		{
+			var items = Enumerable.Range(0, 10).Select(i => new ListViewItem { Content = i }).ToArray();
+			var list = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Extended,
+			};
+
+			items.ForEach((ListViewItem item) => list.Items.Add(item));
+
+			WindowHelper.WindowContent = list;
+			await WindowHelper.WaitForIdle();
+
+			var selected = new List<ListViewItem>();
+			await AssertSelected();
+
+			list.SelectedIndex = 1;
+			var result = await FocusManager.TryFocusAsync(list.ContainerFromIndex(1), FocusState.Pointer);
+			Assert.IsTrue(result.Succeeded);
+
+			selected.Add(items[1]);
+			await AssertSelected();
+
+			list.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(list, VirtualKey.Down, VirtualKeyModifiers.Shift));
+			list.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(list, VirtualKey.Down, VirtualKeyModifiers.Shift));
+
+			selected.AddRange(items.Where((_, i) => i is > 1 and <= 3).ToList());
+			await AssertSelected();
+
+			list.SelectedIndex = 6;
+			items.Where((_, i) => i is >= 1 and <= 3).ForEach(item => selected.Remove(item));
+			selected.Add(items[6]);
+			await AssertSelected();
+
+			list.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(list, VirtualKey.Down, VirtualKeyModifiers.Shift));
+
+			selected.Remove(items[6]);
+			selected.AddRange(items.Where((_, i) => i is >= 1 and <= 4).ToList());
+			await AssertSelected();
+
+			async Task AssertSelected()
+			{
+				await WindowHelper.WaitForIdle();
+				selected.ForEach(item => Assert.AreEqual(item.IsSelected, true));
+				items.Except(selected).ForEach(item => Assert.AreEqual(item.IsSelected, false));
+			}
+		}
+#endif
+
+#if HAS_UNO
+		[TestMethod]
+		[RunsOnUIThread]
+#if !__SKIA__
+        [Ignore("InputInjector is only supported on skia")]
+#endif
+		public async Task When_Extended_Selection_SelectedIndex_Changed_Mixed()
+		{
+			var items = Enumerable.Range(0, 10).Select(i => new ListViewItem { Content = i }).ToArray();
+			var list = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Extended,
+			};
+
+			items.ForEach((ListViewItem item) => list.Items.Add(item));
+
+			WindowHelper.WindowContent = list;
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var selected = new List<ListViewItem>();
+			await AssertSelected();
+
+			list.SelectedIndex = 1;
+			var result = await FocusManager.TryFocusAsync(list.ContainerFromIndex(1), FocusState.Pointer);
+			Assert.IsTrue(result.Succeeded);
+
+			selected.Add(items[1]);
+			await AssertSelected();
+
+			list.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(list, VirtualKey.Down, VirtualKeyModifiers.Shift));
+			list.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(list, VirtualKey.Down, VirtualKeyModifiers.Shift));
+
+			selected.AddRange(items.Where((_, i) => i is > 1 and <= 3).ToList());
+			await AssertSelected();
+
+			list.SelectedIndex = 6;
+			items.Where((_, i) => i is >= 1 and <= 3).ForEach(item => selected.Remove(item));
+			selected.Add(items[6]);
+			await AssertSelected();
+
+			mouse.Press(((ListViewItem)list.ContainerFromIndex(8)).GetAbsoluteBounds().GetCenter(), VirtualKeyModifiers.Shift);
+			mouse.Release(VirtualKeyModifiers.Shift);
+
+			selected.AddRange(items.Where((_, i) => i is >= 1 and <= 8 and not 6).ToList());
+			await AssertSelected();
+
+			async Task AssertSelected()
+			{
+				await WindowHelper.WaitForIdle();
+				selected.ForEach(item => Assert.AreEqual(item.IsSelected, true));
+				items.Except(selected).ForEach(item => Assert.AreEqual(item.IsSelected, false));
+			}
+		}
+#endif
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if NETFX_CORE
+		[Ignore("KeyboardHelper doesn't work on Windows")]
+#endif
+		public async Task When_Horizontal_Keyboard_Navigation()
+		{
+			var SUT = (ListView)XamlReader.Load("""
+				<ListView
+					xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+					ItemsSource="12345"
+				        ScrollViewer.HorizontalScrollBarVisibility="Visible"
+				        ScrollViewer.HorizontalScrollMode="Enabled"
+				        ScrollViewer.VerticalScrollMode="Disabled">
+					<ListView.ItemsPanel>
+						<ItemsPanelTemplate>
+							<ItemsStackPanel Orientation="Horizontal" />
+						</ItemsPanelTemplate>
+					</ListView.ItemsPanel>
+				</ListView>
+			""");
+
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForIdle();
+
+			SUT.SelectedIndex = 1;
+			var result = await FocusManager.TryFocusAsync(SUT.ContainerFromIndex(1), FocusState.Pointer);
+			Assert.IsTrue(result.Succeeded);
+
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, SUT.SelectedIndex);
+
+			KeyboardHelper.Right();
+			KeyboardHelper.Right();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(3, SUT.SelectedIndex);
+
+			KeyboardHelper.Left();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(2, SUT.SelectedIndex);
+		}
 
 		[TestMethod]
 		public async Task When_IsItsOwnItemContainer_Recycling()

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/Primitives/CalendarPanel.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/Primitives/CalendarPanel.Properties.cs
@@ -95,6 +95,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			}
 		}
 
+		internal override Orientation? InternalOrientation => Orientation;
+
 		internal static readonly DependencyProperty OrientationProperty = DependencyProperty.Register(
 			"Orientation", typeof(Orientation), typeof(CalendarPanel), new FrameworkPropertyMetadata(default(Orientation)));
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanel.cs
@@ -20,6 +20,8 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		public int LastVisibleIndex => _layout?.LastVisibleIndex ?? -1;
 
+		internal override Orientation? InternalOrientation => Orientation;
+
 #if __ANDROID__
 		public int FirstCacheIndex => _layout.XamlParent.NativePanel.ViewCache.FirstCacheIndex;
 		public int LastCacheIndex => _layout.XamlParent.NativePanel.ViewCache.LastCacheIndex;

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGrid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGrid.cs
@@ -14,6 +14,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public int LastVisibleIndex => _layout?.LastVisibleIndex ?? -1;
 
+		internal override Orientation? InternalOrientation => Orientation;
+
 #if __ANDROID__
 		public int FirstCacheIndex => _layout.XamlParent.NativePanel.ViewCache.FirstCacheIndex;
 		public int LastCacheIndex => _layout.XamlParent.NativePanel.ViewCache.LastCacheIndex;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -107,7 +107,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				var orientation = ItemsPanelRoot.InternalOrientation ?? Orientation.Vertical;
+				var orientation = ItemsPanelRoot?.InternalOrientation ?? Orientation.Vertical;
 
 				switch (args.Key)
 				{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -457,6 +457,11 @@ namespace Windows.UI.Xaml.Controls
 		internal override void OnSelectedIndexChanged(int oldSelectedIndex, int newSelectedIndex)
 		{
 			base.OnSelectedIndexChanged(oldSelectedIndex, newSelectedIndex);
+			if (ExtendedShiftSelectionStart == -1)
+			{
+				// only changed if it wasn't already set. This matches the behaviour on WinUI.
+				ExtendedShiftSelectionStart = newSelectedIndex;
+			}
 
 			try
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -105,13 +105,21 @@ namespace Windows.UI.Xaml.Controls
 					OnItemClicked(focusedContainer, args.KeyboardModifiers);
 				}
 			}
-			else if (args.Key == VirtualKey.Down)
+			else
 			{
-				return TryMoveKeyboardFocusAndSelection(+1, args.KeyboardModifiers);
-			}
-			else if (args.Key == VirtualKey.Up)
-			{
-				return TryMoveKeyboardFocusAndSelection(-1, args.KeyboardModifiers);
+				var orientation = ItemsPanelRoot.InternalOrientation ?? Orientation.Vertical;
+
+				switch (args.Key)
+				{
+					case VirtualKey.Down when orientation == Orientation.Vertical:
+						return TryMoveKeyboardFocusAndSelection(+1, args.KeyboardModifiers);
+					case VirtualKey.Up when orientation == Orientation.Vertical:
+						return TryMoveKeyboardFocusAndSelection(-1, args.KeyboardModifiers);
+					case VirtualKey.Right when orientation == Orientation.Horizontal:
+						return TryMoveKeyboardFocusAndSelection(+1, args.KeyboardModifiers);
+					case VirtualKey.Left when orientation == Orientation.Horizontal:
+						return TryMoveKeyboardFocusAndSelection(-1, args.KeyboardModifiers);
+				}
 			}
 			return false;
 		}
@@ -123,6 +131,11 @@ namespace Windows.UI.Xaml.Controls
 			var newIndex = prevIndex + offset;
 			var newContainer = ContainerFromIndex(newIndex) as SelectorItem;
 			var newItem = ItemFromIndex(newIndex);
+
+			if (newIndex < 0 || newIndex >= Items.Count)
+			{
+				return false;
+			}
 
 			FocusedIndexContainerItem = (newIndex, newContainer, newItem);
 

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
@@ -106,6 +106,13 @@ namespace Windows.UI.Xaml.Controls
 
 		#endregion
 
+		/// <summary>
+		/// Panels don't have an Orientation in UWP, but many derived types do.
+		/// This should be overriden by the derived types to refer to match their
+		/// own Orientation.
+		/// </summary>
+		internal virtual Orientation? InternalOrientation { get; }
+
 		internal Thickness PaddingInternal { get; set; }
 
 		internal Thickness BorderThicknessInternal { get; set; }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -392,6 +392,12 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		{
 			base.OnGotFocus(e);
 			ChangeVisualState(true);
+
+			if (Selector is ListViewBase lvb)
+			{
+				var index = lvb.IndexFromContainer(this);
+				lvb.FocusedIndexContainerItem = (index, this, lvb.ItemFromIndex(index));
+			}
 		}
 
 		protected override void OnLostFocus(RoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.cs
@@ -138,6 +138,8 @@ namespace Windows.UI.Xaml.Controls
 
 		#region Orientation DependencyProperty
 
+		internal override Orientation? InternalOrientation => Orientation;
+
 		public Orientation Orientation
 		{
 			get { return (Orientation)GetValue(OrientationProperty); }

--- a/src/Uno.UI/UI/Xaml/Controls/VariableSizedWrapGrid/VariableSizedWrapGrid.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/VariableSizedWrapGrid/VariableSizedWrapGrid.Properties.cs
@@ -104,6 +104,8 @@ partial class VariableSizedWrapGrid
 			typeof(VariableSizedWrapGrid),
 			new FrameworkPropertyMetadata(-1));
 
+	internal override Orientation? InternalOrientation => Orientation;
+
 	/// <summary>
 	/// Gets or sets the direction in which child elements are arranged.
 	/// </summary>

--- a/src/Uno.UI/UI/Xaml/Controls/VirtualizingPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/VirtualizingPanel.cs
@@ -13,5 +13,7 @@ namespace Windows.UI.Xaml.Controls
 		public VirtualizingPanelLayout GetLayouter() => GetLayouterCore();
 
 		private protected virtual VirtualizingPanelLayout GetLayouterCore() => throw new NotSupportedException($"This method must be overridden by implementing classes.");
+
+		internal override Orientation? InternalOrientation => GetLayouter().Orientation;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13196

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a44ab9</samp>

This pull request adds an `InternalOrientation` property to the `Panel` class and its subclasses that have an orientation, such as `StackPanel`, `ItemsStackPanel`, and `ItemsWrapGrid`. This property is used by the `ListViewBase` class to improve keyboard navigation for horizontal and boundary cases.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
