### PR TITLE
fix(skia): Fix app staying blank if no background on the main page

### DIFF
--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -23,12 +23,7 @@ public partial class Compositor
 
 		_isDirty = false;
 
-		// TODO: Why are we enumerating children manually instead of just let the ContainerVisual do its job?
-		var children = rootVisual.GetChildrenInRenderOrder();
-		for (var i = 0; i < children.Count; i++)
-		{
-			children[i].RenderRootVisual(surface);
-		}
+		rootVisual.RenderRootVisual(surface);
 	}
 
 	partial void InvalidateRenderPartial()

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -1,4 +1,6 @@
-﻿//#define ENABLE_CONTAINER_VISUAL_TRACKING
+﻿#if DEBUG
+#define ENABLE_CONTAINER_VISUAL_TRACKING
+#endif
 
 using Windows.Foundation;
 using Windows.UI.Xaml.Input;


### PR DESCRIPTION
## Bugfix
Fix app staying blank if no background on the main page

## What is the current behavior?
Since https://github.com/unoplatform/uno/pull/12428 If the main page has no background, then the whole app remains blank

## What is the new behavior?
We are no longer using some specific code the rendering of the root of the app.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed34f40</samp>

This pull request improves the rendering performance and code quality of the Skia backend for Uno.UI. It simplifies the rendering of the root visual by using `ContainerVisual`, and adds a debug-only feature to track `ContainerVisual` instances.

## PR Checklist

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
