### PR TITLE
test: Run leak tests for both fluent and non-fluent style

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -820,7 +820,13 @@ namespace Uno.UI.Samples.Tests
 											await initializeReturnTask;
 										}
 
+										var methodParameters = test.Method.GetParameters();
+										if (methodParameters.Length > methodArguments.Length)
+										{
+											methodArguments = ExpandArgumentsWithDefaultValues(methodArguments, methodParameters);
+										}
 										returnValue = test.Method.Invoke(instance, methodArguments);
+
 										sw.Stop();
 
 										cts.TrySetResult(true);
@@ -975,6 +981,30 @@ namespace Uno.UI.Samples.Tests
 					Run();
 				}
 			}
+		}
+
+		private static object[] ExpandArgumentsWithDefaultValues(object[] methodArguments, ParameterInfo[] methodParameters)
+		{
+			var expandedArguments = new List<object>(methodParameters.Length);
+			for (int i = 0; i < methodArguments.Length; i++)
+			{
+				expandedArguments.Add(methodArguments[i]);
+			}
+			// Try to get default values for the rest
+			for (int i = 0; i < methodParameters.Length - methodArguments.Length; i++)
+			{
+				var parameter = methodParameters[methodArguments.Length + i];
+				if (!parameter.HasDefaultValue)
+				{
+					throw new InvalidOperationException("Missing parameter does not have default value");
+				}
+				else
+				{
+					expandedArguments.Add(parameter.DefaultValue);
+				}
+			}
+
+			return expandedArguments.ToArray();
 		}
 
 		private TimeSpan GetTestTimeout(UnitTestMethodInfo test)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -17,6 +17,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
 using Uno.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -128,6 +129,17 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(PasswordBox_Focus_Leak), 15)]
 #endif
 		public async Task When_Add_Remove(object controlTypeRaw, int count)
+		{
+			// Test for leaks both without and with fluent styles
+			await When_Add_Remove_Inner(controlTypeRaw, count);
+
+			using (var themeHelper = StyleHelper.UseFluentStyles())
+			{
+				await When_Add_Remove_Inner(controlTypeRaw, count);
+			}
+		}
+
+		private async Task When_Add_Remove_Inner(object controlTypeRaw, int count)
 		{
 #if TRACK_REFS
 			var initialInactiveStats = Uno.UI.DataBinding.BinderReferenceHolder.GetInactiveViewReferencesStats();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -82,7 +82,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(ToggleSwitch), 15)]
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.SwipeControl), 15)]
 		[DataRow(typeof(SplitView), 15)]
+#if !__ANDROID__ // Disabled #14341
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.AnimatedIcon), 15)]
+#endif
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.BreadcrumbBar), 15)]
 		[DataRow(typeof(Microsoft.UI.Xaml.Controls.BreadcrumbBarItem), 15)]
 #if !__IOS__ // Disabled https://github.com/unoplatform/uno/issues/9080
@@ -126,7 +128,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #endif
 #if !__IOS__ // Disabled - #10344
 		[DataRow(typeof(TextBox_Focus_Leak), 15)]
+#if !__ANDROID // Disabled - #14340
 		[DataRow(typeof(PasswordBox_Focus_Leak), 15)]
+#endif
 #endif
 		public async Task When_Add_Remove(object controlTypeRaw, int count)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14295

## PR Type

What kind of change does this PR introduce?

- Project automation

## What is the current behavior?

Run leak tests in both modes

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f6ae76</samp>

Improved a memory leak test for `FrameworkElement` by adding a fluent styles option and a test helper class.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
