### PR TITLE
fix: Fix animation setters not executed if a transition contains RepositionThemeAnimation

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/RepositionThemeAnimation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/RepositionThemeAnimation.cs
@@ -3,7 +3,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Media.Animation
 {
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false || false || false || false || false || false || false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class RepositionThemeAnimation : global::Windows.UI.Xaml.Media.Animation.Timeline

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.cs
@@ -201,35 +201,6 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		public ToggleSwitchTemplateSettings TemplateSettings { get; private set; }
 
-		private double GetEndAbsoluteOffset()
-		{
-			var minOffset = 0;
-			var maxOffset = GetMaxOffset();
-			var startOffset = IsOn ? maxOffset : 0;
-			var absoluteOffset = startOffset;
-			absoluteOffset = Math.Max(minOffset, absoluteOffset);
-			absoluteOffset = Math.Min(maxOffset, absoluteOffset);
-			return absoluteOffset;
-		}
-
-		private double GetMaxOffset()
-		{
-			if (_tpKnobBounds == null || _tpKnob == null)
-			{
-				return 0;
-			}
-
-			return _tpKnobBounds.ActualWidth - _tpKnob.ActualWidth;
-		}
-
-		private void ForceSwitchKnobEndPosition()
-		{
-			if (_spKnobTransform != null)
-			{
-				_spKnobTransform.X = GetEndAbsoluteOffset();
-			}
-		}
-
 		public void OnTemplateRecycled()
 		{
 			try

--- a/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToggleSwitch/ToggleSwitch.mux.cs
@@ -107,15 +107,6 @@ namespace Windows.UI.Xaml.Controls
 				isOn = IsOn;
 				GoToState(useTransitions, isOn ? "On" : "Off");
 				GoToState(useTransitions, isOn ? "OnContent" : "OffContent");
-
-				// TODO Uno specific: We must force the knob to position, because
-				// we don't yet support the transitions which do this automatically
-				// in XAML template.
-				if (IsLoaded)
-				{
-					global::System.Diagnostics.Debug.Assert(GetMaxOffset() > 0);
-					ForceSwitchKnobEndPosition();
-				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/RepositionThemeAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/RepositionThemeAnimation.cs
@@ -1,0 +1,14 @@
+namespace Windows.UI.Xaml.Media.Animation;
+
+#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+[global::Uno.NotImplemented]
+#endif
+public partial class RepositionThemeAnimation : Timeline, ITimeline
+{
+	// RepositionThemeAnimation is currently not implemented.
+	// But we need to call OnCompleted() so that whenever RepositionThemeAnimation is
+	// included in a Storyboard, we want to allow the Storyboard to fire Completed event
+	// This is important especially when RepositionThemeAnimation is part of a transition Storyboard.
+	// Visual state setters aren't executed unless the transition is completed.
+	void ITimeline.Begin() => OnCompleted();
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13303

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
