### PR TITLE
feat: Partially implement `MediaSomethingEventArgs`

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/MediaTransportControlsThumbnailRequestedEventArgs.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/MediaTransportControlsThumbnailRequestedEventArgs.Android.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Windows.UI.Xaml.Media;
+
+partial class MediaTransportControlsThumbnailRequestedEventArgs
+{
+	public global::Windows.Foundation.Deferral GetDeferral()
+	{
+		// CODE!
+		Android.Views.ViewGroup viewGroup = null;
+		Context
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/MediaTransportControlsThumbnailRequestedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Media/MediaTransportControlsThumbnailRequestedEventArgs.cs
@@ -1,0 +1,15 @@
+namespace Windows.UI.Xaml.Media
+{
+	public partial class MediaTransportControlsThumbnailRequestedEventArgs
+	{
+//#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+//		internal MediaTransportControlsThumbnailRequestedEventArgs()
+//		{
+//		}
+//#endif
+		public void SetThumbnailImage(global::Windows.Storage.Streams.IInputStream source)
+		{
+			// IMPLEMENT THIS!
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4231 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?



## What is the new behavior?


## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36fe3f3</samp>

This pull request adds partial methods and classes to support the `ThumbnailRequested` event for the `MediaTransportControls` control on Android. It also removes an unused internal constructor from the common event args class.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
