### PR TITLE
chore: remove Window.Current (not completely) and Window.Dispatcher (completely) usages

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.System;
 using Windows.UI.Core;
 
 #if !HAS_UNO
@@ -64,8 +65,7 @@ partial class App
 
 			var testId = Interlocked.Increment(ref _testIdCounter);
 
-			_ = _mainWindow.Dispatcher.RunAsync(
-				CoreDispatcherPriority.Normal,
+			_ = _mainWindow.DispatcherQueue.EnqueueAsync(
 				async () =>
 				{
 					try
@@ -142,18 +142,18 @@ partial class App
 				throw new InvalidOperationException("Main window must be initialized before running screenshot tests");
 			}
 
-			var n = _mainWindow.Dispatcher.RunIdleAsync(
-				_ =>
+			var n = _mainWindow.DispatcherQueue.EnqueueAsync(
+				() =>
 				{
-					var n = _mainWindow.Dispatcher.RunAsync(
-						CoreDispatcherPriority.Normal,
+					_ = _mainWindow.DispatcherQueue.EnqueueAsync(
 						async () =>
 						{
 							await SampleControl.Presentation.SampleChooserViewModel.Instance.RecordAllTests(CancellationToken.None, screenshotsPath, () => System.Environment.Exit(0));
 						}
 					);
-
-				});
+				},
+				DispatcherQueuePriority.Low
+				);
 
 			return true;
 		}

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -120,11 +120,7 @@ namespace SamplesApp
 			}
 
 			var sw = Stopwatch.StartNew();
-			var n = _mainWindow.Dispatcher.RunIdleAsync(
-				_ =>
-				{
-					Console.WriteLine("Done loading " + sw.Elapsed);
-				});
+			_ = _mainWindow.DispatcherQueue.EnqueueAsync(() => Console.WriteLine("Done loading " + sw.Elapsed));
 
 #if DEBUG
 			if (System.Diagnostics.Debugger.IsAttached)

--- a/src/SamplesApp/SamplesApp.Shared/DispatcherQueueExtensions.cs
+++ b/src/SamplesApp/SamplesApp.Shared/DispatcherQueueExtensions.cs
@@ -1,0 +1,273 @@
+// Windows Community Toolkit
+// Copyright © .NET Foundation and Contributors
+// All rights reserved.
+// ## MIT License (MIT)
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Windows.Foundation.Metadata;
+using Windows.System;
+
+#nullable enable
+
+namespace SamplesApp
+{
+    /// <summary>
+    /// Helpers for executing code in a <see cref="DispatcherQueue"/>.
+    /// </summary>
+    public static class DispatcherQueueExtensions
+    {
+        /// <summary>
+        /// Indicates whether or not <see cref="DispatcherQueue.HasThreadAccess"/> is available.
+        /// </summary>
+        private static readonly bool IsHasThreadAccessPropertyAvailable = ApiInformation.IsMethodPresent("Windows.System.DispatcherQueue", "HasThreadAccess");
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task"/> that completes when the invocation of the function is completed.
+        /// </summary>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Action"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task"/> that completes when the invocation of <paramref name="function"/> is over.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task EnqueueAsync(this DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            // Run the function directly when we have thread access.
+            // Also reuse Task.CompletedTask in case of success,
+            // to skip an unnecessary heap allocation for every invocation.
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    function();
+
+                    return Task.CompletedTask;
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException(e);
+                }
+            }
+
+            static Task TryEnqueueAsync(DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<object?>();
+
+                if (!dispatcher.TryEnqueue(priority, () =>
+                {
+                    try
+                    {
+                        function();
+
+                        taskCompletionSource.SetResult(null);
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task{TResult}"/> that completes when the invocation of the function is completed.
+        /// </summary>
+        /// <typeparam name="T">The return type of <paramref name="function"/> to relay through the returned <see cref="Task{TResult}"/>.</typeparam>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Func{TResult}"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task"/> that completes when the invocation of <paramref name="function"/> is over.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task<T> EnqueueAsync<T>(this DispatcherQueue dispatcher, Func<T> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    return Task.FromResult(function());
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException<T>(e);
+                }
+            }
+
+            static Task<T> TryEnqueueAsync(DispatcherQueue dispatcher, Func<T> function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<T>();
+
+                if (!dispatcher.TryEnqueue(priority, () =>
+                {
+                    try
+                    {
+                        taskCompletionSource.SetResult(function());
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task"/> that acts as a proxy for the one returned by the given function.
+        /// </summary>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Func{TResult}"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task"/> that acts as a proxy for the one returned by <paramref name="function"/>.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task EnqueueAsync(this DispatcherQueue dispatcher, Func<Task> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            // If we have thread access, we can retrieve the task directly.
+            // We don't use ConfigureAwait(false) in this case, in order
+            // to let the caller continue its execution on the same thread
+            // after awaiting the task returned by this function.
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    if (function() is Task awaitableResult)
+                    {
+                        return awaitableResult;
+                    }
+
+                    return Task.FromException(GetEnqueueException("The Task returned by function cannot be null."));
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException(e);
+                }
+            }
+
+            static Task TryEnqueueAsync(DispatcherQueue dispatcher, Func<Task> function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<object?>();
+
+                if (!dispatcher.TryEnqueue(priority, async () =>
+                {
+                    try
+                    {
+                        if (function() is Task awaitableResult)
+                        {
+                            await awaitableResult.ConfigureAwait(false);
+
+                            taskCompletionSource.SetResult(null);
+                        }
+                        else
+                        {
+                            taskCompletionSource.SetException(GetEnqueueException("The Task returned by function cannot be null."));
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task{TResult}"/> that acts as a proxy for the one returned by the given function.
+        /// </summary>
+        /// <typeparam name="T">The return type of <paramref name="function"/> to relay through the returned <see cref="Task{TResult}"/>.</typeparam>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Func{TResult}"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that relays the one returned by <paramref name="function"/>.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task<T> EnqueueAsync<T>(this DispatcherQueue dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    if (function() is Task<T> awaitableResult)
+                    {
+                        return awaitableResult;
+                    }
+
+                    return Task.FromException<T>(GetEnqueueException("The Task returned by function cannot be null."));
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException<T>(e);
+                }
+            }
+
+            static Task<T> TryEnqueueAsync(DispatcherQueue dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<T>();
+
+                if (!dispatcher.TryEnqueue(priority, async () =>
+                {
+                    try
+                    {
+                        if (function() is Task<T> awaitableResult)
+                        {
+                            var result = await awaitableResult.ConfigureAwait(false);
+
+                            taskCompletionSource.SetResult(result);
+                        }
+                        else
+                        {
+                            taskCompletionSource.SetException(GetEnqueueException("The Task returned by function cannot be null."));
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="InvalidOperationException"/> to return when an enqueue operation fails.
+        /// </summary>
+        /// <param name="message">The message of the exception.</param>
+        /// <returns>An <see cref="InvalidOperationException"/> with a specified message.</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetEnqueueException(string message)
+        {
+            return new InvalidOperationException(message);
+        }
+    }
+}

--- a/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)App.Assertions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)App.Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)App.UnoIslands.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DispatcherQueueExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
@@ -10,6 +10,7 @@ using Windows.UI.Xaml;
 using Uno.UI.Common;
 using Microsoft.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
+using Uno.UI.Xaml.Core;
 
 #if XAMARIN || UNO_REFERENCE_API
 using Windows.UI.Xaml.Controls;
@@ -403,7 +404,10 @@ namespace SampleControl.Presentation
 				var updateReason = ResourceUpdateReason.ThemeResource;
 				Application.Current.Resources?.UpdateThemeBindings(updateReason);
 				Uno.UI.ResourceResolver.UpdateSystemThemeBindings(updateReason);
-				Application.PropagateResourcesChanged(Windows.UI.Xaml.Window.Current.Content, updateReason);
+				foreach (var root in CoreServices.Instance.ContentRootCoordinator.ContentRoots)
+				{
+					Application.PropagateResourcesChanged(root.XamlRoot?.Content, updateReason);
+				}
 #endif
 				RaisePropertyChanged();
 			}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -31,6 +31,7 @@ using Uno.Logging;
 using Windows.UI.Xaml.Controls;
 using Windows.Graphics.Imaging;
 using Windows.Graphics.Display;
+using SamplesApp;
 using Uno.UI.Extensions;
 
 namespace SampleControl.Presentation
@@ -113,8 +114,7 @@ namespace SampleControl.Presentation
 				_log.Info($"Found {_categories.SelectMany(c => c.SamplesContent).Distinct().Count()} sample(s) in {_categories.Count} categories.");
 			}
 
-			_ = Window.Current.Dispatcher.RunAsync(
-				CoreDispatcherPriority.Normal,
+			_ = Window.Current.DispatcherQueue.EnqueueAsync(
 				async () =>
 				{
 					// Initialize favorites and recents list as soon as possible.
@@ -211,8 +211,7 @@ namespace SampleControl.Presentation
 
 		private async Task LogViewDump(CancellationToken ct)
 		{
-			await Window.Current.Dispatcher.RunAsync(
-				CoreDispatcherPriority.Normal,
+			await Window.Current.DispatcherQueue.EnqueueAsync(
 				() =>
 				{
 					var currentContent = ContentPhone as Control;
@@ -291,8 +290,7 @@ namespace SampleControl.Presentation
 
 				await DumpOutputFolderName(ct, folderName);
 
-				await Window.Current.Dispatcher.RunAsync(
-					CoreDispatcherPriority.Normal,
+				await Window.Current.DispatcherQueue.EnqueueAsync(
 					async () =>
 					{
 						try
@@ -508,8 +506,7 @@ namespace SampleControl.Presentation
 					{
 						return;
 					}
-					var unused = Window.Current.Dispatcher.RunAsync(
-						CoreDispatcherPriority.Normal,
+					_ = Window.Current.DispatcherQueue.EnqueueAsync(
 						async () =>
 						{
 							CurrentSelectedSample = newContent;
@@ -574,8 +571,8 @@ namespace SampleControl.Presentation
 
 			var search = SearchTerm;
 
-			var unused = Window.Current.Dispatcher.RunAsync(
-				CoreDispatcherPriority.Normal, async () =>
+			_ = Window.Current.DispatcherQueue.EnqueueAsync(
+				async () =>
 				{
 					await Task.Delay(200);
 
@@ -823,7 +820,7 @@ description: {sample.Description}";
 		private async Task UpdateFavoriteForSample(CancellationToken ct, SampleChooserContent sample, bool isFavorite)
 		{
 			// Have to update favorite on UI thread for the INotifyPropertyChanged in SampleChooserControl
-			await Window.Current.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => sample.IsFavorite = isFavorite);
+			await Window.Current.DispatcherQueue.EnqueueAsync(() => sample.IsFavorite = isFavorite);
 		}
 
 		/// <summary>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -90,9 +90,6 @@ namespace Uno.UI.Samples.Tests
 				}
 			);
 
-			Private.Infrastructure.TestServices.WindowHelper.CurrentTestWindow =
-				Windows.UI.Xaml.Window.Current;
-
 			Private.Infrastructure.TestServices.WindowHelper.IsXamlIsland =
 #if HAS_UNO
 				Uno.UI.Xaml.Core.CoreServices.Instance.InitializationType == Xaml.Core.InitializationType.IslandsOnly;

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/TopMode/NavigationViewTopNavOnlyPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/NavigationViewTests/TopMode/NavigationViewTopNavOnlyPage.xaml.cs
@@ -52,7 +52,7 @@ namespace MUXControlsTestApp
 			viewTitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
 			viewTitleBar.ButtonForegroundColor = (Color)Resources["SystemBaseHighColor"];
 
-			Windows.UI.Xaml.Window.Current.CoreWindow.SizeChanged += (s, e) => UpdateAppTitle();
+			XamlRoot!.Changed += (s, e) => UpdateAppTitle();
 			coreTitleBar.LayoutMetricsChanged += (s, e) => UpdateAppTitle();
 		}
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/ReloadedControlTheme.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/ThemeResources/ReloadedControlTheme.xaml.cs
@@ -34,7 +34,7 @@ namespace UITests.Windows_UI_Xaml.ThemeResources
 
 			this.Loaded += (s, e) =>
 			{
-				var root = XamlWindow.Current.Content as FrameworkElement;
+				var root = XamlRoot?.Content as FrameworkElement;
 				var isDark = GetCurrentOsTheme() == ApplicationTheme.Dark;
 
 				DarkModeToggle.IsOn = isDark;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/TransformToVisual_Transform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/UIElementTests/TransformToVisual_Transform.xaml.cs
@@ -46,7 +46,7 @@ namespace UITests.Shared.Windows_UI_Xaml.UIElementTests
 
 		public void When_TransformToRoot()
 		{
-			var windowBounds = Windows.UI.Xaml.Window.Current.Bounds;
+			var windowBounds = XamlRoot!.Bounds;
 			var visible = VisibleBoundsPadding.WindowPadding;
 			var originAbs = new Point(windowBounds.Width - visible.Right - Border1.ActualWidth, windowBounds.Height - visible.Bottom - Border1.ActualHeight);
 
@@ -58,7 +58,7 @@ namespace UITests.Shared.Windows_UI_Xaml.UIElementTests
 
 		public void When_TransformToRoot_With_TranslateTransform()
 		{
-			var windowBounds = Windows.UI.Xaml.Window.Current.Bounds;
+			var windowBounds = XamlRoot!.Bounds;
 			var visible = VisibleBoundsPadding.WindowPadding;
 			var originAbs = new Point(windowBounds.Width - visible.Right - Border2.ActualWidth, windowBounds.Height - visible.Bottom - Border2.ActualHeight);
 			const int tX = -50;
@@ -72,7 +72,7 @@ namespace UITests.Shared.Windows_UI_Xaml.UIElementTests
 
 		public void When_TransformToRoot_With_InheritedTranslateTransform_And_Margin()
 		{
-			var windowBounds = Windows.UI.Xaml.Window.Current.Bounds;
+			var windowBounds = XamlRoot!.Bounds;
 			var visible = VisibleBoundsPadding.WindowPadding;
 			var originAbs = new Point(windowBounds.Width - visible.Right - Border2.ActualWidth, windowBounds.Height - visible.Bottom - Border2.ActualHeight);
 			const int tX = -50;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_AdaptiveTrigger_Storyboard.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/VisualStateTests/VisualState_AdaptiveTrigger_Storyboard.xaml.cs
@@ -13,7 +13,7 @@ namespace UITests.Shared.Windows_UI_Xaml.ViusalStateTests
 
 			void OnSizeChanged(object snd, SizeChangedEventArgs evt)
 			{
-				var w = global::Windows.UI.Xaml.Window.Current.Bounds.Width;
+				var w = XamlRoot!.Bounds.Width;
 
 				txt.Text += $"Control Size: {evt?.NewSize.Width}, Window Size:{w}\n";
 			}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_SetBackground.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/WindowTests/Window_SetBackground.xaml.cs
@@ -29,7 +29,7 @@ namespace UITests.Windows_UI_Xaml.WindowTests
 			this.InitializeComponent();
 
 #if HAS_UNO
-			_selectedColor = (Windows.UI.Xaml.Window.Current.Background as SolidColorBrush)?.Color ?? Colors.White;
+			_selectedColor = (Window.CurrentSafe.Background as SolidColorBrush)?.Color ?? Colors.White;
 #endif
 		}
 
@@ -41,7 +41,10 @@ namespace UITests.Windows_UI_Xaml.WindowTests
 				_selectedColor = value;
 
 #if HAS_UNO
-				Windows.UI.Xaml.Window.Current.Background = new SolidColorBrush(_selectedColor);
+				if (Window.CurrentSafe is { }) // could be null if on WinUI tree
+				{
+					Window.CurrentSafe.Background = new SolidColorBrush(_selectedColor);
+				}
 #endif
 			}
 		}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Theming.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Theming.xaml.cs
@@ -20,7 +20,7 @@ namespace UITests.Windows_UI_Xaml_Controls.CalendarView
 		private void ToggleButton_Click(object sender, RoutedEventArgs e)
 		{
 			// Set theme for window root.
-			if (global::Windows.UI.Xaml.Window.Current.Content is FrameworkElement root)
+			if (XamlRoot?.Content is FrameworkElement root)
 			{
 				switch (root.ActualTheme)
 				{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_Chooser.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_Chooser.xaml.cs
@@ -29,27 +29,27 @@ namespace Uno.UI.Samples.Content.UITests.CommandBar.BackGesture
 
 		private void Back_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
 		}
 
 		private void Normal_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_Normal));
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_Normal));
 		}
 
 		private void Collapsed_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_Collapsed));
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_Collapsed));
 		}
 
 		private void NavigationCommand_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_NavigationCommand));
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_NavigationCommand));
 		}
 
 		private void CollapsedNavigationCommand_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_CollapsedNavigationCommand));
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_CollapsedNavigationCommand));
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_Collapsed.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_Collapsed.xaml.cs
@@ -29,7 +29,7 @@ namespace Uno.UI.Samples.Content.UITests.CommandBar.BackGesture
 
 		private void GoBack_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_CollapsedNavigationCommand.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_CollapsedNavigationCommand.xaml.cs
@@ -30,7 +30,7 @@ namespace Uno.UI.Samples.Content.UITests.CommandBar.BackGesture
 
 		private void GoBack_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_NavigationCommand.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_NavigationCommand.xaml.cs
@@ -30,7 +30,7 @@ namespace Uno.UI.Samples.Content.UITests.CommandBar.BackGesture
 
 		private void GoBack_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_Normal.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/BackGesture/BackGesture_Normal.xaml.cs
@@ -29,7 +29,7 @@ namespace Uno.UI.Samples.Content.UITests.CommandBar.BackGesture
 
 		private void GoBack_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).GoBack();
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_BackGesture.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CommandBar/CommandBar_BackGesture.xaml.cs
@@ -29,7 +29,7 @@ namespace Uno.UI.Samples.Content.UITests.CommandBar
 
 		private void FullWindow_Click(object sender, RoutedEventArgs e)
 		{
-			(Windows.UI.Xaml.Window.Current.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_Chooser));
+			(XamlRoot?.Content as Windows.UI.Xaml.Controls.Frame).Navigate(typeof(BackGesture_Chooser));
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ShowAt_Window_Content.xaml.cs
@@ -43,7 +43,7 @@ namespace UITests.Windows_UI_Xaml_Controls.FlyoutTests
 					Background = new SolidColorBrush(Windows.UI.Colors.Red),
 				};
 
-			flyout.ShowAt(global::Windows.UI.Xaml.Window.Current.Content as FrameworkElement);
+			flyout.ShowAt(XamlRoot?.Content as FrameworkElement);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Theming.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Theming.xaml.cs
@@ -30,14 +30,14 @@ namespace UITests.Windows_UI_Xaml_Controls.ListView
 
 		private void Button_Click1(object sender, RoutedEventArgs e)
 		{
-			if (global::Windows.UI.Xaml.Window.Current.Content is FrameworkElement root)
+			if (XamlRoot?.Content is FrameworkElement root)
 			{
 				root.RequestedTheme = ElementTheme.Light;
 			}
 		}
 		private void Button_Click2(object sender, RoutedEventArgs e)
 		{
-			if (global::Windows.UI.Xaml.Window.Current.Content is FrameworkElement root)
+			if (XamlRoot?.Content is FrameworkElement root)
 			{
 				root.RequestedTheme = ElementTheme.Dark;
 			}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ParallaxListView/ParallaxListView.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ParallaxListView/ParallaxListView.cs
@@ -142,7 +142,7 @@ namespace SamplesApp.Windows_UI_Xaml_Controls.ListView
 
 		private void OnLoaded(object sender, RoutedEventArgs e)
 		{
-			_screenHeight = Windows.UI.Xaml.Window.Current.Bounds.Height;
+			_screenHeight = XamlRoot!.Bounds.Height;
 
 			var applied = _mainListview.ApplyTemplate();
 			_mainScrollViewer = _mainListview.FindFirstChild<Windows.UI.Xaml.Controls.ScrollViewer>();

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Events.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Events.xaml.cs
@@ -17,7 +17,9 @@ namespace UITests.Windows_UI_Xaml_Input.Keyboard
 			SetupEvent(_root);
 			SetupEvent(_btt1);
 			SetupEvent(_btt2);
-			SetupEvent(global::Windows.UI.Xaml.Window.Current.CoreWindow);
+#if !HAS_UNO_WINUI
+			SetupEvent(global::Windows.UI.Xaml.Window.CurrentSafe.CoreWindow);
+#endif
 		}
 
 		private void SetupEvent(FrameworkElement elt)

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_iOS_Theme.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_iOS_Theme.xaml.cs
@@ -31,7 +31,7 @@ namespace UITests.Windows_UI_Xaml_Input.Keyboard
 
 		private void UpdateTheme(object sender, RoutedEventArgs e)
 		{
-			var root = global::Windows.UI.Xaml.Window.Current.Content as FrameworkElement;
+			var root = XamlRoot?.Content as FrameworkElement;
 			var theme = (sender as RadioButton).Content switch
 			{
 				"Light" => ElementTheme.Light,

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Shapes/Shape_StrokeTest.xaml.cs
@@ -42,7 +42,7 @@ namespace UITests.Windows_UI_Xaml_Shapes
 
 		private void ChangeTheme()
 		{
-			if (XamlWindow.Current?.Content is FrameworkElement root)
+			if (XamlRoot?.Content is FrameworkElement root)
 			{
 				var theme = root.ActualTheme switch
 				{

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
@@ -28,7 +28,6 @@ namespace Uno.UI.Runtime.Skia
 			_fbDev = new FrameBufferDevice();
 			_fbDev.Init();
 
-			WUX.Window.Current.ToString();
 			_host = host;
 		}
 
@@ -77,7 +76,7 @@ namespace Uno.UI.Runtime.Skia
 
 				if (_host.RootElement?.Visual is { } rootVisual)
 				{
-					WUX.Window.Current.Compositor.RenderRootVisual(surface, rootVisual);
+					_host.RootElement.XamlRoot!.Compositor.RenderRootVisual(surface, rootVisual);
 				}
 
 				_fbDev.VSync();

--- a/src/Uno.UI.RuntimeTests/Extensions/DispatcherQueueExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Extensions/DispatcherQueueExtensions.cs
@@ -1,0 +1,273 @@
+// Windows Community Toolkit
+// Copyright © .NET Foundation and Contributors
+// All rights reserved.
+// ## MIT License (MIT)
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Windows.Foundation.Metadata;
+using Windows.System;
+
+#nullable enable
+
+namespace Uno.UI.RuntimeTests.Extensions
+{
+    /// <summary>
+    /// Helpers for executing code in a <see cref="DispatcherQueue"/>.
+    /// </summary>
+    public static class DispatcherQueueExtensions
+    {
+        /// <summary>
+        /// Indicates whether or not <see cref="DispatcherQueue.HasThreadAccess"/> is available.
+        /// </summary>
+        private static readonly bool IsHasThreadAccessPropertyAvailable = ApiInformation.IsMethodPresent("Windows.System.DispatcherQueue", "HasThreadAccess");
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task"/> that completes when the invocation of the function is completed.
+        /// </summary>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Action"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task"/> that completes when the invocation of <paramref name="function"/> is over.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task EnqueueAsync(this DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            // Run the function directly when we have thread access.
+            // Also reuse Task.CompletedTask in case of success,
+            // to skip an unnecessary heap allocation for every invocation.
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    function();
+
+                    return Task.CompletedTask;
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException(e);
+                }
+            }
+
+            static Task TryEnqueueAsync(DispatcherQueue dispatcher, Action function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<object?>();
+
+                if (!dispatcher.TryEnqueue(priority, () =>
+                {
+                    try
+                    {
+                        function();
+
+                        taskCompletionSource.SetResult(null);
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task{TResult}"/> that completes when the invocation of the function is completed.
+        /// </summary>
+        /// <typeparam name="T">The return type of <paramref name="function"/> to relay through the returned <see cref="Task{TResult}"/>.</typeparam>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Func{TResult}"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task"/> that completes when the invocation of <paramref name="function"/> is over.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task<T> EnqueueAsync<T>(this DispatcherQueue dispatcher, Func<T> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    return Task.FromResult(function());
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException<T>(e);
+                }
+            }
+
+            static Task<T> TryEnqueueAsync(DispatcherQueue dispatcher, Func<T> function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<T>();
+
+                if (!dispatcher.TryEnqueue(priority, () =>
+                {
+                    try
+                    {
+                        taskCompletionSource.SetResult(function());
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task"/> that acts as a proxy for the one returned by the given function.
+        /// </summary>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Func{TResult}"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task"/> that acts as a proxy for the one returned by <paramref name="function"/>.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task EnqueueAsync(this DispatcherQueue dispatcher, Func<Task> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            // If we have thread access, we can retrieve the task directly.
+            // We don't use ConfigureAwait(false) in this case, in order
+            // to let the caller continue its execution on the same thread
+            // after awaiting the task returned by this function.
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    if (function() is Task awaitableResult)
+                    {
+                        return awaitableResult;
+                    }
+
+                    return Task.FromException(GetEnqueueException("The Task returned by function cannot be null."));
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException(e);
+                }
+            }
+
+            static Task TryEnqueueAsync(DispatcherQueue dispatcher, Func<Task> function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<object?>();
+
+                if (!dispatcher.TryEnqueue(priority, async () =>
+                {
+                    try
+                    {
+                        if (function() is Task awaitableResult)
+                        {
+                            await awaitableResult.ConfigureAwait(false);
+
+                            taskCompletionSource.SetResult(null);
+                        }
+                        else
+                        {
+                            taskCompletionSource.SetException(GetEnqueueException("The Task returned by function cannot be null."));
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a
+        /// <see cref="Task{TResult}"/> that acts as a proxy for the one returned by the given function.
+        /// </summary>
+        /// <typeparam name="T">The return type of <paramref name="function"/> to relay through the returned <see cref="Task{TResult}"/>.</typeparam>
+        /// <param name="dispatcher">The target <see cref="DispatcherQueue"/> to invoke the code on.</param>
+        /// <param name="function">The <see cref="Func{TResult}"/> to invoke.</param>
+        /// <param name="priority">The priority level for the function to invoke.</param>
+        /// <returns>A <see cref="Task{TResult}"/> that relays the one returned by <paramref name="function"/>.</returns>
+        /// <remarks>If the current thread has access to <paramref name="dispatcher"/>, <paramref name="function"/> will be invoked directly.</remarks>
+        public static Task<T> EnqueueAsync<T>(this DispatcherQueue dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority = DispatcherQueuePriority.Normal)
+        {
+            if (IsHasThreadAccessPropertyAvailable && dispatcher.HasThreadAccess)
+            {
+                try
+                {
+                    if (function() is Task<T> awaitableResult)
+                    {
+                        return awaitableResult;
+                    }
+
+                    return Task.FromException<T>(GetEnqueueException("The Task returned by function cannot be null."));
+                }
+                catch (Exception e)
+                {
+                    return Task.FromException<T>(e);
+                }
+            }
+
+            static Task<T> TryEnqueueAsync(DispatcherQueue dispatcher, Func<Task<T>> function, DispatcherQueuePriority priority)
+            {
+                var taskCompletionSource = new TaskCompletionSource<T>();
+
+                if (!dispatcher.TryEnqueue(priority, async () =>
+                {
+                    try
+                    {
+                        if (function() is Task<T> awaitableResult)
+                        {
+                            var result = await awaitableResult.ConfigureAwait(false);
+
+                            taskCompletionSource.SetResult(result);
+                        }
+                        else
+                        {
+                            taskCompletionSource.SetException(GetEnqueueException("The Task returned by function cannot be null."));
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        taskCompletionSource.SetException(e);
+                    }
+                }))
+                {
+                    taskCompletionSource.SetException(GetEnqueueException("Failed to enqueue the operation"));
+                }
+
+                return taskCompletionSource.Task;
+            }
+
+            return TryEnqueueAsync(dispatcher, function, priority);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="InvalidOperationException"/> to return when an enqueue operation fails.
+        /// </summary>
+        /// <param name="message">The message of the exception.</param>
+        /// <returns>An <see cref="InvalidOperationException"/> with a specified message.</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetEnqueueException(string message)
+        {
+            return new InvalidOperationException(message);
+        }
+    }
+}

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
@@ -55,7 +55,7 @@ namespace Private.Infrastructure
 				MUXControlsTestApp.Utilities.RunOnUIThread.Execute(() =>
 				{
 					finger = InputInjector.TryCreate()?.GetFinger() ?? throw new InvalidOperationException("Failed to create finger");
-					var topLeft = element.TransformToVisual(Window.Current.Content).TransformPoint(new Point(0, 0));
+					var topLeft = element.TransformToVisual(WindowHelper.XamlRoot.Content).TransformPoint(new Point(0, 0));
 					var center = new Point(topLeft.X + element.RenderSize.Width / 2, topLeft.Y + element.RenderSize.Height / 2);
 					finger.Press(center);
 				});

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
@@ -63,7 +63,7 @@ namespace Private.Infrastructure
 						}
 						else
 						{
-							Window.Current.Content = value;
+							CurrentTestWindow.Content = value;
 						}
 					}
 					else if (EmbeddedTestRoot.setContent is { } setter)
@@ -96,7 +96,7 @@ namespace Private.Infrastructure
 				}
 				else
 				{
-					_originalWindowContent = Window.Current.Content;
+					_originalWindowContent = CurrentTestWindow.Content;
 				}
 			}
 
@@ -110,7 +110,7 @@ namespace Private.Infrastructure
 					}
 					else
 					{
-						Window.Current.Content = _originalWindowContent;
+						CurrentTestWindow.Content = _originalWindowContent;
 					}
 					_originalWindowContent = null;
 				}

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
@@ -4,10 +4,12 @@ using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using System.Runtime.CompilerServices;
+using Windows.System;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Tests.Enterprise;
 using Windows.UI.Core;
 using MUXControlsTestApp.Utilities;
+using Uno.UI.RuntimeTests.Extensions;
 #if NETFX_CORE
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -106,10 +108,10 @@ namespace Private.Infrastructure
 			public static UIElement RootElement => UseActualWindowRoot ?
 				XamlRoot.Content : EmbeddedTestRoot.control;
 
-			// Dispatcher is a separate property, as accessing CurrentTestWindow.COntent when
+			// Dispatcher is a separate property, as accessing CurrentTestWindow.Content when
 			// not on the UI thread will throw an exception in WinUI.
-			public static CoreDispatcher RootElementDispatcher => UseActualWindowRoot ?
-				Window.Current.Dispatcher : EmbeddedTestRoot.control.Dispatcher;
+			public static DispatcherQueue RootElementDispatcherQueue => UseActualWindowRoot ?
+				Window.Current.DispatcherQueue : EmbeddedTestRoot.control.DispatcherQueue;
 
 			internal static Page SetupSimulatedAppPage()
 			{
@@ -126,8 +128,8 @@ namespace Private.Infrastructure
 
 			internal static async Task WaitForIdle()
 			{
-				await RootElementDispatcher.RunIdleAsync(_ => { /* Empty to wait for the idle queue to be reached */ });
-				await RootElementDispatcher.RunIdleAsync(_ => { /* Empty to wait for the idle queue to be reached */ });
+				await RootElementDispatcherQueue.EnqueueAsync(() => { /* Empty to wait for the idle queue to be reached */ }, DispatcherQueuePriority.Low);
+				await RootElementDispatcherQueue.EnqueueAsync(() => { /* Empty to wait for the idle queue to be reached */ }, DispatcherQueuePriority.Low);
 			}
 
 			/// <summary>

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
@@ -33,6 +33,19 @@ namespace Private.Infrastructure
 
 			public static bool IsXamlIsland { get; set; }
 
+			public static Windows.UI.Xaml.Window CurrentTestWindow
+			{
+				get
+				{
+					if (_currentTestWindow is null)
+					{
+						throw new InvalidOperationException("Current test window not set.");
+					}
+					return _currentTestWindow;
+				}
+				set => _currentTestWindow = value;
+			}
+
 			public static bool UseActualWindowRoot { get; set; }
 
 			public static UIElement WindowContent

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.WindowHelper.cs
@@ -31,25 +31,12 @@ namespace Private.Infrastructure
 
 			public static bool IsXamlIsland { get; set; }
 
-			public static Windows.UI.Xaml.Window CurrentTestWindow
-			{
-				get
-				{
-					if (_currentTestWindow is null)
-					{
-						throw new InvalidOperationException("Current test window not set.");
-					}
-					return _currentTestWindow;
-				}
-				set => _currentTestWindow = value;
-			}
-
 			public static bool UseActualWindowRoot { get; set; }
 
 			public static UIElement WindowContent
 			{
 				get => UseActualWindowRoot
-					? (IsXamlIsland ? GetXamlIslandRootContentControl().Content as UIElement : CurrentTestWindow.Content)
+					? (IsXamlIsland ? GetXamlIslandRootContentControl().Content as UIElement : XamlRoot.Content)
 					: EmbeddedTestRoot.getContent?.Invoke();
 				internal set
 				{
@@ -61,7 +48,7 @@ namespace Private.Infrastructure
 						}
 						else
 						{
-							CurrentTestWindow.Content = value;
+							Window.Current.Content = value;
 						}
 					}
 					else if (EmbeddedTestRoot.setContent is { } setter)
@@ -94,7 +81,7 @@ namespace Private.Infrastructure
 				}
 				else
 				{
-					_originalWindowContent = CurrentTestWindow.Content;
+					_originalWindowContent = Window.Current.Content;
 				}
 			}
 
@@ -108,7 +95,7 @@ namespace Private.Infrastructure
 					}
 					else
 					{
-						CurrentTestWindow.Content = _originalWindowContent;
+						Window.Current.Content = _originalWindowContent;
 					}
 					_originalWindowContent = null;
 				}
@@ -117,12 +104,12 @@ namespace Private.Infrastructure
 			public static (UIElement control, Func<UIElement> getContent, Action<UIElement> setContent) EmbeddedTestRoot { get; set; }
 
 			public static UIElement RootElement => UseActualWindowRoot ?
-				CurrentTestWindow.Content : EmbeddedTestRoot.control;
+				XamlRoot.Content : EmbeddedTestRoot.control;
 
 			// Dispatcher is a separate property, as accessing CurrentTestWindow.COntent when
 			// not on the UI thread will throw an exception in WinUI.
 			public static CoreDispatcher RootElementDispatcher => UseActualWindowRoot ?
-				CurrentTestWindow.Dispatcher : EmbeddedTestRoot.control.Dispatcher;
+				Window.Current.Dispatcher : EmbeddedTestRoot.control.Dispatcher;
 
 			internal static Page SetupSimulatedAppPage()
 			{

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Uno.UI.RuntimeTests.Extensions;
 
 namespace Private.Infrastructure
 {
@@ -55,7 +56,7 @@ namespace Private.Infrastructure
 			action();
 			return Task.CompletedTask;
 #else
-			await WindowHelper.RootElementDispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () => action());
+			await WindowHelper.RootElementDispatcherQueue.EnqueueAsync(() => action());
 #endif
 		}
 

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/appbar/AppBarIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/appbar/AppBarIntegrationTests.cs
@@ -943,7 +943,7 @@ namespace Windows.UI.Tests.Enterprise
 			// Verify that the focus stayed on the pageButton.
 			await RunOnUIThread(() =>
 			{
-				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot).Equals(pageButton));
+				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.XamlRoot).Equals(pageButton));
 			});
 			await WindowHelper.WaitForIdle();
 		}
@@ -980,7 +980,7 @@ namespace Windows.UI.Tests.Enterprise
 			await RunOnUIThread(() =>
 			{
 				appBarButton = (AppBarButton)TreeHelper.GetVisualChildByName(page.BottomAppBar, "AppBarButton");
-				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot).Equals(appBarButton));
+				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.XamlRoot).Equals(appBarButton));
 			});
 			await WindowHelper.WaitForIdle();
 		}
@@ -1025,7 +1025,7 @@ namespace Windows.UI.Tests.Enterprise
 			await RunOnUIThread(() =>
 			{
 				appBarButton = (AppBarButton)TreeHelper.GetVisualChildByName(page.BottomAppBar, "AppBarButton");
-				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot).Equals(appBarButton));
+				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.XamlRoot).Equals(appBarButton));
 				appBar.IsOpen = false;
 			});
 			await WindowHelper.WaitForIdle();
@@ -1033,7 +1033,7 @@ namespace Windows.UI.Tests.Enterprise
 			// Verify that the focus moved back to the pageButton (previously focused element) since the AppBar was closed.
 			await RunOnUIThread(() =>
 			{
-				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot).Equals(pageButton));
+				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.XamlRoot).Equals(pageButton));
 			});
 			await WindowHelper.WaitForIdle();
 		}
@@ -1076,7 +1076,7 @@ namespace Windows.UI.Tests.Enterprise
 			// Then, close the AppBar programmatically.
 			await RunOnUIThread(() =>
 			{
-				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot).Equals(expandButton));
+				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.XamlRoot).Equals(expandButton));
 				appBar.IsOpen = false;
 			});
 			await WindowHelper.WaitForIdle();
@@ -1084,7 +1084,7 @@ namespace Windows.UI.Tests.Enterprise
 			// Verify that the focus is still on the expandButton after the AppBar closed.
 			await RunOnUIThread(() =>
 			{
-				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot).Equals(expandButton));
+				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.XamlRoot).Equals(expandButton));
 			});
 			await WindowHelper.WaitForIdle();
 		}
@@ -2257,7 +2257,7 @@ namespace Windows.UI.Tests.Enterprise
 			});
 			await WindowHelper.WaitForIdle();
 
-			await RunOnUIThread(() => VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot).Equals(expandButton)));
+			await RunOnUIThread(() => VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.XamlRoot).Equals(expandButton)));
 			await WindowHelper.WaitForIdle();
 
 			LOG_OUTPUT("After closing AppBars, further calls to 'close function', while focus is on top AppBar, should not get handled.");

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
@@ -1398,7 +1398,7 @@ namespace Windows.UI.Tests.Enterprise
 
 			await RunOnUIThread(() =>
 			{
-				var focusedElement = FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot);
+				var focusedElement = FocusManager.GetFocusedElement(WindowHelper.XamlRoot);
 				var moreButton = TreeHelper.GetVisualChildByName(cmdBar, "MoreButton");
 
 				VERIFY_IS_TRUE(focusedElement.Equals(moreButton));
@@ -1510,7 +1510,7 @@ namespace Windows.UI.Tests.Enterprise
 			await RunOnUIThread(() =>
 			{
 				LOG_OUTPUT("Validate the second primary command still has focus.");
-				VERIFY_ARE_EQUAL(commandBar.PrimaryCommands.GetAt(1), (ICommandBarElement)FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot));
+				VERIFY_ARE_EQUAL(commandBar.PrimaryCommands.GetAt(1), (ICommandBarElement)FocusManager.GetFocusedElement(WindowHelper.XamlRoot));
 
 				LOG_OUTPUT("Focus the second secondary command.");
 				((Control)commandBar.SecondaryCommands.GetAt(1)).Focus(FocusState.Keyboard);
@@ -1523,7 +1523,7 @@ namespace Windows.UI.Tests.Enterprise
 			await RunOnUIThread(() =>
 			{
 				LOG_OUTPUT("Validate the second secondary command still has focus.");
-				VERIFY_ARE_EQUAL(commandBar.SecondaryCommands.GetAt(1), (ICommandBarElement)(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot)));
+				VERIFY_ARE_EQUAL(commandBar.SecondaryCommands.GetAt(1), (ICommandBarElement)(FocusManager.GetFocusedElement(WindowHelper.XamlRoot)));
 
 				LOG_OUTPUT("Clearing all secondary commands. Focus is expected to go to the more button.");
 				commandBar.SecondaryCommands.Clear();
@@ -1534,7 +1534,7 @@ namespace Windows.UI.Tests.Enterprise
 			{
 				LOG_OUTPUT("Validate the more button has focus.");
 				var moreButton = (Button)(TreeHelper.GetVisualChildByName(commandBar, "MoreButton"));
-				var focused = (Button)FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot);
+				var focused = (Button)FocusManager.GetFocusedElement(WindowHelper.XamlRoot);
 				VERIFY_ARE_EQUAL(moreButton, focused);
 
 				LOG_OUTPUT("Focus fourth primary command, enable dynamic overflow and resize command bar.");
@@ -1547,7 +1547,7 @@ namespace Windows.UI.Tests.Enterprise
 			await RunOnUIThread(() =>
 			{
 				LOG_OUTPUT("Fourth primary command is now in the secondary ItemsControl. Validate it still has focus.");
-				VERIFY_ARE_EQUAL(commandBar.PrimaryCommands.GetAt(3), (ICommandBarElement)(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot)));
+				VERIFY_ARE_EQUAL(commandBar.PrimaryCommands.GetAt(3), (ICommandBarElement)(FocusManager.GetFocusedElement(WindowHelper.XamlRoot)));
 
 				LOG_OUTPUT("Resize command bar back to its original size.");
 				commandBar.Width = 500;
@@ -1557,7 +1557,7 @@ namespace Windows.UI.Tests.Enterprise
 			await RunOnUIThread(() =>
 			{
 				LOG_OUTPUT("Fourth primary command is back in the primary ItemsControl. Validate it still has focus.");
-				VERIFY_ARE_EQUAL(commandBar.PrimaryCommands.GetAt(3), (ICommandBarElement)(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot)));
+				VERIFY_ARE_EQUAL(commandBar.PrimaryCommands.GetAt(3), (ICommandBarElement)(FocusManager.GetFocusedElement(WindowHelper.XamlRoot)));
 			});
 		}
 
@@ -1953,7 +1953,7 @@ namespace Windows.UI.Tests.Enterprise
 
 			await RunOnUIThread(() =>
 			{
-				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot).Equals(appBarButton));
+				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.XamlRoot).Equals(appBarButton));
 
 				cmdBar.IsOpen = false;
 
@@ -1972,7 +1972,7 @@ namespace Windows.UI.Tests.Enterprise
 
 			await RunOnUIThread(() =>
 			{
-				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot).Equals(appBarButton));
+				VERIFY_IS_TRUE(FocusManager.GetFocusedElement(WindowHelper.XamlRoot).Equals(appBarButton));
 
 				cmdBar.IsOpen = false;
 			});
@@ -2537,11 +2537,7 @@ namespace Windows.UI.Tests.Enterprise
 			//UNO ONLY: SetWindowSizeOverride is not supported, so we are fullscreen
 			//double expectedCommandBarWidth = 500;
 
-			double expectedCommandBarWidth = Window.Current.Bounds.Width;
-			if (TestServices.WindowHelper.IsXamlIsland)
-			{
-				expectedCommandBarWidth = TestServices.WindowHelper.XamlRoot.Size.Width;
-			}
+			double expectedCommandBarWidth = WindowHelper.IsXamlIsland ? WindowHelper.XamlRoot.Size.Width : Window.CurrentSafe!.Bounds.Width;
 
 #if __IOS__
 			await RunOnUIThread(() =>
@@ -3488,7 +3484,7 @@ namespace Windows.UI.Tests.Enterprise
 
 				await RunOnUIThread(() =>
 				{
-					var focusedElement = FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot);
+					var focusedElement = FocusManager.GetFocusedElement(WindowHelper.XamlRoot);
 					VERIFY_IS_TRUE(focusedElement.Equals(cmdBar.PrimaryCommands.GetAt(0)));
 				});
 
@@ -3498,7 +3494,7 @@ namespace Windows.UI.Tests.Enterprise
 
 				await RunOnUIThread(async () =>
 				{
-					var focusedElement = FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot);
+					var focusedElement = FocusManager.GetFocusedElement(WindowHelper.XamlRoot);
 					var moreButton = await GetMoreButton(cmdBar);
 					VERIFY_IS_TRUE(focusedElement.Equals(moreButton), $"Input: {inputDevice}, Focused element ({focusedElement.GetHashCode()}) should be moreButton ({moreButton.GetHashCode()})");
 				});
@@ -3509,7 +3505,7 @@ namespace Windows.UI.Tests.Enterprise
 
 				await RunOnUIThread(() =>
 				{
-					var focusedElement = FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot);
+					var focusedElement = FocusManager.GetFocusedElement(WindowHelper.XamlRoot);
 					VERIFY_IS_TRUE(focusedElement.Equals(cmdBar.PrimaryCommands.GetAt(0)), $"Input: {inputDevice}, Focused element ({focusedElement.GetHashCode()}) should be primary command ({cmdBar.PrimaryCommands.GetAt(0).GetHashCode()})");
 				});
 
@@ -3519,7 +3515,7 @@ namespace Windows.UI.Tests.Enterprise
 
 				await RunOnUIThread(() =>
 				{
-					var focusedElement = FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot);
+					var focusedElement = FocusManager.GetFocusedElement(WindowHelper.XamlRoot);
 					VERIFY_IS_TRUE(focusedElement.Equals(cmdBar.Content), $"Input: {inputDevice}, Focused element ({focusedElement.GetHashCode()}) should be content ({cmdBar.Content.GetHashCode()})");
 				});
 			};
@@ -3574,7 +3570,7 @@ namespace Windows.UI.Tests.Enterprise
 
 			await RunOnUIThread(() =>
 			{
-				var focusedElement = FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot);
+				var focusedElement = FocusManager.GetFocusedElement(WindowHelper.XamlRoot);
 				VERIFY_IS_TRUE(focusedElement.Equals(cmdBar.SecondaryCommands.GetAt(2)));
 			});
 			await CloseCommandBar(cmdBar);
@@ -3585,7 +3581,7 @@ namespace Windows.UI.Tests.Enterprise
 
 			await RunOnUIThread(() =>
 			{
-				var focusedElement = FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot);
+				var focusedElement = FocusManager.GetFocusedElement(WindowHelper.XamlRoot);
 				VERIFY_IS_TRUE(focusedElement.Equals(cmdBar.SecondaryCommands.GetAt(0)));
 			});
 			await CloseCommandBar(cmdBar);

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/Common/OrientationBasedMeasures.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/Common/OrientationBasedMeasures.cs
@@ -4,6 +4,7 @@
 using MUXControlsTestApp.Utilities;
 using Windows.Foundation;
 using Windows.UI.Xaml.Controls;
+using Private.Infrastructure;
 using DisplayInformation = Windows.Graphics.Display.DisplayInformation;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
@@ -24,9 +25,11 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
 			ScrollOrientation = o;
 			m_useLayoutRounding = useLayoutRounding;
 
-			bool? hasThreadAccess = Window.Current.DispatcherQueue.HasThreadAccess;
-			if (useLayoutRounding && hasThreadAccess.HasValue && hasThreadAccess.Value)
+			var hasThreadAccess = TestServices.WindowHelper.RootElementDispatcherQueue.HasThreadAccess;
+			if (useLayoutRounding && hasThreadAccess)
+			{
 				m_rawPixelsPerViewPixel = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+			}
 		}
 
 		public double Major(Size size)

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/Common/OrientationBasedMeasures.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/Common/OrientationBasedMeasures.cs
@@ -24,7 +24,7 @@ namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests.Common
 			ScrollOrientation = o;
 			m_useLayoutRounding = useLayoutRounding;
 
-			bool? hasThreadAccess = Window.Current?.Dispatcher?.HasThreadAccess;
+			bool? hasThreadAccess = Window.Current.DispatcherQueue.HasThreadAccess;
 			if (useLayoutRounding && hasThreadAccess.HasValue && hasThreadAccess.Value)
 				m_rawPixelsPerViewPixel = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_VisibleBoundsPadding.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Toolkit/Given_VisibleBoundsPadding.cs
@@ -58,7 +58,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Toolkit
 				await WindowHelper.WaitForLoaded(inner);
 
 				var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
-				var windowBounds = Window.Current.Bounds;
+				var windowBounds = WindowHelper.XamlRoot.Bounds;
 				RectAssert.AreNotEqual(windowBounds, visibleBounds);
 
 				var containerBounds = container.GetOnScreenBounds();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ContainerVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ContainerVisual.cs
@@ -17,7 +17,7 @@ public class Given_ContainerVisual
 	[RunsOnUIThread]
 	public void When_Children_Change()
 	{
-		var compositor = Windows.UI.Xaml.Window.Current.Compositor;
+		var compositor = TestServices.WindowHelper.XamlRoot.Compositor;
 		var containerVisual = compositor.CreateContainerVisual();
 		Assert.IsFalse(containerVisual.IsChildrenRenderOrderDirty);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
@@ -31,7 +31,7 @@ public class Given_FlowDirection
 #if WINDOWS_UWP
 		Window.Current.Bounds;
 #else
-		TestServices.WindowHelper.WindowContent.XamlRoot.Bounds;
+		TestServices.WindowHelper.XamlRoot.Bounds;
 #endif
 
 	private static Rect Get100x100RectAt(double x, double y) => new Rect(new Point(x, y), new Size(100, 100));

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_EffectiveViewport.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_EffectiveViewport.cs
@@ -48,7 +48,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #if HAS_UNO
 			TestServices.WindowHelper.EmbeddedTestRoot.control?.XamlRoot?.Bounds ??
 #endif
-			Window.Current.Bounds;
+			TestServices.WindowHelper.XamlRoot.Bounds;
 #endif
 
 		private Point RootLocation

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
@@ -228,7 +228,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[RunsOnUIThread]
 		public void When_UpdateLayout_Then_TreeNotMeasuredUsingCachedValue()
 		{
-			if (Window.Current.RootElement is Panel root)
+			if (TestServices.WindowHelper.RootElement is Panel root)
 			{
 				var sut = new Grid
 				{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_XamlRoot.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_XamlRoot.cs
@@ -10,6 +10,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 	{
 		[TestMethod]
 		[RunsOnUIThread]
+#if HAS_UNO_WINUI
+		[Ignore("Window.Current is null on WinUI")]
+#endif
 		public async Task When_Loaded_Matches_Window_Root()
 		{
 			if (TestServices.WindowHelper.IsXamlIsland)
@@ -25,8 +28,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			};
 			TestServices.WindowHelper.WindowContent = border;
 			var xamlRoot = await completionSource.Task;
-			Assert.AreEqual(Window.Current.Content, xamlRoot.Content);
-			Assert.AreEqual(Window.Current.Content.RenderSize, xamlRoot.Size);
+			Assert.AreEqual(Window.CurrentSafe!.Content, xamlRoot.Content);
+			Assert.AreEqual(Window.CurrentSafe!.Content!.RenderSize, xamlRoot.Size);
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_VisualTreeHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_VisualTreeHelper.cs
@@ -91,7 +91,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 
 			foreach (var point in GetPointsOutside(bounds, perimeterOffset: 5))
 			{
-				var hitTest = VisualTreeHelper.HitTest(point, WindowHelper.WindowContent.XamlRoot);
+				var hitTest = VisualTreeHelper.HitTest(point, WindowHelper.XamlRoot);
 				Assert.IsNotNull(hitTest.element);
 				Assert.AreNotEqual(sut, hitTest.element);
 			}

--- a/src/Uno.UI/UI/Xaml/Internal/VisualTree.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/VisualTree.cs
@@ -107,7 +107,7 @@ namespace Uno.UI.Xaml.Core
 
 		/// <summary>
 		/// RootElement is the parent of the roots. For XAML app window content, this is the RootVisual.
-		/// For XamlIsland content, it's the XamlIslandRoot.
+		/// For XamlIsland content, it's the XamlIsland.
 		/// </summary>
 		public UIElement RootElement { get; }
 

--- a/src/Uno.UI/UI/Xaml/UIElement.MuxInternal.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.MuxInternal.cs
@@ -26,7 +26,7 @@ namespace Windows.UI.Xaml
 
 #if !HAS_UNO_WINUI
 		// This is to ensure forward compatibility with WinUI
-		private protected DispatcherQueue DispatcherQueue => DispatcherQueue.GetForCurrentThread();
+		protected internal DispatcherQueue DispatcherQueue => DispatcherQueue.GetForCurrentThread();
 #endif
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3014ffb</samp>

This pull request migrates the SamplesApp project to use the new `DispatcherQueue` and `XamlRoot` APIs in Uno Platform. It replaces the obsolete `Dispatcher` and `Window.Current` usages with the newer and more efficient alternatives, and adds some extension methods and null checks to handle the changes. It also updates some UI tests and samples to use the new APIs and listen to the appropriate events.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
