### PR TITLE
fix: Match TextBox.VerticalContentAlignment with Windows

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -897,7 +897,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(VerticalAlignment.Center, textBox.VerticalContentAlignment);
 			textBox.VerticalContentAlignment = VerticalAlignment.Bottom;
 
-#if WINDOWS_UWP
+#if WINAPPSDK
 			var getTemplateChild = typeof(Control).GetMethod("GetTemplateChild", BindingFlags.Instance | BindingFlags.NonPublic);
 			var placeHolder = (ContentControl)getTemplateChild.Invoke(textBox, new object[] { "PlaceholderTextContentPresenter" });
 			var contentElement = (ContentControl)getTemplateChild.Invoke(textBox, new object[] { "ContentElement" });

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -1,17 +1,21 @@
 ﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.UI.RuntimeTests.Helpers;
+using FluentAssertions;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using static Private.Infrastructure.TestServices;
-using Microsoft.UI.Xaml;
-using Windows.UI;
-using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MUXControlsTestApp.Utilities;
-using System.Runtime.InteropServices;
+using Uno.UI.Helpers;
+using Uno.UI.RuntimeTests.Helpers;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.UI;
+
+using static Private.Infrastructure.TestServices;
 
 #if WINAPPSDK
 using Uno.UI.Extensions;
@@ -852,6 +856,59 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 
 			Assert.AreEqual(0, SUT.VerticalOffset);
+		}
+
+		[TestMethod]
+		public async Task When_VerticalContentAlignment_Is_Changed()
+		{
+			// This test ensures that setting VerticalContentAlignment on the TextBox doesn't flow to:
+			// 1) PlaceholderTextContentPresenter.VerticalContentAlignment
+			// 2) ContentElement.VerticalContentAlignment
+			// 3) PlaceholderTextContentPresenter.VerticalAlignment
+			// 4) ContentElement.VerticalAlignment
+			// This matches the behavior observed on Windows
+			var xaml = """
+				    <Grid>
+				        <Grid.Resources>
+				            <Style x:Key="TextBoxAlignmentTestStyle" TargetType="TextBox">
+				                <Setter Property="Template">
+				                    <Setter.Value>
+				                        <ControlTemplate TargetType="TextBox">
+				                            <Grid x:Name="RootGrid">
+				                                <Grid VerticalAlignment="Stretch">
+				                                    <ContentControl x:Name="PlaceholderTextContentPresenter" />
+				                                    <ContentControl x:Name="ContentElement" />
+				                                </Grid>
+				                            </Grid>
+				                        </ControlTemplate>
+				                    </Setter.Value>
+				                </Setter>
+				            </Style>
+				        </Grid.Resources>
+
+				        <TextBox Style="{StaticResource TextBoxAlignmentTestStyle}" />
+				    </Grid>
+				""";
+			var grid = XamlHelper.LoadXaml<Grid>(xaml);
+			WindowHelper.WindowContent = grid;
+			await WindowHelper.WaitForLoaded(grid);
+			var textBox = (TextBox)grid.Children.Single();
+
+			Assert.AreEqual(VerticalAlignment.Center, textBox.VerticalContentAlignment);
+			textBox.VerticalContentAlignment = VerticalAlignment.Bottom;
+
+#if WINDOWS_UWP
+			var getTemplateChild = typeof(Control).GetMethod("GetTemplateChild", BindingFlags.Instance | BindingFlags.NonPublic);
+			var placeHolder = (ContentControl)getTemplateChild.Invoke(textBox, new object[] { "PlaceholderTextContentPresenter" });
+			var contentElement = (ContentControl)getTemplateChild.Invoke(textBox, new object[] { "ContentElement" });
+#else
+			var placeHolder = (ContentControl)textBox.GetTemplateChild("PlaceholderTextContentPresenter");
+			var contentElement = (ContentControl)textBox.GetTemplateChild("ContentElement");
+#endif
+			Assert.AreEqual(VerticalAlignment.Top, placeHolder.VerticalContentAlignment);
+			Assert.AreEqual(VerticalAlignment.Top, contentElement.VerticalContentAlignment);
+			Assert.AreEqual(VerticalAlignment.Stretch, placeHolder.VerticalAlignment);
+			Assert.AreEqual(VerticalAlignment.Stretch, contentElement.VerticalAlignment);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -1158,6 +1158,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 		public override string GetAccessibilityInnerText() => Text;
 
+		// TODO: Remove as a breaking change for Uno 6
+		// Also, make OnVerticalContentAlignmentChanged private protected.
+		protected override void OnVerticalContentAlignmentChanged(VerticalAlignment oldVerticalContentAlignment, VerticalAlignment newVerticalContentAlignment) { }
+
 		public void Select(int start, int length)
 		{
 			if (start < 0)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -195,7 +195,6 @@ namespace Microsoft.UI.Xaml.Controls
 			OnTextAlignmentChanged(TextAlignment);
 			OnTextWrappingChanged();
 			OnFocusStateChanged((FocusState)FocusStateProperty.GetMetadata(GetType()).DefaultValue, FocusState, initial: true);
-			OnVerticalContentAlignmentChanged(VerticalAlignment.Top, VerticalContentAlignment);
 			OnTextCharacterCasingChanged(CharacterCasing);
 			UpdateDescriptionVisibility(true);
 			var buttonRef = _deleteButton?.GetTarget();
@@ -1158,25 +1157,6 @@ namespace Microsoft.UI.Xaml.Controls
 		protected override AutomationPeer OnCreateAutomationPeer() => new TextBoxAutomationPeer(this);
 
 		public override string GetAccessibilityInnerText() => Text;
-
-		protected override void OnVerticalContentAlignmentChanged(VerticalAlignment oldVerticalContentAlignment, VerticalAlignment newVerticalContentAlignment)
-		{
-			base.OnVerticalContentAlignmentChanged(oldVerticalContentAlignment, newVerticalContentAlignment);
-
-			if (_contentElement != null)
-			{
-				_contentElement.VerticalContentAlignment = newVerticalContentAlignment;
-			}
-
-			if (_placeHolder != null)
-			{
-				_placeHolder.VerticalAlignment = newVerticalContentAlignment;
-			}
-
-			OnVerticalContentAlignmentChangedPartial(oldVerticalContentAlignment, newVerticalContentAlignment);
-		}
-
-		partial void OnVerticalContentAlignmentChangedPartial(VerticalAlignment oldVerticalContentAlignment, VerticalAlignment newVerticalContentAlignment);
 
 		public void Select(int start, int length)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #4502, closes #14705.

This is a revert of https://github.com/unoplatform/uno/pull/4180

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5dd22d4</samp>

This pull request fixes a layout bug in `TextBox` controls and adds a unit test to verify the fix. It also improves the XAML loading logic by using .NET 7.0 source generators and a helper method `LoadXaml`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
