### PR TITLE
fix: Disable resizetizer codegen for UWP

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,6 +43,9 @@
 		<UNO_UWP_BUILD>true</UNO_UWP_BUILD>
 		<DefineConstants Condition="'$(UNO_UWP_BUILD)'!='true'">$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
 
+		<!-- Resizetizer codegen is not supported in UWP -->
+		<UnoResizetizerDisableWindowIconExtensions Condition="'$(UNO_UWP_BUILD)'=='true'">true</UnoResizetizerDisableWindowIconExtensions>
+
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 
 		<UnoEnableXamlFuzzyMatching>false</UnoEnableXamlFuzzyMatching>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -83,7 +83,7 @@
 		<PackageReference Update="Uno.UITest.Xamarin" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.UITest.Helpers" Version="1.1.0-dev.70" />
 		<PackageReference Update="Uno.Fonts.Fluent" Version="2.3.0" />
-		<PackageReference Update="Uno.Resizetizer" Version="1.1.3" />
+		<PackageReference Update="Uno.Resizetizer" Version="1.2.0-dev.66" />
 		<PackageReference Update="Xamarin.DuoSdk" Version="0.0.3.4" />
 		<PackageReference Update="Xamarin.UITest" Version="4.1.4" />
 		<PackageReference Update="Xamarin.TestCloud.Agent" Version="0.23.2" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13819

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Disable resizetizer codegen for UWP

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eef33f3</samp>

This pull request fixes the UWP build and updates the dependencies of the Uno Gallery app. It adds a property to disable the `Resizetizer` code generation for UWP projects in `Directory.Build.props` and updates the `Uno.Resizetizer` package version in `Directory.Build.targets`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
