### PR TITLE
fix(gtk): Adjust window bounds computation

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Input/GtkCorePointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Input/GtkCorePointerInputSource.cs
@@ -16,6 +16,7 @@ using Exception = System.Exception;
 using Windows.Foundation;
 using Uno.UI.Runtime.Skia.Gtk.UI.Controls;
 using Windows.UI.Xaml.Controls;
+using Windows.Graphics.Display;
 
 namespace Uno.UI.Runtime.Skia.Gtk;
 
@@ -389,9 +390,11 @@ internal sealed class GtkCorePointerInputSource : IUnoCorePointerInputSource
 		ModifierType state,
 		Event? evt)
 	{
+		var scale = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+
 		var pointerDevice = PointerDevice.For(devType);
-		var rawPosition = new Windows.Foundation.Point(rootX, rootY);
-		var position = new Windows.Foundation.Point(x, y);
+		var rawPosition = new Windows.Foundation.Point(rootX / scale, rootY / scale);
+		var position = new Windows.Foundation.Point(x / scale, y / scale);
 		var modifiers = GtkKeyboardInputSource.GetKeyModifiers(state);
 		var properties = new PointerPointProperties();
 

--- a/src/Uno.UI.Runtime.Skia.Gtk/Rendering/GLRenderSurfaceBase.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Rendering/GLRenderSurfaceBase.cs
@@ -91,8 +91,8 @@ namespace Uno.UI.Runtime.Skia.Gtk
 			var scale = _scale ?? 1f;
 			var scaledGuardBand = (int)(GuardBand * scale);
 
-			var w = (int)Math.Max(0, AllocatedWidth * scale + scaledGuardBand);
-			var h = (int)Math.Max(0, AllocatedHeight * scale + scaledGuardBand);
+			var w = (int)Math.Max(0, AllocatedWidth + scaledGuardBand);
+			var h = (int)Math.Max(0, AllocatedHeight + scaledGuardBand);
 
 			if (_renderTarget == null || _surface == null || _renderTarget.Width != w || _renderTarget.Height != h)
 			{

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/UnoGtkWindowHost.cs
@@ -9,6 +9,7 @@ using Uno.UI.Hosting;
 using Uno.UI.Runtime.Skia.Gtk.Hosting;
 using Uno.UI.Runtime.Skia.Gtk.Rendering;
 using Uno.UI.Xaml.Core;
+using Windows.Graphics.Display;
 using WinUI = Windows.UI.Xaml;
 using WinUIWindow = Windows.UI.Xaml.Window;
 
@@ -58,12 +59,14 @@ internal class UnoGtkWindowHost : IGtkXamlRootHost
 
 		_area.Realized += (s, e) =>
 		{
-			_winUIWindow.OnNativeSizeChanged(new Windows.Foundation.Size(_area.AllocatedWidth, _area.AllocatedHeight));
+			var scale = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+			_winUIWindow.OnNativeSizeChanged(new Windows.Foundation.Size(_area.AllocatedWidth / scale, _area.AllocatedHeight / scale));
 		};
 
 		_area.SizeAllocated += (s, e) =>
 		{
-			_winUIWindow.OnNativeSizeChanged(new Windows.Foundation.Size(e.Allocation.Width, e.Allocation.Height));
+			var scale = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+			_winUIWindow.OnNativeSizeChanged(new Windows.Foundation.Size(e.Allocation.Width / scale, e.Allocation.Height / scale));
 			if (!_firstSizeAllocated)
 			{
 				_firstSizeAllocated = true;


### PR DESCRIPTION
Related to https://github.com/unoplatform/uno/pull/13993

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adjust GTK bounds computation to use proper windows fractional scaling.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b8ff85</samp>

This pull request improves the GTK platform support for Uno UI Runtime Skia by fixing pointer input, window layout, and rendering issues related to the device scale factor. It modifies the files `GtkCorePointerInputSource.cs`, `UnoGtkWindowHost.cs`, and `GLRenderSurfaceBase.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
