### PR TITLE
feat: WinUI `StandardUICommand`

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -4030,6 +4030,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\XamlUICommandTests.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Clickthrough_Modal.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7745,6 +7749,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\UndefinedHeightListView.xaml.cs">
       <DependentUpon>UndefinedHeightListView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\XamlUICommandTests.xaml.cs">
+      <DependentUpon>XamlUICommandTests.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Clickthrough_Modal.xaml.cs">
       <DependentUpon>Keyboard_Clickthrough_Modal.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/XamlUICommandTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/XamlUICommandTests.xaml
@@ -1,0 +1,46 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Input.XamlUICommandTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Uno.UI.Samples.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="300"
+    d:DesignWidth="400"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+
+    <StackPanel
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Orientation="Horizontal">
+        <Button>
+            <Button.Command>
+                <StandardUICommand Kind="Cut" />
+            </Button.Command>
+        </Button>
+        <AppBarButton>
+            <AppBarButton.Command>
+                <StandardUICommand Kind="Copy" />
+            </AppBarButton.Command>
+        </AppBarButton>
+        <Button>
+            <Button.Command>
+                <XamlUICommand Description="Home button" Label="Home">
+                    <XamlUICommand.IconSource>
+                        <SymbolIconSource Symbol="Home" />
+                    </XamlUICommand.IconSource>
+                </XamlUICommand>
+            </Button.Command>
+        </Button>
+        <AppBarButton>
+            <AppBarButton.Command>
+                <XamlUICommand Description="Next" Label="Forward we go!">
+                    <XamlUICommand.IconSource>
+                        <SymbolIconSource Symbol="Forward" />
+                    </XamlUICommand.IconSource>
+                </XamlUICommand>
+            </AppBarButton.Command>
+        </AppBarButton>
+    </StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/XamlUICommandTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/XamlUICommandTests.xaml.cs
@@ -11,14 +11,13 @@ using Windows.UI.Xaml.Input;
 using Microsoft.UI.Input;
 #endif
 
-namespace UITests.Windows_UI_Xaml_Input
+namespace UITests.Windows_UI_Xaml_Input;
+
+[Sample("Windows.UI.Xaml.Input", Name = "XamlUICommand", Description = "You should see Cut button without icon, Copy button with icon, Home button without icon and Forward we go! with icon.", IsManualTest = true)]
+public sealed partial class XamlUICommandTests : Page
 {
-	[SampleControlInfo("Windows.UI.Xaml.Input", "XamlUICommand", description: "Demonstrates use of XamlUICommand and StandardUICommand")]
-	public sealed partial class XamlUICommandTests : Page
+	public XamlUICommandTests()
 	{
-		public XamlUICommandTests()
-		{
-			this.InitializeComponent();
-		}
+		this.InitializeComponent();
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/XamlUICommandTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/XamlUICommandTests.xaml.cs
@@ -4,8 +4,11 @@ using Uno.UI.Samples.Controls;
 using System.Collections.Generic;
 using System;
 using Windows.Foundation;
-using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+
+#if !HAS_UNO_WINUI
+using Windows.UI.Xaml.Controls;
+#endif
 
 #if !WINDOWS_UWP
 using Microsoft.UI.Input;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/XamlUICommandTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/XamlUICommandTests.xaml.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+using System.Collections.Generic;
+using System;
+using Windows.Foundation;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+#if !WINDOWS_UWP
+using Microsoft.UI.Input;
+#endif
+
+namespace UITests.Windows_UI_Xaml_Input
+{
+	[SampleControlInfo("Windows.UI.Xaml.Input", "XamlUICommand", description: "Demonstrates use of XamlUICommand and StandardUICommand")]
+	public sealed partial class XamlUICommandTests : Page
+	{
+		public XamlUICommandTests()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.Foundation/DelegateCommand.T.cs
+++ b/src/Uno.Foundation/DelegateCommand.T.cs
@@ -18,6 +18,11 @@ internal class DelegateCommand<T> : ICommand
 
 	public void Execute(object parameter)
 	{
+		if (!CanExecuteEnabled)
+		{
+			return;
+		}
+
 		if (parameter is T t)
 		{
 			_action?.Invoke(t);

--- a/src/Uno.Foundation/DelegateCommand.cs
+++ b/src/Uno.Foundation/DelegateCommand.cs
@@ -16,7 +16,15 @@ internal class DelegateCommand : ICommand
 
 	public bool CanExecute(object parameter) => CanExecuteEnabled;
 
-	public void Execute(object parameter) => _action?.Invoke();
+	public void Execute(object parameter)
+	{
+		if (!CanExecuteEnabled)
+		{
+			return;
+		}
+
+		_action?.Invoke();
+	}
 
 	private void OnCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_StandardUICommand.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_StandardUICommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿#if HAS_UNO
+using System.Threading.Tasks;
 using Private.Infrastructure;
 using Uno.UI.Common;
 using Windows.System;
@@ -344,3 +345,4 @@ public class Given_StandardUICommand
 		}
 	}
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_StandardUICommand.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_StandardUICommand.cs
@@ -1,0 +1,346 @@
+﻿using System.Threading.Tasks;
+using Private.Infrastructure;
+using Uno.UI.Common;
+using Windows.System;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Markup;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_StandardUICommand
+{
+	[TestMethod]
+	public void When_KeyboardAccelerators_Retrieved()
+	{
+		var xamlUICommand = new StandardUICommand();
+		var keyboardAccelerators = xamlUICommand.KeyboardAccelerators;
+		Assert.IsNotNull(keyboardAccelerators);
+	}
+
+	[TestMethod]
+	public void When_CanExecute_Default()
+	{
+		var SUT = new StandardUICommand();
+		Assert.IsTrue(SUT.CanExecute(null));
+	}
+
+	[TestMethod]
+	public void When_Execute()
+	{
+		bool executed = false;
+		var SUT = new StandardUICommand();
+		SUT.ExecuteRequested += (s, e) => executed = true;
+		SUT.Execute(null);
+		Assert.IsTrue(executed);
+	}
+
+	[TestMethod]
+	public void When_CanExecute_Handled()
+	{
+		var uiCommand = new StandardUICommand();
+		uiCommand.CanExecuteRequested += (sender, args) => args.CanExecute = false;
+		Assert.IsFalse(uiCommand.CanExecute(null));
+	}
+
+
+	[TestMethod]
+	public void When_CanExecute_Changed()
+	{
+		var uiCommand = new StandardUICommand();
+		bool raised = false;
+		uiCommand.CanExecuteChanged += (sender, args) => raised = true;
+		uiCommand.NotifyCanExecuteChanged();
+		Assert.IsTrue(raised);
+	}
+
+	[TestMethod]
+	public void When_Child_Command_CanExecute()
+	{
+		var uiCommand = new StandardUICommand();
+
+		var parameter = "Test string";
+		bool executeCalled = false;
+		var childCommand = new DelegateCommand<object>(param => { executeCalled = true; });
+		childCommand.CanExecuteEnabled = false;
+
+		uiCommand.Command = childCommand;
+		Assert.IsFalse(uiCommand.CanExecute(parameter));
+		uiCommand.Execute(parameter);
+		Assert.IsFalse(executeCalled);
+
+		childCommand.CanExecuteEnabled = true;
+		Assert.IsTrue(uiCommand.CanExecute(parameter));
+
+		uiCommand.Execute(parameter);
+		Assert.IsTrue(executeCalled);
+	}
+
+	[TestMethod]
+	[DataRow(
+		StandardUICommandKind.Cut,
+		"Cut",
+		"Remove the selected content and put it on the clipboard",
+		Symbol.Cut,
+		VirtualKey.X,
+		VirtualKeyModifiers.Control)]
+	[DataRow(
+		StandardUICommandKind.Copy,
+		"Copy",
+		"Copy the selected content to the clipboard",
+		Symbol.Copy,
+		VirtualKey.C,
+		VirtualKeyModifiers.Control)]
+	[DataRow(
+		StandardUICommandKind.Paste,
+		"Paste",
+		"Insert the contents of the clipboard at the current location",
+		Symbol.Paste,
+		VirtualKey.V,
+		VirtualKeyModifiers.Control)]
+	[DataRow(
+		StandardUICommandKind.SelectAll,
+		"Select All",
+		"Select all content",
+		Symbol.SelectAll,
+		VirtualKey.A,
+		VirtualKeyModifiers.Control)]
+	[DataRow(
+		StandardUICommandKind.Delete,
+		"Delete",
+		"Delete the selected content",
+		Symbol.Delete,
+		VirtualKey.Delete,
+		VirtualKeyModifiers.None)]
+	[DataRow(
+		StandardUICommandKind.Share,
+		"Share",
+		"Share the selected content",
+		Symbol.Share,
+		VirtualKey.None,
+		VirtualKeyModifiers.None)]
+	[DataRow(
+		StandardUICommandKind.Save,
+		"Save",
+		"Save your changes",
+		Symbol.Save,
+		VirtualKey.S,
+		VirtualKeyModifiers.Control)]
+	[DataRow(
+		StandardUICommandKind.Open,
+		"Open",
+		"Open",
+		Symbol.OpenFile,
+		VirtualKey.O,
+		VirtualKeyModifiers.Control)]
+	[DataRow(
+		StandardUICommandKind.Close,
+		"Close",
+		"Close",
+		Symbol.Cancel,
+		VirtualKey.W,
+		VirtualKeyModifiers.Control)]
+	[DataRow(
+		StandardUICommandKind.Pause,
+		"Pause",
+		"Pause",
+		Symbol.Pause,
+		VirtualKey.None,
+		VirtualKeyModifiers.None)]
+	[DataRow(
+		StandardUICommandKind.Play,
+		"Play",
+		"Play",
+		Symbol.Play,
+		VirtualKey.None,
+		VirtualKeyModifiers.None)]
+	[DataRow(
+		StandardUICommandKind.Stop,
+		"Stop",
+		"Stop",
+		Symbol.Stop,
+		VirtualKey.None,
+		VirtualKeyModifiers.None)]
+	[DataRow(
+		StandardUICommandKind.Forward,
+		"Forward",
+		"Go to the next item",
+		Symbol.Forward,
+		VirtualKey.None,
+		VirtualKeyModifiers.None)]
+	[DataRow(
+		StandardUICommandKind.Backward,
+		"Backward",
+		"Go to the previous item",
+		Symbol.Back,
+		VirtualKey.None,
+		VirtualKeyModifiers.None)]
+	[DataRow(
+		StandardUICommandKind.Undo,
+		"Undo",
+		"Reverse the most recent action",
+		Symbol.Undo,
+		VirtualKey.Z,
+		VirtualKeyModifiers.Control)]
+	[DataRow(
+		StandardUICommandKind.Redo,
+		"Redo",
+		"Repeat the most recently undone action",
+		Symbol.Redo,
+		VirtualKey.Y,
+		VirtualKeyModifiers.Control)]
+	public void When_Predefined_StandardUICommand(
+		StandardUICommandKind kind,
+		string label,
+		string description,
+		Symbol symbol,
+		VirtualKey virtualKey,
+		VirtualKeyModifiers modifiers)
+	{
+		var SUT = new StandardUICommand(kind);
+		AssertStandardUICommandProperties(SUT, label, description, symbol, virtualKey, modifiers);
+	}
+
+	[TestMethod]
+	public void When_StandardUICommand_In_Xaml()
+	{
+		var xamlString =
+"""
+<StandardUICommand 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	Kind="Copy" />
+""";
+		var xaml = XamlReader.Load(xamlString);
+		Assert.IsInstanceOfType(xaml, typeof(StandardUICommand));
+		var command = (StandardUICommand)xaml;
+		AssertStandardUICommandProperties(
+			command,
+			"Copy",
+			"Copy the selected content to the clipboard",
+			Symbol.Copy,
+			VirtualKey.C,
+			VirtualKeyModifiers.Control);
+	}
+
+	[TestMethod]
+	public void When_Kind_Changes_Overrides_Default_Properties()
+	{
+		var SUT = new StandardUICommand();
+
+		AssertStandardUICommandProperties(
+			SUT,
+			"",
+			"",
+			null,
+			VirtualKey.None,
+			VirtualKeyModifiers.None);
+
+		SUT.Kind = StandardUICommandKind.Copy;
+
+		AssertStandardUICommandProperties(
+			SUT,
+			"Copy",
+			"Copy the selected content to the clipboard",
+			Symbol.Copy,
+			VirtualKey.C,
+			VirtualKeyModifiers.Control);
+
+		SUT.Kind = StandardUICommandKind.Cut;
+
+		AssertStandardUICommandProperties(
+			SUT,
+			"Cut",
+			"Remove the selected content and put it on the clipboard",
+			Symbol.Cut,
+			VirtualKey.X,
+			VirtualKeyModifiers.Control);
+	}
+
+	[TestMethod]
+	public void When_Kind_Changes_Does_Not_Override_Set_Properties()
+	{
+		var myLabel = "My label";
+		var myDescription = "My description";
+
+		var SUT = new StandardUICommand(StandardUICommandKind.Cut);
+		SUT.Label = myLabel;
+		SUT.Description = myDescription;
+
+		var myAccelerator = new KeyboardAccelerator();
+		myAccelerator.Key = VirtualKey.M;
+		myAccelerator.Modifiers = VirtualKeyModifiers.Menu;
+
+		SUT.KeyboardAccelerators.Clear();
+		SUT.KeyboardAccelerators.Add(myAccelerator);
+
+		AssertStandardUICommandProperties(
+			SUT,
+			myLabel,
+			myDescription,
+			Symbol.Cut,
+			VirtualKey.M,
+			VirtualKeyModifiers.Menu);
+
+		SUT.Kind = StandardUICommandKind.Copy;
+
+		AssertStandardUICommandProperties(
+			SUT,
+			myLabel,
+			myDescription,
+			Symbol.Copy,
+			VirtualKey.M,
+			VirtualKeyModifiers.Menu);
+
+		var mySymbol = Symbol.Favorite;
+		var mySymbolIconSource = new SymbolIconSource();
+		mySymbolIconSource.Symbol = mySymbol;
+		SUT.IconSource = mySymbolIconSource;
+
+		SUT.Kind = StandardUICommandKind.SelectAll;
+
+		AssertStandardUICommandProperties(
+			SUT,
+			myLabel,
+			myDescription,
+			mySymbol,
+			VirtualKey.M,
+			VirtualKeyModifiers.Menu);
+	}
+
+	private void AssertStandardUICommandProperties(
+		StandardUICommand command,
+		string label,
+		string description,
+		Symbol? symbol,
+		VirtualKey virtualKey,
+		VirtualKeyModifiers modifiers)
+	{
+		Assert.AreEqual(label, command.Label);
+		Assert.AreEqual(description, command.Description);
+		var iconSource = command.IconSource;
+		if (symbol is null)
+		{
+			Assert.IsNull(iconSource);
+		}
+		else
+		{
+			Assert.IsInstanceOfType(iconSource, typeof(SymbolIconSource));
+			var symbolIconSource = (SymbolIconSource)iconSource;
+			Assert.AreEqual(symbol, symbolIconSource.Symbol);
+		}
+		if (virtualKey == VirtualKey.None)
+		{
+			Assert.AreEqual(0, command.KeyboardAccelerators.Count);
+		}
+		else
+		{
+			Assert.AreEqual(1, command.KeyboardAccelerators.Count);
+			var keyboardAccelerator = command.KeyboardAccelerators[0];
+			Assert.AreEqual(virtualKey, keyboardAccelerator.Key);
+			Assert.AreEqual(modifiers, keyboardAccelerator.Modifiers);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_StandardUICommand.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_StandardUICommand.cs
@@ -1,7 +1,6 @@
-﻿#if HAS_UNO
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using System.Windows.Input;
 using Private.Infrastructure;
-using Uno.UI.Common;
 using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
@@ -25,7 +24,8 @@ public class Given_StandardUICommand
 	public void When_CanExecute_Default()
 	{
 		var SUT = new StandardUICommand();
-		Assert.IsTrue(SUT.CanExecute(null));
+		var command = (ICommand)SUT;
+		Assert.IsTrue(command.CanExecute(null));
 	}
 
 	[TestMethod]
@@ -33,51 +33,56 @@ public class Given_StandardUICommand
 	{
 		bool executed = false;
 		var SUT = new StandardUICommand();
+		var command = (ICommand)SUT;
 		SUT.ExecuteRequested += (s, e) => executed = true;
-		SUT.Execute(null);
+		command.Execute(null);
 		Assert.IsTrue(executed);
 	}
 
 	[TestMethod]
 	public void When_CanExecute_Handled()
 	{
-		var uiCommand = new StandardUICommand();
-		uiCommand.CanExecuteRequested += (sender, args) => args.CanExecute = false;
-		Assert.IsFalse(uiCommand.CanExecute(null));
+		var SUT = new StandardUICommand();
+		var command = (ICommand)SUT;
+		SUT.CanExecuteRequested += (sender, args) => args.CanExecute = false;
+		Assert.IsFalse(command.CanExecute(null));
 	}
 
 
 	[TestMethod]
 	public void When_CanExecute_Changed()
 	{
-		var uiCommand = new StandardUICommand();
+		var SUT = new StandardUICommand();
+		var command = (ICommand)SUT;
 		bool raised = false;
-		uiCommand.CanExecuteChanged += (sender, args) => raised = true;
-		uiCommand.NotifyCanExecuteChanged();
+		command.CanExecuteChanged += (sender, args) => raised = true;
+		SUT.NotifyCanExecuteChanged();
 		Assert.IsTrue(raised);
 	}
 
+#if HAS_UNO
 	[TestMethod]
 	public void When_Child_Command_CanExecute()
 	{
-		var uiCommand = new StandardUICommand();
+		var SUT = new StandardUICommand();
 
 		var parameter = "Test string";
 		bool executeCalled = false;
-		var childCommand = new DelegateCommand<object>(param => { executeCalled = true; });
+		var childCommand = new Uno.UI.Common.DelegateCommand<object>(param => { executeCalled = true; });
 		childCommand.CanExecuteEnabled = false;
 
-		uiCommand.Command = childCommand;
-		Assert.IsFalse(uiCommand.CanExecute(parameter));
-		uiCommand.Execute(parameter);
+		SUT.Command = childCommand;
+		Assert.IsFalse(SUT.CanExecute(parameter));
+		SUT.Execute(parameter);
 		Assert.IsFalse(executeCalled);
 
 		childCommand.CanExecuteEnabled = true;
-		Assert.IsTrue(uiCommand.CanExecute(parameter));
+		Assert.IsTrue(SUT.CanExecute(parameter));
 
-		uiCommand.Execute(parameter);
+		SUT.Execute(parameter);
 		Assert.IsTrue(executeCalled);
 	}
+#endif
 
 	[TestMethod]
 	[DataRow(
@@ -345,4 +350,3 @@ public class Given_StandardUICommand
 		}
 	}
 }
-#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XamlUICommand.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XamlUICommand.cs
@@ -1,5 +1,4 @@
-﻿#if HAS_UNO
-using Uno.UI.Common;
+﻿using System.Windows.Input;
 using Windows.UI.Xaml.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input;
@@ -20,7 +19,8 @@ public class Given_XamlUICommand
 	public void When_CanExecute_Default()
 	{
 		var SUT = new XamlUICommand();
-		Assert.IsTrue(SUT.CanExecute(null));
+		var command = (ICommand)SUT;
+		Assert.IsTrue(command.CanExecute(null));
 	}
 
 	[TestMethod]
@@ -28,50 +28,54 @@ public class Given_XamlUICommand
 	{
 		bool executed = false;
 		var SUT = new XamlUICommand();
+		var command = (ICommand)SUT;
 		SUT.ExecuteRequested += (s, e) => executed = true;
-		SUT.Execute(null);
+		command.Execute(null);
 		Assert.IsTrue(executed);
 	}
 
 	[TestMethod]
 	public void When_CanExecute_Handled()
 	{
-		var uiCommand = new XamlUICommand();
-		uiCommand.CanExecuteRequested += (sender, args) => args.CanExecute = false;
-		Assert.IsFalse(uiCommand.CanExecute(null));
+		var SUT = new XamlUICommand();
+		var command = (ICommand)SUT;
+		SUT.CanExecuteRequested += (sender, args) => args.CanExecute = false;
+		Assert.IsFalse(command.CanExecute(null));
 	}
 
 
 	[TestMethod]
 	public void When_CanExecute_Changed()
 	{
-		var uiCommand = new XamlUICommand();
+		var SUT = new XamlUICommand();
+		var command = (ICommand)SUT;
 		bool raised = false;
-		uiCommand.CanExecuteChanged += (sender, args) => raised = true;
-		uiCommand.NotifyCanExecuteChanged();
+		command.CanExecuteChanged += (sender, args) => raised = true;
+		SUT.NotifyCanExecuteChanged();
 		Assert.IsTrue(raised);
 	}
 
+#if HAS_UNO
 	[TestMethod]
 	public void When_Child_Command_CanExecute()
 	{
-		var uiCommand = new XamlUICommand();
+		var SUT = new XamlUICommand();
 
 		var parameter = "Test string";
 		bool executeCalled = false;
-		var childCommand = new DelegateCommand<object>(param => { executeCalled = true; });
+		var childCommand = new Uno.UI.Common.DelegateCommand<object>(param => { executeCalled = true; });
 		childCommand.CanExecuteEnabled = false;
 
-		uiCommand.Command = childCommand;
-		Assert.IsFalse(uiCommand.CanExecute(parameter));
-		uiCommand.Execute(parameter);
+		SUT.Command = childCommand;
+		Assert.IsFalse(SUT.CanExecute(parameter));
+		SUT.Execute(parameter);
 		Assert.IsFalse(executeCalled);
 
 		childCommand.CanExecuteEnabled = true;
-		Assert.IsTrue(uiCommand.CanExecute(parameter));
+		Assert.IsTrue(SUT.CanExecute(parameter));
 
-		uiCommand.Execute(parameter);
+		SUT.Execute(parameter);
 		Assert.IsTrue(executeCalled);
 	}
-}
 #endif
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XamlUICommand.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XamlUICommand.cs
@@ -1,21 +1,75 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Uno.UI.Common;
 using Windows.UI.Xaml.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input;
 
 [TestClass]
+[RunsOnUIThread]
 public class Given_XamlUICommand
 {
 	[TestMethod]
-	[RunsOnUIThread]
 	public void When_KeyboardAccelerators_Retrieved()
 	{
 		var xamlUICommand = new XamlUICommand();
 		var keyboardAccelerators = xamlUICommand.KeyboardAccelerators;
 		Assert.IsNotNull(keyboardAccelerators);
+	}
+
+	[TestMethod]
+	public void When_CanExecute_Default()
+	{
+		var SUT = new XamlUICommand();
+		Assert.IsTrue(SUT.CanExecute(null));
+	}
+
+	[TestMethod]
+	public void When_Execute()
+	{
+		bool executed = false;
+		var SUT = new XamlUICommand();
+		SUT.ExecuteRequested += (s, e) => executed = true;
+		SUT.Execute(null);
+		Assert.IsTrue(executed);
+	}
+
+	[TestMethod]
+	public void When_CanExecute_Handled()
+	{
+		var uiCommand = new XamlUICommand();
+		uiCommand.CanExecuteRequested += (sender, args) => args.CanExecute = false;
+		Assert.IsFalse(uiCommand.CanExecute(null));
+	}
+
+
+	[TestMethod]
+	public void When_CanExecute_Changed()
+	{
+		var uiCommand = new XamlUICommand();
+		bool raised = false;
+		uiCommand.CanExecuteChanged += (sender, args) => raised = true;
+		uiCommand.NotifyCanExecuteChanged();
+		Assert.IsTrue(raised);
+	}
+
+	[TestMethod]
+	public void When_Child_Command_CanExecute()
+	{
+		var uiCommand = new XamlUICommand();
+
+		var parameter = "Test string";
+		bool executeCalled = false;
+		var childCommand = new DelegateCommand<object>(param => { executeCalled = true; });
+		childCommand.CanExecuteEnabled = false;
+
+		uiCommand.Command = childCommand;
+		Assert.IsFalse(uiCommand.CanExecute(parameter));
+		uiCommand.Execute(parameter);
+		Assert.IsFalse(executeCalled);
+
+		childCommand.CanExecuteEnabled = true;
+		Assert.IsTrue(uiCommand.CanExecute(parameter));
+
+		uiCommand.Execute(parameter);
+		Assert.IsTrue(executeCalled);
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XamlUICommand.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XamlUICommand.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Input;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input;
+
+[TestClass]
+public class Given_XamlUICommand
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public void When_KeyboardAccelerators_Retrieved()
+	{
+		var xamlUICommand = new XamlUICommand();
+		var keyboardAccelerators = xamlUICommand.KeyboardAccelerators;
+		Assert.IsNotNull(keyboardAccelerators);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XamlUICommand.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_XamlUICommand.cs
@@ -1,4 +1,5 @@
-﻿using Uno.UI.Common;
+﻿#if HAS_UNO
+using Uno.UI.Common;
 using Windows.UI.Xaml.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input;
@@ -73,3 +74,4 @@ public class Given_XamlUICommand
 		Assert.IsTrue(executeCalled);
 	}
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
@@ -5,6 +5,7 @@ using Uno.UI.Helpers;
 using Uno.Xaml;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 {
@@ -268,6 +269,20 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 			Assert.AreEqual(ScrollMode.Disabled, sut.HorizontalScrollMode);
 			ScrollViewer.SetHorizontalScrollMode(setup, ScrollMode.Enabled);
 			Assert.AreEqual(ScrollMode.Enabled, sut.HorizontalScrollMode);
+		}
+
+		[TestMethod]
+		public void When_Input_Namespace()
+		{
+			var xamlString =
+"""
+<StandardUICommand 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	Kind="Copy" />
+""";
+			var xaml = Windows.UI.Xaml.Markup.XamlReader.Load(xamlString);
+			Assert.IsInstanceOfType(xaml, typeof(StandardUICommand));
 		}
 	}
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/CommandBarFlyout/Strings/en-GB/Resources.resw
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/CommandBarFlyout/Strings/en-GB/Resources.resw
@@ -223,4 +223,64 @@
   <data name="TextCommandLabelUndo" xml:space="preserve">
     <value>Undo</value>
   </data>
+  <data name="TextCommandDescriptionBackward" xml:space="preserve">
+    <value>Go to the previous item</value>
+  </data>
+  <data name="TextCommandDescriptionClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="TextCommandDescriptionDelete" xml:space="preserve">
+    <value>Delete the selected content</value>
+  </data>
+  <data name="TextCommandDescriptionForward" xml:space="preserve">
+    <value>Go to the next item</value>
+  </data>
+  <data name="TextCommandDescriptionOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="TextCommandDescriptionPause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="TextCommandDescriptionPlay" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="TextCommandDescriptionSave" xml:space="preserve">
+    <value>Save your changes</value>
+  </data>
+  <data name="TextCommandDescriptionShare" xml:space="preserve">
+    <value>Share the selected content</value>
+  </data>
+  <data name="TextCommandDescriptionStop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="TextCommandLabelBackward" xml:space="preserve">
+    <value>Backward</value>
+  </data>
+  <data name="TextCommandLabelClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="TextCommandLabelDelete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="TextCommandLabelForward" xml:space="preserve">
+    <value>Forward</value>
+  </data>
+  <data name="TextCommandLabelOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="TextCommandLabelPause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="TextCommandLabelPlay" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="TextCommandLabelSave" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="TextCommandLabelShare" xml:space="preserve">
+    <value>Share</value>
+  </data>
+  <data name="TextCommandLabelStop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
 </root>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/CommandBarFlyout/Strings/en-US/Resources.resw
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/CommandBarFlyout/Strings/en-US/Resources.resw
@@ -223,4 +223,76 @@
   <data name="TextCommandLabelUndo" xml:space="preserve">
     <value>Undo</value>
   </data>
+  <data name="TextCommandDescriptionBackward" xml:space="preserve">
+    <value>Go to the previous item</value>
+  </data>
+  <data name="TextCommandDescriptionClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="TextCommandDescriptionDelete" xml:space="preserve">
+    <value>Delete the selected content</value>
+  </data>
+  <data name="TextCommandDescriptionForward" xml:space="preserve">
+    <value>Go to the next item</value>
+  </data>
+  <data name="TextCommandDescriptionOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="TextCommandDescriptionPause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="TextCommandDescriptionPlay" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="TextCommandDescriptionSave" xml:space="preserve">
+    <value>Save your changes</value>
+  </data>
+  <data name="TextCommandDescriptionShare" xml:space="preserve">
+    <value>Share the selected content</value>
+  </data>
+  <data name="TextCommandDescriptionStop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="TextCommandLabelBackward" xml:space="preserve">
+    <value>Backward</value>
+  </data>
+  <data name="TextCommandLabelClose" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="TextCommandLabelDelete" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="TextCommandLabelForward" xml:space="preserve">
+    <value>Forward</value>
+  </data>
+  <data name="TextCommandLabelOpen" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="TextCommandLabelPause" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="TextCommandLabelPlay" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="TextCommandLabelSave" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="TextCommandLabelShare" xml:space="preserve">
+    <value>Share</value>
+  </data>
+  <data name="TextCommandLabelStop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyClose" xml:space="preserve">
+    <value>W</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for closing - Ctrl+W. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeyOpen" xml:space="preserve">
+    <value>O</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for opening - Ctrl+O. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
+  <data name="TextCommandKeyboardAcceleratorKeySave" xml:space="preserve">
+    <value>S</value>
+    <comment>{ValidChars="A-Z"}{MinLength=source}{MaxLength=source}Keyboard accelerator key for undoing - Ctrl+S. Must be unique with respect to every other keyboard accelerator in this file.</comment>
+  </data>
 </root>

--- a/src/Uno.UI/UI/Xaml/Input/StandardUICommand.Constants.cs
+++ b/src/Uno.UI/UI/Xaml/Input/StandardUICommand.Constants.cs
@@ -1,0 +1,48 @@
+﻿namespace Windows.UI.Xaml.Input;
+
+partial class StandardUICommand
+{
+	private string TEXT_COMMAND_LABEL_CUT = "TextCommandLabelCut";
+	private string TEXT_COMMAND_LABEL_COPY = "TextCommandLabelCopy";
+	private string TEXT_COMMAND_LABEL_PASTE = "TextCommandLabelPaste";
+	private string TEXT_COMMAND_LABEL_SELECTALL = "TextCommandLabelSelectAll";
+	private string TEXT_COMMAND_LABEL_DELETE = "TextCommandLabelDelete";
+	private string TEXT_COMMAND_LABEL_SHARE = "TextCommandLabelShare";
+	private string TEXT_COMMAND_LABEL_SAVE = "TextCommandLabelSave";
+	private string TEXT_COMMAND_LABEL_OPEN = "TextCommandLabelOpen";
+	private string TEXT_COMMAND_LABEL_CLOSE = "TextCommandLabelClose";
+	private string TEXT_COMMAND_LABEL_PAUSE = "TextCommandLabelPause";
+	private string TEXT_COMMAND_LABEL_PLAY = "TextCommandLabelPlay";
+	private string TEXT_COMMAND_LABEL_STOP = "TextCommandLabelStop";
+	private string TEXT_COMMAND_LABEL_FORWARD = "TextCommandLabelForward";
+	private string TEXT_COMMAND_LABEL_BACKWARD = "TextCommandLabelBackward";
+	private string TEXT_COMMAND_LABEL_UNDO = "TextCommandLabelUndo";
+	private string TEXT_COMMAND_LABEL_REDO = "TextCommandLabelRedo";
+
+	private string TEXT_COMMAND_DESCRIPTION_CUT = "TextCommandDescriptionCut";
+	private string TEXT_COMMAND_DESCRIPTION_COPY = "TextCommandDescriptionCopy";
+	private string TEXT_COMMAND_DESCRIPTION_PASTE = "TextCommandDescriptionPaste";
+	private string TEXT_COMMAND_DESCRIPTION_SELECTALL = "TextCommandDescriptionSelectAll";
+	private string TEXT_COMMAND_DESCRIPTION_DELETE = "TextCommandDescriptionDelete";
+	private string TEXT_COMMAND_DESCRIPTION_SHARE = "TextCommandDescriptionShare";
+	private string TEXT_COMMAND_DESCRIPTION_SAVE = "TextCommandDescriptionSave";
+	private string TEXT_COMMAND_DESCRIPTION_OPEN = "TextCommandDescriptionOpen";
+	private string TEXT_COMMAND_DESCRIPTION_CLOSE = "TextCommandDescriptionClose";
+	private string TEXT_COMMAND_DESCRIPTION_PAUSE = "TextCommandDescriptionPause";
+	private string TEXT_COMMAND_DESCRIPTION_PLAY = "TextCommandDescriptionPlay";
+	private string TEXT_COMMAND_DESCRIPTION_STOP = "TextCommandDescriptionStop";
+	private string TEXT_COMMAND_DESCRIPTION_FORWARD = "TextCommandDescriptionForward";
+	private string TEXT_COMMAND_DESCRIPTION_BACKWARD = "TextCommandDescriptionBackward";
+	private string TEXT_COMMAND_DESCRIPTION_UNDO = "TextCommandDescriptionUndo";
+	private string TEXT_COMMAND_DESCRIPTION_REDO = "TextCommandDescriptionRedo";
+
+	private string TEXT_COMMAND_KEYBOARDACCELERATORKEY_CUT = "TextCommandKeyboardAcceleratorKeyCut";
+	private string TEXT_COMMAND_KEYBOARDACCELERATORKEY_COPY = "TextCommandKeyboardAcceleratorKeyCopy";
+	private string TEXT_COMMAND_KEYBOARDACCELERATORKEY_PASTE = "TextCommandKeyboardAcceleratorKeyPaste";
+	private string TEXT_COMMAND_KEYBOARDACCELERATORKEY_SELECTALL = "TextCommandKeyboardAcceleratorKeySelectAll";
+	private string TEXT_COMMAND_KEYBOARDACCELERATORKEY_SAVE = "TextCommandKeyboardAcceleratorKeySave";
+	private string TEXT_COMMAND_KEYBOARDACCELERATORKEY_OPEN = "TextCommandKeyboardAcceleratorKeyOpen";
+	private string TEXT_COMMAND_KEYBOARDACCELERATORKEY_CLOSE = "TextCommandKeyboardAcceleratorKeyClose";
+	private string TEXT_COMMAND_KEYBOARDACCELERATORKEY_UNDO = "TextCommandKeyboardAcceleratorKeyUndo";
+	private string TEXT_COMMAND_KEYBOARDACCELERATORKEY_REDO = "TextCommandKeyboardAcceleratorKeyRedo";
+}

--- a/src/Uno.UI/UI/Xaml/Input/StandardUICommand.cs
+++ b/src/Uno.UI/UI/Xaml/Input/StandardUICommand.cs
@@ -10,13 +10,14 @@ public partial class StandardUICommand : XamlUICommand
 	/// </summary>
 	public StandardUICommand()
 	{
+		PrepareState();
 	}
 
 	/// <summary>
 	/// Initializes a new instance of the StandardUICommand class of the specified kind.
 	/// </summary>
 	/// <param name="kind"></param>
-	public StandardUICommand(StandardUICommandKind kind)
+	public StandardUICommand(StandardUICommandKind kind) : this()
 	{
 		Kind = kind;
 	}
@@ -26,7 +27,11 @@ public partial class StandardUICommand : XamlUICommand
 	/// icon, keyboard accelerator, and description) that can be used
 	/// with a StandardUICommand.
 	/// </summary>
-	public StandardUICommandKind Kind { get; set; }
+	public StandardUICommandKind Kind
+	{
+		get => (StandardUICommandKind)GetValue(KindProperty);
+		set => SetValue(KindProperty, value);
+	}
 
 	/// <summary>
 	/// Identifies the Kind dependency property.

--- a/src/Uno.UI/UI/Xaml/Input/StandardUICommand.cs
+++ b/src/Uno.UI/UI/Xaml/Input/StandardUICommand.cs
@@ -1,41 +1,40 @@
-namespace Windows.UI.Xaml.Input
+namespace Windows.UI.Xaml.Input;
+
+/// <summary>
+/// Derives from XamlUICommand, adding a set of standard platform commands with pre-defined properties.
+/// </summary>
+public partial class StandardUICommand : XamlUICommand
 {
 	/// <summary>
-	/// Derives from XamlUICommand, adding a set of standard platform commands with pre-defined properties.
+	/// Initializes a new instance of the StandardUICommand class.
 	/// </summary>
-	public partial class StandardUICommand : XamlUICommand
+	public StandardUICommand()
 	{
-		/// <summary>
-		/// Initializes a new instance of the StandardUICommand class.
-		/// </summary>
-		public StandardUICommand()
-		{
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the StandardUICommand class of the specified kind.
-		/// </summary>
-		/// <param name="kind"></param>
-		public StandardUICommand(StandardUICommandKind kind)
-		{
-			Kind = kind;
-		}
-
-		/// <summary>
-		/// Gets the platform command (with pre-defined properties such as
-		/// icon, keyboard accelerator, and description) that can be used
-		/// with a StandardUICommand.
-		/// </summary>
-		public StandardUICommandKind Kind { get; set; }
-
-		/// <summary>
-		/// Identifies the Kind dependency property.
-		/// </summary>
-		public static DependencyProperty KindProperty { get; } =
-			DependencyProperty.Register(
-				nameof(Kind),
-				typeof(StandardUICommandKind),
-				typeof(StandardUICommand),
-				new FrameworkPropertyMetadata(default(StandardUICommandKind)));
 	}
+
+	/// <summary>
+	/// Initializes a new instance of the StandardUICommand class of the specified kind.
+	/// </summary>
+	/// <param name="kind"></param>
+	public StandardUICommand(StandardUICommandKind kind)
+	{
+		Kind = kind;
+	}
+
+	/// <summary>
+	/// Gets the platform command (with pre-defined properties such as
+	/// icon, keyboard accelerator, and description) that can be used
+	/// with a StandardUICommand.
+	/// </summary>
+	public StandardUICommandKind Kind { get; set; }
+
+	/// <summary>
+	/// Identifies the Kind dependency property.
+	/// </summary>
+	public static DependencyProperty KindProperty { get; } =
+		DependencyProperty.Register(
+			nameof(Kind),
+			typeof(StandardUICommandKind),
+			typeof(StandardUICommand),
+			new FrameworkPropertyMetadata(default(StandardUICommandKind)));
 }

--- a/src/Uno.UI/UI/Xaml/Input/StandardUICommand.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Input/StandardUICommand.mux.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference StandardUICommand_Partial.cpp, tag winui3/release/1.4.2
+
+using System;
 using DirectUI;
 using Uno.Disposables;
 using Windows.System;
@@ -44,13 +48,15 @@ partial class StandardUICommand : IDependencyObjectInternal
 		}
 	}
 
-	private void EnterImpl()
-	{
-		if (Kind == StandardUICommandKind.None)
-		{
-			throw new InvalidOperationException("StandardUICommand Kind must be set");
-		}
-	}
+	// TODO: Uno - this should be called for every DependencyObject when
+	// added to the visual tree
+	//private void EnterImpl()
+	//{
+	//	if (Kind == StandardUICommandKind.None)
+	//	{
+	//		throw new InvalidOperationException("StandardUICommand Kind must be set");
+	//	}
+	//}
 
 	private void PopulateForKind(StandardUICommandKind kind)
 	{

--- a/src/Uno.UI/UI/Xaml/Input/StandardUICommand.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Input/StandardUICommand.mux.cs
@@ -1,0 +1,455 @@
+﻿using System;
+using DirectUI;
+using Uno.Disposables;
+using Windows.System;
+using Windows.UI.Xaml.Controls;
+
+namespace Windows.UI.Xaml.Input;
+
+partial class StandardUICommand : IDependencyObjectInternal
+{
+	private void PrepareState()
+	{
+		//base.PrepareState();
+
+		StandardUICommandKind kind = Kind;
+
+		PopulateForKind(kind);
+	}
+
+	void IDependencyObjectInternal.OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
+	{
+		//base.OnPropertyChanged2(args);
+
+		if (m_settingPropertyInternally)
+		{
+			return;
+		}
+
+		if (args.Property == KindProperty)
+		{
+			PopulateForKind((StandardUICommandKind)(args.NewValue));
+		}
+		else if (args.Property == LabelProperty)
+		{
+			m_ownsLabel = false;
+		}
+		else if (args.Property == IconSourceProperty)
+		{
+			m_ownsIconSource = false;
+		}
+		else if (args.Property == DescriptionProperty)
+		{
+			m_ownsDescription = false;
+		}
+	}
+
+	private void EnterImpl()
+	{
+		if (Kind == StandardUICommandKind.None)
+		{
+			throw new InvalidOperationException("StandardUICommand Kind must be set");
+		}
+	}
+
+	private void PopulateForKind(StandardUICommandKind kind)
+	{
+		switch (kind)
+		{
+			case StandardUICommandKind.None:
+				break;
+
+			case StandardUICommandKind.Cut:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_CUT,
+					Symbol.Cut,
+					TEXT_COMMAND_KEYBOARDACCELERATORKEY_CUT,
+					VirtualKeyModifiers.Control,
+					TEXT_COMMAND_DESCRIPTION_CUT);
+				break;
+
+			case StandardUICommandKind.Copy:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_COPY,
+					Symbol.Copy,
+					TEXT_COMMAND_KEYBOARDACCELERATORKEY_COPY,
+					VirtualKeyModifiers.Control,
+					TEXT_COMMAND_DESCRIPTION_COPY);
+				break;
+
+			case StandardUICommandKind.Paste:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_PASTE,
+					Symbol.Paste,
+					TEXT_COMMAND_KEYBOARDACCELERATORKEY_PASTE,
+					VirtualKeyModifiers.Control,
+					TEXT_COMMAND_DESCRIPTION_PASTE);
+				break;
+
+			case StandardUICommandKind.SelectAll:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_SELECTALL,
+					Symbol.SelectAll,
+					TEXT_COMMAND_KEYBOARDACCELERATORKEY_SELECTALL,
+					VirtualKeyModifiers.Control,
+					TEXT_COMMAND_DESCRIPTION_SELECTALL);
+				break;
+
+			case StandardUICommandKind.Delete:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_DELETE,
+					Symbol.Delete,
+					VirtualKey.Delete,
+					VirtualKeyModifiers.None,
+					TEXT_COMMAND_DESCRIPTION_DELETE);
+				break;
+
+			case StandardUICommandKind.Share:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_SHARE,
+					Symbol.Share,
+					VirtualKey.None,
+					VirtualKeyModifiers.None,
+					TEXT_COMMAND_DESCRIPTION_SHARE);
+				break;
+
+			case StandardUICommandKind.Save:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_SAVE,
+					Symbol.Save,
+					TEXT_COMMAND_KEYBOARDACCELERATORKEY_SAVE,
+					VirtualKeyModifiers.Control,
+					TEXT_COMMAND_DESCRIPTION_SAVE);
+				break;
+
+			case StandardUICommandKind.Open:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_OPEN,
+					Symbol.OpenFile,
+					TEXT_COMMAND_KEYBOARDACCELERATORKEY_OPEN,
+					VirtualKeyModifiers.Control,
+					TEXT_COMMAND_DESCRIPTION_OPEN);
+				break;
+
+			case StandardUICommandKind.Close:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_CLOSE,
+					Symbol.Cancel,
+					TEXT_COMMAND_KEYBOARDACCELERATORKEY_CLOSE,
+					VirtualKeyModifiers.Control,
+					TEXT_COMMAND_DESCRIPTION_CLOSE);
+				break;
+
+			case StandardUICommandKind.Pause:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_PAUSE,
+					Symbol.Pause,
+					VirtualKey.None,
+					VirtualKeyModifiers.None,
+					TEXT_COMMAND_DESCRIPTION_PAUSE);
+				break;
+
+			case StandardUICommandKind.Play:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_PLAY,
+					Symbol.Play,
+					VirtualKey.None,
+					VirtualKeyModifiers.None,
+					TEXT_COMMAND_DESCRIPTION_PLAY);
+				break;
+
+			case StandardUICommandKind.Stop:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_STOP,
+					Symbol.Stop,
+					VirtualKey.None,
+					VirtualKeyModifiers.None,
+					TEXT_COMMAND_DESCRIPTION_STOP);
+				break;
+
+			case StandardUICommandKind.Forward:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_FORWARD,
+					Symbol.Forward,
+					VirtualKey.None,
+					VirtualKeyModifiers.None,
+					TEXT_COMMAND_DESCRIPTION_FORWARD);
+				break;
+
+			case StandardUICommandKind.Backward:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_BACKWARD,
+					Symbol.Back,
+					VirtualKey.None,
+					VirtualKeyModifiers.None,
+					TEXT_COMMAND_DESCRIPTION_BACKWARD);
+				break;
+
+			case StandardUICommandKind.Undo:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_UNDO,
+					Symbol.Undo,
+					TEXT_COMMAND_KEYBOARDACCELERATORKEY_UNDO,
+					VirtualKeyModifiers.Control,
+					TEXT_COMMAND_DESCRIPTION_UNDO);
+				break;
+
+			case StandardUICommandKind.Redo:
+				PopulateWithProperties(
+					TEXT_COMMAND_LABEL_REDO,
+					Symbol.Redo,
+					TEXT_COMMAND_KEYBOARDACCELERATORKEY_REDO,
+					VirtualKeyModifiers.Control,
+					TEXT_COMMAND_DESCRIPTION_REDO);
+				break;
+
+			default:
+				throw new InvalidOperationException("Unknown StandardUICommandKind");
+		}
+	}
+
+	private void PopulateWithProperties(
+	   string labelResourceId,
+	   Symbol symbol,
+	   string acceleratorKeyResourceId,
+	   VirtualKeyModifiers acceleratorModifiers,
+	   string descriptionResourceId)
+	{
+		// If the accelerator key we've been passed is a string,
+		// we need to convert it to an enum value.
+		var acceleratorKeyString = DXamlCore.Current.GetLocalizedResourceString(acceleratorKeyResourceId);
+
+		char acceleratorKeyChar = acceleratorKeyString.Length >= 1 ? acceleratorKeyString[0] : '\0';
+		VirtualKey acceleratorKey = VirtualKey.None;
+
+		switch (acceleratorKeyChar)
+		{
+			case 'A':
+			case 'a':
+				acceleratorKey = VirtualKey.A;
+				break;
+			case 'B':
+			case 'b':
+				acceleratorKey = VirtualKey.B;
+				break;
+			case 'C':
+			case 'c':
+				acceleratorKey = VirtualKey.C;
+				break;
+			case 'D':
+			case 'd':
+				acceleratorKey = VirtualKey.D;
+				break;
+			case 'E':
+			case 'e':
+				acceleratorKey = VirtualKey.E;
+				break;
+			case 'F':
+			case 'f':
+				acceleratorKey = VirtualKey.F;
+				break;
+			case 'G':
+			case 'g':
+				acceleratorKey = VirtualKey.G;
+				break;
+			case 'H':
+			case 'h':
+				acceleratorKey = VirtualKey.H;
+				break;
+			case 'I':
+			case 'i':
+				acceleratorKey = VirtualKey.I;
+				break;
+			case 'J':
+			case 'j':
+				acceleratorKey = VirtualKey.J;
+				break;
+			case 'K':
+			case 'k':
+				acceleratorKey = VirtualKey.K;
+				break;
+			case 'L':
+			case 'l':
+				acceleratorKey = VirtualKey.L;
+				break;
+			case 'M':
+			case 'm':
+				acceleratorKey = VirtualKey.M;
+				break;
+			case 'N':
+			case 'n':
+				acceleratorKey = VirtualKey.N;
+				break;
+			case 'O':
+			case 'o':
+				acceleratorKey = VirtualKey.O;
+				break;
+			case 'P':
+			case 'p':
+				acceleratorKey = VirtualKey.P;
+				break;
+			case 'Q':
+			case 'q':
+				acceleratorKey = VirtualKey.Q;
+				break;
+			case 'R':
+			case 'r':
+				acceleratorKey = VirtualKey.R;
+				break;
+			case 'S':
+			case 's':
+				acceleratorKey = VirtualKey.S;
+				break;
+			case 'T':
+			case 't':
+				acceleratorKey = VirtualKey.T;
+				break;
+			case 'U':
+			case 'u':
+				acceleratorKey = VirtualKey.U;
+				break;
+			case 'V':
+			case 'v':
+				acceleratorKey = VirtualKey.V;
+				break;
+			case 'W':
+			case 'w':
+				acceleratorKey = VirtualKey.W;
+				break;
+			case 'X':
+			case 'x':
+				acceleratorKey = VirtualKey.X;
+				break;
+			case 'Y':
+			case 'y':
+				acceleratorKey = VirtualKey.Y;
+				break;
+			case 'Z':
+			case 'z':
+				acceleratorKey = VirtualKey.Z;
+				break;
+		}
+
+		PopulateWithProperties(
+			labelResourceId,
+			symbol,
+			acceleratorKey,
+			acceleratorKey != VirtualKey.None ? acceleratorModifiers : VirtualKeyModifiers.None,
+			descriptionResourceId);
+	}
+
+	private void PopulateWithProperties(
+	   string labelResourceId,
+	   Symbol symbol,
+	   VirtualKey acceleratorKey,
+	   VirtualKeyModifiers acceleratorModifiers,
+	   string descriptionResourceId)
+	{
+		SetLabelIfUnset(labelResourceId);
+		SetIconSourceIfUnset(symbol);
+		SetKeyboardAcceleratorIfUnset(acceleratorKey, acceleratorModifiers);
+		SetDescriptionIfUnset(descriptionResourceId);
+	}
+
+	private void SetLabelIfUnset(string labelResourceId)
+	{
+		if (m_ownsLabel)
+		{
+			using var scopeGuard = Disposable.Create(() => m_settingPropertyInternally = false);
+			m_settingPropertyInternally = true;
+
+			string label = DXamlCore.Current.GetLocalizedResourceString(labelResourceId);
+			Label = label;
+		}
+	}
+
+	private void SetIconSourceIfUnset(Symbol symbol)
+	{
+		if (m_ownsIconSource)
+		{
+			using var scopeGuard = Disposable.Create(() => m_settingPropertyInternally = false);
+			m_settingPropertyInternally = true;
+
+			SymbolIconSource symbolIconSource = new();
+			symbolIconSource.Symbol = symbol;
+
+			IconSource = symbolIconSource;
+		}
+	}
+
+	private void SetKeyboardAcceleratorIfUnset(
+	   VirtualKey acceleratorKey,
+	   VirtualKeyModifiers acceleratorModifiers)
+	{
+		if (!m_ownsKeyboardAccelerator)
+		{
+			return;
+		}
+
+		var keyboardAccelerators = KeyboardAccelerators;
+
+		int keyboardAcceleratorCount = keyboardAccelerators.Count;
+
+		// If we ever detect a keyboard accelerator value that we didn't set,
+		// we'll cede ownership at that point to the app developer, and won't
+		// touch the keyboard accelerators further.
+		if (keyboardAcceleratorCount == 0 &&
+			m_previousAcceleratorKey != VirtualKey.None)
+		{
+			// Unless the accelerator key was "None", we should always have an accelerator -
+			// so, if we don't, then we know that the app developer has changed things.
+			m_ownsKeyboardAccelerator = false;
+			return;
+		}
+		else if (keyboardAcceleratorCount == 1)
+		{
+			var keyboardAccelerator = keyboardAccelerators[0];
+
+			var currentAcceleratorKey = keyboardAccelerator.Key;
+			var currentAcceleratorModifiers = keyboardAccelerator.Modifiers;
+
+			if (currentAcceleratorKey != m_previousAcceleratorKey ||
+				currentAcceleratorModifiers != m_previousAcceleratorModifiers)
+			{
+				m_ownsKeyboardAccelerator = false;
+				return;
+			}
+		}
+		else if (keyboardAcceleratorCount > 1)
+		{
+			// We'll never set more than one keyboard accelerator,
+			// so if we have more than one, then we know that the app developer
+			// has changed things.
+			m_ownsKeyboardAccelerator = false;
+			return;
+		}
+
+		keyboardAccelerators.Clear();
+
+		if (acceleratorKey != VirtualKey.None)
+		{
+			var keyboardAccelerator = new KeyboardAccelerator();
+			keyboardAccelerator.Key = acceleratorKey;
+			keyboardAccelerator.Modifiers = acceleratorModifiers;
+			keyboardAccelerators.Add(keyboardAccelerator);
+		}
+
+		m_previousAcceleratorKey = acceleratorKey;
+		m_previousAcceleratorModifiers = acceleratorModifiers;
+
+		return;
+	}
+
+	private void SetDescriptionIfUnset(string descriptionResourceId)
+	{
+		if (m_ownsDescription)
+		{
+			using var _ = Disposable.Create(() => m_settingPropertyInternally = false);
+
+			m_settingPropertyInternally = true;
+
+			var description = DXamlCore.Current.GetLocalizedResourceString(descriptionResourceId);
+			Description = description;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Input/StandardUICommand.mux.h.cs
+++ b/src/Uno.UI/UI/Xaml/Input/StandardUICommand.mux.h.cs
@@ -1,4 +1,8 @@
-﻿using Windows.System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference StandardUICommand_Partial.h, tag winui3/release/1.4.2
+
+using Windows.System;
 
 namespace Windows.UI.Xaml.Input;
 

--- a/src/Uno.UI/UI/Xaml/Input/StandardUICommand.mux.h.cs
+++ b/src/Uno.UI/UI/Xaml/Input/StandardUICommand.mux.h.cs
@@ -1,0 +1,15 @@
+﻿using Windows.System;
+
+namespace Windows.UI.Xaml.Input;
+
+partial class StandardUICommand
+{
+	private bool m_ownsLabel = true;
+	private bool m_ownsIconSource = true;
+	private bool m_ownsKeyboardAccelerator = true;
+	private bool m_ownsDescription = true;
+
+	private VirtualKey m_previousAcceleratorKey;
+	private VirtualKeyModifiers m_previousAcceleratorModifiers;
+	private bool m_settingPropertyInternally;
+}

--- a/src/Uno.UI/UI/Xaml/Input/StandardUICommandKind.cs
+++ b/src/Uno.UI/UI/Xaml/Input/StandardUICommandKind.cs
@@ -1,94 +1,93 @@
-namespace Windows.UI.Xaml.Input
+namespace Windows.UI.Xaml.Input;
+
+/// <summary>
+/// Specifies the set of platform commands (with pre-defined properties such as icon,
+/// keyboard accelerator, and description) that can be used with a StandardUICommand.
+/// </summary>
+public enum StandardUICommandKind
 {
 	/// <summary>
-	/// Specifies the set of platform commands (with pre-defined properties such as icon,
-	/// keyboard accelerator, and description) that can be used with a StandardUICommand.
+	/// No command. Default.
 	/// </summary>
-	public enum StandardUICommandKind
-	{
-		/// <summary>
-		/// No command. Default.
-		/// </summary>
-		None,
+	None,
 
-		/// <summary>
-		/// Specifies the cut command.
-		/// </summary>
-		Cut,
+	/// <summary>
+	/// Specifies the cut command.
+	/// </summary>
+	Cut,
 
-		/// <summary>
-		/// Specifies the copy command.
-		/// </summary>
-		Copy,
+	/// <summary>
+	/// Specifies the copy command.
+	/// </summary>
+	Copy,
 
-		/// <summary>
-		/// Specifies the paste command.
-		/// </summary>
-		Paste,
+	/// <summary>
+	/// Specifies the paste command.
+	/// </summary>
+	Paste,
 
-		/// <summary>
-		/// Specifies the select all command.
-		/// </summary>
-		SelectAll,
+	/// <summary>
+	/// Specifies the select all command.
+	/// </summary>
+	SelectAll,
 
-		/// <summary>
-		/// Specifies the delete command.
-		/// </summary>
-		Delete,
+	/// <summary>
+	/// Specifies the delete command.
+	/// </summary>
+	Delete,
 
-		/// <summary>
-		/// Specifies the share command.
-		/// </summary>
-		Share,
+	/// <summary>
+	/// Specifies the share command.
+	/// </summary>
+	Share,
 
-		/// <summary>
-		/// Specifies the save command.
-		/// </summary>
-		Save,
+	/// <summary>
+	/// Specifies the save command.
+	/// </summary>
+	Save,
 
-		/// <summary>
-		/// Specifies the open command.
-		/// </summary>
-		Open,
+	/// <summary>
+	/// Specifies the open command.
+	/// </summary>
+	Open,
 
-		/// <summary>
-		/// Specifies the close command.
-		/// </summary>
-		Close,
+	/// <summary>
+	/// Specifies the close command.
+	/// </summary>
+	Close,
 
-		/// <summary>
-		/// Specifies the pause command.
-		/// </summary>
-		Pause,
+	/// <summary>
+	/// Specifies the pause command.
+	/// </summary>
+	Pause,
 
-		/// <summary>
-		/// Specifies the play command.
-		/// </summary>
-		Play,
+	/// <summary>
+	/// Specifies the play command.
+	/// </summary>
+	Play,
 
-		/// <summary>
-		/// Specifies the stop command.
-		/// </summary>
-		Stop,
+	/// <summary>
+	/// Specifies the stop command.
+	/// </summary>
+	Stop,
 
-		/// <summary>
-		/// Specifies the forward command.
-		/// </summary>
-		Forward,
+	/// <summary>
+	/// Specifies the forward command.
+	/// </summary>
+	Forward,
 
-		/// <summary>
-		/// Specifies the backward command.
-		/// </summary>
-		Backward,
+	/// <summary>
+	/// Specifies the backward command.
+	/// </summary>
+	Backward,
 
-		/// <summary>
-		/// Specifies the undo command.
-		/// </summary>
-		Undo,
+	/// <summary>
+	/// Specifies the undo command.
+	/// </summary>
+	Undo,
 
-		/// <summary>
-		/// Specifies the redo command.
-		/// </summary>
-		Redo,
-	}
+	/// <summary>
+	/// Specifies the redo command.
+	/// </summary>
+	Redo,
 }

--- a/src/Uno.UI/UI/Xaml/Input/XamlUICommand.cs
+++ b/src/Uno.UI/UI/Xaml/Input/XamlUICommand.cs
@@ -1,221 +1,231 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference XamlUICommand_Partial.cpp, tag winui3/release/1.4.2
+
 using System;
 using System.Collections.Generic;
 using System.Windows.Input;
 using Windows.Foundation;
 using Windows.UI.Xaml.Controls;
 
-namespace Windows.UI.Xaml.Input
+namespace Windows.UI.Xaml.Input;
+
+/// <summary>
+/// Provides a base class for defining the command behavior of an interactive
+/// UI element that performs an action when invoked (such as sending an email,
+/// deleting an item, or submitting a form).
+/// </summary>
+public partial class XamlUICommand : DependencyObject, ICommand
 {
-	/// <summary>
-	/// Provides a base class for defining the command behavior of an interactive
-	/// UI element that performs an action when invoked (such as sending an email,
-	/// deleting an item, or submitting a form).
-	/// </summary>
-	public partial class XamlUICommand : DependencyObject, ICommand
+	public XamlUICommand()
 	{
-		/// <summary>
-		/// Occurs whenever something happens that affects whether the command can execute.
-		/// </summary>
-		public event EventHandler CanExecuteChanged;
+		// TODO: Uno specific - we need to initialize KeyboardAccelerators here
+		// WinUI does this automatically on demand via IsValueCreatedOnDemand.
+		SetValue(KeyboardAcceleratorsProperty, new List<KeyboardAccelerator>());
+	}
 
-		/// <summary>
-		/// Occurs when a CanExecute call is made.
-		/// </summary>
-		public event TypedEventHandler<XamlUICommand, CanExecuteRequestedEventArgs> CanExecuteRequested;
+	/// <summary>
+	/// Occurs whenever something happens that affects whether the command can execute.
+	/// </summary>
+	public event EventHandler CanExecuteChanged;
 
-		/// <summary>
-		/// Occurs when an Execute call is made.
-		/// </summary>
-		public event TypedEventHandler<XamlUICommand, ExecuteRequestedEventArgs> ExecuteRequested;
+	/// <summary>
+	/// Occurs when a CanExecute call is made.
+	/// </summary>
+	public event TypedEventHandler<XamlUICommand, CanExecuteRequestedEventArgs> CanExecuteRequested;
 
-		/// <summary>
-		/// Gets or sets the label for this element.
-		/// </summary>
-		public string Label
-		{
-			get => (string)GetValue(LabelProperty) ?? "";
-			set => SetValue(LabelProperty, value);
-		}
+	/// <summary>
+	/// Occurs when an Execute call is made.
+	/// </summary>
+	public event TypedEventHandler<XamlUICommand, ExecuteRequestedEventArgs> ExecuteRequested;
 
-		/// <summary>
-		/// Gets or sets a glyph from the Segoe MDL2 Assets font for this element.
-		/// </summary>
-		public IconSource IconSource
-		{
-			get => (IconSource)GetValue(IconSourceProperty);
-			set => SetValue(IconSourceProperty, value);
-		}
+	/// <summary>
+	/// Gets or sets the label for this element.
+	/// </summary>
+	public string Label
+	{
+		get => (string)GetValue(LabelProperty) ?? "";
+		set => SetValue(LabelProperty, value);
+	}
 
-		/// <summary>
-		/// Gets or sets a description for this element.
-		/// </summary>
-		public string Description
-		{
-			get => (string)GetValue(DescriptionProperty) ?? "";
-			set => SetValue(DescriptionProperty, value);
-		}
+	/// <summary>
+	/// Gets or sets a glyph from the Segoe MDL2 Assets font for this element.
+	/// </summary>
+	public IconSource IconSource
+	{
+		get => (IconSource)GetValue(IconSourceProperty);
+		set => SetValue(IconSourceProperty, value);
+	}
 
-		/// <summary>
-		/// Gets or sets the command behavior of an interactive UI element
-		/// that performs an action when invoked, such as sending an email,
-		/// deleting an item, or submitting a form.
-		/// </summary>
-		public ICommand Command
-		{
-			get => (ICommand)GetValue(CommandProperty);
-			set => SetValue(CommandProperty, value);
-		}
+	/// <summary>
+	/// Gets or sets a description for this element.
+	/// </summary>
+	public string Description
+	{
+		get => (string)GetValue(DescriptionProperty) ?? "";
+		set => SetValue(DescriptionProperty, value);
+	}
 
-		/// <summary>
-		/// Gets or sets the access key (mnemonic) for this element.
-		/// </summary>
-		public string AccessKey
-		{
-			get => (string)GetValue(AccessKeyProperty) ?? "";
-			set => SetValue(AccessKeyProperty, value);
-		}
+	/// <summary>
+	/// Gets or sets the command behavior of an interactive UI element
+	/// that performs an action when invoked, such as sending an email,
+	/// deleting an item, or submitting a form.
+	/// </summary>
+	public ICommand Command
+	{
+		get => (ICommand)GetValue(CommandProperty);
+		set => SetValue(CommandProperty, value);
+	}
 
-		/// <summary>
-		/// Gets or sets the collection of key combinations for this element that invoke an action using the keyboard.
-		/// </summary>
-		public IList<KeyboardAccelerator> KeyboardAccelerators => (IList<KeyboardAccelerator>)GetValue(KeyboardAcceleratorsProperty);
+	/// <summary>
+	/// Gets or sets the access key (mnemonic) for this element.
+	/// </summary>
+	public string AccessKey
+	{
+		get => (string)GetValue(AccessKeyProperty) ?? "";
+		set => SetValue(AccessKeyProperty, value);
+	}
 
-		/// <summary>
-		/// Identifies the AccessKey dependency property.
-		/// </summary>
-		public static DependencyProperty AccessKeyProperty { get; } =
-			DependencyProperty.Register(
-				nameof(AccessKey),
-				typeof(string),
-				typeof(XamlUICommand),
-				new FrameworkPropertyMetadata(default(string)));
+	/// <summary>
+	/// Gets or sets the collection of key combinations for this element that invoke an action using the keyboard.
+	/// </summary>
+	public IList<KeyboardAccelerator> KeyboardAccelerators => (IList<KeyboardAccelerator>)GetValue(KeyboardAcceleratorsProperty);
 
-		/// <summary>
-		/// Identifies the Command dependency property.
-		/// </summary>
-		public static DependencyProperty CommandProperty { get; } =
-			DependencyProperty.Register(
-				nameof(Command),
-				typeof(ICommand),
-				typeof(XamlUICommand),
-				new FrameworkPropertyMetadata(default(ICommand)));
+	/// <summary>
+	/// Identifies the AccessKey dependency property.
+	/// </summary>
+	public static DependencyProperty AccessKeyProperty { get; } =
+		DependencyProperty.Register(
+			nameof(AccessKey),
+			typeof(string),
+			typeof(XamlUICommand),
+			new FrameworkPropertyMetadata(default(string)));
 
-		/// <summary>
-		/// Identifies the Description dependency property.
-		/// </summary>
-		public static DependencyProperty DescriptionProperty { get; } =
-			DependencyProperty.Register(
-				nameof(Description),
-				typeof(string),
-				typeof(XamlUICommand),
-				new FrameworkPropertyMetadata(default(string)));
+	/// <summary>
+	/// Identifies the Command dependency property.
+	/// </summary>
+	public static DependencyProperty CommandProperty { get; } =
+		DependencyProperty.Register(
+			nameof(Command),
+			typeof(ICommand),
+			typeof(XamlUICommand),
+			new FrameworkPropertyMetadata(default(ICommand)));
 
-		/// <summary>
-		/// Identifies the IconSource dependency property.
-		/// </summary>
-		public static DependencyProperty IconSourceProperty { get; } =
-			DependencyProperty.Register(
-				nameof(IconSource),
-				typeof(IconSource),
-				typeof(XamlUICommand),
-				new FrameworkPropertyMetadata(default(IconSource)));
+	/// <summary>
+	/// Identifies the Description dependency property.
+	/// </summary>
+	public static DependencyProperty DescriptionProperty { get; } =
+		DependencyProperty.Register(
+			nameof(Description),
+			typeof(string),
+			typeof(XamlUICommand),
+			new FrameworkPropertyMetadata(default(string)));
 
-		/// <summary>
-		/// Identifies the KeyboardAccelerators dependency property.
-		/// </summary>
-		public static DependencyProperty KeyboardAcceleratorsProperty { get; } =
-			DependencyProperty.Register(
-				nameof(KeyboardAccelerators),
-				typeof(IList<KeyboardAccelerator>),
-				typeof(XamlUICommand),
-				new FrameworkPropertyMetadata(default(IList<KeyboardAccelerator>)));
+	/// <summary>
+	/// Identifies the IconSource dependency property.
+	/// </summary>
+	public static DependencyProperty IconSourceProperty { get; } =
+		DependencyProperty.Register(
+			nameof(IconSource),
+			typeof(IconSource),
+			typeof(XamlUICommand),
+			new FrameworkPropertyMetadata(default(IconSource)));
 
-		/// <summary>
-		/// Identifies the Label dependency property.
-		/// </summary>
-		public static DependencyProperty LabelProperty { get; } =
-			DependencyProperty.Register(
-				nameof(Label),
-				typeof(string),
-				typeof(XamlUICommand),
-				new FrameworkPropertyMetadata(default(string)));
+	/// <summary>
+	/// Identifies the KeyboardAccelerators dependency property.
+	/// </summary>
+	public static DependencyProperty KeyboardAcceleratorsProperty { get; } =
+		DependencyProperty.Register(
+			nameof(KeyboardAccelerators),
+			typeof(IList<KeyboardAccelerator>),
+			typeof(XamlUICommand),
+			new FrameworkPropertyMetadata(default(IList<KeyboardAccelerator>)));
 
-		/// <summary>
-		/// Notifies the system that the command state has changed.
-		/// </summary>
-		public void NotifyCanExecuteChanged() => CanExecuteChanged?.Invoke(this, null);
+	/// <summary>
+	/// Identifies the Label dependency property.
+	/// </summary>
+	public static DependencyProperty LabelProperty { get; } =
+		DependencyProperty.Register(
+			nameof(Label),
+			typeof(string),
+			typeof(XamlUICommand),
+			new FrameworkPropertyMetadata(default(string)));
 
-		/// <summary>
-		/// Retrieves whether the command can execute in its current state.
-		/// </summary>
-		/// <param name="parameter">Data used by the command. If the command
-		/// does not require data, this object can be set to null.</param>
-		/// <returns>true if this command can be executed; otherwise, false.</returns>
-		public bool CanExecute(object parameter)
-		{
-			bool canExecute = false;
+	/// <summary>
+	/// Notifies the system that the command state has changed.
+	/// </summary>
+	public void NotifyCanExecuteChanged() => CanExecuteChanged?.Invoke(this, null);
 
-			CanExecuteRequestedEventArgs args = new CanExecuteRequestedEventArgs();
+	/// <summary>
+	/// Retrieves whether the command can execute in its current state.
+	/// </summary>
+	/// <param name="parameter">Data used by the command. If the command
+	/// does not require data, this object can be set to null.</param>
+	/// <returns>true if this command can be executed; otherwise, false.</returns>
+	public bool CanExecute(object parameter)
+	{
+		bool canExecute = false;
 
-			args.Parameter = parameter;
-			args.CanExecute = true;
+		CanExecuteRequestedEventArgs args = new CanExecuteRequestedEventArgs();
 
-#if false // WI_IS_FEATURE_PRESENT(Feature_CommandingImprovements)
-			ctl::ComPtr<CommandingContainer> focusedCommandingContainer;
-			IFC_RETURN(GetFocusedCommandingContainer(&focusedCommandingContainer));
-
-			if (focusedCommandingContainer)
-			{
-				IFC_RETURN(args->put_CommandTarget(focusedCommandingContainer->GetCommandTargetNoRef()));
-				IFC_RETURN(args->put_ListCommandTarget(focusedCommandingContainer->GetListCommandTargetNoRef()));
-			}
-#endif
-
-			CanExecuteRequested?.Invoke(this, args);
-
-			canExecute = args.CanExecute;
-
-			ICommand childCommand = Command;
-
-			if (childCommand != null)
-			{
-				bool childCommandCanExecute = childCommand.CanExecute(parameter);
-				canExecute = canExecute && childCommandCanExecute;
-			}
-
-			return canExecute;
-		}
-
-		/// <summary>
-		/// Invokes the command.
-		/// </summary>
-		/// <param name="parameter">Data used by the command. If the command does not
-		/// require data, this object can be set to null.</param>
-		public void Execute(object parameter)
-		{
-			ExecuteRequestedEventArgs args = new ExecuteRequestedEventArgs();
-
-			args.Parameter = parameter;
+		args.Parameter = parameter;
+		args.CanExecute = true;
 
 #if false // WI_IS_FEATURE_PRESENT(Feature_CommandingImprovements)
-			ctl::ComPtr<CommandingContainer> focusedCommandingContainer;
-			IFC_RETURN(GetFocusedCommandingContainer(&focusedCommandingContainer));
+		ctl::ComPtr<CommandingContainer> focusedCommandingContainer;
+		IFC_RETURN(GetFocusedCommandingContainer(&focusedCommandingContainer));
 
-			if (focusedCommandingContainer)
-			{
-				IFC_RETURN(args->put_CommandTarget(focusedCommandingContainer->GetCommandTargetNoRef()));
-				IFC_RETURN(args->put_ListCommandTarget(focusedCommandingContainer->GetListCommandTargetNoRef()));
-			}
+		if (focusedCommandingContainer)
+		{
+			IFC_RETURN(args->put_CommandTarget(focusedCommandingContainer->GetCommandTargetNoRef()));
+			IFC_RETURN(args->put_ListCommandTarget(focusedCommandingContainer->GetListCommandTargetNoRef()));
+		}
 #endif
 
-			ExecuteRequested?.Invoke(this, args);
+		CanExecuteRequested?.Invoke(this, args);
 
-			ICommand childCommand = Command;
+		canExecute = args.CanExecute;
 
-			if (childCommand != null)
-			{
-				childCommand.Execute(parameter);
-			}
+		ICommand childCommand = Command;
+
+		if (childCommand != null)
+		{
+			bool childCommandCanExecute = childCommand.CanExecute(parameter);
+			canExecute = canExecute && childCommandCanExecute;
+		}
+
+		return canExecute;
+	}
+
+	/// <summary>
+	/// Invokes the command.
+	/// </summary>
+	/// <param name="parameter">Data used by the command. If the command does not
+	/// require data, this object can be set to null.</param>
+	public void Execute(object parameter)
+	{
+		ExecuteRequestedEventArgs args = new ExecuteRequestedEventArgs();
+
+		args.Parameter = parameter;
+
+#if false // WI_IS_FEATURE_PRESENT(Feature_CommandingImprovements)
+		ctl::ComPtr<CommandingContainer> focusedCommandingContainer;
+		IFC_RETURN(GetFocusedCommandingContainer(&focusedCommandingContainer));
+
+		if (focusedCommandingContainer)
+		{
+			IFC_RETURN(args->put_CommandTarget(focusedCommandingContainer->GetCommandTargetNoRef()));
+			IFC_RETURN(args->put_ListCommandTarget(focusedCommandingContainer->GetListCommandTargetNoRef()));
+		}
+#endif
+
+		ExecuteRequested?.Invoke(this, args);
+
+		ICommand childCommand = Command;
+
+		if (childCommand != null)
+		{
+			childCommand.Execute(parameter);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlConstants.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlConstants.cs
@@ -29,6 +29,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 			public const string MediaAnimation = BaseXamlNamespace + ".Media.Animation";
 			public const string MediaImaging = BaseXamlNamespace + ".Media.Imaging";
 			public const string Shapes = BaseXamlNamespace + ".Shapes";
+			public const string Input = BaseXamlNamespace + ".Input";
 
 			public static readonly string[] PresentationNamespaces =
 			{
@@ -37,6 +38,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 				Controls,
 				Primitives,
 				Data,
+				Input,
 				Documents,
 				Shapes,
 				Media,


### PR DESCRIPTION
GitHub Issue (If applicable): closes #5769, closes #14321

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Not supported 😭

## What is the new behavior?

Supported! 🥳🥳🥳

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a75af1</samp>

This pull request adds a new UI test for `XamlUICommand` and `StandardUICommand`, which are classes that represent commands with properties such as label, icon, and keyboard shortcut. It also refactors the `StandardUICommand` class to use constants for the resource keys of the command properties and to handle property changes based on the command kind.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.