### PR TITLE
chore!: Remove SetterBase.set_Property

### DIFF
--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -123,6 +123,9 @@ This change has no effect on Controls behavior.
 #### Change `RenderSurfaceType` namespace
 There used two be two `RenderSurfaceType`s, `Uno.UI.Runtime.Skia.RenderSurfaceType` (for Gtk) and `Uno.UI.Skia.RenderSurfaceType` (for Skia). They are now `Uno.UI.Runtime.Skia.Gtk.RenderSurfaceType` and `Uno.UI.Runtime.Skia.Wpf.RenderSurfaceType` respectively.
 
+#### Rmove `SetterBase.set_Property`
+This method was only present for binary backward compatibility with `Setter<T>`. Use `Setter.Property` or `Setter<T>.Property` instead
+
 #### `Panel`s no longer measure or arrange any children in `MeasureOverride` or `ArrangeOverride`, respectively
 `Panel`s used to measure and arrange the first child in `MeasureOverride` or `ArrangeOverride`, respectively. This is no longer the case. Now, to match WinUI, `Panel`s just return an empty size in `MeasureOverride`, and the `finalSize` as is in `ArrangeOverride`. You should override these layout-override methods in `Panel`-derived subclasses instead.
 

--- a/src/Uno.UI/UI/Xaml/Setter.Generic.cs
+++ b/src/Uno.UI/UI/Xaml/Setter.Generic.cs
@@ -26,8 +26,6 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		public string Property { get; set; }
 
-		internal override void OnStringPropertyChanged(string name) => Property = name;
-
 		internal override void ApplyTo(DependencyObject o)
 		{
 			if (!(o is T))

--- a/src/Uno.UI/UI/Xaml/SetterBase.cs
+++ b/src/Uno.UI/UI/Xaml/SetterBase.cs
@@ -15,15 +15,6 @@ namespace Windows.UI.Xaml
 
 		internal abstract void ApplyTo(DependencyObject o);
 
-		/// <summary>
-		/// This method is present for binary backward compatibility with <see cref="Setter{T}"/>.
-		/// Use <see cref="Setter.Property"/> or <see cref="Setter{T}.Property"/> instead.
-		/// </summary>
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public void set_Property(string name) => OnStringPropertyChanged(name);
-
-		internal virtual void OnStringPropertyChanged(string name) { }
-
 		partial void OnDataContextChangedPartial(DependencyPropertyChangedEventArgs e)
 		{
 			this.Log().Debug("SetterBase.DataContextChanged");


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13050

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43635aa</samp>

This pull request removes the `SetterBase.set_Property` method and its related logic from the `Setter` classes, and updates the documentation accordingly. This simplifies the XAML parsing and reduces the binary size.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
