### PR TITLE
MediaPlayer tests are failing too often

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
@@ -24,10 +24,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 [RunsOnUIThread]
 public partial class Given_MediaPlayerElement
 {
-	private static readonly Uri TestVideoUrl = new Uri("https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/Big_Buck_Bunny_720_10s_5MB.mp4");
+	private static readonly Uri TestVideoUrl = new Uri("https://uno-assets.platform.uno/tests/videos/Getting_Started_with_Uno_Platform_and_Visual_Studio_Code.mp4");
 
 	[TestMethod]
-	[Ignore("https://github.com/unoplatform/uno/issues/13384")]
 	public async Task When_MediaPlayerElement_NotAutoPlay_Source()
 	{
 		CheckMediaPlayerExtensionAvailability();
@@ -46,10 +45,10 @@ public partial class Given_MediaPlayerElement
 			timeoutMS: 5000,
 			message: "Timeout waiting for the media player to enter Paused state."
 		);
+
 	}
 
 	[TestMethod]
-	[Ignore("https://github.com/unoplatform/uno/issues/13384")]
 	public async Task When_MediaPlayerElement_AutoPlay_Source()
 	{
 		CheckMediaPlayerExtensionAvailability();
@@ -111,8 +110,7 @@ public partial class Given_MediaPlayerElement
 	}
 
 #if __IOS__ || !HAS_UNO
-	// [Ignore("Test ignored on windows. Could not find the element by name. And Not supported under MAC [https://github.com/unoplatform/uno/issues/12663]")]
-	[Ignore("https://github.com/unoplatform/uno/issues/13384")]
+	[Ignore("Test ignored on windows. Could not find the element by name. And Not supported under MAC [https://github.com/unoplatform/uno/issues/12663]")]
 #endif
 	[TestMethod]
 	public async Task When_MediaPlayerElement_SetIsFullWindow_Check_Fullscreen()
@@ -171,7 +169,6 @@ public partial class Given_MediaPlayerElement
 	}
 
 	[TestMethod]
-	[Ignore("https://github.com/unoplatform/uno/issues/13384")]
 	public async Task When_MediaPlayerElement_SetSource_Check_PlayStop()
 	{
 		CheckMediaPlayerExtensionAvailability();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13384


## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?


When_MediaPlayerElement_AutoPlay_Source
When_MediaPlayerElement_NotAutoPlay_Source
When_MediaPlayerElement_SetIsFullWindow_Check_Fullscreen
When_MediaPlayerElement_SetSource_Check_PlayStop

It is likely caused by the URL that may not always be available. Let's use uno assets site instead (maybe with a version of the file that is smaller than 5MB).


```
---
	Details:
Failed: When_MediaPlayerElement_AutoPlay_Source() [Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException] 
 Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: Timed out waiting for condition to be met. Windows.UI.Xaml.Controls.MediaPlayerElement loaded
   at Private.Infrastructure.TestServices.WindowHelper.WaitFor(Func`1 condition, Int32 timeoutMS, String message, String callerMemberName, Int32 lineNumber)
   at Private.Infrastructure.TestServices.WindowHelper.<>c__DisplayClass33_0.<<WaitForLoaded>g__Do|0>d.MoveNext()
--- End of stack trace from previous location ---
   at Private.Infrastructure.TestServices.WindowHelper.WaitForLoaded(FrameworkElement element, Int32 timeoutMS)
   at Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Given_MediaPlayerElement.When_MediaPlayerElement_AutoPlay_Source()
   at Uno.UI.Samples.Tests.UnitTestsControl.<>c__DisplayClass63_1.<<ExecuteTestsForInstance>g__InvokeTestMethod|2>d.MoveNext()

Failed: When_MediaPlayerElement_NotAutoPlay_Source() [Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException] 
 Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: Timed out waiting for condition to be met. Windows.UI.Xaml.Controls.MediaPlayerElement loaded
   at Private.Infrastructure.TestServices.WindowHelper.WaitFor(Func`1 condition, Int32 timeoutMS, String message, String callerMemberName, Int32 lineNumber)
   at Private.Infrastructure.TestServices.WindowHelper.<>c__DisplayClass33_0.<<WaitForLoaded>g__Do|0>d.MoveNext()
--- End of stack trace from previous location ---
   at Private.Infrastructure.TestServices.WindowHelper.WaitForLoaded(FrameworkElement element, Int32 timeoutMS)
   at Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Given_MediaPlayerElement.When_MediaPlayerElement_NotAutoPlay_Source()
   at Uno.UI.Samples.Tests.UnitTestsControl.<>c__DisplayClass63_1.<<ExecuteTestsForInstance>g__InvokeTestMethod|2>d.MoveNext()

Failed: When_MediaPlayerElement_SetIsFullWindow_Check_Fullscreen() [Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException] 
 Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: Timed out waiting for condition to be met. Windows.UI.Xaml.Controls.MediaPlayerElement loaded
   at Private.Infrastructure.TestServices.WindowHelper.WaitFor(Func`1 condition, Int32 timeoutMS, String message, String callerMemberName, Int32 lineNumber)
   at Private.Infrastructure.TestServices.WindowHelper.<>c__DisplayClass33_0.<<WaitForLoaded>g__Do|0>d.MoveNext()
--- End of stack trace from previous location ---
   at Private.Infrastructure.TestServices.WindowHelper.WaitForLoaded(FrameworkElement element, Int32 timeoutMS)
   at Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Given_MediaPlayerElement.When_MediaPlayerElement_SetIsFullWindow_Check_Fullscreen()
   at Uno.UI.Samples.Tests.UnitTestsControl.<>c__DisplayClass63_1.<<ExecuteTestsForInstance>g__InvokeTestMethod|2>d.MoveNext()

Failed: When_MediaPlayerElement_SetSource_Check_PlayStop() [Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException] 
 Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: Timed out waiting for condition to be met. Windows.UI.Xaml.Controls.MediaPlayerElement loaded
   at Private.Infrastructure.TestServices.WindowHelper.WaitFor(Func`1 condition, Int32 timeoutMS, String message, String callerMemberName, Int32 lineNumber)
   at Private.Infrastructure.TestServices.WindowHelper.<>c__DisplayClass33_0.<<WaitForLoaded>g__Do|0>d.MoveNext()
--- End of stack trace from previous location ---
   at Private.Infrastructure.TestServices.WindowHelper.WaitForLoaded(FrameworkElement element, Int32 timeoutMS)
   at Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Contr
```


## What is the new behavior?

Runs from a URL from uno-assets

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f60f165</samp>

Enabled and fixed some media player element tests in `Given_MediaPlayerElement.cs`. Updated the test video URL to improve reliability.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
