### PR TITLE
feat(WPF Window): Extend into Title Bar

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoWpfWindow.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoWpfWindow.cs
@@ -3,6 +3,8 @@
 using System;
 using System.ComponentModel;
 using System.IO;
+using System.Windows;
+using Windows.ApplicationModel.Core;
 using Uno.Foundation.Logging;
 using Windows.Foundation;
 using Windows.UI.Core.Preview;
@@ -10,6 +12,7 @@ using Windows.UI.ViewManagement;
 using WinUI = Windows.UI.Xaml;
 using WinUIApplication = Windows.UI.Xaml.Application;
 using WpfWindow = System.Windows.Window;
+using System.Windows.Shell;
 
 namespace Uno.UI.Runtime.Skia.Wpf.UI.Controls;
 
@@ -93,6 +96,24 @@ internal class UnoWpfWindow : WpfWindow
 		Title = appView.Title;
 		MinWidth = appView.PreferredMinSize.Width;
 		MinHeight = appView.PreferredMinSize.Height;
+	}
+
+	internal void UpdateWindowPropertiesFromCoreApplication()
+	{
+		var coreApplicationView = CoreApplication.GetCurrentView();
+		if (coreApplicationView.TitleBar.ExtendViewIntoTitleBar)
+		{
+			WindowStyle = WindowStyle.None;
+			WindowChrome.SetWindowChrome(this, new WindowChrome()
+			{
+				GlassFrameThickness = new Thickness(-1),
+				UseAeroCaptionButtons = false
+			});
+
+			ResizeMode = ResizeMode.NoResize;
+
+			WindowChrome.SetIsHitTestVisibleInChrome((IInputElement)Content, true);
+		}
 	}
 
 	internal void UpdateWindowPropertiesFromPackage()

--- a/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/WpfHost.cs
@@ -74,6 +74,7 @@ public class WpfHost : IWpfApplicationHost
 		unoWpfWindow.Activated += MainWindow_Activated;
 		unoWpfWindow.UpdateWindowPropertiesFromPackage();
 		unoWpfWindow.UpdateWindowPropertiesFromApplicationView();
+		unoWpfWindow.UpdateWindowPropertiesFromCoreApplication();
 	}
 
 	internal event EventHandler? MainWindowShown;


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/10874 , closes https://github.com/unoplatform/uno/issues/10368

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We can not extend into title bar in WPF

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

We can extend the content to title bar in WPF by hide the WPF window title bar

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 59fdc8d</samp>

Added support for the UWP TitleBar API on WPF by updating the window style and chrome of the `UnoWpfWindow` based on the `ExtendViewIntoTitleBar` property. This allows apps to customize the appearance of the title bar and extend their content into it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Reference: https://github.com/unoplatform/uno/pull/13597

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
