### PR TITLE
refactor: Refactor VirtualizingPanelLayout

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.managed.cs
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml.Controls
 
 			AddView(view, fillDirection, extentOffset, 0);
 
-			return new Line(item, (view, nextVisibleItem));
+			return new Line(item, view, nextVisibleItem);
 		}
 
 		protected override int GetItemsPerLine() => 1;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14052

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7114090</samp>

This pull request improves the performance and readability of the `VirtualizingPanelLayout` and `ItemsStackPanelLayout` classes by refactoring the `Line` class and its usage. The `Line` class now holds a single view and index pair, instead of an array, and its constructor takes them as direct parameters. This reduces the memory allocation and the complexity of the layout logic.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
