### PR TITLE
fix: Ensure fractional DPI is avoided in HW GTK renderer

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/GtkDisplayInformationExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/GtkDisplayInformationExtension.cs
@@ -55,7 +55,7 @@ internal class GtkDisplayInformationExtension : IDisplayInformationExtension
 				var nativeWindow = window.Window;
 				if (nativeWindow is not null)
 				{
-					_dpi = _dpiHelper.GetNativeDpi();
+					_dpi = GetNativeDpi();
 				}
 			}
 
@@ -72,7 +72,24 @@ internal class GtkDisplayInformationExtension : IDisplayInformationExtension
 
 	private void OnDpiChanged(object? sender, EventArgs args)
 	{
-		_dpi = _dpiHelper.GetNativeDpi();
+		_dpi = GetNativeDpi();
 		_displayInformation.NotifyDpiChanged();
+	}
+
+	private float GetNativeDpi()
+	{
+		var dpi = _dpiHelper.GetNativeDpi();
+
+		if (GtkHost.Current?.RenderSurfaceType == RenderSurfaceType.Software)
+		{
+			// Software rendering is not affected by fractional DPI.
+			return dpi;
+		}
+
+		// We need to make sure that in case of fractional DPI, we use the nearest whole DPI instead,
+		// otherwise we get GuardBand related rendering issues.
+		var fractionalDpi = dpi / DisplayInformation.BaseDpi;
+		var wholeDpi = Math.Max(1.0, float.Floor(fractionalDpi));
+		return wholeDpi * DisplayInformation.BaseDpi;
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Gtk/Extensions/GtkDisplayInformationExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Extensions/GtkDisplayInformationExtension.cs
@@ -89,7 +89,7 @@ internal class GtkDisplayInformationExtension : IDisplayInformationExtension
 		// We need to make sure that in case of fractional DPI, we use the nearest whole DPI instead,
 		// otherwise we get GuardBand related rendering issues.
 		var fractionalDpi = dpi / DisplayInformation.BaseDpi;
-		var wholeDpi = Math.Max(1.0, float.Floor(fractionalDpi));
+		var wholeDpi = Math.Max(1.0f, float.Floor(fractionalDpi));
 		return wholeDpi * DisplayInformation.BaseDpi;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/14402, fixes #14250

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Due to GuardBand, the rendering of fractional scales is misbehaving terribly


## What is the new behavior?

We now fall back to whole scales instead.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at edcf4e5</samp>

Fix UI rendering bug on GTK with fractional DPI. Use `GetNativeDpi()` to get the correct DPI value for the render surface in `GtkDisplayInformationExtension.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
