### PR TITLE
fix(ColorPicker): fix the issue that ToolTip's position is incorrect in ColorPickerSlider

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/ColorPicker/ColorPickerSlider.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/ColorPicker/ColorPickerSlider.cs
@@ -43,6 +43,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			if (m_toolTip is ToolTip toolTip)
 			{
 				toolTip.Content = GetToolTipString();
+				toolTip.m_isSliderThumbToolTip = true;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.mux.cs
@@ -1141,7 +1141,7 @@ public partial class Slider
 					}
 				}
 
-				if (_tpElementHorizontalThumb != null && isThumbToolTipEnabled)
+				if (_tpElementHorizontalThumb != null)
 				{
 					Point origin = Point.Zero;
 					Point targetTopLeft = Point.Zero;
@@ -1227,7 +1227,7 @@ public partial class Slider
 					}
 				}
 
-				if (_tpElementVerticalThumb != null && isThumbToolTipEnabled)
+				if (_tpElementVerticalThumb != null)
 				{
 					Point origin = Point.Zero;
 					Point targetTopLeft = Point.Zero;

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -49,6 +49,8 @@ namespace Windows.UI.Xaml.Controls
 
 		internal long CurrentHoverId { get; set; }
 
+		internal bool IsOpenedByHover { get; set; }
+
 		internal IDisposable? OwnerEventSubscriptions { get; set; }
 
 		internal IDisposable? OwnerVisibilitySubscription { get; set; }
@@ -122,6 +124,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnOpenChanged(bool isOpen)
 		{
+			IsOpenedByHover = false;
 			PerformPlacementInternal();
 			if (_owner is not null)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipService.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTipService.cs
@@ -213,6 +213,10 @@ namespace Windows.UI.Xaml.Controls
 				async Task HoverTask(long hoverId)
 				{
 					await Task.Delay(FeatureConfiguration.ToolTip.ShowDelay);
+					if (toolTip.IsOpen == true)
+					{
+						return;
+					}
 					if (toolTip.CurrentHoverId != hoverId)
 					{
 						return;
@@ -221,11 +225,15 @@ namespace Windows.UI.Xaml.Controls
 					if (owner.IsLoaded)
 					{
 						toolTip.IsOpen = true;
-
+						toolTip.IsOpenedByHover = true;
 						await Task.Delay(FeatureConfiguration.ToolTip.ShowDuration);
 						if (toolTip.CurrentHoverId == hoverId)
 						{
-							toolTip.IsOpen = false;
+							if (toolTip.IsOpen && toolTip.IsOpenedByHover)
+							{
+								toolTip.IsOpen = false;
+								toolTip.IsOpenedByHover = false;
+							}
 						}
 					}
 				}
@@ -236,7 +244,11 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (sender is FrameworkElement owner && GetToolTipReference(owner) is { } toolTip)
 			{
-				toolTip.IsOpen = false;
+				if (toolTip.IsOpen && toolTip.IsOpenedByHover)
+				{
+					toolTip.IsOpen = false;
+					toolTip.IsOpenedByHover = false;
+				}
 				toolTip.CurrentHoverId++;
 			}
 		}
@@ -245,7 +257,11 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (sender is FrameworkElement owner && GetToolTipReference(owner) is { } toolTip)
 			{
-				toolTip.IsOpen = false;
+				if (toolTip.IsOpen && toolTip.IsOpenedByHover)
+				{
+					toolTip.IsOpen = false;
+					toolTip.IsOpenedByHover = false;
+				}
 				toolTip.CurrentHoverId++;
 			}
 		}
@@ -262,7 +278,11 @@ namespace Windows.UI.Xaml.Controls
 					case Windows.System.VirtualKey.Right:
 						return;
 				}
-				toolTip.IsOpen = false;
+				if (toolTip.IsOpen && toolTip.IsOpenedByHover)
+				{
+					toolTip.IsOpen = false;
+					toolTip.IsOpenedByHover = false;
+				}
 				toolTip.CurrentHoverId++;
 			}
 		}
@@ -273,7 +293,11 @@ namespace Windows.UI.Xaml.Controls
 			{
 				if (e.GetCurrentPoint(owner).Properties.IsLeftButtonPressed)
 				{
-					toolTip.IsOpen = false;
+					if (toolTip.IsOpen && toolTip.IsOpenedByHover)
+					{
+						toolTip.IsOpen = false;
+						toolTip.IsOpenedByHover = false;
+					}
 					toolTip.CurrentHoverId++;
 				}
 			}


### PR DESCRIPTION
…in ColorPickerSlider

GitHub Issue (If applicable): closes #13865

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60a0c29</samp>

This pull request improves the tool tip functionality for the `ColorPickerSlider` control, which is a custom slider that shows the selected color value. It simplifies the positioning logic for the slider thumb tool tip, and adds logic to handle different tool tip opening modes based on the input modality. It also prevents the tool tip from opening or closing unnecessarily when the user interacts with the slider.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
