### PR TITLE
Adjust DataTemplate reload

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
@@ -46,12 +46,12 @@ namespace TestRepro
 			"myTemplate"
 			] = 
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
-				new global::Windows.UI.Xaml.DataTemplate(__ResourceOwner_1 , __owner => 				new _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0().Build(__owner)
+				new global::Windows.UI.Xaml.DataTemplate(__ResourceOwner_1 , __owner => 				new _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0_().Build(__owner)
 				)			)
 			;
 		}
 
-		private class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0
+		private class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0_
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
@@ -176,7 +176,7 @@ namespace MyProject
 
 			// Method for resource myTemplate 
 			private object Get_1(object __ResourceOwner_1) =>
-				new global::Windows.UI.Xaml.DataTemplate(__ResourceOwner_1 , __owner => 				new __Resources._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1().Build(__owner)
+				new global::Windows.UI.Xaml.DataTemplate(__ResourceOwner_1 , __owner => 				new __Resources._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1_().Build(__owner)
 				)				;
 
 			private global::Windows.UI.Xaml.ResourceDictionary _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
@@ -195,7 +195,7 @@ namespace MyProject
 							"myTemplate"
 							] = 
 							new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
-								new global::Windows.UI.Xaml.DataTemplate(__ResourceOwner_1 , __owner => 								new __Resources._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2().Build(__owner)
+								new global::Windows.UI.Xaml.DataTemplate(__ResourceOwner_1 , __owner => 								new __Resources._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2_().Build(__owner)
 								)							)
 							,
 						}
@@ -215,7 +215,7 @@ namespace MyProject
 }
 namespace MyProject.__Resources
 {
-	 class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1
+	 class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1_
 	{
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
@@ -303,7 +303,7 @@ namespace MyProject.__Resources
 			return true;
 		}
 	}
-	 class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2
+	 class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2_
 	{
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
@@ -59,7 +59,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 						IsParsing = true,
 						Name = "topLevel",
 						Tag = @"42",
-						ContentTemplate = 						new global::Windows.UI.Xaml.DataTemplate(this , __owner => 						new _Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0().Build(__owner)
+						ContentTemplate = 						new global::Windows.UI.Xaml.DataTemplate(this , __owner => 						new _Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0_().Build(__owner)
 						)						,
 						// Source 0\Binding_ElementName_In_Template.xaml (Line 11:4)
 					}
@@ -115,7 +115,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 				_topLevelSubject.ElementInstance = value;
 			}
 		}
-		private class _Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0
+		private class _Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0_
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			private const string __baseUri_prefix_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca = "ms-appx:///TestProject/";

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileDefinition.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileDefinition.cs
@@ -2,7 +2,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using Uno.UI.SourceGenerators.Helpers;
 using Uno.UI.SourceGenerators.XamlGenerator.XamlRedirection;
 
@@ -10,7 +13,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 {
 	internal class XamlFileDefinition : IEquatable<XamlFileDefinition>
 	{
-		public XamlFileDefinition(string file, string targetFilePath)
+		public XamlFileDefinition(string file, string targetFilePath, ImmutableArray<byte> checksum)
 		{
 			Namespaces = new List<NamespaceDeclaration>();
 			Objects = new List<XamlObjectDefinition>();
@@ -18,6 +21,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			TargetFilePath = targetFilePath;
 
 			UniqueID = SanitizedFileName + "_" + HashBuilder.Build(FilePath);
+
+			Checksum = string.Concat(checksum.Select(c => c.ToString("x2", CultureInfo.InvariantCulture)));
 		}
 
 		private string SanitizedFileName => Path
@@ -29,6 +34,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		public List<XamlObjectDefinition> Objects { get; private set; }
 
 		public string FilePath { get; }
+
+		public string Checksum { get; }
 
 		public string? SourceLink { get; internal set; }
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -6469,7 +6469,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			var namespacePrefix = _scopeStack.Count == 1 && _scopeStack.Last().Name.EndsWith("RD", StringComparison.Ordinal) ? "__Resources." : "";
 
-			var subclassName = $"_{_fileUniqueId}_{subClassPrefix}SC{(_subclassIndex++).ToString(CultureInfo.InvariantCulture)}";
+			// This is needed to avoid having outer classes being marked
+			// as updated types, but not having new types created as a result
+			// of an inner change, which may prevent XAML HR to apply changes.
+			var hashValue = _isHotReloadEnabled && !subClassPrefix.Contains(_fileDefinition.Checksum)
+				? _fileDefinition.Checksum
+				: "";
+
+			var subclassName = $"_{_fileUniqueId}_{subClassPrefix}SC{(_subclassIndex++).ToString(CultureInfo.InvariantCulture)}_{hashValue}";
 
 			RegisterChildSubclass(subclassName, contentOwner, returnType);
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
@@ -17,6 +17,7 @@ using Uno.UI.SourceGenerators.XamlGenerator.XamlRedirection;
 using Uno.UI.SourceGenerators.XamlGenerator.Utils;
 using Uno.Roslyn;
 using Windows.Foundation.Metadata;
+using System.Collections.Immutable;
 
 namespace Uno.UI.SourceGenerators.XamlGenerator
 {
@@ -118,7 +119,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					{
 						cancellationToken.ThrowIfCancellationRequested();
 
-						var xamlFileDefinition = Visit(reader, file.Path, targetFilePath, cancellationToken);
+						var xamlFileDefinition = Visit(reader, file, targetFilePath, cancellationToken);
 						if (!reader.DisableCaching)
 						{
 							_cachedFiles[cachedFileKey] = new CachedFile(DateTimeOffset.Now, xamlFileDefinition);
@@ -228,11 +229,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 		}
 
-		private XamlFileDefinition Visit(XamlXmlReader reader, string file, string targetFilePath, CancellationToken cancellationToken)
+		private XamlFileDefinition Visit(XamlXmlReader reader, AdditionalText source, string targetFilePath, CancellationToken cancellationToken)
 		{
 			WriteState(reader);
 
-			var xamlFile = new XamlFileDefinition(file, targetFilePath);
+			var xamlFile = new XamlFileDefinition(source.Path, targetFilePath, source.GetText(cancellationToken)?.GetChecksum() ?? ImmutableArray<byte>.Empty);
 
 			do
 			{

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -25,10 +25,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.7.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0-2.final" />
 		<!-- TODO: Use version 8 when compiling against .NET 8? -->
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Build" Version="16.10.0" ExcludeAssets="runtime" />
@@ -38,10 +38,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.7.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0-2.final" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Build" Version="16.10.0" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" ExcludeAssets="runtime" />

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -209,7 +209,8 @@ namespace Uno.UI.RemoteControl.HotReload
 						async (fe, key) =>
 						{
 							// Get the original type of the element, in case it's been replaced
-							var originalType = fe.GetType().GetOriginalType() ?? fe.GetType();
+							var liveType = fe.GetType();
+							var originalType = liveType.GetOriginalType() ?? fe.GetType();
 
 							// Get the handler for the type specified
 							// Since we're only interested in handlers for specific element types
@@ -244,15 +245,25 @@ namespace Uno.UI.RemoteControl.HotReload
 								}
 							}
 
-							return (handler is not null || mappedType is not null) ? (fe, handler, mappedType) : default;
+							if (updatedTypes.Contains(liveType))
+							{
+								// This may happen if one of the nested types has been hot reloaded, but not the type itself.
+								// For instance, a DataTemplate in a resource dictionary may mark the type as updated in `updatedTypes`
+								// but it will not be considered as a new type even if "CreateNewOnMetadataUpdate" was set.
+
+								return (fe, null, liveType);
+							}
+							else
+							{
+								return (handler is not null || mappedType is not null) ? (fe, handler, mappedType) : default;
+							}
 						},
 						parentKey: default);
 
 				// Forced iteration to capture all state before doing ui update
 				var instancesToUpdate = await treeIterator.ToArrayAsync();
 
-
-				// Iterate through the visual tree and either invole ElementUpdate, 
+				// Iterate through the visual tree and either invoke ElementUpdate, 
 				// or replace the element with a new one
 				foreach (var (element, elementHandler, elementMappedType) in instancesToUpdate)
 				{
@@ -262,6 +273,11 @@ namespace Uno.UI.RemoteControl.HotReload
 
 					if (elementMappedType is not null)
 					{
+						if (_log.IsEnabled(LogLevel.Trace))
+						{
+							_log.Error($"Updating element [{element}] to [{elementMappedType}]");
+						}
+
 						ReplaceViewInstance(element, elementMappedType, elementHandler);
 					}
 				}
@@ -281,7 +297,6 @@ namespace Uno.UI.RemoteControl.HotReload
 				}
 				throw;
 			}
-
 		}
 
 		private static void ReplaceViewInstance(UIElement instance, Type replacementType, ElementUpdateAgent.ElementUpdateHandlerActions? handler = default, Type[]? updatedTypes = default)
@@ -290,7 +305,7 @@ namespace Uno.UI.RemoteControl.HotReload
 			{
 				if (_log.IsEnabled(LogLevel.Trace))
 				{
-					_log.Trace($"Creating instance of type {instance.GetType()}");
+					_log.Trace($"Creating instance of type {replacementType}");
 				}
 
 				var newInstance = Activator.CreateInstance(replacementType);

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_DataTemplate.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_DataTemplate.cs
@@ -1,0 +1,47 @@
+﻿
+using System.Reflection.Metadata;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Uno.UI.Helpers;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_DataTemplate : BaseTestClass
+{
+	/// <summary>
+	/// Change the Text of a TextBlock inside a UserControl, where the UserControl 
+	/// is nested inside a Viewbox
+	/// </summary>
+	[TestMethod]
+	public async Task When_Change_DataTemplate()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+
+		// We're not storing the instance explicitly, as the HR engine replaces
+		// the top level content of the window. We keep poking at the UnitTestsUIContentHelper.Content
+		// as it gets updated with reloaded content.
+		UnitTestsUIContentHelper.Content = new HR_Frame_Pages_DataTemplate();
+
+		var originalText = "** Original Text **";
+		var updatedText = "** Updated Text **";
+
+		// Check the initial text of the TextBlock
+		await UnitTestsUIContentHelper.Content.ValidateTextOnChildTextBlock(originalText, 0);
+
+		// Check the updated text of the TextBlock
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_DataTemplate>(
+			originalText,
+			updatedText,
+			() => UnitTestsUIContentHelper.Content.ValidateTextOnChildTextBlock(updatedText, 0),
+			ct);
+
+		// Validate that content been returned to the original text
+		await UnitTestsUIContentHelper.Content.ValidateTextOnChildTextBlock(originalText, 0);
+
+		await Task.Yield();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataTemplate.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataTemplate.xaml
@@ -1,0 +1,18 @@
+<Page x:Class="Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages.HR_Frame_Pages_DataTemplate"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+	<Page.Resources>
+		<DataTemplate x:Key="myTemplate">
+			<TextBlock Text="** Original Text **" />
+		</DataTemplate>
+	</Page.Resources>
+	<StackPanel>
+		<ContentControl ContentTemplate="{StaticResource myTemplate}" Content="21">			
+		</ContentControl>
+	</StackPanel>
+</Page>
+

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataTemplate.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataTemplate.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
+
+public sealed partial class HR_Frame_Pages_DataTemplate : Page
+{
+	public HR_Frame_Pages_DataTemplate()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Skia.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Skia.csproj
@@ -14,6 +14,14 @@
 		<DefineConstants>$(DefineConstants);IS_RUNTIME_UI_TESTS</DefineConstants>
 		<NoWarn>$(NoWarn);CS1998</NoWarn>
 	</PropertyGroup>
+	
+	<!--
+	Uncomment this block to enable generated source debugging
+	<PropertyGroup>
+		<UnoUISourceGeneratorDebuggerBreak>True</UnoUISourceGeneratorDebuggerBreak>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+	</PropertyGroup>
+	-->
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/212

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Improved support for nested generated classes reload detection.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1373695</samp>

This pull request improves the XAML source generation and hot reload features of the Uno Platform. It adds a `Checksum` property to the `XamlFileDefinition` class to track the source file content and avoid unnecessary regeneration. It updates the `XamlFileParser` and `XamlFileGenerator` classes to use the `Checksum` value and improve the performance and reliability of the source generator. It also updates the `Microsoft.CodeAnalysis` packages to the latest version and fixes some minor issues in the `ClientHotReloadProcessor` class. Additionally, it adds a new test class and a new XAML page to the Uno.UI.RuntimeTests project to verify the hot reload behavior of a data template in a content control. It also adds a commented-out block of code to the project file for Uno.UI.RuntimeTests.Skia, which can be used to enable generated source debugging and compiler generated files emission for the source generators.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
