### PR TITLE
fix: FilePickerSelectedFilesArray.Count shouldn't have a throwing setter #6885

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1687,6 +1687,8 @@
 			<Member fullName="System.Double Microsoft.UI.Xaml.Controls.NavigationViewTemplateSettings.get_OpenPaneWidth()" reason="Does not exist in UWP" />
 			<Member fullName="System.Void Microsoft.UI.Xaml.Controls.NavigationViewTemplateSettings.set_OpenPaneWidth(System.Double value)" reason="Does not exist in UWP" />
 			<Member fullName="Windows.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.NavigationViewTemplateSettings.get_OpenPaneWidthProperty()" reason="Does not exist in UWP" />
+
+			<Member fullName="System.Void Windows.Storage.Pickers.FilePickerSelectedFilesArray.set_Count(System.Int32 value)" reason="Does not exists in UWP" />
 		</Methods>
 	</IgnoreSet>
 	  <!--

--- a/src/Uno.UWP/Storage/Pickers/FilePickerSelectedFilesArray.cs
+++ b/src/Uno.UWP/Storage/Pickers/FilePickerSelectedFilesArray.cs
@@ -35,7 +35,6 @@ namespace Windows.Storage.Pickers
 		public int Count
 		{
 			get => _items.Count;
-			//set => throw new InvalidOperationException();
 		}
 	}
 }

--- a/src/Uno.UWP/Storage/Pickers/FilePickerSelectedFilesArray.cs
+++ b/src/Uno.UWP/Storage/Pickers/FilePickerSelectedFilesArray.cs
@@ -35,7 +35,7 @@ namespace Windows.Storage.Pickers
 		public int Count
 		{
 			get => _items.Count;
-			set => throw new InvalidOperationException();
+			//set => throw new InvalidOperationException();
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #6885

https://github.com/unoplatform/uno/issues/6885

## PR Type

What kind of change does this PR introduce?

- Feature

<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

It's thowing an InvalidOperationException: 

`set => throw new InvalidOperationException();`


## What is the new behavior?

There is no setter.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6fecc1d</samp>

Fix a bug in `FileOpenPicker` on UWP by commenting out the `Count` setter in `FilePickerSelectedFilesArray`. This prevents an exception when the array is modified by the `IList<T>` interface.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):

https://github.com/unoplatform/uno/issues/6885
