### PR TITLE
docs: update file name for setting the GTK render target

### DIFF
--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -31,7 +31,7 @@ or by using the Visual Studio ["project new" templates](xref:Uno.GetStarted.vs20
 
 It may be required, depending on the environment, to use software rendering.
 
-To do so, immediately before the line `host.Run()` in you `main.cs` file, add the following:
+To do so, immediately before the line `host.Run()` in you `Program.cs` file, add the following:
 ```
 host.RenderSurfaceType = RenderSurfaceType.Software;
 ```


### PR DESCRIPTION
Current templates put it in Program.cs, not main.cs

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

Documentation content changes

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

mentions wrong file name

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

Now uses the correct file name.

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fbe096</samp>

Fixed a typo in the Skia GTK documentation. The file name `main.cs` was replaced with `Program.cs` to reflect the correct C# and Uno naming conventions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Found while investigating something else. This is just a drive-by docs fix.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
