### PR TITLE
fix: Empty `TextBlock` should have non-zero height

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3834,6 +3834,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_AnimateHeader.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PasteEvent.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7568,6 +7572,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Simple.xaml.cs">
       <DependentUpon>TextBox_Simple.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_AnimateHeader.xaml.cs">
+      <DependentUpon>TextBox_AnimateHeader.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\FromEmptyStringToValueConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_PasteEvent.xaml.cs">
       <DependentUpon>TextBox_PasteEvent.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/FromEmptyStringToValueConverter.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/FromEmptyStringToValueConverter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#if WinUI
+using Microsoft.UI.Xaml.Data;
+#else
+using Windows.UI.Xaml.Data;
+#endif
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+	public class FromEmptyStringToValueConverter : IValueConverter
+	{
+		public object NullOrEmptyValue { get; set; }
+
+		public object NotNullOrEmptyValue { get; set; }
+
+		public object Convert(object value, Type targetType, object parameter, string language)
+		{
+			if (!(value is string str) || string.IsNullOrEmpty(str))
+			{
+				return NullOrEmptyValue;
+			}
+
+			return NotNullOrEmptyValue;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, string language)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_AnimateHeader.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_AnimateHeader.xaml
@@ -1,0 +1,188 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_AnimateHeader"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Page.Resources>
+		<local:FromEmptyStringToValueConverter x:Key="MaterialEmptyToFalse"
+        NotNullOrEmptyValue="True"
+        NullOrEmptyValue="False" />
+		<local:FromEmptyStringToValueConverter x:Key="MaterialEmptyToTrue"
+        NotNullOrEmptyValue="False"
+        NullOrEmptyValue="True" />
+		<CubicEase x:Key="MaterialEaseInOutFunction"
+        EasingMode="EaseInOut" />
+		<Duration x:Key="MaterialTextBoxAnimationDuration">0:0:0.25</Duration>
+		<Duration x:Key="MaterialAnimationDuration">0:0:0.25</Duration>
+		<Style x:Key="MaterialOutlinedTextBoxStyle"
+      TargetType="TextBox">
+			<Setter Property="Background" Value="Transparent" />
+			<Setter Property="Foreground" Value="Black" />
+			<Setter Property="PlaceholderForeground" Value="Blue" />
+			<Setter Property="BorderBrush" Value="Black" />
+			<Setter Property="BorderThickness" Value="1" />
+			<Setter Property="CornerRadius" Value="2" />
+			<Setter Property="HorizontalContentAlignment" Value="Left" />
+			<Setter Property="VerticalContentAlignment" Value="Center" />
+
+			<Setter Property="Padding" Value="8" />
+
+			<Setter Property="MinHeight" Value="56" />
+
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="TextBox">
+						<Border x:Name="RootBorder"
+             BorderBrush="{TemplateBinding BorderBrush}"
+             BorderThickness="{TemplateBinding BorderThickness}"
+             CornerRadius="{TemplateBinding CornerRadius}"
+             Padding="1">
+
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver">
+										<!-- <VisualState.Setters>
+                   <Setter Target="RootBorder.BorderBrush" Value="{ThemeResource OutlinedTextBoxBorderBrushPointerOver}" />
+                   <Setter Target="ContentElement.Foreground" Value="{ThemeResource OutlinedTextBoxForegroundPointerOver}" />
+                   <Setter Target="PlaceholderElement.Foreground" Value="{ThemeResource OutlinedTextBoxPlaceholderForegroundPointerOver}" />
+                 </VisualState.Setters> -->
+									</VisualState>
+									<VisualState x:Name="Pressed" />
+
+									<VisualState x:Name="Disabled">
+									</VisualState>
+
+									<VisualState x:Name="Focused">
+
+									</VisualState>
+								</VisualStateGroup>
+								<VisualStateGroup x:Name="ButtonStates">
+									<VisualState x:Name="ButtonVisible">
+										<VisualState.Setters>
+											<Setter Target="DeleteButton.Visibility" Value="Visible" />
+										</VisualState.Setters>
+									</VisualState>
+									<VisualState x:Name="ButtonCollapsed" />
+								</VisualStateGroup>
+								<VisualStateGroup x:Name="HeaderStates">
+									<VisualState x:Name="NotEmpty">
+										<Storyboard>
+											<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
+                            Storyboard.TargetProperty="TranslateY"
+                            Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+                            EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+                            To="-11" />
+											<!-- ContentElement TranslateY value changing depending if there is a PlaceholderText or not -->
+											<DoubleAnimation Storyboard.TargetName="ContentElement_CompositeTransform"
+                            Storyboard.TargetProperty="TranslateY"
+                            Duration="{StaticResource MaterialAnimationDuration}"
+                            EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+                            To="8" />
+											<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
+                            Storyboard.TargetProperty="ScaleX"
+                            Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+                            EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+                            To="0.7" />
+											<DoubleAnimation Storyboard.TargetName="PlaceholderElement_CompositeTransform"
+                            Storyboard.TargetProperty="ScaleY"
+                            Duration="{StaticResource MaterialTextBoxAnimationDuration}"
+                            EasingFunction="{StaticResource MaterialEaseInOutFunction}"
+                            To="0.7" />
+										</Storyboard>
+										<VisualState.StateTriggers>
+											<StateTrigger IsActive="{Binding Text, Converter={StaticResource MaterialEmptyToFalse}, RelativeSource={RelativeSource TemplatedParent}}" />
+										</VisualState.StateTriggers>
+									</VisualState>
+									<VisualState x:Name="Empty">
+										<VisualState.StateTriggers>
+											<StateTrigger IsActive="{Binding Text, Converter={StaticResource MaterialEmptyToTrue}, RelativeSource={RelativeSource TemplatedParent}}" />
+										</VisualState.StateTriggers>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+
+							<Grid x:Name="Root"
+               Background="{TemplateBinding Background}"
+               Padding="{TemplateBinding Padding}">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="*" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+
+								<!-- Border in place to properly vertically center the icon inside when it's a one-line TextBox -->
+								<!-- but keep it in the same place and at the top when it's a multiline TextBox -->
+								<Border Height="20"
+                 VerticalAlignment="Top">
+									<ContentPresenter x:Name="IconPresenter"                         
+                         HorizontalAlignment="Center"
+                         Width="20"
+                         Margin="1,0,18,0"
+                         Foreground="Black"
+                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                         Visibility="Collapsed" />
+								</Border>
+
+								<ScrollViewer x:Name="ContentElement"
+                     Grid.Column="1"
+                     HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                     HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                     IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                     IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                     IsTabStop="False"
+                     IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                     VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                     VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                     ZoomMode="Disabled"
+                     AutomationProperties.AccessibilityView="Raw">
+									<ScrollViewer.RenderTransform>
+										<CompositeTransform x:Name="ContentElement_CompositeTransform" />
+									</ScrollViewer.RenderTransform>
+								</ScrollViewer>
+
+								<!-- Border in place to properly vertically center the placeholder inside when it's a one-line TextBox -->
+								<!-- but keep it in the same place and at the top when it's a multiline TextBox -->
+								<Border Grid.Column="1"
+                 Height="20"
+                 VerticalAlignment="Top">
+									<TextBlock x:Name="PlaceholderElement"
+                      Foreground="{Binding PlaceholderForeground, RelativeSource={RelativeSource TemplatedParent}}"
+                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                      IsHitTestVisible="False"
+                      RenderTransformOrigin="0,0.5"
+                      Text="{TemplateBinding PlaceholderText}"
+                      TextAlignment="{TemplateBinding TextAlignment}"
+                      TextWrapping="{TemplateBinding TextWrapping}"
+                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+										<TextBlock.RenderTransform>
+											<CompositeTransform x:Name="PlaceholderElement_CompositeTransform" />
+										</TextBlock.RenderTransform>
+									</TextBlock>
+								</Border>
+
+								<Button x:Name="DeleteButton"
+                 Grid.Column="2"
+                 Margin="8,0,0,0"
+                 IsTabStop="False"
+                 VerticalAlignment="Stretch"
+                 Visibility="Collapsed"
+                 AutomationProperties.AccessibilityView="Raw" />
+							</Grid>
+						</Border>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+	</Page.Resources>
+	<StackPanel>
+		<TextBox Style="{StaticResource MaterialOutlinedTextBoxStyle}" PlaceholderText="Test me" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_AnimateHeader.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_AnimateHeader.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+	[Sample(Description = "This simulates the Material UI TextBox Header animation", IsManualTest = true, IgnoreInSnapshotTests = true)]
+	public sealed partial class TextBox_AnimateHeader : Page
+	{
+		public TextBox_AnimateHeader()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -276,7 +276,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForLoaded(container);
 			await WindowHelper.WaitFor(() => SUT.DesiredSize != default);
 
+#if !__WASM__ // Disabled due to #14231
 			Assert.AreEqual(0, SUT.DesiredSize.Width);
+#endif
 			Assert.IsTrue(SUT.DesiredSize.Height > 0);
 		}
 
@@ -296,7 +298,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForLoaded(container);
 			await WindowHelper.WaitFor(() => SUT.DesiredSize != default);
 
+#if !__WASM__ // Disabled due to #14231
 			Assert.AreEqual(0, SUT.DesiredSize.Width);
+#endif
 			Assert.AreEqual(100, SUT.DesiredSize.Height);
 		}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -1,6 +1,9 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.RuntimeTests.Helpers;
+using Uno.Helpers;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI;
@@ -9,6 +12,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -270,11 +270,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			container.Children.Add(SUT);
 			WindowHelper.WindowContent = container;
 			await WindowHelper.WaitForLoaded(container);
+			await WindowHelper.WaitFor(() => SUT.DesiredSize != default);
 
 			Assert.AreEqual(0, SUT.DesiredSize.Width);
 			Assert.IsTrue(SUT.DesiredSize.Height > 0);
 		}
 
+#if !__IOS__ // Line height is not supported on iOS
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_Empty_TextBlock_LineHeight_Override()
@@ -288,10 +290,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			container.Children.Add(SUT);
 			WindowHelper.WindowContent = container;
 			await WindowHelper.WaitForLoaded(container);
+			await WindowHelper.WaitFor(() => SUT.DesiredSize != default);
 
 			Assert.AreEqual(0, SUT.DesiredSize.Width);
 			Assert.AreEqual(100, SUT.DesiredSize.Height);
 		}
+#endif
 
 		[TestMethod]
 		[RunsOnUIThread]
@@ -312,6 +316,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			WindowHelper.WindowContent = container;
 			await WindowHelper.WaitForLoaded(container);
+			foreach(var child in container.Children)
+			{
+				await WindowHelper.WaitFor(() => child.DesiredSize != default);
+			}
 
 			// Get the transform of the top left of the container
 			var previousTransform = container.TransformToVisual(null);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -316,7 +316,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			WindowHelper.WindowContent = container;
 			await WindowHelper.WaitForLoaded(container);
-			foreach(var child in container.Children)
+			foreach (var child in container.Children)
 			{
 				await WindowHelper.WaitFor(() => child.DesiredSize != default);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -23,8 +23,6 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private readonly TextVisual _textVisual;
 
-		private float? _cachedFontLineHeight;
-
 		public TextBlock()
 		{
 			SetDefaultForeground(ForegroundProperty);
@@ -45,7 +43,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var padding = Padding;
 			var availableSizeWithoutPadding = availableSize.Subtract(padding);
-			var defaultLineHeight = (float)GetComputedLineHeight();
+			var defaultLineHeight = GetComputedLineHeight();
 			var desiredSize = Inlines.Measure(availableSizeWithoutPadding, defaultLineHeight);
 
 			return desiredSize.Add(padding);
@@ -89,12 +87,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				if (_cachedFontLineHeight is null)
-				{
-					var font = FontDetailsCache.GetFont(FontFamily?.Source, (float)FontSize, FontWeight, FontStyle);
-					_cachedFontLineHeight = font.LineHeight;
-				}
-				return _cachedFontLineHeight.Value;
+				var font = FontDetailsCache.GetFont(FontFamily?.Source, (float)FontSize, FontWeight, FontStyle);
+				return font.LineHeight;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -92,11 +92,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		partial void InvalidateTextBlockPartial()
-		{
-			_cachedFontLineHeight = null;
-		}
-
 		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
 		{
 			base.OnPropertyChanged2(args);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -23,6 +23,8 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private readonly TextVisual _textVisual;
 
+		private float? _cachedFontLineHeight;
+
 		public TextBlock()
 		{
 			SetDefaultForeground(ForegroundProperty);
@@ -43,7 +45,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var padding = Padding;
 			var availableSizeWithoutPadding = availableSize.Subtract(padding);
-			var desiredSize = Inlines.Measure(availableSizeWithoutPadding);
+			var defaultLineHeight = (float)GetComputedLineHeight();
+			var desiredSize = Inlines.Measure(availableSizeWithoutPadding, defaultLineHeight);
 
 			return desiredSize.Add(padding);
 		}
@@ -69,6 +72,35 @@ namespace Windows.UI.Xaml.Controls
 			_textVisual.Offset = new Vector3((float)padding.Left, (float)padding.Top, 0);
 			ApplyFlowDirection((float)finalSize.Width);
 			return base.ArrangeOverride(finalSize);
+		}
+
+		/// <summary>
+		/// Gets the line height of the TextBlock either 
+		/// based on the LineHeight property or the default 
+		/// font line height.
+		/// </summary>
+		/// <returns>Computed line height</returns>
+		internal float GetComputedLineHeight()
+		{
+			var lineHeight = LineHeight;
+			if (!lineHeight.IsNaN() && lineHeight > 0)
+			{
+				return (float)lineHeight;
+			}
+			else
+			{
+				if (_cachedFontLineHeight is null)
+				{
+					var font = FontDetailsCache.GetFont(FontFamily?.Source, (float)FontSize, FontWeight, FontStyle);
+					_cachedFontLineHeight = font.LineHeight;
+				}
+				return _cachedFontLineHeight.Value;
+			}
+		}
+
+		partial void InvalidateTextBlockPartial()
+		{
+			_cachedFontLineHeight = null;
 		}
 
 		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Documents/Inline.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/Inline.skia.cs
@@ -29,14 +29,7 @@ namespace Windows.UI.Xaml.Documents
 
 		internal FontDetails FontInfo => _fontInfo ??= FontDetailsCache.GetFont(FontFamily?.Source, (float)FontSize, FontWeight, FontStyle);
 
-		internal float LineHeight
-		{
-			get
-			{
-				var metrics = FontInfo.SKFontMetrics;
-				return metrics.Descent - metrics.Ascent;
-			}
-		}
+		internal float LineHeight => FontInfo.LineHeight;
 
 		internal float AboveBaselineHeight => -FontInfo.SKFontMetrics.Ascent;
 

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -20,14 +20,16 @@ namespace Windows.UI.Xaml.Documents
 
 		private bool _invalidationPending;
 		private double _lastMeasuredWidth;
+		private float _lastDefaultLineHeight;
 		private Size _lastDesiredSize;
 		private Size _lastArrangedSize;
 
 		/// <summary>
 		/// Measures a block-level inline collection, i.e. one that belongs to a TextBlock (or Paragraph, in the future).
 		/// </summary>
-		internal Size Measure(Size availableSize)
+		internal Size Measure(Size availableSize, float defaultLineHeight)
 		{
+			_lastDefaultLineHeight = defaultLineHeight;
 			if (!_invalidationPending &&
 				availableSize.Width <= _lastMeasuredWidth &&
 				availableSize.Width >= _lastDesiredSize.Width)
@@ -215,7 +217,7 @@ namespace Windows.UI.Xaml.Documents
 
 			if (_renderLines.Count == 0)
 			{
-				_lastDesiredSize = new Size(0, 0);
+				_lastDesiredSize = new Size(0, defaultLineHeight);
 			}
 			else
 			{
@@ -277,7 +279,7 @@ namespace Windows.UI.Xaml.Documents
 				return _lastDesiredSize;
 			}
 
-			return Measure(finalSize);
+			return Measure(finalSize, _lastDefaultLineHeight);
 		}
 
 		internal void InvalidateMeasure()

--- a/src/Uno.UI/UI/Xaml/Documents/TextFormatting/FontDetails.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextFormatting/FontDetails.skia.cs
@@ -3,4 +3,14 @@ using SkiaSharp;
 
 namespace Windows.UI.Xaml.Documents.TextFormatting;
 
-internal record FontDetails(SKFont SKFont, float SKFontSize, float SKFontScaleX, SKFontMetrics SKFontMetrics, SKTypeface SKTypeface, Font Font, Face Face);
+internal record FontDetails(SKFont SKFont, float SKFontSize, float SKFontScaleX, SKFontMetrics SKFontMetrics, SKTypeface SKTypeface, Font Font, Face Face)
+{
+	internal float LineHeight
+	{
+		get
+		{
+			var metrics = SKFontMetrics;
+			return metrics.Descent - metrics.Ascent;
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/14201

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b96916</samp>

This pull request adds a new sample page for a `TextBox` with an animated header, and improves the line height calculation and rendering of the `TextBlock` control on Skia-based targets. It modifies several files in the `src` folder, such as `TextBlock.skia.cs`, `InlineCollection.skia.cs`, `Inline.skia.cs` and `FontDetails.skia.cs`, to use a new cached font line height value and simplify the layout logic. It also adds some new unit tests for the `TextBlock` control in the `Given_TextBlock.cs` file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
