### PR TITLE
fix: property escape `%` in resw files

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Helpers/StringUtilTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Helpers/StringUtilTests.cs
@@ -16,6 +16,8 @@ namespace Uno.UI.RuntimeTests.MUX.Helpers
 			Validate_Formatting("test, icon", "%1!s!, icon", "test");
 			Validate_Formatting("test, 42 items", "%1!s!, %2!u! items", "test", 42);
 			Validate_Formatting("test, 42 test2", "%1!s!, %2!u! %3!s!", "test", 42, "test2");
+			Validate_Formatting("test %, 42% test2", "%1!s!, %2!u!%% %3!s!", "test %", 42, "test2");
+			Validate_Formatting("test, 42% test2", "%1!s!, %2!u!%% %3!s!", "test", 42, "test2");
 		}
 
 		private void Validate_Formatting(string expected, string format, params object[] args)

--- a/src/Uno.UI/Helpers/WinUI/StringUtil.cs
+++ b/src/Uno.UI/Helpers/WinUI/StringUtil.cs
@@ -26,7 +26,7 @@ namespace Uno.UI.Helpers.WinUI
 			// the output string, as the C++ index is staring at 1.
 			list.Insert(0, null);
 
-			return string.Format(CultureInfo.CurrentCulture, dotnetFormat, list.ToArray());
+			return string.Format(CultureInfo.CurrentCulture, dotnetFormat.Replace("%%", "%"), list.ToArray());
 		}
 
 		[GeneratedRegex(@"\%(\d+)!.*?!", RegexOptions.Singleline)]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13863 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e69047d</samp>

This pull request fixes a bug in the `StringUtil.FormatString` method that caused the percent sign to be duplicated in the output string. It also adds two unit tests to verify the correct behavior of the method with different format strings and arguments.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
