### PR TITLE
fix(ToggleSwitch): Don't force end position when ToggleSwitch is unloaded

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToggleSwitch.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToggleSwitch.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_ToggleSwitch
+{
+	[TestMethod]
+	public async Task Knob_Translation()
+	{
+		var toggleSwitch = new ToggleSwitch() { IsOn = true };
+		WindowHelper.WindowContent = toggleSwitch;
+		await WindowHelper.WaitForLoaded(toggleSwitch);
+		var minKnobTranslation = (double)typeof(ToggleSwitch).GetField("_minKnobTranslation", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(toggleSwitch);
+		var maxKnobTranslation = (double)typeof(ToggleSwitch).GetField("_maxKnobTranslation", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(toggleSwitch);
+		Assert.AreEqual(0, minKnobTranslation);
+		Assert.AreEqual(24, maxKnobTranslation);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToggleSwitch.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToggleSwitch.cs
@@ -15,6 +15,7 @@ public class Given_ToggleSwitch
 		var toggleSwitch = new ToggleSwitch() { IsOn = true };
 		WindowHelper.WindowContent = toggleSwitch;
 		await WindowHelper.WaitForLoaded(toggleSwitch);
+		await WindowHelper.WaitForIdle();
 		var minKnobTranslation = (double)typeof(ToggleSwitch).GetField("_minKnobTranslation", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(toggleSwitch);
 		var maxKnobTranslation = (double)typeof(ToggleSwitch).GetField("_maxKnobTranslation", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(toggleSwitch);
 		Assert.AreEqual(0, minKnobTranslation);

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics;
 using DirectUI;
 using Uno.Disposables;
 using Uno.UI.Xaml.Core;
@@ -107,10 +108,15 @@ namespace Windows.UI.Xaml.Controls
 				isOn = IsOn;
 				GoToState(useTransitions, isOn ? "On" : "Off");
 				GoToState(useTransitions, isOn ? "OnContent" : "OffContent");
+
 				// TODO Uno specific: We must force the knob to position, because
 				// we don't yet support the transitions which do this automatically
 				// in XAML template.
-				ForceSwitchKnobEndPosition();
+				if (IsLoaded)
+				{
+					Debug.Assert(GetMaxOffset() > 0);
+					ForceSwitchKnobEndPosition();
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
@@ -5,7 +5,6 @@
 #nullable enable
 
 using System;
-using System.Diagnostics;
 using DirectUI;
 using Uno.Disposables;
 using Uno.UI.Xaml.Core;
@@ -114,7 +113,7 @@ namespace Windows.UI.Xaml.Controls
 				// in XAML template.
 				if (IsLoaded)
 				{
-					Debug.Assert(GetMaxOffset() > 0);
+					global::System.Diagnostics.Debug.Assert(GetMaxOffset() > 0);
 					ForceSwitchKnobEndPosition();
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/unoplatform/uno/issues/12643

I had a previous fix for this, but it's either that some other changes have competed with #12643 or that my PR fixed the issue in a certain situation but not all scenarios. I can't recall exactly the code sample I was testing my PR against. Anyway, this is a small fix to ensure we don't set the translation incorrectly when unloaded.

Setting it incorrectly when unloaded will later affect the values set for the minimum and maximum knob translation.

I'm not sure how to go about testing this.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ad2ca2</samp>

Fixed potential errors in the `ToggleSwitch` control by adding validation and initialization logic. Modified `ToggleSwitch.mux.cs` to prevent invalid knob positions and check for null values.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
