### PR TITLE
fix: Only set children parents to null on UIElement cleanup

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -380,23 +380,9 @@ namespace Windows.UI.Xaml
 		{
 			NativeDispatcher.Main.Enqueue(() =>
 			{
-				if (this.GetParent() is UIElement originalParent)
+				for (var i = 0; i < _children.Count; i++)
 				{
-					originalParent.RemoveChild(this);
-				}
-
-				if (this is Panel panel)
-				{
-					panel.Children.Clear();
-				}
-				else
-				{
-					for (var i = 0; i < _children.Count; i++)
-					{
-						_children[i].SetParent(null);
-					}
-
-					_children.Clear();
+					_children[i].SetParent(null);
 				}
 			}, NativeDispatcherPriority.Idle);
 		}


### PR DESCRIPTION
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Per the discussions with @jeromelaban and @ebariche.

This is the only piece of code needed for template pooling to work. The template pool only cares about parent changed when the new parent is null to be able to reuse the pooled instance.

The deleted code has bad side effects such as ending up interacting with disposed DependencyObjectStore/DependencyPropertyDetailsCollection, and is actually not needed.

I have tested that this change works within my lifecycle branch.


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 28edf67</samp>

Simplify the `Cleanup` method of `UIElement` on Skia platforms to avoid memory leaks and improve performance. Remove unnecessary logic that was duplicating the native Skia view management.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
