### PR TITLE
perf: Avoid InterpEntry for BindingPropertyHelper.GetPropertyType()

### DIFF
--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.GetPropertyTypeKey.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.GetPropertyTypeKey.cs
@@ -1,0 +1,63 @@
+﻿#nullable enable
+
+#if !NETFX_CORE
+using System;
+using System.Collections;
+
+namespace Uno.UI.DataBinding
+{
+	internal static partial class BindingPropertyHelper
+	{
+		private class GetPropertyTypeKey
+		{
+			private Type? _type;
+			private string? _property;
+			private bool _allowPrivateMembers;
+
+			private int _cachedHashcode;
+
+			internal GetPropertyTypeKey()
+			{
+			}
+
+			private GetPropertyTypeKey(Type type, string property, bool allowPrivateMembers, int cachedHashcode)
+			{
+				_type = type;
+				_property = property;
+				_allowPrivateMembers = allowPrivateMembers;
+
+				_cachedHashcode = cachedHashcode;
+			}
+
+			internal GetPropertyTypeKey Clone() => new(_type!, _property!, _allowPrivateMembers, _cachedHashcode);
+
+			internal void Update(Type type, string property, bool allowPrivateMembers)
+			{
+				_type = type;
+				_property = property;
+				_allowPrivateMembers = allowPrivateMembers;
+
+				_cachedHashcode =
+					type.GetHashCode() ^
+					property.GetHashCode() ^
+					allowPrivateMembers.GetHashCode();
+			}
+
+			internal static readonly IEqualityComparer Comparer = new EqualityComparer();
+
+			internal class EqualityComparer : IEqualityComparer
+			{
+				bool IEqualityComparer.Equals(object? x, object? y)
+					=>
+						x is GetPropertyTypeKey k1 &&
+						y is GetPropertyTypeKey k2 &&
+						k1._allowPrivateMembers == k2._allowPrivateMembers &&
+						k1._type == k2._type &&
+						k1._property == k2._property;
+
+				int IEqualityComparer.GetHashCode(object obj) => obj is GetPropertyTypeKey key ? key._cachedHashcode : 0;
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Perf

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db14c4e</samp>

This pull request enhances the data binding system by optimizing the `GetPropertyType` method for faster and safer access to property types. It also removes some unused or redundant namespaces from the `BindingPropertyHelper.cs` file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
