### PR TITLE
fix(lottie): Use a net8 compatible property for lottie/skiasharp detection

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.UI.Lottie.targets
+++ b/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.UI.Lottie.targets
@@ -8,7 +8,7 @@
 
 	<Target Name="_ValidateLottieDependencySkia"
 			BeforeTargets="CoreCompile"
-			Condition="'$(IsUnoHead)'=='true' and '$(UnoRuntimeIdentifier)'=='Skia'">
+			Condition="'$(IsUnoHead)'=='true' and '$(UnoRuntimeIdentifier)'=='Skia' and '$(UnoDisableLottieVersionCheck)'==''">
 
 		<!--
 		Nuget does not support dynamic references in packages, and we need Skottie only for the Skia UnoRuntime
@@ -21,8 +21,8 @@
 			<_SkiaSharpPackageName Condition="'$(MSBuildThisFile)'=='uno.winui.lottie.targets'">SkiaSharp.Views.Uno.WinUI</_SkiaSharpPackageName>
 		</PropertyGroup>
 		<ItemGroup>
-			<_SkiaSharpViewsRefs Include="@(RuntimeCopyLocalItems)" Condition="'%(RuntimeCopyLocalItems.NuGetPackageId)' == '$(_SkiaSharpPackageName)'" />
-			<_SkottieRefs Include="@(RuntimeCopyLocalItems)" Condition="'%(RuntimeCopyLocalItems.NuGetPackageId)' == 'SkiaSharp.Skottie'" />
+			<_SkiaSharpViewsRefs Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)' == '$(_SkiaSharpPackageName)'" />
+			<_SkottieRefs Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)' == 'SkiaSharp.Skottie'" />
 		</ItemGroup>
 
 		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Lottie support, the '$(_SkiaSharpPackageName)' NuGet Package (2.88.3 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;2.88.3&quot; /> to your project." />

--- a/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.UI.Lottie.targets
+++ b/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.UI.Lottie.targets
@@ -7,7 +7,7 @@
 	</ItemGroup>
 
 	<Target Name="_ValidateLottieDependencySkia"
-			BeforeTargets="CoreCompile"
+			BeforeTargets="Compile"
 			Condition="'$(IsUnoHead)'=='true' and '$(UnoRuntimeIdentifier)'=='Skia' and '$(UnoDisableLottieSkiaVersionCheck)'==''">
 
 		<!--

--- a/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.UI.Lottie.targets
+++ b/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.UI.Lottie.targets
@@ -8,7 +8,7 @@
 
 	<Target Name="_ValidateLottieDependencySkia"
 			BeforeTargets="CoreCompile"
-			Condition="'$(IsUnoHead)'=='true' and '$(UnoRuntimeIdentifier)'=='Skia' and '$(UnoDisableLottieVersionCheck)'==''">
+			Condition="'$(IsUnoHead)'=='true' and '$(UnoRuntimeIdentifier)'=='Skia' and '$(UnoDisableLottieSkiaVersionCheck)'==''">
 
 		<!--
 		Nuget does not support dynamic references in packages, and we need Skottie only for the Skia UnoRuntime

--- a/src/AddIns/Uno.UI.Svg/buildTransitive/Uno.UI.Svg.targets
+++ b/src/AddIns/Uno.UI.Svg/buildTransitive/Uno.UI.Svg.targets
@@ -7,7 +7,7 @@
 	</ItemGroup>
 
 	<Target Name="_ValidateSvgDependencySkia"
-			BeforeTargets="CoreCompile"
+			BeforeTargets="Compile"
 			Condition="'$(IsUnoHead)'=='true' and '$(UnoRuntimeIdentifier)'=='Skia' and '$(UnoDisableSvgSkiaVersionCheck)'==''">
 
 		<!--

--- a/src/AddIns/Uno.UI.Svg/buildTransitive/Uno.UI.Svg.targets
+++ b/src/AddIns/Uno.UI.Svg/buildTransitive/Uno.UI.Svg.targets
@@ -8,7 +8,7 @@
 
 	<Target Name="_ValidateSvgDependencySkia"
 			BeforeTargets="CoreCompile"
-			Condition="'$(IsUnoHead)'=='true' and '$(UnoRuntimeIdentifier)'=='Skia'">
+			Condition="'$(IsUnoHead)'=='true' and '$(UnoRuntimeIdentifier)'=='Skia' and '$(UnoDisableSvgSkiaVersionCheck)'==''">
 
 		<!--
 		Nuget does not support dynamic references in packages, and we need Skottie only for the Skia UnoRuntime
@@ -21,8 +21,8 @@
 			<_SkiaSharpPackageName Condition="'$(MSBuildThisFile)'=='uno.winui.svg.targets'">SkiaSharp.Views.Uno.WinUI</_SkiaSharpPackageName>
 		</PropertyGroup>
 		<ItemGroup>
-			<_SkiaSharpViewsRefs Include="@(RuntimeCopyLocalItems)" Condition="'%(RuntimeCopyLocalItems.NuGetPackageId)' == '$(_SkiaSharpPackageName)'" />
-			<_SvgSkiaRefs Include="@(RuntimeCopyLocalItems)" Condition="'%(RuntimeCopyLocalItems.NuGetPackageId)' == 'Svg.Skia' AND '%(RuntimeCopyLocalItems.NuGetPackageVersion)' >= '1.0.0.1'" />
+			<_SkiaSharpViewsRefs Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)' == '$(_SkiaSharpPackageName)'" />
+			<_SvgSkiaRefs Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)' == 'Svg.Skia' AND '%(ReferencePath.NuGetPackageVersion)' >= '1.0.0.1'" />
 		</ItemGroup>
 
 		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Svg support, the '$(_SkiaSharpPackageName)' NuGet Package (2.88.3 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;2.88.3&quot; /> to your project." />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adjust skiasharp/skottie detection under net8 as `RuntimeCopyLocalItems` is not available anymore. Using `ReferencePath` instead.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 088ac8e</samp>

Improve Lottie version check for SkiaSharp packages. Use a condition and a different item group to support different project types and scenarios.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
