### PR TITLE
feat: add feat flag to disable droid measure cache

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
+using Uno.Disposables;
+using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.GridPages;
 using Windows.Foundation;
@@ -16,6 +18,11 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
+
+#if HAS_UNO
+using DirectUI;
+using Uno.UI.Helpers;
+#endif
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -308,6 +315,69 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			NumberAssert.Greater(SUT.ActualWidth, 0);
 #endif
 		}
+
+#if __ANDROID__
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Grid_Remeasure()
+		{
+			// uno#12315: rows/columns of Grid can sometimes fail to re-measure due to android measure caching
+			// causing incorrect measure/arrange for views belonging to that rows/columns.
+
+			// ensure the flag is active, and will be restored after test
+			var flag = FeatureConfiguration.FrameworkElement.InvalidateNativeCacheOnRemeasure;
+			using var restore = Disposable.Create(() => FeatureConfiguration.FrameworkElement.InvalidateNativeCacheOnRemeasure = flag);
+			FeatureConfiguration.FrameworkElement.InvalidateNativeCacheOnRemeasure = true;
+
+			var setup = XamlHelper.LoadXaml<Border>("""
+				<Border BorderThickness="5" BorderBrush="Red">
+					<Grid x:Name="SutGrid" Height="400" Width="600">
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto" />
+							<RowDefinition Height="*" />
+						</Grid.RowDefinitions>
+
+						<StackPanel>
+							<!--<Button x:Name="ToggleVisibility" Content="ON|OFF" Style="{StaticResource BasicButtonStyle}" />-->
+							<Border x:Name="TogglableBorder" Height="50" Background="SkyBlue" />
+						</StackPanel>
+
+						<ListView x:Name="SutLV" Grid.Row="1" ItemsSource="{Binding}" />
+						<TextBlock Grid.Row="1" Text="TEXT MUST BE HERE" HorizontalAlignment="Center" VerticalAlignment="Bottom" />
+					</Grid>
+				</Border>
+				""");
+			setup.DataContext = Enumerable.Range(0, 50);
+
+			var grid = setup.FindFirstDescendant<Grid>(x => x.Name == "SutGrid");
+			var togglableBorder = setup.FindFirstDescendant<Border>(x => x.Name == "TogglableBorder");
+			var lv = setup.FindFirstDescendant<ListView>(x => x.Name == "SutLV");
+
+			TestServices.WindowHelper.WindowContent = setup;
+			await TestServices.WindowHelper.WaitForLoaded(setup);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var initial = lv.ActualHeight;
+
+			// On first cycle, everything will be normal.
+			togglableBorder.Visibility = Visibility.Collapsed; // C = 1
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.IsTrue(lv.ActualHeight > initial, $"C1: SutLV should've expanded with the border collapsed: Lv.ActualHeight>initial --> ({lv.ActualHeight}>{initial})");
+			togglableBorder.Visibility = Visibility.Visible; // C = 2
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.IsTrue(DoubleUtil.AreWithinTolerance(lv.ActualHeight, initial, 0.1), $"C2: SutLV should've returned to initial size with the border visible: Lv.ActualHeight==initial --> ({lv.ActualHeight}=={initial})");
+
+			// On the following cycles, everything should still be normal.
+			// [Android:] However, in context of uno12315, it would fail on C4,C6,C8...
+			// due to measure caching of Android.Views.View.Measure inside the measure pass of Grid.
+			togglableBorder.Visibility = Visibility.Collapsed; // C = 3
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.IsTrue(lv.ActualHeight > initial, $"C3: SutLV should've expanded with the border collapsed: Lv.ActualHeight>initial --> ({lv.ActualHeight}>{initial})");
+			togglableBorder.Visibility = Visibility.Visible; // C = 4
+			await TestServices.WindowHelper.WaitForIdle();
+			Assert.IsTrue(DoubleUtil.AreWithinTolerance(lv.ActualHeight, initial, 0.1), $"C4: SutLV should've returned to initial size with the border visible: Lv.ActualHeight==initial --> ({lv.ActualHeight}=={initial})");
+		}
+#endif
 
 		private static void AddChild(Grid parent, FrameworkElement child, int row, int col, int? rowSpan = null, int? colSpan = null)
 		{

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -219,6 +219,13 @@ namespace Uno.UI
 			public static bool AndroidUseManagedLoadedUnloaded { get; set; } = true;
 #endif
 
+#if __ANDROID__
+			/// <summary>
+			/// Invalidate native android measure cache when measure-spec has changed since last measure.
+			/// </summary>
+			public static bool InvalidateNativeCacheOnRemeasure { get; set; } = true;
+#endif
+
 			/// <summary>
 			/// [WebAssembly Only] Controls the propagation of <see cref="Windows.UI.Xaml.FrameworkElement.Loaded"/> and
 			/// <see cref="Windows.UI.Xaml.FrameworkElement.Unloaded"/> events through managed

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
@@ -27,7 +27,13 @@ namespace Windows.UI.Xaml.Controls
 			var widthSpec = ViewHelper.SpecFromLogicalSize(slotSize.Width);
 			var heightSpec = ViewHelper.SpecFromLogicalSize(slotSize.Height);
 
-			var needsForceLayout = double.IsPositiveInfinity(slotSize.Width) || double.IsPositiveInfinity(slotSize.Height);
+			var needsForceLayout =
+				(double.IsPositiveInfinity(slotSize.Width) || double.IsPositiveInfinity(slotSize.Height)) ||
+				// uno12315: ensure the native measure cache is not used when measure-spec has changed since.
+				FeatureConfiguration.FrameworkElement.InvalidateNativeCacheOnRemeasure && (
+					view.MeasuredWidth != ViewHelper.LogicalToPhysicalPixels(slotSize.Width) ||
+					view.MeasuredHeight != ViewHelper.LogicalToPhysicalPixels(slotSize.Height)
+				);
 
 			Uno.UI.Controls.BindableView.TryFastRequestLayout(view, needsForceLayout);
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12315, closes https://github.com/unoplatform/tradezero-private/issues/7

## PR Type
What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Added `FeatureConfiguration.FrameworkElement.InvalidateNativeCacheOnRemeasure` which disables native android measure cache when measure-spec has changed since last measure.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe119b6</samp>

This pull request adds a feature flag `InvalidateNativeCacheOnRemeasure` and uses it to fix a layout issue on Android where some controls may have incorrect sizes due to stale native measure cache values. The flag allows to invalidate the cache and force a layout when the measure-spec changes for a view.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->