### PR TITLE
fix(binding): Avoid reading source property on UpdateSource for non-DP

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -862,6 +862,85 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+		[TestMethod]
+		public async Task When_SelectedItem_TwoWay_Binding_Clear()
+		{
+			var root = new Grid();
+
+			var comboBox = new ComboBox();
+
+			root.Children.Add(comboBox);
+
+			comboBox.SetBinding(ComboBox.ItemsSourceProperty, new Binding { Path = new("Items") });
+			comboBox.SetBinding(ComboBox.SelectedItemProperty, new Binding { Path = new("Item"), Mode = BindingMode.TwoWay });
+
+			WindowHelper.WindowContent = root;
+
+			var dc = new TwoWayBindingClearViewModel();
+			root.DataContext = dc;
+
+			await WindowHelper.WaitForIdle();
+
+			dc.Dispose();
+			root.DataContext = null;
+
+			Assert.AreEqual(1, dc.ItemGetCount);
+			Assert.AreEqual(1, dc.ItemSetCount);
+		}
+
+		public sealed class TwoWayBindingClearViewModel : IDisposable
+		{
+			public enum Themes
+			{
+				Invalid,
+				Day,
+				Night
+			}
+
+			public TwoWayBindingClearViewModel()
+			{
+				_item = Items[0];
+			}
+
+			public Themes[] Items { get; } = new Themes[] { Themes.Day, Themes.Night };
+			private Themes _item;
+			private bool _isDisposed;
+			public Themes Item
+			{
+				get
+				{
+					ItemGetCount++;
+
+					if (_isDisposed)
+					{
+						return Themes.Invalid;
+					}
+
+					return _item;
+				}
+				set
+				{
+					ItemSetCount++;
+
+					if (_isDisposed)
+					{
+						_item = Themes.Invalid;
+						return;
+					}
+
+					_item = value;
+				}
+			}
+
+			public int ItemGetCount { get; private set; }
+			public int ItemSetCount { get; private set; }
+
+			public void Dispose()
+			{
+				_isDisposed = true;
+			}
+		}
+
 		public class TwoWayBindingItem : System.ComponentModel.INotifyPropertyChanged
 		{
 			private int _selectedNumber;
@@ -932,6 +1011,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 	}
+
+
 #if __IOS__
 	#region "Helper classes for the iOS Modal Page (UIModalPresentationStyle.pageSheet)"
 	public partial class MultiFrame : Grid

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ObjectAnimationUsingKeyFrames.cs
@@ -74,7 +74,9 @@ namespace Uno.UI.RuntimeTests
 			await target.GetValue(ct, 3);
 			await Task.Yield();
 
-			target.History.Should().BeEquivalentTo(v1, v2, v3);
+			// v3 is repeated because the target property is not a DependencyProperty
+			// and no deduplication happens in the binding engine.
+			target.History.Should().BeEquivalentTo(v1, v2, v3, v3);
 			sut.State.Should().Be(Timeline.TimelineState.Filling);
 		}
 
@@ -147,7 +149,9 @@ namespace Uno.UI.RuntimeTests
 			await target.GetValue(ct, 3);
 			await Task.Yield();
 
-			target.History.Should().BeEquivalentTo(v1, v2, v3);
+			// v3 is repeated because the target property is not a DependencyProperty
+			// and no deduplication happens in the binding engine.
+			target.History.Should().BeEquivalentTo(v1, v2, v3, v3);
 			sut.State.Should().Be(Timeline.TimelineState.Filling);
 		}
 
@@ -178,7 +182,9 @@ namespace Uno.UI.RuntimeTests
 			await target.GetValue(ct, 9);
 			await Task.Yield();
 
-			target.History.Should().BeEquivalentTo(v1, v2, v3, v1, v2, v3, v1, v2, v3);
+			// v3 is repeated because the target property is not a DependencyProperty
+			// and no deduplication happens in the binding engine.
+			target.History.Should().BeEquivalentTo(v1, v2, v3, v1, v2, v3, v1, v2, v3, v3);
 			sut.State.Should().Be(Timeline.TimelineState.Filling);
 		}
 

--- a/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
@@ -4,6 +4,8 @@
 using System;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
+using Uno.UI.Xaml.Input;
+using Windows.ApplicationModel.Appointments;
 using Windows.UI.Xaml;
 
 namespace Uno.UI.DataBinding
@@ -15,12 +17,10 @@ namespace Uno.UI.DataBinding
 			private delegate void PropertyChangedHandler(object? previousValue, object? newValue, bool shouldRaiseValueChanged);
 
 			private ManagedWeakReference? _dataContextWeakStorage;
+			private Flags _flags;
 
 			private readonly SerialDisposable _propertyChanged = new SerialDisposable();
-			private bool _disposed;
 			private readonly DependencyPropertyValuePrecedences? _precedence;
-			private readonly object? _fallbackValue;
-			private readonly bool _allowPrivateMembers;
 			private ValueGetterHandler? _valueGetter;
 			private ValueGetterHandler? _precedenceSpecificGetter;
 			private ValueGetterHandler? _substituteValueGetter;
@@ -32,18 +32,27 @@ namespace Uno.UI.DataBinding
 
 			private Type? _dataContextType;
 
-			public BindingItem(BindingItem next, string property, object fallbackValue) :
-				this(next, property, fallbackValue, null, false)
+			[Flags]
+			private enum Flags
+			{
+				None = 0,
+				Disposed = 1 << 0,
+				AllowPrivateMembers = 1 << 1,
+				IsDependencyProperty = 1 << 2,
+				IsDependencyPropertyValueSet = 1 << 3,
+			}
+
+			public BindingItem(BindingItem next, string property) :
+				this(next, property, null, false)
 			{
 			}
 
-			internal BindingItem(BindingItem? next, string property, object? fallbackValue, DependencyPropertyValuePrecedences? precedence, bool allowPrivateMembers)
+			internal BindingItem(BindingItem? next, string property, DependencyPropertyValuePrecedences? precedence, bool allowPrivateMembers)
 			{
 				Next = next;
 				PropertyName = property;
 				_precedence = precedence;
-				_fallbackValue = fallbackValue;
-				_allowPrivateMembers = allowPrivateMembers;
+				AllowPrivateMembers = allowPrivateMembers;
 			}
 
 			public object? DataContext
@@ -51,7 +60,7 @@ namespace Uno.UI.DataBinding
 				get => _dataContextWeakStorage?.Target;
 				set
 				{
-					if (!_disposed)
+					if (!IsDisposed)
 					{
 						// Historically, Uno was processing property changes using INPC. Since the inclusion of DependencyObject
 						// values changes are now filtered by DependencyProperty updates, making equality updates at this location
@@ -131,7 +140,7 @@ namespace Uno.UI.DataBinding
 				{
 					if (DataContext != null)
 					{
-						return BindingPropertyHelper.GetPropertyType(_dataContextType!, PropertyName, _allowPrivateMembers);
+						return BindingPropertyHelper.GetPropertyType(_dataContextType!, PropertyName, AllowPrivateMembers);
 					}
 					else
 					{
@@ -226,6 +235,7 @@ namespace Uno.UI.DataBinding
 
 				if (_dataContextType != currentType && _dataContextType != null)
 				{
+					IsDependencyPropertyValueSet = false;
 					_valueGetter = null;
 					_precedenceSpecificGetter = null;
 					_substituteValueGetter = null;
@@ -312,7 +322,7 @@ namespace Uno.UI.DataBinding
 			{
 				if (_valueGetter == null && _dataContextType != null)
 				{
-					_valueGetter = BindingPropertyHelper.GetValueGetter(_dataContextType, PropertyName, _precedence, _allowPrivateMembers);
+					_valueGetter = BindingPropertyHelper.GetValueGetter(_dataContextType, PropertyName, _precedence, AllowPrivateMembers);
 				}
 			}
 
@@ -320,7 +330,7 @@ namespace Uno.UI.DataBinding
 			{
 				if (_precedenceSpecificGetter == null && _dataContextType != null)
 				{
-					_precedenceSpecificGetter = BindingPropertyHelper.GetValueGetter(_dataContextType, PropertyName, _precedence, _allowPrivateMembers);
+					_precedenceSpecificGetter = BindingPropertyHelper.GetValueGetter(_dataContextType, PropertyName, _precedence, AllowPrivateMembers);
 				}
 			}
 
@@ -478,8 +488,61 @@ namespace Uno.UI.DataBinding
 
 			public void Dispose()
 			{
-				_disposed = true;
+				IsDisposed = true;
 				_propertyChanged.Dispose();
+			}
+
+			private bool IsDisposed
+			{
+				get => _flags.HasFlag(Flags.Disposed);
+				set => SetFlag(value, Flags.Disposed);
+			}
+
+			private bool AllowPrivateMembers
+			{
+				get => _flags.HasFlag(Flags.AllowPrivateMembers);
+				set => SetFlag(value, Flags.AllowPrivateMembers);
+			}
+
+			private bool IsDependencyPropertyValueSet
+			{
+				get => _flags.HasFlag(Flags.IsDependencyPropertyValueSet);
+				set => SetFlag(value, Flags.IsDependencyPropertyValueSet);
+			}
+
+			internal bool IsDependencyProperty
+			{
+				get
+				{
+					if (!IsDependencyPropertyValueSet)
+					{
+						var isDP =
+							_dataContextType is not null
+							&& DependencyProperty.GetProperty(_dataContextType!, PropertyName) is not null;
+
+						SetFlag(isDP, Flags.IsDependencyProperty);
+
+						IsDependencyPropertyValueSet = true;
+
+						return isDP;
+					}
+					else
+					{
+						return _flags.HasFlag(Flags.IsDependencyProperty);
+					}
+				}
+			}
+
+			private void SetFlag(bool value, Flags flag)
+			{
+				if (!value)
+				{
+					_flags &= ~flag;
+				}
+				else
+				{
+					_flags |= flag;
+				}
 			}
 
 			/// <summary>

--- a/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.BindingItem.cs
@@ -494,19 +494,19 @@ namespace Uno.UI.DataBinding
 
 			private bool IsDisposed
 			{
-				get => _flags.HasFlag(Flags.Disposed);
+				get => (_flags & Flags.Disposed) != 0;
 				set => SetFlag(value, Flags.Disposed);
 			}
 
 			private bool AllowPrivateMembers
 			{
-				get => _flags.HasFlag(Flags.AllowPrivateMembers);
+				get => (_flags & Flags.AllowPrivateMembers) != 0;
 				set => SetFlag(value, Flags.AllowPrivateMembers);
 			}
 
 			private bool IsDependencyPropertyValueSet
 			{
-				get => _flags.HasFlag(Flags.IsDependencyPropertyValueSet);
+				get => (_flags & Flags.IsDependencyPropertyValueSet) != 0;
 				set => SetFlag(value, Flags.IsDependencyPropertyValueSet);
 			}
 
@@ -528,7 +528,7 @@ namespace Uno.UI.DataBinding
 					}
 					else
 					{
-						return _flags.HasFlag(Flags.IsDependencyProperty);
+						return (_flags & Flags.IsDependencyProperty) != 0;
 					}
 				}
 			}

--- a/src/Uno.UI/DataBinding/BindingPath.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.cs
@@ -195,8 +195,14 @@ namespace Uno.UI.DataBinding
 			{
 				if (!_disposed
 					&& _value != null
-					&& DependencyObjectStore.AreDifferent(value, _value.GetPrecedenceSpecificValue())
-				)
+					&& (
+						!_value.IsDependencyProperty
+
+						// Don't get the source value if we're not accessing a dependency property.
+						// WinUI does not read the property value before setting the value for a
+						// non-dependency property source.
+						|| DependencyObjectStore.AreDifferent(value, _value.GetPrecedenceSpecificValue())
+					))
 				{
 					_value.Value = value;
 				}
@@ -428,7 +434,7 @@ namespace Uno.UI.DataBinding
 			}
 
 			var itemPath = path.Substring(start, length);
-			var item = new BindingItem(head, itemPath, fallbackValue, precedence, allowPrivateMembers);
+			var item = new BindingItem(head, itemPath, precedence, allowPrivateMembers);
 
 			head = item;
 			tail ??= item;


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/11956

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

During a two-way binding, the source bound property will not be read before being set. This will avoid scenarios during datacontext reset that may read properties for out of date instances.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 203609d</samp>

This pull request enhances the data binding system and the `ComboBox` control in Uno.UI. It adds a new unit test for `ComboBox`, refactors the `BindingItem` class to use flags and support a new scenario, fixes a data binding bug in the `BindingPath` class, and improves the performance and memory usage of the binding system.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
