### PR TITLE
perf: TextBlock performance improvements on Skia

### DIFF
--- a/src/Uno.UI/Helpers/UnoSkiaApi.skia.cs
+++ b/src/Uno.UI/Helpers/UnoSkiaApi.skia.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SkiaSharp;
+
+internal static class UnoSkiaApi
+{
+	private const string SKIA = "libSkiaSharp";
+
+	[DllImport(SKIA, CallingConvention = CallingConvention.Cdecl)]
+	internal unsafe static extern void sk_textblob_builder_alloc_run_pos(IntPtr builder, IntPtr font, int count, SKRect* bounds, UnoSKRunBufferInternal* runbuffer);
+}

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -16,6 +16,13 @@ namespace Windows.UI.Xaml.Documents
 {
 	partial class InlineCollection
 	{
+		// This is safe as a static field.
+		// 1) It's only accessed from UI thread.
+		// 2) Once we call SKTextBlobBuilder.Build(), the instance is reset to its initial state.
+		// See https://api.skia.org/classSkTextBlobBuilder.html#abf5e20208fd5656981191a3778ee5fef:
+		// > Resets SkTextBlobBuilder to its initial empty state, allowing it to be reused to build a new set of runs.
+		// The reset to the initial state happens here:
+		// https://github.com/google/skia/blob/d29cc3fe182f6e8a8539004a6a4ee8251677a6fd/src/core/SkTextBlob.cpp#L652-L656
 		private static SKTextBlobBuilder _textBlobBuilder = new();
 
 		private readonly List<RenderLine> _renderLines = new();
@@ -377,9 +384,9 @@ namespace Windows.UI.Xaml.Documents
 						}
 					}
 
-					var run = _textBlobBuilder.AllocatePositionedRun(fontInfo.SKFont, segmentSpan.GlyphsLength);
-					var glyphs = run.GetGlyphSpan();
-					var positions = run.GetPositionSpan();
+					var run = _textBlobBuilder.AllocatePositionedRunFast(fontInfo.SKFont, segmentSpan.GlyphsLength);
+					var glyphs = run.GetGlyphSpan(segmentSpan.GlyphsLength);
+					var positions = run.GetPositionSpan(segmentSpan.GlyphsLength);
 
 					if (segment.Direction == FlowDirection.LeftToRight)
 					{

--- a/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/InlineCollection.skia.cs
@@ -16,6 +16,8 @@ namespace Windows.UI.Xaml.Documents
 {
 	partial class InlineCollection
 	{
+		private static SKTextBlobBuilder _textBlobBuilder = new();
+
 		private readonly List<RenderLine> _renderLines = new();
 
 		private bool _invalidationPending;
@@ -375,8 +377,7 @@ namespace Windows.UI.Xaml.Documents
 						}
 					}
 
-					using var textBlobBuilder = new SKTextBlobBuilder();
-					var run = textBlobBuilder.AllocatePositionedRun(fontInfo.SKFont, segmentSpan.GlyphsLength);
+					var run = _textBlobBuilder.AllocatePositionedRun(fontInfo.SKFont, segmentSpan.GlyphsLength);
 					var glyphs = run.GetGlyphSpan();
 					var positions = run.GetPositionSpan();
 
@@ -427,7 +428,7 @@ namespace Windows.UI.Xaml.Documents
 						}
 					}
 
-					using var textBlob = textBlobBuilder.Build();
+					using var textBlob = _textBlobBuilder.Build();
 					canvas.DrawText(textBlob, 0, y + baselineOffsetY, paint);
 
 					x += justifySpaceOffset * segmentSpan.TrailingSpaces;

--- a/src/Uno.UI/UI/Xaml/Documents/Run.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/Run.skia.cs
@@ -249,8 +249,8 @@ namespace Windows.UI.Xaml.Documents
 			static List<TextFormatting.GlyphInfo> GetGlyphs(HarfBuzzSharp.Buffer buffer, int clusterStart, float textSizeX, float textSizeY)
 			{
 				int length = buffer.Length;
-				var hbGlyphs = buffer.GlyphInfos;
-				var hbPositions = buffer.GlyphPositions;
+				var hbGlyphs = buffer.GetGlyphInfoSpan();
+				var hbPositions = buffer.GetGlyphPositionSpan();
 
 				List<TextFormatting.GlyphInfo> glyphs = new(length);
 

--- a/src/Uno.UI/UI/Xaml/Documents/SKTextBlobBuilderExtensions.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/SKTextBlobBuilderExtensions.skia.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace SkiaSharp;
+
+internal static class SKTextBlobBuilderExtensions
+{
+	// This mostly mimics what SkiaSharp does.
+	// Except that we avoid allocations of unnecessary SKPositionedRunBuffer
+	public static unsafe UnoSKRunBufferInternal AllocatePositionedRunFast(this SKTextBlobBuilder builder, SKFont font, int count, SKRect? bounds = null)
+	{
+		if (font == null)
+		{
+			throw new ArgumentNullException(nameof(font));
+		}
+
+		UnoSKRunBufferInternal buffer = default(UnoSKRunBufferInternal);
+		if (bounds.HasValue)
+		{
+			SKRect valueOrDefault = bounds.Value;
+			UnoSkiaApi.sk_textblob_builder_alloc_run_pos(builder.Handle, font.Handle, count, &valueOrDefault, &buffer);
+		}
+		else
+		{
+			UnoSkiaApi.sk_textblob_builder_alloc_run_pos(builder.Handle, font.Handle, count, null, &buffer);
+		}
+
+		return buffer;
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Documents/UnoSKRunBufferInternal.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnoSKRunBufferInternal.skia.cs
@@ -1,0 +1,65 @@
+using System;
+using SkiaSharp;
+
+namespace SkiaSharp;
+
+internal struct UnoSKRunBufferInternal : IEquatable<UnoSKRunBufferInternal>
+{
+	public unsafe void* glyphs;
+
+	public unsafe void* pos;
+
+	public unsafe void* utf8text;
+
+	public unsafe void* clusters;
+
+	public unsafe readonly bool Equals(UnoSKRunBufferInternal obj)
+	{
+		if (glyphs == obj.glyphs && pos == obj.pos && utf8text == obj.utf8text)
+		{
+			return clusters == obj.clusters;
+		}
+
+		return false;
+	}
+
+	public override readonly bool Equals(object obj)
+	{
+		if (obj is UnoSKRunBufferInternal obj2)
+		{
+			return Equals(obj2);
+		}
+
+		return false;
+	}
+
+	public static bool operator ==(UnoSKRunBufferInternal left, UnoSKRunBufferInternal right)
+	{
+		return left.Equals(right);
+	}
+
+	public static bool operator !=(UnoSKRunBufferInternal left, UnoSKRunBufferInternal right)
+	{
+		return !left.Equals(right);
+	}
+
+	public unsafe override readonly int GetHashCode()
+	{
+		HashCode hashCode = default(HashCode);
+		hashCode.Add(glyphs == null ? 0 : (IntPtr)glyphs);
+		hashCode.Add(pos == null ? 0 : (IntPtr)pos);
+		hashCode.Add(utf8text == null ? 0 : (IntPtr)utf8text);
+		hashCode.Add(clusters == null ? 0 : (IntPtr)clusters);
+		return hashCode.ToHashCode();
+	}
+
+	public unsafe Span<SKPoint> GetPositionSpan(int size)
+	{
+		return new Span<SKPoint>(pos, (pos != null) ? size : 0);
+	}
+
+	public unsafe Span<ushort> GetGlyphSpan(int size)
+	{
+		return new Span<ushort>(glyphs, (glyphs != null) ? size : 0);
+	}
+}


### PR DESCRIPTION
This addresses most allocations observed in https://github.com/unoplatform/uno/issues/13825.

Keeping the issue open for now to investigate further if there are more improvements that could be done.

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddefe45</samp>

Improved text rendering performance on Skia platforms by reusing a text blob builder in `InlineCollection`. This reduces memory allocations and native interop calls when rendering text elements.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
