### PR TITLE
build: Adjust Mixin generation

### DIFF
--- a/src/Uno.UI/MixinGeneration.targets
+++ b/src/Uno.UI/MixinGeneration.targets
@@ -74,19 +74,19 @@
 		<ItemGroup>
 			<_t4Path Include="$(NuGetPackageRoot)/dotnet-t4/$(_T4ToolVersion)/**/t4.dll" />
 
-			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsAndroid)">
+			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsAndroid) or $(TargetFrameworks.Contains('-android'))">
 				<Properties>_t4Path=@(_t4Path);InputFile=$(MSBuildThisFileDirectory)Mixins\Android\BaseActivity.Callbacks.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\Android\BaseActivity.Callbacks.g.cs</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsAndroid)">
+			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsAndroid) or $(TargetFrameworks.Contains('-android'))">
 				<Properties>_t4Path=@(_t4Path);InputFile=$(MSBuildThisFileDirectory)Mixins\Android\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\Android\FrameworkElementMixins.g.cs</Properties>
 			</MixinDefinition>
 			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets">
 				<Properties>_t4Path=@(_t4Path);InputFile=$(MSBuildThisFileDirectory)Mixins\DependencyPropertyMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\DependencyPropertyMixins.g.cs</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsIOSOrCatalyst)">
+			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsIOSOrCatalyst) or $(TargetFrameworks.Contains('-ios')) or  or $(TargetFrameworks.Contains('-maccatalyst'))">
 				<Properties>_t4Path=@(_t4Path);InputFile=$(MSBuildThisFileDirectory)Mixins\iOS\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\iOS\FrameworkElementMixins.g.cs</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsMacOS)">
+			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsMacOS) or $(TargetFrameworks.Contains('-macos'))">
 				<Properties>_t4Path=@(_t4Path);InputFile=$(MSBuildThisFileDirectory)Mixins\macOS\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\macOS\FrameworkElementMixins.g.cs</Properties>
 			</MixinDefinition>
 		</ItemGroup>

--- a/src/Uno.UI/MixinGeneration.targets
+++ b/src/Uno.UI/MixinGeneration.targets
@@ -83,7 +83,7 @@
 			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets">
 				<Properties>_t4Path=@(_t4Path);InputFile=$(MSBuildThisFileDirectory)Mixins\DependencyPropertyMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\DependencyPropertyMixins.g.cs</Properties>
 			</MixinDefinition>
-			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsIOSOrCatalyst) or $(TargetFrameworks.Contains('-ios')) or  or $(TargetFrameworks.Contains('-maccatalyst'))">
+			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsIOSOrCatalyst) or $(TargetFrameworks.Contains('-ios')) or $(TargetFrameworks.Contains('-maccatalyst'))">
 				<Properties>_t4Path=@(_t4Path);InputFile=$(MSBuildThisFileDirectory)Mixins\iOS\FrameworkElementMixins.tt;OutputPath=$(MSBuildThisFileDirectory)Mixins\iOS\FrameworkElementMixins.g.cs</Properties>
 			</MixinDefinition>
 			<MixinDefinition Include="$(MSBuildThisFileDirectory)MixinGenerationCore.targets" Condition="$(IsMacOS) or $(TargetFrameworks.Contains('-macos'))">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When building ios and maccatalyst in parallel, both builds will execute the same command:

```
dotnet "C:\a\.nuget\dotnet-t4\2.3.1\tools\netcoreapp3.1\any\t4.dll" C:\a\1\s\src\Uno.UI\Mixins\iOS\FrameworkElementMixins.tt -o C:\a\1\s\src\Uno.UI\Mixins\iOS\FrameworkElementMixins.g.cs
```

This can randomly result in build failures like:

> System.IO.IOException: The process cannot access the file 'C:\a\1\s\src\Uno.UI\Mixins\iOS\NativeListViewBase.FrameworkElement.EffectiveViewport.g.cs' because it is being used by another process.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Now, in such scenarios, we will try to generate for all platforms once before dispatching inner builds if we know we will end up building for that platform by checking TargetFrameworks. Meaning that if we are building for both iOS and maccatalyst, we will generate the mixins early and only once.

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75e18c2</samp>

No summary available (An error occurred while summarizing these changes: Gave up after 3 retries: Failed to read error response)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
