### PR TITLE
fix(resource): Register lazy named resources in namescope

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/EventSequence_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/EventSequence_Tests.cs
@@ -29,6 +29,7 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Input
 
 		[Test]
 		[AutoRetry]
+		[ActivePlatforms(Platform.Android, Platform.iOS)] // Wasm is disabled https://github.com/unoplatform/uno/issues/13844
 		public void TestTranslatedClick()
 			=> RunSequence("TranslatedClick", TranslateOverElement);
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2775,7 +2775,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 							if (resource.Members.FirstOrDefault(m => m.Member.Name == "Name") is { } nameMember
 								&& nameMember.Value?.ToString() is { } nameValue
-								&& !string.IsNullOrEmpty(nameValue))
+								&& !string.IsNullOrEmpty(nameValue)
+
+								// Skip generating namescope if the resource is declared directly
+								// inside a top level dictionary (there's no __nameScope available there).
+								&& resource.Owner?.Owner != null)
 							{
 								using (var blockWriter = CreateApplyBlock(writer, null, out var closureName))
 								{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2772,6 +2772,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							{
 								BuildChild(writer, null, resource);
 							}
+
+							if (resource.Members.FirstOrDefault(m => m.Member.Name == "Name") is { } nameMember
+								&& nameMember.Value?.ToString() is { } nameValue
+								&& !string.IsNullOrEmpty(nameValue))
+							{
+								using (var blockWriter = CreateApplyBlock(writer, null, out var closureName))
+								{
+									// The weak initializer must be registered to be found through
+									// Control.GetTemplateChild.
+									blockWriter.AppendLineInvariantIndented($"__nameScope.RegisterName(\"{nameValue}\", {closureName});");
+								}
+							}
 						}
 					}
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate.xaml
@@ -1,0 +1,36 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests.Controls.When_VisualStateManager_xName_DataTemplate"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<ContentControl x:Name="rootTemplatedControl" 
+					x:FieldModifier="public" 
+					Content="42">
+		<ContentControl.Template>
+			<ControlTemplate TargetType="ContentControl">
+				<Grid x:Name="root">
+					<Grid.Resources>
+						<Storyboard x:Name="storyboard01">
+							<ObjectAnimationUsingKeyFrames x:Name="testAnimation"
+															x:FieldModifier="public" 
+															Storyboard.TargetName="myControl"
+															Storyboard.TargetProperty="Tag">
+								<DiscreteObjectKeyFrame x:Name="testKeyFrame"
+														x:FieldModifier="public"
+														KeyTime="0"
+														Value="0" />
+							</ObjectAnimationUsingKeyFrames>
+						</Storyboard>
+					</Grid.Resources>
+
+					<ContentPresenter x:Name="myControl" Content="{TemplateBinding Content}" />
+				</Grid>
+			</ControlTemplate>
+		</ContentControl.Template>
+	</ContentControl>
+	
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests.Controls
+{
+	public sealed partial class When_VisualStateManager_xName_DataTemplate : UserControl
+	{
+		public When_VisualStateManager_xName_DataTemplate()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate_From_Dictionary.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate_From_Dictionary.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests.Controls.When_VisualStateManager_xName_DataTemplate_From_Dictionary"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<UserControl.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+				<!-- Load WinUI resources -->
+				<ResourceDictionary Source="ms-appx:///Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate_From_Dictionary_Resources.xaml" />
+
+			</ResourceDictionary.MergedDictionaries>
+		</ResourceDictionary>
+	</UserControl.Resources>
+
+	<ContentControl x:Name="rootTemplatedControl" 
+					x:FieldModifier="public" 
+					Content="42"
+					Style="{StaticResource MyStyle}">
+	</ContentControl>
+	
+</UserControl>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate_From_Dictionary.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate_From_Dictionary.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests.Controls
+{
+	public sealed partial class When_VisualStateManager_xName_DataTemplate_From_Dictionary : UserControl
+	{
+		public When_VisualStateManager_xName_DataTemplate_From_Dictionary()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate_From_Dictionary_Resources.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/Controls/When_VisualStateManager_xName_DataTemplate_From_Dictionary_Resources.xaml
@@ -1,0 +1,35 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	
+	<Duration x:Key="STYLE_DURATION_VeryLongAnimation">00:00:05</Duration>
+
+	<Style x:Key="MyStyle" TargetType="ContentControl">
+
+		<Setter Property="Template">
+			<Setter.Value>
+
+				<ControlTemplate x:Key="myTemplate" TargetType="ContentControl">
+					<Grid x:Name="root">
+						<Grid.Resources>
+							<Storyboard x:Name="storyboard01">
+								<ObjectAnimationUsingKeyFrames x:Name="testAnimation"
+												x:FieldModifier="public" 
+												Storyboard.TargetName="myControl"
+												Storyboard.TargetProperty="Tag">
+									<DiscreteObjectKeyFrame x:Name="testKeyFrame"
+											x:FieldModifier="public"
+											KeyTime="0"
+											Value="{StaticResource STYLE_DURATION_VeryLongAnimation}" />
+								</ObjectAnimationUsingKeyFrames>
+							</Storyboard>
+						</Grid.Resources>
+
+						<ContentPresenter x:Name="myControl" Content="{TemplateBinding Content}" />
+					</Grid>
+				</ControlTemplate>
+				
+			</Setter.Value>
+		</Setter>
+	</Style>
+</ResourceDictionary>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/VisualStateManager_Lazy.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/VisualStateManager_Lazy_Tests/VisualStateManager_Lazy.cs
@@ -9,6 +9,7 @@ using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Animation;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests
 {
@@ -149,6 +150,39 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.VisualStateManager_Lazy_Tests
 			Assert.IsNotNull(SUT.testAnimation);
 			Assert.IsNotNull(SUT.testKeyFrame);
 			Assert.AreEqual("0", SUT.testKeyFrame.Value);
+		}
+
+		[TestMethod]
+		public async Task When_VisualStateManager_xName_DataTemplate()
+		{
+			var SUT = new When_VisualStateManager_xName_DataTemplate();
+			var app = UnitTestsApp.App.EnsureApplication();
+			app.HostView.Children.Add(SUT);
+
+			await WaitForIdle();
+
+			var sb = SUT.rootTemplatedControl.GetTemplateChild("storyboard01") as Storyboard;
+
+			Assert.IsNotNull(sb);
+		}
+
+		[TestMethod]
+		public async Task When_VisualStateManager_xName_DataTemplate_From_Dictionary()
+		{
+			var SUT = new When_VisualStateManager_xName_DataTemplate_From_Dictionary();
+			var app = UnitTestsApp.App.EnsureApplication();
+			app.HostView.Children.Add(SUT);
+
+			await WaitForIdle();
+
+			var storyboardFromChildTemplate = SUT.rootTemplatedControl.GetTemplateChild("storyboard01") as Storyboard;
+
+			Assert.IsNotNull(storyboardFromChildTemplate);
+
+			var rootGrid = SUT.FindName("root") as Grid;
+			var storyboardFromDictionary = rootGrid.Resources["storyboard01"] as Storyboard;
+
+			Assert.AreSame(storyboardFromDictionary, storyboardFromChildTemplate);
 		}
 
 		private static void ShowDialog(MyContentDialog dialog)

--- a/src/Uno.UI/UI/Xaml/NameScope.cs
+++ b/src/Uno.UI/UI/Xaml/NameScope.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI.DataBinding;
+using Uno.UI.Xaml;
 using Windows.UI.Xaml.Markup;
 
 namespace Windows.UI.Xaml
@@ -42,7 +43,8 @@ namespace Windows.UI.Xaml
 
 		public void RegisterName(string name, object scopedElement)
 		{
-			if (_names.ContainsKey(name))
+			if (_names.TryGetValue(name, out var instanceRef)
+				&& instanceRef?.Target is not WeakResourceInitializer)
 			{
 				this.Log().Warn($"The name [{name}] already exists in the current XAML scope");
 			}

--- a/src/Uno.UI/UI/Xaml/WeakResourceInitializer.cs
+++ b/src/Uno.UI/UI/Xaml/WeakResourceInitializer.cs
@@ -22,10 +22,18 @@ namespace Uno.UI.Xaml
 
 		private readonly ManagedWeakReference _owner;
 
+		/// <summary>
+		/// Store the materialized value of the resource so it can be reused
+		/// in the context of Control.GetTemplateChild for a non-materialized x:Name.
+		/// This assumes that WeakResourceInitializer gets collected when materialized
+		/// in its target ResourceDictionary.
+		/// </summary>
+		private object? __value;
+
 		public WeakResourceInitializer(object owner, ResourceInitializerWithOwner initializer)
 		{
 			_owner = WeakReferencePool.RentWeakReference(this, owner);
-			Initializer = () => initializer(_owner?.Target);
+			Initializer = () => __value ??= initializer(_owner?.Target);
 		}
 
 		public ResourceDictionary.ResourceInitializer Initializer { get; }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/13684

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Lazy materialized named resources are now registered in the XAML scope

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a44493f</samp>

This pull request fixes a bug where `GetTemplateChild` could not find x:Names defined in resources. It adds tests for the `VisualStateManager` class and the `GetTemplateChild` method. It also modifies the `NameScope`, `Control`, and `WeakResourceInitializer` classes to handle resource initialization and registration.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
