### PR TITLE
fix: `Resuming` should run only after `Suspend`

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
@@ -142,4 +142,17 @@ partial class App
 		}
 #endif
 	}
+
+	private void AssertIssue10313ResumingAfterActivate()
+	{
+		if (!_wasActivated)
+		{
+			Assert.Fail("Resuming should never be triggered before initial Window activation.");
+		}
+
+		if (!_isSuspended)
+		{
+			Assert.Fail("Resuming should never be triggered unless the app is suspended.");
+		}
+	}
 }

--- a/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
@@ -1,0 +1,145 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.ApplicationModel;
+
+namespace SamplesApp;
+
+partial class App
+{
+	/// <summary>
+	/// Assert that ApplicationData.Current.[LocalFolder|RoamingFolder] is usable in the constructor of App.xaml.cs on all platforms.
+	/// </summary>
+	/// <seealso href="https://github.com/unoplatform/uno/issues/1741"/>
+	public void AssertIssue1790ApplicationSettingsUsable()
+	{
+		void AssertIsUsable(Windows.Storage.ApplicationDataContainer container)
+		{
+			const string issue1790 = nameof(issue1790);
+
+			container.Values.Remove(issue1790);
+			container.Values.Add(issue1790, "ApplicationData.Current.[LocalFolder|RoamingFolder] is usable in the constructor of App.xaml.cs on this platform.");
+
+			Assert.IsTrue(container.Values.ContainsKey(issue1790));
+		}
+
+		AssertIsUsable(Windows.Storage.ApplicationData.Current.LocalSettings);
+		AssertIsUsable(Windows.Storage.ApplicationData.Current.RoamingSettings);
+	}
+
+	/// <summary>
+	/// Assert that the App DisplayName was found in manifest and loaded from resources
+	/// </summary>
+	public void AssertIssue12936()
+	{
+		//On Wasm the DisplayName is currently empty, as it is not being load from manifest
+#if !__WASM__
+		var displayName = Package.Current.DisplayName;
+
+		Assert.IsFalse(string.IsNullOrEmpty(displayName), "DisplayName is empty.");
+
+		Assert.IsFalse(displayName.Contains("ms-resource:"), $"'{displayName}' wasn't found in resources.");
+#endif
+	}
+
+	/// <summary>
+	/// Assert that Application Title is getting its value from manifest
+	/// </summary>
+	public void AssertIssue8356()
+	{
+#if __SKIA__
+		Uno.UI.RuntimeTests.Tests.Windows_UI_ViewManagement_ApplicationView.Given_ApplicationView.StartupTitle = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Title;
+#endif
+	}
+
+	/// <summary>
+	/// Assert that the native overlay layer for Skia targets is initialized in time for UI to appear.
+	/// </summary>
+	public void AssertIssue8641NativeOverlayInitialized()
+	{
+#if __SKIA__
+		if (Uno.UI.Xaml.Core.CoreServices.Instance.InitializationType == Uno.UI.Xaml.Core.InitializationType.IslandsOnly)
+		{
+			return;
+		}
+		// Temporarily add a TextBox to the current page's content to verify native overlay is available
+		if (Windows.UI.Xaml.Window?.Content is not Frame rootFrame)
+		{
+			throw new InvalidOperationException("Native overlay verification executed too early");
+		}
+
+		var textBox = new TextBox();
+		textBox.XamlRoot = rootFrame.XamlRoot;
+		var textBoxView = new TextBoxView(textBox);
+		ApiExtensibility.CreateInstance<IOverlayTextBoxViewExtension>(textBoxView, out var textBoxViewExtension);
+		Assert.IsNotNull(textBoxViewExtension);
+		Assert.IsTrue(textBoxViewExtension!.IsOverlayLayerInitialized(rootFrame.XamlRoot));
+#endif
+	}
+
+	public void AssertInitialWindowSize()
+	{
+#if !__SKIA__ // Will be fixed as part of #8341
+		Assert.IsTrue(global::Windows.UI.Xaml.Window.Current.Bounds.Width > 0);
+		Assert.IsTrue(global::Windows.UI.Xaml.Window.Current.Bounds.Height > 0);
+#endif
+	}
+
+	/// <summary>
+	/// Verifies that ApplicationData are available immediately after the application class is created
+	/// and the data are stored in proper application specific lcoations.
+	/// </summary>
+	public void AssertApplicationData()
+	{
+#if __SKIA__
+		var appName = Package.Current.Id.Name;
+		var publisher = string.IsNullOrEmpty(Package.Current.Id.Publisher) ? "" : "Uno Platform";
+
+		AssertForFolder(ApplicationData.Current.LocalFolder);
+		AssertForFolder(ApplicationData.Current.RoamingFolder);
+		AssertForFolder(ApplicationData.Current.TemporaryFolder);
+		AssertForFolder(ApplicationData.Current.LocalCacheFolder);
+		AssertSettings(ApplicationData.Current.LocalSettings);
+		AssertSettings(ApplicationData.Current.RoamingSettings);
+
+		void AssertForFolder(StorageFolder folder)
+		{
+			AssertContainsIdProps(folder);
+			AssertCanCreateFile(folder);
+		}
+
+		void AssertSettings(ApplicationDataContainer container)
+		{
+			var key = Guid.NewGuid().ToString();
+			var value = Guid.NewGuid().ToString();
+
+			container.Values[key] = value;
+			Assert.IsTrue(container.Values.ContainsKey(key));
+			Assert.AreEqual(value, container.Values[key]);
+			container.Values.Remove(key);
+		}
+
+		void AssertContainsIdProps(StorageFolder folder)
+		{
+			Assert.IsTrue(folder.Path.Contains(appName, StringComparison.Ordinal));
+			Assert.IsTrue(folder.Path.Contains(publisher, StringComparison.Ordinal));
+		}
+
+		void AssertCanCreateFile(StorageFolder folder)
+		{
+			var filename = Guid.NewGuid() + ".txt";
+			var path = Path.Combine(folder.Path, filename);
+			var expectedContent = "Test";
+			try
+			{
+				File.WriteAllText(path, expectedContent);
+				var actualContent = File.ReadAllText(path);
+
+				Assert.AreEqual(expectedContent, actualContent);
+			}
+			finally
+			{
+				File.Delete(path);
+			}
+		}
+#endif
+	}
+}

--- a/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
@@ -1,5 +1,15 @@
+using System;
+using System.IO;
+using Windows.Storage;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.ApplicationModel;
+
+#if __SKIA__
+using Uno.Foundation.Extensibility;
+using Uno.UI.Xaml.Controls.Extensions;
+#endif
 
 namespace SamplesApp;
 
@@ -61,7 +71,7 @@ partial class App
 			return;
 		}
 		// Temporarily add a TextBox to the current page's content to verify native overlay is available
-		if (Windows.UI.Xaml.Window?.Content is not Frame rootFrame)
+		if (Windows.UI.Xaml.Window.Current?.Content is not Frame rootFrame)
 		{
 			throw new InvalidOperationException("Native overlay verification executed too early");
 		}

--- a/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Uno.Logging;
 using Windows.UI.Core;
 
 namespace SamplesApp;
@@ -176,7 +177,7 @@ partial class App
 		}
 		catch (Exception ex)
 		{
-			_log?.LogError($"Could not navigate to initial sample - {ex}");
+			_log?.Error($"Could not navigate to initial sample - {ex}");
 		}
 		return false;
 	}

--- a/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
@@ -5,8 +5,11 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Uno.Logging;
 using Windows.UI.Core;
+
+#if !HAS_UNO
+using Uno.Logging;
+#endif
 
 namespace SamplesApp;
 

--- a/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
@@ -73,8 +73,8 @@ partial class App
 #endif
 
 #if __ANDROID__
-							Windows.ApplicationModel.Core.CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = false;
-							Uno.UI.FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay = TimeSpan.Zero;
+						Windows.ApplicationModel.Core.CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = false;
+						Uno.UI.FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay = TimeSpan.Zero;
 #endif
 
 #if HAS_UNO
@@ -176,7 +176,7 @@ partial class App
 		}
 		catch (Exception ex)
 		{
-			_log?.Error($"Could not navigate to initial sample - {ex}");
+			_log?.LogError($"Could not navigate to initial sample - {ex}");
 		}
 		return false;
 	}

--- a/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.UI.Core;
@@ -127,15 +128,15 @@ partial class App
 
 		if (!string.IsNullOrEmpty(screenshotsPath))
 		{
-			if (Windows.UI.Xaml.Window is null)
+			if (Windows.UI.Xaml.Window.Current is null)
 			{
 				throw new InvalidOperationException("Main window must be initialized before running screenshot tests");
 			}
 
-			var n = Windows.UI.Xaml.Window.Dispatcher.RunIdleAsync(
+			var n = Windows.UI.Xaml.Window.Current.Dispatcher.RunIdleAsync(
 				_ =>
 				{
-					var n = Windows.UI.Xaml.Window.Dispatcher.RunAsync(
+					var n = Windows.UI.Xaml.Window.Current.Dispatcher.RunAsync(
 						CoreDispatcherPriority.Normal,
 						async () =>
 						{

--- a/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
@@ -1,0 +1,193 @@
+#nullable enable
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.UI.Core;
+
+namespace SamplesApp;
+
+partial class App
+{
+	private static ImmutableHashSet<int> _doneTests = ImmutableHashSet<int>.Empty;
+	private static int _testIdCounter = 0;
+
+	public static string GetAllTests() => SampleControl.Presentation.SampleChooserViewModel.Instance.GetAllSamplesNames();
+
+	public static bool IsTestDone(string testId) => int.TryParse(testId, out var id) ? _doneTests.Contains(id) : false;
+
+	public static async Task<bool> HandleRuntimeTests(string args)
+	{
+#if __SKIA__ || __MACOS__
+		var runRuntimeTestsResultsParam =
+			args.Split(';').FirstOrDefault(a => a.StartsWith("--runtime-tests"));
+
+		var runtimeTestResultFilePath = runRuntimeTestsResultsParam?.Split('=').LastOrDefault();
+
+		if (!string.IsNullOrEmpty(runtimeTestResultFilePath))
+		{
+			Console.WriteLine($"HandleSkiaRuntimeTests: {runtimeTestResultFilePath}");
+
+			// let the app finish its startup
+			await Task.Delay(TimeSpan.FromSeconds(5));
+
+			await SampleControl.Presentation.SampleChooserViewModel.Instance.RunRuntimeTests(
+				CancellationToken.None,
+				runtimeTestResultFilePath,
+				() => System.Environment.Exit(0));
+
+			return true;
+		}
+
+		return false;
+#else
+		return await Task.FromResult(false);
+#endif
+	}
+
+	public static string RunTest(string metadataName)
+	{
+		try
+		{
+			Console.WriteLine($"Initiate Running Test {metadataName}");
+
+			var testId = Interlocked.Increment(ref _testIdCounter);
+
+			_ = Windows.UI.Xaml.Window.Current.Dispatcher.RunAsync(
+				CoreDispatcherPriority.Normal,
+				async () =>
+				{
+					try
+					{
+#if __IOS__ || __ANDROID__
+						var statusBar = Windows.UI.ViewManagement.StatusBar.GetForCurrentView();
+						if (statusBar != null)
+						{
+							_ = Windows.UI.Xaml.Window.Current.Dispatcher.RunAsync(
+								Windows.UI.Core.CoreDispatcherPriority.Normal,
+								async () => await statusBar.HideAsync()
+							);
+						}
+#endif
+
+#if __ANDROID__
+							Windows.ApplicationModel.Core.CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = false;
+							Uno.UI.FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay = TimeSpan.Zero;
+#endif
+
+#if HAS_UNO
+						// Disable the TextBox caret for new instances
+						Uno.UI.FeatureConfiguration.TextBox.HideCaret = true;
+#endif
+
+						var t = SampleControl.Presentation.SampleChooserViewModel.Instance.SetSelectedSample(CancellationToken.None, metadataName);
+						var timeout = Task.Delay(30000);
+
+						await Task.WhenAny(t, timeout);
+
+						if (!(t.IsCompleted && !t.IsFaulted))
+						{
+							throw new TimeoutException();
+						}
+
+						ImmutableInterlocked.Update(ref _doneTests, lst => lst.Add(testId));
+					}
+					catch (Exception e)
+					{
+						Console.WriteLine($"Failed to run test {metadataName}, {e}");
+					}
+					finally
+					{
+#if HAS_UNO
+						// Restore the caret for new instances
+						Uno.UI.FeatureConfiguration.TextBox.HideCaret = false;
+#endif
+					}
+				}
+			);
+
+			return testId.ToString();
+		}
+		catch (Exception e)
+		{
+			Console.WriteLine($"Failed Running Test {metadataName}, {e}");
+			return "";
+		}
+	}
+
+
+	private bool HandleAutoScreenshots(string args)
+	{
+#if __SKIA__ || __MACOS__
+		var runAutoScreenshotsParam =
+		args.Split(';').FirstOrDefault(a => a.StartsWith("--auto-screenshots"));
+
+		var screenshotsPath = runAutoScreenshotsParam?.Split('=').LastOrDefault();
+
+		if (!string.IsNullOrEmpty(screenshotsPath))
+		{
+			if (Windows.UI.Xaml.Window is null)
+			{
+				throw new InvalidOperationException("Main window must be initialized before running screenshot tests");
+			}
+
+			var n = Windows.UI.Xaml.Window.Dispatcher.RunIdleAsync(
+				_ =>
+				{
+					var n = Windows.UI.Xaml.Window.Dispatcher.RunAsync(
+						CoreDispatcherPriority.Normal,
+						async () =>
+						{
+							await SampleControl.Presentation.SampleChooserViewModel.Instance.RecordAllTests(CancellationToken.None, screenshotsPath, () => System.Environment.Exit(0));
+						}
+					);
+
+				});
+
+			return true;
+		}
+#endif
+
+		return false;
+	}
+
+	private bool TryNavigateToLaunchSample(string args)
+	{
+		const string samplePrefix = "sample=";
+		try
+		{
+			args = Uri.UnescapeDataString(args);
+
+			if (string.IsNullOrEmpty(args) || !args.StartsWith(samplePrefix))
+			{
+				return false;
+			}
+
+			args = args.Substring(samplePrefix.Length);
+
+			var pathParts = args.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+			var category = pathParts[0];
+			var sampleName = pathParts[1];
+
+			SampleControl.Presentation.SampleChooserViewModel.Instance.SetSelectedSample(CancellationToken.None, category, sampleName);
+			return true;
+		}
+		catch (Exception ex)
+		{
+			_log?.Error($"Could not navigate to initial sample - {ex}");
+		}
+		return false;
+	}
+
+#if __IOS__
+	[Foundation.Export("runTest:")] // notice the colon at the end of the method name
+	public Foundation.NSString RunTestBackdoor(Foundation.NSString value) => new Foundation.NSString(RunTest(value));
+
+	[Foundation.Export("isTestDone:")] // notice the colon at the end of the method name
+	public Foundation.NSString IsTestDoneBackdoor(Foundation.NSString value) => new Foundation.NSString(IsTestDone(value).ToString());
+
+	[Foundation.Export("getDisplayScreenScaling:")] // notice the colon at the end of the method name
+	public Foundation.NSString GetDisplayScreenScalingBackdoor(Foundation.NSString value) => new Foundation.NSString(GetDisplayScreenScaling(value).ToString());
+#endif
+}

--- a/src/SamplesApp/SamplesApp.Shared/App.UnoIslands.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.UnoIslands.cs
@@ -7,7 +7,7 @@ using Uno.UI.XamlHost;
 
 namespace SamplesApp;
 
-sealed public partial class App
+partial class App
 {
 	public App(List<IXamlMetadataProvider> providers)
 	{

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -1,41 +1,24 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using System.Threading.Tasks;
-using Uno.Extensions;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.UI.Core;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.Foundation.Metadata;
 using Windows.Graphics.Display;
 using System.Globalization;
 using Windows.UI.ViewManagement;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Logging;
 using Uno;
+using System.Diagnostics.CodeAnalysis;
 
 #if __SKIA__
-using Uno.UI.Xaml.Controls.Extensions;
-using Uno.Foundation.Extensibility;
-using MUXControlsTestApp.Utilities;
-using Windows.Storage;
+using System.Diagnostics.CodeAnalysis;
 #endif
 
 #if !HAS_UNO
@@ -69,9 +52,12 @@ namespace SamplesApp
 		private static ILogger _log;
 #endif
 
+		private bool _wasActivated;
+		private bool _isSuspended;
+
 		static App()
 		{
-			ConfigureFilters();
+			ConfigureLogging();
 		}
 
 		/// <summary>
@@ -95,6 +81,7 @@ namespace SamplesApp
 
 			this.InitializeComponent();
 			this.Suspending += OnSuspending;
+			this.Resuming += OnResuming;
 		}
 
 		/// <summary>
@@ -148,9 +135,10 @@ namespace SamplesApp
 
 			AssertIssue8641NativeOverlayInitialized();
 
-			Windows.UI.Xaml.Window.Current.Activate();
+			ActivateMainWindow();
 
 			ApplicationView.GetForCurrentView().Title = "Uno Samples";
+
 #if __SKIA__ && DEBUG
 			AppendRepositoryPathToTitleBar();
 #endif
@@ -172,71 +160,6 @@ namespace SamplesApp
 			ApplicationView.GetForCurrentView().Title += $" ({repositoryPath})";
 		}
 #endif
-
-		private static bool HandleSkiaAutoScreenshots(LaunchActivatedEventArgs e)
-		{
-#if __SKIA__ || __MACOS__
-			var runAutoScreenshotsParam =
-			e.Arguments.Split(';').FirstOrDefault(a => a.StartsWith("--auto-screenshots"));
-
-			var screenshotsPath = runAutoScreenshotsParam?.Split('=').LastOrDefault();
-
-			if (!string.IsNullOrEmpty(screenshotsPath))
-			{
-				var n = Windows.UI.Xaml.Window.Current.Dispatcher.RunIdleAsync(
-					_ =>
-					{
-						var n = Windows.UI.Xaml.Window.Current.Dispatcher.RunAsync(
-							CoreDispatcherPriority.Normal,
-							async () =>
-							{
-								await SampleControl.Presentation.SampleChooserViewModel.Instance.RecordAllTests(CancellationToken.None, screenshotsPath, () => System.Environment.Exit(0));
-							}
-						);
-
-					});
-
-				return true;
-			}
-#endif
-
-			return false;
-		}
-
-		private static Task<bool> HandleSkiaRuntimeTests(LaunchActivatedEventArgs e) => HandleSkiaRuntimeTests(e.Arguments);
-
-		public static
-#if __SKIA__ || __MACOS__
-			async
-#endif
-			Task<bool> HandleSkiaRuntimeTests(string args)
-		{
-#if __SKIA__ || __MACOS__
-			var runRuntimeTestsResultsParam =
-				args.Split(';').FirstOrDefault(a => a.StartsWith("--runtime-tests"));
-
-			var runtimeTestResultFilePath = runRuntimeTestsResultsParam?.Split('=').LastOrDefault();
-
-			if (!string.IsNullOrEmpty(runtimeTestResultFilePath))
-			{
-				Console.WriteLine($"HandleSkiaRuntimeTests: {runtimeTestResultFilePath}");
-
-				// let the app finish its startup
-				await Task.Delay(TimeSpan.FromSeconds(5));
-
-				await SampleControl.Presentation.SampleChooserViewModel.Instance.RunRuntimeTests(
-					CancellationToken.None,
-					runtimeTestResultFilePath,
-					() => System.Environment.Exit(0));
-
-				return true;
-			}
-
-			return false;
-#else
-			return Task.FromResult(false);
-#endif
-		}
 
 #if __IOS__
 		/// <summary>
@@ -291,7 +214,7 @@ namespace SamplesApp
 			base.OnActivated(e);
 
 			InitializeFrame();
-			Windows.UI.Xaml.Window.Current.Activate();
+			ActivateMainWindow();
 
 			if (e.Kind == ActivationKind.Protocol)
 			{
@@ -305,6 +228,13 @@ namespace SamplesApp
 					await dlg.ShowAsync();
 				}
 			}
+		}
+
+		private void ActivateMainWindow()
+		{
+			Windows.UI.Xaml.Window.Current.Activate();
+			_wasActivated = true;
+			_isSuspended = false;
 		}
 
 #if !HAS_UNO_WINUI
@@ -356,59 +286,31 @@ namespace SamplesApp
 		{
 			Console.WriteLine($"HandleLaunchArguments: {launchActivatedEventArgs.Arguments}");
 
-			if (HandleSkiaAutoScreenshots(launchActivatedEventArgs))
+			if (launchActivatedEventArgs.Arguments is not { } args)
 			{
 				return;
 			}
 
-			if (await HandleSkiaRuntimeTests(launchActivatedEventArgs))
+			if (HandleAutoScreenshots(args))
 			{
 				return;
 			}
 
-			if (TryNavigateToLaunchSample(launchActivatedEventArgs))
+			if (await HandleRuntimeTests(args))
 			{
 				return;
 			}
 
-			if (!string.IsNullOrEmpty(launchActivatedEventArgs.Arguments))
+			if (TryNavigateToLaunchSample(args))
 			{
-				var dlg = new MessageDialog(launchActivatedEventArgs.Arguments, "Launch arguments");
+				return;
+			}
+
+			if (!string.IsNullOrEmpty(args))
+			{
+				var dlg = new MessageDialog(args, "Launch arguments");
 				await dlg.ShowAsync();
 			}
-		}
-
-		private bool TryNavigateToLaunchSample(LaunchActivatedEventArgs launchActivatedEventArgs)
-		{
-			const string samplePrefix = "sample=";
-			try
-			{
-				if (launchActivatedEventArgs.Arguments == null)
-				{
-					return false;
-				}
-
-				var args = Uri.UnescapeDataString(launchActivatedEventArgs.Arguments);
-
-				if (string.IsNullOrEmpty(args) || !args.StartsWith(samplePrefix))
-				{
-					return false;
-				}
-
-				args = args.Substring(samplePrefix.Length);
-
-				var pathParts = args.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-				var category = pathParts[0];
-				var sampleName = pathParts[1];
-
-				SampleControl.Presentation.SampleChooserViewModel.Instance.SetSelectedSample(CancellationToken.None, category, sampleName);
-				return true;
-			}
-			catch (Exception ex)
-			{
-				_log.Error($"Could not navigate to initial sample - {ex}");
-			}
-			return false;
 		}
 
 		/// <summary>
@@ -430,6 +332,8 @@ namespace SamplesApp
 		/// <param name="e">Details about the suspend request.</param>
 		private void OnSuspending(object sender, SuspendingEventArgs e)
 		{
+			_isSuspended = true;
+
 			var deferral = e.SuspendingOperation.GetDeferral();
 
 			Console.WriteLine($"OnSuspending (Deadline:{e.SuspendingOperation.Deadline})");
@@ -437,11 +341,20 @@ namespace SamplesApp
 			deferral.Complete();
 		}
 
-		public static void ConfigureFilters()
+		private void OnResuming(object sender, object e)
+		{
+			Console.WriteLine("OnResuming");
+
+			AssertIssue10313ResumingAfterActivate();
+
+			_isSuspended = false;
+		}
+
+		public static void ConfigureLogging()
 		{
 #if HAS_UNO
-			System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (s, e) => _log.Error("UnobservedTaskException", e.Exception);
-			AppDomain.CurrentDomain.UnhandledException += (s, e) => _log.Error("UnhandledException", e.ExceptionObject as Exception);
+			System.Threading.Tasks.TaskScheduler.UnobservedTaskException += (s, e) => _log?.Error("UnobservedTaskException", e.Exception);
+			AppDomain.CurrentDomain.UnhandledException += (s, e) => _log?.Error("UnhandledException", (e.ExceptionObject as Exception) ?? new Exception("Unknown exception " + e.ExceptionObject));
 #endif
 			var factory = Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
 			{
@@ -512,10 +425,7 @@ namespace SamplesApp
 				// builder.AddFilter("Windows.UI.Xaml.Controls.NativeListViewBaseAdapter", LogLevel.Debug ); //Android
 				// builder.AddFilter("Windows.UI.Xaml.Controls.BufferViewCache", LogLevel.Debug ); //Android
 				// builder.AddFilter("Windows.UI.Xaml.Controls.VirtualizingPanelGenerator", LogLevel.Debug ); //WASM
-
-
 			});
-
 
 			Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = factory;
 #if HAS_UNO
@@ -539,230 +449,7 @@ namespace SamplesApp
 #endif
 		}
 
-
-		private static ImmutableHashSet<int> _doneTests = ImmutableHashSet<int>.Empty;
-		private static int _testIdCounter = 0;
-
-		public static string GetAllTests()
-			=> SampleControl.Presentation.SampleChooserViewModel.Instance.GetAllSamplesNames();
-
 		public static string GetDisplayScreenScaling(string displayId)
 			=> (DisplayInformation.GetForCurrentView().LogicalDpi * 100f / 96f).ToString(CultureInfo.InvariantCulture);
-
-		public static string RunTest(string metadataName)
-		{
-			try
-			{
-				Console.WriteLine($"Initiate Running Test {metadataName}");
-
-				var testId = Interlocked.Increment(ref _testIdCounter);
-
-				_ = Windows.UI.Xaml.Window.Current.Dispatcher.RunAsync(
-					CoreDispatcherPriority.Normal,
-					async () =>
-					{
-						try
-						{
-#if __IOS__ || __ANDROID__
-							var statusBar = Windows.UI.ViewManagement.StatusBar.GetForCurrentView();
-							if (statusBar != null)
-							{
-								_ = Windows.UI.Xaml.Window.Current.Dispatcher.RunAsync(
-									Windows.UI.Core.CoreDispatcherPriority.Normal,
-									async () => await statusBar.HideAsync()
-								);
-							}
-#endif
-
-#if __ANDROID__
-							Windows.ApplicationModel.Core.CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = false;
-							Uno.UI.FeatureConfiguration.ScrollViewer.AndroidScrollbarFadeDelay = TimeSpan.Zero;
-#endif
-
-#if HAS_UNO
-							// Disable the TextBox caret for new instances
-							Uno.UI.FeatureConfiguration.TextBox.HideCaret = true;
-#endif
-
-							var t = SampleControl.Presentation.SampleChooserViewModel.Instance.SetSelectedSample(CancellationToken.None, metadataName);
-							var timeout = Task.Delay(30000);
-
-							await Task.WhenAny(t, timeout);
-
-							if (!(t.IsCompleted && !t.IsFaulted))
-							{
-								throw new TimeoutException();
-							}
-
-							ImmutableInterlocked.Update(ref _doneTests, lst => lst.Add(testId));
-						}
-						catch (Exception e)
-						{
-							Console.WriteLine($"Failed to run test {metadataName}, {e}");
-						}
-						finally
-						{
-#if HAS_UNO
-							// Restore the caret for new instances
-							Uno.UI.FeatureConfiguration.TextBox.HideCaret = false;
-#endif
-						}
-					}
-				);
-
-				return testId.ToString();
-			}
-			catch (Exception e)
-			{
-				Console.WriteLine($"Failed Running Test {metadataName}, {e}");
-				return "";
-			}
-		}
-
-#if __IOS__
-		[Foundation.Export("runTest:")] // notice the colon at the end of the method name
-		public Foundation.NSString RunTestBackdoor(Foundation.NSString value) => new Foundation.NSString(RunTest(value));
-
-		[Foundation.Export("isTestDone:")] // notice the colon at the end of the method name
-		public Foundation.NSString IsTestDoneBackdoor(Foundation.NSString value) => new Foundation.NSString(IsTestDone(value).ToString());
-
-		[Foundation.Export("getDisplayScreenScaling:")] // notice the colon at the end of the method name
-		public Foundation.NSString GetDisplayScreenScalingBackdoor(Foundation.NSString value) => new Foundation.NSString(GetDisplayScreenScaling(value).ToString());
-#endif
-
-		public static bool IsTestDone(string testId) => int.TryParse(testId, out var id) ? _doneTests.Contains(id) : false;
-
-		/// <summary>
-		/// Assert that ApplicationData.Current.[LocalFolder|RoamingFolder] is usable in the constructor of App.xaml.cs on all platforms.
-		/// </summary>
-		/// <seealso href="https://github.com/unoplatform/uno/issues/1741"/>
-		public void AssertIssue1790ApplicationSettingsUsable()
-		{
-			void AssertIsUsable(Windows.Storage.ApplicationDataContainer container)
-			{
-				const string issue1790 = nameof(issue1790);
-
-				container.Values.Remove(issue1790);
-				container.Values.Add(issue1790, "ApplicationData.Current.[LocalFolder|RoamingFolder] is usable in the constructor of App.xaml.cs on this platform.");
-
-				Assert.IsTrue(container.Values.ContainsKey(issue1790));
-			}
-
-			AssertIsUsable(Windows.Storage.ApplicationData.Current.LocalSettings);
-			AssertIsUsable(Windows.Storage.ApplicationData.Current.RoamingSettings);
-		}
-
-		/// <summary>
-		/// Assert that the App DisplayName was found in manifest and loaded from resources
-		/// </summary>
-		public void AssertIssue12936()
-		{
-			//On Wasm the DisplayName is currently empty, as it is not being load from manifest
-#if !__WASM__
-			var displayName = Package.Current.DisplayName;
-
-			Assert.IsFalse(string.IsNullOrEmpty(displayName), "DisplayName is empty.");
-
-			Assert.IsFalse(displayName.Contains("ms-resource:"), $"'{displayName}' wasn't found in resources.");
-#endif
-		}
-
-		/// <summary>
-		/// Assert that Application Title is getting its value from manifest
-		/// </summary>
-		public void AssertIssue8356()
-		{
-#if __SKIA__
-			Uno.UI.RuntimeTests.Tests.Windows_UI_ViewManagement_ApplicationView.Given_ApplicationView.StartupTitle = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().Title;
-#endif
-		}
-
-		/// <summary>
-		/// Assert that the native overlay layer for Skia targets is initialized in time for UI to appear.
-		/// </summary>
-		public void AssertIssue8641NativeOverlayInitialized()
-		{
-#if __SKIA__
-			if (Uno.UI.Xaml.Core.CoreServices.Instance.InitializationType == Uno.UI.Xaml.Core.InitializationType.IslandsOnly)
-			{
-				return;
-			}
-			// Temporarily add a TextBox to the current page's content to verify native overlay is available
-			Frame rootFrame = Windows.UI.Xaml.Window.Current.Content as Frame;
-			var textBox = new TextBox();
-			textBox.XamlRoot = rootFrame.XamlRoot;
-			var textBoxView = new TextBoxView(textBox);
-			ApiExtensibility.CreateInstance<IOverlayTextBoxViewExtension>(textBoxView, out var textBoxViewExtension);
-			Assert.IsTrue(textBoxViewExtension.IsOverlayLayerInitialized(rootFrame.XamlRoot));
-#endif
-		}
-
-		public void AssertInitialWindowSize()
-		{
-#if !__SKIA__ // Will be fixed as part of #8341
-			Assert.IsTrue(global::Windows.UI.Xaml.Window.Current.Bounds.Width > 0);
-			Assert.IsTrue(global::Windows.UI.Xaml.Window.Current.Bounds.Height > 0);
-#endif
-		}
-
-		/// <summary>
-		/// Verifies that ApplicationData are available immediately after the application class is created
-		/// and the data are stored in proper application specific lcoations.
-		/// </summary>
-		public void AssertApplicationData()
-		{
-#if __SKIA__
-			var appName = Package.Current.Id.Name;
-			var publisher = string.IsNullOrEmpty(Package.Current.Id.Publisher) ? "" : "Uno Platform";
-
-			AssertForFolder(ApplicationData.Current.LocalFolder);
-			AssertForFolder(ApplicationData.Current.RoamingFolder);
-			AssertForFolder(ApplicationData.Current.TemporaryFolder);
-			AssertForFolder(ApplicationData.Current.LocalCacheFolder);
-			AssertSettings(ApplicationData.Current.LocalSettings);
-			AssertSettings(ApplicationData.Current.RoamingSettings);
-
-			void AssertForFolder(StorageFolder folder)
-			{
-				AssertContainsIdProps(folder);
-				AssertCanCreateFile(folder);
-			}
-
-			void AssertSettings(ApplicationDataContainer container)
-			{
-				var key = Guid.NewGuid().ToString();
-				var value = Guid.NewGuid().ToString();
-
-				container.Values[key] = value;
-				Assert.IsTrue(container.Values.ContainsKey(key));
-				Assert.AreEqual(value, container.Values[key]);
-				container.Values.Remove(key);
-			}
-
-			void AssertContainsIdProps(StorageFolder folder)
-			{
-				Assert.IsTrue(folder.Path.Contains(appName, StringComparison.Ordinal));
-				Assert.IsTrue(folder.Path.Contains(publisher, StringComparison.Ordinal));
-			}
-
-			void AssertCanCreateFile(StorageFolder folder)
-			{
-				var filename = Guid.NewGuid() + ".txt";
-				var path = Path.Combine(folder.Path, filename);
-				var expectedContent = "Test";
-				try
-				{
-					File.WriteAllText(path, expectedContent);
-					var actualContent = File.ReadAllText(path);
-
-					Assert.AreEqual(expectedContent, actualContent);
-				}
-				finally
-				{
-					File.Delete(path);
-				}
-			}
-#endif
-		}
 	}
 }

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,10 +17,6 @@ using Windows.UI.ViewManagement;
 using Microsoft.Extensions.Logging;
 using Uno;
 using System.Diagnostics.CodeAnalysis;
-
-#if __SKIA__
-using System.Diagnostics.CodeAnalysis;
-#endif
 
 #if !HAS_UNO
 using Uno.Logging;

--- a/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
@@ -19,6 +19,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)App.Assertions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)App.Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)App.UnoIslands.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>

--- a/src/SamplesApp/SamplesApp.Skia.Gtk/Program.cs
+++ b/src/SamplesApp/SamplesApp.Skia.Gtk/Program.cs
@@ -15,7 +15,7 @@ namespace SkiaSharpExample
 		[STAThread]
 		public static void Main(string[] args)
 		{
-			SamplesApp.App.ConfigureFilters(); // Enable tracing of the host
+			SamplesApp.App.ConfigureLogging(); // Enable tracing of the host
 
 			ApiExtensibility.Register(typeof(IMediaPlayerExtension), o => new Uno.UI.Media.MediaPlayerExtension(o));
 			ApiExtensibility.Register(typeof(IMediaPlayerPresenterExtension), o => new Uno.UI.Media.MediaPlayerPresenterExtension(o));

--- a/src/SamplesApp/SamplesApp.Skia.Linux.FrameBuffer/Program.cs
+++ b/src/SamplesApp/SamplesApp.Skia.Linux.FrameBuffer/Program.cs
@@ -15,7 +15,7 @@ namespace SkiaSharpExample
 		{
 			try
 			{
-				SamplesApp.App.ConfigureFilters(); // Enable tracing of the host
+				SamplesApp.App.ConfigureLogging(); // Enable tracing of the host
 
 				Console.CursorVisible = false;
 				var host = new FrameBufferHost(() =>

--- a/src/SamplesApp/SamplesApp.Skia.Wpf/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Skia.Wpf/App.xaml.cs
@@ -9,7 +9,7 @@ namespace SamplesApp.Wpf
 	{
 		public App()
 		{
-			SamplesApp.App.ConfigureFilters();
+			SamplesApp.App.ConfigureLogging();
 
 			var host = new WpfHost(Dispatcher, () => new SamplesApp.App());
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Core/WindowActivationTests.xaml.cs
@@ -61,7 +61,7 @@ namespace UITests.Windows_UI_Core
 			CoreApplication.LeavingBackground += CoreApplicationLeavingBackground;
 			Application.Current.Suspending += ApplicationSuspending;
 			Application.Current.Resuming += ApplicationResuming;
-			CoreApplication.Suspending += CoreApplicationResuming;
+			CoreApplication.Suspending += CoreApplicationSuspending;
 			CoreApplication.Resuming += CoreApplicationResuming;
 
 			Disposables.Add(() =>
@@ -75,7 +75,7 @@ namespace UITests.Windows_UI_Core
 				CoreApplication.LeavingBackground -= CoreApplicationLeavingBackground;
 				Application.Current.Suspending -= ApplicationSuspending;
 				Application.Current.Resuming -= ApplicationResuming;
-				CoreApplication.Suspending -= CoreApplicationResuming;
+				CoreApplication.Suspending -= CoreApplicationSuspending;
 				CoreApplication.Resuming -= CoreApplicationResuming;
 			});
 		}

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/MainWindow.xaml.cs
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/MainWindow.xaml.cs
@@ -10,7 +10,7 @@ namespace UnoIslandsSamplesApp.Skia.Wpf
 			xamlHost.Loaded += XamlHost_Loaded;
 		}
 
-		private async void XamlHost_Loaded(object sender, RoutedEventArgs e) => 
+		private async void XamlHost_Loaded(object sender, RoutedEventArgs e) =>
 			await SamplesApp.App.HandleRuntimeTests(string.Join(";", System.Environment.GetCommandLineArgs()));
 	}
 }

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/MainWindow.xaml.cs
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ namespace UnoIslandsSamplesApp.Skia.Wpf
 			xamlHost.Loaded += XamlHost_Loaded;
 		}
 
-		private async void XamlHost_Loaded(object sender, RoutedEventArgs e) => await SamplesApp.App.HandleSkiaRuntimeTests(string.Join(";", System.Environment.GetCommandLineArgs()));
+		private async void XamlHost_Loaded(object sender, RoutedEventArgs e) => 
+			await SamplesApp.App.HandleRuntimeTests(string.Join(";", System.Environment.GetCommandLineArgs()));
 	}
 }

--- a/src/Uno.UI/Controls/Window.macOS.cs
+++ b/src/Uno.UI/Controls/Window.macOS.cs
@@ -408,10 +408,10 @@ namespace Uno.UI.Controls
 				}
 
 				// Closing should continue, perform suspension.
-				if (!Application.Current.Suspended)
+				if (!Application.Current.IsSuspended)
 				{
 					Application.Current.RaiseSuspending();
-					return Application.Current.Suspended;
+					return Application.Current.IsSuspended;
 				}
 
 				// All prerequisites passed, can safely close.

--- a/src/Uno.UI/UI/Xaml/Application.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Android.cs
@@ -9,31 +9,24 @@ using Windows.Foundation.Metadata;
 using Windows.Globalization;
 using Windows.UI.Xaml.Controls.Primitives;
 
-#if HAS_UNO_WINUI
-using LaunchActivatedEventArgs = Microsoft.UI.Xaml.LaunchActivatedEventArgs;
-#else
-using LaunchActivatedEventArgs = Windows.ApplicationModel.Activation.LaunchActivatedEventArgs;
-#endif
+namespace Windows.UI.Xaml;
 
-namespace Windows.UI.Xaml
+public partial class Application
 {
-	public partial class Application
+	partial void InitializePartial()
 	{
-		partial void InitializePartial()
-		{
-			Window.Current.ToString();
-			PermissionsHelper.Initialize();
-		}
-
-		static partial void StartPartial(ApplicationInitializationCallback callback)
-		{
-			callback(new ApplicationInitializationCallbackParams());
-		}
-
-		/// <remarks>
-		/// The 5 second timeout seems to be the safest timeout for suspension activities.
-		/// See - https://stackoverflow.com/a/3987733/732221
-		/// </remarks>
-		private DateTimeOffset GetSuspendingOffset() => DateTimeOffset.Now.AddSeconds(5);
+		Window.Current.ToString();
+		PermissionsHelper.Initialize();
 	}
+
+	static partial void StartPartial(ApplicationInitializationCallback callback)
+	{
+		callback(new ApplicationInitializationCallbackParams());
+	}
+
+	/// <remarks>
+	/// The 5 second timeout seems to be the safest timeout for suspension activities.
+	/// See - https://stackoverflow.com/a/3987733/732221
+	/// </remarks>
+	private DateTimeOffset GetSuspendingOffset() => DateTimeOffset.Now.AddSeconds(5);
 }

--- a/src/Uno.UI/UI/Xaml/Application.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Application.Android.cs
@@ -30,16 +30,10 @@ namespace Windows.UI.Xaml
 			callback(new ApplicationInitializationCallbackParams());
 		}
 
-		partial void OnResumingPartial()
-		{
-			Resuming?.Invoke(null, null);
-		}
-
 		/// <remarks>
 		/// The 5 second timeout seems to be the safest timeout for suspension activities.
 		/// See - https://stackoverflow.com/a/3987733/732221
 		/// </remarks>
-		private SuspendingOperation CreateSuspendingOperation() =>
-			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(5), null);
+		private DateTimeOffset GetSuspendingOffset() => DateTimeOffset.Now.AddSeconds(5);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -59,7 +59,6 @@ namespace Windows.UI.Xaml
 		private ApplicationTheme _requestedTheme = ApplicationTheme.Dark;
 		private SpecializedResourceDictionary.ResourceKey _requestedThemeForResources;
 		private bool _isInBackground;
-		//private bool _isSuspended;
 
 		static Application()
 		{

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -396,7 +396,7 @@ namespace Windows.UI.Xaml
 #endif
 		}
 
-#if !__IOS__ && !__ANDROID__ && !__MACOS__
+#if !__IOS__ && !__ANDROID__
 		/// <summary>
 		/// On platforms which don't support asynchronous suspension we indicate that with immediate
 		/// deadline and warning in logs.

--- a/src/Uno.UI/UI/Xaml/Application.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.iOS.cs
@@ -24,9 +24,6 @@ namespace Windows.UI.Xaml
 	[Register("UnoAppDelegate")]
 	public partial class Application : UIApplicationDelegate
 	{
-		private bool _suspended;
-		internal bool IsSuspended => _suspended;
-
 		private bool _preventSecondaryActivationHandling;
 
 		partial void InitializePartial()
@@ -128,18 +125,7 @@ namespace Windows.UI.Xaml
 			_preventSecondaryActivationHandling = false;
 		}
 
-		private SuspendingOperation CreateSuspendingOperation() =>
-			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(10), () => _suspended = true);
-
-		partial void OnResumingPartial()
-		{
-			if (_suspended)
-			{
-				_suspended = false;
-
-				Resuming?.Invoke(this, null);
-			}
-		}
+		private DateTimeOffset GetSuspendingOffset() => DateTimeOffset.Now.AddSeconds(10);
 
 		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations(UIApplication application, [Transient] UIWindow forWindow)
 		{

--- a/src/Uno.UI/UI/Xaml/Application.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.macOS.cs
@@ -47,8 +47,6 @@ namespace Windows.UI.Xaml
 
 		public override bool ApplicationShouldTerminateAfterLastWindowClosed(NSApplication sender) => true;
 
-		internal bool Suspended { get; private set; }
-
 		static partial void StartPartial(ApplicationInitializationCallback callback)
 		{
 			callback(new ApplicationInitializationCallbackParams());
@@ -83,12 +81,6 @@ namespace Windows.UI.Xaml
 				OnLaunched(new LaunchActivatedEventArgs(ActivationKind.Launch, argumentsString));
 			}
 		}
-
-		private SuspendingOperation CreateSuspendingOperation() =>
-			new SuspendingOperation(DateTimeOffset.Now.AddSeconds(0), () =>
-			{
-				Suspended = true;
-			});
 
 		/// <summary>
 		/// This method enables UI Tests to get the output path


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10313


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- `Resuming` runs on startup on iOS
- `Resuming` is executed twice when app is brought up from background

## What is the new behavior?

Fixed!

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1cf9298</samp>

This pull request refactors and improves the app suspension and resumption logic across different platforms, and adds UI testing and assertion methods to the SamplesApp. It also renames a method for configuring logging and updates the references to it in the Skia projects. It affects the files `App.xaml.cs`, `WindowActivationTests.xaml.cs`, `Application.cs`, `Application.iOS.cs`, `Application.macOS.cs`, `App.Assertions.cs`, `App.Tests.cs`, `App.UnoIslands.cs`, `SamplesApp.Shared.projitems`, `Program.cs` (in Skia projects), and `Application.Android.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.