### PR TITLE
fix(resources): Incorrect resource resolution for multiple identical source dictionaries

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override.xaml
@@ -1,0 +1,66 @@
+﻿<Page x:Class="Uno.UI.Tests.Windows_UI_Xaml.Controls.ThemeResource_Named_ResourceDictionary_Override"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	<Page.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+				<local:ThemeResource_Named_ResourceDictionary_Override_Custom />
+			</ResourceDictionary.MergedDictionaries>
+		</ResourceDictionary>
+	</Page.Resources>
+
+	<StackPanel HorizontalAlignment="Center"
+				VerticalAlignment="Center"
+				Spacing="20">
+
+		<Border x:Name="border01" 
+				x:FieldModifier="public"
+				Background="{ThemeResource MyBrush}"
+				Width="200"
+				Height="200">
+			<TextBlock HorizontalAlignment="Center"
+					   VerticalAlignment="Center"
+					   Text="Should Be Red" />
+		</Border>
+
+		<Border>
+			<Border.Resources>
+				<SolidColorBrush x:Key="MyBrush"
+								 Color="Blue" />
+			</Border.Resources>
+			<Border x:Name="border02"
+					x:FieldModifier="public"
+					Background="{ThemeResource MyBrush}"
+					Width="200"
+					Height="200">
+				<TextBlock HorizontalAlignment="Center"
+						   VerticalAlignment="Center"
+						   Text="Should Be Blue" />
+			</Border>
+		</Border>
+
+		<Border>
+			<Border.Resources>
+				<ResourceDictionary>
+					<ResourceDictionary.MergedDictionaries>
+						<local:ThemeResource_Named_ResourceDictionary_Override_Custom />
+					</ResourceDictionary.MergedDictionaries>
+				</ResourceDictionary>
+			</Border.Resources>
+			<Border x:Name="border03"
+					x:FieldModifier="public"
+					Background="{ThemeResource MyBrush}"
+					Width="200"
+					Height="200">
+				<TextBlock HorizontalAlignment="Center"
+						   VerticalAlignment="Center"
+						   Text="Should Be Green" />
+			</Border>
+		</Border>
+	</StackPanel>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.Controls;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class ThemeResource_Named_ResourceDictionary_Override : Page
+{
+	public ThemeResource_Named_ResourceDictionary_Override()
+	{
+		this.InitializeComponent();
+	}
+}
+
+public class ThemeResource_Named_ResourceDictionary_Override_Custom : ResourceDictionary
+{
+	private const string GreenUri = "ms-appx:///Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override_Green.xaml";
+	private const string RedUri = "ms-appx:///Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override_Red.xaml";
+	private const string BrushUri = "ms-appx:///Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override_MyBrush.xaml";
+	private static string ColorUri = string.Empty;
+
+	private string _selectedColorUri = string.Empty;
+
+	public ThemeResource_Named_ResourceDictionary_Override_Custom()
+	{
+		// Toggle whether we use MyColorGreen.xaml or MyColorRed.xaml as the merged-dict override
+		_selectedColorUri = ColorUri = ColorUri == RedUri ? GreenUri : RedUri;
+
+		// Instanciating this dictionary multiple times in different XAML scopes
+		// should not force the inner merged dictionaries to the first instance ever
+		// created for "BrushUri".
+		var myBrush = new ResourceDictionary { Source = new Uri(BrushUri) };
+
+		myBrush.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri(ColorUri) });
+
+		this.MergedDictionaries.Add(myBrush);
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override_Green.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override_Green.xaml
@@ -1,0 +1,11 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Light">
+			<Color x:Key="MyColor">Green</Color>
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Default">
+			<Color x:Key="MyColor">Green</Color>
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override_MyBrush.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override_MyBrush.xaml
@@ -1,0 +1,12 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Light">
+			<SolidColorBrush x:Key="MyBrush" Color="{StaticResource MyColor}" />
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Default">
+			<SolidColorBrush x:Key="MyBrush" Color="{StaticResource MyColor}" />
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override_Red.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Controls/ThemeResource_Named_ResourceDictionary_Override_Red.xaml
@@ -1,0 +1,11 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<ResourceDictionary.ThemeDictionaries>
+		<ResourceDictionary x:Key="Light">
+			<Color x:Key="MyColor">Red</Color>
+		</ResourceDictionary>
+		<ResourceDictionary x:Key="Default">
+			<Color x:Key="MyColor">Red</Color>
+		</ResourceDictionary>
+	</ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_ResourceDictionary.cs
@@ -945,5 +945,18 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			AssertEx.AssertContainsColorBrushResource(resources, "LarcenousColorBrush", Colors.PaleVioletRed);
 			Assert.AreEqual(initialCreationCount, SomeNotImplType.CreationAttempts);
 		}
+
+		[TestMethod]
+		public void ThemeResource_Named_ResourceDictionary_Override()
+		{
+			var app = UnitTestsApp.App.EnsureApplication();
+
+			var SUT = new ThemeResource_Named_ResourceDictionary_Override();
+			SUT.ForceLoaded();
+
+			Assert.AreEqual(Colors.Red, (SUT.border01.Background as SolidColorBrush)?.Color);
+			Assert.AreEqual(Colors.Blue, (SUT.border02.Background as SolidColorBrush)?.Color);
+			Assert.AreEqual(Colors.Green, (SUT.border03.Background as SolidColorBrush)?.Color);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -427,15 +427,17 @@ namespace Windows.UI.Xaml
 			// In order to ensure the theme updates covers all of them, we need to keep track of this source instance for theme updates before it is lost.
 			_sourceDictionary = WeakReferencePool.RentWeakReference(this, source);
 
-			// Lazy resource initialization needs the current XamlScope
-			// to resolve values, and the originally defined scope that 
-			// was set when the source dictionary was created may not be 
-			// value for the current XAML scope. We rewrite the initializer
-			// in order for the name resolution to work properly.
+			_values.EnsureCapacity(source._values.Count);
+
 			foreach (var pair in source._values)
 			{
 				var (key, value) = pair;
 
+				// Lazy resource initialization needs the current XamlScope
+				// to resolve values, and the originally defined scope that 
+				// was set when the source dictionary was created may not be 
+				// value for the current XAML scope. We rewrite the initializer
+				// in order for the name resolution to work properly.
 				if (value is LazyInitializer lazy)
 				{
 					value = new LazyInitializer(ResourceResolver.CurrentScope, lazy.Initializer);

--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -427,7 +427,23 @@ namespace Windows.UI.Xaml
 			// In order to ensure the theme updates covers all of them, we need to keep track of this source instance for theme updates before it is lost.
 			_sourceDictionary = WeakReferencePool.RentWeakReference(this, source);
 
-			_values.AddRange(source._values);
+			// Lazy resource initialization needs the current XamlScope
+			// to resolve values, and the originally defined scope that 
+			// was set when the source dictionary was created may not be 
+			// value for the current XAML scope. We rewrite the initializer
+			// in order for the name resolution to work properly.
+			foreach (var pair in source._values)
+			{
+				var (key, value) = pair;
+
+				if (value is LazyInitializer lazy)
+				{
+					value = new LazyInitializer(ResourceResolver.CurrentScope, lazy.Initializer);
+				}
+
+				_values.Add(key, value);
+			}
+
 			_mergedDictionaries.AddRange(source._mergedDictionaries);
 			if (source._themeDictionaries != null)
 			{

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -405,14 +405,17 @@ namespace Uno.UI
 				return false;
 			}
 
-			if (_registeredDictionariesByAssembly.TryGetValue(parseContext.AssemblyName, out var assemblyDict))
+			if (parseContext.AssemblyName is not null)
 			{
-				foreach (var kvp in assemblyDict)
+				if (_registeredDictionariesByAssembly.TryGetValue(parseContext.AssemblyName, out var assemblyDict))
 				{
-					var rd = kvp.Value as ResourceDictionary;
-					if (rd.TryGetValue(resourceKey, out value, shouldCheckSystem: false))
+					foreach (var kvp in assemblyDict)
 					{
-						return true;
+						var rd = kvp.Value as ResourceDictionary;
+						if (rd.TryGetValue(resourceKey, out value, shouldCheckSystem: false))
+						{
+							return true;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/13799

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that lazy initializers resolve resources using the appropriate XAML name scope.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f58be7b</samp>

This pull request adds a new XAML page and a unit test to verify the behavior of theme resources when they are overridden by named resource dictionaries in different scopes. It also fixes a bug in the `ResourceDictionary.CopyFrom` method that caused lazy resource initializers to use the wrong XAML scope. The changes affect the files `ThemeResource_Named_ResourceDictionary_Override.xaml`, `ThemeResource_Named_ResourceDictionary_Override.xaml.cs`, `Given_ResourceDictionary.cs`, and `ResourceDictionary.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
