### PR TITLE
feat: Filters are passed from sample app to hot reload test app 

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestMethodInfo.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestMethodInfo.cs
@@ -25,6 +25,9 @@ internal record UnitTestMethodInfo
 		RequiresFullWindow =
 			HasCustomAttribute<RequiresFullWindowAttribute>(method) ||
 			HasCustomAttribute<RequiresFullWindowAttribute>(method.DeclaringType);
+		PassFiltersAsFirstParameter =
+			HasCustomAttribute<FiltersAttribute>(method) ||
+			HasCustomAttribute<FiltersAttribute>(method.DeclaringType);
 		ExpectedException = method
 			.GetCustomAttributes<ExpectedExceptionAttribute>()
 			.SingleOrDefault()
@@ -59,6 +62,8 @@ internal record UnitTestMethodInfo
 	public bool RequiresFullWindow { get; }
 
 	public bool RunsOnUIThread { get; }
+
+	public bool PassFiltersAsFirstParameter { get; }
 
 	private bool HasCustomAttribute<T>(MemberInfo? testMethod)
 		=> testMethod?.GetCustomAttribute(typeof(T)) != null;

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -786,7 +786,8 @@ namespace Uno.UI.Samples.Tests
 							var methodArguments = testCase.Parameters;
 							if (test.PassFiltersAsFirstParameter)
 							{
-								methodArguments = methodArguments.ToImmutableArray().Insert(0, string.Join(";", config.Filters)).ToArray();
+								var configFilters = config.Filters ??= Array.Empty<string>();
+								methodArguments = methodArguments.ToImmutableArray().Insert(0, string.Join(";", configFilters)).ToArray();
 							}
 							if (test.RunsOnUIThread)
 							{

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -28,6 +28,7 @@ using Windows.UI.Xaml.Media;
 using Newtonsoft.Json;
 using System.Text;
 using System.Security.Cryptography;
+using System.Collections.Immutable;
 
 #if HAS_UNO
 using Uno.Foundation.Logging;
@@ -782,6 +783,11 @@ namespace Uno.UI.Samples.Tests
 							}
 
 							object returnValue = null;
+							var methodArguments = testCase.Parameters;
+							if (test.PassFiltersAsFirstParameter)
+							{
+								methodArguments = methodArguments.ToImmutableArray().Insert(0, string.Join(";", config.Filters)).ToArray();
+							}
 							if (test.RunsOnUIThread)
 							{
 								var cts = new TaskCompletionSource<bool>();
@@ -813,7 +819,7 @@ namespace Uno.UI.Samples.Tests
 											await initializeReturnTask;
 										}
 
-										returnValue = test.Method.Invoke(instance, testCase.Parameters);
+										returnValue = test.Method.Invoke(instance, methodArguments);
 										sw.Stop();
 
 										cts.TrySetResult(true);
@@ -846,7 +852,7 @@ namespace Uno.UI.Samples.Tests
 									await initializeReturnTask;
 								}
 
-								returnValue = test.Method.Invoke(instance, testCase.Parameters);
+								returnValue = test.Method.Invoke(instance, methodArguments);
 								sw.Stop();
 							}
 

--- a/src/Uno.UI.RuntimeTests/Helpers/FiltersAttribute.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/FiltersAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Uno.UI.RuntimeTests;
+
+/// <summary>
+/// Test method requires filters to be injected as first parameter
+/// </summary>
+public class FiltersAttribute : Attribute
+{
+}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/MainPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/MainPage.xaml.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using Uno.UI.RemoteControl;
 using Uno.UI.RemoteControl.HotReload;
+using Uno.UI.RuntimeTests;
 
 namespace UnoApp50
 {
@@ -45,7 +46,15 @@ namespace UnoApp50
 				Console.WriteLine($"Initialized remote control");
 			}
 
-			await testControl.RunTests(CancellationToken.None, new());
+			var filters = Environment.GetCommandLineArgs().SkipWhile(a => a != "--filters").Skip(1).FirstOrDefault();
+			Console.WriteLine($"Filters = {filters}");
+			UnitTestEngineConfig testConfig = new();
+			if (filters is { Length: > 0 })
+			{
+				testConfig.Filters = filters?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
+			}
+
+			await testControl.RunTests(CancellationToken.None, testConfig);
 
 			// get the first command line argument after `--uitest`
 			var testResultPath = Environment.GetCommandLineArgs().SkipWhile(a => a != "--uitest").Skip(1).FirstOrDefault();

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame.cs
@@ -76,8 +76,11 @@ public class Given_Frame : BaseTestClass
 			FirstPageTextBlockChangedText,
 			() => frame.ValidateFirstTextBlockOnCurrentPageText(FirstPageTextBlockChangedText),
 			ct);
-	}
 
+		// Validate that the page has been returned to the original text
+		await frame.ValidateFirstTextBlockOnCurrentPageText(FirstPageTextBlockOriginalText);
+	}
+	
 	/// <summary>
 	/// Checks that a simple xaml change to the current page will be retained when
 	/// navigating forward to a new page and then going back to the original page	


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13744

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

All hot reload tests, which run in a separate app, always run (ie not filtered). This is painful when debugging tests as it's hard to follow the output from multiple tests

## What is the new behavior?

Filters specified in the sample app are passed through to the HR app. In order to limit sample app to only run hot reload tests, use Given_HotReloadWorkspace (class) or When_HotReloadScenario (method) as the first filter value (these values will be removed from the filter before it's sent to the HR app). If no other filter is provided, all HR tests will run. If additional filters are specified (eg Given_HotReloadWorkspace;HR_Test_To_Run) the additional filters will be set to the HR test app.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9507d6e</samp>

This pull request adds support for filtering UI tests based on command line arguments, and improves the hot reload functionality and testing for the `HRApp` project. It introduces a new `FiltersAttribute` class and a `PassFiltersAsFirstParameter` property to enable the injection of filters as a parameter for some test methods. It also adds a `ClearMappings` method to the `TypeMappingHelper` class to reset the hot reload type mappings before each test, and updates the test classes to inherit from a common `BaseTestClass` class.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
