### PR TITLE
fix(assets): Adjust upri handling

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -32,6 +32,7 @@
 			<_AllChildProjectItemsWithTargetPath Include="$(ProjectUnoPriFullPath)">
 				<TargetPath>$(ProjectUnoPriFileName)</TargetPath>
 				<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+				<PublishFolderType>None</PublishFolderType>
 			</_AllChildProjectItemsWithTargetPath>
 		</ItemGroup>
 
@@ -198,7 +199,7 @@
 	as nuget packages content.
 	-->
 	<Target Name="_UnoAssetsGetCopyToPublishDirectory"
-	BeforeTargets="GetCopyToPublishDirectoryItems">
+			BeforeTargets="GetCopyToPublishDirectoryItems;_UnoGeneratePriMarker">
 		<ItemGroup>
 			<ContentWithTargetPath Include="@(_TransitiveItemsToCopyToOutputDirectory)">
 				<TargetPath>%(TargetPath)</TargetPath>

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -40,10 +40,13 @@
 	
 	<!--
 	Marker generation to ensure that assets are only copied for uno-enabled targets
+
+	The target needs also to run in the context of generating a nuget package after a build 
+	has already occurred. See https://github.com/unoplatform/uno/issues/13167#issuecomment-1677286706
 	-->
 	<Target Name="_UnoGeneratePriMarker"
 			Condition="'$(GenerateLibraryLayout)' == 'true' AND '$(SDKIdentifier)' != 'Windows'"
-			BeforeTargets="PrepareForRun"
+			BeforeTargets="PrepareForRun;GenerateNuSpec"
 			DependsOnTargets="_DefineUnoPriProperties">
 		
 		<WriteLinesToFile File="$(ProjectUnoPriFullPath)"
@@ -199,7 +202,7 @@
 	as nuget packages content.
 	-->
 	<Target Name="_UnoAssetsGetCopyToPublishDirectory"
-			BeforeTargets="GetCopyToPublishDirectoryItems;_UnoGeneratePriMarker">
+			BeforeTargets="GetCopyToPublishDirectoryItems">
 		<ItemGroup>
 			<ContentWithTargetPath Include="@(_TransitiveItemsToCopyToOutputDirectory)">
 				<TargetPath>%(TargetPath)</TargetPath>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/13167

## What is the new behavior?

- Ensures that the upri handling is done after its inputs have been filled
- Marks upri files as not publishable to avoid https://github.com/xamarin/xamarin-macios/blob/8b3bf352d16d68b493c578be57ffe67bf37043c6/msbuild/Xamarin.MacDev.Tasks/Tasks/ComputeBundleLocationTaskBase.cs#L368


## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e37c2d7</samp>

This pull request optimizes the web assembly build and publish process by adjusting the content items and targets in the `uno.ui.tasks.assets.targets` file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
