### PR TITLE
Draft for Loaded being fired early

### DIFF
--- a/src/Uno.UI/UI/Xaml/Window.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Window.skia.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
+using Uno.UI.Dispatching;
 using Uno.UI.Xaml.Core;
 using Windows.Foundation;
 using Windows.Security.Cryptography.Core;
@@ -130,7 +131,7 @@ public sealed partial class Window
 			_rootVisual.XamlRoot!.InvalidateMeasure();
 			_rootVisual.XamlRoot!.InvalidateArrange();
 
-			UIElement.RootElementLoaded(_rootVisual);
+			NativeDispatcher.Main.Enqueue(() => UIElement.RootElementLoaded(_rootVisual));
 		}
 
 		if (Dispatcher.HasThreadAccess)


### PR DESCRIPTION
Fixes #7001

TODO: Add test for https://github.com/unoplatform/uno/issues/7001
**DO NOT MERGE**

This change should wait for #12883 to avoid merge conflicts. This PR is only intended to see the CI outcome of the change.

The idea of the change is that:
 
InvalidateMeasure/InvalidateArrange are scheduling the measure/arrange phases.
Then, we want Loaded event to be fired after measure/arrange, so I'm scheduling Loaded too.