### PR TITLE
fix(XamlReader): Properly support TemplateBinding of attached properties

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
@@ -264,12 +264,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 			var sut = setup.FindFirstDescendant<ScrollViewer>(x => x.Name == "SUT");
 			var expr = sut.GetBindingExpression(ScrollViewer.HorizontalScrollModeProperty);
 
-			Assert.AreEqual(expr.ParentBinding.Path.Path, "ScrollViewer.HorizontalScrollMode");
-
-			// disabled due to https://github.com/unoplatform/uno/issues/13121#issuecomment-1666666795 (point 2)
-			//Assert.AreEqual(ScrollMode.Disabled, sut.HorizontalScrollMode);
-			//ScrollViewer.SetHorizontalScrollMode(setup, ScrollMode.Enabled);
-			//Assert.AreEqual(ScrollMode.Enabled, sut.HorizontalScrollMode);
+			Assert.AreEqual(expr.ParentBinding.Path.Path, "(Windows.UI.Xaml.Controls:ScrollViewer.HorizontalScrollMode)");
+			Assert.AreEqual(ScrollMode.Disabled, sut.HorizontalScrollMode);
+			ScrollViewer.SetHorizontalScrollMode(setup, ScrollMode.Enabled);
+			Assert.AreEqual(ScrollMode.Enabled, sut.HorizontalScrollMode);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -943,7 +943,13 @@ namespace Windows.UI.Xaml.Markup.Reader
 				{
 					case "_PositionalParameters":
 					case nameof(Binding.Path):
-						binding.Path = RewriteAttachedPropertyPath(bindingProperty.Value?.ToString());
+						var path = bindingProperty.Value?.ToString();
+						if (templateBindingNode is not null && TypeResolver.IsAttachedProperty(member))
+						{
+							path = $"({path})";
+						}
+
+						binding.Path = RewriteAttachedPropertyPath(path);
 						break;
 
 					case nameof(Binding.ElementName):


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13517

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c187ba5</samp>

This pull request fixes a bug in the `XamlReader` that caused attached properties to be parsed incorrectly in some cases. It also updates the `XamlObjectBuilder` and the test assertions to follow the Xaml standard for attached properties and TemplateBindings.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
