### PR TITLE
chore: Sync Togglebutton sources with WinUI 3

### DIFF
--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ToggleButtonAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ToggleButtonAutomationPeer.cs
@@ -33,7 +33,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 		{
 			if (IsEnabled())
 			{
-				((ToggleButton)Owner).AutomationPeerToggle();
+				((ToggleButton)Owner).AutomationToggleButtonOnToggle();
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/AppBar/AppBarToggleButtonAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AppBar/AppBarToggleButtonAutomationPeer.cs
@@ -68,7 +68,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 			}
 
 			var owner = GetOwningAppBarToggleButton();
-			owner.AutomationPeerToggle();
+			owner.AutomationToggleButtonOnToggle();
 		}
 
 		public new ToggleState ToggleState

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.cs
@@ -99,7 +99,5 @@ namespace Windows.UI.Xaml.Controls.Primitives
 				_suppressCheckedChanged = false;
 			}
 		}
-
-		internal void AutomationPeerToggle() => OnClick();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ToggleButton.mux.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// ToggleButton_Partial.h, ToggleButton_Partial.cpp
+// ToggleButton_Partial.h, ToggleButton_Partial.cpp, tag winui3/release/1.4.2
 
 #nullable enable
 
@@ -10,9 +10,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
 {
 	public partial class ToggleButton
 	{
-#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value false
+#if false // Uno docs: This appears to be unused, even on WinUI.
 		private bool _skipCreateAutomationPeer;
-#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value false
+#endif
+
 		private protected override void Initialize()
 		{
 			base.Initialize();
@@ -252,13 +253,11 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			}
 		}
 
-#if false
-		private void AutomationToggleButtonOnToggle()
+		internal void AutomationToggleButtonOnToggle()
 		{
 			// OnToggle through UIAutomation
 			OnClick();
 		}
-#endif
 
 		/// <summary>
 		/// Create ToggleButtonAutomationPeer to represent the ToggleButton.
@@ -266,15 +265,15 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		/// <returns>Automation peer.</returns>
 		protected override AutomationPeer? OnCreateAutomationPeer()
 		{
-			if (!_skipCreateAutomationPeer)
+			//if (!_skipCreateAutomationPeer)
 			{
 				return new ToggleButtonAutomationPeer(this);
 			}
 
-			return null;
+			//return null;
 		}
 
-#if false
+#if false // Uno docs: This appears to be unused, even on WinUI.
 		private void SetSkipAutomationPeerCreation() => _skipCreateAutomationPeer = true;
 #endif
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d7fd77f</samp>

Updated the `ToggleButton` and its automation peers to match the latest WinUI source code and fix a bug with the toggle state property changed event. Removed unused code from the `ToggleButton` class.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
