### PR TITLE
fix: PersonPicture image stretch UniformToFill from tiled None on Skia.GTK

### DIFF
--- a/src/Uno.UI.FluentTheme.v1/Resources/Version1/PriorityDefault/PersonPicture.xaml
+++ b/src/Uno.UI.FluentTheme.v1/Resources/Version1/PriorityDefault/PersonPicture.xaml
@@ -1,12 +1,13 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:wasm="http://uno.ui/wasm"
+    xmlns:netstdref="http://uno.ui/netstdref"
+    xmlns:not_netstdref="http://uno.ui/not_netstdref"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
-    mc:Ignorable="d wasm">
+    mc:Ignorable="d netstdref not_netstdref">
 
     <Style TargetType="local:PersonPicture" BasedOn="{StaticResource DefaultPersonPictureStyle}" />
 
@@ -27,10 +28,10 @@
                                 <!-- Visual State when a Photo is available for display -->
                                 <VisualState x:Name="Photo">
                                     <VisualState.Setters>
-                                        <Setter Target="PersonPictureEllipse.Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush}"/>
+                                        <not_netstdref:Setter Target="PersonPictureEllipse.Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush}"/>
 
-                                        <!-- ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 -->
-                                        <wasm:Setter Target="PersonPictureImage.Source" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush.ImageSource}"/>
+                                        <!-- ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 and https://github.com/unoplatform/uno/issues/7815 -->
+                                        <netstdref:Setter Target="PersonPictureImage.Source" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush.ImageSource}"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <!-- Visual State when no Photo is available (but there are initials).-->
@@ -92,16 +93,16 @@
                             IsTextScaleFactorEnabled="False"
                             Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualInitials}" />
 
-                        <Ellipse
+                        <not_netstdref:Ellipse
                             x:Name="PersonPictureEllipse"
                             x:DeferLoadStrategy="Lazy"
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
                             FlowDirection="LeftToRight">
-                        </Ellipse>
+                        </not_netstdref:Ellipse>
 
-                                        <!-- ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 -->
-                        <wasm:Border
+                        <!-- ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 and https://github.com/unoplatform/uno/issues/7815 -->
+                        <netstdref:Border
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
                             CornerRadius="{TemplateBinding Width}"
@@ -110,7 +111,7 @@
                                    Stretch="UniformToFill"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center" />
-                        </wasm:Border>
+                        </netstdref:Border>
 
                         <Grid
                             x:Name="BadgeGrid"

--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/PersonPicture.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/PersonPicture.xaml
@@ -3,10 +3,11 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
-    xmlns:wasm="http://uno.ui/wasm"
+    xmlns:netstdref="http://uno.ui/netstdref"
+    xmlns:not_netstdref="http://uno.ui/not_netstdref"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d wasm">
+    mc:Ignorable="d netstdref not_netstdref">
 
     <Style TargetType="local:PersonPicture" BasedOn="{StaticResource DefaultPersonPictureStyle}" />
 
@@ -27,10 +28,10 @@
                                 <!-- Visual State when a Photo is available for display -->
                                 <VisualState x:Name="Photo">
                                     <VisualState.Setters>
-                                        <Setter Target="PersonPictureEllipse.Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush}"/>
+                                        <not_netstdref:Setter Target="PersonPictureEllipse.Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush}"/>
 
-                                        <!-- UNO WORKAROUND: ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 -->
-                                        <wasm:Setter Target="PersonPictureImage.Source"
+                                        <!-- UNO WORKAROUND: ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 and https://github.com/unoplatform/uno/issues/7815 -->
+                                        <netstdref:Setter Target="PersonPictureImage.Source"
 														 Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush.ImageSource}" />
                                     </VisualState.Setters>
                                 </VisualState>
@@ -93,16 +94,16 @@
                             IsTextScaleFactorEnabled="False"
                             Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualInitials}" />
 
-                        <Ellipse
+                        <not_netstdref:Ellipse
                             x:Name="PersonPictureEllipse"
                             x:DeferLoadStrategy="Lazy"
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
                             FlowDirection="LeftToRight">
-                        </Ellipse>
+                        </not_netstdref:Ellipse>
 
-                        <!-- UNO WORKAROUND: ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 -->
-                        <wasm:Border Width="{TemplateBinding Width}"
+                        <!-- UNO WORKAROUND: ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 and https://github.com/unoplatform/uno/issues/7815 -->
+                        <netstdref:Border Width="{TemplateBinding Width}"
 										 Height="{TemplateBinding Height}"
 										 CornerRadius="{TemplateBinding Width}"
 										 FlowDirection="LeftToRight">
@@ -110,7 +111,7 @@
 									   Stretch="UniformToFill"
 									   HorizontalAlignment="Center"
 									   VerticalAlignment="Center" />
-                        </wasm:Border>
+                        </netstdref:Border>
 
                         <!-- UNO WORKAROUND: Removed Margin="{ThemeResource PersonPictureBadgeGridMargin}". Clipping issue with negative margin: #-->
                         <Grid

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PersonPicture/PersonPicture.xaml
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PersonPicture/PersonPicture.xaml
@@ -1,12 +1,13 @@
-﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
 <ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:wasm="http://uno.ui/wasm"
+    xmlns:netstdref="http://uno.ui/netstdref"
+    xmlns:not_netstdref="http://uno.ui/not_netstdref"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="using:Microsoft.UI.Xaml.Controls"
-    mc:Ignorable="d wasm">
+    mc:Ignorable="d netstdref not_netstdref">
 
     <Style TargetType="local:PersonPicture" BasedOn="{StaticResource DefaultPersonPictureStyle}" />
 
@@ -27,10 +28,10 @@
                                 <!-- Visual State when a Photo is available for display -->
                                 <VisualState x:Name="Photo">
                                     <VisualState.Setters>
-                                        <Setter Target="PersonPictureEllipse.Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush}"/>
+                                        <not_netstdref:Setter Target="PersonPictureEllipse.Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush}"/>
 
-                                        <!-- ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 -->
-                                        <wasm:Setter Target="PersonPictureImage.Source" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush.ImageSource}"/>
+                                        <!-- ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 and https://github.com/unoplatform/uno/issues/7815 -->
+                                        <netstdref:Setter Target="PersonPictureImage.Source" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualImageBrush.ImageSource}"/>
                                     </VisualState.Setters>
                                 </VisualState>
                                 <!-- Visual State when no Photo is available (but there are initials).-->
@@ -92,16 +93,16 @@
                             IsTextScaleFactorEnabled="False"
                             Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.ActualInitials}" />
 
-                        <Ellipse
+                        <not_netstdref:Ellipse
                             x:Name="PersonPictureEllipse"
                             x:DeferLoadStrategy="Lazy"
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
                             FlowDirection="LeftToRight">
-                        </Ellipse>
+                        </not_netstdref:Ellipse>
 
-                        <!-- ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 -->
-                        <wasm:Border
+                        <!-- ImageBrush is not stretching properly https://github.com/unoplatform/uno/issues/4951 and https://github.com/unoplatform/uno/issues/7815 -->
+                        <netstdref:Border
                             Width="{TemplateBinding Width}"
                             Height="{TemplateBinding Height}"
                             CornerRadius="{TemplateBinding Width}"
@@ -110,7 +111,7 @@
                                    Stretch="UniformToFill"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center" />
-                        </wasm:Border>
+                        </netstdref:Border>
 
                         <Grid
                             x:Name="BadgeGrid"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7815 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cddb93d</samp>

This pull request improves the cross-platform compatibility of the `PersonPicture` control by using conditional XML namespaces to apply different styles and elements for .NET Standard and non-.NET Standard platforms. It affects the Fluent Theme version 1 and 2 resource dictionaries, as well as the default style of the control in `PersonPicture.xaml`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
