### PR TITLE
fix: Adjust `x:Load` insertion on iOS/Catalyst considering manual CALayers

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Order.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Order.xaml
@@ -1,0 +1,29 @@
+﻿<UserControl x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.When_xLoad_Order"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<Grid x:Name="root"
+				x:FieldModifier="public" Background="Orange" Width="200" Height="200">
+		<Border x:Name="tb01"
+				x:FieldModifier="public"
+				x:Load="{x:Bind IsLoaded1, Mode=OneWay}" 
+				Width="50" 
+				Height="50"
+				Background="Red" />
+		<Border x:Name="tb02"
+				x:FieldModifier="public"
+				x:Load="{x:Bind IsLoaded2, Mode=OneWay}"
+				Width="150"
+				Height="50"
+				Background="Green" />
+		<Border x:Name="tb03"
+				x:FieldModifier="public"
+				x:Load="{x:Bind IsLoaded3, Mode=OneWay}"
+				Width="50"
+				Height="150"
+				Background="Blue" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Order.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_xLoad_Order.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls
+{
+	public sealed partial class When_xLoad_Order : UserControl
+	{
+		public When_xLoad_Order()
+		{
+			this.InitializeComponent();
+		}
+
+		public bool IsLoaded1 { get; set; }
+		public bool IsLoaded2 { get; set; }
+		public bool IsLoaded3 { get; set; }
+
+		public void Refresh()
+		{
+			Bindings.Update();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -32,6 +32,46 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 		[TestMethod]
 		[RunsOnUIThread]
+		public async Task When_xLoad_Order()
+		{
+			var sut = new When_xLoad_Order();
+
+			TestServices.WindowHelper.WindowContent = sut;
+
+			Assert.IsInstanceOfType(sut.root.Children[0], typeof(ElementStub));
+			Assert.IsInstanceOfType(sut.root.Children[1], typeof(ElementStub));
+			Assert.IsInstanceOfType(sut.root.Children[2], typeof(ElementStub));
+
+			sut.IsLoaded2 = true;
+			sut.Refresh();
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsInstanceOfType(sut.root.Children[0], typeof(ElementStub));
+			Assert.IsInstanceOfType(sut.root.Children[1], typeof(Border));
+			Assert.IsInstanceOfType(sut.root.Children[2], typeof(ElementStub));
+
+			sut.IsLoaded3 = true;
+			sut.Refresh();
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsInstanceOfType(sut.root.Children[0], typeof(ElementStub));
+			Assert.IsInstanceOfType(sut.root.Children[1], typeof(Border));
+			Assert.IsInstanceOfType(sut.root.Children[2], typeof(Border));
+
+			sut.IsLoaded1 = true;
+			sut.Refresh();
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsInstanceOfType(sut.root.Children[0], typeof(Border));
+			Assert.IsInstanceOfType(sut.root.Children[1], typeof(Border));
+			Assert.IsInstanceOfType(sut.root.Children[2], typeof(Border));
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
 		public async Task When_xLoad_xBind()
 		{
 			var sut = new xLoad_xBind();


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/13966

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fix iOS `x:Load` swapping order to avoid CALayer-based indexing.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9467b0</samp>

This pull request fixes a bug and adds a test for the `ElementStub` class on iOS and macOS, which handles the logic for swapping views based on `x:Load` bindings. It changes the `SwapViews` method in `ElementStub.iOSmacOS.cs` and adds a new user control `When_xLoad_Order` with three borders that have different `x:Load` values. It also adds a test method in `Given_xLoad.cs` that asserts the expected view ordering after changing the bindings.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
