### PR TITLE
fix(mediaplayerelement): fix MPE position when scrolling

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.cs
@@ -34,6 +34,7 @@ public partial class GtkMediaPlayer : FrameworkElement
 	private Windows.UI.Xaml.Media.Stretch _stretch = Windows.UI.Xaml.Media.Stretch.Uniform;
 	private double _videoRatio;
 	private readonly MediaPlayerPresenter _owner;
+	private (double playerHeight, double playerWidth, uint videoHeight, uint videoWidth) _lastSetDimensions;
 
 	public GtkMediaPlayer(MediaPlayerPresenter owner)
 	{
@@ -415,8 +416,12 @@ public partial class GtkMediaPlayer : FrameworkElement
 		}
 	}
 
+	internal void UpdateVideoLayout() => UpdateVideoSizeAllocate(_lastSetDimensions.playerHeight, _lastSetDimensions.playerWidth, _lastSetDimensions.videoHeight, _lastSetDimensions.videoWidth);
+
 	private void UpdateVideoSizeAllocate(double playerHeight, double playerWidth, uint videoHeight, uint videoWidth)
 	{
+		_lastSetDimensions = (playerHeight, playerWidth, videoHeight, videoWidth);
+
 		if (_videoView != null && _mediaPlayer != null && _videoContainer != null)
 		{
 			if (videoWidth == 0 || videoHeight == 0)
@@ -440,7 +445,6 @@ public partial class GtkMediaPlayer : FrameworkElement
 					break;
 
 				case Windows.UI.Xaml.Media.Stretch.Uniform:
-
 					var topInsetUniform = (playerHeight - newHeight) / 2;
 					var leftInsetUniform = (playerWidth - newWidth) / 2;
 

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerPresenterExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerPresenterExtension.cs
@@ -39,6 +39,9 @@ public class MediaPlayerPresenterExtension : IMediaPlayerPresenterExtension
 		_owner = presenter;
 		_player = new GtkMediaPlayer(_owner);
 		var contentView = new ContentControl();
+
+		contentView.EffectiveViewportChanged += (_, _) => _player.UpdateVideoLayout();
+
 		contentView.Content = _player;
 		contentView.VerticalContentAlignment = Windows.UI.Xaml.VerticalAlignment.Stretch;
 		contentView.HorizontalContentAlignment = Windows.UI.Xaml.HorizontalAlignment.Stretch;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13954

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c7202f</samp>

Improved the video layout handling for the `GtkMediaPlayer` class and the `MediaPlayerPresenterExtension` class in the `Uno.UI.MediaPlayer.Skia.Gtk` add-in. This is to ensure that the video layout adapts to the size and orientation of the window and the content view.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
