### PR TITLE
fix: Match FrameworkElement.[Measure|Arrange]Override with Windows

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.cs
@@ -490,7 +490,7 @@ public partial class GtkMediaPlayer : FrameworkElement
 
 	protected override Size ArrangeOverride(Size finalSize)
 	{
-		var result = base.ArrangeOverride(finalSize);
+		var result = ArrangeFirstChild(finalSize);
 		UpdateVideoStretch();
 
 		return result;

--- a/src/Uno.UI/AssemblyInfo.cs
+++ b/src/Uno.UI/AssemblyInfo.cs
@@ -26,6 +26,8 @@ using Uno.Foundation.Diagnostics.CodeAnalysis;
 [assembly: InternalsVisibleTo("Uno.UI.FluentTheme")]
 [assembly: InternalsVisibleTo("Uno.UI.FluentTheme.v1")]
 [assembly: InternalsVisibleTo("Uno.UI.FluentTheme.v2")]
+[assembly: InternalsVisibleTo("Uno.UI.MediaPlayer.Skia.Gtk")]
+[assembly: InternalsVisibleTo("Uno.UI.MediaPlayer.WebAssembly")]
 
 [assembly: AssemblyMetadata("IsTrimmable", "True")]
 

--- a/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
@@ -7,6 +7,7 @@ using UIKit;
 using Uno.Extensions;
 using Uno.UI.Helpers;
 using Uno.Foundation.Logging;
+using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
@@ -86,6 +87,12 @@ namespace Uno.UI.Controls
 			// Hide the NavigationBar by default. Only show if navigating to a Page that contains a CommandBar.
 			NavigationController.NavigationBarHidden = true;
 		}
+
+		protected override Size MeasureOverride(Size availableSize)
+			=> MeasureFirstChild(availableSize);
+
+		protected override Size ArrangeOverride(Size finalSize)
+			=> ArrangeFirstChild(finalSize);
 
 		internal protected override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/NativeMenuBarPresenter.macOS.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/NativeMenuBarPresenter.macOS.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using AppKit;
 using Foundation;
+using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -90,5 +91,11 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			flyoutItem.InvokeClick();
 		}
+
+		protected override Size MeasureOverride(Size availableSize)
+			=> MeasureFirstChild(availableSize);
+
+		protected override Size ArrangeOverride(Size finalSize)
+			=> ArrangeFirstChild(finalSize);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/AnimatedVisualPlayer/AnimatedVisualPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AnimatedVisualPlayer/AnimatedVisualPlayer.cs
@@ -132,8 +132,10 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else
 			{
-				return base.MeasureOverride(availableSize);
+				return MeasureFirstChild(availableSize);
 			}
 		}
+
+		protected override Size ArrangeOverride(Size finalSize) => ArrangeFirstChild(finalSize);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.Layout.cs
@@ -32,12 +32,19 @@ namespace Windows.UI.Xaml.Controls
 			var padding = Padding;
 			var borderThickness = BorderThickness;
 
-			var measuredSize = base.MeasureOverride(
-				new Size(
+			Size measuredSize;
+			if (Child is { } child)
+			{
+				var childSize = new Size(
 					availableSize.Width - padding.Left - padding.Right - borderThickness.Left - borderThickness.Right,
 					availableSize.Height - padding.Top - padding.Bottom - borderThickness.Top - borderThickness.Bottom
-				)
-			);
+				);
+				measuredSize = MeasureElement(child, childSize);
+			}
+			else
+			{
+				measuredSize = default;
+			}
 
 			return new Size(
 				measuredSize.Width + padding.Left + padding.Right + borderThickness.Left + borderThickness.Right,

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -1131,7 +1131,7 @@ namespace Windows.UI.Xaml.Controls
 			var padding = Padding;
 			var borderThickness = BorderThickness;
 
-			var measuredSize = base.MeasureOverride(
+			var measuredSize = MeasureFirstChild(
 				new Size(
 					size.Width - padding.Left - padding.Right - borderThickness.Left - borderThickness.Right,
 					size.Height - padding.Top - padding.Bottom - borderThickness.Top - borderThickness.Bottom

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -466,6 +466,12 @@ namespace Windows.UI.Xaml.Controls
 
 		}
 
+		protected override Size MeasureOverride(Size availableSize)
+			=> MeasureFirstChild(availableSize);
+
+		protected override Size ArrangeOverride(Size finalSize)
+			=> ArrangeFirstChild(finalSize);
+
 		/// <summary>
 		/// Loads the relevant control template so that its parts can be referenced.
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
@@ -485,7 +485,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 #endif
 
-			return base.ArrangeOverride(finalSize);
+			return ArrangeFirstChild(finalSize);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml.Controls
 			else
 			{
 				_imageSprite.Size = default;
-				return base.ArrangeOverride(finalSize);
+				return ArrangeFirstChild(finalSize);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.cs
@@ -65,16 +65,6 @@ namespace Windows.UI.Xaml.Controls
 			UpdateTransitions(element);
 		}
 
-		// In WinUI, the base Panel doesn't measure or arrange anything. This is likely due
-		// to FrameworkElement.<Measure|Arrange>Override itself not doing anything. In Uno,
-		// FrameworkElement.<Measure|Arrange>Override have a default implementation that assumes
-		// a single child and measures/arranges it. This is helpful as most elements have one or no
-		// children. However, since derived types of Panel can add their own Children, we need to make
-		// sure our internal FrameworkElement.<Measure|Arrange>Override isn't used by user-defined
-		// subclasses of Panel.
-		protected override Size MeasureOverride(Size availableSize) => new Size(0, 0);
-		protected override Size ArrangeOverride(Size finalSize) => finalSize;
-
 		private void UpdateTransitions(IFrameworkElement element)
 		{
 			if (_transitionHelper == null)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -115,6 +115,9 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override Size MeasureOverride(Size availableSize) => MeasureView(availableSize);
 
+		protected override Size ArrangeOverride(Size finalSize)
+			=> ArrangeFirstChild(finalSize);
+
 		internal void SetPasswordRevealState(PasswordRevealState revealState)
 		{
 			if (IsMultiline)

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -7,6 +7,7 @@ using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI;
 using Uno.UI.DataBinding;
+using Windows.Foundation;
 
 #if __ANDROID__
 using View = Android.Views.View;
@@ -139,6 +140,12 @@ namespace Windows.UI.Xaml
 		/// A function that will create the actual view.
 		/// </summary>
 		public Func<View> ContentBuilder { get; set; }
+
+		protected override Size MeasureOverride(Size availableSize)
+			=> MeasureFirstChild(availableSize);
+
+		protected override Size ArrangeOverride(Size finalSize)
+			=> ArrangeFirstChild(finalSize);
 
 		protected override void OnVisibilityChanged(Visibility oldValue, Visibility newValue)
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -272,8 +272,7 @@ namespace Windows.UI.Xaml
 		/// <returns>The size that this object determines it needs during layout, based on its calculations of the allocated sizes for child objects or based on other considerations such as a fixed container size.</returns>
 		protected virtual Size MeasureOverride(Size availableSize)
 		{
-			var child = this.FindFirstChild();
-			return child != null ? MeasureElement(child, availableSize) : new Size(0, 0);
+			return default;
 		}
 
 		/// <summary>
@@ -283,21 +282,7 @@ namespace Windows.UI.Xaml
 		/// <returns>The actual size that is used after the element is arranged in layout.</returns>
 		protected virtual Size ArrangeOverride(Size finalSize)
 		{
-			var child = this.FindFirstChild();
-
-			if (child != null)
-			{
-#if UNO_REFERENCE_API
-				child.Arrange(new Rect(0, 0, finalSize.Width, finalSize.Height));
-#else
-				ArrangeElement(child, new Rect(0, 0, finalSize.Width, finalSize.Height));
-#endif
-				return finalSize;
-			}
-			else
-			{
-				return finalSize;
-			}
+			return finalSize;
 		}
 
 		/// <summary>
@@ -755,6 +740,23 @@ namespace Windows.UI.Xaml
 		}
 
 		private protected virtual Thickness GetBorderThickness() => Thickness.Empty;
+
+		private protected Size MeasureFirstChild(Size availableSize)
+		{
+			var child = this.FindFirstChild();
+			return child != null ? MeasureElement(child, availableSize) : new Size(0, 0);
+		}
+
+		private protected Size ArrangeFirstChild(Size finalSize)
+		{
+			var child = this.FindFirstChild();
+			if (child != null)
+			{
+				ArrangeElement(child, new Rect(0, 0, finalSize.Width, finalSize.Height));
+			}
+
+			return finalSize;
+		}
 
 #if XAMARIN
 		private static FrameworkElement FindPhaseEnabledRoot(ContentControl content)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1554

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b75eac</samp>

This pull request refactors the layout logic for `FrameworkElement` and its subclasses by introducing helper methods to measure and arrange the first child element, and by returning the default size in the base `FrameworkElement` methods. This simplifies the code and improves the consistency with the WinUI behavior. The pull request also adds the necessary assembly attributes and using directives to support the media player implementations.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
