### PR TITLE
feat(wasm): Support RTL FlowDirection on Wasm

### DIFF
--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -62,7 +62,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoRuntimeIdentifier)'=='WebAssembly'">
-		<DefineConstants>$(DefineConstants);__WASM__;UNO_HAS_ENHANCED_HIT_TEST_PROPERTY</DefineConstants>
+		<DefineConstants>$(DefineConstants);__WASM__;UNO_HAS_ENHANCED_HIT_TEST_PROPERTY;SUPPORTS_RTL</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(UnoRuntimeIdentifier)'=='Skia'">

--- a/src/Uno.UI/Media/NativeRenderTransformAdapter.wasm.cs
+++ b/src/Uno.UI/Media/NativeRenderTransformAdapter.wasm.cs
@@ -35,12 +35,22 @@ namespace Uno.UI.Media
 			}
 			else
 			{
-				Owner.SetNativeTransform(Transform.MatrixCore);
+				FlowDirectionTransform = Owner.GetFlowDirectionTransform();
+
+				if (Transform is null)
+				{
+					Owner.SetNativeTransform(FlowDirectionTransform);
+				}
+				else
+				{
+					Owner.SetNativeTransform(Transform.MatrixCore * FlowDirectionTransform);
+				}
 			}
 		}
 
 		partial void Cleanup()
 		{
+			FlowDirectionTransform = Matrix3x2.Identity;
 			Owner.ResetStyle("transform");
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Media;
 using Uno.UI;
+using System.Numerics;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -148,6 +149,16 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			return base.ArrangeOverride(arrangeSize);
+		}
+
+		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
+		{
+			base.OnPropertyChanged2(args);
+			if (args.Property == FlowDirectionProperty)
+			{
+				OnTextAlignmentChanged();
+				ApplyFlowDirection(FlowDirection == FlowDirection.RightToLeft);
+			}
 		}
 
 		partial void OnFontStyleChangedPartial() => _fontStyleChanged = true;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -12,6 +12,7 @@ namespace Windows.UI.Xaml.Controls
 		internal TextBoxView TextBoxView => _textBoxView;
 
 		protected override bool IsDelegatingFocusToTemplateChild() => true; // _textBoxView
+
 		partial void OnDeleteButtonClickPartial() => FocusTextView();
 		internal bool FocusTextView() => FocusManager.FocusNative(_textBoxView);
 
@@ -48,6 +49,8 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void InitializePropertiesPartial()
 		{
+			ApplyFlowDirection(FlowDirection == FlowDirection.RightToLeft);
+
 			if (_header != null)
 			{
 				AddHandler(PointerReleasedEvent, (PointerEventHandler)OnHeaderClick, true);
@@ -62,6 +65,12 @@ namespace Windows.UI.Xaml.Controls
 		private void OnHeaderClick(object sender, object args)
 		{
 			FocusTextView();
+		}
+
+		partial void OnFlowDirectionChangedPartial()
+		{
+			OnTextAlignmentChanged(TextAlignment);
+			_textBoxView?.ApplyFlowDirection(FlowDirection == FlowDirection.RightToLeft);
 		}
 
 		partial void OnForegroundColorChangedPartial(Brush newValue)

--- a/src/Uno.UI/UI/Xaml/UIElement.TextHelper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.TextHelper.wasm.cs
@@ -14,6 +14,7 @@ using Uno.UI.Xaml.Media;
 
 using RadialGradientBrush = Microsoft.UI.Xaml.Media.RadialGradientBrush;
 using Uno.UI.Helpers;
+using System.Numerics;
 
 namespace Windows.UI.Xaml
 {
@@ -146,6 +147,21 @@ namespace Windows.UI.Xaml
 			}
 		}
 
+		internal void ApplyFlowDirection(bool isRtl)
+		{
+			// TODO: This will break if RenderTransform is used on the TextBlock.
+			// One of the transforms will override the other.
+			// TODO: Verify whether this breaks TextBlock if RTL FlowDirection is set "locally" (not inherited)
+			if (isRtl)
+			{
+				this.SetNativeTransform(new Matrix3x2(-1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f));
+			}
+			else
+			{
+				this.SetNativeTransform(Matrix3x2.Identity);
+			}
+		}
+
 		internal void SetForeground(object localValue)
 		{
 			switch (localValue)
@@ -260,6 +276,7 @@ namespace Windows.UI.Xaml
 			else
 			{
 				var value = (TextAlignment)localValue;
+
 				switch (value)
 				{
 					case TextAlignment.Left:

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -19,6 +19,7 @@ using Windows.System;
 using Color = Windows.UI.Color;
 using System.Globalization;
 using Microsoft.UI.Input;
+using Uno.UI.Media;
 
 namespace Windows.UI.Xaml
 {
@@ -236,6 +237,13 @@ namespace Windows.UI.Xaml
 
 			Uno.UI.Xaml.WindowManagerInterop.ArrangeElement(HtmlId, rect, clipRect);
 			OnViewportUpdated(clipRect ?? Rect.Empty);
+
+			if (_renderTransform is null && !GetFlowDirectionTransform().IsIdentity)
+			{
+				_renderTransform = new NativeRenderTransformAdapter(this, RenderTransform, RenderTransformOrigin);
+			}
+
+			_renderTransform?.UpdateFlowDirectionTransform();
 
 #if DEBUG
 			var count = ++_arrangeCount;


### PR DESCRIPTION
To be rebased after #13524 is merged

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d700959</samp>

This pull request adds support for the `FlowDirection` property to various UI controls and elements on the WebAssembly and Skia platforms, which enables rendering the UI in different languages and cultures that use right-to-left or left-to-right text flow. It also adds some tests and helper methods to verify the RTL feature, and introduces a new conditional compilation symbol, `SUPPORTS_RTL`, to enable or disable the RTL code depending on the target platform.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
