### PR TITLE
fix(bitmapicon): fix BitmapIcon respecting ForegroundProperty on skia

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1282,6 +1282,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Foreground.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Sizing.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5851,6 +5855,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Clipping.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_SoftKeboard.xaml.cs">
       <DependentUpon>AutoSuggestBox_SoftKeboard.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Foreground.xaml.cs">
+      <DependentUpon>BitmapIcon_Foreground.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BitmapIconTests\BitmapIcon_Monochromatic.xaml.cs">
       <DependentUpon>BitmapIcon_Monochromatic.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BitmapIconTests/BitmapIcon_Foreground.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BitmapIconTests/BitmapIcon_Foreground.xaml
@@ -1,0 +1,65 @@
+﻿<UserControl
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.BitmapIconTests.BitmapIcon_Foreground"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.BitmapIconTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="100" />
+			<RowDefinition Height="100" />
+			<RowDefinition Height="100" />
+			<RowDefinition Height="100" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="200" />
+			<ColumnDefinition Width="200" />
+			<ColumnDefinition Width="200" />
+		</Grid.ColumnDefinitions>
+		<TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center">
+			Default Foreground
+			<LineBreak />
+			ShowAsMonochrome="false"
+		</TextBlock>
+		<BitmapIcon Grid.Row="0" Grid.Column="1" ShowAsMonochrome="False"
+		            UriSource="ms-appx:///Assets/Formats/uno-overalls.png" VerticalAlignment="Center"
+		            HorizontalAlignment="Center" />
+		<BitmapIcon Grid.Row="0" Grid.Column="2" ShowAsMonochrome="False"
+		            UriSource="ms-appx:///Assets/star_empty.png" VerticalAlignment="Center" HorizontalAlignment="Center" />
+		<TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center">
+			Default Foreground
+			<LineBreak />
+			ShowAsMonochrome="true"
+		</TextBlock>
+		<BitmapIcon Grid.Row="1" Grid.Column="1" ShowAsMonochrome="True"
+		            UriSource="ms-appx:///Assets/Formats/uno-overalls.png" VerticalAlignment="Center"
+		            HorizontalAlignment="Center" />
+		<BitmapIcon Grid.Row="1" Grid.Column="2" ShowAsMonochrome="True"
+		            UriSource="ms-appx:///Assets/star_empty.png" VerticalAlignment="Center" HorizontalAlignment="Center" />
+		<TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center">
+			Foreground = green
+			<LineBreak />
+			ShowAsMonochrome="false"
+		</TextBlock>
+		<BitmapIcon Grid.Row="2" Grid.Column="1" ShowAsMonochrome="False" Foreground="Green"
+		            UriSource="ms-appx:///Assets/Formats/uno-overalls.png" VerticalAlignment="Center"
+		            HorizontalAlignment="Center" />
+		<BitmapIcon Grid.Row="2" Grid.Column="2" ShowAsMonochrome="False" Foreground="Green"
+		            UriSource="ms-appx:///Assets/star_empty.png" VerticalAlignment="Center" HorizontalAlignment="Center" />
+		<TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Center">
+			Foreground = green
+			<LineBreak />
+			ShowAsMonochrome="true"
+		</TextBlock>
+		<BitmapIcon Grid.Row="3" Grid.Column="1" ShowAsMonochrome="True" Foreground="Green"
+		            UriSource="ms-appx:///Assets/Formats/uno-overalls.png" VerticalAlignment="Center"
+		            HorizontalAlignment="Center" />
+		<BitmapIcon Grid.Row="3" Grid.Column="2" ShowAsMonochrome="True" Foreground="Green"
+		            UriSource="ms-appx:///Assets/star_empty.png" VerticalAlignment="Center" HorizontalAlignment="Center" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BitmapIconTests/BitmapIcon_Foreground.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/BitmapIconTests/BitmapIcon_Foreground.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.BitmapIconTests
+{
+	[Sample("Icons", Description = "This sample showcases BitmapIcon "
+		+ "in different conditions with regards to ForegroundProperty and ShowAsMonochromeColor. "
+		+ "Additionally, turn dark mode on and off to see the rendering in different themes.")]
+	public sealed partial class BitmapIcon_Foreground : UserControl
+	{
+		public BitmapIcon_Foreground()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Composition/Composition/CompositionSurfaceBrush.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSurfaceBrush.skia.cs
@@ -87,7 +87,17 @@ namespace Windows.UI.Composition
 
 				var imageShader = SKShader.CreateImage(scs.Image, SKShaderTileMode.Decal, SKShaderTileMode.Decal, matrix.ToSKMatrix());
 
-				fillPaint.Shader = imageShader;
+				if (UsePaintColorToColorSurface)
+				{
+					// use the set color instead of the image pixel values. This is what happens on WinUI.
+					var blendedShader = SKShader.CreateColorFilter(imageShader, SKColorFilter.CreateBlendMode(fillPaint.Color, SKBlendMode.SrcIn));
+
+					fillPaint.Shader = blendedShader;
+				}
+				else
+				{
+					fillPaint.Shader = imageShader;
+				}
 
 				fillPaint.IsAntialias = true;
 			}
@@ -111,6 +121,8 @@ namespace Windows.UI.Composition
 				fillPaint.Shader = null;
 			}
 		}
+
+		internal bool UsePaintColorToColorSurface { private get; set; }
 
 		void IOnlineBrush.Draw(in DrawingSession session, SKRect bounds)
 		{

--- a/src/Uno.UI.Composition/Composition/SpriteVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/SpriteVisual.skia.cs
@@ -3,6 +3,8 @@
 using SkiaSharp;
 using Uno.UI.Composition;
 
+using Color = global::Windows/*Intentional space for WinUI upgrade tool*/.UI.Color;
+
 namespace Windows.UI.Composition
 {
 	public partial class SpriteVisual : ContainerVisual
@@ -21,6 +23,20 @@ namespace Windows.UI.Composition
 		private void UpdatePaint()
 		{
 			Brush?.UpdatePaint(_paint, new SKRect(left: 0, top: 0, right: Size.X, bottom: Size.Y));
+		}
+
+		/// <param name="color">color to set SKPaint to, null to reset</param>
+		internal void SetPaintColor(Color? color)
+		{
+			if (color is { } c)
+			{
+				_paint.Color = c;
+			}
+			else
+			{
+				_paint.Color = SKColors.Black; // resets to default, equivalent to `_paint.Color = new SKPaint().Color`
+			}
+			UpdatePaint();
 		}
 
 		internal override void Draw(in DrawingSession session)

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
@@ -130,6 +130,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_currentSurface = currentData.CompositionSurface;
 				_surfaceBrush = Visual.Compositor.CreateSurfaceBrush(_currentSurface);
+				_surfaceBrush.UsePaintColorToColorSurface = MonochromeColor is not null;
+				_imageSprite.SetPaintColor(MonochromeColor);
 				_imageSprite.Brush = _surfaceBrush;
 				ImageOpened?.Invoke(this, new RoutedEventArgs(this));
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14454

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5b95bc2</samp>

This pull request adds support for rendering monochrome bitmap icons with a custom foreground color in the Skia backend. It introduces a new test page and user control for the `BitmapIcon` control, and modifies the `CompositionSurfaceBrush`, `SpriteVisual` and `Image` classes to enable the feature.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
