### PR TITLE
perf(xamlgen): Reduce allocations in RewriteNamespaces

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
@@ -4587,26 +4588,99 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			foreach (var ns in _fileDefinition.Namespaces)
 			{
-				if (ns.Namespace.StartsWith("using:", StringComparison.Ordinal))
-				{
-					// Replace namespaces with their fully qualified namespace.
-					// Add global:: so that qualified paths can be expluded from binding
-					// path observation.
-					xamlString = Regex.Replace(
-						xamlString,
-						$@"(^|[^\w])({ns.Prefix}:)",
-						"$1global::" + ns.Namespace.TrimStart("using:") + ".");
-				}
-				else if (ns.Namespace == XamlConstants.XamlXmlNamespace)
-				{
-					xamlString = Regex.Replace(
-						xamlString,
-						$@"(^|[^\w])({ns.Prefix}:)",
-						"$1global::System.");
-				}
+				xamlString = ReplaceNamespace(xamlString, ns);
 			}
 
 			return xamlString;
+
+			// This is a performance-sensitive code. It used to be using Regex and was improved to avoid Regex.
+			// It might be possible to improve it further, but that seems to do the job for now.
+			// We can optimize further if future performance measures shows it being problematic.
+			// What this method does is:
+			// Given a xamlString like "muxc:SomeControl", converts it to Microsoft.UI.Xaml.Controls.SomeControl.
+			// Note that the given xamlString can be a more complex expression involving multiple namespaces.
+			static string ReplaceNamespace(string xamlString, NamespaceDeclaration ns)
+			{
+				// Note: The call xamlString.IndexOf($"{ns.Prefix}:", StringComparison.Ordinal) can be replaced with xamlString.IndexOf(ns.Prefix)
+				// followed by a separate check for ":" character. This will save a string allocation.
+				// But for now, we keep it as is. We can always revisit if it shows performance issues.
+				if (ns.Namespace.StartsWith("using:", StringComparison.Ordinal))
+				{
+					while (xamlString.Length > ns.Prefix.Length)
+					{
+						var index = xamlString.IndexOf($"{ns.Prefix}:", StringComparison.Ordinal);
+						if (index == 0 || (index > 0 && !char.IsLetterOrDigit(xamlString[index - 1])))
+						{
+							var nsGlobalized = ns.Namespace.Replace("using:", "global::");
+
+							// following is the equivalent of "string.Concat(xamlString.Substring(0, index), nsGlobalized, ".", xamlString.Substring(index + ns.Prefix.Length + 1))"
+							// but in a way that allocates less memory.
+							var newLength = xamlString.Length + nsGlobalized.Length - ns.Prefix.Length;
+							xamlString = StringExtensions.Create(newLength, (xamlString, index, nsGlobalized, ns.Prefix), static (span, state) =>
+							{
+								var (xamlString, index, nsGlobalized, nsPrefix) = state;
+								var copiedLengthSoFar = 0;
+
+								xamlString.AsSpan().Slice(0, index).CopyTo(span.Slice(copiedLengthSoFar));
+								copiedLengthSoFar += index;
+
+								nsGlobalized.AsSpan().CopyTo(span.Slice(copiedLengthSoFar));
+								copiedLengthSoFar += nsGlobalized.Length;
+
+								span[copiedLengthSoFar] = '.';
+								copiedLengthSoFar++;
+
+								xamlString.AsSpan().Slice(index + nsPrefix.Length + 1).CopyTo(span.Slice(copiedLengthSoFar));
+							});
+
+						}
+						else
+						{
+							break;
+						}
+					}
+
+					return xamlString;
+				}
+				else if (ns.Namespace == XamlConstants.XamlXmlNamespace)
+				{
+					while (xamlString.Length > ns.Prefix.Length)
+					{
+						var index = xamlString.IndexOf($"{ns.Prefix}:", StringComparison.Ordinal);
+						if (index == 0 || (index > 0 && !char.IsLetterOrDigit(xamlString[index - 1])))
+						{
+							const string nsGlobalized = "global::System.";
+
+							// following is the equivalent of "string.Concat(xamlString.Substring(0, index), nsGlobalized, xamlString.Substring(index + ns.Prefix.Length + 1))"
+							// but in a way that allocates less memory.
+							var newLength = xamlString.Length + nsGlobalized.Length - ns.Prefix.Length - 1;
+							xamlString = StringExtensions.Create(newLength, (xamlString, index, ns.Prefix), static (span, state) =>
+							{
+								var (xamlString, index, nsPrefix) = state;
+								var copiedLengthSoFar = 0;
+
+								xamlString.AsSpan().Slice(0, index).CopyTo(span.Slice(copiedLengthSoFar));
+								copiedLengthSoFar += index;
+
+								nsGlobalized.AsSpan().CopyTo(span.Slice(copiedLengthSoFar));
+								copiedLengthSoFar += nsGlobalized.Length;
+
+								xamlString.AsSpan().Slice(index + nsPrefix.Length + 1).CopyTo(span.Slice(copiedLengthSoFar));
+							});
+						}
+						else
+						{
+							break;
+						}
+					}
+
+					return xamlString;
+				}
+				else
+				{
+					return xamlString;
+				}
+			}
 		}
 
 		private string GetDefaultBindMode() => _currentDefaultBindMode.Peek();

--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions/StringExtensions.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions/StringExtensions.cs
@@ -161,7 +161,7 @@ namespace Uno.Extensions
 			scoped Span<char> buffer;
 
 			if (length <= 128)
-				buffer = stackalloc char[512];
+				buffer = stackalloc char[128];
 			else
 				buffer = new char[length];
 

--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions/StringExtensions.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions/StringExtensions.cs
@@ -27,6 +27,8 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Uno.Extensions
 {
+	public delegate void SpanAction<T, in TArg>(Span<T> span, TArg arg);
+
 	internal static partial class StringExtensions
 	{
 		// https://www.meziantou.net/split-a-string-into-lines-without-allocation.htm
@@ -152,6 +154,19 @@ namespace Uno.Extensions
 			{
 				return source;
 			}
+		}
+
+		public static string Create<TState>(int length, TState state, SpanAction<char, TState> action)
+		{
+			scoped Span<char> buffer;
+
+			if (length <= 128)
+				buffer = stackalloc char[512];
+			else
+				buffer = new char[length];
+
+			action(buffer.Slice(0, length), state);
+			return buffer.Slice(0, length).ToString();
 		}
 	}
 }


### PR DESCRIPTION
closes #14527

Benchmark:

```csharp
    [Params("Abc", "muxc:Abc", "(muxc:Abc)", "M(muxc:Abc.A, muxc:Abc.B)")]
    public string xamlString { get; set; }

    [Params("muxc")]
    public string nsPrefix { get; set; }

    [Params("using:Microsoft.UI.Xaml.Controls")]
    public string nsNamespace { get; set; }


    [Benchmark(Baseline = true)]
    public string RegexBench()
        => Regex.Replace(xamlString, $@"(^|[^\w])({nsPrefix}:)", "$1global::" + nsNamespace.TrimStart("using:") + ".");

    [Benchmark]
    public string WithSpanSlicingAndCopying()
    {
        if (nsNamespace.StartsWith("using:", StringComparison.Ordinal))
        {
            while (xamlString.Length > nsPrefix.Length)
            {
                var index = xamlString.IndexOf($"{nsPrefix}:", StringComparison.Ordinal);
                if (index == 0 || (index > 0 && !char.IsLetterOrDigit(xamlString[index - 1])))
                {
                    var nsGlobalized = nsNamespace.Replace("using:", "global::");

                    // following is the equivalent of "string.Concat(xamlString.Substring(0, index), nsGlobalized, ".", xamlString.Substring(index + ns.Prefix.Length + 1))"
                    // but in a way that allocates less memory.
                    var newLength = xamlString.Length + nsGlobalized.Length - nsPrefix.Length;
                    xamlString = StringExtensions.Create(newLength, (xamlString, index, nsGlobalized, nsPrefix), static (span, state) =>
                    {
                        var (xamlString, index, nsGlobalized, nsPrefix) = state;
                        var copiedLengthSoFar = 0;

                        xamlString.AsSpan().Slice(0, index).CopyTo(span.Slice(copiedLengthSoFar));
                        copiedLengthSoFar += index;

                        nsGlobalized.AsSpan().CopyTo(span.Slice(copiedLengthSoFar));
                        copiedLengthSoFar += nsGlobalized.Length;

                        span[copiedLengthSoFar] = '.';
                        copiedLengthSoFar++;

                        xamlString.AsSpan().Slice(index + nsPrefix.Length + 1).CopyTo(span.Slice(copiedLengthSoFar));
                    });
                }
                else
                    break;
            }

            return xamlString;
        }
        else
        {
            return xamlString;
        }
    }
```

and

```csharp
public static class Extensions
{
    public static string TrimStart(this string source, string trimText, bool ignoreCase = false)
    {
        if (!string.IsNullOrEmpty(trimText) && source.StartsWith(trimText, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
        {
            return source.Substring(trimText.Length);
        }
        else
        {
            return source;
        }
    }
}
```

and

```csharp
public delegate void SpanAction<T, in TArg>(Span<T> span, TArg arg);


namespace MyBench
{
    public static class StringExtensions
    {

        public static string Create<TState>(int length, TState state, SpanAction<char, TState> action)
        {
            scoped Span<char> buffer;

            if (length <= 128)
                buffer = stackalloc char[512];
            else
                buffer = new char[length];

            action(buffer.Slice(0, length), state);
            return buffer.Slice(0, length).ToString();
        }
    }
}
```

Result:

|                    Method |           xamlString | nsPrefix |          nsNamespace |         Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |--------------------- |--------- |--------------------- |-------------:|----------:|----------:|------:|-------:|------:|------:|----------:|
|                RegexBench |           (muxc:Abc) |     muxc | using(...)trols [32] |   393.654 ns | 1.5770 ns | 1.3168 ns |  1.00 | 0.1602 |     - |     - |     336 B |
| WithSpanSlicingAndCopying |           (muxc:Abc) |     muxc | using(...)trols [32] |    18.640 ns | 0.0729 ns | 0.0647 ns |  0.05 | 0.0153 |     - |     - |      32 B |
|                           |                      |          |                      |              |           |           |       |        |       |       |           |
|                RegexBench |                  Abc |     muxc | using(...)trols [32] |   118.172 ns | 0.3048 ns | 0.2545 ns |  1.00 | 0.1109 |     - |     - |     232 B |
| WithSpanSlicingAndCopying |                  Abc |     muxc | using(...)trols [32] |     2.142 ns | 0.0088 ns | 0.0082 ns |  0.02 |      - |     - |     - |         - |
|                           |                      |          |                      |              |           |           |       |        |       |       |           |
|                RegexBench | M(mux(...)bc.B) [25] |     muxc | using(...)trols [32] | 1,092.265 ns | 3.1872 ns | 2.9813 ns |  1.00 | 0.2022 |     - |     - |     424 B |
| WithSpanSlicingAndCopying | M(mux(...)bc.B) [25] |     muxc | using(...)trols [32] |    20.957 ns | 0.1646 ns | 0.1540 ns |  0.02 | 0.0153 |     - |     - |      32 B |
|                           |                      |          |                      |              |           |           |       |        |       |       |           |
|                RegexBench |             muxc:Abc |     muxc | using(...)trols [32] |   330.517 ns | 0.9944 ns | 0.9301 ns |  1.00 | 0.1602 |     - |     - |     336 B |
| WithSpanSlicingAndCopying |             muxc:Abc |     muxc | using(...)trols [32] |    18.535 ns | 0.0431 ns | 0.0403 ns |  0.06 | 0.0153 |     - |     - |      32 B |

That is A MUCH more improvement than what I was expecting.