### PR TITLE
feat: Port LayoutRound code from WinUI

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
@@ -19,6 +19,46 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
 #endif
 public class Given_FlowDirection
 {
+	private static Rectangle CreateRectangle(Stretch stretch, Color fillColor)
+	{
+		return new Rectangle()
+		{
+			Stretch = stretch,
+			UseLayoutRounding = false,
+			Fill = new SolidColorBrush(fillColor),
+		};
+	}
+
+	private static Grid CreateGrid(Color background)
+	{
+		return new Grid()
+		{
+			UseLayoutRounding = false,
+			Background = new SolidColorBrush(background),
+		};
+	}
+
+	private static Grid CreateRTLGrid200x200WithTwoRowsAndTwoColumns()
+	{
+		return new Grid()
+		{
+			RowDefinitions =
+			{
+				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
+				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
+			},
+			ColumnDefinitions =
+			{
+				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
+				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
+			},
+			Width = 200,
+			Height = 200,
+			FlowDirection = FlowDirection.RightToLeft,
+			UseLayoutRounding = false,
+		};
+	}
+
 	private static void AssertRects(Rect rect1, Rect rect2)
 	{
 		Assert.AreEqual(rect1.X, rect2.X);
@@ -47,59 +87,25 @@ public class Given_FlowDirection
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}
 
-		var rootGrid = new Grid()
-		{
-			Background = new SolidColorBrush(Colors.WhiteSmoke),
-		};
+		var rootGrid = CreateGrid(Colors.WhiteSmoke);
 
-		var grid = new Grid()
-		{
-			RowDefinitions =
-			{
-				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
-				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
-			},
-			ColumnDefinitions =
-			{
-				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
-				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
-			},
-			Width = 200,
-			Height = 200,
-			FlowDirection = FlowDirection.RightToLeft,
-		};
+		var grid = CreateRTLGrid200x200WithTwoRowsAndTwoColumns();
 
 		rootGrid.Children.Add(grid);
 
-		var red = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Red),
-		};
+		var red = CreateRectangle(Stretch.Fill, Colors.Red);
 		Grid.SetRow(red, 0);
 		Grid.SetColumn(red, 0);
 
-		var green = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Green),
-		};
+		var green = CreateRectangle(Stretch.Fill, Colors.Green);
 		Grid.SetRow(green, 0);
 		Grid.SetColumn(green, 1);
 
-		var blue = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Blue),
-		};
+		var blue = CreateRectangle(Stretch.Fill, Colors.Blue);
 		Grid.SetRow(blue, 1);
 		Grid.SetColumn(blue, 0);
 
-		var yellow = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Yellow),
-		};
+		var yellow = CreateRectangle(Stretch.Fill, Colors.Yellow);
 		Grid.SetRow(yellow, 1);
 		Grid.SetColumn(yellow, 1);
 
@@ -205,64 +211,30 @@ public class Given_FlowDirection
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}
 
-		var rootGrid = new Grid()
-		{
-			Background = new SolidColorBrush(Colors.WhiteSmoke),
-		};
+		var rootGrid = CreateGrid(Colors.WhiteSmoke);
 
-		var grid = new Grid()
+		var grid = CreateRTLGrid200x200WithTwoRowsAndTwoColumns();
+		grid.RenderTransform = new TranslateTransform()
 		{
-			RowDefinitions =
-			{
-				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
-				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
-			},
-			ColumnDefinitions =
-			{
-				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
-				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
-			},
-			Width = 200,
-			Height = 200,
-			FlowDirection = FlowDirection.RightToLeft,
-			RenderTransform = new TranslateTransform()
-			{
-				X = 30,
-				Y = 30,
-			},
+			X = 30,
+			Y = 30,
 		};
 
 		rootGrid.Children.Add(grid);
 
-		var red = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Red),
-		};
+		var red = CreateRectangle(Stretch.Fill, Colors.Red);
 		Grid.SetRow(red, 0);
 		Grid.SetColumn(red, 0);
 
-		var green = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Green),
-		};
+		var green = CreateRectangle(Stretch.Fill, Colors.Green);
 		Grid.SetRow(green, 0);
 		Grid.SetColumn(green, 1);
 
-		var blue = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Blue),
-		};
+		var blue = CreateRectangle(Stretch.Fill, Colors.Blue);
 		Grid.SetRow(blue, 1);
 		Grid.SetColumn(blue, 0);
 
-		var yellow = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Yellow),
-		};
+		var yellow = CreateRectangle(Stretch.Fill, Colors.Yellow);
 		Grid.SetRow(yellow, 1);
 		Grid.SetColumn(yellow, 1);
 
@@ -370,64 +342,30 @@ public class Given_FlowDirection
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}
 
-		var rootGrid = new Grid()
-		{
-			Background = new SolidColorBrush(Colors.WhiteSmoke),
-		};
+		var rootGrid = CreateGrid(Colors.WhiteSmoke);
 
-		var grid = new Grid()
+		var grid = CreateRTLGrid200x200WithTwoRowsAndTwoColumns();
+		grid.RenderTransform = new ScaleTransform()
 		{
-			RowDefinitions =
-			{
-				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
-				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
-			},
-			ColumnDefinitions =
-			{
-				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
-				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
-			},
-			Width = 200,
-			Height = 200,
-			FlowDirection = FlowDirection.RightToLeft,
-			RenderTransform = new ScaleTransform()
-			{
-				ScaleX = 0.5,
-				ScaleY = 0.5,
-			},
+			ScaleX = 0.5,
+			ScaleY = 0.5,
 		};
 
 		rootGrid.Children.Add(grid);
 
-		var red = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Red),
-		};
+		var red = CreateRectangle(Stretch.Fill, Colors.Red);
 		Grid.SetRow(red, 0);
 		Grid.SetColumn(red, 0);
 
-		var green = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Green),
-		};
+		var green = CreateRectangle(Stretch.Fill, Colors.Green);
 		Grid.SetRow(green, 0);
 		Grid.SetColumn(green, 1);
 
-		var blue = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Blue),
-		};
+		var blue = CreateRectangle(Stretch.Fill, Colors.Blue);
 		Grid.SetRow(blue, 1);
 		Grid.SetColumn(blue, 0);
 
-		var yellow = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Yellow),
-		};
+		var yellow = CreateRectangle(Stretch.Fill, Colors.Yellow);
 		Grid.SetRow(yellow, 1);
 		Grid.SetColumn(yellow, 1);
 
@@ -536,66 +474,32 @@ public class Given_FlowDirection
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}
 
-		var rootGrid = new Grid()
-		{
-			Background = new SolidColorBrush(Colors.WhiteSmoke),
-		};
+		var rootGrid = CreateGrid(Colors.WhiteSmoke);
 
-		var grid = new Grid()
+		var grid = CreateRTLGrid200x200WithTwoRowsAndTwoColumns();
+		grid.RenderTransform = new CompositeTransform()
 		{
-			RowDefinitions =
-			{
-				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
-				new RowDefinition() { Height = new GridLength(1, GridUnitType.Star) },
-			},
-			ColumnDefinitions =
-			{
-				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
-				new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) },
-			},
-			Width = 200,
-			Height = 200,
-			FlowDirection = FlowDirection.RightToLeft,
-			RenderTransform = new CompositeTransform()
-			{
-				ScaleX = 0.5,
-				ScaleY = 0.5,
-				TranslateX = 30,
-				TranslateY = 30,
-			},
+			ScaleX = 0.5,
+			ScaleY = 0.5,
+			TranslateX = 30,
+			TranslateY = 30,
 		};
 
 		rootGrid.Children.Add(grid);
 
-		var red = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Red),
-		};
+		var red = CreateRectangle(Stretch.Fill, Colors.Red);
 		Grid.SetRow(red, 0);
 		Grid.SetColumn(red, 0);
 
-		var green = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Green),
-		};
+		var green = CreateRectangle(Stretch.Fill, Colors.Green);
 		Grid.SetRow(green, 0);
 		Grid.SetColumn(green, 1);
 
-		var blue = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Blue),
-		};
+		var blue = CreateRectangle(Stretch.Fill, Colors.Blue);
 		Grid.SetRow(blue, 1);
 		Grid.SetColumn(blue, 0);
 
-		var yellow = new Rectangle()
-		{
-			Stretch = Stretch.Fill,
-			Fill = new SolidColorBrush(Colors.Yellow),
-		};
+		var yellow = CreateRectangle(Stretch.Fill, Colors.Yellow);
 		Grid.SetRow(yellow, 1);
 		Grid.SetColumn(yellow, 1);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_EffectiveViewport.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_EffectiveViewport.cs
@@ -58,7 +58,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				var root = (FrameworkElement)WindowContent;
 				var windowBounds = WindowBounds;
 
-				return new Point(X(root, windowBounds.Width), Y(root, windowBounds.Height));
+				var x = X(root, windowBounds.Width);
+				var y = Y(root, windowBounds.Height);
+				if (root.UseLayoutRounding)
+				{
+					x = root.LayoutRound(x);
+					y = root.LayoutRound(y);
+				}
+
+				return new Point(x, y);
 			}
 		}
 
@@ -255,7 +263,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				HorizontalAlignment = hAlign,
 				VerticalAlignment = vAlign,
 				Width = width,
-				Height = height
+				Height = height,
 			};
 			using var vp = VP(sut);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_EffectiveViewport.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_EffectiveViewport.cs
@@ -60,11 +60,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 				var x = X(root, windowBounds.Width);
 				var y = Y(root, windowBounds.Height);
+#if HAS_UNO // LayoutRound isn't public in UWP/WinUI. Ignore that block of code there for now.
 				if (root.UseLayoutRounding)
 				{
 					x = root.LayoutRound(x);
 					y = root.LayoutRound(y);
 				}
+#endif
 
 				return new Point(x, y);
 			}

--- a/src/Uno.UI/UI/LayoutHelper.cs
+++ b/src/Uno.UI/UI/LayoutHelper.cs
@@ -52,6 +52,21 @@ namespace Uno.UI
 				.AtMost(maxSize)
 				.AtLeast(minSize); // UWP is applying "min" after "max", so if "min" > "max", "min" wins
 
+			if (e is UIElement uiElement && uiElement.GetUseLayoutRounding())
+			{
+				// It is possible for max vars to be INF so be don't want to round those.
+
+				minSize.Width = uiElement.LayoutRound(minSize.Width);
+
+				if (double.IsFinite(maxSize.Width))
+					maxSize.Width = uiElement.LayoutRound(maxSize.Width);
+
+				minSize.Height = uiElement.LayoutRound(minSize.Height);
+
+				if (double.IsFinite(maxSize.Height))
+					maxSize.Height = uiElement.LayoutRound(maxSize.Height);
+			}
+
 			return (minSize, maxSize);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.Layout.cs
@@ -1,24 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Windows.Foundation;
-using Uno.UI;
-
-#if __ANDROID__
-using View = Android.Views.View;
-using Font = Android.Graphics.Typeface;
-#elif __IOS__
-using UIKit;
-using View = UIKit.UIView;
-using Color = UIKit.UIColor;
-using Font = UIKit.UIFont;
-#elif __MACOS__
-using AppKit;
-using View = AppKit.NSView;
-using Color = AppKit.NSColor;
-using Font = AppKit.NSFont;
-#endif
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -69,7 +50,9 @@ namespace Windows.UI.Xaml.Controls
 
 				// Give the child the inner rectangle as the available size
 				// and ask it to arrange itself within this rectangle.
-				child.Arrange(childRect);
+				// Uno TODO: child.Arrange(childRect) doesn't work properly here while it should.
+				//           It fails some tests, e.g, TestVariousArrangedPosition
+				base.ArrangeElement(child, childRect);
 			}
 
 			return finalSize;

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewBaseItemChrome.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewBaseItemChrome.cs
@@ -18,6 +18,7 @@ using Windows.UI.Xaml.Media;
 using DirectUI;
 using CCalendarViewBaseItemChrome = Windows.UI.Xaml.Controls.CalendarViewBaseItem;
 using DateTime = System.DateTimeOffset;
+using Uno.UI.Xaml.Core;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -241,6 +242,25 @@ namespace Windows.UI.Xaml.Controls
 			// Uno workaround
 			Uno_MeasureChrome(availableSize);
 
+			// TODO UNO
+			//if (IsRoundedCalendarViewBaseItemChromeEnabled())
+			//{
+			//	if (m_outerBorder)
+			//	{
+			//		IFC_RETURN(m_outerBorder->Measure(availableSize));
+			//	}
+
+			//	if (m_innerBorder)
+			//	{
+			//		IFC_RETURN(m_innerBorder->Measure(availableSize));
+			//	}
+
+			//	if (m_strikethroughLine)
+			//	{
+			//		IFC_RETURN(m_strikethroughLine->Measure(availableSize));
+			//	}
+			//}
+
 			if (m_pMainTextBlock is { })
 			{
 				m_pMainTextBlock.Measure(availableSize);
@@ -275,8 +295,30 @@ namespace Windows.UI.Xaml.Controls
 		protected override Size ArrangeOverride(
 			Size finalSize)
 		{
-			Size newFinalSize = default;
 			Rect finalBounds = new Rect(0.0f, 0.0f, finalSize.Width, finalSize.Height);
+
+			// TODO UNO
+			//if (m_outerBorder)
+			//{
+			//	ASSERT(IsRoundedCalendarViewBaseItemChromeEnabled());
+
+			//	IFC_RETURN(m_outerBorder->Arrange(finalBounds));
+			//}
+
+			//if (m_innerBorder)
+			//{
+			//	ASSERT(IsRoundedCalendarViewBaseItemChromeEnabled());
+
+			//	IFC_RETURN(m_innerBorder->Arrange(finalBounds));
+			//}
+
+			//if (m_strikethroughLine)
+			//{
+			//	ASSERT(IsRoundedCalendarViewBaseItemChromeEnabled());
+
+			//	IFC_RETURN(m_strikethroughLine->Arrange(finalBounds));
+			//}
+
 			Thickness borderThickness = GetItemBorderThickness();
 			Thickness padding = Padding;
 
@@ -316,9 +358,7 @@ namespace Windows.UI.Xaml.Controls
 				pChildNoRef.Arrange(finalBounds);
 			}
 
-			newFinalSize = finalSize;
-
-			return newFinalSize;
+			return finalSize;
 		}
 
 		private void CreateTextBlock(
@@ -451,12 +491,9 @@ namespace Windows.UI.Xaml.Controls
 
 		private bool ShouldUseLayoutRounding()
 		{
-			// TODO UNO
-			//// Similar to what Borders do, but we don't care about corner radius (ours is always 0).
-			//var scale = RootScale.GetRasterizationScaleForElement(this);
-			//return (scale != 1.0f) && GetUseLayoutRounding();
-
-			return false;
+			// Similar to what Borders do, but we don't care about corner radius (ours is always 0).
+			var scale = RootScale.GetRasterizationScaleForElement(this);
+			return (scale != 1.0f) && GetUseLayoutRounding();
 		}
 
 #if false

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -594,11 +594,6 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void RegisterContentTemplateRoot();
 
-
-		protected override void OnApplyTemplate()
-		{
-		}
-
 		#region Foreground Dependency Property
 
 		public

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.mux.cs
@@ -148,6 +148,19 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		protected override void OnApplyTemplate()
+		{
+			base.OnApplyTemplate();
+
+			var spFocusVisualWhiteDO = GetTemplateChild("FocusVisualWhite");
+			var spFocusVisualBlackDO = GetTemplateChild("FocusVisualBlack");
+			if (spFocusVisualWhiteDO is Rectangle spFocusVisualWhiteDORect && spFocusVisualBlackDO is Rectangle spFocusVisualBlackDORect)
+			{
+				LayoutRoundRectangleStrokeThickness(spFocusVisualWhiteDORect);
+				LayoutRoundRectangleStrokeThickness(spFocusVisualBlackDORect);
+			}
+		}
+
 		private protected void LayoutRoundRectangleStrokeThickness(Rectangle pRectangle)
 		{
 			bool roundStrokeThickness = false;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -941,14 +941,6 @@ namespace Windows.UI.Xaml.Controls
 
 			base.OnApplyTemplate();
 
-#if __SKIA__
-			// To work around non-uniformly applied layout rounding behavior, we need to force set layout
-			// rounding on the child Grid currently. #12082
-			if (this.FindFirstDescendant<Grid>() is { } grid)
-			{
-				grid.UseLayoutRounding = false;
-			}
-#endif
 
 			var scpTemplatePart = GetTemplateChild(Parts.WinUI3.Scroller) ?? GetTemplateChild(Parts.Uwp.ScrollContentPresenter);
 			_presenter = scpTemplatePart as _ScrollContentPresenter;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -690,7 +690,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private double LayoutRoundIfNeeded(FrameworkElement fe, double value)
 		{
-			return UseLayoutRounding ? fe.LayoutRound(value) : value;
+			return this.GetUseLayoutRounding() ? fe.LayoutRound(value) : value;
 		}
 
 #if __IOS__

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -688,6 +688,11 @@ namespace Windows.UI.Xaml.Controls
 			UpdateZoomedContentAlignment();
 		}
 
+		private double LayoutRoundIfNeeded(FrameworkElement fe, double value)
+		{
+			return UseLayoutRounding ? fe.LayoutRound(value) : value;
+		}
+
 #if __IOS__
 		internal
 #else
@@ -737,7 +742,7 @@ namespace Windows.UI.Xaml.Controls
 						fe.ActualHeight > 0 &&
 						fe.VerticalAlignment == VerticalAlignment.Stretch;
 
-					extentHeight = canUseActualHeightAsExtent ? fe.ActualHeight : fe.DesiredSize.Height;
+					extentHeight = canUseActualHeightAsExtent ? LayoutRoundIfNeeded(fe, fe.ActualHeight) : fe.DesiredSize.Height;
 				}
 
 #if __WASM__
@@ -760,7 +765,7 @@ namespace Windows.UI.Xaml.Controls
 						fe.ActualWidth > 0 &&
 						fe.HorizontalAlignment == HorizontalAlignment.Stretch;
 
-					extentWidth = canUseActualWidthAsExtent ? fe.ActualWidth : fe.DesiredSize.Width;
+					extentWidth = canUseActualWidthAsExtent ? LayoutRoundIfNeeded(fe, fe.ActualWidth) : fe.DesiredSize.Width;
 				}
 
 #if __WASM__

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.crossruntime.cs
@@ -134,10 +134,7 @@ namespace Windows.UI.Xaml
 			//	frameworkAvailableSize = availableSize;
 			//}
 
-
 			var desiredSize = MeasureOverride(frameworkAvailableSize);
-
-
 
 			// We need to round now since we save the values off, and use them to determine
 			// if a layout clip will be applied.
@@ -213,21 +210,23 @@ namespace Windows.UI.Xaml
 
 				// only clip and constrain if the tree wants that.
 				// currently only listviewitems do not want clipping
-				//if (!pLayoutManager->GetIsInNonClippingTree())
-				//{
-				//	// In overconstrained scenario, parent wins and measured size of the child,
-				//	// including any sizes set or computed, can not be larger then
-				//	// available size. We will clip the guy later.
-				//	if (clippedDesiredWidth > availableSize.Width)
-				//	{
-				//		clippedDesiredWidth = availableSize.Width;
-				//	}
+				// UNO TODO
 
-				//	if (clippedDesiredHeight > availableSize.Height)
-				//	{
-				//		clippedDesiredHeight = availableSize.Height;
-				//	}
-				//}
+				//if (!pLayoutManager->GetIsInNonClippingTree())
+				{
+					// In overconstrained scenario, parent wins and measured size of the child,
+					// including any sizes set or computed, can not be larger then
+					// available size. We will clip the guy later.
+					if (clippedDesiredWidth > availableSize.Width)
+					{
+						clippedDesiredWidth = availableSize.Width;
+					}
+
+					if (clippedDesiredHeight > availableSize.Height)
+					{
+						clippedDesiredHeight = availableSize.Height;
+					}
+				}
 
 				//  Note: unclippedDesiredSize is needed in ArrangeCore,
 				//  because due to the layout protocol, arrange should be called

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.crossruntime.cs
@@ -13,6 +13,7 @@ using Uno.UI;
 using static System.Math;
 using static Uno.UI.LayoutHelper;
 using Windows.UI.Xaml.Controls;
+using Uno.UI.Xaml.Core;
 
 namespace Windows.UI.Xaml
 {
@@ -79,53 +80,183 @@ namespace Windows.UI.Xaml
 
 		private void InnerMeasureCore(Size availableSize)
 		{
-			var (minSize, maxSize) = this.GetMinMax();
-			var marginSize = this.GetMarginSize();
+			// Uno TODO
+			//CLayoutManager* pLayoutManager = VisualTree::GetLayoutManagerForElement(this);
+			//bool bInLayoutTransition = pLayoutManager ? pLayoutManager->GetTransitioningElement() == this : false;
 
-			// NaN values are accepted as input here, particularly when coming from
-			// SizeThatFits in Image or Scrollviewer. Clamp the value here as it is reused
-			// below for the clipping value.
-			availableSize = availableSize
-				.NumberOrDefault(MaxSize);
+			Size frameworkAvailableSize = default;
+			double minWidth = 0.0f;
+			double maxWidth = 0.0f;
+			double minHeight = 0.0f;
+			double maxHeight = 0.0f;
 
-			var frameworkAvailableSize = availableSize
-				.Subtract(marginSize)
-				.AtLeastZero()
-				.AtMost(maxSize)
-				.AtLeast(minSize);
+			double clippedDesiredWidth;
+			double clippedDesiredHeight;
+
+			double marginWidth = 0.0f;
+			double marginHeight = 0.0f;
+
+			//bool bTemplateApplied = false;
+
+			//RaiseLoadingEventIfNeeded();
+
+			//if (!bInLayoutTransition)
+			{
+				// Templates should be applied here.
+				//bTemplateApplied = InvokeApplyTemplate();
+
+				// Subtract the margins from the available size
+				var margin = Margin;
+				marginWidth = margin.Left + margin.Right;
+				marginHeight = margin.Top + margin.Bottom;
+
+				// We check to see if availableSize.width and availableSize.height are finite since that will
+				// also protect against NaN getting in.
+				frameworkAvailableSize.Width = double.IsFinite(availableSize.Width) ? Math.Max(availableSize.Width - marginWidth, 0) : double.PositiveInfinity;
+				frameworkAvailableSize.Height = double.IsFinite(availableSize.Height) ? Math.Max(availableSize.Height - marginHeight, 0) : double.PositiveInfinity;
+
+				// Layout transforms would get processed here.
+
+				// Adjust available size by Min/Max Width/Height
+
+				var (minSize, maxSize) = this.GetMinMax();
+				minWidth = minSize.Width;
+				minHeight = minSize.Height;
+				maxWidth = maxSize.Width;
+				maxHeight = maxSize.Height;
+
+				frameworkAvailableSize.Width = Math.Max(minWidth, Math.Min(frameworkAvailableSize.Width, maxWidth));
+				frameworkAvailableSize.Height = Math.Max(minHeight, Math.Min(frameworkAvailableSize.Height, maxHeight));
+			}
+			//else
+			//{
+			//	// when in a transition, just take the passed in constraint without considering the above
+			//	frameworkAvailableSize = availableSize;
+			//}
+
 
 			var desiredSize = MeasureOverride(frameworkAvailableSize);
 
-			_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}.MeasureOverride(availableSize={frameworkAvailableSize}): desiredSize={desiredSize} minSize={minSize} maxSize={maxSize} marginSize={marginSize}");
 
-			if (
-				double.IsNaN(desiredSize.Width)
-				|| double.IsNaN(desiredSize.Height)
-				|| double.IsInfinity(desiredSize.Width)
-				|| double.IsInfinity(desiredSize.Height)
-			)
+
+			// We need to round now since we save the values off, and use them to determine
+			// if a layout clip will be applied.
+			if (GetUseLayoutRounding())
 			{
-				throw new InvalidOperationException($"{FormatDebugName()}: Invalid measured size {desiredSize}. NaN or Infinity are invalid desired size.");
+				desiredSize.Width = LayoutRound(desiredSize.Width);
+				desiredSize.Height = LayoutRound(desiredSize.Height);
+
 			}
 
-			desiredSize = desiredSize
-				.AtLeast(minSize)
-				.AtLeastZero();
+			//if (!bInLayoutTransition)
+			{
+				// Maximize desired size with user provided min size. It's also possible that MeasureOverride returned NaN for either
+				// width or height, in which case we should use the min size as well.
+				desiredSize.Width = Math.Max(desiredSize.Width, minWidth);
+				if (double.IsNaN(desiredSize.Width))
+				{
+					desiredSize.Width = minWidth;
+				}
+				desiredSize.Height = Math.Max(desiredSize.Height, minHeight);
+				if (double.IsNaN(desiredSize.Height))
+				{
+					desiredSize.Height = minHeight;
+				}
 
-			_unclippedDesiredSize = desiredSize;
+				// We need to round now since we save the values off, and use them to determine
+				// if a layout clip will be applied.
 
-			var clippedDesiredSize = desiredSize
-				.AtMost(maxSize)
-				.Add(marginSize)
-				// Making sure after adding margins that clipped DesiredSize is not bigger than the AvailableSize
-				.AtMost(availableSize)
-				// Margin may be negative
-				.AtLeastZero();
+				if (GetUseLayoutRounding())
+				{
+					desiredSize.Width = LayoutRound(desiredSize.Width);
+					desiredSize.Height = LayoutRound(desiredSize.Height);
+				}
+
+				// Here is the "true minimum" desired size - the one that is
+				// for sure enough for the control to render its content.
+				// EnsureLayoutStorage();
+				_unclippedDesiredSize = desiredSize;
+
+				// More layout transforms processing here.
+
+				if (desiredSize.Width > maxWidth)
+				{
+					desiredSize.Width = maxWidth;
+				}
+
+				if (desiredSize.Height > maxHeight)
+				{
+					desiredSize.Height = maxHeight;
+				}
+
+				// Transform desired size to layout slot space (placeholder for when we do layout transforms)
+
+				// Layout round the margins too. This corresponds to the behavior in ArrangeCore, where we check the unclipped desired
+				// size against available space minus the rounded margin. This also prevents a bug where MeasureCore adds the unrounded
+				// margin (e.g. 14) to the desired size (e.g. 55.56) and rounds the final result (69.56 rounded to 69.33 under 2.25x scale),
+				// then ArrangeCore takes that rounded result (i.e. 69.33), subtracts the unrounded margin (i.e. 14) and ends up with a
+				// size smaller than the desired size (69.33 - 14 = 55.33 < 55.56). This ends up putting a layout clip on an element that
+				// doesn't need one, and causes big problems if the element is the scrollable extent of a carousel panel.
+				double roundedMarginWidth = marginWidth;
+				double roundedMarginHeight = marginHeight;
+				if (GetUseLayoutRounding())
+				{
+					roundedMarginWidth = LayoutRound(marginWidth);
+					roundedMarginHeight = LayoutRound(marginHeight);
+				}
+
+				//  Because of negative margins, clipped desired size may be negative.
+				//  Need to keep it as XFLOATS for that reason and maximize with 0 at the
+				//  very last point - before returning desired size to the parent.
+				clippedDesiredWidth = desiredSize.Width + roundedMarginWidth;
+				clippedDesiredHeight = desiredSize.Height + roundedMarginHeight;
+
+				// only clip and constrain if the tree wants that.
+				// currently only listviewitems do not want clipping
+				//if (!pLayoutManager->GetIsInNonClippingTree())
+				//{
+				//	// In overconstrained scenario, parent wins and measured size of the child,
+				//	// including any sizes set or computed, can not be larger then
+				//	// available size. We will clip the guy later.
+				//	if (clippedDesiredWidth > availableSize.Width)
+				//	{
+				//		clippedDesiredWidth = availableSize.Width;
+				//	}
+
+				//	if (clippedDesiredHeight > availableSize.Height)
+				//	{
+				//		clippedDesiredHeight = availableSize.Height;
+				//	}
+				//}
+
+				//  Note: unclippedDesiredSize is needed in ArrangeCore,
+				//  because due to the layout protocol, arrange should be called
+				//  with constraints greater or equal to child's desired size
+				//  returned from MeasureOverride. But in most circumstances
+				//  it is possible to reconstruct original unclipped desired size.
+
+				desiredSize.Width = Math.Max(0, clippedDesiredWidth);
+				desiredSize.Height = Math.Max(0, clippedDesiredHeight);
+			}
+			//else
+			//{
+			//	// in LT, need to take precautions
+			//	desiredSize.Width = Math.Max(desiredSize.Width, 0.0f);
+			//	desiredSize.Height = Math.Max(desiredSize.Height, 0.0f);
+			//}
+
+			// We need to round again in case the desired size has been modified since we originally
+			// rounded it.
+			if (GetUseLayoutRounding())
+			{
+				desiredSize.Width = LayoutRound(desiredSize.Width);
+				desiredSize.Height = LayoutRound(desiredSize.Height);
+			}
 
 			// DesiredSize must include margins
-			LayoutInformation.SetDesiredSize(this, clippedDesiredSize);
+			LayoutInformation.SetDesiredSize(this, desiredSize);
 
-			_logDebug?.Debug($"{DepthIndentation}[{FormatDebugName()}] Measure({Name}/{availableSize}/{Margin}) = {clippedDesiredSize} _unclippedDesiredSize={_unclippedDesiredSize}");
+			_logDebug?.Debug($"{DepthIndentation}[{FormatDebugName()}] Measure({Name}/{availableSize}/{Margin}) = {desiredSize} _unclippedDesiredSize={_unclippedDesiredSize}");
 		}
 
 		private string FormatDebugName()
@@ -165,106 +296,282 @@ namespace Windows.UI.Xaml
 		private void InnerArrangeCore(Rect finalRect)
 		{
 			_logDebug?.Debug($"{DepthIndentation}{FormatDebugName()}: InnerArrangeCore({finalRect})");
+
+			// Uno TODO:
+			//CLayoutManager* pLayoutManager = VisualTree::GetLayoutManagerForElement(this);
+			//bool bInLayoutTransition = pLayoutManager ? pLayoutManager->GetTransitioningElement() == this : false;
+
+			bool needsClipBounds = false;
+
 			var arrangeSize = finalRect.Size;
 
-			var (_, maxSize) = this.GetMinMax();
-			var marginSize = this.GetMarginSize();
+			var margin = Margin;
+			var marginWidth = margin.Left + margin.Right;
+			var marginHeight = margin.Top + margin.Bottom;
 
-			arrangeSize = arrangeSize
-				.Subtract(marginSize)
-				.AtLeastZero();
+			var ha = HorizontalAlignment;
+			var va = VerticalAlignment;
 
-			var needsClipToSlot = false;
+			Size unclippedDesiredSize = default;
+			double minWidth = 0, maxWidth = 0, minHeight = 0, maxHeight = 0;
+			double effectiveMaxWidth = 0, effectiveMaxHeight = 0;
 
-			_logDebug?.Debug($"{DepthIndentation}{FormatDebugName()}: InnerArrangeCore({finalRect}), arrangeSize={arrangeSize}, _unclippedDesiredSize={_unclippedDesiredSize}, forcedClipping={needsClipToSlot}");
+			Size oldRenderSize = default;
+			Size innerInkSize = default;
+			Size clippedInkSize = default;
+			Size clientSize = default;
+			double offsetX = 0, offsetY = 0;
 
-			if (!needsClipToSlot)
+			// Uno TODO:
+			//IFC_RETURN(EnsureLayoutStorage());
+
+			unclippedDesiredSize = _unclippedDesiredSize;
+			oldRenderSize = RenderSize;
+
+			//if (!bInLayoutTransition)
 			{
-				if (IsLessThanAndNotCloseTo(arrangeSize.Width, _unclippedDesiredSize.Width))
+				Size arrangeSizeWithoutMargin = new Size(
+					Math.Max(arrangeSize.Width - marginWidth, 0),
+					Math.Max(arrangeSize.Height - marginHeight, 0)
+				);
+
+				var roundedMarginWidth = marginWidth;
+				var roundedMarginHeight = marginHeight;
+
+				if (GetUseLayoutRounding())
 				{
-					_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}: (arrangeSize.Width) {arrangeSize.Width} < {_unclippedDesiredSize.Width}: NEEDS CLIPPING.");
-					needsClipToSlot = true;
-					arrangeSize.Width = _unclippedDesiredSize.Width;
+					roundedMarginWidth = LayoutRound(marginWidth);
+					roundedMarginHeight = LayoutRound(marginHeight);
 				}
 
-				if (IsLessThanAndNotCloseTo(arrangeSize.Height, _unclippedDesiredSize.Height))
+				// We handle layout rounding inconsistently across our code, this change is restricted to using layout
+				// rounding for margin only on certain scenarios to avoid introducing unexpected problems.
+				// If further rounding issues appear we should consider opening this behaviour to more scenarios.
+				if (roundedMarginWidth != marginWidth && arrangeSizeWithoutMargin.Width != unclippedDesiredSize.Width)
 				{
-					_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}: (arrangeSize.Height) {arrangeSize.Height} < {_unclippedDesiredSize.Height}: NEEDS CLIPPING.");
-					needsClipToSlot = true;
-					arrangeSize.Height = _unclippedDesiredSize.Height;
+					double arrangeWidthWithoutRoundedMargin = Math.Max(arrangeSize.Width - roundedMarginWidth, 0);
+					if (arrangeWidthWithoutRoundedMargin == unclippedDesiredSize.Width)
+					{
+						// The rounding difference between arrangeSizeWithoutMargin.width and unclippedDesiredSize.width
+						// comes from the horizontal margin. The rounded value of that margin must be used so that this
+						// FrameworkElement's ActualWidth does not return an incorrect value.
+						marginWidth = roundedMarginWidth;
+						arrangeSize.Width = arrangeWidthWithoutRoundedMargin;
+					}
+					else
+					{
+						arrangeSize.Width = arrangeSizeWithoutMargin.Width;
+					}
+				}
+				else
+				{
+					arrangeSize.Width = arrangeSizeWithoutMargin.Width;
+				}
+
+				if (roundedMarginHeight != marginHeight && arrangeSizeWithoutMargin.Height != unclippedDesiredSize.Height)
+				{
+					double arrangeHeightWithoutRoundedMargin = Math.Max(arrangeSize.Height - roundedMarginHeight, 0);
+					if (arrangeHeightWithoutRoundedMargin == unclippedDesiredSize.Height)
+					{
+						// The rounding difference between arrangeSizeWithoutMargin.height and unclippedDesiredSize.height
+						// comes from the vertical margin. The rounded value of that margin must be used so that this
+						// FrameworkElement's ActualHeight does not return an incorrect value.
+						marginHeight = roundedMarginHeight;
+						arrangeSize.Height = arrangeHeightWithoutRoundedMargin;
+					}
+					else
+					{
+						arrangeSize.Height = arrangeSizeWithoutMargin.Height;
+					}
+				}
+				else
+				{
+					arrangeSize.Height = arrangeSizeWithoutMargin.Height;
+				}
+
+				if (IsLessThanAndNotCloseTo(arrangeSize.Width, unclippedDesiredSize.Width))
+				{
+					needsClipBounds = true;
+					arrangeSize.Width = unclippedDesiredSize.Width;
+				}
+
+				if (IsLessThanAndNotCloseTo(arrangeSize.Height, unclippedDesiredSize.Height))
+				{
+					needsClipBounds = true;
+					arrangeSize.Height = unclippedDesiredSize.Height;
+				}
+
+				// Alignment==Stretch --> arrange at the slot size minus margins
+				// Alignment!=Stretch --> arrange at the unclippedDesiredSize
+				if (ha != HorizontalAlignment.Stretch)
+				{
+					arrangeSize.Width = unclippedDesiredSize.Width;
+				}
+
+				if (va != VerticalAlignment.Stretch)
+				{
+					arrangeSize.Height = unclippedDesiredSize.Height;
+				}
+
+				var (minSize, maxSize) = this.GetMinMax();
+				minWidth = minSize.Width;
+				maxWidth = maxSize.Width;
+				minHeight = minSize.Height;
+				maxHeight = maxSize.Height;
+
+				// Layout transforms processed here
+
+				// We have to choose max between UnclippedDesiredSize and Max here, because
+				// otherwise setting of max property could cause arrange at less then unclippedDS.
+				// Clipping by Max is needed to limit stretch here
+
+				effectiveMaxWidth = Math.Max(unclippedDesiredSize.Width, maxWidth);
+				if (IsLessThanAndNotCloseTo(effectiveMaxWidth, arrangeSize.Width))
+				{
+					needsClipBounds = true;
+					arrangeSize.Width = effectiveMaxWidth;
+				}
+
+				effectiveMaxHeight = Math.Max(unclippedDesiredSize.Height, maxHeight);
+				if (IsLessThanAndNotCloseTo(effectiveMaxHeight, arrangeSize.Height))
+				{
+					needsClipBounds = true;
+					arrangeSize.Height = effectiveMaxHeight;
 				}
 			}
 
-			if (HorizontalAlignment != HorizontalAlignment.Stretch)
+			innerInkSize = ArrangeOverride(arrangeSize);
+
+			// Here we use un-clipped InkSize because element does not know that it is
+			// clipped by layout system and it shoudl have as much space to render as
+			// it returned from its own ArrangeOverride
+			// Inner ink size is not guaranteed to be rounded, but should be.
+			// TODO: inner ink size currently only rounded if plateau > 1 to minimize impact in RC,
+			// but should be consistently rounded in all plateaus.
+			var scale = RootScale.GetRasterizationScaleForElement(this);
+			if ((scale != 1.0f) && GetUseLayoutRounding())
 			{
-				arrangeSize.Width = _unclippedDesiredSize.Width;
+				innerInkSize.Width = LayoutRound(innerInkSize.Width);
+				innerInkSize.Height = LayoutRound(innerInkSize.Height);
 			}
-
-			if (VerticalAlignment != VerticalAlignment.Stretch)
-			{
-				arrangeSize.Height = _unclippedDesiredSize.Height;
-			}
-
-			// We have to choose max between _unclippedDesiredSize and maxSize here, because
-			// otherwise setting of max property could cause arrange at less then _unclippedDesiredSize.
-			// Clipping by Max is needed to limit stretch here
-			var effectiveMaxSize = Max(_unclippedDesiredSize, maxSize);
-
-			_logDebug?.Debug($"{DepthIndentation}{FormatDebugName()}: InnerArrangeCore({finalRect}) - effectiveMaxSize={effectiveMaxSize}, maxSize={maxSize}, _unclippedDesiredSize={_unclippedDesiredSize}, forcedClipping={needsClipToSlot}");
-
-			if (IsLessThanAndNotCloseTo(effectiveMaxSize.Width, arrangeSize.Width))
-			{
-				_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}: (effectiveMaxSize.Width) {effectiveMaxSize.Width} < {arrangeSize.Width}: NEEDS CLIPPING.");
-				needsClipToSlot = true;
-				arrangeSize.Width = effectiveMaxSize.Width;
-			}
-			if (IsLessThanAndNotCloseTo(effectiveMaxSize.Height, arrangeSize.Height))
-			{
-				_logDebug?.Trace($"{DepthIndentation}{FormatDebugName()}: (effectiveMaxSize.Height) {effectiveMaxSize.Height} < {arrangeSize.Height}: NEEDS CLIPPING.");
-				needsClipToSlot = true;
-				arrangeSize.Height = effectiveMaxSize.Height;
-			}
-
-			var oldRenderSize = RenderSize;
-			var innerInkSize = ArrangeOverride(arrangeSize);
-
-			var clippedInkSize = innerInkSize.AtMost(maxSize);
-
 			RenderSize = innerInkSize;
 
-			_logDebug?.Debug($"{DepthIndentation}{FormatDebugName()}: ArrangeOverride({arrangeSize})={innerInkSize}, clipped={clippedInkSize} (max={maxSize}) needsClipToSlot={needsClipToSlot}");
+			//if (!IsSameSize(oldRenderSize, innerInkSize))
+			//{
+			//	OnActualSizeChanged();
+			//}
 
-			var clientSize = finalRect.Size
-				.Subtract(marginSize)
-				.AtLeastZero();
+			//if (!IsSameSize(oldRenderSize, innerInkSize))
+			//{
+			//	VisualTree.GetLayoutManagerForElement(this).EnqueueForSizeChanged(this, oldRenderSize);
+			//}
 
-			// Give opportunity to element to alter arranged size
-			clippedInkSize = AdjustArrange(clippedInkSize);
-
-			if (IsLessThanAndNotCloseTo(clippedInkSize.Width, innerInkSize.Width) ||
-				IsLessThanAndNotCloseTo(clippedInkSize.Height, innerInkSize.Height))
+			//if (!bInLayoutTransition)
 			{
-				needsClipToSlot = true;
+				// ClippedInkSize differs from InkSize only what MaxWidth/Height explicitly clip the
+				// otherwise good arrangement. For ex, DS<clientSize but DS>MaxWidth - in this
+				// case we should initiate clip at MaxWidth and only show Top-Left portion
+				// of the element limited by Max properties. It is Top-left because in case when we
+				// are clipped by container we also degrade to Top-Left, so we are consistent.
+				clippedInkSize.Width = Math.Min(innerInkSize.Width, maxWidth);
+				clippedInkSize.Height = Math.Min(innerInkSize.Height, maxHeight);
+
+				// remember we have to clip if Max properties limit the inkSize
+				needsClipBounds |=
+					IsLessThanAndNotCloseTo(clippedInkSize.Width, innerInkSize.Width)
+					|| IsLessThanAndNotCloseTo(clippedInkSize.Height, innerInkSize.Height);
+
+				// Transform stuff here
+
+				// Note that inkSize now can be bigger then layoutSlotSize-margin (because of layout
+				// squeeze by the parent or LayoutConstrained=true, which clips desired size in Measure).
+
+				// The client size is the size of layout slot decreased by margins.
+				// This is the "window" through which we see the content of the child.
+				// Alignments position ink of the child in this "window".
+				// Max with 0 is necessary because layout slot may be smaller then unclipped desired size.
+				clientSize.Width = Math.Max(0, finalRect.Width - marginWidth);
+				clientSize.Height = Math.Max(0, finalRect.Height - marginHeight);
+
+				// Remember we have to clip if clientSize limits the inkSize
+				needsClipBounds |=
+					IsLessThanAndNotCloseTo(clientSize.Width, clippedInkSize.Width)
+					|| IsLessThanAndNotCloseTo(clientSize.Height, clippedInkSize.Height);
+
+				//bool isAlignedByDirectManipulation = IsAlignedByDirectManipulation();
+
+				//if (isAlignedByDirectManipulation)
+				//{
+				//	// Skip the layout engine's contribution to the element's offsets when it is already aligned by DirectManipulation.
+
+				//	if (m_pLayoutProperties.m_horizontalAlignment == HorizontalAlignment.Stretch)
+				//	{
+				//		// Check if the Stretch alignment needs to be overridden with a Left alignment.
+				//		// The "IsStretchHorizontalAlignmentTreatedAsLeft" case corresponds to CFrameworkElement::ComputeAlignmentOffset's "degenerate Stretch to Top-Left" branch.
+				//		// The "IsFinalArrangeSizeMaximized()" case is for text controls CTextBlock, CRichTextBlock and CRichTextBlockOverflow which stretch their desired width to the finalSize argument in their ArrangeOverride method.
+				//		// The "(clippedInkSize.width == clientSize.width && unclippedDesiredSize.width < clientSize.width)" case is for 3rd party controls that stretch their desired width to the final arrange width too.
+				//		bool isStretchAlignmentTreatedAsNear_New =
+				//			IsStretchHorizontalAlignmentTreatedAsLeft(HorizontalAlignment.Stretch, clientSize, clippedInkSize) ||
+				//			(clippedInkSize.Width == clientSize.Width && unclippedDesiredSize.Width < clientSize.Width) ||
+				//			IsFinalArrangeSizeMaximized();
+
+				//		// Check if the overriding needs are changing by accessing the current status from the owning ScrollViewer control.
+				//		bool isStretchAlignmentTreatedAsNear_Old = IsStretchAlignmentTreatedAsNear(true /*isForHorizontalAlignment*/);
+				//		if (isStretchAlignmentTreatedAsNear_New != isStretchAlignmentTreatedAsNear_Old)
+				//		{
+				//			// The overriding needs are changing - push the new status to the owning ScrollViewer control.
+				//			OnAlignmentChanged(true /*fIsForHorizontalAlignment*/, true/*fIsForStretchAlignment*/, isStretchAlignmentTreatedAsNear_New);
+				//		}
+				//	}
+
+				//	if (m_pLayoutProperties.m_verticalAlignment == VerticalAlignment.Stretch)
+				//	{
+				//		// Check if the Stretch alignment needs to be overridden with a Top alignment.
+				//		// The "IsStretchVerticalAlignmentTreatedAsTop" case corresponds to CFrameworkElement::ComputeAlignmentOffset's "degenerate Stretch to Top-Left" branch.
+				//		// The "IsFinalArrangeSizeMaximized()" case is for text controls CTextBlock, CRichTextBlock and CRichTextBlockOverflow which stretch their desired height to the finalSize argument in their ArrangeOverride method.
+				//		// The "(clippedInkSize.height == clientSize.height && unclippedDesiredSize.height < clientSize.height)" case is for 3rd party controls that stretch their desired height to the final arrange height too.
+				//		bool isStretchAlignmentTreatedAsNear_New =
+				//			IsStretchVerticalAlignmentTreatedAsTop(VerticalAlignment.Stretch, clientSize, clippedInkSize) ||
+				//			(clippedInkSize.Height == clientSize.Height && unclippedDesiredSize.Height < clientSize.Height) ||
+				//			IsFinalArrangeSizeMaximized();
+
+				//		// Check if the overriding needs are changing by accessing the current status from the owning ScrollViewer control.
+				//		bool isStretchAlignmentTreatedAsNear_Old = IsStretchAlignmentTreatedAsNear(false /*isForHorizontalAlignment*/);
+				//		if (isStretchAlignmentTreatedAsNear_New != isStretchAlignmentTreatedAsNear_Old)
+				//		{
+				//			// The overriding needs are changing - push the new status to the owning ScrollViewer control.
+				//			OnAlignmentChanged(false /*fIsForHorizontalAlignment*/, true /*fIsForStretchAlignment*/, isStretchAlignmentTreatedAsNear_New);
+				//		}
+				//	}
+				//}
+				//else
+				{
+					var offset = this.GetAlignmentOffset(clientSize, clippedInkSize);
+					offsetX = offset.X;
+					offsetY = offset.Y;
+				}
+
+				//oldOffset = VisualOffset;
+
+				//VisualOffset.x = offsetX + finalRect.X + m_pLayoutProperties->m_margin.left;
+				//VisualOffset.y = offsetY + finalRect.Y + m_pLayoutProperties->m_margin.top;
+
+				offsetX = offsetX + finalRect.X + margin.Left;
+				offsetY = offsetY + finalRect.Y + margin.Top;
+
+				if (GetUseLayoutRounding())
+				{
+					offsetX = LayoutRound(offsetX);
+					offsetY = LayoutRound(offsetY);
+				}
 			}
+			//else
+			//{
+			//	offsetX = finalRect.X;
+			//	offsetY = finalRect.Y;
+			//}
 
-			if (IsLessThanAndNotCloseTo(clientSize.Width, clippedInkSize.Width) ||
-				IsLessThanAndNotCloseTo(clientSize.Height, clippedInkSize.Height))
-			{
-				needsClipToSlot = true;
-			}
-
-			var offset = this.GetAlignmentOffset(clientSize, clippedInkSize);
-			var margin = Margin;
-
-			offset = new Point(
-				offset.X + finalRect.X + margin.Left,
-				offset.Y + finalRect.Y + margin.Top
-			);
-
-			_logDebug?.Debug(
-				$"{DepthIndentation}[{FormatDebugName()}] ArrangeChild(offset={offset}, margin={margin}) [oldRenderSize={oldRenderSize}] [RenderSize={RenderSize}] [clippedInkSize={clippedInkSize}] [RequiresClipping={needsClipToSlot}]");
-
-			NeedsClipToSlot = needsClipToSlot;
+			NeedsClipToSlot = needsClipBounds;
 
 #if __WASM__
 			if (FeatureConfiguration.UIElement.AssignDOMXamlProperties)
@@ -273,14 +580,14 @@ namespace Windows.UI.Xaml
 			}
 #endif
 
-			var clippedFrame = GetClipRect(needsClipToSlot, finalRect, maxSize, margin);
+			var clippedFrame = GetClipRect(needsClipBounds, finalRect, new Size(maxWidth, maxHeight), margin);
 			if (clippedFrame is null)
 			{
-				ArrangeNative(offset, false);
+				ArrangeNative(new Point(offsetX, offsetY), false);
 			}
 			else
 			{
-				ArrangeNative(offset, true, clippedFrame.Value);
+				ArrangeNative(new Point(offsetX, offsetY), true, clippedFrame.Value);
 			}
 
 			OnLayoutUpdated();
@@ -291,43 +598,116 @@ namespace Windows.UI.Xaml
 		{
 			if (needsClipToSlot)
 			{
-				Rect clippedFrame = default;
+				Rect clipRect = default;
+
+				// TODO: Clip rect currently only rounded in plateau > 1 to minimize impact, but should be consistently rounded in all plateaus.
+				var scale = RootScale.GetRasterizationScaleForElement(this);
+				var roundClipRect = (scale != 1.0f) && GetUseLayoutRounding();
+
+				var maxWidth = maxSize.Width;
+				var maxHeight = maxSize.Height;
+
+				// this is in element's local rendering coord system
 				var inkSize = RenderSize;
+				var layoutSlotSize = finalRect.Size;
 
-				var maxClip = maxSize.FiniteOrDefault(inkSize);
+				var maxWidthClip = maxSize.Width.FiniteOrDefault(inkSize.Width);
+				var maxHeightClip = maxSize.Height.FiniteOrDefault(inkSize.Height);
 
-				//need to clip because the computed sizes exceed MaxWidth/MaxHeight/Width/Height
-				bool needToClipLocally = IsLessThanAndNotCloseTo(maxClip.Width, inkSize.Width) || IsLessThanAndNotCloseTo(maxClip.Height, inkSize.Height);
+				bool needToClipLocally;
 
-				inkSize = inkSize.AtMost(maxSize);
+				Size clippingSize = default;
 
-				var marginSize = new Size(margin.Left + margin.Right, margin.Top + margin.Bottom);
-				Size clippingSize = finalRect.Size.Subtract(marginSize).AtLeastZero();
-				bool needToClipSlot = IsLessThanAndNotCloseTo(clippingSize.Width, inkSize.Width) || IsLessThanAndNotCloseTo(clippingSize.Height, inkSize.Height);
+				// EnsureLayoutStorage();
+
+				// If clipping is forced, ensure the clip is at least as small as the RenderSize.
+				//if (forceClipToRenderSize)
+				//{
+				//	maxWidthClip = MIN(inkSize.width, maxWidthClip);
+				//	maxHeightClip = MIN(inkSize.height, maxHeightClip);
+				//	needToClipLocally = TRUE;
+				//}
+				//else
+				{
+					// need to clip if the computed sizes exceed MaxWidth/MaxHeight/Width/Height
+					needToClipLocally = IsLessThanAndNotCloseTo(maxWidthClip, inkSize.Width)
+									 || IsLessThanAndNotCloseTo(maxHeightClip, inkSize.Height);
+				}
+
+				// now lets say we already clipped by MaxWidth/MaxHeight, lets see if further clipping is needed
+				inkSize.Width = Math.Min(inkSize.Width, maxWidth);
+				inkSize.Height = Math.Min(inkSize.Height, maxHeight);
+
+				// now lets say we already clipped by MaxWidth/MaxHeight, lets see if further clipping is needed
+				inkSize.Width = Math.Min(inkSize.Width, maxWidth);
+				inkSize.Height = Math.Min(inkSize.Height, maxHeight);
+
+				//now see if layout slot should clip the element
+				var marginWidth = margin.Left + margin.Right;
+				var marginHeight = margin.Top + margin.Bottom;
+
+				clippingSize.Width = Math.Max(0, layoutSlotSize.Width - marginWidth);
+				clippingSize.Height = Math.Max(0, layoutSlotSize.Height - marginHeight);
+
+				// With layout rounding, MinMax and RenderSize are rounded. Clip size should be rounded as well.
+				if (roundClipRect)
+				{
+					clippingSize.Width = LayoutRound(clippingSize.Width);
+					clippingSize.Height = LayoutRound(clippingSize.Height);
+				}
+
+				bool needToClipSlot = IsLessThanAndNotCloseTo(clippingSize.Width, inkSize.Width)
+					|| IsLessThanAndNotCloseTo(clippingSize.Height, inkSize.Height);
+
 
 				if (needToClipSlot)
 				{
+					// The layout clip is created from the slot size determined in the parent's coordinate space,
+					// but is set on the child, meaning it's affected by the child's transform/offset and is applied in
+					// the child's coordinate space.  The inverse of the offset is applied to the clip to prevent the clip's
+					// position from shifting as a result of the change in coordinates.
 					var offset = LayoutHelper.GetAlignmentOffset(this, clippingSize, inkSize);
-					clippedFrame = new Rect(-offset.X, -offset.Y, clippingSize.Width, clippingSize.Height);
+					var offsetX = offset.X;
+					var offsetY = offset.Y;
+					if (roundClipRect)
+					{
+						offsetX = LayoutRound(offsetX);
+						offsetY = LayoutRound(offsetY);
+					}
+
+					clipRect = new Rect(-offsetX, -offsetY, clippingSize.Width, clippingSize.Height);
 					if (needToClipLocally)
 					{
-						clippedFrame = clippedFrame.IntersectWith(new Rect(default, maxClip)) ?? Rect.Empty;
+						clipRect = clipRect.IntersectWith(new Rect(0, 0, maxWidthClip, maxHeightClip)) ?? Rect.Empty;
 					}
 				}
 				else if (needToClipLocally)
 				{
-					clippedFrame = new Rect(default, maxClip);
+					// In this case clipRect starts at 0, 0 and max width/height clips are rounded due
+					// to RenderSize and MinMax being rounded. So clipRect is already rounded.
+					clipRect.Width = maxWidthClip;
+					clipRect.Height = maxHeightClip;
 				}
+
+				// if we have difference between child and parent FlowDirection
+				// then we have to change origin of Clipping rectangle
+				// which allows us to visually keep it at the same place
+				// UNO TODO
+				//pParent = GetUIElementAdjustedParentInternal(FALSE /*fPublicParentsOnly*/);
+				//if (pParent && pParent->IsRightToLeft() != IsRightToLeft())
+				//{
+				//	clipRect.X = RenderSize.width - (clipRect.X + clipRect.Width);
+				//}
 
 				if (needToClipSlot || needToClipLocally)
 				{
 					if (this is Panel && RenderTransform is { } renderTransform)
 					{
-						clippedFrame.X -= renderTransform.MatrixCore.M31;
-						clippedFrame.Y -= renderTransform.MatrixCore.M32;
+						clipRect.X -= renderTransform.MatrixCore.M31;
+						clipRect.Y -= renderTransform.MatrixCore.M32;
 					}
 
-					return clippedFrame;
+					return clipRect;
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
@@ -362,6 +362,14 @@ namespace Windows.UI.Xaml
 				return; // Nothing do to
 			}
 
+			if (GetUseLayoutRounding())
+			{
+				finalRect.X = LayoutRound(finalRect.X);
+				finalRect.Y = LayoutRound(finalRect.Y);
+				finalRect.Width = LayoutRound(finalRect.Width);
+				finalRect.Height = LayoutRound(finalRect.Height);
+			}
+
 			var remainingTries = MaxLayoutIterations;
 
 			while (--remainingTries > 0)

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -1182,7 +1182,7 @@ namespace Windows.UI.Xaml
 #endif
 		}
 
-		private double LayoutRound(double value, double scaleFactor)
+		private static double LayoutRound(double value, double scaleFactor)
 		{
 			double returnValue = value;
 
@@ -1213,7 +1213,7 @@ namespace Windows.UI.Xaml
 			return global::Windows.Graphics.Display.DisplayInformation.GetForCurrentView().LogicalDpi / DisplayInformation.BaseDpi; // 100%
 		}
 
-		double XcpRound(double x)
+		private static double XcpRound(double x)
 		{
 			return Math.Round(x);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): So far, Skia only part of #12082

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 409ac22</samp>

This pull request implements and refactors the layout rounding feature for Uno, which improves the visual quality of UI elements by aligning them to pixel boundaries. It adds and modifies code in the `LayoutHelper`, `UIElement`, `Border`, `CalendarViewBaseItem`, and `TextBlock` classes, and updates the corresponding files. It also improves the code formatting and removes some unused or redundant methods.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
