### PR TITLE
Fix `DoubleTapped` not fired properly when a child subscribes to `Tapped`

### DIFF
--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
@@ -72,7 +72,7 @@ namespace Private.Infrastructure
 #else
 				// fall back to a tap event on platforms where InputInjector isn't implemented. Ideally tap should be triggered
 				// by GestureRecognizer when a pointer is pressed and released, but here we do a hacky workaround
-				var args = new TappedEventArgs(PointerDeviceType.Touch, default, 1);
+				var args = new TappedEventArgs(1, PointerDeviceType.Touch, default, 1);
 				element.SafeRaiseEvent(UIElement.TappedEvent, new TappedRoutedEventArgs(element, args));
 #endif
 			}

--- a/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -2048,10 +2048,10 @@ namespace Uno.UI.Tests.Windows_UI_Input
 		}
 
 		public static TappedEventArgs Tap(double x, double y, uint tapCount = 1, PointerDeviceType? device = null)
-			=> new TappedEventArgs(device ?? _currentPointer.Value.device?.PointerDeviceType ?? PointerDeviceType.Touch, new Point(x, y), tapCount);
+			=> new TappedEventArgs(1, device ?? _currentPointer.Value.device?.PointerDeviceType ?? PointerDeviceType.Touch, new Point(x, y), tapCount);
 
 		public static RightTappedEventArgs RightTap(double x, double y, PointerDeviceType? device = null)
-			=> new RightTappedEventArgs(device ?? _currentPointer.Value.device?.PointerDeviceType ?? PointerDeviceType.Touch, new Point(x, y));
+			=> new RightTappedEventArgs(1, device ?? _currentPointer.Value.device?.PointerDeviceType ?? PointerDeviceType.Touch, new Point(x, y));
 
 		public static HoldingEventArgs Hold(double x, double y, HoldingState state, PointerDeviceType? device = null, uint? ptId = null)
 			=> new HoldingEventArgs(ptId ?? 1, device ?? _currentPointer.Value.device?.PointerDeviceType ?? PointerDeviceType.Touch, new Point(x, y), state);

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -649,6 +649,12 @@ namespace Uno.UI
 			/// </remarks>
 			public static bool AlwaysClipNativeChildren { get; set; } = true;
 #endif
+
+			/// <summary>
+			/// For non-holding pointer events, use CompleteGesture when bubbling gesture events.
+			/// This defaults to false, which prevents the specific event instead of calling CompleteGesture
+			/// </summary>
+			public static bool DisablePointersSpecificEventPrevention { get; set; }
 		}
 
 		public static class VisualState

--- a/src/Uno.UI/UI/Xaml/Input/DoubleTappedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/DoubleTappedRoutedEventArgs.cs
@@ -23,7 +23,10 @@ namespace Windows.UI.Xaml.Input
 			_originalSource = originalSource;
 			PointerDeviceType = args.PointerDeviceType;
 			_position = args.Position;
+			PointerId = args.PointerId;
 		}
+
+		internal uint PointerId { get; }
 
 		public bool Handled { get; set; }
 

--- a/src/Uno.UI/UI/Xaml/Input/RightTappedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/RightTappedRoutedEventArgs.cs
@@ -22,11 +22,14 @@ namespace Windows.UI.Xaml.Input
 			_originalSource = originalSource;
 			_position = args.Position;
 			PointerDeviceType = args.PointerDeviceType;
+			PointerId = args.PointerId;
 		}
 
 		public bool Handled { get; set; }
 
 		public PointerDeviceType PointerDeviceType { get; }
+
+		internal uint PointerId { get; }
 
 		public Point GetPosition(UIElement relativeTo)
 		{

--- a/src/Uno.UI/UI/Xaml/Input/TappedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/TappedRoutedEventArgs.cs
@@ -26,7 +26,10 @@ namespace Windows.UI.Xaml.Input
 			_originalSource = originalSource;
 			_position = args.Position;
 			PointerDeviceType = (PointerDeviceType)args.PointerDeviceType;
+			PointerId = args.PointerId;
 		}
+
+		internal uint PointerId { get; }
 
 		public bool Handled { get; set; }
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -549,18 +549,24 @@ namespace Windows.UI.Xaml
 		partial void PrepareManagedGestureEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref BubblingMode bubblingMode)
 		{
 			// When we bubble a gesture event from a child, we make sure to abort any pending gesture/manipulation on the current element
-			if (routedEvent == HoldingEvent)
+			if (IsGestureRecognizerCreated)
 			{
-				if (IsGestureRecognizerCreated)
+				if (routedEvent == TappedEvent)
+				{
+					GestureRecognizer.PreventEvents(((TappedRoutedEventArgs)args).PointerId, GestureSettings.Tap);
+				}
+				else if (routedEvent == DoubleTappedEvent)
+				{
+					GestureRecognizer.PreventEvents(((DoubleTappedRoutedEventArgs)args).PointerId, GestureSettings.DoubleTap);
+				}
+				else if (routedEvent == RightTappedEvent)
+				{
+					GestureRecognizer.PreventEvents(((RightTappedRoutedEventArgs)args).PointerId, GestureSettings.RightTap);
+				}
+				else if (routedEvent == HoldingEvent)
 				{
 					GestureRecognizer.PreventEvents(((HoldingRoutedEventArgs)args).PointerId, GestureSettings.Hold);
 				}
-			}
-			else
-			{
-				// Note: Here we should prevent only the same gesture ... but actually currently supported gestures
-				// are mutually exclusive, so if a child element detected a gesture, it's safe to prevent all of them.
-				CompleteGesture(); // Make sure to set the flag _isGestureCompleted, so won't try to recognize double tap
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -548,6 +548,14 @@ namespace Windows.UI.Xaml
 
 		partial void PrepareManagedGestureEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref BubblingMode bubblingMode)
 		{
+			if (routedEvent != HoldingEvent && FeatureConfiguration.UIElement.DisablePointersSpecificEventPrevention)
+			{
+				// If the feature flag is set, call CompleteGesture.
+				// This is known to not be correct, but it's there just in case the prevention logic caused regressions.
+				CompleteGesture();
+				return;
+			}
+
 			// When we bubble a gesture event from a child, we make sure to abort any pending gesture/manipulation on the current element
 			if (IsGestureRecognizerCreated)
 			{

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -142,19 +142,20 @@ namespace Windows.UI.Input
 
 			private bool TryRecognizeTap()
 			{
-				if (Settings.HasFlag(GestureSettings.Tap) && IsTapGesture(LeftButton, this))
+				var isTapGesture = IsTapGesture(LeftButton, this);
+				if (isTapGesture)
 				{
 					// Note: Up cannot be 'null' here!
-
 					_recognizer._lastSingleTap = (PointerIdentifier, Up!.Timestamp, Up.Position);
-					_recognizer.Tapped?.Invoke(_recognizer, new TappedEventArgs(Down.PointerId, PointerType, Down.Position, tapCount: 1));
 
-					return true;
+					if (Settings.HasFlag(GestureSettings.Tap))
+					{
+						_recognizer.Tapped?.Invoke(_recognizer, new TappedEventArgs(Down.PointerId, PointerType, Down.Position, tapCount: 1));
+						return true;
+					}
 				}
-				else
-				{
-					return false;
-				}
+
+				return false;
 			}
 
 			private bool TryRecognizeMultiTap()

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -122,6 +122,11 @@ namespace Windows.UI.Input
 
 			public void PreventGestures(GestureSettings gestures)
 			{
+				if ((gestures & GestureSettings.Hold) != 0)
+				{
+					StopHoldingTimer();
+				}
+
 				Settings &= ~gestures;
 				if ((Settings & GestureSettingsHelper.SupportedGestures) == GestureSettings.None)
 				{

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -120,37 +120,9 @@ namespace Windows.UI.Input
 				TryRecognize();
 			}
 
-			public void PreventTap()
+			public void PreventGestures(GestureSettings gestures)
 			{
-				Settings &= ~GestureSettings.Tap;
-				if ((Settings & GestureSettingsHelper.SupportedGestures) == GestureSettings.None)
-				{
-					IsCompleted = true;
-				}
-			}
-
-			public void PreventDoubleTap()
-			{
-				Settings &= ~GestureSettings.DoubleTap;
-				if ((Settings & GestureSettingsHelper.SupportedGestures) == GestureSettings.None)
-				{
-					IsCompleted = true;
-				}
-			}
-
-			public void PreventRightTap()
-			{
-				Settings &= ~GestureSettings.RightTap;
-				if ((Settings & GestureSettingsHelper.SupportedGestures) == GestureSettings.None)
-				{
-					IsCompleted = true;
-				}
-			}
-
-			public void PreventHolding()
-			{
-				StopHoldingTimer();
-				Settings &= ~(GestureSettings.Hold | GestureSettings.HoldWithMouse);
+				Settings &= ~gestures;
 				if ((Settings & GestureSettingsHelper.SupportedGestures) == GestureSettings.None)
 				{
 					IsCompleted = true;

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.Gesture.cs
@@ -147,7 +147,7 @@ namespace Windows.UI.Input
 					// Note: Up cannot be 'null' here!
 
 					_recognizer._lastSingleTap = (PointerIdentifier, Up!.Timestamp, Up.Position);
-					_recognizer.Tapped?.Invoke(_recognizer, new TappedEventArgs(PointerType, Down.Position, tapCount: 1));
+					_recognizer.Tapped?.Invoke(_recognizer, new TappedEventArgs(Down.PointerId, PointerType, Down.Position, tapCount: 1));
 
 					return true;
 				}
@@ -162,7 +162,7 @@ namespace Windows.UI.Input
 				if (Settings.HasFlag(GestureSettings.DoubleTap) && IsMultiTapGesture(_recognizer._lastSingleTap, Down))
 				{
 					_recognizer._lastSingleTap = default; // The Recognizer supports only double tap, even on UWP
-					_recognizer.Tapped?.Invoke(_recognizer, new TappedEventArgs(PointerType, Down.Position, tapCount: 2));
+					_recognizer.Tapped?.Invoke(_recognizer, new TappedEventArgs(Down.PointerId, PointerType, Down.Position, tapCount: 2));
 
 					return true;
 				}
@@ -176,7 +176,7 @@ namespace Windows.UI.Input
 			{
 				if (Settings.HasFlag(GestureSettings.RightTap) && IsRightTapGesture(this, out var isLongPress))
 				{
-					_recognizer.RightTapped?.Invoke(_recognizer, new RightTappedEventArgs(PointerType, Down.Position));
+					_recognizer.RightTapped?.Invoke(_recognizer, new RightTappedEventArgs(Down.PointerId, PointerType, Down.Position));
 
 					return true;
 				}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -183,8 +183,7 @@ namespace Windows.UI.Input
 		{
 			if (_gestures.TryGetValue(pointerId, out var gesture))
 			{
-				const GestureSettings PreventionMask = GestureSettings.Tap | GestureSettings.RightTap | GestureSettings.DoubleTap | GestureSettings.Hold;
-				gesture.PreventGestures(events & PreventionMask);
+				gesture.PreventGestures(events & GestureSettingsHelper.SupportedGestures);
 
 				return gesture.Settings;
 			}

--- a/src/Uno.UWP/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UWP/UI/Input/GestureRecognizer.cs
@@ -183,25 +183,8 @@ namespace Windows.UI.Input
 		{
 			if (_gestures.TryGetValue(pointerId, out var gesture))
 			{
-				if (events.HasFlag(GestureSettings.Tap))
-				{
-					gesture.PreventTap();
-				}
-
-				if (events.HasFlag(GestureSettings.RightTap))
-				{
-					gesture.PreventRightTap();
-				}
-
-				if (events.HasFlag(GestureSettings.DoubleTap))
-				{
-					gesture.PreventDoubleTap();
-				}
-
-				if (events.HasFlag(GestureSettings.Hold))
-				{
-					gesture.PreventHolding();
-				}
+				const GestureSettings PreventionMask = GestureSettings.Tap | GestureSettings.RightTap | GestureSettings.DoubleTap | GestureSettings.Hold;
+				gesture.PreventGestures(events & PreventionMask);
 
 				return gesture.Settings;
 			}

--- a/src/Uno.UWP/UI/Input/RightTappedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/RightTappedEventArgs.cs
@@ -11,9 +11,9 @@ namespace Windows.UI.Input
 	{
 		internal RightTappedEventArgs(uint pointerId, PointerDeviceType type, Point position)
 		{
+			PointerId = pointerId;
 			PointerDeviceType = type;
 			Position = position;
-			PointerId = pointerId;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }

--- a/src/Uno.UWP/UI/Input/RightTappedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/RightTappedEventArgs.cs
@@ -9,15 +9,18 @@ namespace Windows.UI.Input
 {
 	public partial class RightTappedEventArgs
 	{
-		internal RightTappedEventArgs(PointerDeviceType type, Point position)
+		internal RightTappedEventArgs(uint pointerId, PointerDeviceType type, Point position)
 		{
 			PointerDeviceType = type;
 			Position = position;
+			PointerId = pointerId;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }
 
 		public Point Position { get; }
+
+		internal uint PointerId { get; }
 
 		[global::Uno.NotImplemented]
 		public uint ContactCount

--- a/src/Uno.UWP/UI/Input/TappedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/TappedEventArgs.cs
@@ -11,10 +11,10 @@ namespace Windows.UI.Input
 	{
 		internal TappedEventArgs(uint pointerId, PointerDeviceType type, Point position, uint tapCount)
 		{
+			PointerId = pointerId;
 			PointerDeviceType = type;
 			Position = position;
 			TapCount = tapCount;
-			PointerId = pointerId;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }

--- a/src/Uno.UWP/UI/Input/TappedEventArgs.cs
+++ b/src/Uno.UWP/UI/Input/TappedEventArgs.cs
@@ -9,16 +9,19 @@ namespace Windows.UI.Input
 {
 	public partial class TappedEventArgs
 	{
-		internal TappedEventArgs(PointerDeviceType type, Point position, uint tapCount)
+		internal TappedEventArgs(uint pointerId, PointerDeviceType type, Point position, uint tapCount)
 		{
 			PointerDeviceType = type;
 			Position = position;
 			TapCount = tapCount;
+			PointerId = pointerId;
 		}
 
 		public PointerDeviceType PointerDeviceType { get; }
 
 		public Point Position { get; }
+
+		internal uint PointerId { get; }
 
 		public uint TapCount { get; }
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13856

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8fd096</samp>

This pull request adds the `PointerId` property to various gesture event classes and passes it to the corresponding events to align with the UWP API and provide more information to the event handlers. It also simplifies and fixes the gesture prevention logic in the `Gesture` and `GestureRecognizer` classes and prevents gesture conflicts in the `UIElement` class.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
