### PR TITLE
Autosuggest keyboard nav

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/UI/Xaml/Controls/TextTextBoxView.cs
@@ -33,7 +33,11 @@ internal class TextTextBoxView : WpfTextBoxView
 	public override (int start, int length) Selection
 	{
 		get => (_textBox.SelectionStart, _textBox.SelectionLength);
-		set => (_textBox.SelectionStart, _textBox.SelectionLength) = value;
+		set
+		{
+			(_textBox.SelectionStart, _textBox.SelectionLength) = value;
+			(_selectionBeforeKeyDown.start, _selectionBeforeKeyDown.length) = value;
+		}
 	}
 
 	public override (int start, int length) SelectionBeforeKeyDown

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs
@@ -274,6 +274,398 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 
 		[TestMethod]
+#if NETFX_CORE
+		[Ignore("KeyboardHelper doesn't work on Windows")]
+#endif
+		public async Task When_Keyboard_Handled()
+		{
+			var SUT = new AutoSuggestBox();
+
+			static void AutoSuggestBox_TextChanged(AutoSuggestBox s, AutoSuggestBoxTextChangedEventArgs e)
+			{
+				var items = new List<string>
+				{
+					"A0",
+					"A1",
+					"A2",
+					"B0",
+					"B1",
+					"B2",
+					"C0",
+					"C1",
+					"C2"
+				};
+
+				if (e.Reason != AutoSuggestionBoxTextChangeReason.SuggestionChosen)
+				{
+					s.ItemsSource = items.Where(a => a.StartsWith(s.Text.Trim())).ToArray();
+				}
+			}
+
+			Button button = null;
+			try
+			{
+				button = new Button();
+				var stack = new StackPanel()
+				{
+					Children =
+					{
+						button,
+						SUT
+					}
+				};
+
+				var keyDownHandled = 0;
+				var keyDownNotHandled = 0;
+				SUT.AddHandler(UIElement.KeyDownEvent, new KeyEventHandler((_, a) =>
+				{
+					if (a.Handled)
+					{
+						keyDownHandled++;
+					}
+					else
+					{
+						keyDownNotHandled++;
+					}
+				}), true);
+
+				SUT.TextChanged += AutoSuggestBox_TextChanged;
+				WindowHelper.WindowContent = stack;
+				await WindowHelper.WaitForIdle();
+
+				var tb = SUT.FindVisualChildByType<TextBox>();
+				var popup = SUT.FindVisualChildByType<Popup>();
+
+				SUT.Focus(FocusState.Programmatic);
+				SUT.Text = "A";
+				await WindowHelper.WaitForIdle();
+				tb.Select(1, 0);
+				await WindowHelper.WaitForIdle();
+
+				var lv = popup.Child.FindVisualChildByType<ListView>();
+
+				Assert.AreEqual(-1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+
+				KeyboardHelper.Down();
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(0, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+				Assert.AreEqual(keyDownHandled, 1);
+				Assert.AreEqual(keyDownNotHandled, 0);
+
+				KeyboardHelper.Down();
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+				Assert.AreEqual(keyDownHandled, 2);
+				Assert.AreEqual(keyDownNotHandled, 0);
+
+				KeyboardHelper.Right();
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+				Assert.AreEqual(keyDownHandled, 2);
+				Assert.AreEqual(keyDownNotHandled, 1);
+
+				KeyboardHelper.Left();
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+				Assert.AreEqual(keyDownHandled, 3); // actually handled in textbox
+				Assert.AreEqual(keyDownNotHandled, 1);
+
+				KeyboardHelper.Up();
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(0, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+				Assert.AreEqual(keyDownHandled, 4);
+				Assert.AreEqual(keyDownNotHandled, 1);
+			}
+			finally
+			{
+				button?.Focus(FocusState.Programmatic); // Unfocus the AutoSuggestBox to ensure popup is closed.
+				await WindowHelper.WaitForIdle();
+			}
+		}
+
+		[TestMethod]
+#if NETFX_CORE
+		[Ignore("KeyboardHelper doesn't work on Windows")]
+#endif
+		public async Task When_ArrowKeys_Handled()
+		{
+			var SUT = new AutoSuggestBox();
+
+			static void AutoSuggestBox_TextChanged(AutoSuggestBox s, AutoSuggestBoxTextChangedEventArgs e)
+			{
+				var items = new List<string>
+				{
+					"A0",
+					"A1",
+					"A2",
+					"B0",
+					"B1",
+					"B2",
+					"C0",
+					"C1",
+					"C2"
+				};
+
+				if (e.Reason != AutoSuggestionBoxTextChangeReason.SuggestionChosen)
+				{
+					s.ItemsSource = items.Where(a => a.StartsWith(s.Text.Trim())).ToArray();
+				}
+			}
+
+			Button button = null;
+			try
+			{
+				button = new Button();
+				var stack = new StackPanel()
+				{
+					Children =
+					{
+						button,
+						SUT
+					}
+				};
+
+				var keyDownHandled = 0;
+				var keyDownNotHandled = 0;
+				SUT.AddHandler(UIElement.KeyDownEvent, new KeyEventHandler((_, a) =>
+				{
+					if (a.Handled)
+					{
+						keyDownHandled++;
+					}
+					else
+					{
+						keyDownNotHandled++;
+					}
+				}), true);
+
+				SUT.TextChanged += AutoSuggestBox_TextChanged;
+				WindowHelper.WindowContent = stack;
+				await WindowHelper.WaitForIdle();
+
+				var tb = SUT.FindVisualChildByType<TextBox>();
+				var popup = SUT.FindVisualChildByType<Popup>();
+
+				SUT.Focus(FocusState.Programmatic);
+				SUT.Text = "A";
+				await WindowHelper.WaitForIdle();
+				tb.Select(1, 0);
+				await WindowHelper.WaitForIdle();
+
+				var lv = popup.Child.FindVisualChildByType<ListView>();
+
+				Assert.AreEqual(-1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+
+				KeyboardHelper.Down();
+				await WindowHelper.WaitForIdle();
+				KeyboardHelper.Down();
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+				Assert.AreEqual(keyDownHandled, 2);
+				Assert.AreEqual(keyDownNotHandled, 0);
+
+				KeyboardHelper.Enter();
+				Assert.AreEqual(keyDownHandled, 3);
+				Assert.AreEqual(keyDownNotHandled, 0);
+			}
+			finally
+			{
+				button?.Focus(FocusState.Programmatic); // Unfocus the AutoSuggestBox to ensure popup is closed.
+				await WindowHelper.WaitForIdle();
+			}
+		}
+
+		[TestMethod]
+#if NETFX_CORE
+		[Ignore("KeyboardHelper doesn't work on Windows")]
+#endif
+		[DataRow(false)]
+		[DataRow(true)]
+		public async Task When_Enter_Escape_Handled(bool escape)
+		{
+			var SUT = new AutoSuggestBox();
+
+			static void AutoSuggestBox_TextChanged(AutoSuggestBox s, AutoSuggestBoxTextChangedEventArgs e)
+			{
+				var items = new List<string>
+				{
+					"A0",
+					"A1",
+					"A2",
+					"B0",
+					"B1",
+					"B2",
+					"C0",
+					"C1",
+					"C2"
+				};
+
+				if (e.Reason != AutoSuggestionBoxTextChangeReason.SuggestionChosen)
+				{
+					s.ItemsSource = items.Where(a => a.StartsWith(s.Text.Trim())).ToArray();
+				}
+			}
+
+			Button button = null;
+			try
+			{
+				button = new Button();
+				var stack = new StackPanel()
+				{
+					Children =
+					{
+						button,
+						SUT
+					}
+				};
+
+				var keyDownHandled = 0;
+				var keyDownNotHandled = 0;
+				SUT.AddHandler(UIElement.KeyDownEvent, new KeyEventHandler((_, a) =>
+				{
+					if (a.Handled)
+					{
+						keyDownHandled++;
+					}
+					else
+					{
+						keyDownNotHandled++;
+					}
+				}), true);
+
+				SUT.TextChanged += AutoSuggestBox_TextChanged;
+				WindowHelper.WindowContent = stack;
+				await WindowHelper.WaitForIdle();
+
+				var tb = SUT.FindVisualChildByType<TextBox>();
+				var popup = SUT.FindVisualChildByType<Popup>();
+
+				SUT.Focus(FocusState.Programmatic);
+				SUT.Text = "A";
+				await WindowHelper.WaitForIdle();
+				tb.Select(1, 0);
+				await WindowHelper.WaitForIdle();
+
+				var lv = popup.Child.FindVisualChildByType<ListView>();
+
+				Assert.AreEqual(-1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+
+				KeyboardHelper.Down();
+				await WindowHelper.WaitForIdle();
+				KeyboardHelper.Down();
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+				Assert.AreEqual(keyDownHandled, 2);
+				Assert.AreEqual(keyDownNotHandled, 0);
+
+				if (escape)
+				{
+					KeyboardHelper.Escape();
+				}
+				else
+				{
+					KeyboardHelper.Enter();
+				}
+				Assert.AreEqual(keyDownHandled, 3);
+				Assert.AreEqual(keyDownNotHandled, 0);
+			}
+			finally
+			{
+				button?.Focus(FocusState.Programmatic); // Unfocus the AutoSuggestBox to ensure popup is closed.
+				await WindowHelper.WaitForIdle();
+			}
+		}
+
+		[TestMethod]
+#if NETFX_CORE
+		[Ignore("KeyboardHelper doesn't work on Windows")]
+#endif
+		public async Task When_SuggestionChosen_TextBox_Moves_To_The_End()
+		{
+			var SUT = new AutoSuggestBox();
+
+			static void AutoSuggestBox_TextChanged(AutoSuggestBox s, AutoSuggestBoxTextChangedEventArgs e)
+			{
+				var items = new List<string>
+				{
+					"0",
+					"01",
+					"012",
+					"0123",
+					"01234",
+					"012345",
+					"0123456"
+				};
+
+				if (e.Reason != AutoSuggestionBoxTextChangeReason.SuggestionChosen)
+				{
+					s.ItemsSource = items.Where(a => a.StartsWith(s.Text.Trim())).ToArray();
+				}
+			}
+
+			Button button = null;
+			try
+			{
+				button = new Button();
+				var stack = new StackPanel()
+				{
+					Children =
+					{
+						button,
+						SUT
+					}
+				};
+
+				SUT.TextChanged += AutoSuggestBox_TextChanged;
+				WindowHelper.WindowContent = stack;
+				await WindowHelper.WaitForIdle();
+
+				var tb = SUT.FindVisualChildByType<TextBox>();
+				var popup = SUT.FindVisualChildByType<Popup>();
+
+				SUT.Focus(FocusState.Programmatic);
+				SUT.Text = "0";
+				await WindowHelper.WaitForIdle();
+				tb.Select(1, 0);
+				await WindowHelper.WaitForIdle();
+
+				var lv = popup.Child.FindVisualChildByType<ListView>();
+
+				Assert.AreEqual(-1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+
+				KeyboardHelper.Down();
+				await WindowHelper.WaitForIdle();
+				KeyboardHelper.Down();
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(1, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+				Assert.AreEqual(tb.Text.Length, tb.SelectionStart);
+
+				KeyboardHelper.Up();
+				await WindowHelper.WaitForIdle();
+				Assert.AreEqual(0, lv.SelectedIndex);
+				Assert.IsTrue(popup.IsOpen);
+				Assert.AreEqual(tb.Text.Length, tb.SelectionStart);
+			}
+			finally
+			{
+				button?.Focus(FocusState.Programmatic); // Unfocus the AutoSuggestBox to ensure popup is closed.
+				await WindowHelper.WaitForIdle();
+			}
+		}
+
+		[TestMethod]
 		public async Task When_Typing_Should_Keep_Focus()
 		{
 			static void GettingFocus(object sender, GettingFocusEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -386,6 +386,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (e.Key == Windows.System.VirtualKey.Enter)
 			{
+				e.Handled = true;
 				if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 				{
 					this.Log().Debug($"Enter key pressed");
@@ -395,10 +396,12 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else if ((e.Key == Windows.System.VirtualKey.Up || e.Key == Windows.System.VirtualKey.Down) && IsSuggestionListOpen)
 			{
+				e.Handled = true;
 				HandleUpDownKeys(e);
 			}
 			else if (e.Key == Windows.System.VirtualKey.Escape && IsSuggestionListOpen)
 			{
+				e.Handled = true;
 				RevertTextToUserInput();
 				IsSuggestionListOpen = false;
 			}
@@ -451,6 +454,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			SuggestionChosen?.Invoke(this, new AutoSuggestBoxSuggestionChosenEventArgs(o));
+
+			_textBox?.Select(_textBox.Text.Length, 0);
 		}
 
 		private void RevertTextToUserInput()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11648

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 897c43c</samp>

This pull request improves the `AutoSuggestBox` control in the Uno Platform project by fixing some keyboard event issues and adding new tests. It makes the control more consistent with the UWP behavior and prevents unwanted interactions with other elements on the page. The changes affect the `./src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs` file and the `./src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_AutoSuggestBox.cs` file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
