### PR TITLE
test: Additional tests for DP `DefaultValue`

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DefaultValueProvider.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DefaultValueProvider.cs
@@ -47,6 +47,41 @@ namespace Uno.UI.Tests.DependencyPropertyTests
 			var value = test.GetPrecedenceSpecificValue(DefaultValueProviderSample.TestProperty, DependencyPropertyValuePrecedences.DefaultValue);
 			Assert.AreEqual(3, value); // GetDefaultValue should apply
 		}
+
+		[TestMethod]
+		public void When_GetDefaultValue()
+		{
+			var expected = 42;
+			var defaultValueTest = new DefaultValueTest();
+			Assert.AreEqual(expected, defaultValueTest.GetPrecedenceSpecificValue(DefaultValueTest.TestValueProperty, DependencyPropertyValuePrecedences.DefaultValue));
+			Assert.AreEqual(expected, defaultValueTest.GetValue(DefaultValueTest.TestValueProperty));
+			Assert.AreEqual(expected, (defaultValueTest as IDependencyObjectStoreProvider).Store.GetPropertyDetails(DefaultValueTest.TestValueProperty).GetDefaultValue());
+			Assert.AreEqual(expected, defaultValueTest.TestValue);
+		}
+
+		[TestMethod]
+		public void When_SetDefaultValue()
+		{
+			var expected = 24;
+			var defaultValueTest = new DefaultValueTest();
+			((IDependencyObjectStoreProvider)defaultValueTest).Store.GetPropertyDetails(DefaultValueTest.TestValueProperty).SetDefaultValue(expected);
+			Assert.AreEqual(expected, defaultValueTest.GetPrecedenceSpecificValue(DefaultValueTest.TestValueProperty, DependencyPropertyValuePrecedences.DefaultValue));
+			Assert.AreEqual(expected, defaultValueTest.GetValue(DefaultValueTest.TestValueProperty));
+			Assert.AreEqual(expected, ((IDependencyObjectStoreProvider)defaultValueTest).Store.GetPropertyDetails(DefaultValueTest.TestValueProperty).GetDefaultValue());
+			Assert.AreEqual(expected, defaultValueTest.TestValue);
+		}
+	}
+
+	internal partial class DefaultValueTest : UIElement
+	{
+		public int TestValue
+		{
+			get { return (int)GetValue(TestValueProperty); }
+			set { SetValue(TestValueProperty, value); }
+		}
+
+		public static DependencyProperty TestValueProperty { get; } =
+			DependencyProperty.Register("TestValue", typeof(int), typeof(DefaultValueTest), new PropertyMetadata(42));
 	}
 
 	internal partial class InheritedDefaultValueProviderSample : DefaultValueProviderSample

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetails.cs
@@ -105,7 +105,7 @@ namespace Windows.UI.Xaml
 			hasInherits = false;
 		}
 
-		private object? GetDefaultValue()
+		internal object? GetDefaultValue()
 		{
 			if (!HasDefaultValueSet)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): related to #14453

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Project automation

## What is the current behavior?


## What is the new behavior?

Additional test coverage to ensure `SetDefaultValue` has the proper effect

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f1af74b</samp>

Added tests for `DependencyPropertyDetails` default value provider and made `GetDefaultValue` method internal. The tests verify the logic for getting and setting the default value of a dependency property, which can be customized or inherited.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
