### PR TITLE
refactor: Cleanup dead shapes code on Wasm

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -872,6 +872,8 @@
 			<!-- End Skia lifecycle -->
 
 			<Member fullName="System.Nullable`1&lt;Uno.UI.Skia.RenderSurfaceType&gt; Uno.UI.XamlHost.Skia.Wpf.UnoXamlHostBase::RenderSurfaceType()" reason="Changed RenderSurfaceType namespace to Uno.UI.Runtime.Skia.Wpf" />
+
+			<Member fullName="System.Boolean Windows.UI.Xaml.Shapes.ArbitraryShapeBase::ShouldPreserveOrigin()" reason="Cleanup shapes on Wasm" />
 		</Properties>
 		<Methods>
 			<Member fullName="System.Void Windows.UI.Core.CoreWindow.RaisePointerCancelled(Windows.UI.Core.PointerEventArgs args)" reason="Not present in WInUI" />
@@ -1650,6 +1652,9 @@
 			<Member fullName="System.Numerics.Quaternion Windows.UI.Composition.Visual.get_Orientation()" reason="Converted to auto-property" />
 			<!-- END Skia clipping -->
 
+			<Member fullName="System.Void Windows.UI.Xaml.Shapes.Shape.RefreshShape(System.Boolean forceRefresh)" reason="Cleanup shapes on Wasm" />
+			<Member fullName="System.Double Windows.UI.Xaml.Shapes.ArbitraryShapeBase.LimitWithUserSize(System.Double availableSize, System.Double userSize, System.Double naNFallbackValue)" reason="Cleanup shapes on Wasm" />
+			<Member fullName="System.Boolean Windows.UI.Xaml.Shapes.ArbitraryShapeBase.get_ShouldPreserveOrigin()" reason="Cleanup shapes on Wasm" />
 		</Methods>
 	</IgnoreSet>
 	  <!--

--- a/src/Uno.UI/Mock/ArbitraryShapeBase.reference.cs
+++ b/src/Uno.UI/Mock/ArbitraryShapeBase.reference.cs
@@ -9,8 +9,5 @@ namespace Windows.UI.Xaml.Shapes
 {
 	public abstract partial class ArbitraryShapeBase : Shape
 	{
-		private IDisposable BuildDrawableLayer() => null;
-
-		private Windows.Foundation.Size GetActualSize() => default;
 	}
 }

--- a/src/Uno.UI/Mock/ArbitraryShapeBase.unittests.cs
+++ b/src/Uno.UI/Mock/ArbitraryShapeBase.unittests.cs
@@ -9,8 +9,5 @@ namespace Windows.UI.Xaml.Shapes
 {
 	public abstract partial class ArbitraryShapeBase : Shape
 	{
-		private IDisposable BuildDrawableLayer() => null;
-
-		private Windows.Foundation.Size GetActualSize() => default;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.cs
@@ -18,9 +18,6 @@ namespace Windows.UI.Xaml.Shapes
 		private const double _scaleX = 0;
 		private const double _scaleY = 0;
 
-		private readonly SerialDisposable _layer = new SerialDisposable();
-		private object?[]? _layerState;
-
 		protected static double LimitWithUserSize(double availableSize, double userSize, double naNFallbackValue)
 		{
 			var hasUserSize = userSize != 0 && !double.IsNaN(userSize) && !double.IsInfinity(userSize);
@@ -45,37 +42,6 @@ namespace Windows.UI.Xaml.Shapes
 
 			//If both availableSize and userSize are NaN, use the fallback.
 			return naNFallbackValue;
-		}
-
-#if !UNO_REFERENCE_API
-		protected internal override void OnInvalidateMeasure()
-		{
-			base.OnInvalidateMeasure();
-			RefreshShape(true);
-		}
-#endif
-
-		/// <summary>
-		/// Refreshes the current shape, considering its drawinf parameters.
-		/// </summary>
-		/// <param name="forceRefresh">Forces a refresh by ignoring the shape parameters.</param>
-		protected override void RefreshShape(bool forceRefresh = false)
-		{
-			if (!IsLoaded)
-			{
-				return;
-			}
-
-			var newLayerState = GetShapeParameters().ToArray();
-
-			if (forceRefresh || !(_layerState?.SequenceEqual(newLayerState) ?? false))
-			{
-				// Remove the previous layer
-				_layer.Disposable = null;
-
-				_layerState = newLayerState;
-				_layer.Disposable = BuildDrawableLayer();
-			}
 		}
 
 		private protected Rect GetBounds()
@@ -116,22 +82,6 @@ namespace Windows.UI.Xaml.Shapes
 			}
 
 			return new Rect(0.0, 0.0, width, height);
-		}
-
-		/// <summary>
-		/// Provides a enumeration of values that are used to determine if the shape
-		/// should be rebuilt. Inheritors should append the base's enumeration.
-		/// </summary>
-		protected internal virtual IEnumerable<object?> GetShapeParameters()
-		{
-			yield return GetActualSize();
-			yield return Fill;
-			yield return Stroke;
-			yield return StrokeThickness;
-			yield return Stretch;
-			yield return StrokeDashArray;
-			yield return _scaleX;
-			yield return _scaleY;
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.cs
@@ -4,90 +4,11 @@
 
 #if LEGACY_SHAPE_MEASURE
 #nullable enable
-using Windows.UI.Xaml.Media;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Uno.Disposables;
-using Windows.Foundation;
 
-namespace Windows.UI.Xaml.Shapes
+namespace Windows.UI.Xaml.Shapes;
+
+public abstract partial class ArbitraryShapeBase : Shape
 {
-	public abstract partial class ArbitraryShapeBase : Shape
-	{
-		private const double _scaleX = 0;
-		private const double _scaleY = 0;
 
-		protected static double LimitWithUserSize(double availableSize, double userSize, double naNFallbackValue)
-		{
-			var hasUserSize = userSize != 0 && !double.IsNaN(userSize) && !double.IsInfinity(userSize);
-			var hasAvailableSize = !double.IsNaN(availableSize);
-
-#if UNO_REFERENCE_API
-			// The measuring algorithms for shapes in Wasm and iOS/Android/macOS are not using the
-			// infinity the same way.
-			// Those implementation will need to be merged.
-			hasAvailableSize &= !double.IsInfinity(availableSize);
-#endif
-
-			if (hasUserSize && hasAvailableSize)
-			{
-				return Math.Min(userSize, availableSize);
-			}
-
-			if (hasAvailableSize)
-			{
-				return availableSize;
-			}
-
-			//If both availableSize and userSize are NaN, use the fallback.
-			return naNFallbackValue;
-		}
-
-		private protected Rect GetBounds()
-		{
-			var width = Width;
-			var height = Height;
-
-			if (double.IsNaN(width))
-			{
-				var minWidth = MinWidth;
-				if (minWidth > 0.0)
-				{
-					width = minWidth;
-				}
-			}
-			if (double.IsNaN(height))
-			{
-				var minHeight = MinHeight;
-				if (minHeight > 0.0)
-				{
-					height = minHeight;
-				}
-			}
-
-			if (double.IsNaN(width))
-			{
-				if (double.IsNaN(height))
-				{
-					return new Rect(0.0, 0.0, 0.0, 0.0);
-				}
-
-				return new Rect(0.0, 0.0, height, height);
-			}
-
-			if (double.IsNaN(height))
-			{
-				return new Rect(0.0, 0.0, width, width);
-			}
-
-			return new Rect(0.0, 0.0, width, height);
-		}
-
-		/// <summary>
-		/// Gets whether the shape should preserve the path's origin (and ignore StrokeThickness)
-		/// </summary>
-		protected bool ShouldPreserveOrigin => this is Path && Stretch == Stretch.None;
-	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
@@ -176,5 +176,29 @@ namespace Windows.UI.Xaml.Shapes
 
 			return bBoxWithStrokeThickness;
 		}
+
+		private static double LimitWithUserSize(double availableSize, double userSize, double naNFallbackValue)
+		{
+			var hasUserSize = userSize != 0 && !double.IsNaN(userSize) && !double.IsInfinity(userSize);
+			var hasAvailableSize = !double.IsNaN(availableSize);
+
+			// The measuring algorithms for shapes in Wasm and iOS/Android/macOS are not using the
+			// infinity the same way.
+			// Those implementation will need to be merged.
+			hasAvailableSize &= !double.IsInfinity(availableSize);
+
+			if (hasUserSize && hasAvailableSize)
+			{
+				return Math.Min(userSize, availableSize);
+			}
+
+			if (hasAvailableSize)
+			{
+				return availableSize;
+			}
+
+			//If both availableSize and userSize are NaN, use the fallback.
+			return naNFallbackValue;
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.wasm.cs
@@ -12,10 +12,6 @@ namespace Windows.UI.Xaml.Shapes
 {
 	partial class ArbitraryShapeBase
 	{
-		private IDisposable BuildDrawableLayer() => Disposable.Empty;
-
-		private Size GetActualSize() => Size.Empty;
-
 		protected virtual void InvalidateShape() { }
 
 		protected override Size MeasureOverride(Size availableSize)

--- a/src/Uno.UI/UI/Xaml/Shapes/Line.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Line.cs
@@ -144,19 +144,6 @@ namespace Windows.UI.Xaml.Shapes
 		}
 
 		partial void OnY2PropertyChangedPartial(double oldValue, double newValue);
-
-		protected internal override IEnumerable<object> GetShapeParameters()
-		{
-			yield return X1;
-			yield return X2;
-			yield return Y1;
-			yield return Y2;
-
-			foreach (var p in base.GetShapeParameters())
-			{
-				yield return p;
-			}
-		}
 #endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Path.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Path.cs
@@ -40,19 +40,5 @@ namespace Windows.UI.Xaml.Shapes
 
 		#endregion
 
-#if LEGACY_SHAPE_MEASURE
-		protected internal override IEnumerable<object?> GetShapeParameters()
-		{
-			if (Data is { } data)
-			{
-				yield return data;
-			}
-
-			foreach (var p in base.GetShapeParameters())
-			{
-				yield return p;
-			}
-		}
-#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Polygon.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polygon.cs
@@ -62,16 +62,6 @@ namespace Windows.UI.Xaml.Shapes
 
 #if LEGACY_SHAPE_MEASURE
 		partial void OnPointsChanged();
-
-		protected internal override IEnumerable<object> GetShapeParameters()
-		{
-			yield return Points?.ToArray();
-
-			foreach (var p in base.GetShapeParameters())
-			{
-				yield return p;
-			}
-		}
 #endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Polyline.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polyline.cs
@@ -61,16 +61,6 @@ namespace Windows.UI.Xaml.Shapes
 
 #if LEGACY_SHAPE_MEASURE
 		partial void OnPointsChanged();
-
-		protected internal override IEnumerable<object> GetShapeParameters()
-		{
-			yield return Points?.ToArray();
-
-			foreach (var p in base.GetShapeParameters())
-			{
-				yield return p;
-			}
-		}
 #endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.cs
@@ -212,11 +212,7 @@ namespace Windows.UI.Xaml.Shapes
 		private void OnFillChanged(Brush newValue)
 		{
 			_brushChangedProxy ??= new();
-			_brushChanged ??= () =>
-			{
-				OnFillUpdatedPartial();
-				RefreshShape();
-			};
+			_brushChanged ??= () => OnFillUpdatedPartial();
 
 			_brushChangedProxy.Subscribe(newValue, _brushChanged);
 		}
@@ -226,11 +222,7 @@ namespace Windows.UI.Xaml.Shapes
 		private void OnStrokeChanged(Brush newValue)
 		{
 			_strokeBrushChangedProxy ??= new();
-			_strokeBrushChanged ??= () =>
-			{
-				OnStrokeUpdatedPartial();
-				RefreshShape();
-			};
+			_strokeBrushChanged ??= () => OnStrokeUpdatedPartial();
 			_strokeBrushChangedProxy.Subscribe(newValue, _strokeBrushChanged);
 		}
 		partial void OnStrokeUpdatedPartial();
@@ -238,25 +230,20 @@ namespace Windows.UI.Xaml.Shapes
 		private void OnStrokeThicknessUpdated(double newValue)
 		{
 			OnStrokeThicknessUpdatedPartial();
-			RefreshShape();
 		}
 		partial void OnStrokeThicknessUpdatedPartial();
 
 		private void OnStrokeDashArrayUpdated(DoubleCollection newValue)
 		{
 			OnStrokeDashArrayUpdatedPartial();
-			RefreshShape();
 		}
 		partial void OnStrokeDashArrayUpdatedPartial();
 
 		private void OnStretchUpdated(Stretch newValue)
 		{
 			OnStretchUpdatedPartial();
-			RefreshShape();
 		}
 		partial void OnStretchUpdatedPartial();
-
-		protected virtual void RefreshShape(bool forceRefresh = false) { }
 #endif
 
 		internal override bool IsViewHit()


### PR DESCRIPTION
GitHub Issue (If applicable): Very small step towards https://github.com/unoplatform/uno/issues/2983

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at acc4c57</samp>

This pull request removes or simplifies code related to the `ArbitraryShapeBase` and its derived classes (`Line`, `Path`, `Polygon`, and `Polyline`) in various files. The code was used to manually create and update the shape layers, but it is no longer needed because the native platform handles the shape rendering. The purpose is to improve performance, memory usage, and code readability.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
