### PR TITLE
perf: Optimize SVG array allocations

### DIFF
--- a/src/AddIns/Uno.UI.Svg/SvgProvider.cs
+++ b/src/AddIns/Uno.UI.Svg/SvgProvider.cs
@@ -98,7 +98,7 @@ public partial class SvgProvider : ISvgProvider
 #if !__NETSTD_REFERENCE__
 	async
 #endif
-	Task<bool> TryLoadSvgDataAsync(byte[] svgBytes)
+	Task<bool> TryLoadSvgDataAsync(ArraySegment<byte> svgBytes)
 	{
 #if __NETSTD_REFERENCE__
 		return Task.FromResult(false);
@@ -150,13 +150,13 @@ public partial class SvgProvider : ISvgProvider
 	}
 
 #if !__NETSTD_REFERENCE__
-	private Task<SKSvg?> LoadSvgAsync(byte[] svgBytes) =>
+	private Task<SKSvg?> LoadSvgAsync(ArraySegment<byte> svgBytes) =>
 		Task.Run(() =>
 		{
 			var skSvg = new SKSvg();
 			try
 			{
-				using var memoryStream = new MemoryStream(svgBytes);
+				using var memoryStream = new MemoryStream(svgBytes.Array!, svgBytes.Offset, svgBytes.Count);
 				skSvg.Load(memoryStream);
 			}
 			catch (Exception ex)

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
@@ -319,7 +319,7 @@ namespace Windows.UI.Xaml.Controls
 
 				if (_openedSource is SvgImageSource svgImageSource && imageData.Kind == ImageDataKind.ByteArray)
 				{
-					SetSvgSource(svgImageSource, imageData.ByteArray);
+					SetSvgSource(svgImageSource);
 					InvalidateMeasure();
 					InvalidateArrange();
 				}
@@ -350,7 +350,7 @@ namespace Windows.UI.Xaml.Controls
 			_nativeImageView.SetImageBitmap(bitmap);
 		}
 
-		private void SetSvgSource(SvgImageSource svgImageSource, byte[] byteArray)
+		private void SetSvgSource(SvgImageSource svgImageSource)
 		{
 			_childViewDisposable.Disposable = null;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOSmacOS.cs
@@ -146,7 +146,7 @@ namespace Windows.UI.Xaml.Controls
 
 				if (_openedSource is SvgImageSource svgImageSource && imageData.Kind == ImageDataKind.ByteArray)
 				{
-					SetSvgSource(svgImageSource, imageData.ByteArray);
+					SetSvgSource(svgImageSource);
 				}
 				else if (_openedSource is { } source && imageData.Kind == ImageDataKind.NativeImage)
 				{
@@ -170,7 +170,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		private void SetSvgSource(SvgImageSource svgImageSource, byte[] byteArray)
+		private void SetSvgSource(SvgImageSource svgImageSource)
 		{
 			_childViewDisposable.Disposable = null;
 

--- a/src/Uno.UI/UI/Xaml/Media/ImageData.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageData.cs
@@ -19,12 +19,12 @@ namespace Uno.UI.Xaml.Media;
 /// </summary>
 internal partial struct ImageData
 {
-	public static ImageData FromBytes(byte[] data) => new(data);
+	public static ImageData FromBytes(ArraySegment<byte> data) => new(data);
 
-	private ImageData(byte[] data)
+	private ImageData(ArraySegment<byte> data)
 	{
 		Kind = ImageDataKind.ByteArray;
-		ByteArray = data ?? throw new ArgumentNullException(nameof(data));
+		ByteArray = data;
 	}
 
 	public static ImageData FromError(Exception exception) => new(exception);
@@ -96,7 +96,7 @@ internal partial struct ImageData
 
 	public Exception? Error { get; } = null;
 
-	public byte[]? ByteArray { get; } = null;
+	public ArraySegment<byte>? ByteArray { get; } = null;
 
 #if __IOS__ || __MACOS__
 	public _UIImage? NativeImage { get; } = null;
@@ -115,7 +115,7 @@ internal partial struct ImageData
 		{
 			ImageDataKind.Empty => "Empty",
 			ImageDataKind.Error => $"Error[{Error}]",
-			ImageDataKind.ByteArray => $"Byte array: Length {ByteArray?.Length ?? -1}",
+			ImageDataKind.ByteArray => $"Byte array: Length {ByteArray?.Count ?? -1}",
 #if __IOS__ || __MACOS__
 			ImageDataKind.NativeImage => $"Native UIImage: {NativeImage}",
 #endif

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/Svg/ISvgProvider.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/Svg/ISvgProvider.cs
@@ -23,7 +23,7 @@ public interface ISvgProvider
 
 	event EventHandler? SourceLoaded;
 
-	Task<bool> TryLoadSvgDataAsync(byte[] imageData);
+	Task<bool> TryLoadSvgDataAsync(ArraySegment<byte> imageData);
 
 	void Unload();
 }

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.cs
@@ -144,10 +144,18 @@ public partial class SvgImageSource : ImageSource
 			stream.Position = 0;
 		}
 
-		var memoryStream = new MemoryStream();
-		await stream.CopyToAsync(memoryStream, 81920, ct);
-		var data = memoryStream.ToArray();
-		return ImageData.FromBytes(data);
+		if (stream is not MemoryStream memoryStream)
+		{
+			memoryStream = new MemoryStream();
+			await stream.CopyToAsync(memoryStream, 81920, ct);
+		}
+
+		if (!memoryStream.TryGetBuffer(out var buffer))
+		{
+			buffer = new ArraySegment<byte>(memoryStream.ToArray());
+		}
+
+		return ImageData.FromBytes(buffer);
 	}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.provider.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.provider.cs
@@ -59,7 +59,7 @@ partial class SvgImageSource
 
 		if (imageData.Kind == ImageDataKind.ByteArray &&
 			imageData.ByteArray is not null &&
-			await _svgProvider.TryLoadSvgDataAsync(imageData.ByteArray))
+			await _svgProvider.TryLoadSvgDataAsync(imageData.ByteArray.Value))
 		{
 			return imageData;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14056

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee0ccf4</samp>

This pull request refactors the code related to loading and handling SVG data and image data in the Uno.UI project. It replaces the use of `byte[]` with `ArraySegment<byte>` in several classes and interfaces, such as `SvgProvider`, `ImageData`, and `ISvgProvider`, to improve memory efficiency and performance. It also modifies the `SvgImageSource` class to use the same buffer for the stream and the `SvgProvider`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
