### PR TITLE
fix(menubar): cycle through flyouts when different menu items are hovered

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_MenuBar.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_MenuBar.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Threading.Tasks;
+using Windows.UI.Input.Preview.Injection;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using MUXControlsTestApp.Utilities;
+using Uno.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+using static Private.Infrastructure.TestServices;
+using MenuBar = Microsoft.UI.Xaml.Controls.MenuBar;
+using MenuBarItem = Microsoft.UI.Xaml.Controls.MenuBarItem;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
+
+[TestClass]
+public partial class Given_MenuBar
+{
+#if HAS_UNO
+	[TestMethod]
+	[RunsOnUIThread]
+#if !__SKIA__
+	[Ignore("InputInjector is only supported on skia")]
+#endif
+	public async Task When_Hover_over_Different_Items()
+	{
+		XamlRoot xamlRoot = null;
+		try
+		{
+			var SUT = new MenuBar
+			{
+				Items =
+				{
+					new MenuBarItem
+					{
+						Title = "File",
+						Items =
+						{
+							new MenuFlyoutItem
+							{
+								Text = "New"
+							},
+							new MenuFlyoutItem
+							{
+								Text = "Open"
+							},
+							new MenuFlyoutItem
+							{
+								Text = "Save"
+							},
+						}
+					},
+					new MenuBarItem
+					{
+						Title = "Edit",
+						Items =
+						{
+							new MenuFlyoutItem
+							{
+								Text = "Undo"
+							},
+							new MenuFlyoutItem
+							{
+								Text = "Cut"
+							},
+							new MenuFlyoutItem
+							{
+								Text = "Copy"
+							},
+							new MenuFlyoutItem
+							{
+								Text = "Paste"
+							}
+						}
+					},
+					new MenuBarItem
+					{
+						Title = "Help",
+						Items =
+						{
+							new MenuFlyoutItem
+							{
+								Text = "About"
+							},
+						}
+					}
+				}
+			};
+
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForIdle();
+
+			xamlRoot = SUT.XamlRoot;
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			mouse.MoveTo(SUT.GetAbsoluteBounds().GetCenter());
+			mouse.Press();
+			mouse.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(4, ((Panel)VisualTreeHelper.GetOpenPopupsForXamlRoot(SUT.XamlRoot)[0].Child.FindVisualChildByType<MenuFlyoutItem>().GetParent()).Children.Count);
+
+			mouse.MoveBy(-50, 0);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(3, ((Panel)VisualTreeHelper.GetOpenPopupsForXamlRoot(SUT.XamlRoot)[0].Child.FindVisualChildByType<MenuFlyoutItem>().GetParent()).Children.Count);
+
+			mouse.MoveBy(100, 0);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, ((Panel)VisualTreeHelper.GetOpenPopupsForXamlRoot(SUT.XamlRoot)[0].Child.FindVisualChildByType<MenuFlyoutItem>().GetParent()).Children.Count);
+
+			mouse.MoveBy(0, -50);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(1, ((Panel)VisualTreeHelper.GetOpenPopupsForXamlRoot(SUT.XamlRoot)[0].Child.FindVisualChildByType<MenuFlyoutItem>().GetParent()).Children.Count);
+		}
+		finally
+		{
+			VisualTreeHelper.CloseAllFlyouts(xamlRoot);
+		}
+	}
+#endif
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBar.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBar.cs
@@ -52,6 +52,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 		internal bool IsFlyoutOpen { get; set; }
 
+		/// <summary>
+		/// This is a workaround until FlyoutBase.OverlayInputPassThroughElement is implemented.
+		/// </summary>
 		internal void OnMenuBarItemFlyoutPresenterPointerMoved(PointerRoutedEventArgs e)
 		{
 			if (IsFlyoutOpen)

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBar.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBar.cs
@@ -51,5 +51,32 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		internal bool IsFlyoutOpen { get; set; }
+
+		internal void OnMenuBarItemFlyoutPresenterPointerMoved(PointerRoutedEventArgs e)
+		{
+			if (IsFlyoutOpen)
+			{
+				MenuBarItem oldOpenItem = null;
+				MenuBarItem newOpenItem = null;
+				foreach (var menuBarItem in Items)
+				{
+					var position = e.GetCurrentPoint(menuBarItem).Position;
+					if (position.X >= 0 && position.X < menuBarItem.ActualWidth && position.Y >= 0 && position.Y < menuBarItem.ActualHeight)
+					{
+						newOpenItem = menuBarItem;
+					}
+					else if (menuBarItem.IsFlyoutOpen())
+					{
+						oldOpenItem = menuBarItem;
+					}
+				}
+
+				if (oldOpenItem != newOpenItem && newOpenItem is { })
+				{
+					oldOpenItem?.CloseMenuFlyout();
+					newOpenItem.ShowMenuFlyout();
+				}
+			}
+		}
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBarItem.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/MenuBar/MenuBarItem.cs
@@ -365,6 +365,7 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				m_menuBar.IsFlyoutOpen = true;
 
+				// This is a workaround until FlyoutBase.OverlayInputPassThroughElement is implemented.
 				var menuBar = m_menuBar;
 				var presenter = m_flyout.m_presenter;
 				PointerEventHandler pointerMovedHandler = (_, e) => menuBar.OnMenuBarItemFlyoutPresenterPointerMoved(e);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13826

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14de648</samp>

This pull request improves the mouse interaction with the `MenuBar` and `MenuBarItem` controls by adding and handling pointer moved events. This allows the user to navigate the menu bar items using the mouse pointer as if they were using the keyboard. This also fixes a bug where the menu bar items do not open or close properly when the mouse pointer moves over them.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
