### PR TITLE
chore: Remove unused field `_visualOffset` in FrameworkElement

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -1104,16 +1104,6 @@ namespace Windows.UI.Xaml.Controls
 			return $"Parent ItemsControl={ItemsControl} ItemsSource={ItemsControl?.ItemsSource} NoOfItems={ItemsControl?.NumberOfItems} FirstMaterialized={GetFirstMaterializedIndexPath()} LastMaterialized={GetLastMaterializedIndexPath()} ExtendedViewportStart={ExtendedViewportStart} ExtendedViewportEnd={ExtendedViewportEnd} GetItemsStart()={GetItemsStart()} GetItemsEnd()={GetItemsEnd()}";
 		}
 
-#if __WASM__ || __SKIA__
-		private static Point GetRelativePosition(FrameworkElement child) => child.RelativePosition;
-#elif __NETSTD_REFERENCE__
-		private static Point GetRelativePosition(FrameworkElement child) => throw new NotSupportedException();
-#elif __MACOS__ || __IOS__
-		private static Point GetRelativePosition(FrameworkElement child) => child.Frame.Location;
-#elif __ANDROID__
-		private static Point GetRelativePosition(FrameworkElement child) => new Point(ViewHelper.PhysicalToLogicalPixels(child.Left), ViewHelper.PhysicalToLogicalPixels(child.Top));
-#endif
-
 		private (double offset, double extent, object item, Uno.UI.IndexPath? index)? _pendingReorder;
 		internal void UpdateReorderingItem(Point location, FrameworkElement element, object item)
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.crossruntime.cs
@@ -24,15 +24,9 @@ namespace Windows.UI.Xaml
 		/// DesiredSize from MeasureOverride, after clamping to min size but before being clipped by max size (from GetMinMax())
 		/// </summary>
 		private Size _unclippedDesiredSize;
-		private Point _visualOffset;
 
 		private const double SIZE_EPSILON = 0.05d;
 		private readonly Size MaxSize = new Size(double.PositiveInfinity, double.PositiveInfinity);
-
-		/// <summary>
-		/// The origin of the view's bounds relative to its parent.
-		/// </summary>
-		internal Point RelativePosition => _visualOffset;
 
 		private protected string DepthIndentation
 		{
@@ -348,8 +342,6 @@ namespace Windows.UI.Xaml
 		/// <param name="clippedFrame">Zone to clip, if clipping is required</param>
 		private void ArrangeNative(Point offset, bool needsClipToSlot, Rect clippedFrame = default)
 		{
-			_visualOffset = offset;
-
 			var newRect = new Rect(offset, RenderSize);
 
 			if (


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08b7d3f</samp>

This pull request refactors the layout logic of `FrameworkElement` and `VirtualizingPanelLayout` by removing platform-specific and redundant code. The change improves the cross-runtime compatibility and performance of the UI framework.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
