### PR TITLE
perf: Animations-focused misc optimizations

### DIFF
--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Collections/EnumerableExtensions.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Collections/EnumerableExtensions.cs
@@ -249,42 +249,6 @@ namespace Uno.Extensions
 		}
 
 		/// <summary>
-		/// Finds an item in the sequence for which a projected value is maximized.
-		/// </summary>
-		/// <typeparam name="TSource">Sequence type.</typeparam>
-		/// <typeparam name="TComparable">Projected value type.</typeparam>
-		/// <param name="source">The sequence of items.</param>
-		/// <param name="selector">Function which projects the sequence into a comparable value.</param>
-		/// <returns>A tuple containing the maximum item and its projected value. If multiple items have the same projected value, this will return the first.</returns>
-		public static (TSource Item, TComparable Value) MaxBy<TSource, TComparable>(this IEnumerable<TSource> source, Func<TSource, TComparable> selector)
-		{
-			var comparer = Comparer<TComparable>.Default;
-
-			var enumerator = source.GetEnumerator();
-
-			if (!enumerator.MoveNext())
-			{
-				throw new InvalidOperationException("Source must contain at least one element.");
-			}
-
-			var maxItem = enumerator.Current;
-			var max = selector(maxItem);
-
-			while (enumerator.MoveNext())
-			{
-				var item = enumerator.Current;
-				var value = selector(item);
-				if (comparer.Compare(value, max) > 0)
-				{
-					maxItem = item;
-					max = value;
-				}
-			}
-
-			return (maxItem, max);
-		}
-
-		/// <summary>
 		/// Takes "before" item and "after" item around the "start" item
 		/// </summary>
 		public static IEnumerable<T> Range<T>(this IEnumerable<T> collection, int start, int before, int after, bool fixedCount = true)

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ObjectAnimationUsingKeyFrames.cs
@@ -240,8 +240,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		/// </summary>
 		private void Fill()
 		{
-			var lastTime = KeyFrames.Max(k => k.KeyTime.TimeSpan);
-			var lastKeyFrame = KeyFrames.First(k => k.KeyTime.TimeSpan.Equals(lastTime));
+			var lastKeyFrame = KeyFrames.MaxBy(k => k.KeyTime.TimeSpan);
 
 			_frameScheduler?.Dispose();
 			_frameScheduler = null;

--- a/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
@@ -351,25 +351,39 @@ namespace Windows.UI.Xaml
 			var hasOld = !oldStateName.IsNullOrEmpty();
 			var hasNew = !newStateName.IsNullOrEmpty();
 
-			if (hasOld && hasNew && Transitions.FirstOrDefault(Match(oldStateName, newStateName)) is { } perfectMatch)
+			if (hasOld && hasNew && GetFirstMatch(oldStateName, newStateName) is { } perfectMatch)
 			{
 				return perfectMatch;
 			}
 
-			if (hasOld && Transitions.FirstOrDefault(Match(oldStateName, null)) is { } fromMatch)
+			if (hasOld && GetFirstMatch(oldStateName, null) is { } fromMatch)
 			{
 				return fromMatch;
 			}
 
-			if (hasNew && Transitions.FirstOrDefault(Match(null, newStateName)) is { } newMatch)
+			if (hasNew && GetFirstMatch(null, newStateName) is { } newMatch)
 			{
 				return newMatch;
 			}
 
 			return default;
 
-			Func<VisualTransition, bool> Match(string from, string to)
-				=> tr => string.Equals(tr.From, oldStateName) && string.Equals(tr.To, newStateName);
+			VisualTransition GetFirstMatch(string from, string to)
+			{
+				// Avoid using Transitions.FirstOrDefault as it incurs unnecessary Func<VisualTransition, bool> allocations.
+				foreach (var transition in Transitions)
+				{
+					if (Match(transition, from, to))
+					{
+						return transition;
+					}
+				}
+
+				return null;
+			}
+
+			bool Match(VisualTransition transition, string from, string to)
+				=> string.Equals(transition.From, oldStateName) && string.Equals(transition.To, newStateName);
 		}
 
 		internal void RefreshStateTriggers(bool force = false)

--- a/src/Uno.UI/UI/Xaml/VisualStateManager.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateManager.cs
@@ -258,7 +258,13 @@ namespace Windows.UI.Xaml
 			}
 
 			// Avoid using groups.FirstOrDefault as it incurs unnecessary Func<VisualStateGroup, bool> allocations
-			foreach (var group in GetVisualStateGroups(templateRoot))
+			var groups = GetVisualStateGroups(templateRoot);
+			if (groups is null)
+			{
+				return null;
+			}
+
+			foreach (var group in groups)
 			{
 				if (group.Name == groupName)
 				{

--- a/src/Uno.UI/UI/Xaml/VisualStateManager.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateManager.cs
@@ -257,11 +257,16 @@ namespace Windows.UI.Xaml
 				return null;
 			}
 
-			var group = GetVisualStateGroups(templateRoot)?
-				.Where(g => g.Name == groupName)
-				.FirstOrDefault();
+			// Avoid using groups.FirstOrDefault as it incurs unnecessary Func<VisualStateGroup, bool> allocations
+			foreach (var group in GetVisualStateGroups(templateRoot))
+			{
+				if (group.Name == groupName)
+				{
+					return group.CurrentState;
+				}
+			}
 
-			return group?.CurrentState;
+			return null;
 		}
 
 		private static (VisualStateGroup, VisualState) GetValidGroupAndState(string stateName, IList<VisualStateGroup> groups)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14051

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3c3a91</samp>

This pull request improves the performance and readability of some methods related to visual state transitions in XAML. It uses a custom helper method for finding transitions, removes an unused extension method, and simplifies some LINQ expressions by using the `MaxBy` method. It affects the files `VisualStateGroup.cs`, `EnumerableExtensions.cs`, `ObjectAnimationUsingKeyFrames.cs`, and `VisualStateManager.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
