### PR TITLE
fix(ListView): droid lv crash when scrolled

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
@@ -259,32 +259,54 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override void AttachViewToParent(View child, int index, ViewGroup.LayoutParams layoutParams)
 		{
-			var vh = GetChildViewHolder(child);
-			if (vh != null)
+			var holder = GetChildViewHolder(child);
+			if (holder != null)
 			{
-				vh.IsDetached = false;
-				_detachedViews.Remove(vh);
+				holder.IsDetached = false;
+				_detachedViews.Remove(holder);
 			}
+
 			base.AttachViewToParent(child, index, layoutParams);
+		}
+
+		protected override void DetachViewsFromParent(int start, int count)
+		{
+			for (int i = start; i < start + count; i++)
+			{
+				BeforeDetachViewFromParent(GetChildAt(i));
+			}
+
+			base.DetachViewsFromParent(start, count);
+		}
+
+		protected override void DetachViewFromParent(View child)
+		{
+			BeforeDetachViewFromParent(child);
+
+			base.DetachViewFromParent(child);
 		}
 
 		protected override void DetachViewFromParent(int index)
 		{
-			var view = GetChildAt(index);
-			if (view != null)
+			BeforeDetachViewFromParent(GetChildAt(index));
+
+			base.DetachViewFromParent(index);
+		}
+
+		private void BeforeDetachViewFromParent(View child)
+		{
+			if (child is { } view)
 			{
-				var vh = GetChildViewHolder(view);
-				if (vh != null)
+				if (GetChildViewHolder(view) is { } holder)
 				{
-					vh.IsDetached = true;
+					holder.IsDetached = true;
 					if (_trackDetachedViews)
 					{
 						// Avoid memory leak by adding them only when needed
-						_detachedViews.Add(vh);
+						_detachedViews.Add(holder);
 					}
 				}
 			}
-			base.DetachViewFromParent(index);
 		}
 
 		protected override void RemoveDetachedView(View child, bool animate)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13680, closes #13830

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
In certain situation, on android, scrolling in a ListView can cause it to freeze from this exception:
> [0:] Java.Lang.IllegalArgumentException: called detach on an already detached child UnoViewHolder{f91d06b position=33 id=-1, oldPos=-1, pLpos:-1 tmpDetached} crc6499cc3f8d6dc23bc6.NativeListViewBase{dbb9976 VFED.V... ........ 0,0-1080,1731}, adapter:crc6499cc3f8d6dc23bc6.NativeListViewBaseAdapter@dbfd702, layout:Microsoft.UI.Xaml.Controls.ItemsStackPanelLayout, context:DroidListViewIssue.Droid.MainActivity

## What is the new behavior?
Should no longer happen.

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa89bf3</samp>

Overloaded `DetachViewFromParent` method and added helper method to fix view holder detachment bug in `NativeListViewBase.Android.cs`. Renamed local variable for clarity.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
For context, in uno, we are keepting the record of item attaching/detaching via UnoViewHolder.IsDetached from AttachViewToParent & DetachViewFromParent. However, it seems that we have missed a few other methods that could also be used for similar purpose.
The exact setup to reproduce the issue isn't clear. Repro has been unsuccessful in Uno.UI's and Uno.Gallery's SampleApp as well as
a fresh `unoapp` project...