### PR TITLE
docs: Add missing `Gamepad` and `Compass` docs to toc.yml

### DIFF
--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -320,7 +320,7 @@
             - name: Clipboard
               href: features/clipboard.md
             - name: Compass
-              href: features/compass.md  
+              href: features/compass.md
             - name: Contacts
               href: features/windows-applicationmodel-contacts.md
             - name: Credential Storage
@@ -338,7 +338,7 @@
             - name: Flashlight
               href: features/flashlight.md
             - name: Gamepad
-              href: features/gamepad.md  
+              href: features/gamepad.md
             - name: Geolocation (GPS)
               href: features/windows-devices-geolocation.md
             - name: Gyrometer

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -319,6 +319,8 @@
               href: features/bluetoothdevice.md
             - name: Clipboard
               href: features/clipboard.md
+            - name: Compass
+              href: features/compass.md  
             - name: Contacts
               href: features/windows-applicationmodel-contacts.md
             - name: Credential Storage
@@ -335,6 +337,8 @@
               href: features/windows-storage-pickers.md
             - name: Flashlight
               href: features/flashlight.md
+            - name: Gamepad
+              href: features/gamepad.md  
             - name: Geolocation (GPS)
               href: features/windows-devices-geolocation.md
             - name: Gyrometer


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR
-->
- Bugfix
- Documentation changes

## What is the current behavior?

The `Gamepad` and `Compass` docs are currently not showing up in the navigation.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4e996c3</samp>

Add documentation for Compass and Gamepad features. These features allow developers to access the device's orientation sensor and game controllers in their Uno Platform apps.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.