### PR TITLE
fix: Restore XamlReader HR for mobile targets

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -68,6 +68,8 @@
 		<CompilerVisibleProperty Include="IsUnoHead" />
 		<CompilerVisibleProperty Include="UnoDisableHotRestartHelperGeneration" />
 		<CompilerVisibleProperty Include="RuntimeIdentifier" />
+		<CompilerVisibleProperty Include="UnoRuntimeIdentifier" />
+		<CompilerVisibleProperty Include="UnoHotReloadMode" />
 
 		<CompilerVisibleProperty Include="SolutionFileName" />
 		<CompilerVisibleProperty Include="LangName" />

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
@@ -1,0 +1,136 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.Extensions;
+using Uno.Foundation.Logging;
+using Uno.UI.Extensions;
+using Uno.UI.Helpers;
+using Uno.UI.RemoteControl.HotReload;
+using Windows.Storage.Pickers.Provider;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+using Windows.UI.Xaml.Media;
+
+#if __IOS__
+using UIKit;
+#elif __MACOS__
+using AppKit;
+#elif __ANDROID__
+using Uno.UI;
+#endif
+
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(Uno.UI.RemoteControl.HotReload.ClientHotReloadProcessor))]
+
+namespace Uno.UI.RemoteControl.HotReload
+{
+	partial class ClientHotReloadProcessor
+	{
+		private static async IAsyncEnumerable<TMatch> EnumerateHotReloadInstances<TMatch>(
+			object? instance,
+			Func<FrameworkElement, string, Task<TMatch?>> predicate,
+			string? parentKey)
+		{
+
+			if (instance is FrameworkElement fe)
+			{
+				var instanceTypeName = (instance.GetType().GetOriginalType() ?? instance.GetType()).Name;
+				var instanceKey = parentKey is not null ? $"{parentKey}_{instanceTypeName}" : instanceTypeName;
+				var match = await predicate(fe, instanceKey);
+				if (match is not null)
+				{
+					yield return match;
+				}
+
+				var idx = 0;
+				foreach (var child in fe.EnumerateChildren())
+				{
+					var inner = EnumerateHotReloadInstances(child, predicate, $"{instanceKey}_[{idx}]");
+					idx++;
+					await foreach (var validElement in inner)
+					{
+						yield return validElement;
+					}
+				}
+			}
+		}
+
+		private static void SwapViews(FrameworkElement oldView, FrameworkElement newView)
+		{
+			if (_log.IsEnabled(LogLevel.Trace))
+			{
+				_log.Trace($"Swapping view {newView.GetType()}");
+			}
+
+#if !WINUI
+			var parentAsContentControl = oldView.GetVisualTreeParent() as ContentControl;
+			parentAsContentControl = parentAsContentControl ?? (oldView.GetVisualTreeParent() as ContentPresenter)?.FindFirstParent<ContentControl>();
+#else
+			var parentAsContentControl = VisualTreeHelper.GetParent(oldView) as ContentControl;
+			parentAsContentControl = parentAsContentControl ?? (VisualTreeHelper.GetParent(oldView) as ContentPresenter)?.FindFirstParent<ContentControl>();
+#endif
+
+			if ((parentAsContentControl?.Content as FrameworkElement) == oldView)
+			{
+				parentAsContentControl.Content = newView;
+			}
+			else if (newView is Page newPage && oldView is Page oldPage)
+			{
+				// In the case of Page, swapping the actual page is not supported, so we
+				// need to swap the content of the page instead. This can happen if the Frame
+				// is using a native presenter which does not use the `Frame.Content` property.
+
+				// Clear any local context, so that the new page can inherit the value coming
+				// from the parent Frame. It may happen if the old page set it explicitly.
+
+#if !WINUI
+				oldPage.ClearValue(Page.DataContextProperty, DependencyPropertyValuePrecedences.Local);
+#else
+				oldPage.ClearValue(Page.DataContextProperty);
+#endif
+
+				oldPage.Content = newPage;
+#if !WINUI
+				newPage.Frame = oldPage.Frame;
+#endif
+			}
+#if !WINUI
+			// Currently we don't have SwapViews implementation that works with WinUI
+			// so skip swapping non-Page views initially for WinUI
+			else
+			{
+				VisualTreeHelper.SwapViews(oldView, newView);
+			}
+#endif
+
+			if (oldView is FrameworkElement oldViewAsFE && newView is FrameworkElement newViewAsFE)
+			{
+				PropagateProperties(oldViewAsFE, newViewAsFE);
+			}
+		}
+
+		private static void PropagateProperties(FrameworkElement oldView, FrameworkElement newView)
+		{
+			if (oldView == null || newView == null)
+			{
+				return;
+			}
+
+			if (newView.DataContext is null
+				&& oldView.DataContext is not null)
+			{
+				// If the DataContext is not provided by the page itself, it may
+				// have been provided by an external actor. Copy the value as is
+				// in the DataContext of the new element.
+
+				newView.DataContext = oldView.DataContext;
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.PartialReload.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.PartialReload.cs
@@ -32,15 +32,20 @@ namespace Uno.UI.RemoteControl.HotReload
 
 			_supportsLightweightHotReload =
 				buildingInsideVisualStudio.Equals("true", StringComparison.OrdinalIgnoreCase)
+				&& (_forcedHotReloadMode is null || _forcedHotReloadMode == HotReloadMode.Partial)
 				&& (
 					// As of VS 17.8, when the debugger is attached, mobile targets don't invoke MetadataUpdateHandlers
 					// and both targets are not providing updated types. We simulate parts of this process
 					// to determine which types have been updated, particularly those with "CreateNewOnMetadataUpdate".
-					(Debugger.IsAttached
-						&& (targetFramework.Contains("-android") || targetFramework.Contains("-ios")))
+					//
+					// Disabled until https://github.com/dotnet/runtime/issues/93860 is fixed
+					//
+					//(Debugger.IsAttached
+					//	&& (targetFramework.Contains("-android") || targetFramework.Contains("-ios")))
+					//||
 
 					// WebAssembly does not support sending updated types, and does not support debugger based hot reload.
-					|| (unoRuntimeIdentifier?.Equals("WebAssembly", StringComparison.OrdinalIgnoreCase) ?? false));
+					(unoRuntimeIdentifier?.Equals("WebAssembly", StringComparison.OrdinalIgnoreCase) ?? false));
 
 			if (this.Log().IsEnabled(LogLevel.Trace))
 			{
@@ -54,18 +59,6 @@ namespace Uno.UI.RemoteControl.HotReload
 			_mappedTypes = _supportsLightweightHotReload
 				? BuildMappedTypes()
 				: new();
-		}
-
-		private string GetMSBuildProperty(string property, string defaultValue = "")
-		{
-			var output = defaultValue;
-
-			if (_msbuildProperties is not null && !_msbuildProperties.TryGetValue(property, out output))
-			{
-				return defaultValue;
-			}
-
-			return output;
 		}
 
 		private async Task PartialReload(FileReload fileReload)
@@ -161,14 +154,17 @@ namespace Uno.UI.RemoteControl.HotReload
 						this.Log().Trace($"Found {newTypes.Length} updated types ({types})");
 					}
 
-					var actions = _agent.GetMetadataUpdateHandlerActions();
-
-					actions.ClearCache.ForEach(a => a(newTypes));
-					actions.UpdateApplication.ForEach(a => a(newTypes));
-
-					if (this.Log().IsEnabled(LogLevel.Trace))
+					if (_agent is not null)
 					{
-						this.Log().Trace($"ObserveUpdateTypeMapping: Invoked metadata updaters");
+						var actions = _agent.GetMetadataUpdateHandlerActions();
+
+						actions.ClearCache.ForEach(a => a(newTypes));
+						actions.UpdateApplication.ForEach(a => a(newTypes));
+
+						if (this.Log().IsEnabled(LogLevel.Trace))
+						{
+							this.Log().Trace($"ObserveUpdateTypeMapping: Invoked metadata updaters");
+						}
 					}
 
 					return;

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -90,24 +90,11 @@ namespace Uno.UI.RemoteControl.HotReload
 						|| uri.OriginalString == i.BaseUri?.OriginalString;
 				}
 
-				foreach (var instance in EnumerateInstances(Window.Current.Content, IsSameBaseUri))
+				foreach (var instance in EnumerateInstances(Window.Current.Content, IsSameBaseUri).OfType<FrameworkElement>())
 				{
-					switch (instance)
+					if (XamlReader.LoadUsingXClass(fileContent, uri.ToString()) is FrameworkElement newContent)
 					{
-#if __IOS__
-						case UserControl userControl:
-							if (XamlReader.LoadUsingXClass(fileContent, uri.OriginalString) is UIKit.UIView newInstance)
-							{
-								SwapViews(userControl, newInstance);
-							}
-							break;
-#endif
-						case ContentControl content:
-							if (XamlReader.LoadUsingXClass(fileContent, uri.ToString()) is ContentControl newContent)
-							{
-								SwapViews(content, newContent);
-							}
-							break;
+						SwapViews(instance, newContent);
 					}
 				}
 

--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadMode.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadMode.cs
@@ -1,0 +1,24 @@
+﻿namespace Uno.UI.RemoteControl.HotReload;
+
+internal enum HotReloadMode
+{
+	/// <summary>
+	/// Hot reload is not configured
+	/// </summary>
+	None = 0,
+
+	/// <summary>
+	/// Hot reload using Metadata updates
+	/// </summary>
+	MetadataUpdates,
+
+	/// <summary>
+	/// Hot Reload using partial updated types discovery
+	/// </summary>
+	Partial,
+
+	/// <summary>
+	/// Hot Reload using XAML reader
+	/// </summary>
+	XamlReader,
+}

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Windows.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Windows.csproj
@@ -36,7 +36,7 @@
 
 		<Compile Include="..\Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.MetadataUpdate.cs" Link="Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.MetadataUpdate.cs" />
 		<Compile Include="..\Uno.UI.RemoteControl\HotReload\WindowExtensions.cs" Link="Uno.UI.RemoteControl\HotReload\WindowExtensions.cs" />
-		<Compile Include="..\Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.Xaml.cs" Link="Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.Xaml.cs" />
+		<Compile Include="..\Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.Common.cs" Link="Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.Common.cs" />
 		<Compile Include="..\Uno.UI.RemoteControl\HotReload\MetadataUpdater\ElementUpdaterAgent.cs" Link="Uno.UI.RemoteControl\HotReload\MetadataUpdater\ElementUpdaterAgent.cs" />
 
 		<!--<Compile Include="..\Uno.UI\UI\Xaml\Media\VisualTreeHelper.crossruntime.cs" Link="Uno.UI\UI\Xaml\Media\VisualTreeHelper.crossruntime.cs" />-->


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores XamlReader HR for mobile targets until https://github.com/dotnet/runtime/issues/93860 is fixed.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e68d4f9</samp>

This pull request adds support for different hot reload modes for the Uno Platform, which enable faster and more flexible development workflows. It introduces the `UnoHotReloadMode` MSBuild property, which allows the user to choose the preferred mode, and the `HotReloadMode` enum, which defines the possible values. It also refactors and improves the `ClientHotReloadProcessor` class, which handles the hot reload logic for different modes, and adds some common methods and types to the `ClientHotReloadProcessor.Common.cs` file. It also comments out some sections of the `global.json` file to avoid conflicts with the .NET 6 SDK.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
