### PR TITLE
fix(skia): Adjust framebuffer initialization, symbols fallback rendering

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
@@ -81,7 +81,15 @@ partial class App
 		var textBoxView = new TextBoxView(textBox);
 		ApiExtensibility.CreateInstance<IOverlayTextBoxViewExtension>(textBoxView, out var textBoxViewExtension);
 		Assert.IsNotNull(textBoxViewExtension);
-		Assert.IsTrue(textBoxViewExtension!.IsOverlayLayerInitialized(rootFrame.XamlRoot));
+
+		if (textBoxViewExtension is not null)
+		{
+			Assert.IsTrue(textBoxViewExtension.IsOverlayLayerInitialized(rootFrame.XamlRoot));
+		}
+		else
+		{
+			Console.WriteLine($"TextBoxView is not available for this platform");
+		}
 #endif
 	}
 

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -259,7 +259,6 @@ namespace SamplesApp
 
 				// Place the frame in the current Window
 				Windows.UI.Xaml.Window.Current.Content = rootFrame;
-				Console.WriteLine($"RootFrame: {rootFrame}");
 			}
 
 			if (rootFrame.Content == null)

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/FramebufferHost.cs
@@ -116,13 +116,22 @@ namespace Uno.UI.Runtime.Skia
 						$"DiagonalSizeInInches: {DisplayInformation.GetForCurrentView().DiagonalSizeInInches}, " +
 						$"ScreenInRawPixels: {DisplayInformation.GetForCurrentView().ScreenWidthInRawPixels}x{DisplayInformation.GetForCurrentView().ScreenHeightInRawPixels}");
 				}
+
+				// Force intialization of the DisplayInformation
+				DisplayInformation.GetForCurrentView();
+
+				if (_displayInformationExtension is null)
+				{
+					throw new InvalidOperationException("DisplayInformation is not yet initialized");
+				}
+
+				_displayInformationExtension.Renderer = _renderer;
 			}
 
 			Windows.UI.Core.CoreDispatcher.DispatchOverride = Dispatch;
 			Windows.UI.Core.CoreDispatcher.HasThreadAccessOverride = () => _isDispatcherThread;
 
 			_renderer = new Renderer(this);
-			_displayInformationExtension!.Renderer = _renderer;
 
 			CoreServices.Instance.ContentRootCoordinator.CoreWindowContentRootSet += OnCoreWindowContentRootSet;
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Fix Framebuffer head initialization issues
- Fix infinite loop on unsupported symbols

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ff2cff</samp>

Fixes framebuffer rendering bug and removes redundant code in `FramebufferHost.cs`. Ensures that `DisplayInformation` is properly initialized before using it for rendering.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
