### PR TITLE
fix(wasm): ProgressRing doesnt stop upon exiting indeterminate state

### DIFF
--- a/src/Uno.UI.RuntimeTests/Extensions/VisualTreeExtensions.win.cs
+++ b/src/Uno.UI.RuntimeTests/Extensions/VisualTreeExtensions.win.cs
@@ -1,0 +1,80 @@
+﻿#if !HAS_UNO
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Media;
+using _View = Windows.UI.Xaml.DependencyObject;
+
+namespace Uno.UI.Extensions; // same as in ViewExtensions.visual-tree.cs
+
+internal static class VisualTreeExtensions // non-uno counterpart to src\Uno.UI\Extensions\ViewExtensions.visual-tree.cs
+{
+	/// <summary>
+	/// Returns the first descendant of a specified type.
+	/// </summary>
+	/// <typeparam name="T">The type of descendant to find.</typeparam>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <remarks>The crawling is done depth first.</remarks>
+	public static T? FindFirstDescendant<T>(this _View? reference) => reference.EnumerateDescendants()
+		.OfType<T>()
+		.FirstOrDefault();
+
+	/// <summary>
+	/// Returns the first descendant of a specified type that satisfies the <paramref name="predicate"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of descendant to find.</typeparam>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <param name="predicate">A function to test each node for a condition.</param>
+	/// <remarks>The crawling is done depth first.</remarks>
+	public static T? FindFirstDescendant<T>(this _View? reference, Func<T, bool> predicate) => reference.EnumerateDescendants()
+		.OfType<T>()
+		.FirstOrDefault(predicate);
+
+	/// <summary>
+	/// Returns the first descendant of a specified type that satisfies the <paramref name="predicate"/> whose ancestors (up to <paramref name="reference"/>) and itself satisfy the <paramref name="hierarchyPredicate"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of descendant to find.</typeparam>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <param name="hierarchyPredicate">A function to test each ancestor for a condition.</param>
+	/// <param name="predicate">A function to test each descendant for a condition.</param>
+	/// <remarks>The crawling is done depth first.</remarks>
+	public static T? FindFirstDescendant<T>(this _View? reference, Func<_View, bool> hierarchyPredicate, Func<T, bool> predicate) => reference.EnumerateDescendants(hierarchyPredicate)
+		.OfType<T>()
+		.FirstOrDefault(predicate);
+
+	/// <summary>
+	/// Returns all the visual descendants of a node.
+	/// </summary>
+	/// <param name="reference">Any node of the visual tree</param>
+	public static IEnumerable<_View> EnumerateDescendants(this _View? reference) => reference.EnumerateDescendants(x => true);
+
+	/// <summary>
+	/// Returns all the visual descendants of a node that satisfies the <paramref name="hierarchyPredicate"/>.
+	/// </summary>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <param name="hierarchyPredicate"></param>
+	/// <returns></returns>
+	public static IEnumerable<_View> EnumerateDescendants(this _View? reference, Func<_View, bool> hierarchyPredicate)
+	{
+		foreach (var child in reference.EnumerateChildren().Where(hierarchyPredicate))
+		{
+			yield return child;
+			foreach (var grandchild in child.EnumerateDescendants(hierarchyPredicate))
+			{
+				yield return grandchild;
+			}
+		}
+	}
+
+	private static IEnumerable<_View> EnumerateChildren(this _View? reference)
+	{
+		return Enumerable
+			.Range(0, VisualTreeHelper.GetChildrenCount(reference))
+			.Select(x => VisualTreeHelper.GetChild(reference, x));
+	}
+}
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ProgressRing.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_ProgressRing.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Private.Infrastructure;
+using Uno.UI.Extensions;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
+
+[TestClass, RunsOnUIThread]
+public class Given_ProgressRing
+{
+	[TestMethod]
+#if !(WINDOWS_UWP || __SKIA__ || __WASM__)
+	[Ignore("IAnimatedVisualSource is not implemented")]
+#endif
+	public async Task When_NoProgress_IsIndeterminate_Toggle()
+	{
+		var SUT = new ProgressRing { Width = 20, Height = 20 };
+		(SUT.Minimum, SUT.Value, SUT.Maximum) = (0, 0, 100);
+		SUT.IsActive = true;
+		SUT.IsIndeterminate = false;
+
+		TestServices.WindowHelper.WindowContent = SUT;
+		await TestServices.WindowHelper.WaitForLoaded(SUT);
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var player = SUT.FindFirstDescendant<AnimatedVisualPlayer>(x => x.Name == "LottiePlayer");
+		if (player is null)
+		{
+			// The test may be invalid due to template change.
+			Assert.IsNotNull(player, "Failed to find template part: AnimatedVisualPlayer#LottiePlayer");
+		}
+
+		SUT.IsIndeterminate = true;
+		await TestServices.WindowHelper.WaitForIdle();
+		Assert.IsTrue(player.IsPlaying, "LottiePlayer should be playing.");
+
+		SUT.IsIndeterminate = false;
+		await TestServices.WindowHelper.WaitForIdle();
+		Assert.IsFalse(player.IsPlaying, "LottiePlayer should have stopped playing.");
+	}
+
+	[TestMethod]
+#if !(WINDOWS_UWP || __SKIA__ || __WASM__)
+	[Ignore("IAnimatedVisualSource is not implemented")]
+#endif
+	public async Task When_HalfProgress_IsIndeterminate_Toggle()
+	{
+		var SUT = new ProgressRing { Width = 20, Height = 20 };
+		(SUT.Minimum, SUT.Value, SUT.Maximum) = (0, 50, 100);
+		SUT.IsActive = true;
+		SUT.IsIndeterminate = false;
+
+		TestServices.WindowHelper.WindowContent = SUT;
+		await TestServices.WindowHelper.WaitForLoaded(SUT);
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var player = SUT.FindFirstDescendant<AnimatedVisualPlayer>(x => x.Name == "LottiePlayer");
+		if (player is null)
+		{
+			// The test may be invalid due to template change.
+			Assert.IsNotNull(player, "Failed to find template part: AnimatedVisualPlayer#LottiePlayer");
+		}
+
+		SUT.IsIndeterminate = true;
+		await TestServices.WindowHelper.WaitForIdle();
+		Assert.IsTrue(player.IsPlaying, "LottiePlayer should be playing.");
+
+		// note: unlike in When_NoProgress_IsIndeterminate_Toggle, the progress was (and still is) at 50%.
+		// so upon entering "Determinate" again, it (should animate 0->50%)? before coming to a stop.
+		SUT.IsIndeterminate = false;
+		await TestServices.WindowHelper.WaitForIdle();
+		//Assert.IsTrue(player.IsPlaying, "LottiePlayer should be animating briefly from 0% to 50%."); // not the case for windows, but this is animated on uno
+		await TestServices.WindowHelper.WaitFor(() => player.IsPlaying == false, timeoutMS: 2000, "LottiePlayer should be eventually stop playing.");
+	}
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/ProgressRing/ProgressRing.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/ProgressRing/ProgressRing.cs
@@ -134,7 +134,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private static void OnIsIndeterminatePropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
-			(dependencyObject as ProgressRing)?.ChangeVisualState();
+			if (dependencyObject is ProgressRing pr)
+			{
+				pr._player?.Stop();
+				pr.ChangeVisualState();
+			}
 		}
 
 		private void OnForegroundPropertyChanged(DependencyObject sender, DependencyProperty dp) => SetLottieForegroundColor();


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/kahua-private/issues/86

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On wasm, when the ProgressRing.IsIndeterminate is toggle from true to false, the spinning animation doesnt stop.

## What is the new behavior?
It should stop.

## Copilot Summary
<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed02942</samp>

This pull request adds unit tests for the `ProgressRing` control and fixes a bug where the animation would not stop when `IsIndeterminate` was `false`. The `ProgressRing` control is a new feature in the `Microsoft.UI.Xaml.Controls` namespace that provides a circular progress indicator.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->