### PR TITLE
fix(resw): Log invalid resw language as warnings

### DIFF
--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -18,3 +18,9 @@ This error code means that a WinAppSDK project is referencing a project in your 
 This can happen if a project contains only a `net7.0` TargetFramework and has a NuGet reference to `Uno.WinUI`.
 
 To fix this, it is best to start from a `Cross Platform Library` project template provided by the Uno Platform [visual studio extension](xref:Guide.HowTo.Create-Control-Library), or using [`dotnet new`](xref:Uno.GetStarted.dotnet-new).
+
+## UNOB0003: Ignoring resource XX, could not determine the language
+
+This error may occur during resources (`.resw`) analysis if the framework does not recognize the language being specified.
+
+For instance, the language `zh-CN` is not recognized. `zh-Hans` should be used instead.

--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -21,6 +21,6 @@ To fix this, it is best to start from a `Cross Platform Library` project templat
 
 ## UNOB0003: Ignoring resource XX, could not determine the language
 
-This error may occur during resources (`.resw`) analysis if the framework does not recognize the language being specified.
+This error may occur during resources (`.resw`) analysis if the framework does not recognize the specified language code.
 
-For instance, the language `zh-CN` is not recognized. `zh-Hans` should be used instead.
+For instance, the language code `zh-CN` is not recognized and `zh-Hans` should be used instead.

--- a/src/SourceGenerators/Uno.UI.Tasks/ResourcesGenerator/ResourcesGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/ResourcesGenerator/ResourcesGenerationTask.cs
@@ -80,7 +80,7 @@ public class ResourcesGenerationTask_v0 : Task
 		if (language == null)
 		{
 			// TODO: Add support for resources without a language qualifier
-			TraceLog("No language found, resources ignored");
+			TraceWarning("UNOB0003", $"Ignoring resource {resource.ItemSpec}, could not determine the language");
 			yield break;
 		}
 
@@ -253,11 +253,17 @@ public class ResourcesGenerationTask_v0 : Task
 			}
 		);
 	}
+
 	private void TraceLog(string message)
 	{
 		if (EnableTraceLogging)
 		{
 			Log.LogMessage(message);
 		}
+	}
+
+	private void TraceWarning(string warningCode, string message)
+	{
+		Log.LogWarning(null, warningCode, null, null, 0, 0, 0, 0, message);
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Log a warning during resw file processing if the language is unknown.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77808f0</samp>

This pull request enhances the error reporting for resource files with invalid languages in the `ResourcesGenerationTask_v0` class. It also updates the documentation of Uno build error codes with the new error UNOB0003.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
