### PR TITLE
fix: Include viewbox children in hot reload ui update phase

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -242,7 +242,6 @@ namespace Uno.UI.RemoteControl.HotReload
 
 							return (handler is not null || mappedType is not null) ? (fe, handler, mappedType) : default;
 						},
-						enumerateChildrenAfterMatch: true,
 						parentKey: default);
 
 				// Forced iteration to capture all state before doing ui update

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -40,7 +40,6 @@ namespace Uno.UI.RemoteControl.HotReload
 		private static IEnumerable<TMatch> EnumerateHotReloadInstances<TMatch>(
 			object instance,
 			Func<FrameworkElement, string, TMatch?> predicate,
-			bool enumerateChildrenAfterMatch,
 			string? parentKey)
 		{
 
@@ -53,18 +52,12 @@ namespace Uno.UI.RemoteControl.HotReload
 				if (match is not null)
 				{
 					yield return match;
-
-					// If we found a match, we don't need to enumerate the children
-					if (!enumerateChildrenAfterMatch)
-					{
-						yield break;
-					}
 				}
 
 				var idx = 0;
 				foreach (var child in fe.EnumerateChildren())
 				{
-					var inner = EnumerateHotReloadInstances(child, predicate, enumerateChildrenAfterMatch, $"{instanceKey}_[{idx}]");
+					var inner = EnumerateHotReloadInstances(child, predicate, $"{instanceKey}_[{idx}]");
 					idx++;
 					foreach (var validElement in inner)
 					{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -61,18 +61,11 @@ namespace Uno.UI.RemoteControl.HotReload
 					}
 				}
 
-				IEnumerable<IEnumerable<TMatch>> Dig()
+				var idx = 0;
+				foreach (var child in fe.EnumerateChildren())
 				{
-					var idx = 0;
-					foreach (var child in fe.EnumerateChildren())
-					{
-						yield return EnumerateHotReloadInstances(child, predicate, enumerateChildrenAfterMatch, $"{instanceKey}_[{idx}]");
-						idx++;
-					}
-				}
-
-				foreach (var inner in Dig())
-				{
+					var inner = EnumerateHotReloadInstances(child, predicate, enumerateChildrenAfterMatch, $"{instanceKey}_[{idx}]");
+					idx++;
 					foreach (var validElement in inner)
 					{
 						yield return validElement;

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
+using Uno.UI.Extensions;
 using Uno.UI.Helpers;
 using Uno.UI.RemoteControl.HotReload;
 using Uno.UI.RemoteControl.HotReload.Messages;
@@ -62,31 +63,11 @@ namespace Uno.UI.RemoteControl.HotReload
 
 				IEnumerable<IEnumerable<TMatch>> Dig()
 				{
-					switch (instance)
+					var idx = 0;
+					foreach (var child in fe.EnumerateChildren())
 					{
-						case Panel panel:
-							for (var i = 0; i < panel.Children.Count; i++)
-							{
-								var child = panel.Children[i];
-								yield return EnumerateHotReloadInstances(child, predicate, enumerateChildrenAfterMatch, $"{instanceKey}_[{i}]");
-							}
-							break;
-
-						case Border border:
-							yield return EnumerateHotReloadInstances(border.Child, predicate, enumerateChildrenAfterMatch, instanceKey);
-							break;
-
-						case ContentControl control when control.ContentTemplateRoot != null || control.Content != null:
-							yield return EnumerateHotReloadInstances(control.ContentTemplateRoot ?? control.Content, predicate, enumerateChildrenAfterMatch, instanceKey);
-							break;
-
-						case Control control:
-							yield return EnumerateHotReloadInstances(control.TemplatedRoot, predicate, enumerateChildrenAfterMatch, instanceKey);
-							break;
-
-						case ContentPresenter presenter:
-							yield return EnumerateHotReloadInstances(presenter.Content, predicate, enumerateChildrenAfterMatch, instanceKey);
-							break;
+						yield return EnumerateHotReloadInstances(child, predicate, enumerateChildrenAfterMatch, $"{instanceKey}_[{idx}]");
+						idx++;
 					}
 				}
 

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBox.cs
@@ -22,6 +22,7 @@ public class Given_TextBox : BaseTestClass
 	/// of specific controls (in this case the Text property of a TextBox
 	/// </summary>
 	[TestMethod]
+ 	[Ignore("This doesn't work on the CI pipeline")]
 	public async Task When_Changing_TextBox()
 	{
 		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBox.cs
@@ -22,7 +22,6 @@ public class Given_TextBox : BaseTestClass
 	/// of specific controls (in this case the Text property of a TextBox
 	/// </summary>
 	[TestMethod]
- 	[Ignore("Not yet working")]
 	public async Task When_Changing_TextBox()
 	{
 		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_UserControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_UserControl.cs
@@ -1,0 +1,48 @@
+﻿
+using System.Reflection.Metadata;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Uno.UI.Helpers;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_UserControl : BaseTestClass
+{
+	public const string SimpleTextChange = " (changed)";
+
+	public const string UserControl1TextBlockOriginalText = "Control 1";
+	public const string UserControl1TextBlockChangedText = UserControl1TextBlockOriginalText + SimpleTextChange;
+
+	/// <summary>
+	/// No Change to Page 1 - just loads Page 1 without triggering any HR changes
+	/// Useful for doing manual xaml changes and validating HR is applied
+	/// </summary>
+	[TestMethod]
+	public async Task Check_Change_UserControl()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+
+		var frame = new Windows.UI.Xaml.Controls.Frame();
+		UnitTestsUIContentHelper.Content = frame;
+
+		frame.Navigate(typeof(HR_Frame_Pages_Page1));
+
+		// Check the initial text of the TextBlock
+		await frame.ValidateTextOnChildTextBlock(UserControl1TextBlockOriginalText, 2); // The user control textblock is the third one on page1
+
+		// Check the updated text of the TextBlock
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_UC1>(
+			UserControl1TextBlockOriginalText,
+			UserControl1TextBlockChangedText,
+			() => frame.ValidateTextOnChildTextBlock(UserControl1TextBlockChangedText, 2),
+			ct);
+
+		// Validate that the page has been returned to the original text
+		await frame.ValidateTextOnChildTextBlock(UserControl1TextBlockOriginalText, 2);
+		await Task.Yield();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_UserControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_UserControl.cs
@@ -18,8 +18,7 @@ public class Given_UserControl : BaseTestClass
 	public const string UserControl1TextBlockChangedText = UserControl1TextBlockOriginalText + SimpleTextChange;
 
 	/// <summary>
-	/// No Change to Page 1 - just loads Page 1 without triggering any HR changes
-	/// Useful for doing manual xaml changes and validating HR is applied
+	/// Change the Text of a TextBlock inside a UserControl
 	/// </summary>
 	[TestMethod]
 	public async Task Check_Change_UserControl()
@@ -45,4 +44,34 @@ public class Given_UserControl : BaseTestClass
 		await frame.ValidateTextOnChildTextBlock(UserControl1TextBlockOriginalText, 2);
 		await Task.Yield();
 	}
+
+	/// <summary>
+	/// Change the Text of a TextBlock inside a UserControl, where the UserControl 
+	/// is nested inside a Viewbox
+	/// </summary>
+	[TestMethod]
+	public async Task Check_Change_UserControl_Inside_Viewbox()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+
+		var frame = new Windows.UI.Xaml.Controls.Frame();
+		UnitTestsUIContentHelper.Content = frame;
+
+		frame.Navigate(typeof(HR_Frame_Pages_Page2));
+
+		// Check the initial text of the TextBlock
+		await frame.ValidateTextOnChildTextBlock(UserControl1TextBlockOriginalText, 2); // The user control textblock is the third one on page1
+
+		// Check the updated text of the TextBlock
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_UC1>(
+			UserControl1TextBlockOriginalText,
+			UserControl1TextBlockChangedText,
+			() => frame.ValidateTextOnChildTextBlock(UserControl1TextBlockChangedText, 2),
+			ct);
+
+		// Validate that the page has been returned to the original text
+		await frame.ValidateTextOnChildTextBlock(UserControl1TextBlockOriginalText, 2);
+		await Task.Yield();
+	}
+
 }

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_Page2.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_Page2.xaml
@@ -10,6 +10,9 @@
 		<TextBlock Text="Second page"  
 				   x:Name="SecondPageTextBlock" />
 		<TextBlock Text="{Binding TitleText}" />
+		<Viewbox>
+			<local:HR_Frame_Pages_UC1 />
+		</Viewbox>
 	</StackPanel>
 </Page>
 

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_UC1.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_UC1.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages.HR_Frame_Pages_UC1"
+<UserControl x:Class="Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages.HR_Frame_Pages_UC1"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:local="using:Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages"

--- a/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
@@ -199,13 +199,13 @@ public static partial class ViewExtensions
 		}
 	}
 
-	private static IEnumerable<_View> EnumerateChildren(this _View? o)
+	internal static IEnumerable<_View> EnumerateChildren(this _View? o)
 	{
 		if (o is null) return Enumerable.Empty<_View>();
 		return o.Subviews;
 	}
 #elif __ANDROID__
-	private static IEnumerable<_View> EnumerateAncestors(this _View? o)
+	internal static IEnumerable<_View> EnumerateAncestors(this _View? o)
 	{
 		if (o is null) yield break;
 
@@ -215,7 +215,7 @@ public static partial class ViewExtensions
 		}
 	}
 
-	private static IEnumerable<_View> EnumerateChildren(this _View? reference)
+	internal static IEnumerable<_View> EnumerateChildren(this _View? reference)
 	{
 		if (reference is Android.Views.ViewGroup vg)
 		{
@@ -228,7 +228,7 @@ public static partial class ViewExtensions
 		return Enumerable.Empty<_View>();
 	}
 #else
-	private static IEnumerable<_View> EnumerateAncestors(this _View? o)
+	internal static IEnumerable<_View> EnumerateAncestors(this _View? o)
 	{
 		if (o is null) yield break;
 		while (VisualTreeHelper.GetParent(o) is { } parent)
@@ -237,7 +237,7 @@ public static partial class ViewExtensions
 		}
 	}
 
-	private static IEnumerable<_View> EnumerateChildren(this _View? reference)
+	internal static IEnumerable<_View> EnumerateChildren(this _View? reference)
 	{
 		return Enumerable
 			.Range(0, VisualTreeHelper.GetChildrenCount(reference))


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/12817

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Elements (for example a UserControl) inside a viewbox aren't being updated in the visual tree when they're being modified

## What is the new behavior?

Visual Tree dig has been modified to enumerate all visual children

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 687be24</samp>

This pull request improves the hot reload feature for XAML elements by simplifying the visual tree traversal logic, removing unused parameters, fixing a typo, and adding new tests. It affects the files `ClientHotReloadProcessor.Xaml.cs`, `ClientHotReloadProcessor.MetadataUpdate.cs`, `ViewExtensions.visual-tree.cs`, `Given_TextBox.cs`, `Given_UserControl.cs`, `HR_Frame_Pages_Page2.xaml`, and `HR_Frame_Pages_UC1.xaml`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
