### PR TITLE
fix: Avoid DPI scaling issues on GTK

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/GtkDisplayInformationExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/GtkDisplayInformationExtension.cs
@@ -25,6 +25,7 @@ internal class GtkDisplayInformationExtension : IDisplayInformationExtension
 	private void GtkDisplayInformationExtension_MainWindowShown(object? sender, EventArgs e)
 	{
 		_dpiHelper.DpiChanged += OnDpiChanged;
+		OnDpiChanged(null, EventArgs.Empty);
 	}
 
 	private Window GetWindow()
@@ -54,7 +55,7 @@ internal class GtkDisplayInformationExtension : IDisplayInformationExtension
 				var nativeWindow = window.Window;
 				if (nativeWindow is not null)
 				{
-					_dpi = window.Display.GetMonitorAtWindow(nativeWindow).ScaleFactor * DisplayInformation.BaseDpi;
+					_dpi = _dpiHelper.GetNativeDpi();
 				}
 			}
 
@@ -71,7 +72,7 @@ internal class GtkDisplayInformationExtension : IDisplayInformationExtension
 
 	private void OnDpiChanged(object? sender, EventArgs args)
 	{
-		_dpi = GetWindow().Display.GetMonitorAtWindow(GetWindow().Window).ScaleFactor * DisplayInformation.BaseDpi;
+		_dpi = _dpiHelper.GetNativeDpi();
 		_displayInformation.NotifyDpiChanged();
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/Helpers/Dpi/DpiHelper.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Helpers/Dpi/DpiHelper.cs
@@ -65,7 +65,7 @@ internal class DpiHelper
 		}
 	}
 
-	private float GetNativeDpi()
+	internal float GetNativeDpi()
 	{
 		if (GetWindow().Window == null)
 		{

--- a/src/Uno.UI.Runtime.Skia.Gtk/Rendering/GLRenderSurfaceBase.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Rendering/GLRenderSurfaceBase.cs
@@ -52,6 +52,7 @@ namespace Uno.UI.Runtime.Skia.Gtk
 		{
 			_displayInformation = DisplayInformation.GetForCurrentView();
 			_displayInformation.DpiChanged += OnDpiChanged;
+			UpdateDpi();
 
 			// Set some event handlers
 			Render += UnoGLDrawingArea_Render;

--- a/src/Uno.UI.Runtime.Skia.Gtk/Rendering/SoftwareRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Rendering/SoftwareRenderSurface.cs
@@ -35,6 +35,7 @@ internal class SoftwareRenderSurface : DrawingArea, IGtkRenderer
 	{
 		_displayInformation = DisplayInformation.GetForCurrentView();
 		_displayInformation.DpiChanged += OnDpiChanged;
+		UpdateDpi();
 
 		_colorType = SKImageInfo.PlatformColorType;
 		// R and B channels are inverted on macOS running on arm64 CPU and this is not detected by Skia


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13304

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When screen has non-100 scaling, GTK renders incorrectly

## What is the new behavior?

Scaling works correctly for non-fractional scaling

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eb339e5</samp>

This pull request improves the DPI handling for the GTK platform by using a helper class and calling the `UpdateDpi()` method in the rendering surface constructors. It also exposes the `GetNativeDpi()` method as internal for reuse.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
