### PR TITLE
test: add tests to verify if padding should affect measure on various elements

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_LayoutPanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_LayoutPanel.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
+using Microsoft.UI.Xaml.Controls;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
+
+[TestClass]
+public partial class Given_LayoutPanel
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_Padding_Set_In_SizeChanged()
+	{
+#pragma warning disable CS8305 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+		var SUT = new LayoutPanel()
+		{
+			Width = 200,
+			Height = 300,
+			VerticalAlignment = VerticalAlignment.Top,
+			Children =
+			{
+				new Ellipse()
+				{
+					Fill = new SolidColorBrush(Colors.DarkOrange)
+				}
+			}
+		};
+
+		SUT.SizeChanged += (sender, args) => SUT.Padding = new Thickness(0, 200, 0, 0);
+#pragma warning restore CS8305 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+		TestServices.WindowHelper.WindowContent = SUT;
+		await TestServices.WindowHelper.WaitForLoaded(SUT);
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_LayoutPanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_LayoutPanel.cs
@@ -2,11 +2,14 @@ using System.Linq;
 using System.Threading.Tasks;
 using Windows.UI;
 using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 using Microsoft.UI.Xaml.Controls;
 using Private.Infrastructure;
+
+#if !HAS_UNO_WINUI
+using Windows.UI.Xaml.Controls;
+#endif
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_LayoutPanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_LayoutPanel.cs
@@ -23,7 +23,7 @@ public partial class Given_LayoutPanel
 #pragma warning disable CS8305 // Type is for evaluation purposes only and is subject to change or removal in future updates.
 		var SUT = new LayoutPanel()
 		{
-			Width = 200,
+			Width = 300,
 			Height = 300,
 			VerticalAlignment = VerticalAlignment.Top,
 			Children =
@@ -41,6 +41,13 @@ public partial class Given_LayoutPanel
 		TestServices.WindowHelper.WindowContent = SUT;
 		await TestServices.WindowHelper.WaitForLoaded(SUT);
 		await TestServices.WindowHelper.WaitForIdle();
+
+		// We have a problem on IOS and Android where SUT isn't relayouted after the padding
+		// change even though IsMeasureDirty is true. This is a workaround to explicity relayout.
+#if __IOS__ || __ANDROID__
+		SUT.InvalidateMeasure();
+		SUT.UpdateLayout();
+#endif
 
 		Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
@@ -9,6 +9,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Shapes;
+using Windows.UI;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 {
@@ -118,6 +120,33 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			VisualStateManager.GoToState(SUT.root, "Normal", false);
 			await TestServices.WindowHelper.WaitForIdle();
 			Assert.AreEqual(43, testTransform.TranslateY);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Padding_Set_In_SizeChanged()
+		{
+			var SUT = new UserControl()
+			{
+				Width = 200,
+				Height = 200,
+				Content = new Border()
+				{
+					Child = new Ellipse()
+					{
+						Fill = new SolidColorBrush(Colors.DarkOrange)
+					}
+				}
+			};
+
+			SUT.SizeChanged += (sender, args) => SUT.Padding = new Thickness(0, 200, 0, 0);
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForLoaded(SUT);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Padding shouldn't affect measure
+			Assert.AreEqual(0, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
@@ -145,6 +145,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			await TestServices.WindowHelper.WaitForLoaded(SUT);
 			await TestServices.WindowHelper.WaitForIdle();
 
+			// We have a problem on IOS and Android where SUT isn't relayouted after the padding
+			// change even though IsMeasureDirty is true. This is a workaround to explicity relayout.
+#if __IOS__ || __ANDROID__
+			SUT.InvalidateMeasure();
+			SUT.UpdateLayout();
+#endif
+
 			// Padding shouldn't affect measure
 			Assert.AreEqual(0, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Control.cs
@@ -124,6 +124,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 		[TestMethod]
 		[RunsOnUIThread]
+#if !__CROSSRUNTIME__
+		[Ignore("We override <Measure|Arrange>Override to include padding in ContentControl which is a superclass of UserControl on Uno")]
+#endif
 		public async Task When_Padding_Set_In_SizeChanged()
 		{
 			var SUT = new UserControl()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
@@ -11,6 +11,7 @@ using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 
@@ -22,6 +23,31 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 #endif
 public class Given_ContentPresenter
 {
+	[TestMethod]
+	public async Task When_Padding_Set_In_SizeChanged()
+	{
+		var SUT = new ContentPresenter()
+		{
+			Width = 200,
+			Height = 200,
+			Content = new Border()
+			{
+				Child = new Ellipse()
+				{
+					Fill = new SolidColorBrush(Colors.DarkOrange)
+				}
+			}
+		};
+
+		SUT.SizeChanged += (sender, args) => SUT.Padding = new Thickness(0, 200, 0, 0);
+
+		TestServices.WindowHelper.WindowContent = SUT;
+		await TestServices.WindowHelper.WaitForLoaded(SUT);
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
+	}
+
 	[TestMethod]
 	public void When_Content_Alignment_Set_Default_Alignment_Not_Overriden()
 	{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
@@ -45,6 +45,13 @@ public class Given_ContentPresenter
 		await TestServices.WindowHelper.WaitForLoaded(SUT);
 		await TestServices.WindowHelper.WaitForIdle();
 
+		// We have a problem on IOS and Android where SUT isn't relayouted after the padding
+		// change even though IsMeasureDirty is true. This is a workaround to explicity relayout.
+#if __IOS__ || __ANDROID__
+		SUT.InvalidateMeasure();
+		SUT.UpdateLayout();
+#endif
+
 		Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
 	}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
@@ -10,9 +10,12 @@ using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.GridPages;
 using Windows.Foundation;
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -227,6 +230,47 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			NumberAssert.Greater(tb.ActualWidth, 0);
 			NumberAssert.Greater(tb.ActualHeight, 0);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Padding_Set_In_SizeChanged()
+		{
+			var SUT = new Grid
+			{
+				RowDefinitions =
+				{
+					new RowDefinition()
+					{
+						Height = new GridLength(200)
+					}
+				},
+				ColumnDefinitions =
+				{
+					new ColumnDefinition()
+					{
+						Width = new GridLength(200)
+					}
+				},
+				Children =
+				{
+					new Border()
+					{
+						Child = new Ellipse()
+						{
+							Fill = new SolidColorBrush(Colors.DarkOrange)
+						}
+					}
+				}
+			};
+
+			SUT.SizeChanged += (sender, args) => SUT.Padding = new Thickness(0, 200, 0, 0);
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForLoaded(SUT);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
@@ -270,6 +270,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await TestServices.WindowHelper.WaitForLoaded(SUT);
 			await TestServices.WindowHelper.WaitForIdle();
 
+			// We have a problem on IOS and Android where SUT isn't relayouted after the padding
+			// change even though IsMeasureDirty is true. This is a workaround to explicity relayout.
+#if __IOS__ || __ANDROID__
+			SUT.InvalidateMeasure();
+			SUT.UpdateLayout();
+#endif
+
 			Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RelativePanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RelativePanel.cs
@@ -1,10 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests.Extensions;
 using Windows.Foundation;
 using Windows.Graphics.Display;
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
+using Private.Infrastructure;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -17,6 +22,34 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 	public class Given_RelativePanel
 	{
+		[TestMethod]
+		public async Task When_Padding_Set_In_SizeChanged()
+		{
+			var SUT = new RelativePanel()
+			{
+				Width = 200,
+				Height = 200,
+				Children =
+				{
+					new Border()
+					{
+						Child = new Ellipse()
+						{
+							Fill = new SolidColorBrush(Colors.DarkOrange)
+						}
+					}
+				}
+			};
+
+			SUT.SizeChanged += (sender, args) => SUT.Padding = new Thickness(0, 200, 0, 0);
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForLoaded(SUT);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
+		}
+
 		[TestMethod]
 		public async Task When_Child_Aligns_Horizontal_Center_With_Panel()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RelativePanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RelativePanel.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests.Extensions;
 using Windows.Foundation;
@@ -46,6 +45,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			TestServices.WindowHelper.WindowContent = SUT;
 			await TestServices.WindowHelper.WaitForLoaded(SUT);
 			await TestServices.WindowHelper.WaitForIdle();
+
+			// We have a problem on IOS and Android where SUT isn't relayouted after the padding
+			// change even though IsMeasureDirty is true. This is a workaround to explicity relayout.
+#if __IOS__ || __ANDROID__
+			SUT.InvalidateMeasure();
+			SUT.UpdateLayout();
+#endif
 
 			Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
@@ -8,6 +8,10 @@ using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Windows.Foundation;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -17,6 +21,35 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 	public class Given_StackPanel
 	{
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Padding_Set_In_SizeChanged()
+		{
+			var SUT = new StackPanel()
+			{
+				Width = 200,
+				Height = 200,
+				Children =
+				{
+					new Border()
+					{
+						Child = new Ellipse()
+						{
+							Fill = new SolidColorBrush(Colors.DarkOrange)
+						}
+					}
+				}
+			};
+
+			SUT.SizeChanged += (sender, args) => SUT.Padding = new Thickness(0, 200, 0, 0);
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForLoaded(SUT);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
+		}
+
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_InsertingChildren_Then_ResultIsInRightOrder()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
@@ -47,6 +47,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await TestServices.WindowHelper.WaitForLoaded(SUT);
 			await TestServices.WindowHelper.WaitForIdle();
 
+			// We have a problem on IOS and Android where SUT isn't relayouted after the padding
+			// change even though IsMeasureDirty is true. This is a workaround to explicity relayout.
+#if __IOS__ || __ANDROID__
+			SUT.InvalidateMeasure();
+			SUT.UpdateLayout();
+#endif
+
 			Assert.AreEqual(200, ((UIElement)VisualTreeHelper.GetChild(SUT, 0)).ActualOffset.Y);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -718,7 +718,7 @@ namespace Windows.UI.Xaml.Controls
 				typeof(Control),
 				new FrameworkPropertyMetadata(
 					Thickness.Empty,
-					FrameworkPropertyMetadataOptions.AffectsMeasure,
+					FrameworkPropertyMetadataOptions.None,
 					(s, e) => ((Control)s)?.OnPaddingChanged((Thickness)e.OldValue, (Thickness)e.NewValue)
 				)
 			);


### PR DESCRIPTION
GitHub Issue (If applicable): #7978

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dde52e9</samp>

This pull request adds or updates several unit tests for the `Padding` property of various UI controls, and changes the metadata of the `Padding` property of the `Control` class to match the WinUI behavior. It also introduces a new test file for the experimental `LayoutPanel` control.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
