### PR TITLE
docs: using-skia-hosting-native-controls.md (bad link and incorrect sample code)

### DIFF
--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -35,7 +35,7 @@ host.RenderSurfaceType = RenderSurfaceType.Software;
 
 Hosting native GTK controls is supported through `ContentPresenter` and `ContentControl`.
 
-See this documentation about [embedding native controls](using-skia-hosting-native-controls.md).
+See this documentation about [embedding native controls](xref:Uno.Skia.Embedding.Native).
 
 ### Linux considerations
 When running under Linux, GTK can use OpenGL for the UI rendering but some restrictions can apply depending on the environment and available hardware.

--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -35,7 +35,7 @@ host.RenderSurfaceType = RenderSurfaceType.Software;
 
 Hosting native GTK controls is supported through `ContentPresenter` and `ContentControl`.
 
-See this documentation about [embedding native controls](using-skia-embed-native-controls.md).
+See this documentation about [embedding native controls](using-skia-hosting-native-controls.md).
 
 ### Linux considerations
 When running under Linux, GTK can use OpenGL for the UI rendering but some restrictions can apply depending on the environment and available hardware.

--- a/doc/articles/features/using-skia-hosting-native-controls.md
+++ b/doc/articles/features/using-skia-hosting-native-controls.md
@@ -17,7 +17,7 @@ For instance, in a Skia.GTK app, you can add a control as follows:
 ```xml
 <ContentControl x:Name="MyControl">
     <ContentControl.Content>
-        <CheckBox xmlns="using:Gtk" />
+        <CheckButton xmlns="using:Gtk" />
     </ContentControl.Content>
 </ContentControl>
 ```


### PR DESCRIPTION
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

- Documentation content changes


## What is the current behavior?

- Wrong link to "embedded ski controls.md'.
- The sample code to host native control will produce a build compilation error due to the fact that "CheckBox" control doesn't exists in the Gtk namespace. You should use "CheckButton" instead.

## What is the new behavior?

- Clicking the link will redirect to the using-skia-hosting-native-controls.md file.
- The sample code is now correct and will compile as it.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddfd4e4</samp>

Updated the documentation for using Skia with GTK to fix a broken link and a code typo.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
