### PR TITLE
fix(iOS): ListViewItem detaching from its Parent

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -5182,6 +5182,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_DataContext_Reference.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>    
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BindableBase.cs" />
@@ -9107,6 +9111,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\BackButtonImage\CommandBar_Page2.xaml.cs">
       <DependentUpon>CommandBar_Page2.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_DataContext_Reference.xaml.cs" >
+        <DependentUpon>ListView_DataContext_Reference.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml
@@ -19,10 +19,10 @@
 
 				<TextBlock>
 					<Run Text="Parent data context:" />
-					<Run Text="{Binding DataContext, ElementName=Parent}" />
+					<Run Text="{Binding DataContext, ElementName=ParentListView}" />
 				</TextBlock>
 
-				<Button Command="{Binding DataContext.Command, ElementName=Parent}"
+				<Button Command="{Binding DataContext.Command, ElementName=ParentListView}"
 						CommandParameter="{Binding}"
 						Content="Click" />
 			</StackPanel>
@@ -30,14 +30,8 @@
 	</UserControl.Resources>
 
 	<StackPanel Margin="8, 32">
-		<TextBlock>
-			<Run Text="Page DataContext:" />
-			<Run Text="{Binding DataContext, ElementName=Parent}" />
-		</TextBlock>
-		<Button Command="{Binding DataContext.Command, ElementName=Parent}"
-				Content="Click" />
 		<ListView ItemsSource="{Binding Items}"
-				  x:Name="Parent"
+				  x:Name="ParentListView"
 				  ItemTemplate="{StaticResource ItemTemplate}" />
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml
@@ -8,7 +8,7 @@
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">
-    
+
 	<UserControl.Resources>
 		<DataTemplate x:Key="ItemTemplate">
 			<StackPanel Background="LightBlue">
@@ -29,10 +29,15 @@
 		</DataTemplate>
 	</UserControl.Resources>
 
-	<Grid Margin="8, 32">
-
+	<StackPanel Margin="8, 32">
+		<TextBlock>
+			<Run Text="Page DataContext:" />
+			<Run Text="{Binding DataContext, ElementName=Parent}" />
+		</TextBlock>
+		<Button Command="{Binding DataContext.Command, ElementName=Parent}"
+				Content="Click" />
 		<ListView ItemsSource="{Binding Items}"
 				  x:Name="Parent"
 				  ItemTemplate="{StaticResource ItemTemplate}" />
-	</Grid>
+	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml
@@ -1,0 +1,38 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ListView.ListView_DataContext_Reference"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ListView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+    
+	<UserControl.Resources>
+		<DataTemplate x:Key="ItemTemplate">
+			<StackPanel Background="LightBlue">
+				<TextBlock>
+					<Run Text="Item content:" />
+					<Run Text="{Binding Name}" />
+				</TextBlock>
+
+				<TextBlock>
+					<Run Text="Parent data context:" />
+					<Run Text="{Binding DataContext, ElementName=Parent}" />
+				</TextBlock>
+
+				<Button Command="{Binding DataContext.Command, ElementName=Parent}"
+						CommandParameter="{Binding}"
+						Content="Click" />
+			</StackPanel>
+		</DataTemplate>
+	</UserControl.Resources>
+
+	<Grid Margin="8, 32">
+
+		<ListView ItemsSource="{Binding Items}"
+				  x:Name="Parent"
+				  ItemTemplate="{StaticResource ItemTemplate}" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml.cs
@@ -18,10 +18,9 @@ using System.Windows.Input;
 using System.ComponentModel;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
-
 namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
 {
-	[SampleControlInfo("ListView", "ListView_DataContext_Reference", viewModelType:typeof(DataContextReferenceViewModel))]
+	[SampleControlInfo("ListView", "ListView_DataContext_Reference", viewModelType: typeof(DataContextReferenceViewModel), isManualTest: true)]
 	public sealed partial class ListView_DataContext_Reference : UserControl
 	{
 		public ListView_DataContext_Reference()
@@ -30,72 +29,70 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
 		}
 	}
 
-    public class DataContextReferenceViewModel
-    {
-        //private int nextIndex = 100;
-        public ObservableCollection<Item> Items { get; } =
-            new ObservableCollection<Item>(Enumerable.Range(0, 10).Select(x => new Item(x)));
+	public class DataContextReferenceViewModel
+	{
+		public ObservableCollection<Item> Items { get; } =
+			new ObservableCollection<Item>(Enumerable.Range(0, 10).Select(x => new Item(x)));
 
-        private ICommand _command;
-        public ICommand Command
-        {
-            get
-            {
-                _command ??= new Command<Item>(ExecuteCommand);
-
-                return _command;
-            }
-        }
-
-        private void ExecuteCommand(Item item)
-        {
-            if (item is null)
-            {
-                Console.WriteLine("Item was null");
-                return;
-            }
-
-            Items.Remove(item);
-			//Items.Add(new Item(++nextIndex));
-			//Items.Add(item with { Name = $"Selected item {item.Index}" });
-			Items.Insert(item.Index, item with { Name = $"Selected item {item.Index}" });
+		private ICommand _command;
+		public ICommand Command
+		{
+			get
+			{
+				_command ??= new Command<Item>(ExecuteCommand);
+				return _command;
+			}
 		}
-    }
 
-    public record Item
-    {
-        public Item(int index)
-        {
-            Index = index;
-            Name = $"Item {index}";
-        }
+		private void ExecuteCommand(Item item)
+		{
+			if (item is null)
+			{
+				Console.WriteLine("Item was null");
+				return;
+			}
 
-        public int Index { get; init; }
+			var newItem = item with { Name = $"Selected item {item.Index}" };
 
-        public string Name { get; init; }
-    }
+			Items.Remove(item);
+			Items.Insert(newItem.Index, newItem);
+		}
+	}
 
-    public class Command<T> : ICommand
-    {
-        private readonly Action<T> _act;
+	public record Item
+	{
+		public Item(int index)
+		{
+			Index = index;
+			Name = $"Item {index}";
+		}
 
-        public Command(Action<T> act)
-        {
-            _act = act;
-        }
+		public int Index { get; init; }
 
-        public event EventHandler CanExecuteChanged;
+		public string Name { get; init; }
+	}
 
-        public bool CanExecute(object parameter) => true;
+	public class Command<T> : ICommand
+	{
+		private readonly Action<T> _act;
 
-        public void Execute(object parameter)
-        {
-            _act?.Invoke((T)parameter!);
-        }
+		public Command(Action<T> act)
+		{
+			_act = act;
+		}
 
-        public void UpdateCanExecuteChanged()
-        {
-            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
-        }
-    }	
+		public event EventHandler CanExecuteChanged;
+
+		public bool CanExecute(object parameter) => true;
+
+		public void Execute(object parameter)
+		{
+			_act?.Invoke((T)parameter!);
+		}
+
+		public void UpdateCanExecuteChanged()
+		{
+			CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo("ListView", "ListView_DataContext_Reference", viewModelType:typeof(DataContextReferenceViewModel))]
+	public sealed partial class ListView_DataContext_Reference : UserControl
+	{
+		public ListView_DataContext_Reference()
+		{
+			this.InitializeComponent();
+		}
+	}
+
+    public class DataContextReferenceViewModel
+    {
+        public ObservableCollection<Item> Items { get; } = new ObservableCollection<Item>(Enumerable.Range(0, 10).Select(x => new Item(x)));
+
+        private ICommand? _command;
+        public ICommand Command
+        {
+            get
+            {
+                if (_command is null)
+                {
+                    _command = new Command<Item>(ExecuteCommand);
+                }
+
+                return _command;
+            }
+        }
+
+        private void ExecuteCommand(Item item)
+        {
+            Items.Remove(item);
+            Items.Insert(item.Index, item with { Name = "Selected item" });
+        }
+    }
+
+    public record Item
+    {
+        public Item(int index)
+        {
+            Index = index;
+            Name = $"Item {index}";
+        }
+
+        public int Index { get; init; }
+
+        public string Name { get; init; }
+    }
+
+    public class Command<T> : ICommand
+    {
+        private readonly Action<T> _act;
+
+        public Command(Action<T> act)
+        {
+            _act = act;
+        }
+
+        public event EventHandler? CanExecuteChanged;
+
+        public bool CanExecute(object? parameter) => true;
+
+        public void Execute(object? parameter)
+        {
+            _act((T)parameter!);
+        }
+    }	
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_DataContext_Reference.xaml.cs
@@ -14,6 +14,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using System.Collections.ObjectModel;
+using System.Windows.Input;
 using System.ComponentModel;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
@@ -31,17 +32,16 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
 
     public class DataContextReferenceViewModel
     {
-        public ObservableCollection<Item> Items { get; } = new ObservableCollection<Item>(Enumerable.Range(0, 10).Select(x => new Item(x)));
+        //private int nextIndex = 100;
+        public ObservableCollection<Item> Items { get; } =
+            new ObservableCollection<Item>(Enumerable.Range(0, 10).Select(x => new Item(x)));
 
-        private ICommand? _command;
+        private ICommand _command;
         public ICommand Command
         {
             get
             {
-                if (_command is null)
-                {
-                    _command = new Command<Item>(ExecuteCommand);
-                }
+                _command ??= new Command<Item>(ExecuteCommand);
 
                 return _command;
             }
@@ -49,9 +49,17 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
 
         private void ExecuteCommand(Item item)
         {
+            if (item is null)
+            {
+                Console.WriteLine("Item was null");
+                return;
+            }
+
             Items.Remove(item);
-            Items.Insert(item.Index, item with { Name = "Selected item" });
-        }
+			//Items.Add(new Item(++nextIndex));
+			//Items.Add(item with { Name = $"Selected item {item.Index}" });
+			Items.Insert(item.Index, item with { Name = $"Selected item {item.Index}" });
+		}
     }
 
     public record Item
@@ -76,13 +84,18 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
             _act = act;
         }
 
-        public event EventHandler? CanExecuteChanged;
+        public event EventHandler CanExecuteChanged;
 
-        public bool CanExecute(object? parameter) => true;
+        public bool CanExecute(object parameter) => true;
 
-        public void Execute(object? parameter)
+        public void Execute(object parameter)
         {
-            _act((T)parameter!);
+            _act?.Invoke((T)parameter!);
+        }
+
+        public void UpdateCanExecuteChanged()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
         }
     }	
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -230,39 +230,39 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 
 #if HAS_UNO
-	[TestMethod]
-	[RunsOnUIThread]
-	public async Task ContainerParentIsKept_OnRemoveAndAdd()
-	{
-		var source = new ObservableCollection<string>(Enumerable.Range(0, 5).Select(i => $"Item #{i}"));
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task ContainerParentIsKept_OnRemoveAndAdd()
+		{
+			var source = new ObservableCollection<string>(Enumerable.Range(0, 5).Select(i => $"Item #{i}"));
 
-		var indexToAssert = 1;
-		var item2 = source[indexToAssert];
-		var SUT = new ListView { ItemsSource = source };
-		WindowHelper.WindowContent = SUT;
+			var indexToAssert = 1;
+			var item2 = source[indexToAssert];
+			var SUT = new ListView { ItemsSource = source };
+			WindowHelper.WindowContent = SUT;
 
-		await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForIdle();
 
-		source.RemoveAt(indexToAssert);
-		await WindowHelper.WaitForIdle();
+			source.RemoveAt(indexToAssert);
+			await WindowHelper.WaitForIdle();
 
-		source.Insert(indexToAssert, item2);
-		await WindowHelper.WaitForIdle();
+			source.Insert(indexToAssert, item2);
+			await WindowHelper.WaitForIdle();
 
-		Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
+			Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
 
-		// There are situations where the isse occurs the second time.
-		indexToAssert = 3;
-		var item4 = source[indexToAssert];
+			// There are situations where the isse occurs the second time.
+			indexToAssert = 3;
+			var item4 = source[indexToAssert];
 
-		source.RemoveAt(indexToAssert);
-		await WindowHelper.WaitForIdle();
+			source.RemoveAt(indexToAssert);
+			await WindowHelper.WaitForIdle();
 
-		source.Insert(indexToAssert, item4);
-		await WindowHelper.WaitForIdle();
+			source.Insert(indexToAssert, item4);
+			await WindowHelper.WaitForIdle();
 
-		Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
-	}
+			Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
+		}
 #endif
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -228,6 +228,44 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+
+#if HAS_UNO
+		[TestMethod]
+		[RunsOnUIThread]
+#endif
+		public async Task ContainerParentIsKept_OnRemoveAndAdd()
+		{
+			var source = new ObservableCollection<string>(Enumerable.Range(0, 5).Select(i => $"Item #{i}"));
+
+			var indexToAssert = 1;
+			var item2 = source[indexToAssert];
+			var SUT = new ListView { ItemsSource = source };
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+
+			source.RemoveAt(indexToAssert);
+			await WindowHelper.WaitForIdle();
+
+			source.Insert(indexToAssert, item2);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
+
+			// There are situations where the isse occurs the second time.
+			indexToAssert = 3;
+			var item4 = source[indexToAssert];
+
+			source.RemoveAt(indexToAssert);
+			await WindowHelper.WaitForIdle();
+
+			source.Insert(indexToAssert, item4);
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
+		}
+
+
 		[TestMethod]
 		[RunsOnUIThread]
 		public void InvalidChanges_ShouldNotBeReflectedOnSelectedItem()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -230,41 +230,40 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 
 #if HAS_UNO
-		[TestMethod]
-		[RunsOnUIThread]
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task ContainerParentIsKept_OnRemoveAndAdd()
+	{
+		var source = new ObservableCollection<string>(Enumerable.Range(0, 5).Select(i => $"Item #{i}"));
+
+		var indexToAssert = 1;
+		var item2 = source[indexToAssert];
+		var SUT = new ListView { ItemsSource = source };
+		WindowHelper.WindowContent = SUT;
+
+		await WindowHelper.WaitForIdle();
+
+		source.RemoveAt(indexToAssert);
+		await WindowHelper.WaitForIdle();
+
+		source.Insert(indexToAssert, item2);
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
+
+		// There are situations where the isse occurs the second time.
+		indexToAssert = 3;
+		var item4 = source[indexToAssert];
+
+		source.RemoveAt(indexToAssert);
+		await WindowHelper.WaitForIdle();
+
+		source.Insert(indexToAssert, item4);
+		await WindowHelper.WaitForIdle();
+
+		Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
+	}
 #endif
-		public async Task ContainerParentIsKept_OnRemoveAndAdd()
-		{
-			var source = new ObservableCollection<string>(Enumerable.Range(0, 5).Select(i => $"Item #{i}"));
-
-			var indexToAssert = 1;
-			var item2 = source[indexToAssert];
-			var SUT = new ListView { ItemsSource = source };
-			WindowHelper.WindowContent = SUT;
-
-			await WindowHelper.WaitForIdle();
-
-			source.RemoveAt(indexToAssert);
-			await WindowHelper.WaitForIdle();
-
-			source.Insert(indexToAssert, item2);
-			await WindowHelper.WaitForIdle();
-
-			Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
-
-			// There are situations where the isse occurs the second time.
-			indexToAssert = 3;
-			var item4 = source[indexToAssert];
-
-			source.RemoveAt(indexToAssert);
-			await WindowHelper.WaitForIdle();
-
-			source.Insert(indexToAssert, item4);
-			await WindowHelper.WaitForIdle();
-
-			Assert.IsNotNull((SUT.ContainerFromIndex(indexToAssert) as ListViewItem)?.GetParent());
-		}
-
 
 		[TestMethod]
 		[RunsOnUIThread]

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -243,6 +243,13 @@ namespace Windows.UI.Xaml.Controls
 						this.Log().Debug($"Reusing view at indexPath={indexPath}, previously bound to {selectorItem.DataContext}.");
 					}
 
+					// When reusing the cell there are situation when the parent is detached from the cell.
+					// https://github.com/unoplatform/uno/issues/13199
+					if (selectorItem.GetParent() is null)
+					{
+						selectorItem.SetParent(Owner.XamlParent);
+					}
+
 					Owner?.XamlParent?.PrepareContainerForIndex(selectorItem, index);
 
 					// Normally this happens when the SelectorItem.Content is set, but there's an edge case where after a refresh, a

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -165,7 +165,10 @@ namespace Windows.UI.Xaml.Controls
 
 				// Reset the parent that may have been set by
 				// GetBindableSupplementaryView for header and footer content
-				key.Content.SetParent(null);
+				if (key.ElementKind == NativeListViewBase.ListViewFooterElementKindNS || key.ElementKind == NativeListViewBase.ListViewHeaderElementKindNS)
+				{
+					key.Content.SetParent(null);
+				}
 
 				if (_onRecycled.TryGetValue(key, out var actions))
 				{
@@ -387,6 +390,8 @@ namespace Windows.UI.Xaml.Controls
 				elementKind,
 				reuseIdentifier,
 				indexPath);
+
+			supplementaryView.ElementKind = elementKind;
 
 			using (supplementaryView.InterceptSetNeedsLayout())
 			{
@@ -739,6 +744,8 @@ namespace Windows.UI.Xaml.Controls
 		private Orientation ScrollOrientation => Owner.NativeLayout.ScrollOrientation;
 		private bool SupportsDynamicItemSizes => Owner.NativeLayout.SupportsDynamicItemSizes;
 		private ILayouter Layouter => Owner.NativeLayout.Layouter;
+
+		internal string ElementKind { get; set; }
 
 		protected override void Dispose(bool disposing)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13199 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When removing and adding a new Item in a ListView, the new items lose the connection with their Parent.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1928530</samp>

This pull request adds a new sample control to demonstrate data context and commands in a `ListView`, and fixes a bug in the `ListViewBaseSource` class on iOS that caused null parent issues for reused cells. The sample control uses a user control, a view model, and a generic command class to show how to bind data and execute actions in a `ListView` item template. The bug fix adds a condition to check and set the parent of the selector item in the `GetCell` method.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
