### PR TITLE
fix: Enable FrameworkTemplatePool for Skia targets

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
@@ -33,6 +33,9 @@ internal class Given_FrameworkTemplatePool
 #if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]
+#if __ANDROID__
+	[Ignore("https://github.com/unoplatform/uno/issues/13969")]
+#endif
 	public async Task When_Recycle()
 	{
 		using (FeatureConfigurationHelper.UseTemplatePooling())
@@ -66,10 +69,10 @@ internal class Given_FrameworkTemplatePool
 
 			await WindowHelper.WaitForIdle();
 
-			Assert.IsNull(targetInstance.Target);
-			Assert.IsNotNull(targetTemplateRoot.Target);
+			Assert.IsNull(targetInstance.Target, "targetInstance.Target is not null");
+			Assert.IsNotNull(targetTemplateRoot.Target, "targetTemplateRoot.Target is not null");
 
-			Assert.AreEqual(1, FrameworkTemplatePool.Instance.GetPooledTemplatesCount());
+			Assert.AreEqual(1, FrameworkTemplatePool.Instance.GetPooledTemplatesCount(), "GetPooledTemplatesCount is incorrect");
 
 			FrameworkTemplatePool.Instance.Scavenge(isManual: true);
 
@@ -82,7 +85,7 @@ internal class Given_FrameworkTemplatePool
 				await Task.Delay(50);
 			}
 
-			Assert.AreEqual(0, FrameworkTemplatePool.Instance.GetPooledTemplatesCount());
+			Assert.AreEqual(0, FrameworkTemplatePool.Instance.GetPooledTemplatesCount(), "GetPooledTemplatesCount is incorrect");
 		}
 	}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
@@ -30,6 +30,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 [RunsOnUIThread]
 internal class Given_FrameworkTemplatePool
 {
+#if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]
 	public async Task When_Recycle()
@@ -68,6 +69,7 @@ internal class Given_FrameworkTemplatePool
 			FrameworkTemplatePool.Instance.ForceClear();
 		}
 	}
+#endif
 
 	[TestMethod]
 	public async Task TestCheckBox()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FrameworkTemplatePool.cs
@@ -70,7 +70,7 @@ internal class Given_FrameworkTemplatePool
 			await WindowHelper.WaitForIdle();
 
 			Assert.IsNull(targetInstance.Target, "targetInstance.Target is not null");
-			Assert.IsNotNull(targetTemplateRoot.Target, "targetTemplateRoot.Target is not null");
+			Assert.IsNotNull(targetTemplateRoot.Target, "targetTemplateRoot.Target is null");
 
 			Assert.AreEqual(1, FrameworkTemplatePool.Instance.GetPooledTemplatesCount(), "GetPooledTemplatesCount is incorrect");
 

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -102,7 +102,7 @@ namespace Windows.UI.Xaml
 		/// The root of the behavior is linked to WeakReferences to objects pending for finalizers are considered
 		/// null, something that does not happen on Xamarin.iOS/Android.
 		/// </remarks>
-		private readonly HashSet<UIElement> _activeInstances = new HashSet<View>();
+		private readonly HashSet<View> _activeInstances = new();
 #endif
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -175,6 +175,11 @@ namespace Windows.UI.Xaml
 					{
 						_trace.WriteEvent(TraceProvider.ReleaseTemplate);
 					}
+
+					if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
+					{
+						this.Log().Debug($"Released {removedInstancesCount} template instances");
+					}
 				}
 
 				// Under iOS and Android, we need to force the collection for the GC
@@ -190,6 +195,28 @@ namespace Windows.UI.Xaml
 		/// <remarks>The pool will periodically release templates that haven't been reused within the span of <see cref="TimeToLive"/>, so
 		/// normally you shouldn't need to call this method. It may be useful in advanced memory management scenarios.</remarks>
 		public static void Scavenge() => Instance.Scavenge(true);
+
+		internal void ForceClear()
+		{
+			foreach (var list in _pooledInstances.Values)
+			{
+				list.Clear();
+			}
+
+			_pooledInstances.Clear();
+		}
+
+		internal int GetPooledTemplatesCount()
+		{
+			int count = 0;
+
+			foreach (var list in _pooledInstances.Values)
+			{
+				count += list.Count;
+			}
+
+			return count;
+		}
 
 		internal View? DequeueTemplate(FrameworkTemplate template)
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -164,7 +164,19 @@ namespace Windows.UI.Xaml
 
 			foreach (var list in _pooledInstances.Values)
 			{
-				removedInstancesCount += list.RemoveAll(t => isManual || now - t.CreationTime > TimeToLive);
+				removedInstancesCount += list.RemoveAll(t =>
+				{
+					var remove = isManual || now - t.CreationTime > TimeToLive;
+
+#if USE_HARD_REFERENCES
+					if (remove)
+					{
+						_activeInstances.Remove(t.Control);
+					}
+#endif
+
+					return remove;
+				});
 			}
 
 			if (removedInstancesCount > 0)
@@ -204,6 +216,7 @@ namespace Windows.UI.Xaml
 			}
 
 			_pooledInstances.Clear();
+			_activeInstances.Clear();
 		}
 
 		internal int GetPooledTemplatesCount()

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -216,7 +216,10 @@ namespace Windows.UI.Xaml
 			}
 
 			_pooledInstances.Clear();
+
+#if USE_HARD_REFERENCES
 			_activeInstances.Clear();
+#endif
 		}
 
 		internal int GetPooledTemplatesCount()

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -208,19 +208,6 @@ namespace Windows.UI.Xaml
 		/// normally you shouldn't need to call this method. It may be useful in advanced memory management scenarios.</remarks>
 		public static void Scavenge() => Instance.Scavenge(true);
 
-		internal void ForceClear()
-		{
-			foreach (var list in _pooledInstances.Values)
-			{
-				list.Clear();
-			}
-
-			_pooledInstances.Clear();
-
-#if USE_HARD_REFERENCES
-			_activeInstances.Clear();
-#endif
-		}
 
 		internal int GetPooledTemplatesCount()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

- Restore support for FrameworkTemplatePool for Skia targets
- Fix memory leak in Wasm for active instances tracking

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4edf37f</samp>

No summary available (Limit exceeded: required to process 83338 tokens, but only 50000 are allowed per call)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): closes https://github.com/unoplatform/kahua-private/issues/73
