### PR TITLE
perf(XamlFileParser): extract static array for split characters

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileParser.cs
@@ -25,6 +25,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 	{
 		private static readonly ConcurrentDictionary<CachedFileKey, CachedFile> _cachedFiles = new();
 		private static readonly TimeSpan _cacheEntryLifetime = new TimeSpan(hours: 1, minutes: 0, seconds: 0);
+		private static readonly char[] _splitChars = new char[] { '(', ',', ')' };
 		private readonly string _excludeXamlNamespacesProperty;
 		private readonly string _includeXamlNamespacesProperty;
 		private readonly string[] _excludeXamlNamespaces;
@@ -192,7 +193,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 
 			namespaceUri = valueSplit[0];
-			var elements = valueSplit[1].Split('(', ',', ')');
+			var elements = valueSplit[1].Split(_splitChars);
 
 			var methodName = elements[0];
 


### PR DESCRIPTION
Fixes #14021

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

**Following changes were made**
+ First, declared a static readonly field at the class level.
```java
private static readonly char[] SplitChars = new char[] { '(', ',', ')' };
```
+ Then, replace the line in question with:
```java
var elements = valueSplit[1].Split(SplitChars);
```

This way, the array is only allocated once and reused every time the method is called, which can lead to performance improvements, especially if the method is called frequently.

<!-- Please uncomment one or more that apply to this PR

- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:
-->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2253c5</samp>

Enhanced the performance and readability of the XAML file parser by optimizing the conditional XAML logic.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
