### PR TITLE
fix: Properly override `ProcessCandidateTabStopOverride` in `CalendarView`

### DIFF
--- a/src/Uno.UI/UI/Xaml/Input/Internal/TabStopProcessingResult.cs
+++ b/src/Uno.UI/UI/Xaml/Input/Internal/TabStopProcessingResult.cs
@@ -2,12 +2,17 @@
 
 using Windows.UI.Xaml;
 
-namespace Uno.UI.Xaml.Input
-{
-	internal struct TabStopProcessingResult
-	{
-		public DependencyObject? NewTabStop { get; set; }
+namespace Uno.UI.Xaml.Input;
 
-		public bool IsOverriden { get; set; }
+internal struct TabStopProcessingResult
+{
+	public TabStopProcessingResult(bool isOverriden, DependencyObject? newTabStop)
+	{
+		IsOverriden = isOverriden;
+		NewTabStop = newTabStop;
 	}
+
+	public bool IsOverriden { get; set; }
+
+	public DependencyObject? NewTabStop { get; set; }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10958

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Method not overriden properly.

## What is the new behavior?

Overriden properly.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec72d6c</samp>

This pull request improves the tab stop handling in the `CalendarView` control by aligning the `ProcessCandidateTabStopOverride` method with the base class and using a struct to store the tab stop processing result. It also refactors some code for better readability and consistency.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.