### PR TITLE
feat: Add basic support for `TextBox.Paste` and `PasswordBox.Paste`

### DIFF
--- a/doc/articles/controls/TextBox.md
+++ b/doc/articles/controls/TextBox.md
@@ -57,3 +57,9 @@ uid: Uno.Controls.TextBox
 ## Controlling the Keyboard on iOS
 
 If a view needs to keep the keyboard opened when tapping on it, use the `Uno.UI.Controls.Window.SetNeedsKeyboard` attached property.
+
+## Paste event
+
+Support for capturing and handling the `Paste` event is implemented on all targets except for macOS. 
+
+In case of Android, it is currently limited to the pastes which are triggered by the native context menu (e.g. after long-pressing the `TextBox`). It cannot detect paste triggered from the virtual keyboard or via hardware keyboard shortcut.

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3834,6 +3834,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PasteEvent.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_TextAlignment.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7563,6 +7567,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Simple.xaml.cs">
       <DependentUpon>TextBox_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PasteEvent.xaml.cs">
+      <DependentUpon>TextBox_PasteEvent.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_TextAlignment.xaml.cs">
       <DependentUpon>TextBox_TextAlignment.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_PasteEvent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_PasteEvent.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBoxControl.TextBox_PasteEvent"
+	 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	 mc:Ignorable="d"
+	 d:DesignHeight="300"
+	 d:DesignWidth="400">
+
+	 <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">        
+        <CheckBox x:Name="HandlePasteCheckBox" Content="Handle?" />
+		<TextBox x:Name="SampleTextBox" Header="TextBox" Paste="SampleTextBox_Paste" />
+		<PasswordBox x:Name="SamplePasswordBox" Header="PasswordBox" Paste="SamplePasswordBox_Paste" />
+		<TextBlock x:Name="EventLogTextBlock" />
+    </StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_PasteEvent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_PasteEvent.xaml
@@ -10,6 +10,7 @@
 
 	 <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">        
         <CheckBox x:Name="HandlePasteCheckBox" Content="Handle?" />
+		<CheckBox x:Name="MultilineCheckBox" Checked="OnMultilineChanged" Unchecked="OnMultilineChanged" Content="Multiline" />
 		<TextBox x:Name="SampleTextBox" Header="TextBox" Paste="SampleTextBox_Paste" />
 		<PasswordBox x:Name="SamplePasswordBox" Header="PasswordBox" Paste="SamplePasswordBox_Paste" />
 		<TextBlock x:Name="EventLogTextBlock" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_PasteEvent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_PasteEvent.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBoxControl
+{
+	[Sample(
+		"TextBox",
+		IsManualTest = true,
+		IgnoreInSnapshotTests = true,
+		Description =
+			"Verifies the Paste event functionality. " +
+			"When the CheckBox is not checked, pasting from clipboard should be possible. " +
+			"When checked, pasting should not happen.")]
+	public sealed partial class TextBox_PasteEvent : UserControl
+	{
+		public TextBox_PasteEvent()
+		{
+			InitializeComponent();
+		}
+
+		private void SampleTextBox_Paste(object sender, TextControlPasteEventArgs e)
+		{
+			if (HandlePasteCheckBox.IsChecked == true)
+			{
+				e.Handled = true;
+			}
+
+			EventLogTextBlock.Text = "TextBox.Paste at " + DateTime.Now.ToString() + " " + (e.Handled ? " handled" : "not handled");
+		}
+
+		private void SamplePasswordBox_Paste(object sender, TextControlPasteEventArgs e)
+		{
+			if (HandlePasteCheckBox.IsChecked == true)
+			{
+				e.Handled = true;
+			}
+
+			EventLogTextBlock.Text = "PasswordBox.Paste at " + DateTime.Now.ToString() + " " + (e.Handled ? " handled" : "not handled");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_PasteEvent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_PasteEvent.xaml.cs
@@ -19,6 +19,11 @@ namespace Uno.UI.Samples.Content.UITests.TextBoxControl
 			InitializeComponent();
 		}
 
+		private void OnMultilineChanged(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+		{
+			SampleTextBox.AcceptsReturn = MultilineCheckBox.IsChecked == true;
+		}
+
 		private void SampleTextBox_Paste(object sender, TextControlPasteEventArgs e)
 		{
 			if (HandlePasteCheckBox.IsChecked == true)

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkTextBoxView.cs
@@ -33,6 +33,8 @@ internal abstract class GtkTextBoxView : IOverlayTextBoxView
 		InputWidget.StyleContext.AddClass(TextBoxViewCssClass);
 	}
 
+	public event TextControlPasteEventHandler? Paste;
+
 	/// <summary>
 	/// Represents the root widget of the input layout.
 	/// </summary>

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkTextBoxView.cs
@@ -106,6 +106,8 @@ internal abstract class GtkTextBoxView : IOverlayTextBoxView
 		}
 	}
 
+	protected void RaisePaste(TextControlPasteEventArgs args) => Paste?.Invoke(this, args);
+
 	private void SetFont(TextBox textBox)
 	{
 		var fontDescription = new FontDescription

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/MultilineTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/MultilineTextBoxView.cs
@@ -3,6 +3,7 @@
 using System;
 using Gtk;
 using Uno.Disposables;
+using Uno.UI.Runtime.Skia.Gtk.UI.Controls;
 using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Runtime.Skia.Gtk.UI.Xaml.Controls;
@@ -12,13 +13,16 @@ internal class MultilineTextBoxView : GtkTextBoxView
 	private const string MultilineHostCssClass = "textbox_multiline_host";
 
 	private readonly ScrolledWindow _scrolledWindow = new();
-	private readonly TextView _textView = new();
+	private readonly UnoGtkTextView _textView = new();
 
 	public MultilineTextBoxView()
 	{
 		_scrolledWindow.Add(_textView);
 		_scrolledWindow.StyleContext.AddClass(MultilineHostCssClass);
+		_textView.Paste += OnPaste;
 	}
+
+	private void OnPaste(object sender, TextControlPasteEventArgs args) => RaisePaste(args);
 
 	protected override Widget RootWidget => _scrolledWindow;
 

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/SinglelineTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/SinglelineTextBoxView.cs
@@ -4,19 +4,23 @@ using System;
 using System.Threading;
 using Gtk;
 using Uno.Disposables;
+using Uno.UI.Runtime.Skia.Gtk.UI.Controls;
 using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Runtime.Skia.Gtk.UI.Xaml.Controls;
 
 internal class SinglelineTextBoxView : GtkTextBoxView
 {
-	private readonly Entry _entry = new();
+	private readonly UnoGtkEntry _entry = new();
 	private readonly bool _isPassword;
 
 	public SinglelineTextBoxView(bool isPassword)
 	{
 		_isPassword = isPassword;
+		_entry.Paste += OnPaste;
 	}
+
+	private void OnPaste(object sender, TextControlPasteEventArgs args) => RaisePaste(args);
 
 	protected override Widget InputWidget => _entry;
 

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkEntry.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkEntry.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+
+using Gtk;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Runtime.Skia.Gtk.UI.Controls;
+
+internal class UnoGtkEntry : Entry
+{
+	protected override void OnClipboardPasted()
+	{
+		var args = new TextControlPasteEventArgs();
+		Paste?.Invoke(this, args);
+		if (!args.Handled)
+		{
+			base.OnClipboardPasted();
+		}
+	}
+
+	public event TextControlPasteEventHandler? Paste;
+}

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkTextView.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkTextView.cs
@@ -1,0 +1,20 @@
+﻿#nullable enable
+
+using Gtk;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Runtime.Skia.Gtk.UI.Controls;
+internal class UnoGtkTextView : TextView
+{
+	protected override void OnPasteClipboard()
+	{
+		var args = new TextControlPasteEventArgs();
+		Paste?.Invoke(this, args);
+		if (!args.Handled)
+		{
+			base.OnPasteClipboard();
+		}
+	}
+
+	public event TextControlPasteEventHandler? Paste;
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 #endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.PasswordBox.PasswordChanged
-#if false || __IOS__ || IS_UNIT_TESTS || false || false || false || __MACOS__
+#if false || false || IS_UNIT_TESTS || false || false || false || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 #endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.PasswordBox.PasswordChanged
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 #endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.PasswordBox.PasswordChanged
-#if false || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
+#if false || __IOS__ || IS_UNIT_TESTS || false || false || false || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -207,7 +207,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 #endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.PasswordBox.PasswordChanged
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
+#if false || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -208,15 +208,15 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.PasswordBox.PasswordChanged
 #if false || false || IS_UNIT_TESTS || false || false || false || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("IS_UNIT_TESTS", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			[global::Uno.NotImplemented("IS_UNIT_TESTS", "__MACOS__")]
 			add
 			{
 				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.PasswordBox", "event TextControlPasteEventHandler PasswordBox.Paste");
 			}
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			[global::Uno.NotImplemented("IS_UNIT_TESTS", "__MACOS__")]
 			remove
 			{
 				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.PasswordBox", "event TextControlPasteEventHandler PasswordBox.Paste");

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -488,7 +488,7 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.SelectionChanged
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.TextChanged
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -489,15 +489,15 @@ namespace Windows.UI.Xaml.Controls
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.SelectionChanged
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.TextChanged
 #if false || false || IS_UNIT_TESTS || false || false || false || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+		[global::Uno.NotImplemented("IS_UNIT_TESTS", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			[global::Uno.NotImplemented("IS_UNIT_TESTS", "__MACOS__")]
 			add
 			{
 				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "event TextControlPasteEventHandler TextBox.Paste");
 			}
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
+			[global::Uno.NotImplemented("IS_UNIT_TESTS", "__MACOS__")]
 			remove
 			{
 				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBox", "event TextControlPasteEventHandler TextBox.Paste");

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -488,7 +488,7 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.SelectionChanged
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.TextChanged
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
+#if false || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -488,7 +488,7 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.SelectionChanged
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.TextChanged
-#if false || __IOS__ || IS_UNIT_TESTS || false || false || false || __MACOS__
+#if false || false || IS_UNIT_TESTS || false || false || false || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBox.cs
@@ -488,7 +488,7 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.SelectionChanged
 		// Skipping already declared event Windows.UI.Xaml.Controls.TextBox.TextChanged
-#if false || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || __MACOS__
+#if false || __IOS__ || IS_UNIT_TESTS || false || false || false || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public event global::Windows.UI.Xaml.Controls.TextControlPasteEventHandler Paste
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextControlPasteEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextControlPasteEventArgs.cs
@@ -3,17 +3,17 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class TextControlPasteEventArgs
 	{
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		internal TextControlPasteEventArgs()
 		{
 		}
 #endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public bool Handled
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextControlPasteEventHandler.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextControlPasteEventHandler.cs
@@ -3,7 +3,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 	public delegate void TextControlPasteEventHandler(object sender, global::Windows.UI.Xaml.Controls.TextControlPasteEventArgs e);
 #endif
 }

--- a/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PasswordBox/PasswordBox.cs
@@ -308,5 +308,16 @@ namespace Windows.UI.Xaml.Controls
 				descriptionPresenter.Visibility = Description != null ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
+
+#if !IS_UNIT_TESTS && !__MACOS__
+		/// <summary>
+		/// Occurs when text is pasted into the control.
+		/// </summary>
+		public new event TextControlPasteEventHandler Paste
+		{
+			add => base.Paste += value;
+			remove => base.Paste -= value;
+		}
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxView.iOS.cs
@@ -26,6 +26,27 @@ namespace Windows.UI.Xaml.Controls
 		private WeakReference<Uno.UI.Controls.Window> _window;
 		private Action _foregroundChanged;
 
+		public override void Paste(NSObject sender) => HandlePaste(() => base.Paste(sender));
+
+		public override void PasteAndGo(NSObject sender) => HandlePaste(() => base.PasteAndGo(sender));
+
+		public override void PasteAndMatchStyle(NSObject sender) => HandlePaste(() => base.PasteAndMatchStyle(sender));
+
+		public override void PasteAndSearch(NSObject sender) => HandlePaste(() => base.PasteAndSearch(sender));
+
+		public override void Paste(NSItemProvider[] itemProviders) => HandlePaste(() => base.Paste(itemProviders));
+
+		private void HandlePaste(Action baseAction)
+		{
+			var args = new TextControlPasteEventArgs();
+			var textBox = _textBox.GetTarget();
+			textBox?.RaisePaste(args);
+			if (!args.Handled)
+			{
+				baseAction.Invoke();
+			}
+		}
+
 		CGPoint IUIScrollView.UpperScrollLimit { get { return (CGPoint)(ContentSize - Frame.Size); } }
 
 		void IUIScrollView.ApplyZoomScale(nfloat scale, bool animated)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/OverlayTextBoxView/IOverlayTextBoxView.skia.cs
@@ -8,6 +8,8 @@ namespace Uno.UI.Xaml.Controls.Extensions;
 
 internal interface IOverlayTextBoxView
 {
+	event TextControlPasteEventHandler? Paste;
+
 	bool IsDisplayed { get; }
 
 	string Text { get; set; }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
@@ -8,6 +8,11 @@ using Uno.Extensions;
 using Uno.UI.Controls;
 using Uno.UI.Extensions;
 using Windows.UI.Xaml.Media;
+using Windows.UI;
+using Uno.Disposables;
+using Uno.Foundation.Logging;
+using Uno.UI;
+using static Uno.UI.FeatureConfiguration;
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
@@ -1,23 +1,13 @@
-using CoreGraphics;
-using ObjCRuntime;
-using Uno.UI.DataBinding;
-using Uno.UI.Helpers;
-using Uno.UI.Views.Controls;
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
+using CoreGraphics;
+using Foundation;
+using ObjCRuntime;
 using UIKit;
 using Uno.Extensions;
+using Uno.UI.Controls;
 using Uno.UI.Extensions;
 using Windows.UI.Xaml.Media;
-using Uno.UI.Controls;
-using Windows.UI;
-using Uno.Disposables;
-using Foundation;
-using Uno.Foundation.Logging;
-using Uno.UI;
-using static Uno.UI.FeatureConfiguration;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -33,6 +23,26 @@ namespace Windows.UI.Xaml.Controls
 
 			InitializeBinder();
 			Initialize();
+		}
+
+		public override void Paste(NSObject sender) => HandlePaste(() => base.Paste(sender));
+
+		public override void PasteAndGo(NSObject sender) => HandlePaste(() => base.PasteAndGo(sender));
+
+		public override void PasteAndMatchStyle(NSObject sender) => HandlePaste(() => base.PasteAndMatchStyle(sender));
+
+		public override void PasteAndSearch(NSObject sender) => HandlePaste(() => base.PasteAndSearch(sender));
+
+		public override void Paste(NSItemProvider[] itemProviders) => HandlePaste(() => base.Paste(itemProviders));
+
+		private void HandlePaste(Action baseAction)
+		{
+			var args = new TextControlPasteEventArgs();
+			TextBox?.RaisePaste(args);
+			if (!args.Handled)
+			{
+				baseAction.Invoke();
+			}
 		}
 
 		internal TextBox TextBox => _textBox.GetTarget();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -69,15 +69,19 @@ namespace Windows.UI.Xaml.Controls
 		public event TypedEventHandler<TextBox, TextBoxTextChangingEventArgs> TextChanging;
 		public event TypedEventHandler<TextBox, TextBoxBeforeTextChangingEventArgs> BeforeTextChanging;
 		public event RoutedEventHandler SelectionChanged;
-#if __SKIA__ || __ANDROID__ || __CROSSRUNTIME__ || __IOS__
+
+#if !IS_UNIT_TESTS && !__MACOS__
+		/// <summary>
+		/// Occurs when text is pasted into the control.
+		/// </summary>
 		public
-#if ___IOS__
+#if __IOS__
 			new
 #endif
 			event TextControlPasteEventHandler Paste;
-#endif
 
 		internal void RaisePaste(TextControlPasteEventArgs args) => Paste?.Invoke(this, args);
+#endif
 
 		/// <summary>
 		/// Set when <see cref="TextChanged"/> event is being raised, to ensure modifications by handlers don't trigger an infinite loop.

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -69,6 +69,11 @@ namespace Windows.UI.Xaml.Controls
 		public event TypedEventHandler<TextBox, TextBoxTextChangingEventArgs> TextChanging;
 		public event TypedEventHandler<TextBox, TextBoxBeforeTextChangingEventArgs> BeforeTextChanging;
 		public event RoutedEventHandler SelectionChanged;
+#if __SKIA__
+		public event TextControlPasteEventHandler Paste;
+#endif
+
+		internal void RaisePaste(TextControlPasteEventArgs args) => Paste?.Invoke(this, args);
 
 		/// <summary>
 		/// Set when <see cref="TextChanged"/> event is being raised, to ensure modifications by handlers don't trigger an infinite loop.

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -69,8 +69,8 @@ namespace Windows.UI.Xaml.Controls
 		public event TypedEventHandler<TextBox, TextBoxTextChangingEventArgs> TextChanging;
 		public event TypedEventHandler<TextBox, TextBoxBeforeTextChangingEventArgs> BeforeTextChanging;
 		public event RoutedEventHandler SelectionChanged;
-#if __SKIA__ || __ANDROID__ || __CROSSRUNTIME__
-		public event TextControlPasteEventHandler Paste;
+#if __SKIA__ || __ANDROID__ || __CROSSRUNTIME__ || __IOS__
+		public new event TextControlPasteEventHandler Paste;
 #endif
 
 		internal void RaisePaste(TextControlPasteEventArgs args) => Paste?.Invoke(this, args);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -70,7 +70,11 @@ namespace Windows.UI.Xaml.Controls
 		public event TypedEventHandler<TextBox, TextBoxBeforeTextChangingEventArgs> BeforeTextChanging;
 		public event RoutedEventHandler SelectionChanged;
 #if __SKIA__ || __ANDROID__ || __CROSSRUNTIME__ || __IOS__
-		public new event TextControlPasteEventHandler Paste;
+		public
+#if ___IOS__
+			new
+#endif
+			event TextControlPasteEventHandler Paste;
 #endif
 
 		internal void RaisePaste(TextControlPasteEventArgs args) => Paste?.Invoke(this, args);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Controls
 		public event TypedEventHandler<TextBox, TextBoxTextChangingEventArgs> TextChanging;
 		public event TypedEventHandler<TextBox, TextBoxBeforeTextChangingEventArgs> BeforeTextChanging;
 		public event RoutedEventHandler SelectionChanged;
-#if __SKIA__
+#if __SKIA__ || __ANDROID__
 		public event TextControlPasteEventHandler Paste;
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Controls
 		public event TypedEventHandler<TextBox, TextBoxTextChangingEventArgs> TextChanging;
 		public event TypedEventHandler<TextBox, TextBoxBeforeTextChangingEventArgs> BeforeTextChanging;
 		public event RoutedEventHandler SelectionChanged;
-#if __SKIA__ || __ANDROID__
+#if __SKIA__ || __ANDROID__ || __CROSSRUNTIME__
 		public event TextControlPasteEventHandler Paste;
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
@@ -1,33 +1,20 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using Android.Widget;
-using Uno.UI;
-using Uno.UI.Helpers;
-using Java.Lang.Reflect;
 using Android.Content;
 using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.OS;
-using Android.Runtime;
 using Android.Text;
-using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
 using AndroidX.Core.Content;
 using AndroidX.Core.Graphics;
 using Java.Lang.Reflect;
-using Uno.Disposables;
-using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI;
 using Uno.UI.DataBinding;
-using Uno.UI.Extensions;
-using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
-using Uno.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -102,6 +89,21 @@ namespace Windows.UI.Xaml.Controls
 				/// at the beginning, even if the text is the same.
 				Text = textSafe;
 			}
+		}
+
+		public override bool OnTextContextMenuItem(int id)
+		{
+			if (id == Android.Resource.Id.Paste)
+			{
+				var args = new TextControlPasteEventArgs();
+				Owner?.RaisePaste(args);
+				if (args.Handled)
+				{
+					return true;
+				}
+			}
+
+			return base.OnTextContextMenuItem(id);
 		}
 
 		protected override void OnTextChanged(Java.Lang.ICharSequence? text, int start, int lengthBefore, int lengthAfter)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.wasm.cs
@@ -12,6 +12,7 @@ using Uno.Foundation;
 using Uno.UI.Xaml;
 using Windows.UI.Xaml.Input;
 using Uno.UI.Helpers;
+using Uno.UI.Xaml.Input;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -71,6 +72,12 @@ namespace Windows.UI.Xaml.Controls
 			remove => UnregisterEventHandler("input", value, GenericEventHandlers.RaiseEventHandler);
 		}
 
+		private event RoutedEventHandlerWithHandled HtmlPaste
+		{
+			add => RegisterEventHandler("paste", value, GenericEventHandlers.RaiseRoutedEventHandlerWithHandled);
+			remove => UnregisterEventHandler("paste", value, GenericEventHandlers.RaiseRoutedEventHandlerWithHandled);
+		}
+
 		internal bool IsMultiline { get; }
 
 		private protected override void OnLoaded()
@@ -78,8 +85,16 @@ namespace Windows.UI.Xaml.Controls
 			base.OnLoaded();
 
 			HtmlInput += OnInput;
+			HtmlPaste += OnPaste;
 
 			SetTextNative(_textBox.Text);
+		}
+
+		private bool OnPaste(object sender, RoutedEventArgs e)
+		{
+			var args = new TextControlPasteEventArgs();
+			_textBox.RaisePaste(args);
+			return args.Handled;
 		}
 
 		private protected override void OnUnloaded()
@@ -87,6 +102,7 @@ namespace Windows.UI.Xaml.Controls
 			base.OnUnloaded();
 
 			HtmlInput -= OnInput;
+			HtmlPaste -= OnPaste;
 		}
 
 		private void OnInput(object sender, EventArgs eventArgs)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextControlPasteEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextControlPasteEventArgs.cs
@@ -1,0 +1,20 @@
+#nullable enable
+
+namespace Windows.UI.Xaml.Controls;
+
+/// <summary>
+/// Provides data for the text control Paste event.
+/// </summary>
+public partial class TextControlPasteEventArgs
+{
+	internal TextControlPasteEventArgs()
+	{
+	}
+
+	/// <summary>
+	/// Gets or sets a value that marks the routed event as handled.
+	/// A true value for Handled prevents most handlers along the event 
+	/// route from handling the same event again.
+	/// </summary>
+	public bool Handled { get; set; }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextControlPasteEventHandler.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextControlPasteEventHandler.cs
@@ -1,0 +1,10 @@
+#nullable enable
+
+namespace Windows.UI.Xaml.Controls;
+
+/// <summary>
+/// Represents the method that will handle a Paste event.
+/// </summary>
+/// <param name="sender">The object where the handler is attached.</param>
+/// <param name="e">Event data for the event.</param>
+public delegate void TextControlPasteEventHandler(object sender, TextControlPasteEventArgs e);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3fc9331</samp>

This pull request adds support for the `Paste` event for the `TextBox` and `PasswordBox` controls on the Skia WPF backend, and adds a new UI test to demonstrate the feature. It defines new types and events to match the UWP API for text control paste events, and implements the logic to raise the event from the native text box views to the Uno text box. It also adds conditional compilation directives to enable the feature only for the Skia backend.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
