### PR TITLE
chore: Update `BreadcrumbBar` to winui3/release/1.4.2

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Input/InputKeyboardSource.cs
+++ b/src/Uno.UI/Microsoft/UI/Input/InputKeyboardSource.cs
@@ -1,11 +1,12 @@
-﻿#if HAS_UNO_WINUI
+﻿namespace Microsoft.UI.Input;
 
-namespace Microsoft.UI.Input
+public partial class InputKeyboardSource
 {
-	public partial class InputKeyboardSource
-	{
-		public static Windows.UI.Core.CoreVirtualKeyStates GetKeyStateForCurrentThread(Windows.System.VirtualKey virtualKey)
-			=> Xaml.Window.Current.CoreWindow.GetKeyState(virtualKey);
-	}
-}
+#if HAS_UNO_WINUI
+	public
+#else
+	internal
 #endif
+	static Windows.UI.Core.CoreVirtualKeyStates GetKeyStateForCurrentThread(Windows.System.VirtualKey virtualKey)
+		=> Windows.UI.Xaml.Window.Current.CoreWindow.GetKeyState(virtualKey);
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBar.Header.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBar.Header.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbBar.h, commit f4a2812
+// MUX Reference BreadcrumbBar.h, tag winui3/release/1.4.2
 
 #nullable enable
 
-using System.Collections.Specialized;
 using Uno.Disposables;
 using Windows.UI.Xaml.Controls;
 
@@ -31,9 +30,7 @@ public partial class BreadcrumbBar : Control
 	private BreadcrumbIterable? m_itemsIterable = null;
 
 	private ItemsRepeater? m_itemsRepeater = null;
-
 	private BreadcrumbElementFactory? m_itemsRepeaterElementFactory = null;
-
 	private BreadcrumbLayout? m_itemsRepeaterLayout = null;
 
 	// Pointers to first and last items to update visual states

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBar.properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBar.properties.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbBar.properties.cpp, commit 9aedb00
+// MUX Reference BreadcrumbBar.properties.cpp, tag winui3/release/1.4.2
 
 #nullable enable
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBar.xaml
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBar.xaml
@@ -1,404 +1,264 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
-<!-- MUX Reference BreadcrumbBar.xaml, commit d7b8e9b -->
-<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.UI.Xaml.Controls"
-    xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
-
-    <Style x:Key="DefaultBreadcrumbBarItemStyle" TargetType="local:BreadcrumbBarItem">
-        <Setter Property="Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}" />
-        <Setter Property="FocusVisualMargin" Value="1" />
-        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
-        <Setter Property="FontSize" Value="{ThemeResource BreadcrumbBarItemThemeFontSize}"/>
-        <Setter Property="FontWeight" Value="{ThemeResource BreadcrumbBarItemFontWeight}" />
-        <Setter Property="Foreground" Value="{ThemeResource BreadcrumbBarForegroundBrush}" />
-        <Setter Property="HorizontalAlignment" Value="Stretch" />
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="IsTabStop" Value="True"/>
-        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-        <Setter Property="VerticalAlignment" Value="Center" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
-        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="local:BreadcrumbBarItem">
-                    <Grid x:Name="PART_LayoutRoot"
-                          contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                          contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}">
-
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="ItemTypeStates">
-                                <VisualState x:Name="Inline" />
-
-                                <VisualState x:Name="EllipsisDropDown">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_ItemButton.Visibility" Value="Collapsed"/>
-                                        <Setter Target="PART_ChevronTextBlock.Visibility" Value="Collapsed"/>
-                                        <Setter Target="PART_ContentColumn.Width" Value="*"/>
-                                        <Setter Target="PART_EllipsisDropDownItemContentPresenter.Visibility" Value="Visible"/>
-                                        <Setter Target="PART_LayoutRoot.Padding" Value="11,7,11,9"/>
-                                        <Setter Target="PART_LayoutRoot.Margin" Value="5,3"/>
-                                        <Setter Target="PART_LayoutRoot.FocusVisualMargin" Value="-3" />
-                                        <Setter Target="PART_ItemButton.(Control.IsTemplateFocusTarget)" Value="False" />
-                                        <Setter Target="PART_LayoutRoot.(Control.IsTemplateFocusTarget)" Value="True" />
-                                    </VisualState.Setters>
-                                </VisualState>
+<!-- MUX Reference BreadcrumbBar.xaml, tag winui3/release/1.4.2 -->
+<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:controls="using:Microsoft.UI.Xaml.Controls" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <Style x:Key="DefaultBreadcrumbBarItemStyle" TargetType="controls:BreadcrumbBarItem">
+    <Setter Property="Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}" />
+    <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}" />
+    <Setter Property="FocusVisualMargin" Value="1" />
+    <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+    <Setter Property="FontSize" Value="{ThemeResource BreadcrumbBarItemThemeFontSize}" />
+    <Setter Property="FontWeight" Value="{ThemeResource BreadcrumbBarItemFontWeight}" />
+    <Setter Property="Foreground" Value="{ThemeResource BreadcrumbBarForegroundBrush}" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="IsTabStop" Value="True" />
+    <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="controls:BreadcrumbBarItem">
+          <Grid x:Name="PART_LayoutRoot" CornerRadius="{TemplateBinding CornerRadius}">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="ItemTypeStates">
+                <VisualState x:Name="Inline" />
+                <VisualState x:Name="EllipsisDropDown">
+                  <VisualState.Setters>
+                    <Setter Target="PART_ItemButton.Visibility" Value="Collapsed" />
+                    <Setter Target="PART_ChevronTextBlock.Visibility" Value="Collapsed" />
+                    <Setter Target="PART_ContentColumn.Width" Value="*" />
+                    <Setter Target="PART_EllipsisDropDownItemContentPresenter.Visibility" Value="Visible" />
+                    <Setter Target="PART_LayoutRoot.Padding" Value="11,7,11,9" />
+                    <Setter Target="PART_LayoutRoot.Margin" Value="5,3" />
+                    <Setter Target="PART_LayoutRoot.FocusVisualMargin" Value="-3" />
+                    <Setter Target="PART_ItemButton.(Control.IsTemplateFocusTarget)" Value="False" />
+                    <Setter Target="PART_LayoutRoot.(Control.IsTemplateFocusTarget)" Value="True" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="EllipsisDropDownItemCommonStates">
+                <VisualState x:Name="Normal">
+                  <Storyboard>
+                    <PointerUpThemeAnimation Storyboard.TargetName="PART_LayoutRoot" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="PointerOver">
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_LayoutRoot" Storyboard.TargetProperty="Background">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_EllipsisDropDownItemContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemForegroundPointerOver}" />
+                    </ObjectAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="Pressed">
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_LayoutRoot" Storyboard.TargetProperty="Background">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemBackgroundPressed}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_EllipsisDropDownItemContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemForegroundPressed}" />
+                    </ObjectAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="Disabled">
+                  <Storyboard>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_LayoutRoot" Storyboard.TargetProperty="Background">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemBackgroundDisabled}" />
+                    </ObjectAnimationUsingKeyFrames>
+                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_EllipsisDropDownItemContentPresenter" Storyboard.TargetProperty="Foreground">
+                      <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemForegroundDisabled}" />
+                    </ObjectAnimationUsingKeyFrames>
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="InlineItemTypeStates">
+                <VisualState x:Name="Default">
+                  <VisualState.Setters>
+                    <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbBarChevronLeftToRight}" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="DefaultRTL">
+                  <VisualState.Setters>
+                    <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbBarChevronRightToLeft}" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="LastItem">
+                  <VisualState.Setters>
+                    <Setter Target="PART_ItemButton.Visibility" Value="Collapsed" />
+                    <Setter Target="PART_ChevronTextBlock.Visibility" Value="Collapsed" />
+                    <Setter Target="PART_LastItemContentPresenter.Visibility" Value="Visible" />
+                    <Setter Target="PART_ItemButton.(Control.IsTemplateFocusTarget)" Value="False" />
+                    <Setter Target="PART_LastItemContentPresenter.(Control.IsTemplateFocusTarget)" Value="True" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Ellipsis">
+                  <VisualState.Setters>
+                    <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbBarChevronLeftToRight}" />
+                    <Setter Target="PART_EllipsisTextBlock.Visibility" Value="Visible" />
+                    <Setter Target="PART_ItemContentPresenter.Visibility" Value="Collapsed" />
+                  </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="EllipsisRTL">
+                  <VisualState.Setters>
+                    <Setter Target="PART_EllipsisTextBlock.Visibility" Value="Visible" />
+                    <Setter Target="PART_ItemContentPresenter.Visibility" Value="Collapsed" />
+                    <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbBarChevronRightToLeft}" />
+                  </VisualState.Setters>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Grid.Resources>
+              <Flyout x:Name="PART_EllipsisFlyout">
+                <Flyout.FlyoutPresenterStyle>
+                  <Style TargetType="FlyoutPresenter">
+                    <Setter Property="Background" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBackground}" />
+                    <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderBrush}" />
+                    <Setter Property="BorderThickness" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness}" />
+                    <Setter Property="Padding" Value="0,2" />
+                    <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
+                    <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
+                    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+                    <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
+                    <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
+                    <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
+                    <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
+                    <Setter Property="MinHeight" Value="40" />
+                    <Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
+                    <Setter Property="Template">
+                      <Setter.Value>
+                        <ControlTemplate TargetType="FlyoutPresenter">
+                          <Grid Background="{TemplateBinding Background}" CornerRadius="{TemplateBinding CornerRadius}" BackgroundSizing="InnerBorderEdge">
+                            <ScrollViewer x:Name="FlyoutPresenterScrollViewer" Margin="{TemplateBinding Padding}" HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}" HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}" VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}" VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}" IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}" Content="{TemplateBinding Content}" ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}" AutomationProperties.AccessibilityView="Raw" />
+                            <Border x:Name="FlyoutPresenterBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{TemplateBinding CornerRadius}" />
+                          </Grid>
+                        </ControlTemplate>
+                      </Setter.Value>
+                    </Setter>
+                  </Style>
+                </Flyout.FlyoutPresenterStyle>
+              </Flyout>
+            </Grid.Resources>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto" x:Name="PART_ContentColumn" />
+              <ColumnDefinition Width="Auto" x:Name="PART_ChevronColumn" />
+            </Grid.ColumnDefinitions>
+            <Button x:Name="PART_ItemButton" x:DeferLoadStrategy="Lazy" Grid.Column="0" AutomationProperties.Name="BreadcrumbBarItemButton" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Control.IsTemplateFocusTarget="True" IsTabStop="False" FocusVisualMargin="-3" Padding="1,3" CornerRadius="{TemplateBinding CornerRadius}" AutomationProperties.AccessibilityView="Raw">
+              <Button.Style>
+                <Style TargetType="Button">
+                  <Setter Property="Foreground" Value="{ThemeResource BreadcrumbBarNormalForegroundBrush}" />
+                  <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}" />
+                  <Setter Property="Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}" />
+                  <Setter Property="HorizontalAlignment" Value="Left" />
+                  <Setter Property="VerticalAlignment" Value="Center" />
+                  <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                  <Setter Property="FontWeight" Value="Normal" />
+                  <Setter Property="FontSize" Value="{ThemeResource BreadcrumbBarItemThemeFontSize}" />
+                  <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                  <Setter Property="Padding" Value="0,0,0,0" />
+                  <Setter Property="Template">
+                    <Setter.Value>
+                      <ControlTemplate TargetType="Button">
+                        <Grid Background="Transparent">
+                          <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                              <VisualState x:Name="Normal">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarNormalForegroundBrush}" />
+                                </VisualState.Setters>
+                              </VisualState>
+                              <!-- Current refers to the last item -->
+                              <VisualState x:Name="CurrentNormal">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentNormalForegroundBrush}" />
+                                </VisualState.Setters>
+                              </VisualState>
+                              <VisualState x:Name="PointerOver">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarHoverForegroundBrush}" />
+                                  <Setter Target="PART_ContentPresenter.Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}" />
+                                  <Setter Target="PART_ContentPresenter.BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}" />
+                                </VisualState.Setters>
+                              </VisualState>
+                              <VisualState x:Name="CurrentPointerOver">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentHoverForegroundBrush}" />
+                                  <Setter Target="PART_ContentPresenter.Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}" />
+                                  <Setter Target="PART_ContentPresenter.BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}" />
+                                </VisualState.Setters>
+                              </VisualState>
+                              <VisualState x:Name="Pressed">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarPressedForegroundBrush}" />
+                                  <Setter Target="PART_ContentPresenter.Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}" />
+                                  <Setter Target="PART_ContentPresenter.BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}" />
+                                </VisualState.Setters>
+                              </VisualState>
+                              <VisualState x:Name="CurrentPressed">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentPressedForegroundBrush}" />
+                                  <Setter Target="PART_ContentPresenter.Background" Value="Transparent" />
+                                  <Setter Target="PART_ContentPresenter.BorderBrush" Value="Transparent" />
+                                </VisualState.Setters>
+                              </VisualState>
+                              <VisualState x:Name="Disabled">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarDisabledForegroundBrush}" />
+                                </VisualState.Setters>
+                              </VisualState>
+                              <VisualState x:Name="CurrentDisabled">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentDisabledForegroundBrush}" />
+                                </VisualState.Setters>
+                              </VisualState>
+                              <VisualState x:Name="Focus">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarFocusForegroundBrush}" />
+                                </VisualState.Setters>
+                              </VisualState>
+                              <VisualState x:Name="CurrentFocus">
+                                <VisualState.Setters>
+                                  <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentFocusForegroundBrush}" />
+                                </VisualState.Setters>
+                              </VisualState>
                             </VisualStateGroup>
-
-                            <VisualStateGroup x:Name="EllipsisDropDownItemCommonStates">
-                                <VisualState x:Name="Normal">
-                                    <Storyboard>
-                                        <PointerUpThemeAnimation Storyboard.TargetName="PART_LayoutRoot" />
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="PointerOver">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_EllipsisDropDownItemContentPresenter" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemForegroundPointerOver}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Pressed">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemBackgroundPressed}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_EllipsisDropDownItemContentPresenter" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemForegroundPressed}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Disabled">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_LayoutRoot" Storyboard.TargetProperty="Background">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemBackgroundDisabled}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_EllipsisDropDownItemContentPresenter" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource BreadcrumbBarEllipsisDropDownItemForegroundDisabled}" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
-
-                            <VisualStateGroup x:Name="InlineItemTypeStates">
-                                <VisualState x:Name="Default">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbBarChevronLeftToRight}"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="DefaultRTL">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbBarChevronRightToLeft}"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="LastItem">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_ItemButton.Visibility" Value="Collapsed"/>
-                                        <Setter Target="PART_ChevronTextBlock.Visibility" Value="Collapsed" />
-                                        <Setter Target="PART_LastItemContentPresenter.Visibility" Value="Visible"/>
-                                        <Setter Target="PART_ItemButton.(Control.IsTemplateFocusTarget)" Value="False" />
-                                        <Setter Target="PART_LastItemContentPresenter.(Control.IsTemplateFocusTarget)" Value="True" />
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="Ellipsis">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbBarChevronLeftToRight}"/>
-                                        <Setter Target="PART_EllipsisTextBlock.Visibility" Value="Visible"/>
-                                        <Setter Target="PART_ItemContentPresenter.Visibility" Value="Collapsed"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-
-                                <VisualState x:Name="EllipsisRTL">
-                                    <VisualState.Setters>
-                                        <Setter Target="PART_EllipsisTextBlock.Visibility" Value="Visible"/>
-                                        <Setter Target="PART_ItemContentPresenter.Visibility" Value="Collapsed"/>
-                                        <Setter Target="PART_ChevronTextBlock.Text" Value="{ThemeResource BreadcrumbBarChevronRightToLeft}"/>
-                                    </VisualState.Setters>
-                                </VisualState>
-                            </VisualStateGroup>
-                        </VisualStateManager.VisualStateGroups>
-
-                        <Grid.Resources>
-                            <Flyout x:Name="PART_EllipsisFlyout">
-                                <Flyout.FlyoutPresenterStyle>
-                                    <Style TargetType="FlyoutPresenter">
-                                        <Setter Property="Background" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBackground}" />
-                                        <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderBrush}" />
-                                        <Setter Property="BorderThickness" Value="{ThemeResource BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness}" />
-                                        <Setter Property="Padding" Value="0,2" />
-                                        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
-                                        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
-                                        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-                                        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
-                                        <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
-                                        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
-                                        <Setter Property="MaxWidth" Value="{ThemeResource FlyoutThemeMaxWidth}" />
-                                        <Setter Property="MinHeight" Value="40" />
-                                        <contract7Present:Setter Property="CornerRadius" Value="{ThemeResource OverlayCornerRadius}" />
-
-                                        <Setter Property="Template">
-                                            <Setter.Value>
-                                                <ControlTemplate TargetType="FlyoutPresenter">
-                                                    <Grid Background="{TemplateBinding Background}"
-                                                          contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                                          contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
-                                                          contract7Present:BackgroundSizing="InnerBorderEdge">
-                                                        <ScrollViewer x:Name="FlyoutPresenterScrollViewer"
-                                                                      Margin="{TemplateBinding Padding}"
-                                                                      HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-                                                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                                      VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-                                                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                                                      IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-                                                                      IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-                                                                      Content="{TemplateBinding Content}"
-                                                                      ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-                                                                      AutomationProperties.AccessibilityView="Raw" />
-                                                        <Border x:Name="FlyoutPresenterBorder"
-                                                                BorderBrush="{TemplateBinding BorderBrush}"
-                                                                BorderThickness="{TemplateBinding BorderThickness}"
-                                                                contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                                                                contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"/>
-                                                    </Grid>
-                                                </ControlTemplate>
-                                            </Setter.Value>
-                                        </Setter>
-
-                                    </Style>
-                                </Flyout.FlyoutPresenterStyle>
-                            </Flyout>
-                        </Grid.Resources>
-
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" x:Name="PART_ContentColumn" />
-                            <ColumnDefinition Width="Auto" x:Name="PART_ChevronColumn" />
-                        </Grid.ColumnDefinitions>
-                        
-                        <Button x:Name="PART_ItemButton"
-                            x:DeferLoadStrategy="Lazy"
-                            Grid.Column="0"
-                            AutomationProperties.Name="BreadcrumbBarItemButton"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Control.IsTemplateFocusTarget="True"
-                            IsTabStop="False"
-                            FocusVisualMargin="-3"
-                            Padding="1,3"
-                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                            AutomationProperties.AccessibilityView="Raw">
-                            <Button.Style>
-                                <Style TargetType="Button">
-                                    <Setter Property="Foreground" Value="{ThemeResource BreadcrumbBarNormalForegroundBrush}" />
-                                    <Setter Property="BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}" />
-                                    <Setter Property="Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}" />
-                                    <Setter Property="HorizontalAlignment" Value="Left" />
-                                    <Setter Property="VerticalAlignment" Value="Center" />
-                                    <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
-                                    <Setter Property="FontWeight" Value="Normal" />
-                                    <Setter Property="FontSize" Value="{ThemeResource BreadcrumbBarItemThemeFontSize}" />
-                                    <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-                                    <Setter Property="Padding" Value="0,0,0,0" />
-                                    <Setter Property="Template">
-                                        <Setter.Value>
-                                            <ControlTemplate TargetType="Button">
-                                                <Grid Background="Transparent">
-                                                    <VisualStateManager.VisualStateGroups>
-                                                        <VisualStateGroup x:Name="CommonStates">
-                                                            <VisualState x:Name="Normal">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarNormalForegroundBrush}" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-
-                                                            <!-- Current refers to the last item -->
-                                                            <VisualState x:Name="CurrentNormal">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentNormalForegroundBrush}" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-
-                                                            <VisualState x:Name="PointerOver">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarHoverForegroundBrush}" />
-                                                                    <Setter Target="PART_ContentPresenter.Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}"/>
-                                                                    <Setter Target="PART_ContentPresenter.BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}"/>
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-
-                                                            <VisualState x:Name="CurrentPointerOver">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentHoverForegroundBrush}" />
-                                                                    <Setter Target="PART_ContentPresenter.Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}"/>
-                                                                    <Setter Target="PART_ContentPresenter.BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}"/>
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-
-                                                            <VisualState x:Name="Pressed">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarPressedForegroundBrush}" />
-                                                                    <Setter Target="PART_ContentPresenter.Background" Value="{ThemeResource BreadcrumbBarBackgroundBrush}"/>
-                                                                    <Setter Target="PART_ContentPresenter.BorderBrush" Value="{ThemeResource BreadcrumbBarBorderBrush}"/>
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-
-                                                            <VisualState x:Name="CurrentPressed">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentPressedForegroundBrush}" />
-                                                                    <Setter Target="PART_ContentPresenter.Background" Value="Transparent"/>
-                                                                    <Setter Target="PART_ContentPresenter.BorderBrush" Value="Transparent"/>
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-
-                                                            <VisualState x:Name="Disabled">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarDisabledForegroundBrush}" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-
-                                                            <VisualState x:Name="CurrentDisabled">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentDisabledForegroundBrush}" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-
-                                                            <VisualState x:Name="Focus">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarFocusForegroundBrush}" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-
-                                                            <VisualState x:Name="CurrentFocus">
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="PART_ContentPresenter.Foreground" Value="{ThemeResource BreadcrumbBarCurrentFocusForegroundBrush}" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-                                                        </VisualStateGroup>
-                                                    </VisualStateManager.VisualStateGroups>
-
-                                                    <ContentPresenter x:Name="PART_ContentPresenter"
-                                                        AutomationProperties.Name="ContentPresenter"
-                                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                                        Content="{TemplateBinding Content}"
-                                                        ContentTransitions="{TemplateBinding ContentTransitions}"
-                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                        Padding="{TemplateBinding Padding}"
-                                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                        AutomationProperties.AccessibilityView="Raw"/>
-                                                </Grid>
-                                            </ControlTemplate>
-                                        </Setter.Value>
-                                    </Setter>
-                                </Style>
-                            </Button.Style>
-
-                            <!-- This is the Button Content -->
-                            <Grid AutomationProperties.Name="BreadcrumbBarItemGrid"
-                                  AutomationProperties.AccessibilityView="Raw">
-
-                                <ContentPresenter x:Name="PART_ItemContentPresenter"
-                                    AutomationProperties.Name="BreadcrumbBarItemContentPresenter"
-                                    Grid.Column="0"
-                                    Content="{TemplateBinding Content}"
-                                    ContentTransitions="{TemplateBinding ContentTransitions}"
-                                    ContentTemplate="{TemplateBinding ContentTemplate}"
-                                    FontFamily="{TemplateBinding FontFamily}"
-                                    FontSize="{TemplateBinding FontSize}"
-                                    FontWeight="{TemplateBinding FontWeight}"
-                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                    LineHeight="20"
-                                    AutomationProperties.AccessibilityView="Raw"/>
-
-                                <TextBlock x:Name="PART_EllipsisTextBlock"
-                                    AutomationProperties.Name="BreadcrumbBarEllipsisTextBlock"
-                                    Grid.Column="0"
-                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                    FontSize="{TemplateBinding FontSize}"
-                                    Padding="3"
-                                    Text="&#xE712;"                                       
-                                    Visibility="Collapsed"
-                                    VerticalAlignment="Stretch"
-                                    IsTextScaleFactorEnabled="False"
-                                    AutomationProperties.AccessibilityView="Raw" />
-                            </Grid>
-                            
-                        </Button>
-
-                        <!-- ContentPresenter to be shown only when the rendered item is the Current Item -->
-                        <ContentPresenter x:Name="PART_LastItemContentPresenter"
-                            Grid.Column="0"
-                            Visibility="Collapsed"
-                            Content="{TemplateBinding Content}"
-                            ContentTransitions="{TemplateBinding ContentTransitions}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            FocusVisualMargin="-3"
-                            FontFamily="{TemplateBinding FontFamily}"
-                            FontSize="{TemplateBinding FontSize}"
-                            FontWeight="{TemplateBinding FontWeight}"
-                            Foreground="{ThemeResource BreadcrumbBarCurrentNormalForegroundBrush}"
-                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            LineHeight="20"
-                            Padding="1,3"
-                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            contract7Present:CornerRadius="{TemplateBinding CornerRadius}"
-                            contract7NotPresent:CornerRadius="{ThemeResource ControlCornerRadius}"
-                            AutomationProperties.AccessibilityView="Raw"/>
-
-                        <!-- ContentPresenter to be shown only when the rendered item is a drop down Item -->
-                        <ContentPresenter x:Name="PART_EllipsisDropDownItemContentPresenter"
-                            x:DeferLoadStrategy="Lazy"
-                            Grid.Column="0"
-                            Visibility="Collapsed"
-                            Content="{TemplateBinding Content}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            ContentTransitions="{TemplateBinding ContentTransitions}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            HorizontalContentAlignment="Stretch"
-                            FontWeight="Normal"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            AutomationProperties.AccessibilityView="Raw"/>
-
-                        <!-- TextBlock that contains the chevron icon -->
-                        <TextBlock x:Name="PART_ChevronTextBlock"
-                            AutomationProperties.Name="ChevronTextBlock"
-                            Grid.Column="1"
-                            HorizontalAlignment="Center"
-                            IsTextScaleFactorEnabled="False"       
-                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                            FontSize="{ThemeResource BreadcrumbBarChevronFontSize}"
-                            Foreground="{ThemeResource BreadcrumbBarNormalForegroundBrush}"
-                            Text="&#xE76C;"
-                            Padding="{ThemeResource BreadcrumbBarChevronPadding}"
-                            VerticalAlignment="Center"
-                            AutomationProperties.AccessibilityView="Raw"/>
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-    
-    <Style TargetType="local:BreadcrumbBar">
-        <Setter Property="AutomationProperties.LandmarkType" Value="Navigation"/>
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="local:BreadcrumbBar">
-                    <local:ItemsRepeater x:Name="PART_ItemsRepeater" />
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <Style TargetType="local:BreadcrumbBarItem" BasedOn="{StaticResource DefaultBreadcrumbBarItemStyle}"/>
+                          </VisualStateManager.VisualStateGroups>
+                          <ContentPresenter x:Name="PART_ContentPresenter" AutomationProperties.Name="ContentPresenter" BorderBrush="{TemplateBinding BorderBrush}" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Padding="{TemplateBinding Padding}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
+                        </Grid>
+                      </ControlTemplate>
+                    </Setter.Value>
+                  </Setter>
+                </Style>
+              </Button.Style>
+              <!-- This is the Button Content -->
+              <Grid AutomationProperties.Name="BreadcrumbBarItemGrid" AutomationProperties.AccessibilityView="Raw">
+                <ContentPresenter x:Name="PART_ItemContentPresenter" AutomationProperties.Name="BreadcrumbBarItemContentPresenter" Grid.Column="0" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" FontFamily="{TemplateBinding FontFamily}" FontSize="{TemplateBinding FontSize}" FontWeight="{TemplateBinding FontWeight}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" LineHeight="20" AutomationProperties.AccessibilityView="Raw" />
+                <TextBlock x:Name="PART_EllipsisTextBlock" AutomationProperties.Name="BreadcrumbBarEllipsisTextBlock" Grid.Column="0" FontFamily="{ThemeResource SymbolThemeFontFamily}" FontSize="{TemplateBinding FontSize}" Padding="3" Text="&#xE712;" Visibility="Collapsed" VerticalAlignment="Stretch" IsTextScaleFactorEnabled="False" AutomationProperties.AccessibilityView="Raw" />
+              </Grid>
+            </Button>
+            <!-- ContentPresenter to be shown only when the rendered item is the Current Item -->
+            <ContentPresenter x:Name="PART_LastItemContentPresenter" Grid.Column="0" Visibility="Collapsed" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" FocusVisualMargin="-3" FontFamily="{TemplateBinding FontFamily}" FontSize="{TemplateBinding FontSize}" FontWeight="{TemplateBinding FontWeight}" Foreground="{ThemeResource BreadcrumbBarCurrentNormalForegroundBrush}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" LineHeight="20" Padding="1,3" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" CornerRadius="{TemplateBinding CornerRadius}" AutomationProperties.AccessibilityView="Raw" />
+            <!-- ContentPresenter to be shown only when the rendered item is a drop down Item -->
+            <ContentPresenter x:Name="PART_EllipsisDropDownItemContentPresenter" x:DeferLoadStrategy="Lazy" Grid.Column="0" Visibility="Collapsed" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" ContentTransitions="{TemplateBinding ContentTransitions}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" HorizontalContentAlignment="Stretch" FontWeight="Normal" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
+            <!-- TextBlock that contains the chevron icon -->
+            <TextBlock x:Name="PART_ChevronTextBlock" AutomationProperties.Name="ChevronTextBlock" Grid.Column="1" HorizontalAlignment="Center" IsTextScaleFactorEnabled="False" FontFamily="{ThemeResource SymbolThemeFontFamily}" FontSize="{ThemeResource BreadcrumbBarChevronFontSize}" Foreground="{ThemeResource BreadcrumbBarNormalForegroundBrush}" Text="&#xE76C;" Padding="{ThemeResource BreadcrumbBarChevronPadding}" VerticalAlignment="Center" AutomationProperties.AccessibilityView="Raw" />
+          </Grid>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style TargetType="controls:BreadcrumbBar">
+    <Setter Property="AutomationProperties.LandmarkType" Value="Navigation" />
+    <Setter Property="IsTabStop" Value="False" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="controls:BreadcrumbBar">
+          <controls:ItemsRepeater x:Name="PART_ItemsRepeater" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>
+  <Style TargetType="controls:BreadcrumbBarItem" BasedOn="{StaticResource DefaultBreadcrumbBarItemStyle}" />
 </ResourceDictionary>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarElementFactory.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarElementFactory.cs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbBarElementFactory.cpp, commit 085fbf9
+// MUX Reference BreadcrumbBarElementFactory.cpp, tag winui3/release/1.4.2
 
 #nullable enable
 
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml.Controls;
 
@@ -18,14 +19,17 @@ internal partial class BreadcrumbElementFactory : ElementFactory
 
 	internal void UserElementFactory(object? newValue)
 	{
-		m_itemTemplateWrapper = newValue as IElementFactoryShim;
-		if (m_itemTemplateWrapper == null)
+		if (newValue is DataTemplate dataTemplate)
 		{
-			// ItemTemplate set does not implement IElementFactoryShim. We also want to support DataTemplate.
-			if (newValue is DataTemplate dataTemplate)
-			{
-				m_itemTemplateWrapper = new ItemTemplateWrapper(dataTemplate);
-			}
+			m_itemTemplateWrapper = new ItemTemplateWrapper(dataTemplate);
+		}
+		else if (newValue is DataTemplateSelector selector)
+		{
+			m_itemTemplateWrapper = new ItemTemplateWrapper(selector);
+		}
+		else if (newValue is IElementFactory customElementFactory)
+		{
+			m_itemTemplateWrapper = (IElementFactoryShim?)customElementFactory;
 		}
 	}
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItem.Header.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItem.Header.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbBarItem.h, commit f4a2812
+// MUX Reference BreadcrumbBarItem.h, tag winui3/release/1.4.2
 
 #nullable enable
 
@@ -37,7 +37,7 @@ public partial class BreadcrumbBarItem : ContentControl
 	// Flyout content for ellipsis item
 	private Flyout? m_ellipsisFlyout = null;
 	private ItemsRepeater? m_ellipsisItemsRepeater = null;
-	private DataTemplate? m_ellipsisDropDownItemDataTemplate = null;
+	private IElementFactory? m_ellipsisDropDownItemDataTemplate = null;
 	private BreadcrumbElementFactory? m_ellipsisElementFactory = null;
 
 	// Ellipsis dropdown item fields

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItemAutomationPeer.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItemAutomationPeer.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbBarItemAutomationPeer.cpp, commit f4a2812
+// MUX Reference BreadcrumbBarItemAutomationPeer.cpp, tag winui3/release/1.4.2
 
 #nullable enable
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItemClickedEventArgs.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBarItemClickedEventArgs.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbBarItemClickedEventArgs.cpp, commit 085fbf9
+// MUX Reference BreadcrumbBarItemClickedEventArgs.cpp, tag winui3/release/1.4.2
 
 #nullable enable
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBar_themeresources.xaml
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbBar_themeresources.xaml
@@ -1,130 +1,99 @@
 ﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
-<!-- MUX Reference BreadcrumbBar_themeresources.xaml, commit d7b8e9b -->
-<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-
-    <ResourceDictionary.ThemeDictionaries>
-
-        <ResourceDictionary x:Key="Default">
-            <x:String x:Key="BreadcrumbBarChevronLeftToRight">&#xE974;</x:String>
-            <x:String x:Key="BreadcrumbBarChevronRightToLeft">&#xE973;</x:String>
-
-            <Thickness x:Key="BreadcrumbBarChevronPadding">2,0</Thickness>
-
-            <FontWeight x:Key="BreadcrumbBarItemFontWeight">Normal</FontWeight>
-            
-            <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarHoverForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarPressedForegroundBrush" ResourceKey="TextFillColorTertiaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarDisabledForegroundBrush" ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="BreadcrumbBarFocusForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarCurrentNormalForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentHoverForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentPressedForegroundBrush" ResourceKey="TextFillColorTertiaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentDisabledForegroundBrush" ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentFocusForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPressed" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-            <SolidColorBrush x:Key="BreadcrumbBarBackgroundBrush" Color="Transparent"/>
-            <SolidColorBrush x:Key="BreadcrumbBarBorderBrush" Color="Transparent"/>
-
-            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
-            <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness">1</Thickness>
-
-            <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
-            <x:Double x:Key="BreadcrumbBarChevronFontSize">12</x:Double>
-        </ResourceDictionary>
-
-        <ResourceDictionary x:Key="Light">
-            <x:String x:Key="BreadcrumbBarChevronLeftToRight">&#xE974;</x:String>
-            <x:String x:Key="BreadcrumbBarChevronRightToLeft">&#xE973;</x:String>
-
-            <Thickness x:Key="BreadcrumbBarChevronPadding">2,0</Thickness>
-
-            <FontWeight x:Key="BreadcrumbBarItemFontWeight">Normal</FontWeight>
-
-            <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarHoverForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarPressedForegroundBrush" ResourceKey="TextFillColorTertiaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarDisabledForegroundBrush" ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="BreadcrumbBarFocusForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarCurrentNormalForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentHoverForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentPressedForegroundBrush" ResourceKey="TextFillColorTertiaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentDisabledForegroundBrush" ResourceKey="TextFillColorDisabledBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentFocusForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPressed" ResourceKey="TextFillColorPrimaryBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
-            <!-- TODO: should this be <StaticResource x:Key="BreadcrumbBarItemBackgroundBrush" ResourceKey="SubtleFillColorTransparentBrush" /> instead?-->
-            <SolidColorBrush x:Key="BreadcrumbBarBackgroundBrush" Color="Transparent"/>
-            <SolidColorBrush x:Key="BreadcrumbBarBorderBrush" Color="Transparent"/>
-
-            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
-            <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness">1</Thickness>
-
-            <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
-            <x:Double x:Key="BreadcrumbBarChevronFontSize">12</x:Double>
-        </ResourceDictionary>
-
-        <ResourceDictionary x:Key="HighContrast">
-            <x:String x:Key="BreadcrumbBarChevronLeftToRight">&#xE974;</x:String>
-            <x:String x:Key="BreadcrumbBarChevronRightToLeft">&#xE973;</x:String>
-
-            <Thickness x:Key="BreadcrumbBarChevronPadding">2,0</Thickness>
-
-            <FontWeight x:Key="BreadcrumbBarItemFontWeight">Normal</FontWeight>
-
-            <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarHoverForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarPressedForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarDisabledForegroundBrush" ResourceKey="SystemColorGrayTextColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarFocusForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarCurrentNormalForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentHoverForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentPressedForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentDisabledForegroundBrush" ResourceKey="SystemColorGrayTextColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarCurrentFocusForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackground" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush"  />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPressed" ResourceKey="SystemControlTransparentBrush"  />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundDisabled" ResourceKey="SystemControlTransparentBrush"  />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarBackgroundBrush" ResourceKey="SystemControlTransparentBrush" />
-            <StaticResource x:Key="BreadcrumbBarBorderBrush" ResourceKey="SystemControlTransparentBrush" />
-
-            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="SystemColorWindowColorBrush" />
-            <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SystemColorWindowTextColorBrush" />
-            <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness">2</Thickness>
-
-            <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
-            <x:Double x:Key="BreadcrumbBarChevronFontSize">12</x:Double>
-        </ResourceDictionary>
-    </ResourceDictionary.ThemeDictionaries>
+<!-- MUX Reference BreadcrumbBar_themeresources.xaml, tag winui3/release/1.4.2 -->
+<ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+  <ResourceDictionary.ThemeDictionaries>
+    <ResourceDictionary x:Key="Default">
+      <x:String x:Key="BreadcrumbBarChevronLeftToRight">&#xE974;</x:String>
+      <x:String x:Key="BreadcrumbBarChevronRightToLeft">&#xE973;</x:String>
+      <Thickness x:Key="BreadcrumbBarChevronPadding">2,0</Thickness>
+      <FontWeight x:Key="BreadcrumbBarItemFontWeight">Normal</FontWeight>
+      <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarHoverForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarPressedForegroundBrush" ResourceKey="TextFillColorTertiaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarDisabledForegroundBrush" ResourceKey="TextFillColorDisabledBrush" />
+      <StaticResource x:Key="BreadcrumbBarFocusForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentNormalForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentHoverForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentPressedForegroundBrush" ResourceKey="TextFillColorTertiaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentDisabledForegroundBrush" ResourceKey="TextFillColorDisabledBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentFocusForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPressed" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+      <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <SolidColorBrush x:Key="BreadcrumbBarBackgroundBrush" Color="Transparent" />
+      <SolidColorBrush x:Key="BreadcrumbBarBorderBrush" Color="Transparent" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
+      <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness">1</Thickness>
+      <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
+      <x:Double x:Key="BreadcrumbBarChevronFontSize">12</x:Double>
+    </ResourceDictionary>
+    <ResourceDictionary x:Key="Light">
+      <x:String x:Key="BreadcrumbBarChevronLeftToRight">&#xE974;</x:String>
+      <x:String x:Key="BreadcrumbBarChevronRightToLeft">&#xE973;</x:String>
+      <Thickness x:Key="BreadcrumbBarChevronPadding">2,0</Thickness>
+      <FontWeight x:Key="BreadcrumbBarItemFontWeight">Normal</FontWeight>
+      <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarHoverForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarPressedForegroundBrush" ResourceKey="TextFillColorTertiaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarDisabledForegroundBrush" ResourceKey="TextFillColorDisabledBrush" />
+      <StaticResource x:Key="BreadcrumbBarFocusForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentNormalForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentHoverForegroundBrush" ResourceKey="TextFillColorSecondaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentPressedForegroundBrush" ResourceKey="TextFillColorTertiaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentDisabledForegroundBrush" ResourceKey="TextFillColorDisabledBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentFocusForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackground" ResourceKey="SubtleFillColorTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundDisabled" ResourceKey="SubtleFillColorTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPointerOver" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPressed" ResourceKey="TextFillColorPrimaryBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundDisabled" ResourceKey="TextFillColorDisabledBrush" />
+      <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+      <SolidColorBrush x:Key="BreadcrumbBarBackgroundBrush" Color="Transparent" />
+      <SolidColorBrush x:Key="BreadcrumbBarBorderBrush" Color="Transparent" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="AcrylicBackgroundFillColorDefaultBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SurfaceStrokeColorFlyoutBrush" />
+      <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness">1</Thickness>
+      <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
+      <x:Double x:Key="BreadcrumbBarChevronFontSize">12</x:Double>
+    </ResourceDictionary>
+    <ResourceDictionary x:Key="HighContrast">
+      <x:String x:Key="BreadcrumbBarChevronLeftToRight">&#xE974;</x:String>
+      <x:String x:Key="BreadcrumbBarChevronRightToLeft">&#xE973;</x:String>
+      <Thickness x:Key="BreadcrumbBarChevronPadding">2,0</Thickness>
+      <FontWeight x:Key="BreadcrumbBarItemFontWeight">Normal</FontWeight>
+      <StaticResource x:Key="BreadcrumbBarNormalForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarHoverForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarPressedForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarDisabledForegroundBrush" ResourceKey="SystemColorGrayTextColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarFocusForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentNormalForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentHoverForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentPressedForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentDisabledForegroundBrush" ResourceKey="SystemColorGrayTextColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarCurrentFocusForegroundBrush" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackground" ResourceKey="SystemControlTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPointerOver" ResourceKey="SystemControlTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundPressed" ResourceKey="SystemControlTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemBackgroundDisabled" ResourceKey="SystemControlTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPointerOver" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundPressed" ResourceKey="SystemColorHighlightColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisDropDownItemForegroundDisabled" ResourceKey="SystemColorGrayTextColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarBackgroundBrush" ResourceKey="SystemControlTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarBorderBrush" ResourceKey="SystemControlTransparentBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBackground" ResourceKey="SystemColorWindowColorBrush" />
+      <StaticResource x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderBrush" ResourceKey="SystemColorWindowTextColorBrush" />
+      <Thickness x:Key="BreadcrumbBarEllipsisFlyoutPresenterBorderThemeThickness">2</Thickness>
+      <StaticResource x:Key="BreadcrumbBarItemThemeFontSize" ResourceKey="ControlContentThemeFontSize" />
+      <x:Double x:Key="BreadcrumbBarChevronFontSize">12</x:Double>
+    </ResourceDictionary>
+  </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbIterable.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbIterable.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbIterable.cpp, commit 2abfc83
+// MUX Reference BreadcrumbIterable.cpp, tag winui3/release/1.4.2
 
 #nullable enable
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbIterator.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbIterator.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbIterator.cpp, commit 2abfc83
+// MUX Reference BreadcrumbIterator.cpp, tag winui3/release/1.4.2
 
 #nullable enable
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbLayout.Header.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbLayout.Header.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbLayout.h, commit 085fbf9
+// MUX Reference BreadcrumbLayout.h, tag winui3/release/1.4.2
 
 #nullable enable
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbLayout.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Breadcrumb/BreadcrumbLayout.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX Reference BreadcrumbLayout.cpp, commit 085fbf9
+// MUX Reference BreadcrumbLayout.cpp, tag winui3/release/1.4.2
 
 #nullable enable
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Code style update (formatting)
- Refactoring (no functional changes, no api changes)


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Updated the `BreadcrumbBar` code to match the new public winui3/release/1.4.2

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 187a1cb</samp>

This pull request updates the `BreadcrumbBar` control and its related files to use the latest WinUI 3 APIs and resources, and to improve its keyboard and focus behavior. It also moves the `InputKeyboardSource` class to the global namespace as part of the WinUI 3 migration.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.