### PR TITLE
fix!: Remove Xamarin.AndroidX.Legacy.Support.v4 on net8.0

### DIFF
--- a/build/nuget/Uno.WinUI.nuspec
+++ b/build/nuget/Uno.WinUI.nuspec
@@ -59,7 +59,6 @@
 
 			<!-- net8.0-android30.0 -->
 			<group targetFramework="net8.0-android30.0">
-				<dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.10" />
 				<dependency id="Xamarin.AndroidX.AppCompat" version="1.3.1.3" />
 				<dependency id="Xamarin.AndroidX.RecyclerView" version="1.2.1.3" />
 				<dependency id="Xamarin.AndroidX.Activity" version="1.3.1.2" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -133,7 +133,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0-android'">
-	<PackageReference Update="Xamarin.AndroidX.Legacy.Support.v4" Version="1.0.0.10" />
 	  <PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.3.1.3" />
 	  <PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.2.1.3" />
 	  <PackageReference Update="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.3" />
@@ -141,6 +140,8 @@
   </ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0-android'">
+		<!-- Xamarin.AndroidX.Legacy.Support.v4 shouldn't be brought for any version after net7.0 -->
+		<!-- Remove this line once we are net8.0+ -->
 		<PackageReference Update="Xamarin.AndroidX.Legacy.Support.v4" Version="1.0.0.10" />
 		<PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.3.1.3" />
 		<PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.2.1.3" />

--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.netcoremobile.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.netcoremobile.csproj
@@ -29,9 +29,15 @@
 	<!-- Docs generation build uses UnoTargetFrameworkOverride=net7.0, so this project will build with net7.0 instead of net7.0-android -->
 	<!-- If we attempted to always build with net7.0-android, we will go through the annoyance of installing android workload in docs generation CI job -->
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
 		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
 		<PackageReference Include="Xamarin.AndroidX.RecyclerView" />
+	</ItemGroup>
+
+	<!-- This condition is **explicitly** for net7.0 -->
+	<!-- Don't include this package for any version later than net7.0 -->
+	<!-- Once we remove net7.0 support, this ItemGroup should be deleted. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Composition/Uno.UI.Composition.netcoremobile.csproj
+++ b/src/Uno.UI.Composition/Uno.UI.Composition.netcoremobile.csproj
@@ -26,11 +26,16 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
 		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
 		<PackageReference Include="Xamarin.AndroidX.Fragment" />
 	</ItemGroup>
 
+	<!-- This condition is **explicitly** for net7.0 -->
+	<!-- Don't include this package for any version later than net7.0 -->
+	<!-- Once we remove net7.0 support, this ItemGroup should be deleted. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.UWP\Uno.netcoremobile.csproj" />

--- a/src/Uno.UI.Dispatching/Uno.UI.Dispatching.netcoremobile.csproj
+++ b/src/Uno.UI.Dispatching/Uno.UI.Dispatching.netcoremobile.csproj
@@ -26,11 +26,16 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
 		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
 		<PackageReference Include="Xamarin.AndroidX.Fragment" />
 	</ItemGroup>
 
+	<!-- This condition is **explicitly** for net7.0 -->
+	<!-- Don't include this package for any version later than net7.0 -->
+	<!-- Once we remove net7.0 support, this ItemGroup should be deleted. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Foundation\Uno.Foundation.netcoremobile.csproj" />

--- a/src/Uno.UI.Maps/Uno.UI.Maps.netcoremobile.csproj
+++ b/src/Uno.UI.Maps/Uno.UI.Maps.netcoremobile.csproj
@@ -46,7 +46,6 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0-android'">
 		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="120.0.0.1" />
 		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="118.1.0.1" />
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" PrivateAssets="none" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0-android'">

--- a/src/Uno.UI.XamlHost/Uno.UI.XamlHost.netcoremobile.csproj
+++ b/src/Uno.UI.XamlHost/Uno.UI.XamlHost.netcoremobile.csproj
@@ -28,11 +28,16 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
 		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
 		<PackageReference Include="Xamarin.AndroidX.Fragment" />
 	</ItemGroup>
 
+	<!-- This condition is **explicitly** for net7.0 -->
+	<!-- Don't include this package for any version later than net7.0 -->
+	<!-- Once we remove net7.0 support, this ItemGroup should be deleted. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.Foundation\Uno.Foundation.netcoremobile.csproj" />

--- a/src/Uno.UI/Uno.UI.netcoremobile.csproj
+++ b/src/Uno.UI/Uno.UI.netcoremobile.csproj
@@ -66,10 +66,16 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
 		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
 		<PackageReference Include="Xamarin.AndroidX.RecyclerView" />
 		<PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" />
+	</ItemGroup>
+
+	<!-- This condition is **explicitly** for net7.0 -->
+	<!-- Don't include this package for any version later than net7.0 -->
+	<!-- Once we remove net7.0 support, this ItemGroup should be deleted. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UWP/Uno.netcoremobile.csproj
+++ b/src/Uno.UWP/Uno.netcoremobile.csproj
@@ -32,10 +32,16 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
-		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
 		<PackageReference Include="Xamarin.AndroidX.AppCompat" />
 		<PackageReference Include="Xamarin.AndroidX.Fragment" />
 		<PackageReference Include="Xamarin.AndroidX.Browser" Version="1.0.0" />
+	</ItemGroup>
+
+	<!-- This condition is **explicitly** for net7.0 -->
+	<!-- Don't include this package for any version later than net7.0 -->
+	<!-- Once we remove net7.0 support, this ItemGroup should be deleted. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
+		<PackageReference Include="Xamarin.AndroidX.Legacy.Support.v4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14209

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at faf6ea4</samp>

This pull request removes or conditions the package reference to `Xamarin.AndroidX.Legacy.Support.v4` in several Uno platform projects that target net8.0-android or higher. This is done to avoid compatibility issues with the new AndroidX APIs and to support the migration to .NET 6.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
