### PR TITLE
fix: Don't skip arrange if the element is measured with zero size

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_StackPanel.cs
@@ -97,14 +97,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(50, SUT.LastArrangeOverrideReturn.Height);
 
 			SUT.Children.Remove(SUT.Children.Single());
-#if !__CROSSRUNTIME__
-			await TestServices.WindowHelper.WaitForRelayouted(SUT); // arrange is skipped (incorrectly) when finalRect is default, which is the case after removing the last child from StackPanel.
+			await TestServices.WindowHelper.WaitForRelayouted(SUT);
 			expectedMeasureAndArrangeCount++;
 			Assert.AreEqual(expectedMeasureAndArrangeCount, SUT.MeasureCount);
 			Assert.AreEqual(expectedMeasureAndArrangeCount, SUT.ArrangeCount);
 			Assert.AreEqual(0, SUT.LastMeasureOverrideReturn.Height);
 			Assert.AreEqual(0, SUT.LastArrangeOverrideReturn.Height);
-#endif
 
 			SUT.Children.Add(new Border()
 			{
@@ -119,14 +117,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(50, SUT.LastArrangeOverrideReturn.Height);
 
 			SUT.Children.Clear();
-#if !__CROSSRUNTIME__
-			await TestServices.WindowHelper.WaitForRelayouted(SUT);  // arrange is skipped (incorrectly) when finalRect is default, which is the case after removing the last child from StackPanel.
+			await TestServices.WindowHelper.WaitForRelayouted(SUT);
 			expectedMeasureAndArrangeCount++;
 			Assert.AreEqual(expectedMeasureAndArrangeCount, SUT.MeasureCount);
 			Assert.AreEqual(expectedMeasureAndArrangeCount, SUT.ArrangeCount);
 			Assert.AreEqual(0, SUT.LastMeasureOverrideReturn.Height);
 			Assert.AreEqual(0, SUT.LastArrangeOverrideReturn.Height);
-#endif
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
@@ -304,13 +304,7 @@ namespace Windows.UI.Xaml
 
 			var firstArrangeDone = IsFirstArrangeDone;
 
-			if (Visibility == Visibility.Collapsed
-				// If the layout is clipped, and the arranged size is empty, we can skip arranging children
-				// This scenario is particularly important for the Canvas which always sets its desired size
-				// zero, even after measuring its children.
-				|| (firstArrangeDone
-					&& finalRect == default
-					&& (this is not ICustomClippingElement clipElement || clipElement.AllowClippingToLayoutSlot)))
+			if (Visibility == Visibility.Collapsed)
 			{
 				LayoutInformation.SetLayoutSlot(this, finalRect);
 				HideVisual();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13672

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c7390c</samp>

Fixed a bug in `StackPanel` layout that caused incorrect rendering when the visibility of its children changed. Simplified the logic for skipping the arranging of children in `UIElement.Layout.crossruntime.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
