### PR TITLE
fix(textblock): Fix TextBlock measurement when explicit width is one pixel smaller than needed width

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -22,6 +22,56 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 	{
 		[TestMethod]
 		[RunsOnUIThread]
+		public async Task When_AvailableSize_Is_One_Pixel_Smaller_Than_Text()
+		{
+			var tb1 = new TextBlock()
+			{
+				Text = "Test a Test",
+				FontSize = 12,
+				FontFamily = new FontFamily("Arial"),
+				HorizontalAlignment = HorizontalAlignment.Center,
+				TextWrapping = TextWrapping.Wrap,
+			};
+
+			tb1.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+			var textSize = tb1.DesiredSize;
+
+			var tb2 = new TextBlock()
+			{
+				Text = "Test a Test",
+				FontSize = 12,
+				FontFamily = new FontFamily("Arial"),
+				HorizontalAlignment = HorizontalAlignment.Center,
+				TextWrapping = TextWrapping.Wrap,
+				Width = textSize.Width - 1, // This should let the text wrap and take two lines.
+			};
+
+			var stackPanel = new StackPanel()
+			{
+				Children =
+				{
+					tb1,
+					tb2,
+				},
+			};
+
+			WindowHelper.WindowContent = stackPanel;
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(textSize.Width, tb1.ActualWidth);
+			Assert.AreEqual(textSize.Height, tb1.ActualHeight);
+			Assert.AreEqual(textSize.Width - 1, tb2.ActualWidth);
+			Assert.AreEqual(textSize.Height * 2, tb2.ActualHeight);
+
+#if __WASM__
+			Assert.AreEqual(textSize.Width.ToString(), Uno.Foundation.WebAssemblyRuntime.InvokeJS($"document.getElementById({tb1.HtmlId}).offsetWidth"));
+			Assert.AreEqual(textSize.Height.ToString(), Uno.Foundation.WebAssemblyRuntime.InvokeJS($"document.getElementById({tb1.HtmlId}).offsetHeight"));
+			Assert.AreEqual((textSize.Width - 1).ToString(), Uno.Foundation.WebAssemblyRuntime.InvokeJS($"document.getElementById({tb2.HtmlId}).offsetWidth"));
+			Assert.AreEqual((textSize.Height * 2).ToString(), Uno.Foundation.WebAssemblyRuntime.InvokeJS($"document.getElementById({tb2.HtmlId}).offsetHeight"));
+#endif
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
 		public async Task Check_TextDecorations_Binding()
 		{
 			var SUT = new TextDecorationsBinding();

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -1270,8 +1270,7 @@ namespace Uno.UI {
 			const resultWidth = offsetWidth ? offsetWidth : element.clientWidth;
 			const resultHeight = offsetHeight ? offsetHeight : element.clientHeight;
 
-			// +1 is added to take rounding/flooring into account
-			return [resultWidth + 1, resultHeight];
+			return [resultWidth, resultHeight];
 		}
 
 		private measureViewInternal(viewId: number, maxWidth: number, maxHeight: number, measureContent: boolean): [number, number] {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8522

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8bbc7b</samp>

This pull request adds a new test for `TextBlock` wrapping behavior and fixes a layout bug on the WebAssembly platform by removing a +1 adjustment in the `measureElement` method of `WindowManager.ts`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
