### PR TITLE
fix(droid): flyout having no size in certain case

### DIFF
--- a/src/Uno.UI/UI/LayoutHelper.cs
+++ b/src/Uno.UI/UI/LayoutHelper.cs
@@ -192,6 +192,20 @@ namespace Uno.UI
 		}
 
 		[Pure]
+		internal static Size Subtract(this Size size, double width, double height)
+		{
+			if (width == default && height == default)
+			{
+				return size;
+			}
+
+			return new Size(
+				size.Width - width,
+				size.Height - height
+			);
+		}
+
+		[Pure]
 		internal static Size Subtract(this Size left, Size right)
 		{
 			if (right == default)

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
@@ -185,19 +185,16 @@ partial class PopupPanel
 						y: anchorRect.Top + halfAnchorHeight - halfChildHeight + popup.VerticalOffset);
 					break;
 				case FlyoutBase.MajorPlacementMode.Full:
-#if __IOS__ || __ANDROID__
-					// The status bar should remain visible. On droid, this panel is placed beneath the status bar.
-					desiredSize = new Size(
-						ActualWidth,
-						ActualHeight
-#if __IOS__
-						// On iOS, this panel will cover the status bar, so we have to substract it out.
-						- visibleBounds.Y
-#endif
-					).AtMost(maxSize);
+#if !__IOS__
+					desiredSize = visibleBounds.Size
 #else
-					desiredSize = visibleBounds.Size.AtMost(maxSize);
+					// The mobile status bar should always remain visible.
+					// On droid, this panel is placed beneath the status bar.
+					// On iOS, this panel will cover the status bar, so we have to substract it out.
+					desiredSize = new Size(ActualWidth, ActualHeight)
+						.Subtract(0, visibleBounds.Y)
 #endif
+						.AtMost(maxSize);
 					finalPosition = new Point(
 						x: FindOptimalOffset(desiredSize.Width, visibleBounds.X, visibleBounds.Width, ActualWidth),
 						y: FindOptimalOffset(desiredSize.Height, visibleBounds.Y, visibleBounds.Height, ActualHeight));


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.toolkit.ui#869

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary
<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa26fb3</samp>

Added a new `Subtract` extension method to `LayoutHelper` to simplify size calculations. Refactored `PopupPanel.CalculatePopupPlacement` to use the new method and improve code readability.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->