### PR TITLE
fix(net8): Adjust WinUI property detection

### DIFF
--- a/build/nuget/uno.winui.props
+++ b/build/nuget/uno.winui.props
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<PropertyGroup>
-		<!-- Wrap WinAppSDK detection until a stable property can be used -->
-		<_UnoIsWinAppSDKDefined>false</_UnoIsWinAppSDKDefined>
-		<_UnoIsWinAppSDKDefined Condition="'$(WindowsAppSDKWinUI)'=='true' or '$(UseWinUITools)'=='true'">true</_UnoIsWinAppSDKDefined>
-	</PropertyGroup>
-
-	<Import Project="../uno.winui.common.props" Condition="'$(_UnoIsWinAppSDKDefined)'!='true'" />
+	<!-- 
+		Note that WinUI cannot be detected in properties or imports, as the nuget props
+		import from nuget packages cannot be controlled.
+	-->
+	<Import Project="../uno.winui.common.props" />
 
 </Project>

--- a/build/nuget/uno.winui.targets
+++ b/build/nuget/uno.winui.targets
@@ -2,6 +2,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<PropertyGroup>
+	
+		<!-- Wrap WinAppSDK detection until a stable property can be used -->
+		<_UnoIsWinAppSDKDefined>false</_UnoIsWinAppSDKDefined>
+		<_UnoIsWinAppSDKDefined Condition="'$(WindowsAppSDKWinUI)'=='true' or '$(UseWinUITools)'=='true'">true</_UnoIsWinAppSDKDefined>
+
 		<_IsUnoWinUIPackage>$(MSBuildThisFile.ToLower().Equals('uno.winui.targets'))</_IsUnoWinUIPackage>
 	</PropertyGroup>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/discussions/13678

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

.NET 8 changes the ordering of nuget defined props files, This change makes WinUI detection independent of nuget props import and rely on .targets evaluation.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 591797b</samp>

Moved the import of `uno.winui.common.props` to the targets file and added a check for WinAppSDK projects. This fixes a bug where WinUI projects using WinAppSDK were not recognized by Uno.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
