### PR TITLE
fix: Fix MenuFlyoutSubItem placement on Android on first open

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1642,6 +1642,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyoutSubItem_Placement.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\PasswordBoxTests\PasswordBox_AutoFill.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5793,6 +5797,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Theming.xaml.cs">
       <DependentUpon>ListView_Theming.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyoutSubItem_Placement.xaml.cs">
+      <DependentUpon>MenuFlyoutSubItem_Placement.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Keyboard_Navigation.xaml.cs">
       <DependentUpon>TextBox_Keyboard_Navigation.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutSubItem_Placement.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutSubItem_Placement.xaml
@@ -1,0 +1,29 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests.MenuFlyoutSubItem_Placement"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<Button HorizontalAlignment="Right" Content="Open flyout">
+			<Button.Flyout>
+				<MenuFlyout>
+					<MenuFlyoutSubItem Text="Open submenu">
+						<MenuFlyoutSubItem.Items>
+							<MenuFlyoutItem Text="First item" />
+							<MenuFlyoutItem Text="Second item" />
+							<MenuFlyoutItem Text="Third item" />
+						</MenuFlyoutSubItem.Items>
+					</MenuFlyoutSubItem>
+
+					<MenuFlyoutItem Text="Second item" />
+					<MenuFlyoutItem Text="Third item" />
+				</MenuFlyout>
+			</Button.Flyout>
+		</Button>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutSubItem_Placement.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MenuFlyoutTests/MenuFlyoutSubItem_Placement.xaml.cs
@@ -1,0 +1,13 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.MenuFlyoutTests;
+
+[Sample("Flyouts")]
+public sealed partial class MenuFlyoutSubItem_Placement : Page
+{
+	public MenuFlyoutSubItem_Placement()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -324,6 +325,59 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				{
 					flyout.Hide();
 				}
+			}
+		}
+
+		[TestMethod]
+		public async Task When_MenuFlyoutSubItem_Should_Have_Correct_Placement()
+		{
+			var button = new Button()
+			{
+				HorizontalAlignment = HorizontalAlignment.Right,
+				Content = "Open flyout",
+				Flyout = new MenuFlyout()
+				{
+					Items =
+					{
+						new MenuFlyoutSubItem()
+						{
+							Text = "Open submenu",
+							Items =
+							{
+								new MenuFlyoutSubItem() { Text = "First item" },
+							},
+						},
+					}
+				}
+			};
+
+			WindowHelper.WindowContent = button;
+			await WindowHelper.WaitForLoaded(button);
+			button.AutomationPeerClick();
+
+			var flyout = (MenuFlyout)button.Flyout;
+			var subItem = (MenuFlyoutSubItem)flyout.Items.Single();
+			try
+			{
+				subItem.Open();
+
+				// The "Open submenu" opens at the very right of the screen.
+				// So, the "First item" sub item should open on its left.
+				// We assert that the left of "Open sub menu" is almost the same as the right of "First item"
+
+				await WindowHelper.WaitForIdle();
+
+				var subItemBounds = subItem.GetAbsoluteBounds();
+				var subSubItemBounds = ((MenuFlyoutSubItem)subItem.Items.Single()).GetAbsoluteBounds();
+
+				var difference = subItemBounds.X - subSubItemBounds.Right;
+				Assert.IsTrue(Math.Abs(difference) <= 3);
+
+			}
+			finally
+			{
+				subItem.Close();
+				flyout.Close();
 			}
 		}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -329,6 +329,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[RequiresFullWindow]
 		public async Task When_MenuFlyoutSubItem_Should_Have_Correct_Placement()
 		{
 			var button = new Button()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -332,6 +332,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RequiresFullWindow]
 		public async Task When_MenuFlyoutSubItem_Should_Have_Correct_Placement()
 		{
+			if (WindowHelper.IsXamlIsland)
+			{
+				return;
+			}
+
 			var button = new Button()
 			{
 				HorizontalAlignment = HorizontalAlignment.Right,

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -330,6 +330,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RequiresFullWindow]
+#if __IOS__
+		[Ignore("https://github.com/unoplatform/uno/issues/13314")]
+#endif
 		public async Task When_MenuFlyoutSubItem_Should_Have_Correct_Placement()
 		{
 			if (WindowHelper.IsXamlIsland)

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutSubItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyoutSubItem.cs
@@ -535,8 +535,7 @@ namespace Windows.UI.Xaml.Controls
 
 		}
 
-#if false
-		void Open()
+		internal void Open()
 		{
 #if MFSI_DEBUG
 			IGNOREHR(DebugTrace(XCP_TRACE_OUTPUT_MSG /*traceType*/, "MFSI[0x%p]: Open.", this));
@@ -545,7 +544,7 @@ namespace Windows.UI.Xaml.Controls
 			m_menuHelper.OpenSubMenu();
 		}
 
-		void Close()
+		internal void Close()
 		{
 #if MFSI_DEBUG
 			IGNOREHR(DebugTrace(XCP_TRACE_OUTPUT_MSG /*traceType*/, "MFSI[0x%p]: Close.", this));
@@ -554,7 +553,6 @@ namespace Windows.UI.Xaml.Controls
 			m_menuHelper.CloseSubMenu();
 
 		}
-#endif
 
 		private protected override void ChangeVisualState(bool bUseTransitions)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -181,6 +181,23 @@ internal partial class PopupPanel : Panel
 
 			ArrangeElement(child, finalFrame);
 
+			var updatedFinalFrame = new Rect(
+				anchorLocation.X + (float)Popup.HorizontalOffset,
+				anchorLocation.Y + (float)Popup.VerticalOffset,
+				size.Width,
+				size.Height);
+
+			if (updatedFinalFrame != finalFrame)
+			{
+				// Workraround:
+				// The HorizontalOffset is updated to the correct value in CascadingMenuHelper.OnPresenterSizeChanged
+				// This update appears to be happening *during* ArrangeElement which was already passed wrong finalFrame.
+				// We re-arrange with the new updated finalFrame.
+				// Note: This might be a lifecycle issue, so this workaround needs to be revised in the future and deleted if possible.
+				// See MenuFlyoutSubItem_Placement sample.
+				ArrangeElement(child, updatedFinalFrame);
+			}
+
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{
 				this.Log().LogDebug($"Arranged PopupPanel #={GetHashCode()} DC={Popup.DataContext} child={child} popupLocation={anchorLocation} offset={Popup.HorizontalOffset},{Popup.VerticalOffset} finalSize={finalSize} childFrame={finalFrame}");


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12771

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

**DRAFT for now until I write a test, but the fix itself is ready for review**

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dcd55ff</samp>

This pull request adds a UI test for the `MenuFlyoutSubItem` control and a workaround for a layout issue in the `PopupPanel` class. The test verifies that the subitem menu items are displayed correctly, and the workaround adjusts the popup element position when the horizontal offset changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
