### PR TITLE
fix(ColorPicker): ToolTip of ColorPickerSlider doesn't work properly

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/ColorPickerTests/Given_ColorPicker.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Microsoft_UI_Xaml_Controls/ColorPickerTests/Given_ColorPicker.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+using Uno.UITests.Helpers;
+using Query = System.Func<Uno.UITest.IAppQuery, Uno.UITest.IAppQuery>;
+
+namespace SamplesApp.UITests.Microsoft_UI_Xaml_Controls.ColorPickerTests
+{
+	public partial class Given_ColorPicker : SampleControlUITestBase
+	{
+		[Test]
+		[AutoRetry]
+		public void When_Add_And_Remove_From_VisualTree()
+		{
+			Run("UITests.Microsoft_UI_Xaml_Controls.ColorPickerTests.ColorPickerInElevatedView", skipInitialScreenshot: true);
+
+			var focusButton = _app.Marked("focus");
+			var openButton = _app.Marked("open");
+			var closeButton = _app.Marked("close");
+			_app.Tap(focusButton);
+			var before = _app.Screenshot("before");
+
+			_app.Tap(openButton);
+			_app.WaitForElement(closeButton);
+			_app.Tap(closeButton);
+			_app.WaitForNoElement(closeButton);
+			_app.Tap(focusButton);
+			var after = _app.Screenshot("after");
+
+			ImageAssert.AreEqual(before, after);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ColorPickerTests/ColorPickerInElevatedView.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ColorPickerTests/ColorPickerInElevatedView.cs
@@ -1,0 +1,71 @@
+﻿using Uno.UI.Samples.Controls;
+using Uno.UI.Toolkit;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Microsoft_UI_Xaml_Controls.ColorPickerTests
+{
+	[Sample("ColorPicker", "MUX", "ColorPickerInElevatedView")]
+	public sealed partial class ColorPickerInElevatedView : Page
+	{
+		public ColorPickerInElevatedView()
+		{
+			Button openButton = new Button
+			{
+				Content = "open",
+				Name = "open"
+			};
+			Button closeButton = new Button
+			{
+				Content = "close",
+				Name = "close"
+			};
+			ElevatedView view = new ElevatedView
+			{
+				ElevatedContent = new StackPanel
+				{
+					Children =
+					{
+						closeButton,
+						new Microsoft.UI.Xaml.Controls.ColorPicker
+						{
+							IsAlphaEnabled = true,
+						}
+					}
+				}
+			};
+
+			Content = new StackPanel
+			{
+				Children =
+				{
+					new Button
+					{
+						Content = "focus",
+						Name = "focus",
+					},
+					openButton,
+				}
+			};
+
+			openButton.Click += (s, e) =>
+			{
+				var panel = Content as StackPanel;
+				if (panel is StackPanel)
+				{
+					if (panel.Children.IndexOf(view) < 0)
+						panel.Children.Add(view);
+				}
+			};
+
+			closeButton.Click += (s, e) =>
+			{
+				var panel = Content as StackPanel;
+				if (panel is StackPanel)
+				{
+					if (panel.Children.IndexOf(view) >= 0)
+						panel.Children.Remove(view);
+				}
+			};
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -5226,6 +5226,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\ColorPickerTests\ColorPickerSample.xaml.cs">
       <DependentUpon>ColorPickerSample.xaml</DependentUpon>
     </Compile>
+	<Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\ColorPickerTests\ColorPickerInElevatedView.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\ColorPickerTests\WinUIColorPickerPage.xaml.cs">
       <DependentUpon>WinUIColorPickerPage.xaml</DependentUpon>
     </Compile>

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml.Controls
 		private void OnOpenChanged(bool isOpen)
 		{
 			PerformPlacementInternal();
-			if (_owner is not null)
+			if (_owner is not null && Popup.XamlRoot is null)
 			{
 				XamlRoot = XamlRoot.GetForElement(_owner);
 				Popup.XamlRoot = XamlRoot.GetForElement(_owner);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13868

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2234ae9</samp>

This pull request enhances the `ColorPicker` and `ColorPickerSlider` controls, fixes a bug with the `Slider` thumb tooltip, and adds a new UI test and a new sample page for the `ColorPicker`. It also adds some null checks and flags to improve the stability and performance of the `ToolTip` and `Slider` controls.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
