### PR TITLE
fix(scrollviewer): fix scrollability and offset calculations

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2258,6 +2258,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Content_Smaller_Than_Viewport.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_SnapPoints.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -8931,6 +8935,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Simple.xaml.cs">
       <DependentUpon>ScrollViewer_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Content_Smaller_Than_Viewport.xaml.cs">
+      <DependentUpon>ScrollViewer_Content_Smaller_Than_Viewport.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerFlyout_Automated.xaml.cs">
       <DependentUpon>DatePickerFlyout_Automated.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Content_Smaller_Than_Viewport.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Content_Smaller_Than_Viewport.xaml
@@ -1,0 +1,52 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Content_Smaller_Than_Viewport"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+        <Style x:Key="HorizontalScrollViewerStyle" TargetType="ScrollViewer">
+            <Setter Property="HorizontalScrollMode" Value="Auto" />
+            <Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
+            <Setter Property="VerticalScrollMode" Value="Disabled" />
+            <Setter Property="VerticalScrollBarVisibility" Value="Hidden" />
+            <Setter Property="Margin" Value="0,10" />
+        </Style>
+    </Page.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <ScrollViewer Style="{StaticResource HorizontalScrollViewerStyle}">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="Not scrollable." FontSize="40" />
+            </StackPanel>
+        </ScrollViewer>
+
+        <ScrollViewer Style="{StaticResource HorizontalScrollViewerStyle}" Grid.Row="1">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="This line should not be scrollable." FontSize="40" />
+            </StackPanel>
+        </ScrollViewer>
+
+        <ScrollViewer Style="{StaticResource HorizontalScrollViewerStyle}" Grid.Row="2">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="This line might be scrollable horizontally but not vertically." FontSize="40" />
+            </StackPanel>
+        </ScrollViewer>
+
+        <ScrollViewer Style="{StaticResource HorizontalScrollViewerStyle}" Grid.Row="3">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="This extremely long and exceedingly wide line should be scrollable horizontally but not vertically." FontSize="40" />
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Content_Smaller_Than_Viewport.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Content_Smaller_Than_Viewport.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	[Sample("Scrolling", Name = nameof(ScrollViewer_Content_Smaller_Than_Viewport), Description = "When the content of a ScrollViewer is smaller than the width or height of the ScrollViewer, the ScrollViewer should not be scrollable horizontally or vertically, respectively. To see this in action, resize SamplesApp to around 1000 pixels wide.")]
+	public sealed partial class ScrollViewer_Content_Smaller_Than_Viewport : Page
+	{
+		public ScrollViewer_Content_Smaller_Than_Viewport()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -253,13 +253,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForLoaded(SUT);
 			await WindowHelper.WaitForIdle();
 
-			var scp = SUT.FindVisualChildByType<ScrollContentPresenter>();
-			scp.HorizontalOffset.Should().Be(0);
+			var before = await UITestHelper.ScreenShot(SUT, true);
 
 			SUT.ChangeView(5, null, null);
+			await WindowHelper.WaitForIdle();
 
-			// The content is smaller than the viewport size, so it shouldn't be scrollable
-			scp.HorizontalOffset.Should().Be(0);
+			var after = await UITestHelper.ScreenShot(SUT, true);
+
+			await ImageAssert.AreEqualAsync(before, after);
 		}
 
 #if HAS_UNO

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -108,9 +108,9 @@ namespace Windows.UI.Xaml.Controls
 
 			if (horizontalOffset is double hOffset)
 			{
-				var extentWidth = ExtentWidth;
-				var viewportWidth = ViewportWidth;
-				var scrollX = ValidateInputOffset(hOffset, 0, extentWidth - viewportWidth);
+				var maxOffset = Scroller?.ScrollableWidth ?? ExtentWidth - ViewportWidth;
+
+				var scrollX = ValidateInputOffset(hOffset, 0, maxOffset);
 
 				success &= scrollX == hOffset;
 
@@ -122,9 +122,8 @@ namespace Windows.UI.Xaml.Controls
 
 			if (verticalOffset is double vOffset)
 			{
-				var extentHeight = ExtentHeight;
-				var viewportHeight = ViewportHeight;
-				var scrollY = ValidateInputOffset(vOffset, 0, extentHeight - viewportHeight);
+				var maxOffset = Scroller?.ScrollableHeight ?? ExtentHeight - ViewportHeight;
+				var scrollY = ValidateInputOffset(vOffset, 0, maxOffset);
 
 				success &= scrollY == vOffset;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -200,22 +200,19 @@ namespace Windows.UI.Xaml.Controls
 				{
 					// TODO: Handle zoom https://github.com/unoplatform/uno/issues/4309
 				}
-				else if (!canScrollVertically || properties.IsHorizontalMouseWheel || e.KeyModifiers == VirtualKeyModifiers.Shift)
+				else if (canScrollHorizontally && properties.IsHorizontalMouseWheel)
 				{
-					if (canScrollHorizontally)
-					{
 #if __WASM__ // On wasm the scroll might be async (especially with disableAnimation: false), so we need to use the pending value to support high speed multiple wheel events
-						var horizontalOffset = _pendingScrollTo?.horizontal ?? HorizontalOffset;
+					var horizontalOffset = _pendingScrollTo?.horizontal ?? HorizontalOffset;
 #else
-						var horizontalOffset = HorizontalOffset;
+					var horizontalOffset = HorizontalOffset;
 #endif
 
-						Set(
-							horizontalOffset: horizontalOffset + GetHorizontalScrollWheelDelta(DesiredSize, delta),
-							disableAnimation: false);
-					}
+					Set(
+						horizontalOffset: horizontalOffset + GetHorizontalScrollWheelDelta(DesiredSize, delta),
+						disableAnimation: false);
 				}
-				else
+				else if (canScrollVertically && !properties.IsHorizontalMouseWheel)
 				{
 #if __WASM__ // On wasm the scroll might be async (especially with disableAnimation: false), so we need to use the pending value to support high speed multiple wheel events
 					var verticalOffset = _pendingScrollTo?.vertical ?? VerticalOffset;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -200,7 +200,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					// TODO: Handle zoom https://github.com/unoplatform/uno/issues/4309
 				}
-				else if (canScrollHorizontally && properties.IsHorizontalMouseWheel)
+				else if (canScrollHorizontally && (!canScrollVertically || properties.IsHorizontalMouseWheel || e.KeyModifiers == VirtualKeyModifiers.Shift))
 				{
 #if __WASM__ // On wasm the scroll might be async (especially with disableAnimation: false), so we need to use the pending value to support high speed multiple wheel events
 					var horizontalOffset = _pendingScrollTo?.horizontal ?? HorizontalOffset;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8947

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c72cb35</samp>

This pull request fixes two bugs and adds one test related to the `ScrollContentPresenter` and the `ScrollViewer` controls. It makes the `ScrollContentPresenter` respect the scroll mode settings and the mouse wheel input, and it verifies that the `ScrollViewer` does not scroll when the content fits the viewport. The changes affect the files `ScrollContentPresenter.Managed.cs`, `ScrollContentPresenter.cs`, and `Given_ScrollViewer.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
