### PR TITLE
fix: Adjust HR documentation and error message for uno 5 upgrade

### DIFF
--- a/doc/articles/features/working-with-xaml-hot-reload.md
+++ b/doc/articles/features/working-with-xaml-hot-reload.md
@@ -95,7 +95,7 @@ Hot Reload is supported by Visual Studio for WinAppSDK and provides support in u
   </PropertyGroup>
   ```
 - if you're getting the `Unable to access Dispatcher/DispatcherQueue` error, you'll need to update your app startup to Uno 5 or later:
-  - Add the following lines to the shared librar project `csproj` file :
+  - Add the following lines to the shared library project `csproj` file :
     ```xml
     <ItemGroup>
         <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />

--- a/doc/articles/features/working-with-xaml-hot-reload.md
+++ b/doc/articles/features/working-with-xaml-hot-reload.md
@@ -94,6 +94,25 @@ Hot Reload is supported by Visual Studio for WinAppSDK and provides support in u
     <GenerateAssemblyInfo Condition="'$(Configuration)'=='Debug'">false</GenerateAssemblyInfo>
   </PropertyGroup>
   ```
+- if you're getting the `Unable to access Dispatcher/DispatcherQueue` error, you'll need to update your app startup to Uno 5 or later:
+  - Add the following lines to the shared librar project `csproj` file :
+    ```xml
+    <ItemGroup>
+        <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
+    </ItemGroup>
+    ```
+    > [!NOTE]
+    > If your application is using the UWP API set (Uno.UI packages) you'll need to use the `Uno.UI.DevServer` package instead.
+  - Then, in your `App.cs` file, add the following:
+    ```csharp
+    using Uno.UI;
+
+    //... in the OnLaunched method
+
+    #if DEBUG
+            MainWindow.EnableHotReload();
+    #endif
+    ```
 
 ### Visual Studio 2022
 - The output window in VS has an output named `Uno Platform` in its drop-down. Diagnostics messages from the VS integration appear there.

--- a/doc/articles/migrating-to-uno-5.md
+++ b/doc/articles/migrating-to-uno-5.md
@@ -28,7 +28,7 @@ In order to resolve types properly in a conditional XAML namespace, make use of 
 Hot Reload support has changed in Uno Platform 5.0 and a new API invocation is needed to restore the feature in your existing app.
 
 
-- If your project is built using a shared class library, you'll need to add the following lines to the `csproj``:
+- If your project is built using a shared class library, you'll need to add the following lines to the `csproj`:
     ```xml
     <ItemGroup>
         <PackageReference Include="Uno.WinUI.DevServer" Version="$UnoWinUIVersion$" Condition="'$(Configuration)'=='Debug'" />
@@ -38,6 +38,10 @@ Hot Reload support has changed in Uno Platform 5.0 and a new API invocation is n
     > If your application is using the UWP API set (Uno.UI packages) you'll need to use the `Uno.UI.DevServer` package instead.
 - Then, in your `App.cs` file, add the following:
     ```csharp
+    using Uno.UI;
+
+    //... in the OnLaunched method
+
     #if DEBUG
             MainWindow.EnableHotReload();
     #endif

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -389,7 +389,7 @@ partial class ClientHotReloadProcessor
 #endif
 		else if (_log.IsEnabled(LogLevel.Warning))
 		{
-			_log.Warn($"Unable to access Dispatcher/DispatcherQueue in order to invoke {nameof(ReloadWithUpdatedTypes)}. Make sure you have enabled hot-reload (Window.EnableHotReload()) in app startup.");
+			_log.Warn($"Unable to access Dispatcher/DispatcherQueue in order to invoke {nameof(ReloadWithUpdatedTypes)}. Make sure you have enabled hot-reload (Window.EnableHotReload()) in app startup. See https://aka.platform.uno/hot-reload");
 		}
 	}
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Enhance error message shown during HR sessions when upgrading to Uno 5.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ebdea8</samp>

This pull request improves the documentation and the warning message for the XAML hot reload feature in Uno 5. It fixes some typos and adds more code examples and explanations to help users enable and troubleshoot hot reload in different project types.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
