### PR TITLE
perf: Eliminate enumerator boxing in ResourceBindingCollection.HasBindings

### DIFF
--- a/src/Uno.UI/UI/Xaml/ResourceBindingCollection.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceBindingCollection.cs
@@ -16,7 +16,25 @@ internal class ResourceBindingCollection
 	private readonly Dictionary<DependencyProperty, Dictionary<DependencyPropertyValuePrecedences, ResourceBinding>> _bindings = new();
 	private BindingEntry[]? _cachedAllBindings;
 
-	public bool HasBindings => _bindings.Count > 0 && _bindings.Any(b => b.Value.Any());
+	public bool HasBindings
+	{
+		get
+		{
+			// Avoiding the use of LINQ here to reduce unnecessary enumerator boxing.
+			if (_bindings.Count > 0)
+			{
+				foreach (var (_, value) in _bindings)
+				{
+					if (value.Count > 0)
+					{
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+	}
 
 	public record struct BindingEntry(DependencyProperty Property, ResourceBinding Binding);
 

--- a/src/Uno.UI/UI/Xaml/ResourceBindingCollection.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceBindingCollection.cs
@@ -23,9 +23,9 @@ internal class ResourceBindingCollection
 			// Avoiding the use of LINQ here to reduce unnecessary enumerator boxing.
 			if (_bindings.Count > 0)
 			{
-				foreach (var (_, value) in _bindings)
+				foreach (var entry in _bindings)
 				{
-					if (value.Count > 0)
+					if (entry.Value.Count > 0)
 					{
 						return true;
 					}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14245

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89d2c08</samp>

Improved the efficiency of `ResourceBindingCollection` by avoiding LINQ and boxing in `HasBindings`. This class handles resource bindings for XAML elements and affects XAML performance.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
