### PR TITLE
fix(hr): Use SDK version to run the dev server

### DIFF
--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.UI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.UI.DevServer.targets
@@ -22,7 +22,9 @@
 			<_IsRCClientRemote Condition="'$(PkgUno_Wasm_Bootstrap_DevServer)'!=''">true</_IsRCClientRemote>
 
 			<_UnoRCHostVersionPath>net7.0</_UnoRCHostVersionPath>
-			<_UnoRCHostVersionPath Condition="'$([MSBuild]::GetTargetFrameworkVersion($(TargetFramework)))' &gt; 7">net8.0</_UnoRCHostVersionPath>
+
+			<!-- Use the SDK version used to build the app, not the target framework (e.g. a net7.0 app may be built with a net8 SDK)-->
+			<_UnoRCHostVersionPath Condition="'$(BundledNETCoreAppTargetFrameworkVersion)' &gt; 7">net8.0</_UnoRCHostVersionPath>
 		</PropertyGroup>
 
 		<Message Text="&lt;RemoteControlHostPath&gt;$(MSBuildThisFileDirectory)../tools/rc/host/$(_UnoRCHostVersionPath)/Uno.UI.RemoteControl.Host.dll&lt;/RemoteControlHostPath&gt;" Importance="High" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Properly start the appropriate devserver version based on the installed .NET SDK, not the selected `TargetFramework`.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4326f1</samp>

Use BundledNETCoreAppTargetFrameworkVersion to select Uno Remote Control Host version. This fixes a potential mismatch between the app's runtime and the host's SDK version.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
