### PR TITLE
fix(scrollviewer): a ScrollViewer should not scroll an outer ScrollViewer

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -202,6 +202,8 @@ namespace Windows.UI.Xaml.Controls
 					? -properties.MouseWheelDelta
 					: properties.MouseWheelDelta;
 
+				var success = false;
+
 				if (e.KeyModifiers == VirtualKeyModifiers.Control)
 				{
 					// TODO: Handle zoom https://github.com/unoplatform/uno/issues/4309
@@ -214,7 +216,7 @@ namespace Windows.UI.Xaml.Controls
 					var horizontalOffset = HorizontalOffset;
 #endif
 
-					Set(
+					success = Set(
 						horizontalOffset: horizontalOffset + GetHorizontalScrollWheelDelta(DesiredSize, delta),
 						disableAnimation: false);
 				}
@@ -226,10 +228,16 @@ namespace Windows.UI.Xaml.Controls
 					var verticalOffset = VerticalOffset;
 #endif
 
-					Set(
+					success = Set(
 						verticalOffset: verticalOffset + GetVerticalScrollWheelDelta(DesiredSize, -delta),
 						disableAnimation: false);
 				}
+
+				// This is not similar to what WinUI is doing, since we already differ quite a bit from
+				// the way WinUI does SCP scrolling. On WinUI, ScrollViewer is the PointerWheelChanged receiver
+				// and is the one that decides when to mark as handled. However, this alternative is visually
+				// close (even though not identical)
+				e.Handled = success;
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14125

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d2cd21f</samp>

This pull request enhances the scroll viewer control by improving the pointer wheel event handling and adding a new test case. It fixes the issue of nested scroll viewers not scrolling properly and aligns the Uno behavior with the WinUI behavior. It modifies the `ScrollContentPresenter.cs` file and the `Given_ScrollViewer.cs` file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
