### PR TITLE
perf: Avoid re-creating Android Paint instances

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1669,6 +1669,8 @@
 			<Member fullName="System.Void Windows.UI.Xaml.Shapes.Shape.RefreshShape(System.Boolean forceRefresh)" reason="Cleanup shapes on Wasm" />
 			<Member fullName="System.Double Windows.UI.Xaml.Shapes.ArbitraryShapeBase.LimitWithUserSize(System.Double availableSize, System.Double userSize, System.Double naNFallbackValue)" reason="Cleanup shapes on Wasm" />
 			<Member fullName="System.Boolean Windows.UI.Xaml.Shapes.ArbitraryShapeBase.get_ShouldPreserveOrigin()" reason="Cleanup shapes on Wasm" />
+
+			<Member fullName="Android.Graphics.Paint Microsoft.UI.Xaml.Media.Brush.GetPaintInner(Windows.Foundation.Rect destinationRect)" reason="Does not exist on Android" />
 		</Methods>
 	</IgnoreSet>
 	  <!--

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1670,7 +1670,8 @@
 			<Member fullName="System.Double Windows.UI.Xaml.Shapes.ArbitraryShapeBase.LimitWithUserSize(System.Double availableSize, System.Double userSize, System.Double naNFallbackValue)" reason="Cleanup shapes on Wasm" />
 			<Member fullName="System.Boolean Windows.UI.Xaml.Shapes.ArbitraryShapeBase.get_ShouldPreserveOrigin()" reason="Cleanup shapes on Wasm" />
 
-			<Member fullName="Android.Graphics.Paint Microsoft.UI.Xaml.Media.Brush.GetPaintInner(Windows.Foundation.Rect destinationRect)" reason="Does not exist on Android" />
+			<Member fullName="Android.Graphics.Paint Windows.UI.Xaml.Media.Brush.GetPaintInner(Windows.Foundation.Rect destinationRect)" reason="Does not exist in UWP" />
+			<Member fullName="Android.Graphics.Paint Microsoft.UI.Xaml.Media.Brush.GetPaintInner(Windows.Foundation.Rect destinationRect)" reason="Does not exist in UWP" />
 		</Methods>
 	</IgnoreSet>
 	  <!--

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/BorderLayerRendererNative.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/BorderLayerRendererNative.java
@@ -21,7 +21,7 @@ public final class BorderLayerRendererNative
 		drawable.setShape(new PathShape(borderPath, width, height));
 
 		Paint paint = drawable.getPaint();
-		paing.setAntiAlias(true);
+		paint.setAntiAlias(true);
 		paint.setAlpha(strokePaint.getAlpha());
 		paint.setColor(strokePaint.getColor());
 		paint.setShader(strokePaint.getShader());

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/BorderLayerRendererNative.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/BorderLayerRendererNative.java
@@ -21,6 +21,7 @@ public final class BorderLayerRendererNative
 		drawable.setShape(new PathShape(borderPath, width, height));
 
 		Paint paint = drawable.getPaint();
+		paing.setAntiAlias(true);
 		paint.setAlpha(strokePaint.getAlpha());
 		paint.setColor(strokePaint.getColor());
 		paint.setShader(strokePaint.getShader());

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/BrushNative.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/BrushNative.java
@@ -24,4 +24,19 @@ public final class BrushNative
 		paint.setColor(fillPaint.getColor());
 		paint.setShader(fillPaint.getShader());
 	}
+
+	
+	public static void resetPaintForStroke(Paint paint)
+	{
+		paint.reset();
+		paint.setAntiAlias(true);
+		paint.setStyle(Paint.Style.STROKE);
+	}
+
+	public static void resetPaintForFill(Paint paint)
+	{
+		paint.reset();
+		paint.setAntiAlias(true);
+		paint.setStyle(Paint.Style.FILL);
+	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_RevealBrush.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_RevealBrush.cs
@@ -67,14 +67,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 				var muxRevealBorderBrush = new Microsoft.UI.Xaml.Media.RevealBorderBrush();
 				var muxRevealBackgroundBrush = new Microsoft.UI.Xaml.Media.RevealBackgroundBrush();
 
-				revealBorderBrush.GetStrokePaint(default);
-				revealBackgroundBrush.GetStrokePaint(default);
-				muxRevealBorderBrush.GetStrokePaint(default);
-				muxRevealBackgroundBrush.GetStrokePaint(default);
-				revealBorderBrush.GetFillPaint(default);
-				revealBackgroundBrush.GetFillPaint(default);
-				muxRevealBorderBrush.GetFillPaint(default);
-				muxRevealBackgroundBrush.GetFillPaint(default);
+				var paint = new Android.Graphics.Paint();
+				revealBorderBrush.ApplyToStrokePaint(default, paint);
+				revealBackgroundBrush.ApplyToStrokePaint(default, paint);
+				muxRevealBorderBrush.ApplyToStrokePaint(default, paint);
+				muxRevealBackgroundBrush.ApplyToStrokePaint(default, paint);
+				revealBorderBrush.ApplyToFillPaint(default, paint);
+				revealBackgroundBrush.ApplyToFillPaint(default, paint);
+				muxRevealBorderBrush.ApplyToFillPaint(default, paint);
+				muxRevealBackgroundBrush.ApplyToFillPaint(default, paint);
 			}
 			catch
 			{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.Android.cs
@@ -11,7 +11,7 @@ namespace Microsoft.UI.Xaml.Media
 {
 	partial class RadialGradientBrush
 	{
-		protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
+		private protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 		{
 			paint.SetShader(GetShader(destinationRect.Size));
 			paint.SetStyle(Paint.Style.Stroke);

--- a/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Media/RadialGradientBrush.Android.cs
@@ -11,12 +11,10 @@ namespace Microsoft.UI.Xaml.Media
 {
 	partial class RadialGradientBrush
 	{
-		protected override Paint GetPaintInner(Rect destinationRect)
+		protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 		{
-			var paint = new Paint();
 			paint.SetShader(GetShader(destinationRect.Size));
 			paint.SetStyle(Paint.Style.Stroke);
-			return paint;
 		}
 
 		internal Shader GetShader(Size size)

--- a/src/Uno.UI/Microsoft/UI/Xaml/Media/RevealBrush.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Media/RevealBrush.Android.cs
@@ -7,11 +7,11 @@ namespace Microsoft.UI.Xaml.Media;
 
 public partial class RevealBrush : XamlCompositionBrushBase
 {
-	protected override Paint GetPaintInner(Rect destinationRect)
+	protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 	{
 		var color = this.IsDependencyPropertySet(FallbackColorProperty) ?
 			GetColorWithOpacity(FallbackColor) :
 			GetColorWithOpacity(Color);
-		return new Paint() { Color = color, AntiAlias = true };
+		paint.Color = color;
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Media/RevealBrush.Android.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Media/RevealBrush.Android.cs
@@ -7,7 +7,7 @@ namespace Microsoft.UI.Xaml.Media;
 
 public partial class RevealBrush : XamlCompositionBrushBase
 {
-	protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
+	private protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 	{
 		var color = this.IsDependencyPropertySet(FallbackColorProperty) ?
 			GetColorWithOpacity(FallbackColor) :

--- a/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Android.cs
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Media
 		/// </summary>
 		/// <param name="destinationRect">Destination rect.</param>
 		/// <returns></returns>
-		protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
+		private protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 		{
 			paint.Color = FallbackColorWithOpacity;
 		}

--- a/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Android.cs
@@ -14,17 +14,17 @@ namespace Windows.UI.Xaml.Media
 {
 	public partial class AcrylicBrush
 	{
+		private static Paint _fallbackFillPaint;
+
 		/// <summary>
 		/// Returns the fallback solid color brush.
 		/// </summary>
 		/// <param name="destinationRect">Destination rect.</param>
 		/// <returns></returns>
-		protected override Paint GetPaintInner(Rect destinationRect) =>
-			new Paint()
-			{
-				Color = FallbackColorWithOpacity,
-				AntiAlias = true
-			};
+		protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
+		{
+			paint.Color = FallbackColorWithOpacity;
+		}
 
 		internal IDisposable Subscribe(BindableView owner, Rect drawArea, Path maskingPath)
 		{
@@ -75,8 +75,9 @@ namespace Windows.UI.Xaml.Media
 				state.BlurDisposable.Disposable = null;
 
 				// Fall back to solid color
-				var fillPaint = GetFillPaint(Rect.Empty);
-				ExecuteWithNoRelayout(state.Owner, v => v.SetBackgroundDrawable(Brush.GetBackgroundDrawable(this, state.DrawArea, fillPaint, state.MaskingPath, antiAlias: false)));
+				_fallbackFillPaint ??= new();
+				ApplyToFillPaint(Rect.Empty, _fallbackFillPaint);
+				ExecuteWithNoRelayout(state.Owner, v => v.SetBackgroundDrawable(Brush.GetBackgroundDrawable(this, state.DrawArea, _fallbackFillPaint, state.MaskingPath, antiAlias: false)));
 
 				if (state.FallbackDisposable.Disposable == null)
 				{

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -40,8 +40,8 @@ namespace Windows.UI.Xaml.Media
 			}
 
 			paint.Reset();
-			ApplyToPaintInner(destinationRect, paint);
 			paint.AntiAlias = true;
+			ApplyToPaintInner(destinationRect, paint);
 			paint.SetStyle(SystemFill);
 		}
 
@@ -58,8 +58,8 @@ namespace Windows.UI.Xaml.Media
 			}
 
 			paint.Reset();
-			ApplyToPaintInner(destinationRect, paint);
 			paint.AntiAlias = true;
+			ApplyToPaintInner(destinationRect, paint);
 			paint.SetStyle(SystemStroke);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Media
 			paint.SetStyle(SystemStroke);
 		}
 
-		protected virtual void ApplyToPaintInner(Rect destinationRect, Paint paint) => throw new InvalidOperationException();
+		private protected virtual void ApplyToPaintInner(Rect destinationRect, Paint paint) => throw new InvalidOperationException();
 
 		internal static Drawable GetBackgroundDrawable(Brush background, Windows.Foundation.Rect drawArea, Paint fillPaint, Path maskingPath = null, bool antiAlias = true)
 		{

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -32,11 +32,17 @@ namespace Windows.UI.Xaml.Media
 		/// </summary>
 		/// <param name="destinationRect">RectF that will be drawn into - used by ImageBrush</param>
 		/// <returns>A Paint with Fill style</returns>
-		internal Paint GetFillPaint(Windows.Foundation.Rect destinationRect)
+		internal void ApplyToFillPaint(Windows.Foundation.Rect destinationRect, Paint paint)
 		{
-			var paint = GetPaintInner(destinationRect);
-			paint?.SetStyle(SystemFill);
-			return paint;
+			if (paint is null)
+			{
+				throw new ArgumentNullException(nameof(paint));
+			}
+
+			paint.Reset();
+			ApplyToPaintInner(destinationRect, paint);
+			paint.AntiAlias = true;
+			paint.SetStyle(SystemFill);
 		}
 
 		/// <summary>
@@ -44,14 +50,20 @@ namespace Windows.UI.Xaml.Media
 		/// </summary>
 		/// <param name="destinationRect">RectF that will be drawn into - used by ImageBrush</param>
 		/// <returns>A Paint with Stroke style</returns>
-		internal Paint GetStrokePaint(Windows.Foundation.Rect destinationRect)
+		internal void ApplyToStrokePaint(Windows.Foundation.Rect destinationRect, Paint paint)
 		{
-			var paint = GetPaintInner(destinationRect);
-			paint?.SetStyle(SystemStroke);
-			return paint;
+			if (paint is null)
+			{
+				throw new ArgumentNullException(nameof(paint));
+			}
+
+			paint.Reset();
+			ApplyToPaintInner(destinationRect, paint);
+			paint.AntiAlias = true;
+			paint.SetStyle(SystemStroke);
 		}
 
-		protected virtual Paint GetPaintInner(Rect destinationRect) => throw new InvalidOperationException();
+		protected virtual void ApplyToPaintInner(Rect destinationRect, Paint paint) => throw new InvalidOperationException();
 
 		internal static Drawable GetBackgroundDrawable(Brush background, Windows.Foundation.Rect drawArea, Paint fillPaint, Path maskingPath = null, bool antiAlias = true)
 		{

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -39,10 +39,8 @@ namespace Windows.UI.Xaml.Media
 				throw new ArgumentNullException(nameof(paint));
 			}
 
-			paint.Reset();
-			paint.AntiAlias = true;
+			BrushNative.ResetPaintForFill(paint);
 			ApplyToPaintInner(destinationRect, paint);
-			paint.SetStyle(SystemFill);
 		}
 
 		/// <summary>
@@ -57,10 +55,8 @@ namespace Windows.UI.Xaml.Media
 				throw new ArgumentNullException(nameof(paint));
 			}
 
-			paint.Reset();
-			paint.AntiAlias = true;
+			BrushNative.ResetPaintForStroke(paint);
 			ApplyToPaintInner(destinationRect, paint);
-			paint.SetStyle(SystemStroke);
 		}
 
 		private protected virtual void ApplyToPaintInner(Rect destinationRect, Paint paint) => throw new InvalidOperationException();

--- a/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Brush.Android.cs
@@ -21,12 +21,6 @@ namespace Windows.UI.Xaml.Media
 	//Android partial for Brush
 	public partial class Brush
 	{
-		private static Paint.Style _strokeCache;
-		private static Paint.Style _fillCache;
-
-		private static Paint.Style SystemStroke => _strokeCache ??= Paint.Style.Stroke;
-		private static Paint.Style SystemFill => _fillCache ??= Paint.Style.Fill;
-
 		/// <summary>
 		/// Return a paint with Fill style
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/Media/GradientBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GradientBrush.Android.cs
@@ -6,12 +6,11 @@ namespace Windows.UI.Xaml.Media
 {
 	partial class GradientBrush
 	{
-		protected override Paint GetPaintInner(Rect destinationRect)
+		protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 		{
-			var paint = new Paint();
+			paint.Reset();
 			paint.SetShader(GetShader(destinationRect.Size));
 			paint.SetStyle(Paint.Style.Stroke);
-			return paint;
 		}
 
 		protected internal abstract Shader GetShader(Size size);

--- a/src/Uno.UI/UI/Xaml/Media/GradientBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GradientBrush.Android.cs
@@ -9,7 +9,6 @@ namespace Windows.UI.Xaml.Media
 		private protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 		{
 			paint.SetShader(GetShader(destinationRect.Size));
-			paint.SetStyle(Paint.Style.Stroke);
 		}
 
 		protected internal abstract Shader GetShader(Size size);

--- a/src/Uno.UI/UI/Xaml/Media/GradientBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GradientBrush.Android.cs
@@ -6,7 +6,7 @@ namespace Windows.UI.Xaml.Media
 {
 	partial class GradientBrush
 	{
-		protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
+		private protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 		{
 			paint.SetShader(GetShader(destinationRect.Size));
 			paint.SetStyle(Paint.Style.Stroke);

--- a/src/Uno.UI/UI/Xaml/Media/GradientBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/GradientBrush.Android.cs
@@ -8,7 +8,6 @@ namespace Windows.UI.Xaml.Media
 	{
 		protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 		{
-			paint.Reset();
 			paint.SetShader(GetShader(destinationRect.Size));
 			paint.SetStyle(Paint.Style.Stroke);
 		}

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
@@ -33,9 +33,9 @@ namespace Windows.UI.Xaml.Media
 			_onImageLoaded?.Invoke();
 		}
 
-		protected override Paint GetPaintInner(Rect drawRect)
+		protected override void ApplyToPaintInner(Rect drawRect, Paint paint)
 		{
-			throw new NotSupportedException($"{nameof(GetPaintInner)} is not supported for ImageBrush.");
+			throw new NotSupportedException($"{nameof(ApplyToPaintInner)} is not supported for ImageBrush.");
 		}
 
 		internal void ScheduleRefreshIfNeeded(Windows.Foundation.Rect drawRect, Action onImageLoaded)

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
@@ -33,7 +33,7 @@ namespace Windows.UI.Xaml.Media
 			_onImageLoaded?.Invoke();
 		}
 
-		protected override void ApplyToPaintInner(Rect drawRect, Paint paint)
+		private protected override void ApplyToPaintInner(Rect drawRect, Paint paint)
 		{
 			throw new NotSupportedException($"{nameof(ApplyToPaintInner)} is not supported for ImageBrush.");
 		}

--- a/src/Uno.UI/UI/Xaml/Media/RevealBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RevealBrush.Android.cs
@@ -5,7 +5,7 @@ namespace Windows.UI.Xaml.Media;
 
 partial class RevealBrush
 {
-	protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
+	private protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 	{
 		var color = this.IsDependencyPropertySet(FallbackColorProperty) ?
 			GetColorWithOpacity(FallbackColor) :

--- a/src/Uno.UI/UI/Xaml/Media/RevealBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RevealBrush.Android.cs
@@ -5,11 +5,11 @@ namespace Windows.UI.Xaml.Media;
 
 partial class RevealBrush
 {
-	protected override Paint GetPaintInner(Rect destinationRect)
+	protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 	{
 		var color = this.IsDependencyPropertySet(FallbackColorProperty) ?
 			GetColorWithOpacity(FallbackColor) :
 			GetColorWithOpacity(Color);
-		return new Paint() { Color = color, AntiAlias = true };
+		paint.Color = color;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/SolidColorBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/SolidColorBrush.Android.cs
@@ -1,4 +1,5 @@
-﻿using Android.Graphics;
+﻿using System;
+using Android.Graphics;
 using Rect = Windows.Foundation.Rect;
 
 namespace Windows.UI.Xaml.Media
@@ -6,9 +7,9 @@ namespace Windows.UI.Xaml.Media
 	// Android partial for SolidColorBrush
 	public partial class SolidColorBrush : Brush
 	{
-		protected override Paint GetPaintInner(Rect destinationRect)
+		protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 		{
-			return new Paint() { Color = this.ColorWithOpacity, AntiAlias = true };
+			paint.Color = ColorWithOpacity;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/SolidColorBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/SolidColorBrush.Android.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Xaml.Media
 	// Android partial for SolidColorBrush
 	public partial class SolidColorBrush : Brush
 	{
-		protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
+		private protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 		{
 			paint.Color = ColorWithOpacity;
 		}

--- a/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.Android.cs
@@ -9,6 +9,5 @@ public partial class XamlCompositionBrushBase : Brush
 	{
 		// By default fallback to FallbackColor, unless overridden by a derived class.
 		paint.Color = FallbackColorWithOpacity;
-		paint.AntiAlias = true;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.Android.cs
@@ -5,10 +5,10 @@ namespace Windows.UI.Xaml.Media;
 
 public partial class XamlCompositionBrushBase : Brush
 {
-	protected override Paint GetPaintInner(Rect destinationRect)
+	protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 	{
 		// By default fallback to FallbackColor, unless overridden by a derived class.
-		var color = GetColorWithOpacity(FallbackColor);
-		return new Paint() { Color = color, AntiAlias = true };
+		paint.Color = FallbackColorWithOpacity;
+		paint.AntiAlias = true;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/XamlCompositionBrushBase.Android.cs
@@ -5,7 +5,7 @@ namespace Windows.UI.Xaml.Media;
 
 public partial class XamlCompositionBrushBase : Brush
 {
-	protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
+	private protected override void ApplyToPaintInner(Rect destinationRect, Paint paint)
 	{
 		// By default fallback to FallbackColor, unless overridden by a derived class.
 		paint.Color = FallbackColorWithOpacity;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13258, closes #11685

## PR Type

What kind of change does this PR introduce?

- Performance

## What is the current behavior?

`Brush` always creates new `Paint` instances.

## What is the new behavior?

`BorderLayerRenderer` and `Shape` both keep two static instances of `Paint` alive throughout the application lifetime, reusing them whenever needed. Because rendering happens on UI thread, this is not a problem - the approach is similar to the reuse of corner radius arrays.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59d9ca7</samp>

This pull request improves the performance and memory usage of various `Brush` classes and the `Border` control on Android by reusing and modifying `Paint` instances instead of creating new ones. It also refactors some code to follow the project's style guidelines and adds error handling and validation where needed. It updates the `Brush` abstract methods and the corresponding tests to reflect the new API. It affects the files `BorderLayerRenderer.Android.cs`, `AcrylicBrush.Android.cs`, `Brush.Android.cs`, `SolidColorBrush.Android.cs`, `Shape.Android.cs`, `Given_RevealBrush.cs`, `RadialGradientBrush.Android.cs`, `RevealBrush.Android.cs`, `GradientBrush.Android.cs`, `ImageBrush.Android.cs`, and `XamlCompositionBrushBase.Android.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
