### PR TITLE
Dev/dr/dev server host version

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
@@ -53,8 +53,8 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 
 		public void Execute(GeneratorExecutionContext context)
 		{
-			var isProjectConfigEnabled = Is("UnoDevServer_IncludeProjectConfiguration");
-			var isServerProcessorsConfigEnabled = Is("UnoDevServer_IncludeServerProcessorsConfiguration");
+			var isProjectConfigEnabled = IsMSBuildPropertyTrue("UnoDevServer_IncludeProjectConfiguration");
+			var isServerProcessorsConfigEnabled = IsMSBuildPropertyTrue("UnoDevServer_IncludeServerProcessorsConfiguration");
 
 			if (!DesignTimeHelper.IsDesignTime(context)
 				&& context.GetMSBuildPropertyValue("Configuration") == "Debug")
@@ -109,7 +109,7 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 				context.AddSource("RemoteControl", sb.ToString());
 			}
 
-			bool Is(string propertyName)
+			bool IsMSBuildPropertyTrue(string propertyName)
 				=> bool.TryParse(context.GetMSBuildPropertyValue(propertyName), out var value) && value;
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
@@ -96,7 +96,7 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 
 				var sb = new IndentedStringBuilder();
 				BuildGeneratedFileHeader(sb);
-				
+
 				if (isProjectConfigEnabled)
 				{
 					BuildProjectConfiguration(context, sb);

--- a/src/Uno.UI.RemoteControl.Host/Config/global-net7.0.json
+++ b/src/Uno.UI.RemoteControl.Host/Config/global-net7.0.json
@@ -1,0 +1,10 @@
+{
+	"sdk": {
+		"version": "7.0.100",
+		"allowPrerelease": false,
+		"rollForward": "latestFeature"
+	},
+	"tools": {
+		"dotnet": "7.0.100"
+	}
+}

--- a/src/Uno.UI.RemoteControl.Host/Config/global-net8.0.json
+++ b/src/Uno.UI.RemoteControl.Host/Config/global-net8.0.json
@@ -1,0 +1,10 @@
+{
+	"sdk": {
+		"version": "8.0.100-preview.7.23376.3",
+		"allowPrerelease": false,
+		"rollForward": "latestFeature"
+	},
+	"tools": {
+		"dotnet": "8.0.100-preview.7.23376.3"
+	}
+}

--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -35,6 +35,20 @@
 		</ProjectReference>
 	</ItemGroup>
 
+	<ItemGroup>
+		<Content Update="Config\*.json">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</Content>
+		<Content Update="Config\global-net7.0.json" Condition="'$(TargetFramework)' == 'net7.0'">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<TargetPath>global.json</TargetPath>
+		</Content>
+		<Content Update="Config\global-net8.0.json" Condition="'$(TargetFramework)' == 'net8.0'">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<TargetPath>global.json</TargetPath>
+		</Content>
+	</ItemGroup>
+
 	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
 		<PropertyGroup>
 			<_OverridePackageId>Uno.UI</_OverridePackageId>

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -14,95 +14,95 @@ using Uno.UI.RemoteControl.HotReload.MetadataUpdater;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Uno.UI.RemoteControl.HotReload
+namespace Uno.UI.RemoteControl.HotReload;
+
+partial class ClientHotReloadProcessor : IRemoteControlProcessor
 {
-	partial class ClientHotReloadProcessor : IRemoteControlProcessor
+	private static int _isReloading;
+
+	private bool _linkerEnabled;
+	private HotReloadAgent _agent;
+	private ElementUpdateAgent? _elementAgent;
+	private static ClientHotReloadProcessor? _instance;
+	private readonly TaskCompletionSource<bool> _hotReloadWorkloadSpaceLoaded = new();
+
+	private ElementUpdateAgent ElementAgent
 	{
-		private static int _isReloading;
-
-		private bool _linkerEnabled;
-		private HotReloadAgent _agent;
-		private ElementUpdateAgent? _elementAgent;
-		private static ClientHotReloadProcessor? _instance;
-		private readonly TaskCompletionSource<bool> _hotreloadWorkloadSpaceLoaded = new();
-
-		private ElementUpdateAgent ElementAgent
+		get
 		{
-			get
-			{
-				_elementAgent ??= new ElementUpdateAgent(s =>
+			_elementAgent ??= new ElementUpdateAgent(s =>
+				{
+					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
-						if (this.Log().IsEnabled(LogLevel.Trace))
-						{
-							this.Log().Trace(s);
-						}
-					});
+						this.Log().Trace(s);
+					}
+				});
 
-				return _elementAgent;
-			}
+			return _elementAgent;
+		}
+	}
+
+	private void WorkspaceLoadResult(HotReloadWorkspaceLoadResult hotReloadWorkspaceLoadResult)
+		=> _hotReloadWorkloadSpaceLoaded.SetResult(hotReloadWorkspaceLoadResult.WorkspaceInitialized);
+
+	/// <summary>
+	/// Waits for the server's hot reload workspace to be loaded
+	/// </summary>
+	/// <param name="ct"></param>
+	/// <returns></returns>
+	public Task<bool> WaitForWorkspaceLoaded(CancellationToken ct)
+		=> _hotReloadWorkloadSpaceLoaded.Task;
+
+	/// <summary>
+	/// Determines if the server's hot reload workspace has been loaded
+	/// </summary>
+	internal Task HotReloadWorkspaceLoaded
+		=> _hotReloadWorkloadSpaceLoaded.Task;
+
+	[MemberNotNull(nameof(_agent))]
+	partial void InitializeMetadataUpdater()
+	{
+		_instance = this;
+
+		_linkerEnabled = string.Equals(Environment.GetEnvironmentVariable("UNO_BOOTSTRAP_LINKER_ENABLED"), "true", StringComparison.OrdinalIgnoreCase);
+
+		if (_linkerEnabled)
+		{
+			var message = "The application was compiled with the IL linker enabled, hot reload is disabled. " +
+						"See WasmShellILLinkerEnabled for more details.";
+
+			Console.WriteLine($"[ERROR] {message}");
 		}
 
-		private void WorkspaceLoadResult(HotReloadWorkspaceLoadResult hotReloadWorkspaceLoadResult)
-			=> _hotreloadWorkloadSpaceLoaded.SetResult(hotReloadWorkspaceLoadResult.WorkspaceInitialized);
-
-		/// <summary>
-		/// Determines if the server's hot reload workspace has been loaded
-		/// </summary>
-		internal Task HotReloadWorkspaceLoaded
-			=> _hotreloadWorkloadSpaceLoaded.Task;
-
-		[MemberNotNull(nameof(_agent))]
-		partial void InitializeMetadataUpdater()
+		_agent = new HotReloadAgent(s =>
 		{
-			_instance = this;
-
-			_linkerEnabled = string.Equals(Environment.GetEnvironmentVariable("UNO_BOOTSTRAP_LINKER_ENABLED"), "true", StringComparison.OrdinalIgnoreCase);
-
-			if (_linkerEnabled)
+			if (this.Log().IsEnabled(LogLevel.Trace))
 			{
-				var message = "The application was compiled with the IL linker enabled, hot reload is disabled. " +
-							"See WasmShellILLinkerEnabled for more details.";
-
-				Console.WriteLine($"[ERROR] {message}");
+				this.Log().Trace(s);
 			}
+		});
+	}
 
-			_agent = new HotReloadAgent(s =>
-			{
-				if (this.Log().IsEnabled(LogLevel.Trace))
-				{
-					this.Log().Trace(s);
-				}
-			});
-		}
-
-		private string[] GetMetadataUpdateCapabilities()
+	private string[] GetMetadataUpdateCapabilities()
+	{
+		if (Type.GetType(HotReloadAgent.MetadataUpdaterType) is { } type)
 		{
-			if (Type.GetType(HotReloadAgent.MetadataUpdaterType) is { } type)
+			if (type.GetMethod("GetCapabilities", BindingFlags.Static | BindingFlags.NonPublic) is { } getCapabilities)
 			{
-				if (type.GetMethod("GetCapabilities", BindingFlags.Static | BindingFlags.NonPublic) is { } getCapabilities)
+				if (getCapabilities.Invoke(null, Array.Empty<string>()) is string caps)
 				{
-					if (getCapabilities.Invoke(null, Array.Empty<string>()) is string caps)
+					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
-						if (this.Log().IsEnabled(LogLevel.Trace))
-						{
-							this.Log().Trace($"Metadata Updates runtime capabilities: {caps}");
-						}
+						this.Log().Trace($"Metadata Updates runtime capabilities: {caps}");
+					}
 
-						return caps.Split(' ');
-					}
-					else
-					{
-						if (this.Log().IsEnabled(LogLevel.Warning))
-						{
-							this.Log().Trace($"Runtime does not support Hot Reload (Invalid returned type for {HotReloadAgent.MetadataUpdaterType}.GetCapabilities())");
-						}
-					}
+					return caps.Split(' ');
 				}
 				else
 				{
 					if (this.Log().IsEnabled(LogLevel.Warning))
 					{
-						this.Log().Trace($"Runtime does not support Hot Reload (Unable to find method {HotReloadAgent.MetadataUpdaterType}.GetCapabilities())");
+						this.Log().Trace($"Runtime does not support Hot Reload (Invalid returned type for {HotReloadAgent.MetadataUpdaterType}.GetCapabilities())");
 					}
 				}
 			}
@@ -110,276 +110,283 @@ namespace Uno.UI.RemoteControl.HotReload
 			{
 				if (this.Log().IsEnabled(LogLevel.Warning))
 				{
-					this.Log().Trace($"Runtime does not support Hot Reload (Unable to find type {HotReloadAgent.MetadataUpdaterType})");
+					this.Log().Trace($"Runtime does not support Hot Reload (Unable to find method {HotReloadAgent.MetadataUpdaterType}.GetCapabilities())");
 				}
 			}
-			return Array.Empty<string>();
 		}
+		else
+		{
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().Trace($"Runtime does not support Hot Reload (Unable to find type {HotReloadAgent.MetadataUpdaterType})");
+			}
+		}
+		return Array.Empty<string>();
+	}
 
 #if __WASM__ || __SKIA__
-		private void AssemblyReload(AssemblyDeltaReload assemblyDeltaReload)
+	private void AssemblyReload(AssemblyDeltaReload assemblyDeltaReload)
+	{
+		if (assemblyDeltaReload.IsValid())
 		{
-			if (assemblyDeltaReload.IsValid())
+			if (this.Log().IsEnabled(LogLevel.Trace))
 			{
-				if (this.Log().IsEnabled(LogLevel.Trace))
-				{
-					this.Log().Trace($"Applying IL Delta after {assemblyDeltaReload.FilePath}, Guid:{assemblyDeltaReload.ModuleId}");
-				}
-
-				var changedTypesStreams = new MemoryStream(Convert.FromBase64String(assemblyDeltaReload.UpdatedTypes));
-				var changedTypesReader = new BinaryReader(changedTypesStreams);
-
-				var delta = new UpdateDelta()
-				{
-					MetadataDelta = Convert.FromBase64String(assemblyDeltaReload.MetadataDelta),
-					ILDelta = Convert.FromBase64String(assemblyDeltaReload.ILDelta),
-					PdbBytes = Convert.FromBase64String(assemblyDeltaReload.PdbDelta),
-					ModuleId = Guid.Parse(assemblyDeltaReload.ModuleId),
-					UpdatedTypes = ReadIntArray(changedTypesReader)
-				};
-
-				_agent.ApplyDeltas(new[] { delta });
+				this.Log().Trace($"Applying IL Delta after {assemblyDeltaReload.FilePath}, Guid:{assemblyDeltaReload.ModuleId}");
 			}
-			else
+
+			var changedTypesStreams = new MemoryStream(Convert.FromBase64String(assemblyDeltaReload.UpdatedTypes));
+			var changedTypesReader = new BinaryReader(changedTypesStreams);
+
+			var delta = new UpdateDelta()
 			{
-				if (this.Log().IsEnabled(LogLevel.Trace))
-				{
-					this.Log().Trace($"Failed to apply IL Delta for {assemblyDeltaReload.FilePath} ({assemblyDeltaReload})");
-				}
-			}
+				MetadataDelta = Convert.FromBase64String(assemblyDeltaReload.MetadataDelta),
+				ILDelta = Convert.FromBase64String(assemblyDeltaReload.ILDelta),
+				PdbBytes = Convert.FromBase64String(assemblyDeltaReload.PdbDelta),
+				ModuleId = Guid.Parse(assemblyDeltaReload.ModuleId),
+				UpdatedTypes = ReadIntArray(changedTypesReader)
+			};
+
+			_agent.ApplyDeltas(new[] { delta });
 		}
-
-		static int[] ReadIntArray(BinaryReader binaryReader)
+		else
 		{
-			var numValues = binaryReader.ReadInt32();
-			if (numValues == 0)
+			if (this.Log().IsEnabled(LogLevel.Trace))
 			{
-				return Array.Empty<int>();
+				this.Log().Trace($"Failed to apply IL Delta for {assemblyDeltaReload.FilePath} ({assemblyDeltaReload})");
 			}
-
-			var values = new int[numValues];
-
-			for (var i = 0; i < numValues; i++)
-			{
-				values[i] = binaryReader.ReadInt32();
-			}
-
-			return values;
-		}
-#endif
-
-		private static async Task<bool> ShouldReload()
-		{
-			if (Interlocked.CompareExchange(ref _isReloading, 1, 0) == 1)
-			{
-				return false;
-			}
-			try
-			{
-				await TypeMappings.WaitForMappingsToResume();
-			}
-			finally
-			{
-				Interlocked.Exchange(ref _isReloading, 0);
-			}
-			return true;
-		}
-
-		private static async Task ReloadWithUpdatedTypes(Type[] updatedTypes)
-		{
-			if (!await ShouldReload())
-			{
-				return;
-			}
-
-			try
-			{
-
-				var handlerActions = _instance?.ElementAgent?.ElementHandlerActions;
-
-				// Action: BeforeVisualTreeUpdate
-				// This is called before the visual tree is updated
-				_ = handlerActions?.Do(h => h.Value.BeforeVisualTreeUpdate(updatedTypes)).ToArray();
-
-				var capturedStates = new Dictionary<string, Dictionary<string, object>>();
-
-				var isCapturingState = true;
-				var treeIterator = EnumerateHotReloadInstances(
-						Window.Current.Content,
-						async (fe, key) =>
-						{
-							// Get the original type of the element, in case it's been replaced
-							var liveType = fe.GetType();
-							var originalType = liveType.GetOriginalType() ?? fe.GetType();
-
-							// Get the handler for the type specified
-							// Since we're only interested in handlers for specific element types
-							// we exclude those registered for "object". Handlers that want to run
-							// for all element types should register for FrameworkElement instead
-							var handler = (from h in handlerActions
-										   where (originalType == h.Key ||
-												originalType.IsSubclassOf(h.Key)) &&
-												h.Key != typeof(object)
-										   select h.Value).FirstOrDefault();
-
-							// Get the replacement type, or null if not replaced
-							var mappedType = originalType.GetMappedType();
-
-							if (handler is not null)
-							{
-								if (!capturedStates.TryGetValue(key, out var dict))
-								{
-									dict = new();
-								}
-								if (isCapturingState)
-								{
-									handler.CaptureState(fe, dict, updatedTypes);
-									if (dict.Any())
-									{
-										capturedStates[key] = dict;
-									}
-								}
-								else
-								{
-									await handler.RestoreState(fe, dict, updatedTypes);
-								}
-							}
-
-							if (updatedTypes.Contains(liveType))
-							{
-								// This may happen if one of the nested types has been hot reloaded, but not the type itself.
-								// For instance, a DataTemplate in a resource dictionary may mark the type as updated in `updatedTypes`
-								// but it will not be considered as a new type even if "CreateNewOnMetadataUpdate" was set.
-
-								return (fe, null, liveType);
-							}
-							else
-							{
-								return (handler is not null || mappedType is not null) ? (fe, handler, mappedType) : default;
-							}
-						},
-						parentKey: default);
-
-				// Forced iteration to capture all state before doing ui update
-				var instancesToUpdate = await treeIterator.ToArrayAsync();
-
-				// Iterate through the visual tree and either invoke ElementUpdate, 
-				// or replace the element with a new one
-				foreach (var (element, elementHandler, elementMappedType) in instancesToUpdate)
-				{
-					// Action: ElementUpdate
-					// This is invoked for each existing element that is in the tree that needs to be replaced
-					elementHandler?.ElementUpdate(element, updatedTypes);
-
-					if (elementMappedType is not null)
-					{
-						if (_log.IsEnabled(LogLevel.Trace))
-						{
-							_log.Error($"Updating element [{element}] to [{elementMappedType}]");
-						}
-
-						ReplaceViewInstance(element, elementMappedType, elementHandler);
-					}
-				}
-
-				isCapturingState = false;
-				// Forced iteration again to restore all state after doing ui update
-				_ = await treeIterator.ToArrayAsync();
-
-				// Action: AfterVisualTreeUpdate
-				_ = handlerActions?.Do(h => h.Value.AfterVisualTreeUpdate(updatedTypes)).ToArray();
-			}
-			catch (Exception ex)
-			{
-				if (_log.IsEnabled(LogLevel.Error))
-				{
-					_log.Error($"Error doing UI Update - {ex.Message}", ex);
-				}
-				throw;
-			}
-		}
-
-		private static void ReplaceViewInstance(UIElement instance, Type replacementType, ElementUpdateAgent.ElementUpdateHandlerActions? handler = default, Type[]? updatedTypes = default)
-		{
-			if (replacementType.GetConstructor(Array.Empty<Type>()) is { } creator)
-			{
-				if (_log.IsEnabled(LogLevel.Trace))
-				{
-					_log.Trace($"Creating instance of type {replacementType}");
-				}
-
-				var newInstance = Activator.CreateInstance(replacementType);
-				var instanceFE = instance as FrameworkElement;
-				var newInstanceFE = newInstance as FrameworkElement;
-				if (instanceFE is not null &&
-					newInstanceFE is not null)
-				{
-					handler?.BeforeElementReplaced(instanceFE, newInstanceFE, updatedTypes);
-				}
-				switch (instance)
-				{
-#if __IOS__
-					case UserControl userControl:
-						if (newInstance is UIKit.UIView newUIViewContent)
-						{
-							SwapViews(userControl, newUIViewContent);
-						}
-						break;
-#endif
-					case ContentControl content:
-						if (newInstance is ContentControl newContent)
-						{
-							SwapViews(content, newContent);
-						}
-						break;
-				}
-
-				if (instanceFE is not null &&
-					newInstanceFE is not null)
-				{
-					handler?.AfterElementReplaced(instanceFE, newInstanceFE, updatedTypes);
-				}
-			}
-			else
-			{
-				if (_log.IsEnabled(LogLevel.Debug))
-				{
-					_log.LogDebug($"Type [{instance.GetType()}] has no parameterless constructor, skipping reload");
-				}
-			}
-		}
-
-		public static void UpdateApplication(Type[] types)
-		{
-			foreach (var t in types)
-			{
-				if (t.GetCustomAttribute<System.Runtime.CompilerServices.MetadataUpdateOriginalTypeAttribute>() is { } update)
-				{
-					TypeMappings.RegisterMapping(t, update.OriginalType);
-				}
-			}
-
-			if (_log.IsEnabled(LogLevel.Trace))
-			{
-				_log.Trace($"UpdateApplication (changed types: {string.Join(", ", types.Select(s => s.ToString()))})");
-			}
-
-			_ = Windows.ApplicationModel.Core.CoreApplication.MainView.Dispatcher.RunAsync(
-				Windows.UI.Core.CoreDispatcherPriority.Normal,
-				async () => await ReloadWithUpdatedTypes(types));
 		}
 	}
 
-	public static class AsyncEnumerableExtensions
+	static int[] ReadIntArray(BinaryReader binaryReader)
 	{
-		public async static Task<T[]> ToArrayAsync<T>(this IAsyncEnumerable<T> enumerable)
+		var numValues = binaryReader.ReadInt32();
+		if (numValues == 0)
 		{
-			var list = new List<T>();
-			await foreach (var item in enumerable)
-			{
-				list.Add(item);
-			}
-			return list.ToArray();
+			return Array.Empty<int>();
 		}
+
+		var values = new int[numValues];
+
+		for (var i = 0; i < numValues; i++)
+		{
+			values[i] = binaryReader.ReadInt32();
+		}
+
+		return values;
+	}
+#endif
+
+	private static async Task<bool> ShouldReload()
+	{
+		if (Interlocked.CompareExchange(ref _isReloading, 1, 0) == 1)
+		{
+			return false;
+		}
+		try
+		{
+			await TypeMappings.WaitForMappingsToResume();
+		}
+		finally
+		{
+			Interlocked.Exchange(ref _isReloading, 0);
+		}
+		return true;
+	}
+
+	private static async Task ReloadWithUpdatedTypes(Type[] updatedTypes)
+	{
+		if (!await ShouldReload())
+		{
+			return;
+		}
+
+		try
+		{
+
+			var handlerActions = _instance?.ElementAgent?.ElementHandlerActions;
+
+			// Action: BeforeVisualTreeUpdate
+			// This is called before the visual tree is updated
+			_ = handlerActions?.Do(h => h.Value.BeforeVisualTreeUpdate(updatedTypes)).ToArray();
+
+			var capturedStates = new Dictionary<string, Dictionary<string, object>>();
+
+			var isCapturingState = true;
+			var treeIterator = EnumerateHotReloadInstances(
+					Window.Current.Content,
+					async (fe, key) =>
+					{
+						// Get the original type of the element, in case it's been replaced
+						var liveType = fe.GetType();
+						var originalType = liveType.GetOriginalType() ?? fe.GetType();
+
+						// Get the handler for the type specified
+						// Since we're only interested in handlers for specific element types
+						// we exclude those registered for "object". Handlers that want to run
+						// for all element types should register for FrameworkElement instead
+						var handler = (from h in handlerActions
+									   where (originalType == h.Key ||
+											originalType.IsSubclassOf(h.Key)) &&
+											h.Key != typeof(object)
+									   select h.Value).FirstOrDefault();
+
+						// Get the replacement type, or null if not replaced
+						var mappedType = originalType.GetMappedType();
+
+						if (handler is not null)
+						{
+							if (!capturedStates.TryGetValue(key, out var dict))
+							{
+								dict = new();
+							}
+							if (isCapturingState)
+							{
+								handler.CaptureState(fe, dict, updatedTypes);
+								if (dict.Any())
+								{
+									capturedStates[key] = dict;
+								}
+							}
+							else
+							{
+								await handler.RestoreState(fe, dict, updatedTypes);
+							}
+						}
+
+						if (updatedTypes.Contains(liveType))
+						{
+							// This may happen if one of the nested types has been hot reloaded, but not the type itself.
+							// For instance, a DataTemplate in a resource dictionary may mark the type as updated in `updatedTypes`
+							// but it will not be considered as a new type even if "CreateNewOnMetadataUpdate" was set.
+
+							return (fe, null, liveType);
+						}
+						else
+						{
+							return (handler is not null || mappedType is not null) ? (fe, handler, mappedType) : default;
+						}
+					},
+					parentKey: default);
+
+			// Forced iteration to capture all state before doing ui update
+			var instancesToUpdate = await treeIterator.ToArrayAsync();
+
+			// Iterate through the visual tree and either invoke ElementUpdate, 
+			// or replace the element with a new one
+			foreach (var (element, elementHandler, elementMappedType) in instancesToUpdate)
+			{
+				// Action: ElementUpdate
+				// This is invoked for each existing element that is in the tree that needs to be replaced
+				elementHandler?.ElementUpdate(element, updatedTypes);
+
+				if (elementMappedType is not null)
+				{
+					if (_log.IsEnabled(LogLevel.Trace))
+					{
+						_log.Error($"Updating element [{element}] to [{elementMappedType}]");
+					}
+
+					ReplaceViewInstance(element, elementMappedType, elementHandler);
+				}
+			}
+
+			isCapturingState = false;
+			// Forced iteration again to restore all state after doing ui update
+			_ = await treeIterator.ToArrayAsync();
+
+			// Action: AfterVisualTreeUpdate
+			_ = handlerActions?.Do(h => h.Value.AfterVisualTreeUpdate(updatedTypes)).ToArray();
+		}
+		catch (Exception ex)
+		{
+			if (_log.IsEnabled(LogLevel.Error))
+			{
+				_log.Error($"Error doing UI Update - {ex.Message}", ex);
+			}
+			throw;
+		}
+	}
+
+	private static void ReplaceViewInstance(UIElement instance, Type replacementType, ElementUpdateAgent.ElementUpdateHandlerActions? handler = default, Type[]? updatedTypes = default)
+	{
+		if (replacementType.GetConstructor(Array.Empty<Type>()) is { } creator)
+		{
+			if (_log.IsEnabled(LogLevel.Trace))
+			{
+				_log.Trace($"Creating instance of type {replacementType}");
+			}
+
+			var newInstance = Activator.CreateInstance(replacementType);
+			var instanceFE = instance as FrameworkElement;
+			var newInstanceFE = newInstance as FrameworkElement;
+			if (instanceFE is not null &&
+				newInstanceFE is not null)
+			{
+				handler?.BeforeElementReplaced(instanceFE, newInstanceFE, updatedTypes);
+			}
+			switch (instance)
+			{
+#if __IOS__
+				case UserControl userControl:
+					if (newInstance is UIKit.UIView newUIViewContent)
+					{
+						SwapViews(userControl, newUIViewContent);
+					}
+					break;
+#endif
+				case ContentControl content:
+					if (newInstance is ContentControl newContent)
+					{
+						SwapViews(content, newContent);
+					}
+					break;
+			}
+
+			if (instanceFE is not null &&
+				newInstanceFE is not null)
+			{
+				handler?.AfterElementReplaced(instanceFE, newInstanceFE, updatedTypes);
+			}
+		}
+		else
+		{
+			if (_log.IsEnabled(LogLevel.Debug))
+			{
+				_log.LogDebug($"Type [{instance.GetType()}] has no parameterless constructor, skipping reload");
+			}
+		}
+	}
+
+	public static void UpdateApplication(Type[] types)
+	{
+		foreach (var t in types)
+		{
+			if (t.GetCustomAttribute<System.Runtime.CompilerServices.MetadataUpdateOriginalTypeAttribute>() is { } update)
+			{
+				TypeMappings.RegisterMapping(t, update.OriginalType);
+			}
+		}
+
+		if (_log.IsEnabled(LogLevel.Trace))
+		{
+			_log.Trace($"UpdateApplication (changed types: {string.Join(", ", types.Select(s => s.ToString()))})");
+		}
+
+		_ = Windows.ApplicationModel.Core.CoreApplication.MainView.Dispatcher.RunAsync(
+			Windows.UI.Core.CoreDispatcherPriority.Normal,
+			async () => await ReloadWithUpdatedTypes(types));
+	}
+}
+
+public static class AsyncEnumerableExtensions
+{
+	public async static Task<T[]> ToArrayAsync<T>(this IAsyncEnumerable<T> enumerable)
+	{
+		var list = new List<T>();
+		await foreach (var item in enumerable)
+		{
+			list.Add(item);
+		}
+		return list.ToArray();
 	}
 }

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -53,12 +53,6 @@ partial class ClientHotReloadProcessor : IRemoteControlProcessor
 	public Task<bool> WaitForWorkspaceLoaded(CancellationToken ct)
 		=> _hotReloadWorkloadSpaceLoaded.Task;
 
-	/// <summary>
-	/// Determines if the server's hot reload workspace has been loaded
-	/// </summary>
-	internal Task HotReloadWorkspaceLoaded
-		=> _hotReloadWorkloadSpaceLoaded.Task;
-
 	[MemberNotNull(nameof(_agent))]
 	partial void InitializeMetadataUpdater()
 	{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -12,99 +12,96 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Markup;
 
-namespace Uno.UI.RemoteControl.HotReload
+namespace Uno.UI.RemoteControl.HotReload;
+
+public partial class ClientHotReloadProcessor : IRemoteControlProcessor
 {
-	public partial class ClientHotReloadProcessor : IRemoteControlProcessor
+	private string? _projectPath;
+	private string[]? _xamlPaths;
+	private readonly IRemoteControlClient _rcClient;
+
+	private static readonly Logger _log = typeof(ClientHotReloadProcessor).Log();
+	private Dictionary<string, string>? _msbuildProperties;
+
+	public ClientHotReloadProcessor(IRemoteControlClient rcClient)
 	{
-		private string? _projectPath;
-		private string[]? _xamlPaths;
-		private readonly IRemoteControlClient _rcClient;
+		_rcClient = rcClient;
+		InitializeMetadataUpdater();
+	}
 
-		private static Logger _log = typeof(ClientHotReloadProcessor).Log();
-		private Dictionary<string, string>? _msbuildProperties;
+	partial void InitializeMetadataUpdater();
 
-		public ClientHotReloadProcessor(IRemoteControlClient rcClient)
+	string IRemoteControlProcessor.Scope => HotReloadConstants.HotReload;
+
+	public async Task Initialize()
+		=> await ConfigureServer();
+
+	public async Task ProcessFrame(Messages.Frame frame)
+	{
+		switch (frame.Name)
 		{
-			_rcClient = rcClient;
-			InitializeMetadataUpdater();
-		}
-
-		partial void InitializeMetadataUpdater();
-
-		string IRemoteControlProcessor.Scope => HotReloadConstants.HotReload;
-
-		public async Task Initialize()
-		{
-			await ConfigureServer();
-		}
-
-		public async Task ProcessFrame(Messages.Frame frame)
-		{
-			switch (frame.Name)
-			{
 #if __WASM__ || __SKIA__
-				case AssemblyDeltaReload.Name:
-					AssemblyReload(JsonConvert.DeserializeObject<HotReload.Messages.AssemblyDeltaReload>(frame.Content)!);
-					break;
+			case AssemblyDeltaReload.Name:
+				AssemblyReload(JsonConvert.DeserializeObject<HotReload.Messages.AssemblyDeltaReload>(frame.Content)!);
+				break;
 #endif
 
-				case FileReload.Name:
-					await PartialReload(JsonConvert.DeserializeObject<HotReload.Messages.FileReload>(frame.Content)!);
-					break;
+			case FileReload.Name:
+				await PartialReload(JsonConvert.DeserializeObject<HotReload.Messages.FileReload>(frame.Content)!);
+				break;
 
-				case HotReloadWorkspaceLoadResult.Name:
-					WorkspaceLoadResult(JsonConvert.DeserializeObject<HotReload.Messages.HotReloadWorkspaceLoadResult>(frame.Content)!);
-					break;
+			case HotReloadWorkspaceLoadResult.Name:
+				WorkspaceLoadResult(JsonConvert.DeserializeObject<HotReload.Messages.HotReloadWorkspaceLoadResult>(frame.Content)!);
+				break;
 
-				default:
-					if (this.Log().IsEnabled(LogLevel.Error))
-					{
-						this.Log().LogError($"Unknown frame [{frame.Scope}/{frame.Name}]");
-					}
-					break;
-			}
-
-			return;
-		}
-
-		private async Task ConfigureServer()
-		{
-			var assembly = _rcClient.AppType.Assembly;
-
-			if (assembly.GetCustomAttributes(typeof(ProjectConfigurationAttribute), false) is ProjectConfigurationAttribute[] configs)
-			{
-				var config = configs.First();
-
-				_projectPath = config.ProjectPath;
-				_xamlPaths = config.XamlPaths;
-
-				if (this.Log().IsEnabled(LogLevel.Debug))
-				{
-					this.Log().LogDebug($"ProjectConfigurationAttribute={config.ProjectPath}, Paths={_xamlPaths.Length}");
-				}
-
-				if (this.Log().IsEnabled(LogLevel.Trace))
-				{
-					foreach (var path in _xamlPaths)
-					{
-						this.Log().Trace($"\t- {path}");
-					}
-				}
-
-				ConfigureServer message = new(_projectPath, _xamlPaths, GetMetadataUpdateCapabilities(), config.MSBuildProperties);
-
-				await _rcClient.SendMessage(message);
-
-				_msbuildProperties = message.MSBuildProperties;
-
-				InitializePartialReload();
-			}
-			else
-			{
+			default:
 				if (this.Log().IsEnabled(LogLevel.Error))
 				{
-					this.Log().LogError("Unable to find ProjectConfigurationAttribute");
+					this.Log().LogError($"Unknown frame [{frame.Scope}/{frame.Name}]");
 				}
+				break;
+		}
+
+		return;
+	}
+
+	private async Task ConfigureServer()
+	{
+		var assembly = _rcClient.AppType.Assembly;
+
+		if (assembly.GetCustomAttributes(typeof(ProjectConfigurationAttribute), false) is ProjectConfigurationAttribute[] configs)
+		{
+			var config = configs.First();
+
+			_projectPath = config.ProjectPath;
+			_xamlPaths = config.XamlPaths;
+
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"ProjectConfigurationAttribute={config.ProjectPath}, Paths={_xamlPaths.Length}");
+			}
+
+			if (this.Log().IsEnabled(LogLevel.Trace))
+			{
+				foreach (var path in _xamlPaths)
+				{
+					this.Log().Trace($"\t- {path}");
+				}
+			}
+
+			ConfigureServer message = new(_projectPath, _xamlPaths, GetMetadataUpdateCapabilities(), config.MSBuildProperties);
+
+			await _rcClient.SendMessage(message);
+
+			_msbuildProperties = message.MSBuildProperties;
+
+			InitializePartialReload();
+		}
+		else
+		{
+			if (this.Log().IsEnabled(LogLevel.Error))
+			{
+				this.Log().LogError("Unable to find ProjectConfigurationAttribute");
 			}
 		}
 	}

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -118,7 +118,7 @@ public class RemoteControlClient : IRemoteControlClient
 		_connection = StartConnection();
 	}
 
-	public IEnumerable<object> Processors 
+	public IEnumerable<object> Processors
 		=> _processors.Values;
 
 	internal IRemoteControlProcessor[] RegisteredProcessors

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -118,6 +118,9 @@ public class RemoteControlClient : IRemoteControlClient
 		_connection = StartConnection();
 	}
 
+	public IEnumerable<object> Processors 
+		=> _processors.Values;
+
 	internal IRemoteControlProcessor[] RegisteredProcessors
 		=> _processors.Values.ToArray();
 

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.UI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.UI.DevServer.targets
@@ -6,6 +6,11 @@
 		<UnoRuntimeEnabledPackage Include="Uno.WinUI.DevServer"  PackageBasePath="$(MSBuildThisFileDirectory)" Condition="'$(MSBuildThisFile)'=='uno.winui.devserver.targets'"  />
 	</ItemGroup>
 
+	<ItemGroup>
+		<CompilerVisibleProperty Include="UnoDevServer_IncludeProjectConfiguration" />
+		<CompilerVisibleProperty Include="UnoDevServer_IncludeServerProcessorsConfiguration" />
+	</ItemGroup>
+
 	<PropertyGroup>
 		<!-- Keep the inner path with '/' separator -->
 		<UnoRemoteControlProcessorsPath Condition="'$(SolutionFileName)'!='Uno.UI.sln'">$(MSBuildThisFileDirectory)../tools/rc/processors</UnoRemoteControlProcessorsPath>
@@ -19,7 +24,6 @@
 			<_UnoRCHostVersionPath>net7.0</_UnoRCHostVersionPath>
 			<_UnoRCHostVersionPath Condition="'$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))' &gt; 7">net8.0</_UnoRCHostVersionPath>
 		</PropertyGroup>
-
 
 		<Message Text="&lt;RemoteControlHostPath&gt;$(MSBuildThisFileDirectory)../tools/rc/host/$(_UnoRCHostVersionPath)/Uno.UI.RemoteControl.Host.dll&lt;/RemoteControlHostPath&gt;" Importance="High" />
 		<Message Text="&lt;IntermediateOutputPath&gt;$(MSBuildProjectDirectory)/$(IntermediateOutputPath)&lt;/IntermediateOutputPath&gt;" Importance="High" />

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/MainPage.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/MainPage.xaml.cs
@@ -41,7 +41,7 @@ namespace UnoApp50
 				await RemoteControlClient.Instance.RegisteredProcessors
 					.OfType<ClientHotReloadProcessor>()
 					.First()
-					.HotReloadWorkspaceLoaded;
+					.WaitForWorkspaceLoaded(default);
 
 				Console.WriteLine($"Initialized remote control");
 			}


### PR DESCRIPTION
linked to https://github.com/unoplatform/uno.ui.runtimetests.engine/issues/102

## Feature
* Force the dev-server to use the desired dotnet runtime
* Add ability to configure hot-reload also when app is built in release

## What is the current behavior?
* The dev-server in run using the latest runtime available, breaking assembly loading and compatibility checks
* Dev server is not configured in release preventing usage of hot-reload

## What is the new behavior?
🙃

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc1ed19</samp>

This pull request adds support for hot reload in release mode with apps built on the CI, and updates the remote control host and client projects to use the latest features of .NET 7.0 and 8.0. It also adds a new property to expose the remote control processors, and cleans up some unused and redundant code. The main files affected are `RemoteControlGenerator.cs`, `Uno.UI.DevServer.targets`, `global-net*.json`, `ClientHotReloadProcessor.cs`, and `RemoteControlClient.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable) ==> In runtime tests project!
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
