### PR TITLE
fix: Workaround a lifecycle bug to allow ContentControl to be measured properly when not in visual tree

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -271,10 +271,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				SUT.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
 				Assert.AreEqual(new Size(double.PositiveInfinity, double.PositiveInfinity), SUT.MeasureOverrides.Last());
 				Assert.AreEqual(new Size(0, 0), SUT.DesiredSize);
-
+#if HAS_UNO
+				// Unlike WinUI, we don't crash.
+				SUT.Measure(new Size(double.NaN, double.NaN));
+				SUT.Measure(new Size(42.0, double.NaN));
+				SUT.Measure(new Size(double.NaN, 42.0));
+#else
 				Assert.ThrowsException<InvalidOperationException>(() => SUT.Measure(new Size(double.NaN, double.NaN)));
 				Assert.ThrowsException<InvalidOperationException>(() => SUT.Measure(new Size(42.0, double.NaN)));
 				Assert.ThrowsException<InvalidOperationException>(() => SUT.Measure(new Size(double.NaN, 42.0)));
+#endif
 			});
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -368,14 +368,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// This is matching Windows and is important to keep the behavior of this test like this.
 			Assert.AreEqual(new Size(120, 50), grid.AvailableSizeUsedForMeasure);
 
-#if __SKIA__
-			// https://github.com/unoplatform/uno/issues/7271
-			// This assert is NOT correct. The correct size is 50, 15
-			// It's happening because ContentControl is measuring incorrectly because GetFirstChild is returning null instead of the Border.
-			Assert.AreEqual(new Size(50, 0), grid.DesiredSize);
-#else
 			Assert.AreEqual(new Size(50, 15), grid.DesiredSize);
-#endif
 
 #if NETFX_CORE // Failing on WASM - https://github.com/unoplatform/uno/issues/2314
 			Assert.AreEqual(new Size(110, 15), contentCtl.DesiredSize);

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.skia.cs
@@ -33,6 +33,7 @@ namespace Windows.UI.Xaml.Controls
 			// 1. FrameworkElement.MeasureCore calls 'InvokeApplyTemplate'
 			// 2. ContentControl overrides ApplyTemplate to do a bunch of stuff, including a call to CreateDefaultVisuals.
 			// 3. CreateDefaultVisuals adds the Content as Child if it's a UIElement.
+			// Tracking issue: https://github.com/unoplatform/uno/issues/190
 			var child = this.FindFirstChild() ?? (Content as UIElement);
 			return child != null ? MeasureElement(child, availableSize) : new Size(0, 0);
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.skia.cs
@@ -25,6 +25,16 @@ namespace Windows.UI.Xaml.Controls
 			RemoveChild(ContentTemplateRoot);
 		}
 
-		protected override Size MeasureOverride(Size availableSize) => base.MeasureOverride(availableSize);
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			// This is the same as Control.MeasureOverride, except that we use Content if FindFirstChild is null.
+			// The fact that FindFirstChild is null is actually a BUG!
+			// The way this works in WinUI is:
+			// 1. FrameworkElement.MeasureCore calls 'InvokeApplyTemplate'
+			// 2. ContentControl overrides ApplyTemplate to do a bunch of stuff, including a call to CreateDefaultVisuals.
+			// 3. CreateDefaultVisuals adds the Content as Child if it's a UIElement.
+			var child = this.FindFirstChild() ?? (Content as UIElement);
+			return child != null ? MeasureElement(child, availableSize) : new Size(0, 0);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.crossruntime.cs
@@ -149,11 +149,6 @@ namespace Windows.UI.Xaml
 				return; // Only FrameworkElements are measurable
 			}
 
-			if (double.IsNaN(availableSize.Width) || double.IsNaN(availableSize.Height))
-			{
-				throw new InvalidOperationException($"Cannot measure [{GetType()}] with NaN");
-			}
-
 			if (Visibility == Visibility.Collapsed)
 			{
 				if (availableSize == LastAvailableSize)

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -993,11 +993,6 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
-			if (double.IsNaN(availableSize.Width) || double.IsNaN(availableSize.Height))
-			{
-				throw new InvalidOperationException($"Cannot measure [{GetType()}] with NaN");
-			}
-
 			((ILayouterElement)fwe).Layouter.Measure(availableSize);
 #if IS_UNIT_TESTS
 			OnMeasurePartial(availableSize);


### PR DESCRIPTION
GitHub Issue (If applicable): Related #7271

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b95944</samp>

This pull request fixes a unit test failure on Skia by overriding the `MeasureOverride` method of `ContentControl` to handle a null first child. This is a temporary workaround for a bug in the ContentControl measurement logic on Skia.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
