### PR TITLE
feat(GTK Window): Extend into Title Bar

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/GtkHost.cs
@@ -91,6 +91,7 @@ namespace Uno.UI.Runtime.Skia.Gtk
 			MainWindow.Shown += MainWindow_Shown;
 			MainWindow.UpdateWindowPropertiesFromPackage();
 			MainWindow.UpdateWindowPropertiesFromApplicationView();
+			MainWindow.UpdateWindowPropertiesFromCoreApplication();
 		}
 
 		internal event EventHandler? MainWindowShown;

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkWindow.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkWindow.cs
@@ -7,6 +7,7 @@ using System.IO;
 using Gtk;
 using Uno.Foundation.Logging;
 using Uno.UI.Runtime.Skia.Gtk.UI.Core;
+using Windows.ApplicationModel.Core;
 using Windows.Foundation;
 using Windows.UI.Core.Preview;
 using Windows.UI.ViewManagement;
@@ -140,6 +141,12 @@ internal class UnoGtkWindow : Window
 		var appView = ApplicationView.GetForCurrentView();
 		Title = appView.Title;
 		SetSizeRequest((int)appView.PreferredMinSize.Width, (int)appView.PreferredMinSize.Height);
+	}
+
+	internal void UpdateWindowPropertiesFromCoreApplication()
+	{
+		var coreApplicationView = CoreApplication.GetCurrentView();
+		Decorated = !coreApplicationView.TitleBar.ExtendViewIntoTitleBar;
 	}
 
 	private void OnWindowStateChanged(object o, WindowStateEventArgs args)

--- a/src/Uno.UWP/ApplicationModel/Core/CoreApplicationViewTitleBar.cs
+++ b/src/Uno.UWP/ApplicationModel/Core/CoreApplicationViewTitleBar.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Windows.ApplicationModel.Core
 {
-#if !__ANDROID__
+#if !__ANDROID__ && !__SKIA__
 	[global::Uno.NotImplemented]
 #endif
 	public partial class CoreApplicationViewTitleBar
@@ -13,7 +13,7 @@ namespace Windows.ApplicationModel.Core
 		internal event Action ExtendViewIntoTitleBarChanged;
 #pragma warning restore 67
 
-#if !__ANDROID__
+#if !__ANDROID__ && !__SKIA__
 		[global::Uno.NotImplemented]
 		public bool ExtendViewIntoTitleBar
 		{

--- a/src/Uno.UWP/ApplicationModel/Core/CoreApplicationViewTitleBar.skia.cs
+++ b/src/Uno.UWP/ApplicationModel/Core/CoreApplicationViewTitleBar.skia.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.ApplicationModel.Core;
+
+partial class CoreApplicationViewTitleBar
+{
+	public bool ExtendViewIntoTitleBar { get; set; }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/10874, closes https://github.com/unoplatform/uno/issues/10368

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We can not extned into title bar in GTK

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

We can use the Decorated window in GTK by set `CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true`


## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1f5054</samp>

This pull request adds support for the `ExtendViewIntoTitleBar` feature on the Skia.Gtk platform. It enables the `CoreApplicationViewTitleBar` class and its property for Skia apps, and updates the window decoration accordingly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


---

How can I add the UITest to test the application startup?

Can I know current application are running with GTK?