### PR TITLE
chore: update to 8.0.100

### DIFF
--- a/build/ci/templates/dotnet-mobile-install-windows.yml
+++ b/build/ci/templates/dotnet-mobile-install-windows.yml
@@ -5,8 +5,8 @@ steps:
   - template: jdk-setup.yml
 
   - powershell: |
-      & dotnet tool update --global uno.check --version 1.14.1 --add-source https://api.nuget.org/v3/index.json
-      & uno-check -v --ci --non-interactive --fix --skip androidsdk --skip androidemulator --skip xcode --skip gtk3 --skip vswin --skip vsmac --manifest https://raw.githubusercontent.com/unoplatform/uno.check/79a6b891d5787a28cef4ca3c1cc620ace1c0ae93/manifests/uno.ui-preview-major.manifest.json
+      & dotnet tool update --global uno.check --version 1.17.0-dev.20 --add-source https://api.nuget.org/v3/index.json
+      & uno-check -v --ci --non-interactive --fix --skip androidsdk --skip androidemulator --skip xcode --skip gtk3 --skip vswin --skip vsmac --manifest https://raw.githubusercontent.com/unoplatform/uno.check/3b250f49b719d1cf5ab205f997c3959b5e9fed1d/manifests/uno.ui.manifest.json
     displayName: Install .NET Workloads
     errorActionPreference: continue
     ignoreLASTEXITCODE: true

--- a/global-net8.json
+++ b/global-net8.json
@@ -1,11 +1,11 @@
 {
 	"sdk": {
-		"version": "8.0.100-preview.7.23376.3",
+		"version": "8.0.100",
 		"allowPrerelease": true,
 		"rollForward": "latestPatch"
 	},
 	"tools": {
-		"dotnet": "8.0.100-preview.7.23376.3"
+		"dotnet": "8.0.100"
 	},
 	"msbuild-sdks": {
 		"MSBuild.Sdk.Extras": "3.0.44"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -71,7 +71,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<MicrosoftNetCompilersToolsetVersion>4.8.0</MicrosoftNetCompilersToolsetVersion>
+		<MicrosoftNetCompilersToolsetVersion>4.8.0-3.final</MicrosoftNetCompilersToolsetVersion>
 	</PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -71,7 +71,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<MicrosoftNetCompilersToolsetVersion>4.7.0</MicrosoftNetCompilersToolsetVersion>
+		<MicrosoftNetCompilersToolsetVersion>4.8.0</MicrosoftNetCompilersToolsetVersion>
 	</PropertyGroup>
 
   <ItemGroup>

--- a/src/Uno.UI.RemoteControl.Host/Config/global-net8.0.json
+++ b/src/Uno.UI.RemoteControl.Host/Config/global-net8.0.json
@@ -1,11 +1,11 @@
 {
 	"sdk": {
-		"version": "8.0.100-preview.7.23376.3",
+		"version": "8.0.100",
 		"allowPrerelease": true,
 		"rollForward": "latestPatch"
 	},
 	"tools": {
-		"dotnet": "8.0.100-preview.7.23376.3"
+		"dotnet": "8.0.100"
 	},
 	"msbuild-sdks": {
 		"MSBuild.Sdk.Extras": "3.0.44"

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -25,10 +25,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0-3.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0-3.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0-3.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0-3.final" />
 		<!-- TODO: Use version 8 when compiling against .NET 8? -->
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Build" Version="16.10.0" ExcludeAssets="runtime" />
@@ -38,10 +38,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0-2.final" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0-2.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0-3.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0-3.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0-3.final" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0-3.final" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Build" Version="16.10.0" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" ExcludeAssets="runtime" />

--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -254,7 +254,7 @@ namespace Uno.UI.Controls
 			scalableViews.ForEach(v => v.RefreshFont());
 		}
 
-		public override UIView HitTest(CGPoint point, UIEvent? uievent)
+		public override UIView? HitTest(CGPoint point, UIEvent? uievent)
 		{
 			if (!BypassCheckToCloseKeyboard && uievent is { Type: UIEventType.Touches })
 			{
@@ -275,7 +275,7 @@ namespace Uno.UI.Controls
 				_focusedView = newlyFocusedView;
 
 				if (_inputPane.Visible
-					&& !NeedsKeyboard(_focusedView!))
+					&& !NeedsKeyboard(_focusedView))
 				{
 					// Note: prefer call the IsWithinAWebView after the NeedsKeyboard since it is more power consuming.
 					if (IsWithinAWebView(_focusedView))
@@ -294,7 +294,7 @@ namespace Uno.UI.Controls
 					}
 				}
 
-				return _focusedView! ?? base.HitTest(point, uievent);
+				return _focusedView ?? base.HitTest(point, uievent);
 			}
 			else
 			{
@@ -304,7 +304,7 @@ namespace Uno.UI.Controls
 					_touchTrace = null;
 				}
 
-				return base.HitTest(point, uievent)!;
+				return base.HitTest(point, uievent);
 			}
 		}
 
@@ -469,7 +469,7 @@ namespace Uno.UI.Controls
 			}
 		}
 
-		private static bool GetNeedsKeyboard(UIView view)
+		private static bool GetNeedsKeyboard(UIView? view)
 		{
 			if (view == null)
 			{
@@ -481,7 +481,7 @@ namespace Uno.UI.Controls
 			return superViews.Any(superView => _attachedProperties.GetValue(superView, NeedsKeyboardAttachedPropertyKey, () => default(bool?)).GetValueOrDefault());
 		}
 
-		private static bool NeedsKeyboard(UIView view)
+		private static bool NeedsKeyboard(UIView? view)
 		{
 			return view is UISearchBar
 				|| view is UITextView
@@ -498,7 +498,7 @@ namespace Uno.UI.Controls
 				view?.FindSuperviewOfType<WKWebView>(stopAt: this) != null;
 		}
 
-		private bool IsFocusable(UIView view)
+		private bool IsFocusable(UIView? view)
 		{
 			// Basic IsFocusable support that only works with buttons.
 			// This prevent the keyboard from being dismissed when tapping on a button that doesn't want focus.

--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -275,7 +275,7 @@ namespace Uno.UI.Controls
 				_focusedView = newlyFocusedView;
 
 				if (_inputPane.Visible
-					&& !NeedsKeyboard(_focusedView))
+					&& !NeedsKeyboard(_focusedView!))
 				{
 					// Note: prefer call the IsWithinAWebView after the NeedsKeyboard since it is more power consuming.
 					if (IsWithinAWebView(_focusedView))
@@ -294,7 +294,7 @@ namespace Uno.UI.Controls
 					}
 				}
 
-				return _focusedView ?? base.HitTest(point, uievent);
+				return _focusedView! ?? base.HitTest(point, uievent);
 			}
 			else
 			{
@@ -304,7 +304,7 @@ namespace Uno.UI.Controls
 					_touchTrace = null;
 				}
 
-				return base.HitTest(point, uievent);
+				return base.HitTest(point, uievent)!;
 			}
 		}
 

--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -254,7 +254,13 @@ namespace Uno.UI.Controls
 			scalableViews.ForEach(v => v.RefreshFont());
 		}
 
-		public override UIView? HitTest(CGPoint point, UIEvent? uievent)
+		public override
+#if NET8_0_OR_GREATER
+			UIView?
+#else
+			UIView
+#endif
+			HitTest(CGPoint point, UIEvent? uievent)
 		{
 			if (!BypassCheckToCloseKeyboard && uievent is { Type: UIEventType.Touches })
 			{

--- a/src/Uno.UWP/Storage/MimeTypeService.cs
+++ b/src/Uno.UWP/Storage/MimeTypeService.cs
@@ -8,7 +8,7 @@ namespace Windows.Storage
 	{
 		public static string GetFromExtension(string? fileExtension)
 		{
-			if (WinRTFeatureConfiguration.FileTypes.FileTypeToMimeMapping.TryGetValue(fileExtension, out var customMimeType))
+			if (fileExtension is not null && WinRTFeatureConfiguration.FileTypes.FileTypeToMimeMapping.TryGetValue(fileExtension, out var customMimeType))
 			{
 				return customMimeType;
 			}

--- a/src/Uno.UWP/Storage/Pickers/Internal/UTTypeMapper.iOSmacOS.cs
+++ b/src/Uno.UWP/Storage/Pickers/Internal/UTTypeMapper.iOSmacOS.cs
@@ -41,7 +41,7 @@ namespace Uno.Storage.Pickers.Internal
 		/// <returns>UTType identifier.</returns>
 		private static string GetFromExtension(string? fileExtension)
 		{
-			if (WinRTFeatureConfiguration.FileTypes.FileTypeToUTTypeMapping.TryGetValue(fileExtension, out var customUTType))
+			if (fileExtension is not null && WinRTFeatureConfiguration.FileTypes.FileTypeToUTTypeMapping.TryGetValue(fileExtension, out var customUTType))
 			{
 				return customUTType;
 			}


### PR DESCRIPTION
Update to 8.0.100 RTM, Roslyn 4.8.0-3.final.

Rolsyn update fixes error like this one: 

```
ERROR]System.TypeLoadException: Could not load type 'Enumerator' from assembly 'Microsoft.CodeAnalysis, Version=4.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
   at Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.HostOutputNode`1.AppendOutputs(IncrementalExecutionContext context, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.GeneratorDriver.UpdateOutputs(ImmutableArray`1 outputNodes, IncrementalGeneratorOutputKind outputKind, Builder generatorRunStateBuilder, CancellationToken cancellationToken, Builder driverStateBuilder)
   at Microsoft.CodeAnalysis.GeneratorDriver.RunGeneratorsCore(Compilation compilation, DiagnosticBag diagnosticsBag, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.FinalizeCompilationAsync(SolutionState solution, Compilation compilationWithoutGenerators, CompilationTrackerGeneratorInfo generatorInfo, Compilation compilationWithStaleGeneratedTrees, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.BuildCompilationInfoFromScratchAsync(SolutionState solution, CompilationTrackerGeneratorInfo generatorInfo, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.BuildCompilationInfoAsync(SolutionState solution, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetOrBuildCompilationInfoAsync(SolutionState solution, Boolean lockGate, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetCompilationSlowAsync(SolutionState solution, CancellationToken cancellationToken)
   at Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates.CompilationWorkspaceProvider.CreateProject(TaskCompletionSource`1 taskCompletionSource, String projectPath, IReporter reporter, String[] metadataUpdateCapabilities, Dictionary`2 properties, CancellationToken cancellationToken) in /agent/_work/1/s/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs:line 102
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
   at System.Threading.QueueUserWorkItemCallback.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
```

introduced by a breaking change between `4.8.0-2.final` and `4.8.0-3.final`.