### PR TITLE
fix(textbox): fix textbox overlay showing even when clipping on skia

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkTextBoxView.cs
@@ -23,6 +23,8 @@ internal abstract class GtkTextBoxView : IOverlayTextBoxView
 
 	private static bool _warnedAboutSelectionColorChanges;
 
+	private (int x, int y) _position = (-1, -1);
+
 	private readonly string _textBoxViewId = Guid.NewGuid().ToString();
 	private CssProvider? _foregroundCssProvider;
 	private Windows.UI.Color? _lastForegroundColor;
@@ -90,6 +92,27 @@ internal abstract class GtkTextBoxView : IOverlayTextBoxView
 
 	public void SetFocus() => InputWidget.HasFocus = true;
 
+	public void SetClip(int clipLeft, int clipRight, int clipTop, int clipBottom)
+	{
+		if (_position.x != -1)
+		{
+			RootWidget.GetSizeRequest(out var inputWidth, out var inputHeight);
+
+			var clip = new Gdk.Rectangle(
+				Math.Min(_position.x + inputWidth, _position.x + clipLeft),
+				Math.Min(_position.y + inputHeight, _position.y + clipTop),
+				Math.Max(0, inputWidth - clipRight - clipLeft),
+				Math.Max(0, inputHeight - clipBottom - clipTop)
+			);
+			RootWidget.SetClip(clip);
+		}
+	}
+
+	public void SetVisibility(bool visible)
+	{
+		RootWidget.Visible = visible;
+	}
+
 	public void SetSize(double width, double height)
 	{
 		RootWidget.SetSizeRequest((int)width, (int)height);
@@ -101,6 +124,7 @@ internal abstract class GtkTextBoxView : IOverlayTextBoxView
 		if (RootWidget.Parent is Fixed layer)
 		{
 			layer.Move(RootWidget, (int)x, (int)y);
+			_position = ((int)x, (int)y);
 		}
 	}
 

--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/WpfTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/WpfTextBoxView.cs
@@ -1,10 +1,13 @@
 ﻿#nullable enable
 
 using System;
+using System.Windows;
+using System.Windows.Media;
 using Uno.UI.Hosting;
 using Uno.UI.Runtime.Skia.Wpf.Hosting;
 using Uno.UI.Xaml.Controls.Extensions;
 using Windows.UI.Xaml;
+using Visibility = System.Windows.Visibility;
 using WpfCanvas = System.Windows.Controls.Canvas;
 using WpfControl = System.Windows.Controls.Control;
 using WpfElement = System.Windows.FrameworkElement;
@@ -61,6 +64,30 @@ internal abstract class WpfTextBoxView : IOverlayTextBoxView
 	public abstract void UpdateProperties(Windows.UI.Xaml.Controls.TextBox textBox);
 
 	public abstract void SetFocus();
+
+	public void SetClip(int clipLeft, int clipRight, int clipTop, int clipBottom)
+	{
+		var inputHeight = RootElement.ActualHeight;
+		var inputWidth = RootElement.ActualWidth;
+
+		var clip = new RectangleGeometry(new Rect(
+			Math.Min(inputWidth, clipLeft),
+			Math.Min(inputHeight, clipTop),
+			Math.Max(0, inputWidth - clipRight - clipLeft),
+			Math.Max(0, inputHeight - clipBottom - clipTop)
+		));
+
+		if (RootElement.IsMeasureValid)
+		{
+			RootElement.Clip = clip;
+		}
+		else
+		{
+			RootElement.Clip = null;
+		}
+	}
+
+	public void SetVisibility(bool visible) => RootElement.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
 
 	public void SetSize(double width, double height)
 	{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxView.skia.cs
@@ -29,6 +29,10 @@ internal interface IOverlayTextBoxView
 
 	void SetFocus();
 
+	void SetClip(int clipLeft, int clipRight, int clipTop, int clipBottom);
+
+	void SetVisibility(bool visible);
+
 	void SetPasswordRevealState(PasswordRevealState passwordRevealState);
 
 	void AddToTextInputLayer(XamlRoot xamlRoot);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #9263

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at abc4d6e</samp>

This pull request adds clipping and visibility features to the overlay text box view, which is a custom text box view that can overlay on top of other UI elements. It defines two new methods `SetClip` and `SetVisibility` in the `IOverlayTextBoxView` interface, and implements them in the `GtkTextBoxView` and `WpfTextBoxView` classes, which are platform-specific wrappers for text input controls. It also adds a new method `UpdateClip` to the `OverlayTextBoxViewExtension` class, which handles the clipping logic for the overlay text box view.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
