### PR TITLE
feat(listview): add support for ListView.IsMultiSelectCheckBoxEnabled

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -645,6 +645,154 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(list.SelectedIndex, -1);
 		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_SingleSelection_IsMultiSelectCheckBoxEnabled()
+		{
+			var singleList = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Single,
+				Items =
+				{
+					new ListViewItem
+					{
+						Content = "child 1"
+					}
+				}
+			};
+
+			var multipleList = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Multiple,
+				Items =
+				{
+					new ListViewItem
+					{
+						Content = "child 1"
+					}
+				}
+			};
+
+			var extendedList = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Extended,
+				Items =
+				{
+					new ListViewItem
+					{
+						Content = "child 1"
+					}
+				}
+			};
+
+			var singleList2 = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Single,
+				IsMultiSelectCheckBoxEnabled = true,
+				Items =
+				{
+					new ListViewItem
+					{
+						Content = "child 1"
+					}
+				}
+			};
+
+			var multipleList2 = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Multiple,
+				IsMultiSelectCheckBoxEnabled = true,
+				Items =
+				{
+					new ListViewItem
+					{
+						Content = "child 1"
+					}
+				}
+			};
+
+			var extendedList2 = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Extended,
+				IsMultiSelectCheckBoxEnabled = true,
+				Items =
+				{
+					new ListViewItem
+					{
+						Content = "child 1"
+					}
+				}
+			};
+
+			var singleList3 = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Single,
+				IsMultiSelectCheckBoxEnabled = false,
+				Items =
+				{
+					new ListViewItem
+					{
+						Content = "child 1"
+					}
+				}
+			};
+
+			var multipleList3 = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Multiple,
+				IsMultiSelectCheckBoxEnabled = false,
+				Items =
+				{
+					new ListViewItem
+					{
+						Content = "child 1"
+					}
+				}
+			};
+
+			var extendedList3 = new ListView
+			{
+				SelectionMode = ListViewSelectionMode.Extended,
+				IsMultiSelectCheckBoxEnabled = false,
+				Items =
+				{
+					new ListViewItem
+					{
+						Content = "child 1"
+					}
+				}
+			};
+
+			var sp = new StackPanel
+			{
+				Children =
+				{
+					singleList,
+					multipleList,
+					extendedList,
+					singleList2,
+					multipleList2,
+					extendedList2,
+					singleList3,
+					multipleList3,
+					extendedList3
+				}
+			};
+
+			WindowHelper.WindowContent = sp;
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(Visibility.Collapsed, ((Border)singleList.FindName("MultiSelectSquare")).Visibility);
+			Assert.AreEqual(Visibility.Visible, ((Border)multipleList.FindName("MultiSelectSquare")).Visibility);
+			Assert.AreEqual(Visibility.Collapsed, ((Border)extendedList.FindName("MultiSelectSquare")).Visibility);
+			Assert.AreEqual(Visibility.Collapsed, ((Border)singleList2.FindName("MultiSelectSquare")).Visibility);
+			Assert.AreEqual(Visibility.Visible, ((Border)multipleList2.FindName("MultiSelectSquare")).Visibility);
+			Assert.AreEqual(Visibility.Collapsed, ((Border)extendedList2.FindName("MultiSelectSquare")).Visibility);
+			Assert.AreEqual(Visibility.Collapsed, ((Border)singleList3.FindName("MultiSelectSquare")).Visibility);
+			Assert.AreEqual(Visibility.Collapsed, ((Border)multipleList3.FindName("MultiSelectSquare")).Visibility);
+			Assert.AreEqual(Visibility.Collapsed, ((Border)extendedList3.FindName("MultiSelectSquare")).Visibility);
+		}
+
 #if HAS_UNO
 		[TestMethod]
 		[RunsOnUIThread]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -647,7 +647,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
-		public async Task When_SingleSelection_IsMultiSelectCheckBoxEnabled()
+#if __IOS__
+		[Ignore("The test can't find MultiSelectSquare")]
+#endif
+		public async Task When_Different_Selections_IsMultiSelectCheckBoxEnabled()
 		{
 			var singleList = new ListView
 			{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ListViewBase.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ListViewBase.cs
@@ -92,20 +92,6 @@ namespace Windows.UI.Xaml.Controls
 #endif
 #if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public bool IsMultiSelectCheckBoxEnabled
-		{
-			get
-			{
-				return (bool)this.GetValue(IsMultiSelectCheckBoxEnabledProperty);
-			}
-			set
-			{
-				this.SetValue(IsMultiSelectCheckBoxEnabledProperty, value);
-			}
-		}
-#endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public global::System.Collections.Generic.IReadOnlyList<global::Windows.UI.Xaml.Data.ItemIndexRange> SelectedRanges
 		{
 			get
@@ -231,14 +217,6 @@ namespace Windows.UI.Xaml.Controls
 			nameof(ReorderMode), typeof(global::Windows.UI.Xaml.Controls.ListViewReorderMode),
 			typeof(global::Windows.UI.Xaml.Controls.ListViewBase),
 			new Windows.UI.Xaml.FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.ListViewReorderMode)));
-#endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty IsMultiSelectCheckBoxEnabledProperty { get; } =
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(IsMultiSelectCheckBoxEnabled), typeof(bool),
-			typeof(global::Windows.UI.Xaml.Controls.ListViewBase),
-			new Windows.UI.Xaml.FrameworkPropertyMetadata(default(bool)));
 #endif
 		// Skipping already declared property SingleSelectionFollowsFocusProperty
 		// Skipping already declared method Windows.UI.Xaml.Controls.ListViewBase.ListViewBase()

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.Properties.cs
@@ -1,4 +1,7 @@
-﻿using Windows.UI.Xaml;
+﻿using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls.Primitives;
+using NotImplementedException = System.NotImplementedException;
 
 namespace Windows.UI.Xaml.Controls;
 
@@ -22,4 +25,24 @@ public partial class ListViewBase
 			typeof(bool),
 			typeof(ListViewBase),
 			new FrameworkPropertyMetadata(true));
+
+	public bool IsMultiSelectCheckBoxEnabled
+	{
+		get => (bool)GetValue(IsMultiSelectCheckBoxEnabledProperty);
+		set => SetValue(IsMultiSelectCheckBoxEnabledProperty, value);
+	}
+
+	public static DependencyProperty IsMultiSelectCheckBoxEnabledProperty { get; } =
+		DependencyProperty.Register(
+			nameof(IsMultiSelectCheckBoxEnabled), typeof(bool),
+			typeof(ListViewBase),
+			new FrameworkPropertyMetadata(true, (o, args) => ((ListViewBase)o).OnIsMultiSelectCheckBoxEnabledPropertyChanged(args)));
+
+	private void OnIsMultiSelectCheckBoxEnabledPropertyChanged(DependencyPropertyChangedEventArgs args)
+	{
+		foreach (var item in GetItemsPanelChildren().OfType<SelectorItem>())
+		{
+			ApplyMultiSelectState(item);
+		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -1095,7 +1095,7 @@ namespace Windows.UI.Xaml.Controls
 		/// <param name="selectorItem"></param>
 		internal void ApplyMultiSelectState(SelectorItem selectorItem)
 		{
-			selectorItem.ApplyMultiSelectState(IsSelectionMultiple);
+			selectorItem.ApplyMultiSelectState(SelectionMode == ListViewSelectionMode.Multiple);
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -108,7 +108,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		/// </summary>
 		internal void ApplyMultiSelectState(bool isSelectionMultiple)
 		{
-			if (isSelectionMultiple)
+			if (isSelectionMultiple && Selector is not ListViewBase { IsMultiSelectCheckBoxEnabled: false })
 			{
 				// We can safely always go to multiselect state
 				VisualStateManager.GoToState(this, "MultiSelectEnabled", useTransitions: true);
@@ -285,7 +285,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			UpdateCommonStates();
 			if (Selector is ListView lv)
 			{
-				ApplyMultiSelectState(lv.IsSelectionMultiple);
+				ApplyMultiSelectState(lv.SelectionMode == ListViewSelectionMode.Multiple);
 			}
 
 			// TODO: This may need to be adjusted later when we remove the Visual State mixins.


### PR DESCRIPTION
GitHub Issue (If applicable): closes #8941

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad2691d</samp>

This pull request adds a new feature and fixes some bugs related to the multi-select checkbox in the `ListView` control. It introduces the `IsMultiSelectCheckBoxEnabled` property to the `ListViewBase` class, which allows the user to enable or disable the checkbox. It also fixes the visibility logic of the checkbox in the `SelectorItem` and `ListViewBase` classes, and adds a new test method to verify the behavior.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
