### PR TITLE
fix(gtk): Fix software rendering after scaling adjustments

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Rendering/SoftwareRenderSurface.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Rendering/SoftwareRenderSurface.cs
@@ -104,7 +104,6 @@ internal class SoftwareRenderSurface : DrawingArea, IGtkRenderer
 
 		_gtkSurface!.MarkDirty();
 		cr.Save();
-		cr.Scale(1 / _dpi, 1 / _dpi);
 		cr.SetSourceSurface(_gtkSurface, 0, 0);
 		cr.Paint();
 		cr.Restore();


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Software Rendering for GTK is now taking into account scaling (> 100%) properly.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72c0677</samp>

Fix software rendering mode for high DPI screens on Skia.Gtk. Remove unnecessary scaling of Cairo context in `SoftwareRenderSurface.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
