### PR TITLE
fix: Ensure WPF doesn't override our own synchronization context when calling pointer events

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1354,6 +1354,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Click_Verify_SynchronizationContext.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons_Native.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6212,6 +6216,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\Border_LinearGradientBrush.xaml.cs">
       <DependentUpon>Border_LinearGradientBrush.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_Click_Verify_SynchronizationContext.xaml.cs">
+      <DependentUpon>Button_Click_Verify_SynchronizationContext.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons_Native.xaml.cs">
       <DependentUpon>Buttons_Native.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Click_Verify_SynchronizationContext.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Click_Verify_SynchronizationContext.xaml
@@ -1,0 +1,19 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.Button_Click_Verify_SynchronizationContext"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<TextBlock Text="SynchronizationContext in InitializeComponent:" />
+		<TextBlock x:Name="tbContextInitComponents" />
+
+		<Button Content="Click here" Click="Button_Click"/>
+		<TextBlock Text="SynchronizationContext in Button_Click:" />
+		<TextBlock x:Name="tbContextHandler" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Click_Verify_SynchronizationContext.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_Click_Verify_SynchronizationContext.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading;
+using Uno.UI.Samples.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls;
+
+[Sample("Button", IsManualTest = true)]
+public sealed partial class Button_Click_Verify_SynchronizationContext : Page
+{
+	public Button_Click_Verify_SynchronizationContext()
+	{
+		this.InitializeComponent();
+
+		tbContextInitComponents.Text = GetTestOutcome();
+	}
+
+	private void Button_Click(object sender, RoutedEventArgs e)
+	{
+		tbContextHandler.Text = GetTestOutcome();
+	}
+
+	private static string GetTestOutcome()
+	{
+		var context = SynchronizationContext.Current.GetType().ToString();
+		var correctness = context == "Uno.UI.Dispatching.NativeDispatcherSynchronizationContext" ? " - Correct" : " - WRONG CONTEXT - TEST FAILED!";
+		return context + correctness;
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Application.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Application.skia.cs
@@ -46,6 +46,8 @@ namespace Microsoft.UI.Xaml
 
 		internal ISkiaApplicationHost? Host { get; set; }
 
+		internal static SynchronizationContext ApplicationSynchronizationContext { get; private set; }
+
 		private void SetCurrentLanguage()
 		{
 			if (CultureInfo.CurrentUICulture.IetfLanguageTag == "" &&
@@ -78,7 +80,7 @@ namespace Microsoft.UI.Xaml
 			_startInvoked = true;
 
 			SynchronizationContext.SetSynchronizationContext(
-				new NativeDispatcherSynchronizationContext(NativeDispatcher.Main, NativeDispatcherPriority.Normal)
+				ApplicationSynchronizationContext = new NativeDispatcherSynchronizationContext(NativeDispatcher.Main, NativeDispatcherPriority.Normal)
 			);
 
 			callback(new ApplicationInitializationCallbackParams());


### PR DESCRIPTION
GitHub Issue (If applicable): closes #7829

**Note: I couldn't find any way to test this other than manual testing.**

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c1751b8</samp>

This pull request refactors the code that handles pointer events and synchronization contexts for the SKIA and WASM platforms. It moves the `NativeDispatcherSynchronizationContext` class to a different project, adds a static property to access a singleton instance of it, and simplifies the logic in the `WpfCorePointerInputSource` class. The goal is to improve the code organization, readability, and consistency.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
