### PR TITLE
fix: Adjust compatibility for RemoteControl package

### DIFF
--- a/build/nuget/Uno.WinUI.RemoteControl.nuspec
+++ b/build/nuget/Uno.WinUI.RemoteControl.nuspec
@@ -26,5 +26,17 @@
 	<files>
 		<file src="..\..\src\Common\uno.png" target="/" />
 
+		<file src="_._" target="lib\net8.0" />
+		<file src="_._" target="lib\net7.0" />
+		
+		<file src="_._" target="lib\net8.0-android" />
+		<file src="_._" target="lib\net8.0-ios" />
+		<file src="_._" target="lib\net8.0-maccatalyst" />
+		<file src="_._" target="lib\net8.0-macos" />
+		
+		<file src="_._" target="lib\net7.0-android" />
+		<file src="_._" target="lib\net7.0-ios" />
+		<file src="_._" target="lib\net7.0-maccatalyst" />
+		<file src="_._" target="lib\net7.0-macos" />
 	</files>
 </package>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adjust compatibility with the deprecated RemoteControl package dependencies.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c36733</samp>

Add empty files to `Uno.WinUI.RemoteControl` NuGet package for .NET 8.0 and .NET 7.0 frameworks. This fixes a NuGet compatibility issue for projects using the Uno Platform with the latest .NET versions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
