### PR TITLE
fix: Fix elevated view double border on Wasm

### DIFF
--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_BorderThickness.xaml
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_BorderThickness.xaml
@@ -1,0 +1,23 @@
+﻿<Page
+	x:Class="UITests.Toolkit.ElevatedView_BorderThickness"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:toolkit="using:Uno.UI.Toolkit"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel Spacing="10" Margin="12">
+		<toolkit:ElevatedView
+				Background="Transparent"
+				Elevation="4"
+				Width="120"
+				Height="120"
+				Margin="0,30"
+				CornerRadius="8"
+				BorderThickness="1" BorderBrush="Red">
+			<Rectangle Fill="Orange" Width="120" Height="120" />
+		</toolkit:ElevatedView>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_BorderThickness.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Toolkit/ElevatedView_BorderThickness.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Toolkit
+{
+	[Sample(IsManualTest = true, Description = "The red border shouldn't feel as if it's duplicated (especially from the top-left corner)")]
+	public sealed partial class ElevatedView_BorderThickness : Page
+	{
+		public ElevatedView_BorderThickness()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -382,6 +382,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_BorderThickness.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_CornerRadius.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5478,6 +5482,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedViewTests.xaml.cs">
       <DependentUpon>ElevatedViewTests.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_BorderThickness.xaml.cs">
+      <DependentUpon>ElevatedView_BorderThickness.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\ElevatedView_CornerRadius.xaml.cs">
       <DependentUpon>ElevatedView_CornerRadius.xaml</DependentUpon>

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -204,7 +204,7 @@ namespace Uno.UI.Toolkit
 			}
 			else
 			{
-				var outer = cornerRadius.GetRadii(element.RenderSize, thickness).Outer;
+				var outer = cornerRadius.GetRadii(element.RenderSize, BorderThickness).Outer;
 				WindowManagerInterop.SetCornerRadius(element.HtmlId, outer.TopLeft.X, outer.TopLeft.Y, outer.TopRight.X, outer.TopRight.Y, outer.BottomRight.X, outer.BottomRight.Y, outer.BottomLeft.X, outer.BottomLeft.Y);
 			}
 		}

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -180,7 +180,11 @@ namespace Uno.UI.Toolkit
 			{
 #if __WASM__
 				this.SetElevationInternal(Elevation, ShadowColor);
-				this.SetCornerRadius();
+				// We don't pass BorderThickness here to avoid "double" border being created. The BorderThickness will flow through ElevatedView template to PART_Border
+				// Note that this line was necessary as of writing it even though we pass zero for BorderThickness. Setting the CornerRadius alone has a noticeable effect.
+				// and not setting CornerRadius properly results in wrong rendering.
+				// Note that the brush will not be used if we pass zero thickness, so we pass null instead of wasting time reading the dependency property.
+				this.SetBorder(default, null, CornerRadius);
 #elif __IOS__ || __MACOS__
 				this.SetElevationInternal(Elevation, ShadowColor, _border.BoundsPath);
 #elif __ANDROID__
@@ -195,23 +199,6 @@ namespace Uno.UI.Toolkit
 		}
 
 #if HAS_UNO
-
-#if __WASM__
-		private void SetCornerRadius()
-		{
-  			var cornerRadius = CornerRadius;
-			if (cornerRadius == CornerRadius.None)
-			{
-				this.ResetStyle("border-radius", "overflow");
-			}
-			else
-			{
-				var outer = cornerRadius.GetRadii(this.RenderSize, BorderThickness).Outer;
-				WindowManagerInterop.SetCornerRadius(this.HtmlId, outer.TopLeft.X, outer.TopLeft.Y, outer.TopRight.X, outer.TopRight.Y, outer.BottomRight.X, outer.BottomRight.Y, outer.BottomLeft.X, outer.BottomLeft.Y);
-			}
-		}
-#endif
-
 		bool ICustomClippingElement.AllowClippingToLayoutSlot => false; // Never clip, since it will remove the shadow
 
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => false;

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -13,6 +13,8 @@ using CoreGraphics;
 using _View = AppKit.NSView;
 #elif __ANDROID__
 using Android.Views;
+#elif __WASM__
+using Uno.UI.Xaml;
 #endif
 
 
@@ -200,12 +202,12 @@ namespace Uno.UI.Toolkit
   			var cornerRadius = CornerRadius;
 			if (cornerRadius == CornerRadius.None)
 			{
-				element.ResetStyle("border-radius", "overflow");
+				this.ResetStyle("border-radius", "overflow");
 			}
 			else
 			{
-				var outer = cornerRadius.GetRadii(element.RenderSize, BorderThickness).Outer;
-				WindowManagerInterop.SetCornerRadius(element.HtmlId, outer.TopLeft.X, outer.TopLeft.Y, outer.TopRight.X, outer.TopRight.Y, outer.BottomRight.X, outer.BottomRight.Y, outer.BottomLeft.X, outer.BottomLeft.Y);
+				var outer = cornerRadius.GetRadii(this.RenderSize, BorderThickness).Outer;
+				WindowManagerInterop.SetCornerRadius(this.HtmlId, outer.TopLeft.X, outer.TopLeft.Y, outer.TopRight.X, outer.TopRight.Y, outer.BottomRight.X, outer.BottomRight.Y, outer.BottomLeft.X, outer.BottomLeft.Y);
 			}
 		}
 #endif

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -176,15 +176,12 @@ namespace Uno.UI.Toolkit
 			}
 			else
 			{
-#if __WASM__
-				this.SetElevationInternal(Elevation, ShadowColor);
-				this.SetBorder(BorderThickness, BorderBrush, CornerRadius);
-#elif __IOS__ || __MACOS__
+#if __IOS__ || __MACOS__
 				this.SetElevationInternal(Elevation, ShadowColor, _border.BoundsPath);
 #elif __ANDROID__
 				_invalidateShadow = true;
 				((ViewGroup)this).Invalidate();
-#elif __SKIA__
+#elif __SKIA__ || __WASM__
 				this.SetElevationInternal(Elevation, ShadowColor);
 #elif (NETFX_CORE || NETCOREAPP) && !HAS_UNO
 				_border.SetElevationInternal(Elevation, ShadowColor, _shadowHost as DependencyObject, CornerRadius);

--- a/src/Uno.UI.Toolkit/ElevatedView.cs
+++ b/src/Uno.UI.Toolkit/ElevatedView.cs
@@ -176,12 +176,15 @@ namespace Uno.UI.Toolkit
 			}
 			else
 			{
-#if __IOS__ || __MACOS__
+#if __WASM__
+				this.SetElevationInternal(Elevation, ShadowColor);
+				this.SetCornerRadius();
+#elif __IOS__ || __MACOS__
 				this.SetElevationInternal(Elevation, ShadowColor, _border.BoundsPath);
 #elif __ANDROID__
 				_invalidateShadow = true;
 				((ViewGroup)this).Invalidate();
-#elif __SKIA__ || __WASM__
+#elif __SKIA__
 				this.SetElevationInternal(Elevation, ShadowColor);
 #elif (NETFX_CORE || NETCOREAPP) && !HAS_UNO
 				_border.SetElevationInternal(Elevation, ShadowColor, _shadowHost as DependencyObject, CornerRadius);
@@ -190,6 +193,23 @@ namespace Uno.UI.Toolkit
 		}
 
 #if HAS_UNO
+
+#if __WASM__
+		private void SetCornerRadius()
+		{
+  			var cornerRadius = CornerRadius;
+			if (cornerRadius == CornerRadius.None)
+			{
+				element.ResetStyle("border-radius", "overflow");
+			}
+			else
+			{
+				var outer = cornerRadius.GetRadii(element.RenderSize, thickness).Outer;
+				WindowManagerInterop.SetCornerRadius(element.HtmlId, outer.TopLeft.X, outer.TopLeft.Y, outer.TopRight.X, outer.TopRight.Y, outer.BottomRight.X, outer.BottomRight.Y, outer.BottomLeft.X, outer.BottomLeft.Y);
+			}
+		}
+#endif
+
 		bool ICustomClippingElement.AllowClippingToLayoutSlot => false; // Never clip, since it will remove the shadow
 
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => false;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13904

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Border is added to the ElevatedView itself and also the Border coming from its template.

## What is the new behavior?

The border is now only propagated to the Border through the template:

https://github.com/unoplatform/uno/blob/c756a0c8139437087666a14cc9a45ff6483e10a5/src/Uno.UI.Toolkit/Themes/Generic.xaml#L13-L18

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e02685</samp>

Simplify the code structure of `ElevatedView.cs` by merging the WASM and SKIA branches. This is part of a fix for the border rendering of `ElevatedView` on those platforms.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
