### PR TITLE
fix(itemspresenter): fix ItemsPresenter.<Measure|Arrange>Override in case of padding

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -87,7 +87,7 @@ public class Given_ItemsPresenter
 
 		LayoutInformation.GetLayoutSlot(ic).Should().Be(new Rect(5, 5, 290, 290), Epsilon);
 		LayoutInformation.GetLayoutSlot(ip).Should().Be(new Rect(0, 0, 290, 290), Epsilon);
-		LayoutInformation.GetDesiredSize(ip).Should().Be(new Size (236, 288), Epsilon);
+		LayoutInformation.GetDesiredSize(ip).Should().Be(new Size(236, 288), Epsilon);
 		LayoutInformation.GetLayoutSlot(header).Should().Be(new Rect(100, 100, 90, 20), Epsilon);
 		LayoutInformation.GetLayoutSlot(footer).Should().Be(new Rect(100, 270, 90, 20), Epsilon);
 		LayoutInformation.GetLayoutSlot(panel).Should().Be(new Rect(100, 120, 90, 150), Epsilon);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -25,6 +25,102 @@ public class Given_ItemsPresenter
 		0.0f;
 #endif
 
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_Vertical_With_Padding()
+	{
+		var grid = (Grid)XamlReader.Load(
+		"""
+		<Grid x:Name="g" Width="300" Height="300"
+			  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			  mc:Ignorable="d">
+			<Border BorderBrush="Bisque" BorderThickness="5">
+				<ItemsControl x:Name="ic">
+					<ItemsControl.Items>
+						<Border Width="30" Height="40" Margin="1">
+							<Ellipse Fill="Red" />
+						</Border>
+						<Border Width="30" Height="40" Margin="3">
+							<Ellipse Fill="Green" />
+						</Border>
+					</ItemsControl.Items>
+					<ItemsControl.ItemsPanel>
+						<ItemsPanelTemplate>
+							<StackPanel />
+						</ItemsPanelTemplate>
+					</ItemsControl.ItemsPanel>
+					<ItemsControl.Template>
+						<ControlTemplate TargetType="ItemsControl">
+							<ItemsPresenter Padding="100">
+								<ItemsPresenter.Header>
+									<Border Width="30" Height="20">
+										<Ellipse Fill="Yellow" />
+									</Border>
+								</ItemsPresenter.Header>
+								<ItemsPresenter.Footer>
+									<Border Width="30" Height="20">
+										<Ellipse Fill="Pink" />
+									</Border>
+								</ItemsPresenter.Footer>
+							</ItemsPresenter>
+						</ControlTemplate>
+					</ItemsControl.Template>
+				</ItemsControl>
+			</Border>
+		</Grid>
+		""");
+
+		WindowHelper.WindowContent = grid;
+		await WindowHelper.WaitForLoaded(grid);
+		await WindowHelper.WaitForIdle();
+
+		var ic = (ItemsControl)grid.FindName("ic");
+		var ip = grid.FindVisualChildByType<ItemsPresenter>();
+		var header = (ContentControl)VisualTreeHelper.GetChild(ip, 0);
+		var footer = (ContentControl)VisualTreeHelper.GetChild(ip, 2);
+		var panel = grid.FindVisualChildByType<StackPanel>();
+		var item1 = (FrameworkElement)panel.Children[0];
+		var item2 = (FrameworkElement)panel.Children[1];
+
+		LayoutInformation.GetLayoutSlot(ic).Should().Be(new Rect(5, 5, 290, 290), Epsilon);
+		LayoutInformation.GetLayoutSlot(ip).Should().Be(new Rect(0, 0, 290, 290), Epsilon);
+		LayoutInformation.GetLayoutSlot(header).Should().Be(new Rect(100, 100, 90, 20), Epsilon);
+		LayoutInformation.GetLayoutSlot(footer).Should().Be(new Rect(100, 270, 90, 20), Epsilon);
+		LayoutInformation.GetLayoutSlot(panel).Should().Be(new Rect(100, 120, 90, 150), Epsilon);
+		LayoutInformation.GetLayoutSlot(item1).Should().Be(new Rect(0, 0, 90, 42), Epsilon);
+		LayoutInformation.GetLayoutSlot(item2).Should().Be(new Rect(0, 42, 90, 46), Epsilon);
+
+		ip.GetIrregularSnapPoints(Orientation.Horizontal, SnapPointsAlignment.Near).Should().BeNull();
+		ip.GetIrregularSnapPoints(Orientation.Horizontal, SnapPointsAlignment.Far).Should().BeNull();
+		ip.GetIrregularSnapPoints(Orientation.Horizontal, SnapPointsAlignment.Center).Should().BeNull();
+
+		ip.GetIrregularSnapPoints(Orientation.Vertical, SnapPointsAlignment.Near).ToList().Should().BeEquivalentToWithTolerance<float>(new float[]
+		{
+			100,
+			120,
+			162,
+			208
+		}, Epsilon);
+
+		ip.GetIrregularSnapPoints(Orientation.Vertical, SnapPointsAlignment.Far).ToList().Should().BeEquivalentToWithTolerance<float>(new float[]
+		{
+			120,
+			162,
+			208,
+			228
+		}, Epsilon);
+
+		ip.GetIrregularSnapPoints(Orientation.Vertical, SnapPointsAlignment.Center).ToList().Should().BeEquivalentToWithTolerance<float>(new float[]
+		{
+			110,
+			141,
+			185,
+			218
+		}, Epsilon);
+	}
 
 	[TestMethod]
 	[RunsOnUIThread]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -87,7 +87,7 @@ public class Given_ItemsPresenter
 
 		LayoutInformation.GetLayoutSlot(ic).Should().Be(new Rect(5, 5, 290, 290), Epsilon);
 		LayoutInformation.GetLayoutSlot(ip).Should().Be(new Rect(0, 0, 290, 290), Epsilon);
-		LayoutInformation.GetDesiredSize(ip).Should().Be(new Size(236, 288), Epsilon);
+		ip.DesiredSize.Should().Be(new Size(236, 288), Epsilon);
 		LayoutInformation.GetLayoutSlot(header).Should().Be(new Rect(100, 100, 90, 20), Epsilon);
 		LayoutInformation.GetLayoutSlot(footer).Should().Be(new Rect(100, 270, 90, 20), Epsilon);
 		LayoutInformation.GetLayoutSlot(panel).Should().Be(new Rect(100, 120, 90, 150), Epsilon);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -87,6 +87,7 @@ public class Given_ItemsPresenter
 
 		LayoutInformation.GetLayoutSlot(ic).Should().Be(new Rect(5, 5, 290, 290), Epsilon);
 		LayoutInformation.GetLayoutSlot(ip).Should().Be(new Rect(0, 0, 290, 290), Epsilon);
+		LayoutInformation.GetDesiredSize(ip).Should().Be(new Size (236, 288), Epsilon);
 		LayoutInformation.GetLayoutSlot(header).Should().Be(new Rect(100, 100, 90, 20), Epsilon);
 		LayoutInformation.GetLayoutSlot(footer).Should().Be(new Rect(100, 270, 90, 20), Epsilon);
 		LayoutInformation.GetLayoutSlot(panel).Should().Be(new Rect(100, 120, 90, 150), Epsilon);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -27,7 +27,113 @@ public class Given_ItemsPresenter
 
 	[TestMethod]
 	[RunsOnUIThread]
-	public async Task When_Vertical_With_Padding()
+	public async Task When_Vertical_With_Padding_Only_Panel()
+	{
+		var grid = (Grid)XamlReader.Load(
+		"""
+		<Grid x:Name="g" Width="300" Height="300"
+			  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			  mc:Ignorable="d">
+			<Border HorizontalAlignment="Left"
+			VerticalAlignment="Top"
+			Background="LightBlue"
+			BorderBrush="Blue"
+			BorderThickness="3">
+				<ItemsControl x:Name="ic" Background="Red" Padding="50">
+					<ItemsControl.Items>
+						<Border Width="40" Height="40" Margin="5" Background="MediumVioletRed" />
+						<Border Width="40" Height="40" Margin="5" Background="MediumVioletRed" />
+						<Border Width="40" Height="40" Margin="5" Background="MediumVioletRed" />
+					</ItemsControl.Items>
+					<ItemsControl.Template>
+						<ControlTemplate TargetType="ItemsControl">
+							<ItemsPresenter Padding="{TemplateBinding Padding}" />
+						</ControlTemplate>
+					</ItemsControl.Template>
+				</ItemsControl>
+			</Border>
+		</Grid>
+		""");
+
+		WindowHelper.WindowContent = grid;
+		await WindowHelper.WaitForLoaded(grid);
+		await WindowHelper.WaitForIdle();
+
+		var ic = (ItemsControl)grid.FindName("ic");
+		var ip = grid.FindVisualChildByType<ItemsPresenter>();
+		var panel = grid.FindVisualChildByType<StackPanel>();
+		var item1 = (FrameworkElement)panel.Children[0];
+		var item2 = (FrameworkElement)panel.Children[1];
+
+		// WinUI numbers
+		// LayoutInformation.GetLayoutSlot(ic).Should().Be(new Rect(3, 3, 150, 200), Epsilon);
+		// LayoutInformation.GetLayoutSlot(ip).Should().Be(new Rect(0, 0, 150, 200), Epsilon);
+		// ip.DesiredSize.Should().Be(new Size(150, 200), Epsilon);
+		// LayoutInformation.GetLayoutSlot(panel).Should().Be(new Rect(50, 50, 50, 150), Epsilon);
+		// LayoutInformation.GetLayoutSlot(item1).Should().Be(new Rect(0, 0, 50, 50), Epsilon);
+		// LayoutInformation.GetLayoutSlot(item2).Should().Be(new Rect(0, 50, 50, 50), Epsilon);
+
+		LayoutInformation.GetLayoutSlot(ic).Should().Be(new Rect(3, 3, 150, 250), Epsilon);
+		LayoutInformation.GetLayoutSlot(ip).Should().Be(new Rect(0, 0, 150, 250), Epsilon);
+		ip.DesiredSize.Should().Be(new Size(150, 250), Epsilon);
+		LayoutInformation.GetLayoutSlot(panel).Should().Be(new Rect(50, 50, 50, 200), Epsilon);
+		LayoutInformation.GetLayoutSlot(item1).Should().Be(new Rect(0, 0, 50, 50), Epsilon);
+		LayoutInformation.GetLayoutSlot(item2).Should().Be(new Rect(0, 50, 50, 50), Epsilon);
+
+		ip.GetIrregularSnapPoints(Orientation.Horizontal, SnapPointsAlignment.Near).Should().BeNull();
+		ip.GetIrregularSnapPoints(Orientation.Horizontal, SnapPointsAlignment.Far).Should().BeNull();
+		ip.GetIrregularSnapPoints(Orientation.Horizontal, SnapPointsAlignment.Center).Should().BeNull();
+
+		// WinUI numbers
+		// ip.GetIrregularSnapPoints(Orientation.Vertical, SnapPointsAlignment.Near).ToList().Should().BeEquivalentToWithTolerance<float>(new float[]
+		// {
+		// 	50,
+		// 	100,
+		// 	150
+		// }, Epsilon);
+		//
+		// ip.GetIrregularSnapPoints(Orientation.Vertical, SnapPointsAlignment.Far).ToList().Should().BeEquivalentToWithTolerance<float>(new float[]
+		// {
+		// 	100,
+		// 	150,
+		// 	200
+		// }, Epsilon);
+		//
+		// ip.GetIrregularSnapPoints(Orientation.Vertical, SnapPointsAlignment.Center).ToList().Should().BeEquivalentToWithTolerance<float>(new float[]
+		// {
+		// 	75,
+		// 	125,
+		// 	175
+		// }, Epsilon);
+
+		ip.GetIrregularSnapPoints(Orientation.Vertical, SnapPointsAlignment.Near).ToList().Should().BeEquivalentToWithTolerance<float>(new float[]
+		{
+			0,
+			50,
+			100
+		}, Epsilon);
+
+		ip.GetIrregularSnapPoints(Orientation.Vertical, SnapPointsAlignment.Far).ToList().Should().BeEquivalentToWithTolerance<float>(new float[]
+		{
+			50,
+			100,
+			150
+		}, Epsilon);
+
+		ip.GetIrregularSnapPoints(Orientation.Vertical, SnapPointsAlignment.Center).ToList().Should().BeEquivalentToWithTolerance<float>(new float[]
+		{
+			25,
+			75,
+			125
+		}, Epsilon);
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_Vertical_With_Padding_Header_Footer()
 	{
 		var grid = (Grid)XamlReader.Load(
 		"""

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -349,6 +349,11 @@ namespace Windows.UI.Xaml.Controls
 			var isHorizontal = Orientation == Orientation.Horizontal;
 			var padding = AppliedPadding;
 
+			var unpaddedSize = new Size(
+				finalSize.Width - padding.Left - padding.Right,
+				finalSize.Height - padding.Top - padding.Bottom
+			);
+
 			var childRect = new Rect(new Point(padding.Left, padding.Top), default(Size));
 			var previousChildSize = 0.0;
 
@@ -373,7 +378,7 @@ namespace Windows.UI.Xaml.Controls
 					childRect.X += previousChildSize;
 
 					childRect.Width = desiredChildSize.Width;
-					childRect.Height = Math.Max(finalSize.Height, desiredChildSize.Height);
+					childRect.Height = Math.Max(unpaddedSize.Height, desiredChildSize.Height);
 
 					if (view == _itemsPanel)
 					{
@@ -389,7 +394,7 @@ namespace Windows.UI.Xaml.Controls
 					childRect.Y += previousChildSize;
 
 					childRect.Height = desiredChildSize.Height;
-					childRect.Width = Math.Max(finalSize.Width, desiredChildSize.Width);
+					childRect.Width = Math.Max(unpaddedSize.Width, desiredChildSize.Width);
 
 					if (view == _itemsPanel)
 					{
@@ -453,22 +458,37 @@ namespace Windows.UI.Xaml.Controls
 
 				var measuredSize = MeasureElement(view, unpaddedSize);
 
-				if (isHorizontal)
+				// Footers don't get counted in desiredSize
+				if (view != FooterContentControl)
 				{
-					desiredSize.Width += measuredSize.Width;
-					desiredSize.Height = Math.Max(desiredSize.Height, measuredSize.Height);
-				}
-				else
-				{
-					desiredSize.Width = Math.Max(desiredSize.Width, measuredSize.Width);
-					desiredSize.Height += measuredSize.Height;
+					if (isHorizontal)
+					{
+						desiredSize.Width += measuredSize.Width;
+						desiredSize.Height = Math.Max(desiredSize.Height, measuredSize.Height);
+					}
+					else
+					{
+						desiredSize.Width = Math.Max(desiredSize.Width, measuredSize.Width);
+						desiredSize.Height += measuredSize.Height;
+					}
 				}
 			}
 
-			return new Size(
-				desiredSize.Width + padding.Left + padding.Right,
-				desiredSize.Height + padding.Top + padding.Bottom
-			);
+			// The "ending" padding in the direction of Orientation is not counted
+			if (isHorizontal)
+			{
+				return new Size(
+					desiredSize.Width + padding.Left,
+					desiredSize.Height + padding.Top + padding.Bottom
+				);
+			}
+			else
+			{
+				return new Size(
+					desiredSize.Width + padding.Left + padding.Right,
+					desiredSize.Height + padding.Top
+				);
+			}
 		}
 
 		public IReadOnlyList<float> GetIrregularSnapPoints(Orientation orientation, SnapPointsAlignment alignment)

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -458,40 +458,30 @@ namespace Windows.UI.Xaml.Controls
 
 				var measuredSize = MeasureElement(view, unpaddedSize);
 
-				// Footers don't get counted in desiredSize
-				if (view != FooterContentControl)
+				if (isHorizontal)
 				{
-					if (isHorizontal)
+					if (!PanelIsScrollSpInfo || view == Panel)
 					{
 						desiredSize.Width += measuredSize.Width;
-						desiredSize.Height = Math.Max(desiredSize.Height, measuredSize.Height);
 					}
-					else
+					desiredSize.Height = Math.Max(desiredSize.Height, measuredSize.Height);
+				}
+				else
+				{
+					if (!PanelIsScrollSpInfo || view == Panel)
 					{
-						desiredSize.Width = Math.Max(desiredSize.Width, measuredSize.Width);
 						desiredSize.Height += measuredSize.Height;
 					}
+					desiredSize.Width = Math.Max(desiredSize.Width, measuredSize.Width);
 				}
 			}
 
-			// TODO: find a more precise condition for this
-			// From obsering ItemsPresenter in WinUI templates, the "ending" padding in
-			// the direction of Orientation is only counted when inside the template of ListView, GridView, etc.
-			if (isHorizontal)
-			{
-				return new Size(
-					desiredSize.Width + padding.Left + (TemplatedParent is Selector ? padding.Right : 0),
-					desiredSize.Height + padding.Top + padding.Bottom
-				);
-			}
-			else
-			{
-				return new Size(
-					desiredSize.Width + padding.Left + padding.Right,
-					desiredSize.Height + padding.Top + (TemplatedParent is Selector ? padding.Bottom : 0)
-				);
-			}
+			return new Size(
+				desiredSize.Width + padding.Left + padding.Right,
+				desiredSize.Height + padding.Top + padding.Bottom
+			);
 		}
+		private bool PanelIsScrollSpInfo => Panel is IScrollSnapPointsInfo;
 
 		public IReadOnlyList<float> GetIrregularSnapPoints(Orientation orientation, SnapPointsAlignment alignment)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -474,11 +474,13 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
-			// The "ending" padding in the direction of Orientation is not counted
+			// TODO: find a more precise condition for this
+			// From obsering ItemsPresenter in WinUI templates, the "ending" padding in
+			// the direction of Orientation is only counted when inside the template of ListView, GridView, etc.
 			if (isHorizontal)
 			{
 				return new Size(
-					desiredSize.Width + padding.Left,
+					desiredSize.Width + padding.Left + (TemplatedParent is Selector ? padding.Right : 0),
 					desiredSize.Height + padding.Top + padding.Bottom
 				);
 			}
@@ -486,7 +488,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				return new Size(
 					desiredSize.Width + padding.Left + padding.Right,
-					desiredSize.Height + padding.Top
+					desiredSize.Height + padding.Top + (TemplatedParent is Selector ? padding.Bottom : 0)
 				);
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13750

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b09fbfa</samp>

This pull request fixes a layout bug in `ItemsPresenter` and adds a new unit test for it. The bug fix ensures that the `ItemsPresenter` respects its padding and aligns its footer and snap points with the UWP platform. The unit test verifies the expected behavior of a vertical `ItemsPresenter` with a header, a footer, and a padding.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
