### PR TITLE
fix: Fix hot-reload of nested resource dictionnaries

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
@@ -153,8 +153,8 @@ namespace MyProject
 		internal sealed class ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 : global::Uno.UI.IXamlResourceDictionaryProvider
 		{
 			private static global::Windows.UI.Xaml.NameScope __nameScope = new global::Windows.UI.Xaml.NameScope();
-			private static ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 __that;
-			internal static ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 Instance
+			private static global::Uno.UI.IXamlResourceDictionaryProvider __that;
+			internal static global::Uno.UI.IXamlResourceDictionaryProvider Instance
 			{
 				get
 				{
@@ -167,9 +167,10 @@ namespace MyProject
 				}
 			}
 
-			internal global::Uno.UI.Xaml.XamlParseContext __ParseContext_ {get; }
+			private readonly global::Uno.UI.Xaml.XamlParseContext __ParseContext_;
+			internal static global::Uno.UI.Xaml.XamlParseContext GetParseContext() => ((ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57)Instance).__ParseContext_;
 
-			private ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
+			public ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
 			{
 				__ParseContext_ = global::MyProject.GlobalStaticResources.__ParseContext_;
 			}
@@ -210,7 +211,7 @@ namespace MyProject
 			global::Windows.UI.Xaml.ResourceDictionary global::Uno.UI.IXamlResourceDictionaryProvider.GetResourceDictionary() => MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
 		}
 
-		internal static global::Windows.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
+		internal static global::Windows.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.GetResourceDictionary();
 	}
 }
 namespace MyProject.__Resources

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTLNMD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTLNMD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
@@ -44,8 +44,8 @@ namespace MyProject
 		internal sealed class ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 : global::Uno.UI.IXamlResourceDictionaryProvider
 		{
 			private static global::Windows.UI.Xaml.NameScope __nameScope = new global::Windows.UI.Xaml.NameScope();
-			private static ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 __that;
-			internal static ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 Instance
+			private static global::Uno.UI.IXamlResourceDictionaryProvider __that;
+			internal static global::Uno.UI.IXamlResourceDictionaryProvider Instance
 			{
 				get
 				{
@@ -58,9 +58,10 @@ namespace MyProject
 				}
 			}
 
-			internal global::Uno.UI.Xaml.XamlParseContext __ParseContext_ {get; }
+			private readonly global::Uno.UI.Xaml.XamlParseContext __ParseContext_;
+			internal static global::Uno.UI.Xaml.XamlParseContext GetParseContext() => ((ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57)Instance).__ParseContext_;
 
-			private ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
+			public ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
 			{
 				__ParseContext_ = global::MyProject.GlobalStaticResources.__ParseContext_;
 			}
@@ -104,7 +105,7 @@ namespace MyProject
 			global::Windows.UI.Xaml.ResourceDictionary global::Uno.UI.IXamlResourceDictionaryProvider.GetResourceDictionary() => MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
 		}
 
-		internal static global::Windows.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
+		internal static global::Windows.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.GetResourceDictionary();
 	}
 }
 namespace MyProject.__Resources

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTLNMDWSRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTLNMDWSRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
@@ -44,8 +44,8 @@ namespace MyProject
 		internal sealed class ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 : global::Uno.UI.IXamlResourceDictionaryProvider
 		{
 			private static global::Windows.UI.Xaml.NameScope __nameScope = new global::Windows.UI.Xaml.NameScope();
-			private static ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 __that;
-			internal static ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 Instance
+			private static global::Uno.UI.IXamlResourceDictionaryProvider __that;
+			internal static global::Uno.UI.IXamlResourceDictionaryProvider Instance
 			{
 				get
 				{
@@ -58,9 +58,10 @@ namespace MyProject
 				}
 			}
 
-			internal global::Uno.UI.Xaml.XamlParseContext __ParseContext_ {get; }
+			private readonly global::Uno.UI.Xaml.XamlParseContext __ParseContext_;
+			internal static global::Uno.UI.Xaml.XamlParseContext GetParseContext() => ((ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57)Instance).__ParseContext_;
 
-			private ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
+			public ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
 			{
 				__ParseContext_ = global::MyProject.GlobalStaticResources.__ParseContext_;
 			}
@@ -99,7 +100,7 @@ namespace MyProject
 			global::Windows.UI.Xaml.ResourceDictionary global::Uno.UI.IXamlResourceDictionaryProvider.GetResourceDictionary() => MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
 		}
 
-		internal static global::Windows.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
+		internal static global::Windows.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.GetResourceDictionary();
 	}
 }
 namespace MyProject.__Resources

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTLNMDWTRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTLNMDWTRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
@@ -44,8 +44,8 @@ namespace MyProject
 		internal sealed class ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 : global::Uno.UI.IXamlResourceDictionaryProvider
 		{
 			private static global::Windows.UI.Xaml.NameScope __nameScope = new global::Windows.UI.Xaml.NameScope();
-			private static ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 __that;
-			internal static ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 Instance
+			private static global::Uno.UI.IXamlResourceDictionaryProvider __that;
+			internal static global::Uno.UI.IXamlResourceDictionaryProvider Instance
 			{
 				get
 				{
@@ -58,9 +58,10 @@ namespace MyProject
 				}
 			}
 
-			internal global::Uno.UI.Xaml.XamlParseContext __ParseContext_ {get; }
+			private readonly global::Uno.UI.Xaml.XamlParseContext __ParseContext_;
+			internal static global::Uno.UI.Xaml.XamlParseContext GetParseContext() => ((ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57)Instance).__ParseContext_;
 
-			private ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
+			public ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
 			{
 				__ParseContext_ = global::MyProject.GlobalStaticResources.__ParseContext_;
 			}
@@ -102,7 +103,7 @@ namespace MyProject
 			global::Windows.UI.Xaml.ResourceDictionary global::Uno.UI.IXamlResourceDictionaryProvider.GetResourceDictionary() => MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
 		}
 
-		internal static global::Windows.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
+		internal static global::Windows.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.GetResourceDictionary();
 	}
 }
 namespace MyProject.__Resources

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -32,6 +32,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 	{
 		internal const string ParseContextPropertyName = "__ParseContext_";
 		internal const string ParseContextPropertyType = "global::Uno.UI.Xaml.XamlParseContext";
+		internal const string ParseContextGetterMethod = "GetParseContext";
 
 		private readonly Uno.Roslyn.MSBuildItem[] _xamlSourceFiles;
 		private readonly string[] _xamlSourceLinks;

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -153,11 +153,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private string ParseContextPropertyAccess =>
 			 (_isTopLevelDictionary, _isInSingletonInstance) switch
 			 {
-				 (true, false) => "{0}{1}.GlobalStaticResources.{2}.Instance.{3}".InvariantCultureFormat(
+				 (true, false) => "{0}{1}.GlobalStaticResources.{2}.{3}()".InvariantCultureFormat(
 					GlobalPrefix,
 					_defaultNamespace,
 					SingletonClassName,
-					XamlCodeGeneration.ParseContextPropertyName
+					XamlCodeGeneration.ParseContextGetterMethod
 				),
 				 (true, true) => "this.{0}".InvariantCultureFormat(XamlCodeGeneration.ParseContextPropertyName),
 				 _ => "{0}{1}.GlobalStaticResources.{2}".InvariantCultureFormat(
@@ -1216,23 +1216,28 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						{
 							// Build singleton
 							writer.AppendLineInvariantIndented("private static global::Windows.UI.Xaml.NameScope __nameScope = new global::Windows.UI.Xaml.NameScope();");
-							writer.AppendLineInvariantIndented("private static {0} __that;", SingletonClassName);
-							using (writer.BlockInvariant("internal static {0} Instance", SingletonClassName))
+							writer.AppendLineInvariantIndented("private static {0} __that;", DictionaryProviderInterfaceName);
+							using (writer.BlockInvariant("internal static {0} Instance", DictionaryProviderInterfaceName))
 							{
 								using (writer.BlockInvariant("get"))
 								{
 									using (writer.BlockInvariant("if (__that == null)"))
 									{
-										writer.AppendLineInvariantIndented("__that = new {0}();", SingletonClassName);
+										var activator = _isHotReloadEnabled
+											? $"({DictionaryProviderInterfaceName})global::Uno.UI.Helpers.TypeMappings.CreateInstance<{SingletonClassName}>()"
+											: $"new {SingletonClassName}()";
+
+										writer.AppendLineInvariantIndented($"__that = {activator};");
 									}
 									writer.AppendLine();
 									writer.AppendLineIndented("return __that;");
 								}
 							}
 							writer.AppendLine();
-							writer.AppendLineInvariantIndented("internal {0} {1} {{get; }}", XamlCodeGeneration.ParseContextPropertyType, XamlCodeGeneration.ParseContextPropertyName);
+							writer.AppendLineInvariantIndented("private readonly {0} {1};", XamlCodeGeneration.ParseContextPropertyType, XamlCodeGeneration.ParseContextPropertyName);
+							writer.AppendLineInvariantIndented("internal static {0} {1}() => (({2})Instance).{3};", XamlCodeGeneration.ParseContextPropertyType, XamlCodeGeneration.ParseContextGetterMethod, SingletonClassName, XamlCodeGeneration.ParseContextPropertyName);
 							writer.AppendLine();
-							using (writer.BlockInvariant("private {0}()", SingletonClassName))
+							using (writer.BlockInvariant("public {0}()", SingletonClassName))
 							{
 								var outerProperty = "{0}{1}.GlobalStaticResources.{2}".InvariantCultureFormat(
 									GlobalPrefix,
@@ -1280,10 +1285,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							writer.AppendLineInvariantIndented("global::Windows.UI.Xaml.ResourceDictionary {0}.GetResourceDictionary() => {1}_ResourceDictionary;", DictionaryProviderInterfaceName, _fileUniqueId);
 						}
 						writer.AppendLine();
-						writer.AppendLineInvariantIndented("internal static global::Windows.UI.Xaml.ResourceDictionary {0}_ResourceDictionary => {1}.Instance.{0}_ResourceDictionary;", _fileUniqueId, SingletonClassName);
+						writer.AppendLineInvariantIndented("internal static global::Windows.UI.Xaml.ResourceDictionary {0}_ResourceDictionary => {1}.Instance.GetResourceDictionary();", _fileUniqueId, SingletonClassName);
 						if (hasDefaultStyles)
 						{
-							writer.AppendLineInvariantIndented("static partial void RegisterDefaultStyles_{0}() => {1}.Instance.RegisterDefaultStyles_{0}();", _fileUniqueId, SingletonClassName);
+							writer.AppendLineInvariantIndented("static partial void RegisterDefaultStyles_{0}() => {1}.RegisterDefaultStyles_{0}();", _fileUniqueId, SingletonClassName);
 						}
 
 						BuildXBindTryGetDeclarations(writer);
@@ -1457,7 +1462,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			writer.AppendLine();
 
-			using (writer.BlockInvariant("public void RegisterDefaultStyles_{0}()", _fileUniqueId))
+			using (writer.BlockInvariant("public static void RegisterDefaultStyles_{0}()", _fileUniqueId))
+			{
+				var instance = _isHotReloadEnabled 
+					? $"((dynamic) Instance)" 
+					: $"(({SingletonClassName})Instance)";
+
+				writer.AppendLineInvariantIndented("{0}.RegisterDefaultStyles_{1}_Core();", instance, _fileUniqueId);
+			}
+
+			using (writer.BlockInvariant("private void RegisterDefaultStyles_{0}_Core()", _fileUniqueId))
 			{
 				foreach (var style in stylesCandidates)
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1464,8 +1464,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			using (writer.BlockInvariant("public static void RegisterDefaultStyles_{0}()", _fileUniqueId))
 			{
-				var instance = _isHotReloadEnabled 
-					? $"((dynamic) Instance)" 
+				var instance = _isHotReloadEnabled
+					? $"((dynamic) Instance)"
 					: $"(({SingletonClassName})Instance)";
 
 				writer.AppendLineInvariantIndented("{0}.RegisterDefaultStyles_{1}_Core();", instance, _fileUniqueId);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1464,11 +1464,22 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			using (writer.BlockInvariant("public static void RegisterDefaultStyles_{0}()", _fileUniqueId))
 			{
-				var instance = _isHotReloadEnabled
-					? $"((dynamic) Instance)"
-					: $"(({SingletonClassName})Instance)";
-
-				writer.AppendLineInvariantIndented("{0}.RegisterDefaultStyles_{1}_Core();", instance, _fileUniqueId);
+				if (_isHotReloadEnabled)
+				{
+					writer.AppendLineInvariantIndented("var instance = Instance;");
+					using (writer.BlockInvariant("if (instance is {0} original)", SingletonClassName))
+					{
+						writer.AppendLineInvariantIndented("original.RegisterDefaultStyles_{1}_Core();", SingletonClassName, _fileUniqueId);
+					}
+					using (writer.BlockInvariant("else"))
+					{
+						writer.AppendLineInvariantIndented("instance?.GetType()?.GetMethod(\"RegisterDefaultStyles_{0}_Core\", global::System.Reflection.BindingFlags.Instance | global::System.Reflection.BindingFlags.NonPublic)?.Invoke(instance, null);", _fileUniqueId);
+					}
+				}
+				else
+				{
+					writer.AppendLineInvariantIndented("(({0})Instance).RegisterDefaultStyles_{1}_Core();", SingletonClassName, _fileUniqueId);
+				}
 			}
 
 			using (writer.BlockInvariant("private void RegisterDefaultStyles_{0}_Core()", _fileUniqueId))

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -237,11 +237,25 @@ partial class ClientHotReloadProcessor
 					initializeMethod.Invoke(null, null);
 				}
 
-				if (GetInitMethod(globalResourceType, "RegisterResourceDictionariesBySourceLocal") is { } registerResourceDictionariesBySourceLocalMethod)
+				// This should be called by the init of root app GlobalStaticResource.Initialize(), but here as we are reloading only the StaticResources of the dependency library,
+				// we have to invoke it to make sure that all registrations are updated (including the "ms-appx://[NAME_OF_MY_LIBRARY]/...").
+				if (GetInitMethod(globalResourceType, "RegisterResourceDictionariesBySource") is { } registerResourceDictionariesBySourceMethod)
 				{
 					if (_log.IsEnabled(LogLevel.Trace))
 					{
 						_log.Debug($"Initializing resources sources for {globalResourceType}");
+					}
+
+					// Invoke initializers so default types and other resources get updated.
+					registerResourceDictionariesBySourceMethod.Invoke(null, null);
+				}
+
+				// This is needed for the head only (causes some extra invalid registration ins the ResourceResolver, but it has no negative impact)
+				if (GetInitMethod(globalResourceType, "RegisterResourceDictionariesBySourceLocal") is { } registerResourceDictionariesBySourceLocalMethod)
+				{
+					if (_log.IsEnabled(LogLevel.Trace))
+					{
+						_log.Debug($"Initializing local resources sources for {globalResourceType}");
 					}
 
 					// Invoke initializers so default types and other resources get updated.

--- a/src/Uno.UI/UI/Xaml/XamlParseContext.cs
+++ b/src/Uno.UI/UI/Xaml/XamlParseContext.cs
@@ -13,6 +13,14 @@ namespace Uno.UI.Xaml
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class XamlParseContext
 	{
+		// *************** WARNING ***************
+		// This class instance is not being replaced when a ResourceDictionary is being reloaded (i.e. we continue to use the instance of the original type)
+		// This is valid only because all information hosted by this class doesn't change on hot-reload.
+		// 
+		// Any new property on this class should follow this same rule, or the resolution of this has to be changed to support hot-reload properly
+		// (search for "__ParseContext_" in the xaml generator).
+		// ***************************************
+
 		public string AssemblyName { get; set; }
 	}
 }


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno-private/issues/266

## Bugfix
Fix support of hot-reload of nested XAML dic

## What is the current behavior?
Only the root dic is reloaded

## What is the new behavior?
🙃

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 16b2fff</samp>

This pull request enhances the hot reload feature for xaml resource dictionaries by changing the code generation and registration logic. It uses methods, interfaces, reflection, and conditional expressions to access and create resource dictionary instances, parse contexts, and default styles. It also adds a comment block to document the limitations of the `XamlParseContext` class.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
