### PR TITLE
fix: update Uno.Fonts.Fluent for informational icon

### DIFF
--- a/build/nuget/Uno.WinUI.nuspec
+++ b/build/nuget/Uno.WinUI.nuspec
@@ -33,28 +33,28 @@
 				<dependency id="Xamarin.AndroidX.Browser"  version="1.0.0" />
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 
 			<!-- net7.0-ios -->
 			<group targetFramework="net7.0-ios">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 
 			<!-- net7.0-maccatalyst -->
 			<group targetFramework="net7.0-maccatalyst">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 
 			<!-- net7.0-macos -->
 			<group targetFramework="net7.0-macos">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 
 			<!-- net8.0-android30.0 -->
@@ -66,28 +66,28 @@
 				<dependency id="Xamarin.AndroidX.Browser"  version="1.0.0" />
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 
 			<!-- net8.0-ios -->
 			<group targetFramework="net8.0-ios">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 
 			<!-- net8.0-maccatalyst -->
 			<group targetFramework="net8.0-maccatalyst">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 
 			<!-- net8.0-macos -->
 			<group targetFramework="net8.0-macos">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 
 			<!-- .NET 7 (Reference API) -->
@@ -98,7 +98,7 @@
 				<dependency id="System.Memory" version="4.5.2" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
 				<dependency id="System.Collections.Immutable" version="1.3.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 
 			<!-- .NET 8 (Reference API) -->
@@ -109,7 +109,7 @@
 				<dependency id="System.Memory" version="4.5.2" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
 				<dependency id="System.Collections.Immutable" version="1.3.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.6" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
 			</group>
 		</dependencies>
 

--- a/build/nuget/Uno.WinUI.nuspec
+++ b/build/nuget/Uno.WinUI.nuspec
@@ -33,28 +33,28 @@
 				<dependency id="Xamarin.AndroidX.Browser"  version="1.0.0" />
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 
 			<!-- net7.0-ios -->
 			<group targetFramework="net7.0-ios">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 
 			<!-- net7.0-maccatalyst -->
 			<group targetFramework="net7.0-maccatalyst">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 
 			<!-- net7.0-macos -->
 			<group targetFramework="net7.0-macos">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 
 			<!-- net8.0-android30.0 -->
@@ -66,28 +66,28 @@
 				<dependency id="Xamarin.AndroidX.Browser"  version="1.0.0" />
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 
 			<!-- net8.0-ios -->
 			<group targetFramework="net8.0-ios">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 
 			<!-- net8.0-maccatalyst -->
 			<group targetFramework="net8.0-maccatalyst">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 
 			<!-- net8.0-macos -->
 			<group targetFramework="net8.0-macos">
 				<dependency id="Uno.Foundation.Logging" version="0.0.0" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 
 			<!-- .NET 7 (Reference API) -->
@@ -98,7 +98,7 @@
 				<dependency id="System.Memory" version="4.5.2" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
 				<dependency id="System.Collections.Immutable" version="1.3.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 
 			<!-- .NET 8 (Reference API) -->
@@ -109,7 +109,7 @@
 				<dependency id="System.Memory" version="4.5.2" />
 				<dependency id="Uno.Diagnostics.Eventing" version="2.0.1" />
 				<dependency id="System.Collections.Immutable" version="1.3.1" />
-				<dependency id="Uno.Fonts.Fluent" version="2.3.0-dev.8" />
+				<dependency id="Uno.Fonts.Fluent" version="2.3.0" />
 			</group>
 		</dependencies>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -82,7 +82,7 @@
 		<PackageReference Update="Uno.UITest.Selenium" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Xamarin" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
-		<PackageReference Update="Uno.Fonts.Fluent" Version="2.3.0-dev.6" />
+		<PackageReference Update="Uno.Fonts.Fluent" Version="2.3.0-dev.8" />
 		<PackageReference Update="Xamarin.DuoSdk" Version="0.0.3.4" />
 		<PackageReference Update="Xamarin.UITest" Version="4.1.4" />
 		<PackageReference Update="Xamarin.TestCloud.Agent" Version="0.23.2" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -82,7 +82,7 @@
 		<PackageReference Update="Uno.UITest.Selenium" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Xamarin" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
-		<PackageReference Update="Uno.Fonts.Fluent" Version="2.3.0-dev.8" />
+		<PackageReference Update="Uno.Fonts.Fluent" Version="2.3.0" />
 		<PackageReference Update="Xamarin.DuoSdk" Version="0.0.3.4" />
 		<PackageReference Update="Xamarin.UITest" Version="4.1.4" />
 		<PackageReference Update="Xamarin.TestCloud.Agent" Version="0.23.2" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?

Uno.Fonts.Fluent didn't have the right exa for informational icon

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Uno.Fonts.Fluent did have the right exa for informational icon
<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39eb90f</samp>

This pull request updates the Uno.Fonts.Fluent package to version 2.3.0-dev.8 in both the nuspec file and the source projects. This improves the consistency and compatibility of the Fluent UI icons and fonts for Uno applications.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
