### PR TITLE
fix: Ensure the Uno WindowHost is always focused to capture keyboard events

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -234,7 +234,10 @@ namespace SamplesApp
 			Windows.UI.Xaml.Window.Current.Activate();
 			_wasActivated = true;
 			_isSuspended = false;
+			MainWindowActivated?.Invoke(this, EventArgs.Empty);
 		}
+
+		public event EventHandler MainWindowActivated;
 
 #if !HAS_UNO_WINUI
 		protected override void OnWindowCreated(global::Windows.UI.Xaml.WindowCreatedEventArgs args)

--- a/src/SamplesApp/SamplesApp.Skia.Wpf/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Skia.Wpf/App.xaml.cs
@@ -1,4 +1,6 @@
-﻿using Uno.UI.Runtime.Skia.Wpf;
+﻿using System.Windows;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Runtime.Skia.Wpf;
 
 namespace SamplesApp.Wpf
 {
@@ -7,13 +9,25 @@ namespace SamplesApp.Wpf
 	/// </summary>
 	public partial class App : System.Windows.Application
 	{
+		private SamplesApp.App _app;
+
 		public App()
 		{
 			SamplesApp.App.ConfigureLogging();
 
-			var host = new WpfHost(Dispatcher, () => new SamplesApp.App());
+			var host = new WpfHost(Dispatcher, () => _app ??= new SamplesApp.App());
 
 			host.Run();
+
+			_app.MainWindowActivated += OnMainWindowActivated;
+		}
+
+		private void OnMainWindowActivated(object sender, System.EventArgs e)
+		{
+			var windowContent = Application.Current.Windows[0].Content;
+			Assert.IsInstanceOfType(windowContent, typeof(System.Windows.UIElement));
+			var windowContentAsUIElement = (System.Windows.UIElement)windowContent;
+			Assert.IsTrue(windowContentAsUIElement.IsFocused);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoWpfWindow.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoWpfWindow.cs
@@ -16,6 +16,7 @@ namespace Uno.UI.Runtime.Skia.Wpf.UI.Controls;
 internal class UnoWpfWindow : WpfWindow
 {
 	private readonly WinUI.Window _winUIWindow;
+	private readonly UnoWpfWindowHost _host;
 	private bool _isVisible;
 
 	public UnoWpfWindow(WinUI.Window winUIWindow)
@@ -31,7 +32,7 @@ internal class UnoWpfWindow : WpfWindow
 			Height = (int)preferredWindowSize.Height;
 		}
 
-		Content = new UnoWpfWindowHost(this, winUIWindow);
+		Content = _host = new UnoWpfWindowHost(this, winUIWindow);
 
 		Closing += OnClosing;
 		Activated += OnActivated;
@@ -65,8 +66,11 @@ internal class UnoWpfWindow : WpfWindow
 	private void OnDeactivated(object? sender, EventArgs e) =>
 		_winUIWindow?.OnNativeActivated(Windows.UI.Core.CoreWindowActivationState.Deactivated);
 
-	private void OnActivated(object? sender, EventArgs e) =>
+	private void OnActivated(object? sender, EventArgs e)
+	{
 		_winUIWindow.OnNativeActivated(Windows.UI.Core.CoreWindowActivationState.PointerActivated);
+		_host.Focus();
+	}
 
 	private void OnStateChanged(object? sender, EventArgs e)
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #12786

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

WPF keyboard captures key events only if a control is focused


## What is the new behavior?

Host control is focused to capture events

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db6f700</samp>

Improved keyboard focus handling for `UnoWpfWindow` by using a window content host.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
