### PR TITLE
fix!: Remove Windows.UI.Xaml.Controls.NavigationView from Uno.WinUI

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -657,25 +657,26 @@
 			<Member fullName="Windows.UI.Xaml.Shapes.ArbitraryShapeBase" reason="Shapes refactoring" />
 			<Member fullName="Windows.UI.Xaml.Controls.StackPanelExtensions" reason="Shouldn't be public, and removed completely" />
 
-			<Member fullName="Windows.UI.Xaml.Automation.Peers.NavigationViewItemAutomationPeer" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationView" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewBackButtonVisible" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewBackRequestedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewDisplayMode" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewDisplayModeChangedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemHelper" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemHelper`1" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItem" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemBase" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemHeader" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemSeparator" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewList" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewPaneDisplayMode" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewTemplateSettings" reason="Removed from WinUI tree as it exists in MUXC namespace" />
-			<Member fullName="Windows.UI.Xaml.Controls.Primitives.NavigationViewItemPresenter" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<!-- Using regex with \. as a hack to prevent WinUIRevert from converting these to MUX namespace in WinUI tree -->
+			<Member fullName="Windows\.UI\.Xaml\.Automation\.Peers\.NavigationViewItemAutomationPeer" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationView" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewBackButtonVisible" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewBackRequestedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewDisplayMode" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewDisplayModeChangedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewItemHelper" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewItemHelper`1" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewItem" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewItemBase" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewItemHeader" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewItemInvokedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewItemSeparator" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewList" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewPaneClosingEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewPaneDisplayMode" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewSelectionChangedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.NavigationViewTemplateSettings" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
+			<Member fullName="Windows\.UI\.Xaml\.Controls\.Primitives.NavigationViewItemPresenter" reason="Removed from WinUI tree as it exists in MUXC namespace" isRegex="true" />
 		</Types>
 		<Events>
 			<Member fullName="Windows.Foundation.TypedEventHandler`2&lt;Microsoft.UI.Xaml.Controls.IInputValidationControl,Microsoft.UI.Xaml.Controls.HasValidationErrorsChangedEventArgs&gt; Microsoft.UI.Xaml.Controls.AutoSuggestBox::HasValidationErrorsChanged" reason="Not present in WinAppSDK 1.2" />

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -656,6 +656,26 @@
 
 			<Member fullName="Windows.UI.Xaml.Shapes.ArbitraryShapeBase" reason="Shapes refactoring" />
 			<Member fullName="Windows.UI.Xaml.Controls.StackPanelExtensions" reason="Shouldn't be public, and removed completely" />
+
+			<Member fullName="Windows.UI.Xaml.Automation.Peers.NavigationViewItemAutomationPeer" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationView" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewBackButtonVisible" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewBackRequestedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewDisplayMode" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewDisplayModeChangedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemHelper" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemHelper`1" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItem" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemBase" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemHeader" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewItemSeparator" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewList" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewPaneDisplayMode" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.NavigationViewTemplateSettings" reason="Removed from WinUI tree as it exists in MUXC namespace" />
+			<Member fullName="Windows.UI.Xaml.Controls.Primitives.NavigationViewItemPresenter" reason="Removed from WinUI tree as it exists in MUXC namespace" />
 		</Types>
 		<Events>
 			<Member fullName="Windows.Foundation.TypedEventHandler`2&lt;Microsoft.UI.Xaml.Controls.IInputValidationControl,Microsoft.UI.Xaml.Controls.HasValidationErrorsChangedEventArgs&gt; Microsoft.UI.Xaml.Controls.AutoSuggestBox::HasValidationErrorsChanged" reason="Not present in WinAppSDK 1.2" />

--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -150,6 +150,10 @@ There used two be two `RenderSurfaceType`s, `Uno.UI.Runtime.Skia.RenderSurfaceTy
 #### `Panel`s no longer measure or arrange any children in `MeasureOverride` or `ArrangeOverride`, respectively
 `Panel`s used to measure and arrange the first child in `MeasureOverride` or `ArrangeOverride`, respectively. This is no longer the case. Now, to match WinUI, `Panel`s just return an empty size in `MeasureOverride`, and the `finalSize` as is in `ArrangeOverride`. You should override these layout-override methods in `Panel`-derived subclasses instead.
 
+#### Remove `Windows.UI.Xaml.Controls.NavigationView` in Uno.WinUI
+
+Uno.WinUI used to have NavigationView both in `Microsoft.UI.Xaml.Controls` and `Windows.UI.Xaml.Controls` namespaces. It's now removed from `Windows.UI.Xaml.Controls` and kept only in `Microsoft.UI.Xaml.Controls` namespace.
+
 ### Uno Platform 4.10
 This release does not require upgrade steps.
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
@@ -45,6 +45,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 	[RunsOnUIThread]
 	public partial class Given_NavigationView
 	{
+#if !HAS_UNO_WINUI
 		[TestMethod]
 		[RunsOnUIThread]
 #if __MACOS__
@@ -79,6 +80,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 			Assert.AreEqual(item2, children.Last());
 		}
+#endif
 
 		[TestMethod]
 		[RunsOnUIThread]
@@ -158,6 +160,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 	}
+
+#if !HAS_UNO_WINUI
 	public partial class MyNavigationView : NavigationView
 	{
 		public NavigationViewList MenuItemsHost { get; private set; }
@@ -167,4 +171,5 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			MenuItemsHost = GetTemplateChild("MenuItemsHost") as NavigationViewList;
 		}
 	}
+ #endif
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
@@ -25,9 +25,6 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
-using NavigationView = Windows.UI.Xaml.Controls.NavigationView;
-using NavigationViewItem = Windows.UI.Xaml.Controls.NavigationViewItem;
-using NavigationViewList = Windows.UI.Xaml.Controls.NavigationViewList;
 #else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
@@ -171,5 +171,5 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			MenuItemsHost = GetTemplateChild("MenuItemsHost") as NavigationViewList;
 		}
 	}
- #endif
+#endif
 }

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Events.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Events.cs
@@ -1,8 +1,4 @@
 using Windows.Foundation;
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Members.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Members.cs
@@ -9,10 +9,6 @@ using System.Collections.Generic;
 using Uno.Disposables;
 using Windows.ApplicationModel.Core;
 using Windows.UI.ViewManagement;
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Properties.cs
@@ -7,10 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -21,19 +21,6 @@ using Windows.System;
 using Windows.UI.ViewManagement;
 using Uno.UI;
 using Windows.UI.Core;
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Composition;
-using Microsoft.UI.Xaml.Automation;
-using Microsoft.UI.Xaml.Automation.Peers;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Hosting;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Media.Animation;
-using WindowsWindow = Microsoft.UI.Xaml.Window;
-#else
 using Windows.UI.Composition;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
@@ -43,7 +30,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using WindowsWindow = Windows.UI.Xaml.Window;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewHelper.cs
@@ -5,11 +5,6 @@
 // This file is a C# translation of the NavigationViewHelper.cpp file from WinUI controls.
 //
 
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-#endif
-
 namespace Windows.UI.Xaml.Controls
 {
 	internal enum NavigationViewVisualStateDisplayMode

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItem.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItem.Properties.cs
@@ -5,11 +5,6 @@
 // This file is a C# translation of the NavigationViewItem.cpp file from WinUI controls.
 //
 
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-#endif
-
 namespace Windows.UI.Xaml.Controls
 {
 	public partial class NavigationViewItem : NavigationViewItemBase

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItem.cs
@@ -7,15 +7,8 @@
 
 using System;
 using Uno.Disposables;
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Automation.Peers;
-using Microsoft.UI.Xaml.Hosting;
-#else
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Hosting;
-#endif
 using NavigationViewItemAutomationPeer = Windows.UI.Xaml.Automation.Peers.NavigationViewItemAutomationPeer;
 using NavigationViewItemPresenter = Windows.UI.Xaml.Controls.Primitives.NavigationViewItemPresenter;
 

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemAutomationPeer.cs
@@ -1,7 +1,4 @@
-﻿#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Automation.Peers;
-#endif
-using NavigationViewItem = Windows.UI.Xaml.Controls.NavigationViewItem;
+﻿using NavigationViewItem = Windows.UI.Xaml.Controls.NavigationViewItem;
 
 namespace Windows.UI.Xaml.Automation.Peers
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemBase.cs
@@ -8,17 +8,9 @@
 using System;
 using Uno.UI.Helpers.WinUI;
 using Uno.UI;
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Media;
-#else
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;
-#endif
 
 #if __IOS__
 using UIKit;

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemHeader.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemHeader.cs
@@ -5,13 +5,7 @@
 // This file is a C# translation of the NavigationViewHeader.cpp file from WinUI controls.
 //
 
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Hosting;
-#else
 using Windows.UI.Xaml.Hosting;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemInvokedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemInvokedEventArgs.cs
@@ -5,11 +5,7 @@
 // This file is a C# translation of the NavigationViewItemInvokedEventArgs.cpp file from WinUI controls.
 //
 
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Media.Animation;
-#else
 using Windows.UI.Xaml.Media.Animation;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewItemPresenter.cs
@@ -6,13 +6,7 @@
 //
 
 using Uno.UI.Helpers.WinUI;
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Media;
-#else
 using Windows.UI.Xaml.Media;
-#endif
 
 namespace Windows.UI.Xaml.Controls.Primitives
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewList.Uno.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewList.Uno.cs
@@ -1,13 +1,7 @@
 using System;
 using Windows.System;
 using Uno.UI;
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls.Primitives;
-#else
 using Windows.UI.Xaml.Controls.Primitives;
-#endif
 
 #if __IOS__
 using UIKit;

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewList.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewList.cs
@@ -7,13 +7,7 @@
 
 using System;
 using Windows.System;
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Input;
-#else
 using Windows.UI.Xaml.Input;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewPaneClosingEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewPaneClosingEventArgs.cs
@@ -5,11 +5,6 @@
 // This file is a C# translation of the NavigationViewPaneClosingEventArgs.cpp file from WinUI controls.
 //
 
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-#endif
-
 namespace Windows.UI.Xaml.Controls
 {
 	public partial class NavigationViewPaneClosingEventArgs

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewSelectionChangedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewSelectionChangedEventArgs.cs
@@ -5,13 +5,7 @@
 // This file is a C# translation of the NavigationViewSelectionChangedEventArgs.cpp file from WinUI controls.
 //
 
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Media.Animation;
-#else
 using Windows.UI.Xaml.Media.Animation;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewTemplateSettings.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationViewTemplateSettings.cs
@@ -5,11 +5,6 @@
 // This file is a C# translation of the NavigationViewTemplateSettings.cpp file from WinUI controls.
 //
 
-#if HAS_UNO_WINUI
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-#endif
-
 namespace Windows.UI.Xaml.Controls
 {
 	public partial class NavigationViewTemplateSettings : DependencyObject

--- a/src/Uno.WinUIRevert/Program.cs
+++ b/src/Uno.WinUIRevert/Program.cs
@@ -17,6 +17,7 @@ namespace UnoWinUIRevert
 			DeleteFolder(Path.Combine(basePath, "src", "Uno.UWP", "Generated"));
 			DeleteFolder(Path.Combine(basePath, "src", "Uno.UI", "tsBindings")); // Generated
 			DeleteFolder(Path.Combine(basePath, "src", "Uno.UI", "UI", "Xaml", "Controls", "ProgressBar")); // ProgressBar in WinUI is a replacement of the UWP's version
+			DeleteFolder(Path.Combine(basePath, "src", "Uno.UI", "UI", "Xaml", "Controls", "NavigationView")); // NavigationView in WinUI is a replacement of the UWP's version
 
 			var colorsFilepath = Path.Combine(basePath, @"src", "Uno.UWP", "UI", "Colors.cs");
 			if (File.Exists(colorsFilepath))


### PR DESCRIPTION
BREAKING CHANGE: Uno.WinUI used to have NavigationView both in MUXC and WUXC namespaces. It's now removed from WUXC and kept only in MUXC namespace.

GitHub Issue (If applicable): closes #14123

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca19a4d</samp>

This pull request reverts the NavigationView control to the UWP version, as the WinUI version was causing issues with the Uno platform's XAML implementation. It updates all the files in the `src/Uno.UI/UI/Xaml/Controls/NavigationView` folder to use the `Uno.UI.Xaml` namespace instead of the `Microsoft.UI.Xaml` namespace, and to remove unnecessary preprocessor directives. It also deletes the NavigationView folder from the `Uno.UI` project using the `Uno.WinUIRevert` project.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
