### PR TITLE
feat(textbox): skia textbox implementation

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/Strings/en-US/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/en-US/Resources.resw
@@ -165,23 +165,4 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
-
-  <data name="TextBoxCut" xml:space="preserve">
-    <value>Cut</value>
-  </data>
-  <data name="TextBoxCopy" xml:space="preserve">
-    <value>Copy</value>
-  </data>
-  <data name="TextBoxPaste" xml:space="preserve">
-    <value>Paste</value>
-  </data>
-  <data name="TextBoxUndo" xml:space="preserve">
-    <value>Undo</value>
-  </data>
-  <data name="TextBoxRedo" xml:space="preserve">
-    <value>Redo</value>
-  </data>
-  <data name="TextBoxSelectAll" xml:space="preserve">
-    <value>Select All</value>
-  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/en-US/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/en-US/Resources.resw
@@ -165,4 +165,23 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Cut</value>
+  </data>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Redo</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Select All</value>
+  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
@@ -147,4 +147,23 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Cut</value>
+  </data>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Redo</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Select All</value>
+  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
@@ -147,23 +147,4 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
-
-  <data name="TextBoxCut" xml:space="preserve">
-    <value>Cut</value>
-  </data>
-  <data name="TextBoxCopy" xml:space="preserve">
-    <value>Copy</value>
-  </data>
-  <data name="TextBoxPaste" xml:space="preserve">
-    <value>Paste</value>
-  </data>
-  <data name="TextBoxUndo" xml:space="preserve">
-    <value>Undo</value>
-  </data>
-  <data name="TextBoxRedo" xml:space="preserve">
-    <value>Redo</value>
-  </data>
-  <data name="TextBoxSelectAll" xml:space="preserve">
-    <value>Select All</value>
-  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/es-ES/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/es-ES/Resources.resw
@@ -126,23 +126,4 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
-
-  <data name="TextBoxCut" xml:space="preserve">
-    <value>Cortar</value>
-  </data>
-  <data name="TextBoxCopy" xml:space="preserve">
-    <value>Copiar</value>
-  </data>
-  <data name="TextBoxPaste" xml:space="preserve">
-    <value>Pegar</value>
-  </data>
-  <data name="TextBoxUndo" xml:space="preserve">
-    <value>Deshacer</value>
-  </data>
-  <data name="TextBoxRedo" xml:space="preserve">
-    <value>Rehacer</value>
-  </data>
-  <data name="TextBoxSelectAll" xml:space="preserve">
-    <value>Seleccionar todo</value>
-  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/es-ES/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/es-ES/Resources.resw
@@ -126,4 +126,23 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Cortar</value>
+  </data>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copiar</value>
+  </data>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Pegar</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Deshacer</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Rehacer</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Seleccionar todo</value>
+  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/es-MX/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/es-MX/Resources.resw
@@ -126,23 +126,4 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
-
-  <data name="TextBoxCut" xml:space="preserve">
-    <value>Cortar</value>
-  </data>
-  <data name="TextBoxCopy" xml:space="preserve">
-    <value>Copiar</value>
-  </data>
-  <data name="TextBoxPaste" xml:space="preserve">
-    <value>Pegar</value>
-  </data>
-  <data name="TextBoxUndo" xml:space="preserve">
-    <value>Deshacer</value>
-  </data>
-  <data name="TextBoxRedo" xml:space="preserve">
-    <value>Rehacer</value>
-  </data>
-  <data name="TextBoxSelectAll" xml:space="preserve">
-    <value>Seleccionar todo</value>
-  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/es-MX/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/es-MX/Resources.resw
@@ -126,4 +126,23 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Cortar</value>
+  </data>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copiar</value>
+  </data>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Pegar</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Deshacer</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Rehacer</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Seleccionar todo</value>
+  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/fr-CA/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/fr-CA/Resources.resw
@@ -126,23 +126,4 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
-
-  <data name="TextBoxCut" xml:space="preserve">
-    <value>Couper</value>
-  </data>
-  <data name="TextBoxCopy" xml:space="preserve">
-    <value>Copier</value>
-  </data>
-  <data name="TextBoxPaste" xml:space="preserve">
-    <value>Coller</value>
-  </data>
-  <data name="TextBoxUndo" xml:space="preserve">
-    <value>Annuler</value>
-  </data>
-  <data name="TextBoxRedo" xml:space="preserve">
-    <value>Rétablir</value>
-  </data>
-  <data name="TextBoxSelectAll" xml:space="preserve">
-    <value>Sélectionner tout</value>
-  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/fr-CA/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/fr-CA/Resources.resw
@@ -126,4 +126,23 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Couper</value>
+  </data>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Coller</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Rétablir</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Sélectionner tout</value>
+  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/fr/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/fr/Resources.resw
@@ -126,4 +126,23 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Couper</value>
+  </data>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copier</value>
+  </data>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Coller</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Rétablir</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Sélectionner tout</value>
+  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/sr/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/sr/Resources.resw
@@ -126,23 +126,4 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
-
-  <data name="TextBoxCut" xml:space="preserve">
-    <value>Izreži</value>
-  </data>
-  <data name="TextBoxCopy" xml:space="preserve">
-    <value>Kopiraj</value>
-  </data>
-  <data name="TextBoxPaste" xml:space="preserve">
-    <value>Nalepi</value>
-  </data>
-  <data name="TextBoxUndo" xml:space="preserve">
-    <value>Poništi</value>
-  </data>
-  <data name="TextBoxRedo" xml:space="preserve">
-    <value>Ponovi</value>
-  </data>
-  <data name="TextBoxSelectAll" xml:space="preserve">
-    <value>Odaberi sve</value>
-  </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/sr/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/sr/Resources.resw
@@ -126,4 +126,23 @@
   <data name="PublisherDisplayName" xml:space="preserve">
     <value>Uno Platform</value>
   </data>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Izreži</value>
+  </data>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Kopiraj</value>
+  </data>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Nalepi</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Poništi</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Ponovi</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Odaberi sve</value>
+  </data>
 </root>

--- a/src/Uno.UI.Runtime.Skia.Gtk/Input/GtkKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Input/GtkKeyboardInputSource.cs
@@ -9,6 +9,7 @@ using Windows.System;
 using Windows.UI.Core;
 using Uno.Foundation.Logging;
 using Windows.Foundation;
+using Uno.UI.Helpers;
 
 namespace Uno.UI.Runtime.Skia.Gtk;
 
@@ -96,44 +97,13 @@ partial class GtkKeyboardInputSource : IUnoKeyboardInputSource
 	{
 		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
-			var result = WindowsKeyCodeToUnicode(keyCode);
+			var result = InputHelper.WindowsKeyCodeToUnicode(keyCode);
 			return result.Length > 0 ? result[0] : null; // TODO: supplementary code points
 		}
 
 		var gdkChar = (char)Keyval.ToUnicode(keyVal);
 
 		return gdkChar == 0 ? null : gdkChar;
-	}
-
-	[DllImport("user32.dll")]
-	private static extern bool GetKeyboardState(byte[] lpKeyState);
-
-	[DllImport("user32.dll")]
-	private static extern uint MapVirtualKey(uint uCode, uint uMapType);
-
-	[DllImport("user32.dll")]
-	private static extern IntPtr GetKeyboardLayout(uint idThread);
-
-	[DllImport("user32.dll")]
-	private static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff, int cchBuff, uint wFlags, IntPtr dwhkl);
-
-	private static string WindowsKeyCodeToUnicode(uint keyCode)
-	{
-		var keyboardState = new byte[255];
-		var keyboardStateStatus = GetKeyboardState(keyboardState);
-
-		if (!keyboardStateStatus)
-		{
-			return "";
-		}
-
-		var scanCode = MapVirtualKey(keyCode, 0);
-		var inputLocaleIdentifier = GetKeyboardLayout((uint)Environment.CurrentManagedThreadId);
-
-		var result = new StringBuilder();
-		ToUnicodeEx(keyCode, scanCode, keyboardState, result, (int)5, (uint)0, inputLocaleIdentifier);
-
-		return result.ToString();
 	}
 
 	private static VirtualKey ConvertKey(Gdk.Key key)

--- a/src/Uno.UI.Runtime.Skia.Gtk/Input/GtkKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Input/GtkKeyboardInputSource.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
 using Gdk;
 using Gtk;
 using Windows.System;
@@ -129,7 +128,7 @@ partial class GtkKeyboardInputSource : IUnoKeyboardInputSource
 		}
 
 		var scanCode = MapVirtualKey(keyCode, 0);
-		var inputLocaleIdentifier = GetKeyboardLayout((uint)Thread.CurrentThread.ManagedThreadId);
+		var inputLocaleIdentifier = GetKeyboardLayout((uint)Environment.CurrentManagedThreadId);
 
 		var result = new StringBuilder();
 		ToUnicodeEx(keyCode, scanCode, keyboardState, result, (int)5, (uint)0, inputLocaleIdentifier);

--- a/src/Uno.UI.Runtime.Skia.Wpf/Input/WpfKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Input/WpfKeyboardInputSource.cs
@@ -6,6 +6,7 @@ using Uno.Foundation.Logging;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Core;
+using Uno.UI.Helpers;
 using Uno.UI.Hosting;
 using WpfUIElement = System.Windows.UIElement;
 using WinUIKeyEventArgs = Windows.UI.Core.KeyEventArgs;
@@ -88,39 +89,8 @@ internal class WpfKeyboardInputSource : IUnoKeyboardInputSource
 
 	private static char? KeyCodeToUnicode(uint keyCode)
 	{
-		var result = WindowsKeyCodeToUnicode(keyCode);
+		var result = InputHelper.WindowsKeyCodeToUnicode(keyCode);
 		return result.Length > 0 ? result[0] : null; // TODO: supplementary code points
-	}
-
-	[DllImport("user32.dll")]
-	private static extern bool GetKeyboardState(byte[] lpKeyState);
-
-	[DllImport("user32.dll")]
-	private static extern uint MapVirtualKey(uint uCode, uint uMapType);
-
-	[DllImport("user32.dll")]
-	private static extern IntPtr GetKeyboardLayout(uint idThread);
-
-	[DllImport("user32.dll")]
-	private static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff, int cchBuff, uint wFlags, IntPtr dwhkl);
-
-	private static string WindowsKeyCodeToUnicode(uint keyCode)
-	{
-		var keyboardState = new byte[255];
-		var keyboardStateStatus = GetKeyboardState(keyboardState);
-
-		if (!keyboardStateStatus)
-		{
-			return "";
-		}
-
-		var scanCode = MapVirtualKey(keyCode, 0);
-		var inputLocaleIdentifier = GetKeyboardLayout((uint)Environment.CurrentManagedThreadId);
-
-		var result = new StringBuilder();
-		ToUnicodeEx(keyCode, scanCode, keyboardState, result, (int)5, (uint)0, inputLocaleIdentifier);
-
-		return result.ToString();
 	}
 
 	private static VirtualKeyModifiers GetKeyModifiers(ModifierKeys modifierKeys)

--- a/src/Uno.UI.Runtime.Skia.Wpf/Input/WpfKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Input/WpfKeyboardInputSource.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
 using Uno.Foundation.Logging;
 using Windows.Foundation;
 using Windows.System;
@@ -116,7 +115,7 @@ internal class WpfKeyboardInputSource : IUnoKeyboardInputSource
 		}
 
 		var scanCode = MapVirtualKey(keyCode, 0);
-		var inputLocaleIdentifier = GetKeyboardLayout((uint)Thread.CurrentThread.ManagedThreadId);
+		var inputLocaleIdentifier = GetKeyboardLayout((uint)Environment.CurrentManagedThreadId);
 
 		var result = new StringBuilder();
 		ToUnicodeEx(keyCode, scanCode, keyboardState, result, (int)5, (uint)0, inputLocaleIdentifier);

--- a/src/Uno.UI.Runtime.Skia.Wpf/Input/WpfKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Input/WpfKeyboardInputSource.cs
@@ -4,7 +4,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Uno.Foundation.Logging;
-using Uno.UI.Core;
 using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Core;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -120,6 +120,28 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[Ignore("Fails")]
+		public async Task When_Text_Ends_In_Return()
+		{
+			var SUT = new TextBlock
+			{
+				Text = "hello world"
+			};
+
+			WindowHelper.WindowContent = new Border { Child = SUT };
+
+			await WindowHelper.WaitForLoaded(SUT);
+			await WindowHelper.WaitForIdle();
+
+			var height = SUT.ActualHeight;
+
+			SUT.Text += "\r";
+
+			Assert.IsTrue(SUT.ActualHeight > height * 1.5);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
 		public void When_Inlines_XamlRoot()
 		{
 			var SUT = new InlineTextInSpan();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -25,7 +25,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
 	[TestClass]
 	[RunsOnUIThread]
-	public class Given_TextBox
+	public partial class Given_TextBox
 	{
 #if __ANDROID__
 		[TestMethod]
@@ -140,7 +140,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
 			textBox.Focus(FocusState.Programmatic);
-			Assert.AreEqual(textBox.Text.Length, textBox.SelectionStart);
+			Assert.AreEqual(0, textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(1, 7);
 			Assert.AreEqual(1, textBox.SelectionStart);
@@ -161,7 +161,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
 			textBox.Focus(FocusState.Programmatic);
-			Assert.AreEqual(textBox.Text.Length, textBox.SelectionStart);
+			Assert.AreEqual(0, textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(1, 20);
 			Assert.AreEqual(1, textBox.SelectionStart);
@@ -182,7 +182,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
 			textBox.Focus(FocusState.Programmatic);
-			Assert.AreEqual(textBox.Text.Length, textBox.SelectionStart);
+			Assert.AreEqual(0, textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(20, 5);
 			Assert.AreEqual(10, textBox.SelectionStart);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -509,9 +509,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForLoaded(textBox);
 
 			var contentControl = VisualTreeUtils.FindVisualChildByType<ContentControl>(textBox);
-			// This will no longer be true when we support non-native text box input - test will have to be updated for this option
-			Assert.IsInstanceOfType(contentControl.Content, typeof(TextBlock));
-			Assert.AreEqual(initialText, ((TextBlock)contentControl.Content).Text);
+			if (FeatureConfiguration.TextBox.UseOverlayOnSkia)
+			{
+				Assert.IsInstanceOfType(contentControl.Content, typeof(TextBlock));
+				Assert.AreEqual(initialText, ((TextBlock)contentControl.Content).Text);
+			}
+			else
+			{
+				Assert.IsInstanceOfType(contentControl.Content, typeof(Grid));
+				Assert.AreEqual(initialText, contentControl.FindFirstChild<TextBlock>().Text);
+			}
 		}
 #endif
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -140,7 +140,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
 			textBox.Focus(FocusState.Programmatic);
-			Assert.AreEqual(0, textBox.SelectionStart);
+			// On WinUI, TextBoxes start their selection at 0
+			Assert.AreEqual(
+#if __SKIA__
+				FeatureConfiguration.TextBox.UseOverlayOnSkia? textBox.Text.Length :
+#endif
+				0,
+				textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(1, 7);
 			Assert.AreEqual(1, textBox.SelectionStart);
@@ -161,7 +167,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
 			textBox.Focus(FocusState.Programmatic);
-			Assert.AreEqual(0, textBox.SelectionStart);
+			// On WinUI, TextBoxes start their selection at 0
+			Assert.AreEqual(
+#if __SKIA__
+				FeatureConfiguration.TextBox.UseOverlayOnSkia? textBox.Text.Length :
+#endif
+					0,
+				textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(1, 20);
 			Assert.AreEqual(1, textBox.SelectionStart);
@@ -182,7 +194,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			WindowHelper.WindowContent = textBox;
 			await WindowHelper.WaitForLoaded(textBox);
 			textBox.Focus(FocusState.Programmatic);
-			Assert.AreEqual(0, textBox.SelectionStart);
+			// On WinUI, TextBoxes start their selection at 0
+			Assert.AreEqual(
+#if __SKIA__
+				FeatureConfiguration.TextBox.UseOverlayOnSkia? textBox.Text.Length :
+#endif
+					0,
+				textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(20, 5);
 			Assert.AreEqual(10, textBox.SelectionStart);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -143,9 +143,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// On WinUI, TextBoxes start their selection at 0
 			Assert.AreEqual(
 #if __SKIA__
-				FeatureConfiguration.TextBox.UseOverlayOnSkia? textBox.Text.Length :
+				!FeatureConfiguration.TextBox.UseOverlayOnSkia ? 0 :
 #endif
-				0,
+					textBox.Text.Length,
 				textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(1, 7);
@@ -170,9 +170,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// On WinUI, TextBoxes start their selection at 0
 			Assert.AreEqual(
 #if __SKIA__
-				FeatureConfiguration.TextBox.UseOverlayOnSkia? textBox.Text.Length :
+				!FeatureConfiguration.TextBox.UseOverlayOnSkia ? 0 :
 #endif
-					0,
+					textBox.Text.Length,
 				textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(1, 20);
@@ -197,9 +197,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// On WinUI, TextBoxes start their selection at 0
 			Assert.AreEqual(
 #if __SKIA__
-				FeatureConfiguration.TextBox.UseOverlayOnSkia? textBox.Text.Length :
+				!FeatureConfiguration.TextBox.UseOverlayOnSkia ? 0 :
 #endif
-					0,
+					textBox.Text.Length,
 				textBox.SelectionStart);
 			Assert.AreEqual(0, textBox.SelectionLength);
 			textBox.Select(20, 5);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -421,7 +421,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.AreEqual("1234ABCDEFGHIJKLMNOPQRSTUVWXYZ", textBox.Text);
 #if __SKIA__
-			FocusManager.TryMoveFocus(FocusNavigationDirection.Next); // move focus to dismiss the overlay
+			Xaml.Core.VisualTree.GetFocusManagerForElement(textBox)!.FindAndSetNextFocus(FocusNavigationDirection.Next); // move focus to dismiss the overlay
 #endif
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -420,6 +420,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			textBox.SelectedText = "1234";
 
 			Assert.AreEqual("1234ABCDEFGHIJKLMNOPQRSTUVWXYZ", textBox.Text);
+#if __SKIA__
+			FocusManager.TryMoveFocus(FocusNavigationDirection.Next); // move focus to dismiss the overlay
+#endif
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -534,7 +534,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 			Assert.AreEqual(sv.ScrollableWidth, sv.HorizontalOffset);
 
-			// The TextBox should fit roughly 7 characters
+			// The TextBox should fit roughly 7-8 characters
 			for (var i = 0; i < 6; i++)
 			{
 				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.None));
@@ -550,7 +550,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 			Assert.AreEqual(0, sv.HorizontalOffset);
 
-			for (var i = 0; i < 6; i++)
+			for (var i = 0; i < 7; i++)
 			{
 				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
 				await WindowHelper.WaitForIdle();
@@ -635,7 +635,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			mouse.Release();
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(9, SUT.SelectionStart);
+			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 		}
 
@@ -668,13 +668,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			mouse.Press();
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(9, SUT.SelectionStart);
+			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 
 			mouse.MoveBy(-50, 0);
 
 			Assert.AreEqual(1, SUT.SelectionStart);
-			Assert.AreEqual(8, SUT.SelectionLength);
+			Assert.AreEqual(9, SUT.SelectionLength);
 		}
 
 		[TestMethod]
@@ -706,14 +706,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			mouse.Press();
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(9, SUT.SelectionStart);
+			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 
 			mouse.MoveBy(0, 50);
 			mouse.MoveBy(-150, 0);
 
 			Assert.AreEqual(0, SUT.SelectionStart);
-			Assert.AreEqual(9, SUT.SelectionLength);
+			Assert.AreEqual(10, SUT.SelectionLength);
 		}
 
 		[TestMethod]
@@ -745,7 +745,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			mouse.Press();
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(9, SUT.SelectionStart);
+			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 
 			mouse.MoveBy(0, 50);
@@ -753,14 +753,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(0, SUT.SelectionStart);
-			Assert.AreEqual(9, SUT.SelectionLength);
+			Assert.AreEqual(10, SUT.SelectionLength);
 
 			mouse.MoveBy(0, 50);
 			mouse.MoveBy(600, 0);
 			await WindowHelper.WaitForIdle();
 
-			Assert.AreEqual(9, SUT.SelectionStart);
-			Assert.AreEqual(SUT.Text.Length - 9, SUT.SelectionLength);
+			Assert.AreEqual(10, SUT.SelectionStart);
+			Assert.AreEqual(SUT.Text.Length - 10, SUT.SelectionLength);
 		}
 
 		[TestMethod]
@@ -805,6 +805,101 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.AreEqual(6, SUT.SelectionStart);
 			Assert.AreEqual(4, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Chunk_DoubleTapHeld()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 150,
+				Text = "Hello world"
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var bounds = SUT.GetAbsoluteBounds();
+			mouse.MoveTo(bounds.GetCenter());
+			await WindowHelper.WaitForIdle();
+
+			// double tap
+			mouse.Press();
+			mouse.Release();
+			mouse.Press();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(6, SUT.SelectionStart);
+			Assert.AreEqual(5, SUT.SelectionLength);
+
+			mouse.MoveBy(-40, 0);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(SUT.Text.Length, SUT.SelectionLength);
+
+			// the selection should start on the right
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.Shift));
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, SUT.SelectionStart);
+			Assert.AreEqual(SUT.Text.Length - 1, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Chunk_TripleTapped()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 150,
+				Text = "Hello world"
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var bounds = SUT.GetAbsoluteBounds();
+			mouse.MoveTo(bounds.GetCenter());
+			await WindowHelper.WaitForIdle();
+
+			// double tap
+			mouse.Press();
+			mouse.Release();
+			mouse.Press();
+			mouse.Release();
+			mouse.Press();
+			mouse.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(SUT.Text.Length, SUT.SelectionLength);
+
+			// the selection should start on the left
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.Shift));
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(SUT.Text.Length - 1, SUT.SelectionLength);
 		}
 
 		[TestMethod]
@@ -952,6 +1047,5 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				FeatureConfiguration.TextBox.HideCaret = _hideCaret;
 			}
 		}
-
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -8,6 +8,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
+using FluentAssertions;
 using MUXControlsTestApp.Utilities;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
@@ -441,11 +442,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 
 			var sv = SUT.FindVisualChildByType<ScrollViewer>();
-			Assert.IsTrue(sv.HorizontalOffset > 0);
+			sv.HorizontalOffset.Should().BeGreaterThan(0);
 			Assert.AreEqual(sv.ScrollableWidth, sv.HorizontalOffset);
 
 			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Home, VirtualKeyModifiers.None));
-			Assert.IsTrue(sv.ScrollableWidth > 0);
+			sv.ScrollableWidth.Should().BeGreaterThan(0);
 			Assert.AreEqual(0, sv.HorizontalOffset);
 		}
 
@@ -673,11 +674,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.Select(SUT.Text.Length, 0);
 			await WindowHelper.WaitForIdle();
 			// DeleteButton Takes space to the right of sv
-			Assert.IsTrue(LayoutInformation.GetLayoutSlot(SUT).Right - LayoutInformation.GetLayoutSlot(sv).Right > 10);
+			LayoutInformation.GetLayoutSlot(SUT).Right.Should().BeGreaterThan(LayoutInformation.GetLayoutSlot(sv).Right + 10);
 
 			btn.Focus(FocusState.Programmatic);
 			await WindowHelper.WaitForIdle();
-			Assert.IsTrue(LayoutInformation.GetLayoutSlot(SUT).Right - LayoutInformation.GetLayoutSlot(sv).Right < 10);
+			LayoutInformation.GetLayoutSlot(SUT).Right.Should().BeLessThan(LayoutInformation.GetLayoutSlot(sv).Right + 10);
 		}
 
 		[TestMethod]
@@ -714,7 +715,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.None));
 			await WindowHelper.WaitForIdle();
-			Assert.IsTrue(sv.HorizontalOffset < sv.ScrollableWidth);
+			sv.HorizontalOffset.Should().BeLessThan(sv.ScrollableWidth);
 
 			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Home, VirtualKeyModifiers.None));
 			await WindowHelper.WaitForIdle();
@@ -724,12 +725,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			{
 				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
 				await WindowHelper.WaitForIdle();
-				Assert.AreEqual(0, sv.HorizontalOffset);
+				sv.HorizontalOffset.Should().BeApproximately(0, 2); // CI reports different numbers than local, probably because of scaling difference, hence the tolerance
 			}
 
 			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
 			await WindowHelper.WaitForIdle();
-			Assert.IsTrue(sv.HorizontalOffset > 0);
+			sv.HorizontalOffset.Should().BeGreaterThan(0);
 		}
 
 		[TestMethod]
@@ -756,7 +757,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.Select(SUT.Text.Length, 0);
 			await WindowHelper.WaitForIdle();
 			// DeleteButton Takes space to the right of sv
-			Assert.IsTrue(LayoutInformation.GetLayoutSlot(SUT).Right - LayoutInformation.GetLayoutSlot(sv).Right > 10);
+			LayoutInformation.GetLayoutSlot(SUT).Right.Should().BeGreaterThan(LayoutInformation.GetLayoutSlot(sv).Right + 10);
 
 			var svRight = LayoutInformation.GetLayoutSlot(SUT).Right;
 			for (var i = 0; i < 5; i++)
@@ -1296,7 +1297,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.Text = "hello\rworld";
 			await WindowHelper.WaitForIdle();
 
-			Assert.IsTrue(SUT.ActualHeight > 1.5 * height);
+			SUT.ActualHeight.Should().BeGreaterThan(height * 1.2);
 		}
 
 		[TestMethod]
@@ -1646,7 +1647,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.Text += "\r";
 
-			Assert.IsTrue(SUT.ActualHeight > height * 1.5);
+			SUT.ActualHeight.Should().BeGreaterThan(height * 1.2);
 		}
 
 		[TestMethod]
@@ -1874,7 +1875,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(25, SUT.SelectionStart);
 			Assert.AreEqual(30, SUT.SelectionLength);
 
-			mouse.MoveBy(0, -35);
+			mouse.MoveBy(0, -30);
 			mouse.Release();
 			await WindowHelper.WaitForIdle();
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -1,0 +1,858 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.System;
+using Windows.UI.Input.Preview.Injection;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
+using MUXControlsTestApp.Utilities;
+using Uno.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
+{
+	/// <summary>
+	/// This partial is for testing the skia-based TextBox implementation.
+	/// Most tests here should set UseOverlayOnSkia to false and HideCaret
+	/// to true and then set them back at the end of the test.
+	/// </summary>
+	public partial class Given_TextBox
+	{
+		[TestMethod]
+		public async Task When_Basic_Input()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var text = "Hello world";
+			foreach (var c in text)
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
+			}
+
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(text, SUT.Text);
+			Assert.AreEqual(11, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Basic_Input_With_ArrowKeys()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			foreach (var c in "world")
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
+			}
+
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(5, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			for (int i = 1; i <= 5; i++)
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.None));
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(5 - i, SUT.SelectionStart);
+				Assert.AreEqual(0, SUT.SelectionLength);
+			}
+
+			foreach (var c in "Hello ")
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
+			}
+
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual("Hello world", SUT.Text);
+			Assert.AreEqual(6, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Basic_Input_With_Home_End()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			foreach (var c in "world")
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
+			}
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Home, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			foreach (var c in "Hello ")
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
+			}
+
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual("Hello world", SUT.Text);
+			Assert.AreEqual(6, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.End, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(11, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Selection_With_Keyboard_NoMod_And_Shift()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			foreach (var c in "Hello world")
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
+			}
+
+			await WindowHelper.WaitForIdle();
+
+			for (var i = 1; i <= 11; i++)
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.Shift));
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(11 - i, SUT.SelectionStart);
+				Assert.AreEqual(i, SUT.SelectionLength);
+			}
+
+			for (var i = 1; i <= 5; i++)
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.Shift));
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(i, SUT.SelectionStart);
+				Assert.AreEqual(11 - i, SUT.SelectionLength);
+			}
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(5, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.End, VirtualKeyModifiers.Shift));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(5, SUT.SelectionStart);
+			Assert.AreEqual(6, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(11, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Home, VirtualKeyModifiers.Shift));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(11, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(11, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Selection_With_Keyboard_NoMod_Ctrl_And_Shift()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			foreach (var c in "Hello &(%&^( w0.rld")
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
+			}
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Home, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.Control));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(6, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.Control));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(13, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.Control));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(15, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.Control));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(16, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.Control));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(19, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Text_Bigger_Than_TextBox()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 40
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			foreach (var c in "This should be a lot longer than the width of the TextBox.")
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
+			}
+			await WindowHelper.WaitForIdle();
+
+			var sv = SUT.FindVisualChildByType<ScrollViewer>();
+			Assert.IsTrue(sv.HorizontalOffset > 0);
+			Assert.AreEqual(sv.ScrollableWidth, sv.HorizontalOffset);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Home, VirtualKeyModifiers.None));
+			Assert.IsTrue(sv.ScrollableWidth > 0);
+			Assert.AreEqual(0, sv.HorizontalOffset);
+		}
+
+		[TestMethod]
+		public async Task When_KeyDown_Bubbles_Out()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 100,
+				Text = "Hello world"
+			};
+
+			var keyDownCount = 0;
+			SUT.KeyDown += (_, _) => keyDownCount++;
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(1, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(1, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.End, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(1, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.End, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(2, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(3, keyDownCount);
+
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.Select(2, 0);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Up, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(4, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Down, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(4, keyDownCount);
+			Assert.AreEqual(SUT.Text.Length, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Down, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(5, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Back, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(6, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.Select(0, 0);
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Back, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(7, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Delete, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(7, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.Select(SUT.Text.Length, 0);
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Delete, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(7, keyDownCount);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.A, VirtualKeyModifiers.None, unicodeKey: 'A'));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(8, keyDownCount);
+		}
+
+		[TestMethod]
+		public async Task When_Selection_Initial_Then_Text_Changed()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 40,
+				Text = "Initial"
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.Select(SUT.Text.Length, 0);
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(SUT.Text.Length, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.Text = "Changed";
+
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_ReadOnly()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 40,
+				Text = "Initial",
+				IsReadOnly = true
+			};
+
+			var keyDownCount = 0;
+			SUT.KeyDown += (_, _) => keyDownCount++;
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.A, VirtualKeyModifiers.None, unicodeKey: 'A'));
+
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual("Initial", SUT.Text);
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+			Assert.AreEqual(1, keyDownCount);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.None));
+
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+			Assert.AreEqual(2, keyDownCount);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
+
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(1, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+			Assert.AreEqual(2, keyDownCount);
+		}
+
+		[TestMethod]
+		public async Task When_Long_Text_Unfocused()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 80,
+				Text = "This should be a lot longer than the width of the TextBox."
+			};
+
+			var btn = new Button();
+
+			var sp = new StackPanel
+			{
+				Children =
+				{
+					SUT,
+					btn
+				}
+			};
+
+
+			WindowHelper.WindowContent = sp;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			var sv = SUT.FindVisualChildByType<ScrollViewer>();
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			SUT.Select(SUT.Text.Length, 0);
+			await WindowHelper.WaitForIdle();
+			// DeleteButton Takes space to the right of sv
+			Assert.IsTrue(LayoutInformation.GetLayoutSlot(SUT).Right - LayoutInformation.GetLayoutSlot(sv).Right > 10);
+
+			btn.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(LayoutInformation.GetLayoutSlot(SUT).Right - LayoutInformation.GetLayoutSlot(sv).Right < 10);
+		}
+
+		[TestMethod]
+		public async Task When_Scrolling_Updates_With_Movement()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 40,
+				Text = "This should be a lot longer than the width of the TextBox."
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			var sv = SUT.FindVisualChildByType<ScrollViewer>();
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			SUT.Select(SUT.Text.Length, 0);
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(sv.ScrollableWidth, sv.HorizontalOffset);
+
+			// The TextBox should fit roughly 7 characters
+			for (var i = 0; i < 6; i++)
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.None));
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(sv.ScrollableWidth, sv.HorizontalOffset);
+			}
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(sv.HorizontalOffset < sv.ScrollableWidth);
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Home, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(0, sv.HorizontalOffset);
+
+			for (var i = 0; i < 6; i++)
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(0, sv.HorizontalOffset);
+			}
+
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Right, VirtualKeyModifiers.None));
+			await WindowHelper.WaitForIdle();
+			Assert.IsTrue(sv.HorizontalOffset > 0);
+		}
+
+		[TestMethod]
+		public async Task When_Scrolling_Updates_After_Backspace()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 150,
+				Text = "This should be a lot longer than the width of the TextBox."
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			var sv = SUT.FindVisualChildByType<ScrollViewer>();
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			SUT.Select(SUT.Text.Length, 0);
+			await WindowHelper.WaitForIdle();
+			// DeleteButton Takes space to the right of sv
+			Assert.IsTrue(LayoutInformation.GetLayoutSlot(SUT).Right - LayoutInformation.GetLayoutSlot(sv).Right > 10);
+
+			var svRight = LayoutInformation.GetLayoutSlot(SUT).Right;
+			for (var i = 0; i < 5; i++)
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Back, VirtualKeyModifiers.None));
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(svRight, LayoutInformation.GetLayoutSlot(SUT).Right);
+			}
+
+			for (var i = 0; i < 10; i++)
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Back, VirtualKeyModifiers.Control));
+			}
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, sv.ScrollableWidth);
+		}
+
+		[TestMethod]
+		public async Task When_Pointer_Tap()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 150,
+				Text = "Hello world"
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var bounds = SUT.GetAbsoluteBounds();
+			mouse.MoveTo(bounds.GetCenter());
+			await WindowHelper.WaitForIdle();
+
+			mouse.Press();
+			mouse.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(9, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Pointer_Hold_Drag()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 150,
+				Text = "Hello world"
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var bounds = SUT.GetAbsoluteBounds();
+			mouse.MoveTo(bounds.GetCenter());
+			await WindowHelper.WaitForIdle();
+
+			mouse.Press();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(9, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			mouse.MoveBy(-50, 0);
+
+			Assert.AreEqual(1, SUT.SelectionStart);
+			Assert.AreEqual(8, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Pointer_Hold_Drag_OutOfBounds()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 150,
+				Text = "Hello world"
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var bounds = SUT.GetAbsoluteBounds();
+			mouse.MoveTo(bounds.GetCenter());
+			await WindowHelper.WaitForIdle();
+
+			mouse.Press();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(9, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			mouse.MoveBy(0, 50);
+			mouse.MoveBy(-150, 0);
+
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(9, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_LongText_Pointer_Hold_Drag_OutOfBounds()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 150,
+				Text = "This should be a lot longer than the width of the TextBox."
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var bounds = SUT.GetAbsoluteBounds();
+			mouse.MoveTo(bounds.GetCenter());
+			await WindowHelper.WaitForIdle();
+
+			mouse.Press();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(9, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+
+			mouse.MoveBy(0, 50);
+			mouse.MoveBy(-150, 0);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, SUT.SelectionStart);
+			Assert.AreEqual(9, SUT.SelectionLength);
+
+			mouse.MoveBy(0, 50);
+			mouse.MoveBy(600, 0);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(9, SUT.SelectionStart);
+			Assert.AreEqual(SUT.Text.Length - 9, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Chunk_DoubleTapped()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox
+			{
+				Width = 150,
+				Text = "Hello world"
+			};
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			var bounds = SUT.GetAbsoluteBounds();
+			mouse.MoveTo(bounds.GetCenter());
+			await WindowHelper.WaitForIdle();
+
+			// double tap
+			mouse.Press();
+			mouse.Release();
+			mouse.Press();
+			mouse.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(6, SUT.SelectionStart);
+			Assert.AreEqual(5, SUT.SelectionLength);
+
+			// the selection should start on the left
+			SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.Shift));
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(6, SUT.SelectionStart);
+			Assert.AreEqual(4, SUT.SelectionLength);
+		}
+
+		[TestMethod]
+		public async Task When_Basic_Input()
+		{
+			using var _ = new TextBoxFeatureConfigDisposable();
+
+			var SUT = new TextBox();
+
+			WindowHelper.WindowContent = SUT;
+
+			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForLoaded(SUT);
+
+			SUT.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			var text = "Hello world";
+			foreach (var c in text)
+			{
+				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
+			}
+
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(text, SUT.Text);
+			Assert.AreEqual(11, SUT.SelectionStart);
+			Assert.AreEqual(0, SUT.SelectionLength);
+		}
+
+		private class TextBoxFeatureConfigDisposable : IDisposable
+		{
+			private bool _useOverlay;
+			private bool _hideCaret;
+
+			public TextBoxFeatureConfigDisposable()
+			{
+				_useOverlay = FeatureConfiguration.TextBox.UseOverlayOnSkia;
+				_hideCaret = FeatureConfiguration.TextBox.HideCaret;
+
+				FeatureConfiguration.TextBox.UseOverlayOnSkia = false;
+				FeatureConfiguration.TextBox.HideCaret = true;
+			}
+
+			public void Dispose()
+			{
+				FeatureConfiguration.TextBox.UseOverlayOnSkia = _useOverlay;
+				FeatureConfiguration.TextBox.HideCaret = _hideCaret;
+			}
+		}
+
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -1960,6 +1960,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.SelectAll();
 			await WindowHelper.WaitForIdle();
+			await Task.Delay(100);
 
 			var canvas = SUT.FindVisualChildByType<Canvas>();
 			var initial = await UITestHelper.ScreenShot(canvas);
@@ -1967,6 +1968,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			SUT.Text = "";
 			await WindowHelper.WaitForIdle();
+			await Task.Delay(100);
 
 			// No residual colors on canvas
 			var cleared = await UITestHelper.ScreenShot(canvas);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -807,7 +807,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-		public async Task When_Basic_Input()
+		public async Task When_NonAscii_Characters()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
 
@@ -821,7 +821,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.Focus(FocusState.Programmatic);
 			await WindowHelper.WaitForIdle();
 
-			var text = "Hello world";
+			var text = "صباح الخير";
 			foreach (var c in text)
 			{
 				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.None, VirtualKeyModifiers.None, unicodeKey: c));
@@ -829,8 +829,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitForIdle();
 			Assert.AreEqual(text, SUT.Text);
-			Assert.AreEqual(11, SUT.SelectionStart);
-			Assert.AreEqual(0, SUT.SelectionLength);
 		}
 
 		private class TextBoxFeatureConfigDisposable : IDisposable

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -507,7 +507,7 @@ namespace Uno.UI
 			/// Determines if a native (Gtk/Wpf) TextBox overlay should be used on the skia targets instead of the
 			/// Uno skia-based TextBox implementation.
 			/// </summary>
-			public static bool UseOverlayOnSkia { get; set; } = false;
+			public static bool UseOverlayOnSkia { get; set; } = true;
 
 #if __ANDROID__
 			/// <summary>

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -503,6 +503,12 @@ namespace Uno.UI
 			/// <remarks>This feature is used to avoid screenshot comparisons false positives</remarks>
 			public static bool HideCaret { get; set; }
 
+			/// <summary>
+			/// Determines if a native (Gtk/Wpf) TextBox overlay should be used on the skia targets instead of the
+			/// Uno skia-based TextBox implementation.
+			/// </summary>
+			public static bool UseOverlayOnSkia { get; set; } = false;
+
 #if __ANDROID__
 			/// <summary>
 			/// The legacy <see cref="Windows.UI.Xaml.Controls.TextBox.InputScope"/> prevents invalid input on hardware keyboard.

--- a/src/Uno.UI/Helpers/InputHelper.cs
+++ b/src/Uno.UI/Helpers/InputHelper.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+namespace Uno.UI.Helpers;
+
+internal static class InputHelper
+{
+	[DllImport("user32.dll")]
+	private static extern bool GetKeyboardState(byte[] lpKeyState);
+
+	[DllImport("user32.dll")]
+	private static extern uint MapVirtualKey(uint uCode, uint uMapType);
+
+	[DllImport("user32.dll")]
+	private static extern IntPtr GetKeyboardLayout(uint idThread);
+
+	[DllImport("user32.dll")]
+	private static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState, [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff, int cchBuff, uint wFlags, IntPtr dwhkl);
+
+	public static string WindowsKeyCodeToUnicode(uint keyCode)
+	{
+		var keyboardState = new byte[255];
+		var keyboardStateStatus = GetKeyboardState(keyboardState);
+
+		if (!keyboardStateStatus)
+		{
+			return "";
+		}
+
+		var scanCode = MapVirtualKey(keyCode, 0);
+		var inputLocaleIdentifier = GetKeyboardLayout((uint)Environment.CurrentManagedThreadId);
+
+		var result = new StringBuilder();
+		var conversionStatus = ToUnicodeEx(keyCode, scanCode, keyboardState, result, (int)5, (uint)0, inputLocaleIdentifier);
+		if (conversionStatus <= 0 || char.IsControl(result[0]))
+		{
+			return "";
+		}
+
+		return result.ToString();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -104,7 +104,7 @@ namespace Windows.UI.Xaml.Controls
 		private Hyperlink? FindHyperlinkAt(Point point)
 		{
 			var padding = Padding;
-			var span = Inlines.GetRenderSegmentSpanAt(point - new Point(padding.Left, padding.Top), false);
+			var span = Inlines.GetRenderSegmentSpanAt(point - new Point(padding.Left, padding.Top), false)?.span;
 
 			if (span == null)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/en-US/Resources.resw
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/en-US/Resources.resw
@@ -117,13 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationDescription" xml:space="preserve">
-    <value>is this translation to fr-CA correct? Une application Uno Platform contenant un grand nombre d'échantillons d'interface utilisateur et non-interface utilisateur. Il permet de tester manuellement de nouvelles fonctionnalités et d'enquêter sur les bogues.</value>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Cut</value>
   </data>
-  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copy</value>
   </data>
-  <data name="PublisherDisplayName" xml:space="preserve">
-    <value>Uno Platform</value>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Redo</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Select All</value>
   </data>
 </root>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/en/Resources.resw
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/en/Resources.resw
@@ -117,13 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationDescription" xml:space="preserve">
-    <value>is this translation to fr-CA correct? Une application Uno Platform contenant un grand nombre d'échantillons d'interface utilisateur et non-interface utilisateur. Il permet de tester manuellement de nouvelles fonctionnalités et d'enquêter sur les bogues.</value>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Cut</value>
   </data>
-  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copy</value>
   </data>
-  <data name="PublisherDisplayName" xml:space="preserve">
-    <value>Uno Platform</value>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Redo</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Select All</value>
   </data>
 </root>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/es-ES/Resources.resw
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/es-ES/Resources.resw
@@ -117,13 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationDescription" xml:space="preserve">
-    <value>is this translation to fr-CA correct? Une application Uno Platform contenant un grand nombre d'échantillons d'interface utilisateur et non-interface utilisateur. Il permet de tester manuellement de nouvelles fonctionnalités et d'enquêter sur les bogues.</value>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Cortar</value>
   </data>
-  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copiar</value>
   </data>
-  <data name="PublisherDisplayName" xml:space="preserve">
-    <value>Uno Platform</value>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Pegar</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Deshacer</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Rehacer</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Seleccionar todo</value>
   </data>
 </root>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/es-MX/Resources.resw
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/es-MX/Resources.resw
@@ -117,13 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationDescription" xml:space="preserve">
-    <value>is this translation to fr-CA correct? Une application Uno Platform contenant un grand nombre d'échantillons d'interface utilisateur et non-interface utilisateur. Il permet de tester manuellement de nouvelles fonctionnalités et d'enquêter sur les bogues.</value>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Cortar</value>
   </data>
-  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copiar</value>
   </data>
-  <data name="PublisherDisplayName" xml:space="preserve">
-    <value>Uno Platform</value>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Pegar</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Deshacer</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Rehacer</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Seleccionar todo</value>
   </data>
 </root>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/fr-CA/Resources.resw
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/fr-CA/Resources.resw
@@ -117,13 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationDescription" xml:space="preserve">
-    <value>is this translation to fr-CA correct? Une application Uno Platform contenant un grand nombre d'échantillons d'interface utilisateur et non-interface utilisateur. Il permet de tester manuellement de nouvelles fonctionnalités et d'enquêter sur les bogues.</value>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Couper</value>
   </data>
-  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copier</value>
   </data>
-  <data name="PublisherDisplayName" xml:space="preserve">
-    <value>Uno Platform</value>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Coller</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Rétablir</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Sélectionner tout</value>
   </data>
 </root>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/fr/Resources.resw
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/fr/Resources.resw
@@ -117,13 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationDescription" xml:space="preserve">
-    <value>is this translation to fr-CA correct? Une application Uno Platform contenant un grand nombre d'échantillons d'interface utilisateur et non-interface utilisateur. Il permet de tester manuellement de nouvelles fonctionnalités et d'enquêter sur les bogues.</value>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Couper</value>
   </data>
-  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Copier</value>
   </data>
-  <data name="PublisherDisplayName" xml:space="preserve">
-    <value>Uno Platform</value>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Coller</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Rétablir</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Sélectionner tout</value>
   </data>
 </root>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/sr/Resources.resw
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/Strings/sr/Resources.resw
@@ -117,13 +117,23 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationDescription" xml:space="preserve">
-    <value>is this translation to fr-CA correct? Une application Uno Platform contenant un grand nombre d'échantillons d'interface utilisateur et non-interface utilisateur. Il permet de tester manuellement de nouvelles fonctionnalités et d'enquêter sur les bogues.</value>
+
+  <data name="TextBoxCut" xml:space="preserve">
+    <value>Izreži</value>
   </data>
-  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+  <data name="TextBoxCopy" xml:space="preserve">
+    <value>Kopiraj</value>
   </data>
-  <data name="PublisherDisplayName" xml:space="preserve">
-    <value>Uno Platform</value>
+  <data name="TextBoxPaste" xml:space="preserve">
+    <value>Nalepi</value>
+  </data>
+  <data name="TextBoxUndo" xml:space="preserve">
+    <value>Poništi</value>
+  </data>
+  <data name="TextBoxRedo" xml:space="preserve">
+    <value>Ponovi</value>
+  </data>
+  <data name="TextBoxSelectAll" xml:space="preserve">
+    <value>Odaberi sve</value>
   </data>
 </root>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -1282,7 +1282,17 @@ namespace Windows.UI.Xaml.Controls
 		public void CutSelectionToClipboard()
 		{
 			CopySelectionToClipboard();
+#if __SKIA__
+			_resetSelectionOnChange = false;
+#endif
 			Text = Text.Remove(SelectionStart, SelectionLength);
+#if __SKIA__
+			_resetSelectionOnChange = true;
+			if (!FeatureConfiguration.TextBox.UseOverlayOnSkia)
+			{
+				Select(_selection.start, 0);
+			}
+#endif
 		}
 
 		internal override bool CanHaveChildren() => true;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -990,7 +990,9 @@ namespace Windows.UI.Xaml.Controls
 			OnPointerPressedNative(args);
 		}
 
-		partial void OnPointerPressedNative(PointerRoutedEventArgs e);
+		partial void OnPointerPressedNative(PointerRoutedEventArgs args);
+
+		partial void OnPointerReleasedNative(PointerRoutedEventArgs args);
 
 		/// <inheritdoc />
 		protected override void OnPointerReleased(PointerRoutedEventArgs args)
@@ -1004,17 +1006,7 @@ namespace Windows.UI.Xaml.Controls
 
 			args.Handled = true;
 
-#if __SKIA__
-			if (!FeatureConfiguration.TextBox.UseOverlayOnSkia && _wasJustDoubleTapped)
-			{
-				var displayBlock = TextBoxView.DisplayBlock;
-				var index = displayBlock.Inlines.GetIndexForTextBlock(args.GetCurrentPoint(displayBlock).Position - new Point(displayBlock.Padding.Left, displayBlock.Padding.Top));
-				var chunk = FindChunkAt(index, true);
-				Select(chunk.start, chunk.length);
-			}
-
-			_wasJustDoubleTapped = false;
-#endif
+			OnPointerReleasedNative(args);
 		}
 
 		protected override void OnTapped(TappedRoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -3,7 +3,6 @@
 #endif
 
 using System;
-
 using Uno.Extensions;
 using Uno.UI.Common;
 using Uno.UI.DataBinding;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -379,6 +379,12 @@ namespace Windows.UI.Xaml.Controls
 			{
 				baseString = GetFirstLine(baseString);
 			}
+#if __SKIA__
+			else if (!FeatureConfiguration.TextBox.UseOverlayOnSkia)
+			{
+				baseString = baseString.Replace("\r\n", "\r").Replace("\n", "\r");
+			}
+#endif
 
 			var args = new TextBoxBeforeTextChangingEventArgs(baseString);
 			BeforeTextChanging?.Invoke(this, args);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -307,7 +307,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private partial void OnTextChangedPartial();
+		partial void OnTextChangedPartial();
 
 		private void RaiseTextChanging()
 		{
@@ -924,7 +924,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnFocusStateChangedPartial(FocusState focusState);
 
-		private partial void OnFocusStateChangedPartial2(FocusState focusState);
+		partial void OnFocusStateChangedPartial2(FocusState focusState);
 
 		protected override void OnVisibilityChanged(Visibility oldValue, Visibility newValue)
 		{
@@ -1007,10 +1007,10 @@ namespace Windows.UI.Xaml.Controls
 		/// <inheritdoc />
 		protected override void OnKeyDown(KeyRoutedEventArgs args) => OnKeyDownPartial(args);
 
-		private partial void OnKeyDownPartial(KeyRoutedEventArgs args);
+		partial void OnKeyDownPartial(KeyRoutedEventArgs args);
 
 #if !__SKIA__
-		private partial void OnKeyDownPartial(KeyRoutedEventArgs args) => OnKeyDownInternal(args);
+		partial void OnKeyDownPartial(KeyRoutedEventArgs args) => OnKeyDownInternal(args);
 #endif
 
 		private void OnKeyDownInternal(KeyRoutedEventArgs args)
@@ -1232,7 +1232,7 @@ namespace Windows.UI.Xaml.Controls
 			});
 		}
 
-		private partial void PasteFromClipboardPartial(string clipboardText, int selectionStart, int selectionLength, string newText);
+		partial void PasteFromClipboardPartial(string clipboardText, int selectionStart, int selectionLength, string newText);
 
 		/// <summary>
 		/// Copies the selected content to the OS clipboard.
@@ -1258,7 +1258,7 @@ namespace Windows.UI.Xaml.Controls
 			Text = Text.Remove(SelectionStart, SelectionLength);
 		}
 
-		private partial void CutSelectionToClipboardPartial();
+		partial void CutSelectionToClipboardPartial();
 
 		internal override bool CanHaveChildren() => true;
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -296,9 +296,13 @@ namespace Windows.UI.Xaml.Controls
 #if __SKIA__
 			if (!FeatureConfiguration.TextBox.UseOverlayOnSkia)
 			{
-				if (_resetSelectionOnChange)
+				if (_pendingSelection is { } selection)
 				{
-					Select(0, 0);
+					SelectInternal(selection.start, selection.length);
+				}
+				else
+				{
+					SelectInternal(0, 0);
 				}
 			}
 #endif
@@ -1247,16 +1251,12 @@ namespace Windows.UI.Xaml.Controls
 				currentText = currentText.Insert(selectionStart, clipboardText);
 
 #if __SKIA__
-				_resetSelectionOnChange = false;
-#endif
-				Text = currentText;
-#if __SKIA__
-				_resetSelectionOnChange = true;
 				if (!FeatureConfiguration.TextBox.UseOverlayOnSkia)
 				{
-					Select(selectionStart + clipboardText.Length, 0);
+					_pendingSelection = (selectionStart + clipboardText.Length, 0);
 				}
 #endif
+				Text = currentText;
 			});
 		}
 
@@ -1281,16 +1281,12 @@ namespace Windows.UI.Xaml.Controls
 		{
 			CopySelectionToClipboard();
 #if __SKIA__
-			_resetSelectionOnChange = false;
-#endif
-			Text = Text.Remove(SelectionStart, SelectionLength);
-#if __SKIA__
-			_resetSelectionOnChange = true;
 			if (!FeatureConfiguration.TextBox.UseOverlayOnSkia)
 			{
-				Select(_selection.start, 0);
+				_pendingSelection = (_selection.start, 0);
 			}
 #endif
+			Text = Text.Remove(SelectionStart, SelectionLength);
 		}
 
 		internal override bool CanHaveChildren() => true;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -295,12 +295,11 @@ namespace Windows.UI.Xaml.Controls
 			UpdateButtonStates();
 
 #if __SKIA__
-
 			if (!FeatureConfiguration.TextBox.UseOverlayOnSkia)
 			{
 				if (_resetSelectionOnChange)
 				{
-					Select(((string)e.NewValue).Length, 0);
+					Select(0, 0);
 				}
 			}
 #endif
@@ -1005,6 +1004,18 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			args.Handled = true;
+
+#if __SKIA__
+			if (!FeatureConfiguration.TextBox.UseOverlayOnSkia && _wasJustDoubleTapped)
+			{
+				var displayBlock = TextBoxView.DisplayBlock;
+				var index = displayBlock.Inlines.GetIndexForTextBlock(args.GetCurrentPoint(displayBlock).Position - new Point(displayBlock.Padding.Left, displayBlock.Padding.Top));
+				var chunk = FindChunkAt(index, true);
+				Select(chunk.start, chunk.length);
+			}
+
+			_wasJustDoubleTapped = false;
+#endif
 		}
 
 		protected override void OnTapped(TappedRoutedEventArgs e)
@@ -1023,7 +1034,6 @@ namespace Windows.UI.Xaml.Controls
 
 #if !__SKIA__
 		private partial void OnKeyDownPartial(KeyRoutedEventArgs args) => OnKeyDownInternal(args);
-
 #endif
 
 		private void OnKeyDownInternal(KeyRoutedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.reference.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.reference.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Windows.UI.Xaml.Input;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -13,5 +14,20 @@ namespace Windows.UI.Xaml.Controls
 		public int SelectionStart { get; set; }
 
 		public int SelectionLength { get; set; }
+
+		protected override void OnPointerMoved(PointerRoutedEventArgs e)
+		{
+			base.OnPointerMoved(e);
+		}
+
+		protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
+		{
+			base.OnDoubleTapped(e);
+		}
+
+		protected override void OnRightTapped(RightTappedRoutedEventArgs e)
+		{
+			base.OnRightTapped(e);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -1,10 +1,24 @@
-﻿using Windows.UI.Xaml.Media;
+﻿using System;
+using System.Collections.Generic;
+using Windows.Foundation;
+using Windows.System;
+using Windows.UI.Xaml.Documents;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Uno.UI;
 
 namespace Windows.UI.Xaml.Controls;
 
 public partial class TextBox
 {
 	private TextBoxView _textBoxView;
+	private (int start, int length) _selection;
+	private bool _selectionEndsAtTheStart;
+	private bool _showCaret = true;
+	private readonly DispatcherTimer _timer = new DispatcherTimer
+	{
+		Interval = TimeSpan.FromSeconds(0.5)
+	};
 
 	internal TextBoxView TextBoxView => _textBoxView;
 
@@ -38,24 +52,304 @@ public partial class TextBox
 		}
 	}
 
-	partial void OnFocusStateChangedPartial(FocusState focusState) => TextBoxView?.OnFocusStateChanged(focusState);
+	partial void OnFocusStateChangedPartial(FocusState focusState)
+	{
+		if (FeatureConfiguration.TextBox.UseOverlayOnSkia)
+		{
+			TextBoxView?.OnFocusStateChanged(focusState);
+		}
+		else
+		{
+			if (focusState != FocusState.Unfocused)
+			{
+				_showCaret = true;
+				_timer.Start();
+			}
+			else
+			{
+				_showCaret = false;
+				_timer.Stop();
+			}
+			UpdateDisplaySelection();
+		}
+	}
 
 	partial void SelectPartial(int start, int length)
 	{
-		TextBoxView?.Select(start, length);
+		_selectionEndsAtTheStart = false;
+		_selection = (start, length);
+		if (FeatureConfiguration.TextBox.UseOverlayOnSkia)
+		{
+			TextBoxView?.Select(start, length);
+		}
+		else
+		{
+			_timer.Stop();
+			_showCaret = true;
+			_timer.Start();
+			UpdateDisplaySelection();
+			UpdateLayout();
+			UpdateScrolling();
+		}
 	}
 
 	partial void SelectAllPartial() => Select(0, Text.Length);
 
 	public int SelectionStart
 	{
-		get => TextBoxView?.GetSelectionStart() ?? 0;
+		get => FeatureConfiguration.TextBox.UseOverlayOnSkia ? TextBoxView?.GetSelectionStart() ?? 0 : _selection.start;
 		set => Select(start: value, length: SelectionLength);
 	}
 
 	public int SelectionLength
 	{
-		get => TextBoxView?.GetSelectionLength() ?? 0;
+		get => FeatureConfiguration.TextBox.UseOverlayOnSkia ? TextBoxView?.GetSelectionLength() ?? 0 : _selection.length;
 		set => Select(SelectionStart, value);
+	}
+
+	internal void UpdateDisplaySelection()
+	{
+		if (TextBoxView?.DisplayBlock.Inlines is { } inlines)
+		{
+			inlines.Selection = (0, SelectionStart, 0, SelectionStart + SelectionLength);
+			inlines.RenderSelectionAndCaret = FocusState != FocusState.Unfocused;
+			var showCaret = _showCaret && !FeatureConfiguration.TextBox.HideCaret && !IsReadOnly && _selection.length == 0;
+			inlines.Caret = (!_selectionEndsAtTheStart, showCaret ? Colors.Black : Colors.Transparent);
+			TextBoxView?.DisplayBlock.InvalidateInlines(true);
+		}
+	}
+
+	private void UpdateScrolling()
+	{
+		if (!FeatureConfiguration.TextBox.UseOverlayOnSkia && _contentElement is ScrollViewer sv)
+		{
+			var selectionEnd = _selectionEndsAtTheStart ? _selection.start : _selection.start + _selection.length;
+
+			var horizontalOffset = sv.HorizontalOffset;
+			var verticalOffset = sv.VerticalOffset;
+
+			var rect = TextBoxView.DisplayBlock.Inlines.GetRectForTextBlockIndex(selectionEnd);
+
+			var newHorizontalOffset = horizontalOffset.AtMost(rect.Left).AtLeast(rect.Left - sv.ViewportWidth + rect.Height * InlineCollection.CaretThicknessAsRatioOfLineHeight);
+			var newVerticalOffset = verticalOffset.AtMost(rect.Top).AtLeast(rect.Top - sv.ViewportWidth);
+
+			sv.ChangeView(newHorizontalOffset, newVerticalOffset, null);
+		}
+	}
+
+	private partial void OnKeyDownPartial(KeyRoutedEventArgs args)
+	{
+		if (FeatureConfiguration.TextBox.UseOverlayOnSkia)
+		{
+			OnKeyDownInternal(args);
+			return;
+		}
+
+		base.OnKeyDown(args);
+
+		// Note: On windows only keys that are "moving the cursor" are handled
+		//		 AND ** only KeyDown ** is handled (not KeyUp)
+
+		// move to possibly-negative selection length format
+		var (selectionStart, selectionLength) = _selectionEndsAtTheStart ? (_selection.start + _selection.length, -_selection.length) : (_selection.start, _selection.length);
+
+		var text = Text;
+		var shift = args.KeyboardModifiers.HasFlag(VirtualKeyModifiers.Shift);
+		switch (args.Key)
+		{
+			case VirtualKey.Up:
+				if (shift)
+				{
+					selectionLength = -selectionStart;
+				}
+				else
+				{
+					selectionStart = Math.Min(selectionStart, selectionStart + selectionLength);
+					selectionLength = 0;
+				}
+				break;
+			case VirtualKey.Down:
+				if (selectionStart != text.Length || selectionLength != 0)
+				{
+					args.Handled = true;
+					if (shift)
+					{
+						selectionLength = text.Length - selectionStart;
+					}
+					else
+					{
+						selectionStart = text.Length;
+					}
+				}
+				break;
+			case VirtualKey.Left:
+				var moveOutLeft = !shift && selectionStart == 0 && selectionLength == 0 || shift && selectionStart + selectionLength == 0;
+				if (!moveOutLeft)
+				{
+					args.Handled = true;
+
+					if (shift)
+					{
+						selectionLength -= 1;
+					}
+					else
+					{
+						if (selectionLength != 0)
+						{
+							selectionStart = Math.Min(selectionStart, selectionStart + selectionLength);
+						}
+						else
+						{
+							selectionStart -= 1;
+						}
+						selectionLength = 0;
+					}
+				}
+				break;
+			case VirtualKey.Right:
+				var moveOutRight = !shift && selectionStart == text.Length && selectionLength == 0 || shift && selectionStart + selectionLength == Text.Length;
+				if (!moveOutRight)
+				{
+					args.Handled = true;
+
+					if (shift)
+					{
+						selectionLength += 1;
+					}
+					else
+					{
+						if (selectionLength != 0)
+						{
+							selectionStart = Math.Max(selectionStart, selectionStart + selectionLength);
+						}
+						else
+						{
+							selectionStart += 1;
+						}
+						selectionLength = 0;
+					}
+				}
+				break;
+			case VirtualKey.Home:
+				args.Handled = true;
+				if (shift)
+				{
+					selectionLength = -selectionStart;
+				}
+				else
+				{
+					selectionStart = 0;
+					selectionLength = 0;
+				}
+				break;
+			case VirtualKey.End:
+				args.Handled = true;
+				if (shift)
+				{
+					selectionLength = text.Length - selectionStart;
+				}
+				else
+				{
+					selectionStart = text.Length;
+					selectionLength = 0;
+				}
+				break;
+			case VirtualKey.Back when !IsReadOnly:
+				args.Handled = true;
+				if (selectionLength != 0)
+				{
+					var start = Math.Min(selectionStart, selectionStart + selectionLength);
+					var end = Math.Max(selectionStart, selectionStart + selectionLength);
+					text = text[..start] + text[end..];
+					selectionLength = 0;
+					selectionStart = start;
+				}
+				else if (selectionStart != 0)
+				{
+					text = text[..(selectionStart - 1)] + text[selectionStart..];
+					selectionStart -= 1;
+				}
+				break;
+			case VirtualKey.Delete when !IsReadOnly:
+				args.Handled = true;
+				if (selectionLength != 0)
+				{
+					var start = Math.Min(selectionStart, selectionStart + selectionLength);
+					var end = Math.Max(selectionStart, selectionStart + selectionLength);
+					text = text[..start] + text[end..];
+					selectionLength = 0;
+					selectionStart = start;
+				}
+				else if (selectionStart != text.Length)
+				{
+					text = text[..selectionStart] + text[(selectionStart + 1)..];
+					selectionStart += 1;
+				}
+				break;
+			case VirtualKey.A when args.KeyboardModifiers.HasFlag(VirtualKeyModifiers.Control):
+				args.Handled = true;
+				selectionStart = 0;
+				selectionLength = text.Length;
+				break;
+			default:
+				var key = (int)args.Key;
+				if (!IsReadOnly && key is >= 'A' and <= 'Z' || args.Key == VirtualKey.Space)
+				{
+					args.Handled = true;
+					var c = args.Key == VirtualKey.Space ? ' ' : shift ? (char)key : char.ToLower((char)key);
+
+
+					var start = Math.Min(selectionStart, selectionStart + selectionLength);
+					var end = Math.Max(selectionStart, selectionStart + selectionLength);
+
+					text = text[..start] + c + text[end..];
+					selectionStart = start + 1;
+					selectionLength = 0;
+				}
+				break;
+		}
+
+		Text = text;
+
+		selectionStart = Math.Max(0, Math.Min(text.Length, selectionStart));
+		selectionLength = Math.Max(-selectionStart, Math.Min(text.Length - selectionStart, selectionLength));
+		SelectInternal(selectionStart, selectionLength);
+	}
+
+	/// <summary>
+	/// Takes a possibly-negative selection length, indicating a selection that goes backwards.
+	/// This makes the calculations a lot more natural.
+	/// </summary>
+	private void SelectInternal(int selectionStart, int selectionLength)
+	{
+		Select(Math.Min(selectionStart, selectionStart + selectionLength), Math.Abs(selectionLength));
+		_selectionEndsAtTheStart = selectionLength < 0; // set here because Select clears it
+		UpdateScrolling();
+	}
+
+	private void TimerOnTick(object sender, object e)
+	{
+		_showCaret = !_showCaret;
+		UpdateDisplaySelection();
+	}
+
+	protected override void OnPointerMoved(PointerRoutedEventArgs e)
+	{
+		base.OnPointerMoved(e);
+		var displayBlock = TextBoxView.DisplayBlock;
+		var point = e.GetCurrentPoint(displayBlock);
+		var index = displayBlock.Inlines.GetIndexForTextBlock(point.Position - new Point(displayBlock.Padding.Left, displayBlock.Padding.Top));
+		if (point.Properties.IsLeftButtonPressed)
+		{
+			var selectionInternalStart = _selectionEndsAtTheStart ? _selection.start + _selection.length : _selection.start;
+			SelectInternal(selectionInternalStart, index - selectionInternalStart);
+		}
+	}
+
+	partial void OnPointerPressedNative(PointerRoutedEventArgs e)
+	{
+		var displayBlock = TextBoxView.DisplayBlock;
+		var index = displayBlock.Inlines.GetIndexForTextBlock(e.GetCurrentPoint(displayBlock).Position - new Point(displayBlock.Padding.Left, displayBlock.Padding.Top));
+		Select(index, 0);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -3,13 +3,18 @@ using System.Collections.Generic;
 using System.Windows.Input;
 using Windows.Foundation;
 using Windows.System;
-using Windows.UI.Input;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 using Uno.Extensions;
 using Uno.UI;
+
+#if HAS_UNO_WINUI
+using Microsoft.UI.Input;
+#else
+using Windows.UI.Input;
+#endif
 
 namespace Windows.UI.Xaml.Controls;
 
@@ -254,7 +259,7 @@ public partial class TextBox
 		}
 	}
 
-	private partial void OnKeyDownPartial(KeyRoutedEventArgs args)
+	partial void OnKeyDownPartial(KeyRoutedEventArgs args)
 	{
 		if (!IsSkiaTextBox)
 		{
@@ -641,7 +646,7 @@ public partial class TextBox
 				_contextMenu.Opened += (_, _) => UpdateDisplaySelection();
 
 				// TODO: confirm localized names match WinUI
-				var resourceLoader = ApplicationModel.Resources.ResourceLoader.GetForCurrentView();
+				var resourceLoader = Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView();
 				_flyoutItems.Add(ContextMenuItem.Cut, new MenuFlyoutItem { Text = resourceLoader.GetString("TextBoxCut"), Command = new TextBoxCommand(CutSelectionToClipboard), Icon = new SymbolIcon(Symbol.Cut) });
 				_flyoutItems.Add(ContextMenuItem.Copy, new MenuFlyoutItem { Text = resourceLoader.GetString("TextBoxCopy"), Command = new TextBoxCommand(CopySelectionToClipboard), Icon = new SymbolIcon(Symbol.Copy) });
 				_flyoutItems.Add(ContextMenuItem.Paste, new MenuFlyoutItem { Text = resourceLoader.GetString("TextBoxPaste"), Command = new TextBoxCommand(PasteFromClipboard), Icon = new SymbolIcon(Symbol.Paste) });
@@ -793,7 +798,7 @@ public partial class TextBox
 		var rect = DisplayBlockInlines.GetRectForTextBlockIndex(selectionStart + selectionLength);
 		var x = shift && selectionLength > 0 ? rect.Right : rect.Left;
 		var y = (newLineIndex + 0.5) * rect.Height; // 0.5 is to get the center of the line, rect.Height is line height
-		var index = DisplayBlockInlines.GetIndexForTextBlock(new Point(x,y), true);
+		var index = DisplayBlockInlines.GetIndexForTextBlock(new Point(x, y), true);
 		if (text.Length > index - 1
 			&& index - 1 >= 0
 			&& index == lines[newLineIndex].start + lines[newLineIndex].length
@@ -818,7 +823,7 @@ public partial class TextBox
 		var startLineIndex = lines.IndexOf(startLine);
 		var endLineIndex = lines.IndexOf(endLine);
 
-		if (!shift && (startLineIndex == lines.Count -1 || endLineIndex == lines.Count -1))
+		if (!shift && (startLineIndex == lines.Count - 1 || endLineIndex == lines.Count - 1))
 		{
 			return text.Length; // last line, goes to the end
 		}
@@ -828,7 +833,7 @@ public partial class TextBox
 		var rect = DisplayBlockInlines.GetRectForTextBlockIndex(selectionStart + selectionLength);
 		var x = shift && selectionLength > 0 ? rect.Right : rect.Left;
 		var y = (newLineIndex + 0.5) * rect.Height; // 0.5 is to get the center of the line, rect.Height is line height
-		var index = DisplayBlockInlines.GetIndexForTextBlock(new Point(x,y), true);
+		var index = DisplayBlockInlines.GetIndexForTextBlock(new Point(x, y), true);
 		if (text.Length > index - 1
 			&& index - 1 >= 0
 			&& index == lines[newLineIndex].start + lines[newLineIndex].length
@@ -931,7 +936,7 @@ public partial class TextBox
 		var text = Text;
 
 		i--;
-		for (;i >= 0; i--)
+		for (; i >= 0; i--)
 		{
 			var c = text[i];
 			if (c == '\r')
@@ -945,11 +950,11 @@ public partial class TextBox
 
 	private int EndOfLine(int i)
 	{
-        var index = Text.IndexOf('\r', i);
+		var index = Text.IndexOf('\r', i);
 		return index == -1 ? Text.Length - 1 : index;
 	}
 
-	private partial void OnTextChangedPartial()
+	partial void OnTextChangedPartial()
 	{
 		if (IsSkiaTextBox)
 		{
@@ -964,7 +969,7 @@ public partial class TextBox
 		}
 	}
 
-	private partial void OnFocusStateChangedPartial2(FocusState focusState)
+	partial void OnFocusStateChangedPartial2(FocusState focusState)
 	{
 		if (IsSkiaTextBox)
 		{
@@ -977,7 +982,7 @@ public partial class TextBox
 		}
 	}
 
-	private partial void PasteFromClipboardPartial(string clipboardText, int selectionStart, int selectionLength, string newText)
+	partial void PasteFromClipboardPartial(string clipboardText, int selectionStart, int selectionLength, string newText)
 	{
 		if (IsSkiaTextBox)
 		{
@@ -985,7 +990,7 @@ public partial class TextBox
 		}
 	}
 
-	private partial void CutSelectionToClipboardPartial()
+	partial void CutSelectionToClipboardPartial()
 	{
 		if (IsSkiaTextBox)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -9,6 +9,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 using Uno.Extensions;
 using Uno.UI;
+using Uno.UI.Helpers.WinUI;
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;
@@ -645,13 +646,12 @@ public partial class TextBox
 				_contextMenu = new MenuFlyout();
 				_contextMenu.Opened += (_, _) => UpdateDisplaySelection();
 
-				// TODO: confirm localized names match WinUI
-				var resourceLoader = Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView();
-				_flyoutItems.Add(ContextMenuItem.Cut, new MenuFlyoutItem { Text = resourceLoader.GetString("TextBoxCut"), Command = new TextBoxCommand(CutSelectionToClipboard), Icon = new SymbolIcon(Symbol.Cut) });
-				_flyoutItems.Add(ContextMenuItem.Copy, new MenuFlyoutItem { Text = resourceLoader.GetString("TextBoxCopy"), Command = new TextBoxCommand(CopySelectionToClipboard), Icon = new SymbolIcon(Symbol.Copy) });
-				_flyoutItems.Add(ContextMenuItem.Paste, new MenuFlyoutItem { Text = resourceLoader.GetString("TextBoxPaste"), Command = new TextBoxCommand(PasteFromClipboard), Icon = new SymbolIcon(Symbol.Paste) });
+				// TODO: port localized resources from WinUI
+				_flyoutItems.Add(ContextMenuItem.Cut, new MenuFlyoutItem { Text = ResourceAccessor.GetLocalizedStringResource("TextBoxCut"), Command = new TextBoxCommand(CutSelectionToClipboard), Icon = new SymbolIcon(Symbol.Cut) });
+				_flyoutItems.Add(ContextMenuItem.Copy, new MenuFlyoutItem { Text = ResourceAccessor.GetLocalizedStringResource("TextBoxCopy"), Command = new TextBoxCommand(CopySelectionToClipboard), Icon = new SymbolIcon(Symbol.Copy) });
+				_flyoutItems.Add(ContextMenuItem.Paste, new MenuFlyoutItem { Text = ResourceAccessor.GetLocalizedStringResource("TextBoxPaste"), Command = new TextBoxCommand(PasteFromClipboard), Icon = new SymbolIcon(Symbol.Paste) });
 				// undo/redo
-				_flyoutItems.Add(ContextMenuItem.SelectAll, new MenuFlyoutItem { Text = resourceLoader.GetString("TextBoxSelectAll"), Command = new TextBoxCommand(SelectAll), Icon = new SymbolIcon(Symbol.SelectAll) });
+				_flyoutItems.Add(ContextMenuItem.SelectAll, new MenuFlyoutItem { Text = ResourceAccessor.GetLocalizedStringResource("TextBoxSelectAll"), Command = new TextBoxCommand(SelectAll), Icon = new SymbolIcon(Symbol.SelectAll) });
 			}
 
 			_contextMenu.Items.Clear();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -336,9 +336,15 @@ public partial class TextBox
 				selectionStart = 0;
 				selectionLength = text.Length;
 				break;
+			case VirtualKey.X when ctrl:
+				args.Handled = true;
+				CutSelectionToClipboard();
+				selectionLength = 0;
+				text = Text;
+				break;
 			case VirtualKey.V when ctrl:
 				args.Handled = true;
-				PasteFromClipboard();
+				PasteFromClipboard(); // async so doesn't actually do anything right now
 				break;
 			case VirtualKey.C when ctrl:
 				args.Handled = true;
@@ -541,8 +547,8 @@ public partial class TextBox
 
 		public void Execute(object parameter) => _action();
 
+#pragma warning disable 67 // An event was declared but never used in the class in which it was declared.
 		public event EventHandler CanExecuteChanged;
-
-		private void OnCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+#pragma warning restore 67 // An event was declared but never used in the class in which it was declared.
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -187,5 +187,20 @@ namespace Windows.UI.Xaml.Controls
 				_textBoxView.SelectionEnd = _textBoxView.SelectionStart + value;
 			}
 		}
+
+		protected override void OnPointerMoved(PointerRoutedEventArgs e)
+		{
+			base.OnPointerMoved(e);
+		}
+
+		protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs e)
+		{
+			base.OnDoubleTapped(e);
+		}
+
+		protected override void OnRightTapped(RightTappedRoutedEventArgs e)
+		{
+			base.OnRightTapped(e);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 
 using System;
-
 using Uno.Extensions;
 using Uno.Foundation.Extensibility;
 using Uno.Foundation.Logging;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -94,6 +94,14 @@ namespace Windows.UI.Xaml.Controls
 			DisplayBlock.TextAlignment = textAlignment;
 		}
 
+		internal void SetWrapping()
+		{
+			if (_textBox?.GetTarget() is { } textBox)
+			{
+				DisplayBlock.TextWrapping = textBox.TextWrapping;
+			}
+		}
+
 		internal void OnForegroundChanged(Brush brush)
 		{
 			DisplayBlock.Foreground = brush;
@@ -134,9 +142,17 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		internal void OnFontFamilyChanged(FontFamily fontFamily)
+		internal void UpdateFont()
 		{
-			DisplayBlock.FontFamily = fontFamily;
+			var textBox = _textBox?.GetTarget();
+			if (textBox != null)
+			{
+				DisplayBlock.FontFamily = textBox.FontFamily;
+				DisplayBlock.FontSize = textBox.FontSize;
+				DisplayBlock.FontStyle = textBox.FontStyle;
+				DisplayBlock.FontStretch = textBox.FontStretch;
+				DisplayBlock.FontWeight = textBox.FontWeight;
+			}
 			// TODO: Propagate font family to the native InputWidget via _textBoxExtension.
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -191,7 +191,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				DisplayBlock.Text = text;
 
-				if (text.EndsWith("\r"))
+				if (text.EndsWith("\r", StringComparison.Ordinal))
 				{
 					// this works around a bug in TextBlock where the last newline is not shown
 					DisplayBlock.Text += '\r';

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -190,6 +190,12 @@ namespace Windows.UI.Xaml.Controls
 			else
 			{
 				DisplayBlock.Text = text;
+
+				if (text.EndsWith("\r"))
+				{
+					// this works around a bug in TextBlock where the last newline is not shown
+					DisplayBlock.Text += '\r';
+				}
 			}
 
 			if (!FeatureConfiguration.TextBox.UseOverlayOnSkia)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -191,7 +191,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				DisplayBlock.Text = text;
 
-				if (text.EndsWith("\r", StringComparison.Ordinal))
+				if (text.EndsWith('\r'))
 				{
 					// this works around a bug in TextBlock where the last newline is not shown
 					DisplayBlock.Text += '\r';

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -176,6 +176,12 @@ namespace Windows.UI.Xaml.Controls
 			{
 				DisplayBlock.Text = text;
 			}
+
+			if (!FeatureConfiguration.TextBox.UseOverlayOnSkia)
+			{
+				TextBox?.ContentElement?.InvalidateMeasure();
+				TextBox?.UpdateLayout();
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -7,6 +7,7 @@ using Uno.Foundation.Extensibility;
 using Uno.Foundation.Logging;
 using Uno.UI.Xaml.Controls.Extensions;
 using Windows.UI.Xaml.Media;
+using Uno.UI;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -25,7 +26,7 @@ namespace Windows.UI.Xaml.Controls
 
 			_textBox = new WeakReference<TextBox>(textBox);
 			_isPasswordBox = textBox is PasswordBox;
-			if (!ApiExtensibility.CreateInstance(this, out _textBoxExtension))
+			if (FeatureConfiguration.TextBox.UseOverlayOnSkia && !ApiExtensibility.CreateInstance(this, out _textBoxExtension))
 			{
 				if (this.Log().IsEnabled(LogLevel.Warning))
 				{
@@ -37,7 +38,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public (int start, int length) SelectionBeforeKeyDown =>
-			(_textBoxExtension!.GetSelectionStartBeforeKeyDown(), _textBoxExtension.GetSelectionLengthBeforeKeyDown());
+			(_textBoxExtension?.GetSelectionStartBeforeKeyDown() ?? 0, _textBoxExtension?.GetSelectionLengthBeforeKeyDown() ?? 0);
 
 		internal IOverlayTextBoxViewExtension? Extension => _textBoxExtension;
 
@@ -108,6 +109,11 @@ namespace Windows.UI.Xaml.Controls
 
 		internal void OnFocusStateChanged(FocusState focusState)
 		{
+			if (!FeatureConfiguration.TextBox.UseOverlayOnSkia)
+			{
+				return;
+			}
+
 			if (focusState != FocusState.Unfocused)
 			{
 				DisplayBlock.Opacity = 0;

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -238,7 +238,7 @@ namespace Windows.UI.Xaml.Documents
 			}
 			else
 			{
-				_lastDesiredSize = new Size(widestLineWidth + (RenderSelectionAndCaret && Caret is { } c && c.color != Colors.Transparent ? widestLineHeight * CaretThicknessAsRatioOfLineHeight : 0), height);
+				_lastDesiredSize = new Size(widestLineWidth, height);
 			}
 
 			return _lastDesiredSize;
@@ -312,7 +312,7 @@ namespace Windows.UI.Xaml.Documents
 		/// <summary>
 		/// Renders a block-level inline collection, i.e. one that belongs to a TextBlock (or Paragraph, in the future).
 		/// </summary>
-		internal virtual void Draw(in DrawingSession session)
+		internal void Draw(in DrawingSession session)
 		{
 			if (_renderLines.Count == 0)
 			{
@@ -451,6 +451,7 @@ namespace Windows.UI.Xaml.Documents
 						}
 					}
 
+					// Warning: this is only tested and currently used by single-line single-run skia-based TextBoxes
 					{
 						if (RenderSelectionAndCaret && Selection is { } bg && bg.startLine <= lineIndex && lineIndex <= bg.endLine)
 						{
@@ -543,6 +544,7 @@ namespace Windows.UI.Xaml.Documents
 					using var textBlob = _textBlobBuilder.Build();
 					canvas.DrawText(textBlob, 0, y + baselineOffsetY, paint);
 
+					// Warning: this is only tested and currently used by single-line single-run skia-based TextBoxes
 					{
 						var spanStartingIndex = characterCountSoFar - currentCharacterCount;
 						if (RenderSelectionAndCaret && Caret is { } caret && Selection is { } selection)
@@ -587,6 +589,7 @@ namespace Windows.UI.Xaml.Documents
 			}
 		}
 
+		// Warning: this is only tested and currently used by single-line single-run skia-based TextBoxes
 		internal int GetIndexForTextBlock(Point p)
 		{
 			var line = GetRenderLineAt(p.Y, true)!;
@@ -634,6 +637,7 @@ namespace Windows.UI.Xaml.Documents
 			return characterCount;
 		}
 
+		// Warning: this is only tested and currently used by single-line single-run skia-based TextBoxes
 		internal Rect GetRectForTextBlockIndex(int index)
 		{
 			var characterCount = 0;

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -121,8 +121,8 @@ namespace Windows.UI.Xaml.Documents
 							int trailingSpaces = 0;
 
 							while (start + length < end &&
-								   (width + GetGlyphWidthWithSpacing(segment.Glyphs[length], characterSpacing)) is var newWidth &&
-								   newWidth <= remainingWidth)
+								(width + GetGlyphWidthWithSpacing(segment.Glyphs[length], characterSpacing)) is var newWidth &&
+								newWidth <= remainingWidth)
 							{
 								width = newWidth;
 								length++;
@@ -161,8 +161,8 @@ namespace Windows.UI.Xaml.Documents
 							}
 
 							while (spaces < segment.LeadingSpaces &&
-								   (width + GetGlyphWidthWithSpacing(segment.Glyphs[spaces], characterSpacing)) is var newWidth &&
-								   newWidth < remainingWidth)
+								(width + GetGlyphWidthWithSpacing(segment.Glyphs[spaces], characterSpacing)) is var newWidth &&
+								newWidth < remainingWidth)
 							{
 								width = newWidth;
 								spaces++;

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using SkiaSharp;
 using Windows.Foundation;
-using Windows.UI.Composition;
 using Windows.UI.Text;
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents.TextFormatting;
 using Windows.UI.Xaml.Media;
 using Uno.UI.Composition;
@@ -39,7 +37,7 @@ namespace Windows.UI.Xaml.Documents
 		private bool _lineIntervalsValid;
 
 		// these should only be used by TextBox.
-		internal (int startLine, int startIndex, int endLine, int endIndex)? Selection { get; set; }
+		internal SelectionDetails? Selection { get; set; }
 		internal bool CaretAtEndOfSelection { get; set; }
 		internal bool RenderSelectionAndCaret { get; set; }
 
@@ -457,22 +455,22 @@ namespace Windows.UI.Xaml.Documents
 					}
 
 					{
-						if (RenderSelectionAndCaret && Selection is { } bg && bg.startLine <= lineIndex && lineIndex <= bg.endLine)
+						if (RenderSelectionAndCaret && Selection is { } bg && bg.StartLine <= lineIndex && lineIndex <= bg.EndLine)
 						{
 							var spanStartingIndex = characterCountSoFar;
 
 							// x at this point is set to the right of the rightmost character ignoring spaces.
 
 							float left;
-							if (bg.startIndex < spanStartingIndex)
+							if (bg.StartIndex < spanStartingIndex)
 							{
 								// the selection starts from a previous span, so this span is selected from the very beginning
 								left = positions.Length > 0 ? positions[0].X : x;
 							}
-							else if (bg.startIndex - spanStartingIndex < positions.Length)
+							else if (bg.StartIndex - spanStartingIndex < positions.Length)
 							{
 								// part or all of this span is selected
-								left = positions[bg.startIndex - spanStartingIndex].X;
+								left = positions[bg.StartIndex - spanStartingIndex].X;
 							}
 							else
 							{
@@ -481,15 +479,15 @@ namespace Windows.UI.Xaml.Documents
 							}
 
 							float right;
-							if (bg.endIndex - spanStartingIndex < 0)
+							if (bg.EndIndex - spanStartingIndex < 0)
 							{
 								// this span is not a part of the selection, so we select nothing by making the left edge to the far left
 								right = positions.Length > 0 ? positions[0].X : x;
 							}
-							else if (bg.endIndex - spanStartingIndex < positions.Length)
+							else if (bg.EndIndex - spanStartingIndex < positions.Length)
 							{
 								// part or all of this span is selected
-								right = positions[bg.endIndex - spanStartingIndex].X;
+								right = positions[bg.EndIndex - spanStartingIndex].X;
 							}
 							else
 							{
@@ -497,7 +495,7 @@ namespace Windows.UI.Xaml.Documents
 								var allTrailingSpaces = segmentSpan.FullGlyphsLength - segmentSpan.GlyphsLength; // rendered and non-rendered trailing spaces
 								right = x + justifySpaceOffset * allTrailingSpaces;
 
-								if (bg.startIndex != bg.endIndex && SpanEndsInCR(segment, segmentSpan))
+								if (bg.StartIndex != bg.EndIndex && SpanEndsInCR(segment, segmentSpan))
 								{
 									// fontInfo.SKFontSize / 3 is a heuristic width of a selected \r, which normally doesn't have a width
 									right += (segment.LineBreakAfter ? fontInfo.SKFontSize / 3 : 0);
@@ -521,7 +519,7 @@ namespace Windows.UI.Xaml.Documents
 						var spanStartingIndex = characterCountSoFar;
 						if (RenderSelectionAndCaret && Selection is { } selection)
 						{
-							var (l, i) = CaretAtEndOfSelection ? (selection.endLine, selection.endIndex) : (selection.startLine, selection.startIndex);
+							var (l, i) = CaretAtEndOfSelection ? (selection.EndLine, selection.EndIndex) : (selection.StartLine, selection.StartIndex);
 
 							float caretLocation = float.MinValue;
 
@@ -755,5 +753,7 @@ namespace Windows.UI.Xaml.Documents
 
 		private static bool SpanEndsInCR(Segment segment, RenderSegmentSpan segmentSpan)
 			=> segment.Length > segmentSpan.GlyphsStart + segmentSpan.FullGlyphsLength && segment.Text[segmentSpan.GlyphsStart + segmentSpan.FullGlyphsLength] == '\r';
+
+		internal record SelectionDetails(int StartLine, int StartIndex, int EndLine, int EndIndex);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -6,6 +6,7 @@ using Windows.Foundation;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Documents.TextFormatting;
 using Windows.UI.Xaml.Media;
+using Uno.Foundation.Logging;
 using Uno.UI.Composition;
 
 #nullable enable
@@ -752,7 +753,21 @@ namespace Windows.UI.Xaml.Documents
 			=> span.FullGlyphsLength + (SpanEndsInCR(span.Segment, span) ? 1 : 0);
 
 		private static bool SpanEndsInCR(Segment segment, RenderSegmentSpan segmentSpan)
-			=> segment.Length > segmentSpan.GlyphsStart + segmentSpan.FullGlyphsLength && segment.Text[segmentSpan.GlyphsStart + segmentSpan.FullGlyphsLength] == '\r';
+		{
+			try
+			{
+				return segment.Length > segmentSpan.GlyphsStart + segmentSpan.FullGlyphsLength && segment.Text[segmentSpan.GlyphsStart + segmentSpan.FullGlyphsLength] == '\r';
+			}
+			catch (Exception)
+			{
+				if (segment.Log().IsEnabled(LogLevel.Error))
+				{
+					// There's an exception that happens in CI for some reason. Root cause unknown for now
+					segment.Log().Error($"Unexpected exception: segment.Length = {segment.Length}, segmentSpan.[GlyphsStart,FullGlyphsLength] = [{segmentSpan.GlyphsStart},{segmentSpan.FullGlyphsLength}]");
+				}
+				return false;
+			}
+		}
 
 		internal record SelectionDetails(int StartLine, int StartIndex, int EndLine, int EndIndex);
 	}

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using SkiaSharp;
 using Windows.Foundation;
 using Windows.UI.Composition;
@@ -38,7 +36,7 @@ namespace Windows.UI.Xaml.Documents
 
 		// these should only be used by TextBox.
 		internal (int startLine, int startIndex, int endLine, int endIndex)? Selection { get; set; }
-		internal (bool atEndOfSelection, Color color)? Caret { get; set; }
+		internal (bool atEndOfSelection, Windows.UI.Color color)? Caret { get; set; }
 		internal bool RenderSelectionAndCaret { get; set; }
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Documents/TextFormatting/RenderSegmentSpan.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextFormatting/RenderSegmentSpan.skia.cs
@@ -3,5 +3,13 @@
 	/// <summary>
 	/// Represents a span of a segment that is rendered on a render line.
 	/// </summary>
-	internal record RenderSegmentSpan(Segment Segment, int GlyphsStart, int GlyphsLength, int TrailingSpaces, float CharacterSpacing, float Width, float WidthWithoutTrailingSpaces);
+	/// <param name="Segment">The entire segment that the span is a part of. The segment gets broken into spans based on rendering needs (e.g. wrapping).</param>
+	/// <param name="GlyphsStart">The index of the span's first glyph in Segment. i.e. Segment[GlyphsStart] will get the first glyph in the span.</param>
+	/// <param name="GlyphsLength">The number of rendered glyphs in the span. i.e. Segment[GlyphsStart + GlyphsLength - 1] will get the last glyph in the span. This includes rendered trailing spaces but not newline glyphs ('\r', '\n', etc.) and doesn't include any non-rendered glyphs. Non-rendered glyphs are trailing spaces that don't fit the rendering width. In that case, the spaces are just not rendered at all and don't get added to the next line like any other glyph would.</param>
+	/// <param name="TrailingSpaces">The number of rendered trailing spaces in the span. Similarly to GlyphsLength, this includes rendered trailing spaces but not newlines ('\r', '\n', etc.) and doesn't include any non-rendered glyphs. Non-rendered glyphs are trailing spaces only.</param>
+	/// <param name="Width">The width of the span as rendered. This includes rendered trailing spaces.</param>
+	/// <param name="WidthWithoutTrailingSpaces">The width of the span as rendered without any trailing spaces.</param>
+	/// <param name="Width">The number of rendered trailing spaces in the span. Similarly to GlyphsLength, this includes rendered trailing spaces but not newlines ('\r', '\n', etc.) and doesn't include any non-rendered glyphs. Non-rendered glyphs are trailing spaces only.</param>
+	/// <param name="FullGlyphsLength">The number of rendered and non-rendered glyphs in the span. i.e. Segment[GlyphsStart + FullGlyphsLength - 1] will get the last glyph in the span. This includes all trailing spaces, even the ones that aren't actually rendered due to running out of width. This does not include newline glyphs.</param>
+	internal record RenderSegmentSpan(Segment Segment, int GlyphsStart, int GlyphsLength, int TrailingSpaces, float CharacterSpacing, float Width, float WidthWithoutTrailingSpaces, int FullGlyphsLength);
 }

--- a/src/Uno.UI/UI/Xaml/Input/KeyRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/KeyRoutedEventArgs.cs
@@ -9,13 +9,14 @@ namespace Windows.UI.Xaml.Input
 	{
 		private readonly CorePhysicalKeyStatus? _keyStatus;
 
-		internal KeyRoutedEventArgs(object originalSource, VirtualKey key, VirtualKeyModifiers modifiers, CorePhysicalKeyStatus? keyStatus = null)
+		internal KeyRoutedEventArgs(object originalSource, VirtualKey key, VirtualKeyModifiers modifiers, CorePhysicalKeyStatus? keyStatus = null, char? unicodeKey = null)
 			: base(originalSource)
 		{
 			Key = key;
 			OriginalKey = key;
 			KeyboardModifiers = modifiers;
 			_keyStatus = keyStatus;
+			UnicodeKey = unicodeKey;
 		}
 
 		public bool Handled { get; set; }
@@ -44,5 +45,11 @@ namespace Windows.UI.Xaml.Input
 		public global::Windows.System.VirtualKey OriginalKey { get; }
 
 		internal VirtualKeyModifiers KeyboardModifiers { get; }
+
+		/// <summary>
+		/// This gets the the Unicode Key associated with the event. This is not limited to the
+		/// VirtualKey options. Currently, this is only implemented for skia.
+		/// </summary>
+		internal char? UnicodeKey { get; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Keyboard.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Keyboard.skia.cs
@@ -54,7 +54,7 @@ partial class InputManager
 
 			originalSource.RaiseEvent(
 				UIElement.KeyDownEvent,
-				new KeyRoutedEventArgs(originalSource, args.VirtualKey, args.KeyboardModifiers, args.KeyStatus)
+				new KeyRoutedEventArgs(originalSource, args.VirtualKey, args.KeyboardModifiers, args.KeyStatus, args.UnicodeKey)
 				{
 					CanBubbleNatively = false
 				}
@@ -84,7 +84,7 @@ partial class InputManager
 
 			originalSource.RaiseEvent(
 				UIElement.KeyUpEvent,
-				new KeyRoutedEventArgs(originalSource, args.VirtualKey, args.KeyboardModifiers, args.KeyStatus)
+				new KeyRoutedEventArgs(originalSource, args.VirtualKey, args.KeyboardModifiers, args.KeyStatus, args.UnicodeKey)
 				{
 					CanBubbleNatively = false
 				}

--- a/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
@@ -72,8 +72,8 @@
 			<x:Double x:Key="ComboBoxThemeMinWidth">64</x:Double>
 			<x:Double x:Key="ComboBoxPopupThemeMinWidth">80</x:Double>
 			<x:Double x:Key="ComboBoxPopupThemeTouchMinWidth">240</x:Double>
-			<x:Double x:Key="ControlContentThemeFontSize">15</x:Double>
-			<x:Double x:Key="ContentControlFontSize">15</x:Double>
+			<x:Double x:Key="ControlContentThemeFontSize">14</x:Double>
+			<x:Double x:Key="ContentControlFontSize">14</x:Double>
 			<x:Double x:Key="ContentDialogMinWidth">320</x:Double>
 			<x:Double x:Key="ContentDialogMaxWidth">548</x:Double>
 			<x:Double x:Key="ContentDialogMinHeight">184</x:Double>
@@ -1378,8 +1378,8 @@
 			<x:Double x:Key="ComboBoxThemeMinWidth">64</x:Double>
 			<x:Double x:Key="ComboBoxPopupThemeMinWidth">80</x:Double>
 			<x:Double x:Key="ComboBoxPopupThemeTouchMinWidth">240</x:Double>
-			<x:Double x:Key="ControlContentThemeFontSize">15</x:Double>
-			<x:Double x:Key="ContentControlFontSize">15</x:Double>
+			<x:Double x:Key="ControlContentThemeFontSize">14</x:Double>
+			<x:Double x:Key="ContentControlFontSize">14</x:Double>
 			<x:Double x:Key="ContentDialogMinWidth">320</x:Double>
 			<x:Double x:Key="ContentDialogMaxWidth">548</x:Double>
 			<x:Double x:Key="ContentDialogMinHeight">184</x:Double>
@@ -2672,8 +2672,8 @@
 			<x:Double x:Key="ComboBoxThemeMinWidth">64</x:Double>
 			<x:Double x:Key="ComboBoxPopupThemeMinWidth">80</x:Double>
 			<x:Double x:Key="ComboBoxPopupThemeTouchMinWidth">240</x:Double>
-			<x:Double x:Key="ControlContentThemeFontSize">15</x:Double>
-			<x:Double x:Key="ContentControlFontSize">15</x:Double>
+			<x:Double x:Key="ControlContentThemeFontSize">14</x:Double>
+			<x:Double x:Key="ContentControlFontSize">14</x:Double>
 			<x:Double x:Key="ContentDialogMinWidth">320</x:Double>
 			<x:Double x:Key="ContentDialogMaxWidth">548</x:Double>
 			<x:Double x:Key="ContentDialogMinHeight">184</x:Double>

--- a/src/Uno.UWP/System/KeyEventArgs.cs
+++ b/src/Uno.UWP/System/KeyEventArgs.cs
@@ -8,12 +8,13 @@ namespace Windows.UI.Core
 {
 	public partial class KeyEventArgs : ICoreWindowEventArgs
 	{
-		internal KeyEventArgs(string deviceId, VirtualKey virtualKey, VirtualKeyModifiers modifiers, CorePhysicalKeyStatus keyStatus)
+		internal KeyEventArgs(string deviceId, VirtualKey virtualKey, VirtualKeyModifiers modifiers, CorePhysicalKeyStatus keyStatus, char? unicodeKey = null)
 		{
 			DeviceId = deviceId;
 			VirtualKey = virtualKey;
 			KeyboardModifiers = modifiers;
 			KeyStatus = keyStatus;
+			UnicodeKey = unicodeKey;
 		}
 
 		public bool Handled { get; set; }
@@ -25,5 +26,11 @@ namespace Windows.UI.Core
 		public string DeviceId { get; }
 
 		internal VirtualKeyModifiers KeyboardModifiers { get; }
+
+		/// <summary>
+		/// This gets the the Unicode Key associated with the event. This is not limited to the
+		/// VirtualKey options. Currently, this is only implemented for skia.
+		/// </summary>
+		internal char? UnicodeKey { get; }
 	}
 }

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -23,7 +23,7 @@ namespace Windows.UI.Input
 		/// <summary>
 		/// This is the state machine which handles the gesture ([Double|Right]Tapped and Holding gestures)
 		/// </summary>
-		private class Gesture
+		internal class Gesture
 		{
 			private readonly GestureRecognizer _recognizer;
 			private DispatcherQueueTimer? _holdingTimer;


### PR DESCRIPTION
GitHub Issue (If applicable): #9417

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at acf7c2e</samp>

This pull request adds support for Unicode characters in key events on the Skia platform, by using platform-specific APIs to map keycodes to Unicode and adding a new `UnicodeKey` property to the `KeyRoutedEventArgs` and `KeyEventArgs` classes. It also adds a feature flag to allow switching between using a native overlay or a skia-based implementation for the `TextBox` control on the Skia platform, and fixes some layout, selection, and hyperlink issues for the `TextBlock` and `TextBox` controls.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
