### PR TITLE
fix(pipspager): fix pipspager to show pips correctly when MaxVisiblePips < NumberOfPages

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_PipsPager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_PipsPager.cs
@@ -17,14 +17,6 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
 [TestClass]
 public partial class Given_PipsPager
 {
-	// <PipsPager>
-	// <PipsPager.NormalPipStyle>
-	// <Style TargetType="Ellipse">
-	// <Setter Property="Fill" Value="Red"/>
-	// </Style>
-	// </PipsPager.NormalPipStyle>
-	// </PipsPager>
-
 	[TestMethod]
 	[RunsOnUIThread]
 	public async Task When_MaxVisiblePips_GreaterThan_NumberOfPages()
@@ -39,12 +31,12 @@ public partial class Given_PipsPager
 
 		var initialScreenshot = await UITestHelper.ScreenShot(SUT);
 
-		ImageAssert.HasColorAt(initialScreenshot, initialScreenshot.Width - 5, initialScreenshot.Height / 2, Color.FromArgb(0x3F, 0, 0, 0));
+		var color = initialScreenshot.GetPixel(initialScreenshot.Width - 5, initialScreenshot.Height / 2);
 
 		SUT.SelectedPageIndex = 3;
 		await TestServices.WindowHelper.WaitForIdle();
 
 		var scrolledScreenshot = await UITestHelper.ScreenShot(SUT);
-		ImageAssert.HasColorAt(scrolledScreenshot, scrolledScreenshot.Width - 5, scrolledScreenshot.Height / 2, Color.FromArgb(0x3F, 0, 0, 0));
+		ImageAssert.HasColorAt(scrolledScreenshot, scrolledScreenshot.Width - 5, scrolledScreenshot.Height / 2, color);
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_PipsPager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_PipsPager.cs
@@ -19,6 +19,9 @@ public partial class Given_PipsPager
 {
 	[TestMethod]
 	[RunsOnUIThread]
+#if __WASM__
+	[Ignore("RenderTargetBitmap is not implemented on WASM.")]
+#endif
 	public async Task When_MaxVisiblePips_GreaterThan_NumberOfPages()
 	{
 		var SUT = new PipsPager

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_PipsPager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_PipsPager.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.UI;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
+using Microsoft.UI.Xaml.Controls;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+
+#if !HAS_UNO_WINUI
+using Windows.UI.Xaml.Controls;
+#endif
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
+
+[TestClass]
+public partial class Given_PipsPager
+{
+	// <PipsPager>
+	// <PipsPager.NormalPipStyle>
+	// <Style TargetType="Ellipse">
+	// <Setter Property="Fill" Value="Red"/>
+	// </Style>
+	// </PipsPager.NormalPipStyle>
+	// </PipsPager>
+
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_MaxVisiblePips_GreaterThan_NumberOfPages()
+	{
+		var SUT = new PipsPager
+		{
+			NumberOfPages = 7,
+			MaxVisiblePips = 5
+		};
+
+		await UITestHelper.Load(SUT);
+
+		var initialScreenshot = await UITestHelper.ScreenShot(SUT);
+
+		ImageAssert.HasColorAt(initialScreenshot, initialScreenshot.Width - 5, initialScreenshot.Height / 2, Color.FromArgb(0x3F, 0, 0, 0));
+
+		SUT.SelectedPageIndex = 3;
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var scrolledScreenshot = await UITestHelper.ScreenShot(SUT);
+		ImageAssert.HasColorAt(scrolledScreenshot, scrolledScreenshot.Width - 5, scrolledScreenshot.Height / 2, Color.FromArgb(0x3F, 0, 0, 0));
+	}
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/PipsPager/PipsPager.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/PipsPager/PipsPager.cs
@@ -185,6 +185,25 @@ public partial class PipsPager : Control
 		return new Size(0.0, 0.0);
 	}
 
+	// UNO TODO: this is a workaround for the case when MaxVisiblePips is less than NumberOfPages.
+	// Our current implementation of ScrollContentPresenter  doesn't calculate CanHorizontallyScroll correctly,
+	// and therefore sends an incorrect availableSize to children during the layout cycle.
+	// so we temporarily force it to be scrollable in order to layout correctly and then set it back so that
+	// it's still not scrollable with a pointer, etc.
+	protected override Size MeasureOverride(Size availableSize)
+	{
+		if (m_pipsPagerScrollViewer?.Presenter is { } presenter)
+		{
+			var canHorizontallyScroll = presenter.CanHorizontallyScroll;
+			presenter.CanHorizontallyScroll = true;
+			var result = base.MeasureOverride(availableSize);
+			presenter.CanHorizontallyScroll = canHorizontallyScroll;
+			return result;
+		}
+
+		return base.MeasureOverride(availableSize);
+	}
+
 	protected override void OnKeyDown(KeyRoutedEventArgs args)
 	{
 		FocusNavigationDirection previousPipDirection;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11795

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5f40ce0</samp>

This pull request adds and improves features for the TextBlock and TextBox controls on the skia platform, such as text selection, input injection, undo and redo, and layout. It also adds new UI tests for the Button and PipsPager controls, and fixes some bugs and inconsistencies in the input and text formatting classes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
