### PR TITLE
chore: fix SamplesApp sample selection when opening runtime tests

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -472,6 +472,20 @@ namespace SampleControl.Presentation
 			}
 
 			var content = await UpdateContent(ct, runtimeTests) as FrameworkElement;
+			if (!Equals(SelectedLibrarySample, runtimeTests))
+			{
+				SelectedLibrarySample = null;
+			}
+
+			if (!Equals(SelectedRecentSample, runtimeTests))
+			{
+				SelectedRecentSample = null;
+			}
+
+			if (!Equals(SelectedFavoriteSample, runtimeTests))
+			{
+				SelectedFavoriteSample = null;
+			}
 			ContentPhone = content;
 		}
 
@@ -512,10 +526,9 @@ namespace SampleControl.Presentation
 						CoreDispatcherPriority.Normal,
 						async () =>
 						{
-							CurrentSelectedSample = newContent;
-
-							if (CurrentSelectedSample != null)
+							if (newContent != null)
 							{
+								CurrentSelectedSample = newContent;
 								ContentPhone = await UpdateContent(CancellationToken.None, newContent);
 							}
 						}


### PR DESCRIPTION
GitHub Issue (If applicable):

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

When opening a sample, going to the rutime tests page, and then opening the sample again, it doesn't open.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 652d8e7</samp>

This pull request enhances the sample chooser functionality for the SamplesApp unit tests. It prevents unwanted sample selection when running tests, and avoids a potential null reference exception in `SampleChooserViewModel`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
