### PR TITLE
docs: Update `Launcher` API docs

### DIFF
--- a/doc/articles/features/windows-system.md
+++ b/doc/articles/features/windows-system.md
@@ -16,7 +16,7 @@ On iOS, Android and macOS the `ms-settings:` special URI is supported.
 
 On iOS, launching the special URI opens the main page of system settings because deep-linking to specific settings is not available.
 
-For WASM, launching the special URI will work propperly only when opening the website on Windows. The method will return `true` even if the user cancels the application launch, as there is currently no way to detect if the app was successfully launched.
+For WASM, launching the special URI will work properly only when opening the website on Windows. The method will return `true` even if the user cancels the application launch, as there is currently no way to detect if the app was successfully launched.
 
 In case of Android, we support the following nested URIs.
 

--- a/doc/articles/features/windows-system.md
+++ b/doc/articles/features/windows-system.md
@@ -12,7 +12,11 @@ This API is supported on iOS, Android, WASM and macOS.
 
 On iOS, Android and macOS the `ms-settings:` special URI is supported. 
 
-In case of iOS, any such URI opens the main page of system settings (there is no settings deep-linking available on iOS).
+#### Platform-specifics
+
+On iOS, launching the special URI opens the main page of system settings because deep-linking to specific settings is not available.
+
+For WASM, launching the special URI will work propperly only when opening the website on Windows. The method will return `true` even if the user cancels the application launch, as there is currently no way to detect if the app was successfully launched.
 
 In case of Android, we support the following nested URIs.
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11623

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Documentation content changes

## What is the new behavior?
Update the `Launcher` API docs to reflect launching of the special URIs on WASM. Although we don't officially seem to support this feature on WASM it kind of works when opening the website on Windows.

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f5c636</samp>

Update documentation for `LaunchUriAsync` method with platform-specific details. Add information about `ms-settings:` URI behavior on iOS and WASM in `doc/articles/features/windows-system.md`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.