### PR TITLE
fix: Fix shapes clipping on Android

### DIFF
--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
@@ -113,7 +113,8 @@ public abstract class UnoViewGroup
 	
 		// Original bug: https://github.com/unoplatform/Uno.Gallery/issues/898
 	
-		// Check for opacity (Alpha) and return false if it's less than 1f
+		// We always return false without checking for opacity (Alpha). This is because
+		// the opacity may be set on a parent, and for performance concerns we don't want to walk all the parents.
 		return false;
 	}
 

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
@@ -114,7 +114,7 @@ public abstract class UnoViewGroup
 		// Original bug: https://github.com/unoplatform/Uno.Gallery/issues/898
 	
 		// Check for opacity (Alpha) and return false if it's less than 1f
-		return getAlpha() >= 1 && super.hasOverlappingRendering();
+		return false;
 	}
 
 	private boolean _unoLayoutOverride;

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.Android.cs
@@ -36,19 +36,6 @@ namespace Windows.UI.Xaml.Shapes
 				return;
 			}
 
-			//Drawing paths on the canvas does not respect the canvas' ClipBounds
-			if (ClippedFrame is { } clippedFrame)
-			{
-				clippedFrame = clippedFrame.LogicalToPhysicalPixels();
-				if (FrameRoundingAdjustment is { } fra)
-				{
-					clippedFrame.Width += fra.Width;
-					clippedFrame.Height += fra.Height;
-				}
-
-				canvas.ClipRect(clippedFrame.ToRectF());
-			}
-
 			DrawFill(canvas);
 			DrawStroke(canvas);
 		}


### PR DESCRIPTION
Fixes #13652 
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

This code is causing incorrect clipping, for example:

![image](https://github.com/unoplatform/uno/assets/31348972/8de146cc-5f4b-4505-a03f-64973f631314)

Let's see if there will be any test failures.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6002ca</samp>

Remove canvas clipping from `Shape.Android.cs` and delegate it to `FrameworkElement`. This improves the rendering of shapes with negative margins or offsets on Android.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
