### PR TITLE
Fixed clipping was applied on Android when opacity were used

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -862,6 +862,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\ClippingWithOpacity.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\CornerRadiusControls.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -922,7 +926,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-	<Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_TreeView.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_TreeView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -5764,6 +5768,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\Clipping652.xaml.cs">
       <DependentUpon>Clipping652.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\ClippingWithOpacity.xaml.cs">
+      <DependentUpon>ClippingWithOpacity.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Clipping.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_SoftKeboard.xaml.cs">
       <DependentUpon>AutoSuggestBox_SoftKeboard.xaml</DependentUpon>
@@ -5834,7 +5841,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView.xaml.cs">
       <DependentUpon>DragDrop_ListView.xaml</DependentUpon>
     </Compile>
-	<Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_TreeView.xaml.cs">
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_TreeView.xaml.cs">
       <DependentUpon>DragDrop_TreeView.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_ListView_Custom_States.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ClippingWithOpacity.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ClippingWithOpacity.xaml
@@ -1,0 +1,33 @@
+﻿<Page x:Class="UITests.Shared.Windows_UI_Xaml.Clipping.ClippingWithOpacity"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Shared.Windows_UI_Xaml.Clipping"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="5" Padding="5">
+		<!-- Text should wrap -->
+		<TextBlock FontSize="20" TextWrapping="Wrap">Those 2 rectangles should look the same (red one should be completed, never clipped)</TextBlock>
+
+		<Border Background="Blue" HorizontalAlignment="Center" Opacity=".5">
+			<Rectangle Fill="Red" Width="100" Height="100">
+				<Rectangle.RenderTransform>
+					<RotateTransform Angle="34" />
+				</Rectangle.RenderTransform>
+			</Rectangle>
+		</Border>
+
+		<Border Padding="30" Opacity=".5" x:Name="borderWithOpacity">
+			<Border Background="Blue" HorizontalAlignment="Center" x:Name="borderWithoutOpacity">
+				<Rectangle Fill="Red" Width="100" Height="100">
+					<Rectangle.RenderTransform>
+						<RotateTransform Angle="34" />
+					</Rectangle.RenderTransform>
+				</Rectangle>
+			</Border>
+		</Border>
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ClippingWithOpacity.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ClippingWithOpacity.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading.Tasks;
-using Windows.UI.Xaml.Controls;
-using Java.IO;
+﻿using Windows.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Shared.Windows_UI_Xaml.Clipping
@@ -11,7 +9,7 @@ namespace UITests.Shared.Windows_UI_Xaml.Clipping
 	{
 		public ClippingWithOpacity()
 		{
-			this.InitializeComponent();
+			InitializeComponent();
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ClippingWithOpacity.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/ClippingWithOpacity.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Java.IO;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml.Clipping
+{
+	[SampleControlInfo("Clipping")]
+
+	public sealed partial class ClippingWithOpacity : Page
+	{
+		public ClippingWithOpacity()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
@@ -95,6 +95,26 @@ public abstract class UnoViewGroup
 		);
 
 		setClipChildren(false); // The actual clipping will be calculated in managed code
+		setClipToPadding(false); // Same as above
+	}
+	
+	@Override
+	public boolean hasOverlappingRendering()
+	{
+		// This override is to prevent the Android framework from creating a layer for this view,
+		// which would cause a clipping issue because the layer could potentially be too small for
+		// the view's content.
+		
+		// By preventing Android from creating that layer, the view will be drawn directly into
+		// the parent's layer, so the problem is avoided.
+		
+		// A slight performance hit is expected, but it's should be negligible when it's only
+		// on elements having opacity < 1f.
+	
+		// Original bug: https://github.com/unoplatform/Uno.Gallery/issues/898
+	
+		// Check for opacity (Alpha) and return false if it's less than 1f
+		return getAlpha() >= 1 && super.hasOverlappingRendering();
 	}
 
 	private boolean _unoLayoutOverride;

--- a/src/Uno.UI/Extensions/ViewExtensions.Android.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.Android.cs
@@ -606,7 +606,7 @@ namespace Uno.UI
 					{
 						Inner(childViewGroup, s);
 					}
-					else if (child is { })
+					else if (child is not null)
 					{
 						AppendView(child, s);
 					}
@@ -628,18 +628,20 @@ namespace Uno.UI
 					.Append(innerView.ToString() + namePart)
 					.Append($"-({ViewHelper.PhysicalToLogicalPixels(innerView.Width):F1}x{ViewHelper.PhysicalToLogicalPixels(innerView.Height):F1})@({ViewHelper.PhysicalToLogicalPixels(innerView.Left):F1},{ViewHelper.PhysicalToLogicalPixels(innerView.Top):F1})")
 					.Append($"  {innerView.Visibility}")
-					.Append(fe != null ? $" HA={fe.HorizontalAlignment},VA={fe.VerticalAlignment}" : "")
-					.Append(fe != null && (!double.IsNaN(fe.Width) || !double.IsNaN(fe.Height)) ? $"FE.Width={fe.Width},FE.Height={fe.Height}" : "")
-					.Append(fe != null && fe.Margin != default ? $" Margin={fe.Margin}" : "")
-					.Append(fe != null && fe.TryGetBorderThickness(out var b) && b != default ? $" Border={b}" : "")
-					.Append(fe != null && fe.TryGetPadding(out var p) && p != default ? $" Padding={p}" : "")
-					.Append(u != null ? $" DesiredSize={u.DesiredSize.ToString("F1")}" : "")
-					.Append(u != null && u.NeedsClipToSlot ? " CLIPPED_TO_SLOT" : "")
-					.Append(vg?.ClipChildren is true ? " vg.CLIP_CHILDREN" : "")
-					.Append(vg?.ClipToPadding is true ? " vg.CLIP_TO_PADDING" : "")
-					.Append(u?.Clip != null ? $" Clip={u.Clip.Rect}" : "")
-					.Append(u == null && vg != null ? $" ClipChildren={vg.ClipChildren}" : "")
-					.Append(fe?.Background != null ? $" Background={fe.Background}" : "")
+					.Append(fe is not null ? $" HA={fe.HorizontalAlignment},VA={fe.VerticalAlignment}" : "")
+					.Append(fe is not null && (!double.IsNaN(fe.Width) || !double.IsNaN(fe.Height)) ? $"FE.Width={fe.Width},FE.Height={fe.Height}" : "")
+					.Append(fe is not null && fe.Margin != default ? $" Margin={fe.Margin}" : "")
+					.Append(fe is not null && fe.Opacity < 1 ? $" Opacity={fe.Opacity}" : "")
+					.Append(fe is not null && fe.TryGetBorderThickness(out var b) && b != default ? $" Border={b}" : "")
+					.Append(fe is not null && fe.TryGetPadding(out var p) && p != default ? $" Padding={p}" : "")
+					.Append(u is not null ? $" DesiredSize={u.DesiredSize.ToString("F1")}" : "")
+					.Append(u is { NeedsClipToSlot: true } ? " CLIPPED_TO_SLOT" : "")
+					.Append(vg is { ClipToOutline: true } ? " vg.CLIP_OUTLINE" : "")
+					.Append(vg is { ClipChildren: true } ? " vg.CLIP_CHILDREN" : "")
+					.Append(vg is { ClipToPadding: true } ? " vg.CLIP_TO_PADDING" : "")
+					.Append(u is { Clip: not null } ? $" Clip={u.Clip.Rect}" : "")
+					.Append(u == null && vg is not null ? $" ClipChildren={vg.ClipChildren}" : "")
+					.Append(fe is { Background: not null } ? $" Background={fe.Background}" : "")
 					.Append(u?.GetElementSpecificDetails())
 					.Append(u?.GetElementGridOrCanvasDetails())
 					.Append(u?.RenderTransform.GetTransformDetails())


### PR DESCRIPTION
# Bugfix

## What is the current behavior?
As soon a partial opacity were used on a control, it was applying a clipping in the visual tree. This was caused by the way Android is calculating the clipping by default.

## What is the new behavior?
Opacity won't impact clipping anymore on Android.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5402867</samp>

This pull request adds a new XAML sample page for clipping with opacity and fixes some formatting and layout issues in other XAML sample pages. It also improves the ViewExtensions class for Android and modifies the UnoViewGroup class to avoid a clipping bug with opacity. The changes affect the `src/SamplesApp/UITests.Shared` and the `src/Uno.UI` projects.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

Fixes https://github.com/unoplatform/Uno.Gallery/issues/898
