### PR TITLE
Fix example quote escaping in wasm-javascript-1.md

### DIFF
--- a/doc/articles/interop/wasm-javascript-1.md
+++ b/doc/articles/interop/wasm-javascript-1.md
@@ -173,7 +173,7 @@ await WebAssemblyRuntime.InvokeAsync(
 
 // Invoke javascript asynchronously and await returned string
 var str = await WebAssemblyRuntime.InvokeAsync(
-	"(async () => "It works asynchronously!")();");
+	"(async () => \"It works asynchronously!\")();");
 
 // Escape javascript data to prevent javascript script injection
 var escapedUserId = WebAssemblyRuntime.EscapeJS(userId);


### PR DESCRIPTION
Fixes one of the InvokeJS examples which doesn't escape nested quotes from:
```
var str = await WebAssemblyRuntime.InvokeAsync(
	"(async () => "It works asynchronously!")();");
```
to:
```
var str = await WebAssemblyRuntime.InvokeAsync(
	"(async () => \"It works asynchronously!\")();");
```

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

Current example is not valid C# and produces syntax error at the first inner quote.

## What is the new behavior?

Updates example to match other similar examples in the section to escape the inner quotes.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09f2833</samp>

Fix typo and escape quotes in `interop/wasm-javascript-1.md` code snippet. The change makes the code snippet valid and consistent in both C# and javascript.

