### PR TITLE
fix(listview): Adjust scrollbar height to avoid duplicating the header size

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1630,6 +1630,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewScrollBar.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_BringIntoView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5807,6 +5811,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\SvgImageSource_Binding.xaml.cs">
       <DependentUpon>SvgImageSource_Binding.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewScrollbar.xaml.cs">
+      <DependentUpon>ListViewScrollBar.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_BringIntoView.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\SvgImageSource_FromMsAppData.xaml.cs" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListViewScrollBar.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListViewScrollBar.xaml
@@ -1,0 +1,98 @@
+<UserControl x:Class="SamplesApp.Windows_UI_Xaml_Controls.ListView.ListViewScrollBar"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:u="using:Uno.UI.Samples.Controls"
+			 xmlns:ios="http://uno.ui/ios"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:android="http://uno.ui/android"
+			 mc:Ignorable="d ios android"
+			 d:DesignHeight="2000"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<StackPanel>
+			<TextBlock TextWrapping="Wrap">
+				The scrollbar for the ListView must reach the end when the list is scrolled to the end. 
+				<LineBreak /> 
+				Switching headers and footer off individually must still allow for the scrollbar to reach the end.
+				<LineBreak />
+				This issue is particularly important on iOS and Android which use native scrollbars by default.
+			</TextBlock>
+			<CheckBox Content="Header"
+					  IsChecked="{x:Bind HeaderChecked, Mode=TwoWay}" />
+			<CheckBox Content="Footer"
+					  IsChecked="{x:Bind FooterChecked, Mode=TwoWay}" />
+		</StackPanel>
+
+		<ListView Grid.Row="1"
+				  Width="250"
+				  Height="300"
+				  x:Name="list01"
+				  ItemsSource="{Binding [SampleItems]}">
+			<ListView.HeaderTemplate>
+				<DataTemplate>
+					<Border BorderBrush="Black"
+							BorderThickness="2"
+							Height="450">
+						<Border.Background>
+							<LinearGradientBrush StartPoint="0,0"
+												 EndPoint="1,1">
+								<LinearGradientBrush.GradientStops>
+									<GradientStopCollection>
+										<GradientStop Color="LightBlue"
+													  Offset="0.0" />
+										<GradientStop Color="Blue"
+													  Offset="1.0" />
+									</GradientStopCollection>
+								</LinearGradientBrush.GradientStops>
+							</LinearGradientBrush>
+						</Border.Background>
+						<TextBlock Text="This is the header"
+								   Foreground="Blue" />
+					</Border>
+				</DataTemplate>
+			</ListView.HeaderTemplate>
+			<ListView.ItemTemplate>
+				<DataTemplate>
+					<Border BorderBrush="Red"
+							BorderThickness="2"
+							Width="80"
+							Height="60">
+						<TextBlock Text="{Binding}" />
+					</Border>
+				</DataTemplate>
+			</ListView.ItemTemplate>
+			<ListView.FooterTemplate>
+				<DataTemplate>
+					<Border BorderBrush="Black"
+							BorderThickness="2"
+							Height="450">
+						<Border.Background>
+							<LinearGradientBrush StartPoint="0,0"
+												 EndPoint="1,1">
+								<LinearGradientBrush.GradientStops>
+									<GradientStopCollection>
+										<GradientStop Color="LightGreen"
+													  Offset="0.0" />
+										<GradientStop Color="Green"
+													  Offset="1.0" />
+									</GradientStopCollection>
+								</LinearGradientBrush.GradientStops>
+							</LinearGradientBrush>
+						</Border.Background>
+						<TextBlock Text="This is the footer"
+								   Foreground="Green" />
+					</Border>
+				</DataTemplate>
+			</ListView.FooterTemplate>
+		</ListView>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListViewScrollbar.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListViewScrollbar.xaml.cs
@@ -1,0 +1,61 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.Models;
+using Windows.UI.Xaml;
+
+namespace SamplesApp.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo("ListView", "ListViewScrollBar", typeof(ListViewViewModel), IsManualTest = true)]
+	public sealed partial class ListViewScrollBar : UserControl
+	{
+		DataTemplate _headerTemplate;
+		DataTemplate _footerTemplate;
+
+		public ListViewScrollBar()
+		{
+			this.InitializeComponent();
+		}
+
+		private bool _headerChecked = true;
+
+		public bool HeaderChecked
+		{
+			get => _headerChecked;
+			set
+			{
+				_headerChecked = value;
+
+				if (value)
+				{
+					list01.HeaderTemplate = _headerTemplate;
+				}
+				else
+				{
+					_headerTemplate = list01.HeaderTemplate;
+					list01.HeaderTemplate = null;
+				}
+			}
+		}
+
+		private bool _footerChecked = true;
+
+		public bool FooterChecked
+		{
+			get =>  _footerChecked;
+			set
+			{
+				_footerChecked = value;
+
+				if (value)
+				{
+					list01.FooterTemplate = _footerTemplate;
+				}
+				else
+				{
+					_footerTemplate = list01.FooterTemplate;
+					list01.FooterTemplate = null;
+				}
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListViewScrollbar.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListViewScrollbar.xaml.cs
@@ -41,7 +41,7 @@ namespace SamplesApp.Windows_UI_Xaml_Controls.ListView
 
 		public bool FooterChecked
 		{
-			get =>  _footerChecked;
+			get => _footerChecked;
 			set
 			{
 				_footerChecked = value;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -753,7 +753,7 @@ namespace Windows.UI.Xaml.Controls
 
 			CorrectForEstimationErrors();
 
-			var range = ContentOffset + remainingItemExtent + remainingGroupExtent + headerExtent + footerExtent +
+			var range = ContentOffset + remainingItemExtent + remainingGroupExtent + footerExtent +
 				//TODO: An inline group header might actually be the view at the bottom of the viewport, we should take this into account
 				GetChildEndWithMargin(base.GetChildAt(FirstItemView + ItemViewCount - 1));
 			Debug.Assert(range > 0, "Must report a non-negative scroll range.");


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/tradezero-private/issues/6

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The ListView header is contributing to the position of the scrollbar anymore.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 471298f</samp>

Fix scrolling offset bug in `VirtualizingPanelLayout` on Android. Adjust scroll range calculation to exclude `headerExtent` variable.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
