### PR TITLE
fix: Fix measuring MPE

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1725,6 +1725,7 @@
 
 		<Events>
 			<Member fullName="Windows.Foundation.TypedEventHandler`2&lt;Windows.UI.Core.CoreWindow,Windows.UI.Core.PointerEventArgs&gt; Windows.UI.Core.CoreWindow::PointerCancelled" reason="Exists in uno-runtime implementation but not in Reference. Can't be called from user code anyways and shouldn't really be breaking" />
+			<Member fullName="Windows.Foundation.TypedEventHandler`2&lt;Windows.Media.Playback.MediaPlayer,System.Double&gt; Windows.Media.Playback.MediaPlayer::VideoRatioChanged" reason="Required for a bug fix and intended for internal use. It's not part of WinAppSDK" />
 		</Events>
 
 		<Fields>
@@ -1740,6 +1741,10 @@
 			<Member fullName="Windows.UI.Color Windows.UI.Xaml.Controls.ScrollViewer.get_BackgroundColor()" reason="Exists in uno-runtime implementation but not in Reference. Can't be called from user code anyways and shouldn't really be breaking" />
 			<Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollViewer.set_BackgroundColor(Windows.UI.Color value)" reason="Exists in uno-runtime implementation but not in Reference. Can't be called from user code anyways and shouldn't really be breaking" />
 			<Member fullName="System.Void Microsoft.UI.Xaml.Controls.InfoBadge.set_TemplateSettings(Microsoft.UI.Xaml.Controls.InfoBadgeTemplateSettings value)" reason="No setter in MUX" />
+
+			<Member fullName="System.Void Uno.Media.Playback.IMediaPlayerEventsExtension.RaiseVideoRatioChanged(System.Double videoRatio)" reason="Required for a bug fix and intended for internal use. It's not part of WinAppSDK" />
+			<Member fullName="System.Void Windows.Media.Playback.MediaPlayer.add_VideoRatioChanged(Windows.Foundation.TypedEventHandler`2&lt;Windows.Media.Playback.MediaPlayer,System.Double&gt; value)" reason="Required for a bug fix and intended for internal use. It's not part of WinAppSDK" />
+			<Member fullName="System.Void Windows.Media.Playback.MediaPlayer.remove_VideoRatioChanged(Windows.Foundation.TypedEventHandler`2&lt;Windows.Media.Playback.MediaPlayer,System.Double&gt; value)" reason="Required for a bug fix and intended for internal use. It's not part of WinAppSDK" />
 		</Methods>
 	</IgnoreSet>
 	  <!--

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.events.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/GtkMediaPlayer.events.cs
@@ -29,7 +29,7 @@ public partial class GtkMediaPlayer
 	public event EventHandler<object>? OnMetadataLoaded;
 	public event EventHandler<object>? OnTimeUpdate;
 	public event EventHandler<object>? OnSourceLoaded;
-	public event EventHandler<object?>? OnVideoRatioChanged;
+	public event Action? OnNaturalVideoDimensionChanged;
 
 	private bool _updateVideoSizeOnFirstTimeStamp = true;
 	private bool _isParsedLocalFile;

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.cs
@@ -102,7 +102,7 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 		_player.OnSourceLoaded += OnPrepared;
 		_player.OnSourceEnded += OnCompletion;
 		_player.OnTimeUpdate += OnTimeUpdate;
-		_player.OnVideoRatioChanged += OnVideoRatioChanged;
+		_player.OnNaturalVideoDimensionChanged += OnNaturalVideoDimensionChanged;
 
 		_owner.PlaybackSession.PlaybackStateChanged -= OnStatusChanged;
 		_owner.PlaybackSession.PlaybackStateChanged += OnStatusChanged;

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerExtension.events.cs
@@ -133,14 +133,14 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 		_player?.SetVolume(volume);
 	}
 
-	private void OnVideoRatioChanged(object? sender, object? e)
+	private void OnNaturalVideoDimensionChanged()
 	{
 		if (_player is not null
 			&& _player.IsVideo
 			&& Events is not null)
 		{
 			IsVideo = _player.IsVideo;
-			Events?.RaiseVideoRatioChanged(Math.Max(1, (double)_player.VideoRatio));
+			Events?.RaiseNaturalVideoDimensionChanged();
 		}
 	}
 

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerPresenterExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/MediaPlayerPresenterExtension.cs
@@ -30,6 +30,10 @@ public class MediaPlayerPresenterExtension : IMediaPlayerPresenterExtension
 {
 	private MediaPlayerPresenter? _owner;
 	private GtkMediaPlayer _player;
+
+	public uint NaturalVideoHeight => _player.NaturalVideoHeight;
+	public uint NaturalVideoWidth => _player.NaturalVideoWidth;
+
 	public MediaPlayerPresenterExtension(object owner)
 	{
 		if (owner is not MediaPlayerPresenter presenter)

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -572,7 +572,7 @@ public partial class MediaPlayerExtension : IMediaPlayerExtension
 						this.Log().Debug($"OnPrepared: {mp.VideoWidth}x{mp.VideoHeight}");
 					}
 
-					Events.RaiseVideoRatioChanged((double)mp.VideoWidth / global::System.Math.Max(mp.VideoHeight, 1));
+					Events.RaiseNaturalVideoDimensionChanged();
 				}
 				catch { }
 			}

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerPresenterExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerPresenterExtension.cs
@@ -19,6 +19,9 @@ public class MediaPlayerPresenterExtension : IMediaPlayerPresenterExtension
 	private MediaPlayerPresenter? _owner;
 	private HtmlMediaPlayer _htmlPlayer;
 
+	public uint NaturalVideoHeight => (uint)_htmlPlayer.VideoHeight;
+	public uint NaturalVideoWidth => (uint)_htmlPlayer.VideoWidth;
+
 	public MediaPlayerPresenterExtension(object owner)
 	{
 		if (owner is not MediaPlayerPresenter presenter)

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/IMediaPlayerPresenterExtension.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/IMediaPlayerPresenterExtension.cs
@@ -15,5 +15,9 @@ namespace Windows.UI.Xaml.Controls
 		void RequestCompactOverlay();
 
 		void ExitCompactOverlay();
+
+		uint NaturalVideoHeight { get; }
+
+		uint NaturalVideoWidth { get; }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -220,7 +220,7 @@ namespace Windows.UI.Xaml.Controls
 				{
 					oldMediaPlayer.MediaFailed -= mpe.OnMediaFailed;
 					oldMediaPlayer.MediaOpened -= mpe.OnMediaOpened;
-					oldMediaPlayer.VideoRatioChanged -= mpe.OnVideoRatioChanged;
+					oldMediaPlayer.NaturalVideoDimensionChanged -= mpe.OnNaturalVideoDimensionChanged;
 					oldMediaPlayer.Dispose();
 				}
 
@@ -229,14 +229,14 @@ namespace Windows.UI.Xaml.Controls
 					newMediaPlayer.Source = mpe.Source;
 					newMediaPlayer.MediaFailed += mpe.OnMediaFailed;
 					newMediaPlayer.MediaOpened += mpe.OnMediaOpened;
-					newMediaPlayer.VideoRatioChanged -= mpe.OnVideoRatioChanged;
+					newMediaPlayer.NaturalVideoDimensionChanged -= mpe.OnNaturalVideoDimensionChanged;
 					mpe.TransportControls?.SetMediaPlayer(newMediaPlayer);
 					mpe._isTransportControlsBound = true;
 				}
 			};
 		}
 
-		private void OnVideoRatioChanged(Windows.Media.Playback.MediaPlayer sender, double args)
+		private void OnNaturalVideoDimensionChanged(MediaPlayer sender, object args)
 		{
 			_ = Dispatcher.RunAsync(
 				CoreDispatcherPriority.Normal,
@@ -362,6 +362,7 @@ namespace Windows.UI.Xaml.Controls
 			_layoutRoot = this.GetTemplateChild(LayoutRootName) as Grid;
 			_posterImage = this.GetTemplateChild(PosterImageName) as Image;
 			_mediaPlayerPresenter = this.GetTemplateChild(MediaPlayerPresenterName) as MediaPlayerPresenter;
+			_mediaPlayerPresenter?.SetOwner(this);
 
 			_transportControlsPresenter = this.GetTemplateChild(TransportControlsPresenterName) as ContentPresenter;
 			_transportControlsPresenter.Content = TransportControls;

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElement.cs
@@ -236,7 +236,7 @@ namespace Windows.UI.Xaml.Controls
 			};
 		}
 
-		private void OnNaturalVideoDimensionChanged(MediaPlayer sender, object args)
+		private void OnNaturalVideoDimensionChanged(Windows.Media.Playback.MediaPlayer sender, object args)
 		{
 			_ = Dispatcher.RunAsync(
 				CoreDispatcherPriority.Normal,

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.Android.cs
@@ -8,6 +8,9 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class MediaPlayerPresenter
 	{
+		internal uint NaturalVideoWidth => MediaPlayer?.NaturalVideoWidth ?? 0;
+		internal uint NaturalVideoHeight => MediaPlayer?.NaturalVideoHeight ?? 0;
+
 		private void SetVideoSurface(IVideoSurface videoSurface)
 		{
 			this.Child = VisualTreeHelper.AdaptNative(videoSurface as SurfaceView);

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.Others.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.Others.cs
@@ -30,6 +30,9 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
+		internal uint NaturalVideoHeight => _extension?.NaturalVideoHeight ?? 0;
+		internal uint NaturalVideoWidth => _extension?.NaturalVideoWidth ?? 0;
+
 		partial void OnMediaPlayerChangedPartial(MediaPlayer mediaPlayer)
 			=> _extension?.MediaPlayerChanged();
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
@@ -147,7 +147,7 @@ namespace Windows.UI.Xaml.Controls
 			base.OnUnloaded();
 		}
 
-		private void OnNaturalVideoDimensionChanged(MediaPlayer sender, object args)
+		private void OnNaturalVideoDimensionChanged(Windows.Media.Playback.MediaPlayer sender, object args)
 		{
 			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
@@ -9,7 +9,36 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class MediaPlayerPresenter : Border
 	{
-		private double _currentRatio = 1;
+		private WeakReference<MediaPlayerElement> wrOwner;
+
+		internal void SetOwner(MediaPlayerElement owner)
+		{
+			wrOwner = new WeakReference<MediaPlayerElement>(owner);
+		}
+
+		private float GetScaledOtherDimension(
+			float scaledOneDimension,
+			uint naturalOneDimension,
+			uint naturalOtherDimension)
+		{
+			//
+			// naturalOneDimension is mapped to scaledOneDimension. Map naturalOtherDimension to scaledOtherDimension using the
+			// same scale factor.
+			//
+			// scaledOther / naturalOther = scaledOne / naturalOne
+			//                scaledOther = naturalOther * scaledOne / naturalOne
+			//
+
+			if (naturalOneDimension == 0)
+			{
+				return 0.0f;
+			}
+			else
+			{
+				return (float)naturalOtherDimension * scaledOneDimension / (float)naturalOneDimension;
+			}
+		}
+
 
 		#region MediaPlayer Property
 
@@ -36,14 +65,14 @@ namespace Windows.UI.Xaml.Controls
 				}
 				if (args.OldValue is Windows.Media.Playback.MediaPlayer oldPlayer)
 				{
-					oldPlayer.VideoRatioChanged -= presenter.OnVideoRatioChanged;
+					oldPlayer.NaturalVideoDimensionChanged -= presenter.OnNaturalVideoDimensionChanged;
 					oldPlayer.MediaFailed -= presenter.OnMediaFailed;
 					oldPlayer.SourceChanged -= presenter.OnSourceChanged;
 				}
 
 				if (args.NewValue is Windows.Media.Playback.MediaPlayer newPlayer)
 				{
-					newPlayer.VideoRatioChanged += presenter.OnVideoRatioChanged;
+					newPlayer.NaturalVideoDimensionChanged += presenter.OnNaturalVideoDimensionChanged;
 					newPlayer.MediaFailed += presenter.OnMediaFailed;
 					newPlayer.SourceChanged += presenter.OnSourceChanged;
 
@@ -118,19 +147,14 @@ namespace Windows.UI.Xaml.Controls
 			base.OnUnloaded();
 		}
 
-		private void OnVideoRatioChanged(Windows.Media.Playback.MediaPlayer sender, double args)
+		private void OnNaturalVideoDimensionChanged(MediaPlayer sender, object args)
 		{
-			if (args > 0) // The VideoRect may initially be empty, ignore because a 0 ratio will lead to infinite dims being returned on measure, resulting in an exception
-			{
-				_currentRatio = args;
-			}
-
 			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{
 				Visibility = Visibility.Visible;
 			});
 
-			InvalidateArrange();
+			InvalidateMeasure();
 		}
 
 		private void OnMediaFailed(Windows.Media.Playback.MediaPlayer sender, MediaPlayerFailedEventArgs args)
@@ -148,30 +172,90 @@ namespace Windows.UI.Xaml.Controls
 			});
 		}
 
+		private FrameworkElement GetLayoutOwner()
+		{
+			if (wrOwner?.TryGetTarget(out var owner) == true && owner is not null && !IsFullWindow)
+			{
+				return owner;
+			}
+
+			return this;
+		}
+
 		protected override Size MeasureOverride(Size availableSize)
 		{
-			if (double.IsNaN(Width) && double.IsNaN(Height))
+			var layoutOwner = GetLayoutOwner();
+			var explicitWidth = layoutOwner.Width;
+			var explicitHeight = layoutOwner.Height;
+			if (!double.IsNaN(explicitWidth) && !double.IsNaN(explicitHeight))
 			{
-				availableSize.Width = availableSize.Width;
-				if (_currentRatio != 0)
+				return new Size(explicitWidth, explicitHeight);
+			}
+
+			//
+			// When determining the layout size:
+			//
+			//   1. If the explicit size is provided, then use that.
+			//
+			//   2. If the explicit size is only provided in one dimension, then use the explicit size in that dimension
+			//      and infer the other from the natural size of the media.
+			//
+			//      Note that if the media is not ready yet, then we use 0x0.
+			//
+			//   3. If neither dimension is provided and the stretch is None, then use the natural size of the media.
+			//
+			//   4. If neither dimension is provided, the stretch isn't None, and the available size is finite, then use
+			//      the available size.
+			//
+			//   5. If neither dimension is provided, the stretch isn't None, and the available size is infinite in one
+			//      dimension, then fill the available area in one dimension and infer the other from the natural size
+			//      of the media.
+			//
+			//   6. If neither dimension is provided, the stretch isn't None, and the available size is infinite in both
+			//      dimensions, use the natural size of the media.
+			//
+			if (!double.IsNaN(explicitWidth))
+			{
+				return new Size(
+					explicitWidth,
+					GetScaledOtherDimension((float)explicitWidth, NaturalVideoWidth, NaturalVideoHeight));
+			}
+			else if (!double.IsNaN(explicitHeight))
+			{
+				return new Size(
+					GetScaledOtherDimension((float)explicitHeight, NaturalVideoHeight, NaturalVideoWidth),
+					explicitHeight);
+			}
+			else if (Stretch == Stretch.None)
+			{
+				return new Size(NaturalVideoWidth, NaturalVideoHeight);
+			}
+			else
+			{
+				bool isFiniteWidth = !double.IsInfinity(availableSize.Width);
+				bool isFiniteHeight = !double.IsInfinity(availableSize.Height);
+
+				if (isFiniteWidth && isFiniteHeight)
 				{
-					availableSize.Height = availableSize.Width / _currentRatio;
+					return availableSize;
+				}
+				else if (isFiniteWidth)
+				{
+					return new Size(
+						availableSize.Width,
+						GetScaledOtherDimension((float)availableSize.Width, NaturalVideoWidth, NaturalVideoHeight));
+				}
+				else if (isFiniteHeight)
+				{
+					return new Size(
+						GetScaledOtherDimension((float)availableSize.Height, NaturalVideoHeight, NaturalVideoWidth),
+						availableSize.Height);
+				}
+				else
+				{
+					return new Size(NaturalVideoWidth, NaturalVideoHeight);
 				}
 			}
-			else if (double.IsNaN(Width))
-			{
-				availableSize.Width = Height * _currentRatio;
-				availableSize.Height = Height;
-			}
-			else if (double.IsNaN(Height))
-			{
-				availableSize.Width = Width;
-				availableSize.Height = Width / _currentRatio;
-			}
-
-			base.MeasureOverride(availableSize);
-
-			return availableSize;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.iOSmacOS.cs
@@ -13,6 +13,9 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class MediaPlayerPresenter
 	{
+		internal uint NaturalVideoWidth => MediaPlayer?.NaturalVideoWidth ?? 0;
+		internal uint NaturalVideoHeight => MediaPlayer?.NaturalVideoHeight ?? 0;
+
 		private void SetVideoSurface(IVideoSurface videoSurface)
 		{
 			Add(videoSurface as _View);

--- a/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
@@ -46,9 +46,9 @@ namespace Uno.Media.Playback
 		void RaiseSeekCompleted();
 
 		/// <summary>
-		/// Raises the <see cref="MediaPlayer.VideoRatioChanged"/> event
+		/// Raises the <see cref="MediaPlayer.NaturalVideoDimensionChanged"/> event
 		/// </summary>
-		void RaiseVideoRatioChanged(double videoRatio);
+		void RaiseNaturalVideoDimensionChanged();
 
 		/// <summary>
 		/// Raises the <see cref="MediaPlayer.BufferingEnded"/> event

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -272,7 +272,7 @@ namespace Windows.Media.Playback
 			{
 				PlaybackSession.NaturalDuration = TimeSpan.FromMilliseconds(_player.Duration);
 
-				VideoRatioChanged?.Invoke(this, (double)mp.VideoWidth / global::System.Math.Max(mp.VideoHeight, 1));
+				NaturalVideoDimensionChanged?.Invoke(this, null);
 
 				IsVideo = mp.GetTrackInfo()?.Any(x => x.TrackType == MediaTrackType.Video) == true;
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -50,6 +50,9 @@ namespace Windows.Media.Playback
 
 		const string MsAppXScheme = "ms-appx";
 
+		internal uint NaturalVideoHeight { get; private set; }
+		internal uint NaturalVideoWidth { get; private set; }
+
 		public IVideoSurface RenderSurface { get; private set; } = new VideoSurface(Application.Context);
 
 		private void Initialize()
@@ -271,7 +274,8 @@ namespace Windows.Media.Playback
 			if (mp is not null)
 			{
 				PlaybackSession.NaturalDuration = TimeSpan.FromMilliseconds(_player.Duration);
-
+				NaturalVideoWidth = (uint)mp.VideoWidth;
+				NaturalVideoHeight = (uint)mp.VideoHeight;
 				NaturalVideoDimensionChanged?.Invoke(this, null);
 
 				IsVideo = mp.GetTrackInfo()?.Any(x => x.TrackType == MediaTrackType.Video) == true;

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Events.others.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Events.others.cs
@@ -52,8 +52,8 @@ namespace Windows.Media.Playback
 		void RaiseVideoFrameAvailable()
 			=> VideoFrameAvailable?.Invoke(this, new object());
 
-		void RaiseVideoRatioChanged(double videoRatio)
-			=> VideoRatioChanged?.Invoke(this, videoRatio);
+		void RaiseNaturalVideoDimensionChanged()
+			=> NaturalVideoDimensionChanged?.Invoke(this, null);
 
 		void RaiseVolumeChanged()
 			=> VolumeChanged?.Invoke(this, null);
@@ -112,8 +112,9 @@ namespace Windows.Media.Playback
 			void IMediaPlayerEventsExtension.RaiseVideoFrameAvailable()
 				=> _owner.RaiseVideoFrameAvailable();
 
-			void IMediaPlayerEventsExtension.RaiseVideoRatioChanged(double videoRatio)
-				=> _owner.RaiseVideoRatioChanged(videoRatio);
+			void IMediaPlayerEventsExtension.RaiseNaturalVideoDimensionChanged()
+				=> _owner.RaiseNaturalVideoDimensionChanged();
+
 			void IMediaPlayerEventsExtension.RaiseVolumeChanged()
 				=> _owner.RaiseVolumeChanged();
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.cs
@@ -85,7 +85,7 @@ namespace Windows.Media.Playback
 
 		public event TypedEventHandler<MediaPlayer, object> SeekCompleted;
 
-		public event TypedEventHandler<MediaPlayer, double> VideoRatioChanged;
+		public event TypedEventHandler<MediaPlayer, object> NaturalVideoDimensionChanged;
 
 		#endregion
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOSmacOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOSmacOS.cs
@@ -123,6 +123,9 @@ namespace Windows.Media.Playback
 
 		public IVideoSurface RenderSurface { get; } = new VideoSurface();
 
+		internal uint NaturalVideoHeight { get; private set; }
+		internal uint NaturalVideoWidth { get; private set; }
+
 		private void Initialize()
 		{
 			_observer = new Observer(this);
@@ -386,8 +389,10 @@ namespace Windows.Media.Playback
 
 		private void OnVideoRectChanged()
 		{
-			if (_videoLayer?.VideoRect != null)
+			if (_videoLayer?.VideoRect is { } videoRect)
 			{
+				NaturalVideoWidth = (uint)videoRect.Width;
+				NaturalVideoHeight = (uint)videoRect.Height;
 				NaturalVideoDimensionChanged?.Invoke(this, null);
 			}
 		}

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOSmacOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOSmacOS.cs
@@ -388,7 +388,7 @@ namespace Windows.Media.Playback
 		{
 			if (_videoLayer?.VideoRect != null)
 			{
-				VideoRatioChanged?.Invoke(this, _videoLayer.VideoRect.Width / Math.Max(_videoLayer.VideoRect.Height, 1));
+				NaturalVideoDimensionChanged?.Invoke(this, null);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14490

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 52a8293</samp>

This pull request refactors the media player element and its platform-specific implementations to use the natural video dimensions instead of the video ratio to calculate the layout size and to raise events. It also removes or simplifies some unused or redundant code and improves the consistency and naming of the events and properties. The main files affected are `MediaPlayerElement.cs`, `MediaPlayerPresenter.cs`, `MediaPlayer.cs`, and the platform-specific extensions of these classes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
