### PR TITLE
ci: Adjust sync generator to only load the solution once

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
@@ -112,6 +112,7 @@ public partial class Given_MediaPlayerElement
 
 #if __IOS__ || !HAS_UNO
 	// [Ignore("Test ignored on windows. Could not find the element by name. And Not supported under MAC [https://github.com/unoplatform/uno/issues/12663]")]
+	// [Ignore("https://github.com/unoplatform/uno/issues/13384")]
 	[Ignore("https://github.com/unoplatform/uno/issues/13384")]
 #endif
 	[TestMethod]

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -148,16 +148,16 @@ namespace Uno.UWPSyncGenerator
 
 			_dependencyPropertySymbol = s_referenceCompilation.GetTypeByMetadataName(BaseXamlNamespace + ".DependencyProperty");
 
-			var topProject = "Uno.UI";
+			var topProject = Path.Combine(Path.GetDirectoryName(basePath), "Uno.UI", "Uno.UI");
 
-			_iOSCompilation = await LoadProject($@"{basePath}\{topProject}.netcoremobile.csproj", "net7.0-ios");
-			_androidCompilation = await LoadProject($@"{basePath}\{topProject}.netcoremobile.csproj", "net7.0-android");
-			_unitTestsCompilation = await LoadProject($@"{basePath}\{topProject}.Tests.csproj", "net7.0");
-			_macCompilation = await LoadProject($@"{basePath}\{topProject}.netcoremobile.csproj", "net7.0-macos");
+			_iOSCompilation = await LoadProject($@"{topProject}.netcoremobile.csproj", "net7.0-ios");
+			_androidCompilation = await LoadProject($@"{topProject}.netcoremobile.csproj", "net7.0-android");
+			_unitTestsCompilation = await LoadProject($@"{topProject}.Tests.csproj", "net7.0");
+			_macCompilation = await LoadProject($@"{topProject}.netcoremobile.csproj", "net7.0-macos");
 
-			_netstdReferenceCompilation = await LoadProject($@"{basePath}\{topProject}.Reference.csproj", "net7.0");
-			_wasmCompilation = await LoadProject($@"{basePath}\{topProject}.Wasm.csproj", "net7.0");
-			_skiaCompilation = await LoadProject($@"{basePath}\{topProject}.Skia.csproj", "net7.0");
+			_netstdReferenceCompilation = await LoadProject($@"{topProject}.Reference.csproj", "net7.0");
+			_wasmCompilation = await LoadProject($@"{topProject}.Wasm.csproj", "net7.0");
+			_skiaCompilation = await LoadProject($@"{topProject}.Skia.csproj", "net7.0");
 
 			_iOSBaseSymbol = _iOSCompilation.GetTypeByMetadataName("UIKit.UIView");
 			_androidBaseSymbol = _androidCompilation.GetTypeByMetadataName("Android.Views.View");

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -148,14 +148,16 @@ namespace Uno.UWPSyncGenerator
 
 			_dependencyPropertySymbol = s_referenceCompilation.GetTypeByMetadataName(BaseXamlNamespace + ".DependencyProperty");
 
-			_iOSCompilation = await LoadProject($@"{basePath}\{baseName}.netcoremobile.csproj", "net7.0-ios");
-			_androidCompilation = await LoadProject($@"{basePath}\{baseName}.netcoremobile.csproj", "net7.0-android");
-			_unitTestsCompilation = await LoadProject($@"{basePath}\{baseName}.Tests.csproj", "net7.0");
-			_macCompilation = await LoadProject($@"{basePath}\{baseName}.netcoremobile.csproj", "net7.0-macos");
+			var topProject = "Uno.UI";
 
-			_netstdReferenceCompilation = await LoadProject($@"{basePath}\{baseName}.Reference.csproj", "net7.0");
-			_wasmCompilation = await LoadProject($@"{basePath}\{baseName}.Wasm.csproj", "net7.0");
-			_skiaCompilation = await LoadProject($@"{basePath}\{baseName}.Skia.csproj", "net7.0");
+			_iOSCompilation = await LoadProject($@"{basePath}\{topProject}.netcoremobile.csproj", "net7.0-ios");
+			_androidCompilation = await LoadProject($@"{basePath}\{topProject}.netcoremobile.csproj", "net7.0-android");
+			_unitTestsCompilation = await LoadProject($@"{basePath}\{topProject}.Tests.csproj", "net7.0");
+			_macCompilation = await LoadProject($@"{basePath}\{topProject}.netcoremobile.csproj", "net7.0-macos");
+
+			_netstdReferenceCompilation = await LoadProject($@"{basePath}\{topProject}.Reference.csproj", "net7.0");
+			_wasmCompilation = await LoadProject($@"{basePath}\{topProject}.Wasm.csproj", "net7.0");
+			_skiaCompilation = await LoadProject($@"{basePath}\{topProject}.Skia.csproj", "net7.0");
 
 			_iOSBaseSymbol = _iOSCompilation.GetTypeByMetadataName("UIKit.UIView");
 			_androidBaseSymbol = _androidCompilation.GetTypeByMetadataName("Android.Views.View");


### PR DESCRIPTION
This change moves to loading the solution project onces from the top-most useful project (uno.ui) and get types based on the assembly name, not through the project name.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a19c38</samp>

Simplify project loading logic in `Generator.cs` by using a constant for the Uno.UI project name. Replace `basePath` and `baseName` variables with `topProject` constant.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
