### PR TITLE
fix: Empty `Storyboard` behaviors

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_Storyboard.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_Storyboard.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Private.Infrastructure;
-using Uno.UI.Xaml;
 using Windows.UI.Xaml.Media.Animation;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_Storyboard.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_Storyboard.cs
@@ -1,0 +1,54 @@
+﻿using System.Threading.Tasks;
+using Private.Infrastructure;
+using Uno.UI.Xaml;
+using Windows.UI.Xaml.Media.Animation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Animation;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_Storyboard
+{
+	[TestMethod]
+	public async Task When_Empty_Storyboard_Completes()
+	{
+		var storyboard = new Storyboard();
+		bool completed = false;
+		storyboard.Completed += (s, e) => completed = true;
+		storyboard.Begin();
+		await TestServices.WindowHelper.WaitFor(() => completed);
+	}
+
+	[TestMethod]
+	public async Task When_Empty_Storyboard_Completed_Attached_After()
+	{
+		var storyboard = new Storyboard();
+		bool completed = false;
+		storyboard.Begin();
+		storyboard.Completed += (s, e) => completed = true;
+		await TestServices.WindowHelper.WaitFor(() => completed);
+	}
+
+	[TestMethod]
+	public async Task When_Empty_Storyboard_Stopped()
+	{
+		var storyboard = new Storyboard();
+		storyboard.Completed += (s, e) => Assert.Fail("Storyboard should not trigger Completed");
+		storyboard.Begin();
+		storyboard.Stop();
+		Assert.AreEqual(ClockState.Stopped, storyboard.GetCurrentState());
+		await TestServices.WindowHelper.WaitForIdle();
+	}
+
+	[TestMethod]
+	public async Task When_Empty_Storyboard_Paused()
+	{
+		var storyboard = new Storyboard();
+		var completed = false;
+		storyboard.Completed += (s, e) => completed = true;
+		storyboard.Begin();
+		storyboard.Pause();
+		Assert.AreEqual(ClockState.Active, storyboard.GetCurrentState());
+		await TestServices.WindowHelper.WaitFor(() => completed);
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateManager.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateManager.cs
@@ -103,12 +103,6 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
 			completed1Count.Should().Be(0);
 			completed2Count.Should().Be(0);
 
-			// This is to workaround to the fact that the state is applied as soon as it's injected
-			// in the states list, so it will be complete twice (once when added in the collection,
-			// second when element is set ... which is not the behavior on Windows but is required for some other tests)
-			// This should be removed once the VisualStateGroup (and other tests) have been fixed.
-			completed1Count = -1;
-
 			dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessAllIfPresent);
 
 			trigger1.Set();

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
@@ -12,6 +12,7 @@ using Windows.UI.Core;
 using Uno.Disposables;
 using System.Diagnostics;
 using System.Globalization;
+using Windows.Graphics.Printing.PrintSupport;
 
 namespace Windows.UI.Xaml.Media.Animation
 {
@@ -35,6 +36,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		private int _replayCount = 1;
 		private int _runningChildren;
 		private bool _hasFillingChildren;
+		private bool _hasScheduledCompletion;
 
 		public Storyboard()
 		{
@@ -130,8 +132,16 @@ namespace Windows.UI.Xaml.Media.Animation
 			}
 			else
 			{
+				_hasScheduledCompletion = true;
 				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 				{
+					_hasScheduledCompletion = false;
+					if (State != TimelineState.Stopped)
+					{
+						// If the storyboard was force-stopped,
+						// we don't stop again and don't trigger Completed.
+						return;
+					}
 					// No children, so we complete immediately
 					State = TimelineState.Stopped;
 					OnCompleted();
@@ -179,6 +189,11 @@ namespace Windows.UI.Xaml.Media.Animation
 				);
 			}
 
+			if (_hasScheduledCompletion)
+			{
+				return;
+			}
+
 			if (Children != null && Children.Count > 0)
 			{
 				State = TimelineState.Active;
@@ -202,6 +217,11 @@ namespace Windows.UI.Xaml.Media.Animation
 					activity: _traceActivity,
 					payload: new object[] { Target?.GetType().ToString(), PropertyInfo?.Path }
 				);
+			}
+
+			if (_hasScheduledCompletion)
+			{
+				return;
 			}
 
 			State = TimelineState.Paused;

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Storyboard.cs
@@ -136,12 +136,13 @@ namespace Windows.UI.Xaml.Media.Animation
 				_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 				{
 					_hasScheduledCompletion = false;
-					if (State != TimelineState.Stopped)
+					if (State == TimelineState.Stopped)
 					{
 						// If the storyboard was force-stopped,
 						// we don't stop again and don't trigger Completed.
 						return;
 					}
+
 					// No children, so we complete immediately
 					State = TimelineState.Stopped;
 					OnCompleted();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14144

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Differences from WinUI

## What is the new behavior?

Matching WinUI

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb77956</samp>

This pull request fixes a bug in `Storyboard` and adds unit tests for it. It changes the `Storyboard` class to handle empty storyboards correctly and avoid firing the `Completed` event prematurely. It also adds a new test class `Given_Storyboard` with four test methods in `src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_Storyboard.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
