### PR TITLE
fix(listview): header losing datacontext on ios between frame navigation

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.iOS.cs
@@ -232,5 +232,20 @@ namespace Windows.UI.Xaml.Controls
 				InvalidateMeasure();
 			}
 		}
+
+		public override void MovedToWindow()
+		{
+			base.MovedToWindow();
+
+			// Uno#13172: The header container can sometimes lose its data-context between/after frame navigation,
+			// especially so when the header has been scrolled out of viewport (far enough to be recycled) once.
+			if (Window is { })
+			{
+				if (InternalItemsPanelRoot is NativeListViewBase panel)
+				{
+					panel.UpdateHeaderAndFooter();
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #13173
Internal Issue (If applicable): unoplatform/tradezero-private#44

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
## What is the new behavior?
prevent ios listview header from losing data-context between frame navigation

## Copilot Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 14689be</samp>

Override `MovedToWindow` method of `ListViewBase` on iOS to fix header data context bug. Call `UpdateHeaderAndFooter` method of internal items panel when the list view has a window.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information