### PR TITLE
fix(TreeView): raise DragItemsCompleted when dragging items is completed

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_TreeView_Reorder_Automated.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml/DragAndDropTests/DragDrop_TreeView_Reorder_Automated.cs
@@ -5,6 +5,7 @@ using Uno.UITest.Helpers;
 using Uno.UITest.Helpers.Queries;
 using System.Linq;
 using System;
+using System.Threading.Tasks;
 
 namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 {
@@ -25,6 +26,10 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			var bt2 = _app.Marked("bt2");
 			var bt3 = _app.Marked("bt3");
 			var focusbt = _app.Marked("focusbt");
+			var radio_disable = _app.Marked("radio_disable");
+
+			_app.WaitForElement(radio_disable);
+			_app.Tap(radio_disable);
 
 			_app.WaitForElement(tv);
 			_app.Tap(bt1);
@@ -63,6 +68,35 @@ namespace SamplesApp.UITests.Windows_UI_Xaml.DragAndDropTests
 			_app.Tap(focusbt);
 			result = _app.Screenshot("result3");
 			ImageAssert.AreEqual(case3, result);
+		}
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)]
+		public void When_OnDragItemsCompleted()
+		{
+			Run("UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_TreeView", skipInitialScreenshot: true);
+			var tv = _app.Marked("tv");
+			var bt0 = _app.Marked("bt0");
+			var radio_enable = _app.Marked("radio_enable");
+			var tb = _app.Marked("tb");
+
+			_app.WaitForElement(tv);
+
+			_app.WaitForElement(radio_enable);
+			_app.Tap(radio_enable);
+			_app.WaitForElement(bt0);
+			_app.Tap(bt0);
+
+			var tvBounds = _app.Query("tv").Single().Rect;
+			float fromX = tvBounds.X + 100;
+			float fromY = tvBounds.Y + _itemHeight * 3 + _offset;
+			float toX = tvBounds.X + 100;
+			float toY = tvBounds.Y + _offset;
+			_app.DragCoordinates(fromX, fromY, toX, toY);
+
+			string text = _app.GetText("tb").Trim();
+			Assert.AreEqual("DragItemsCompleted is triggered", text);
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TreeView.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TreeView.xaml
@@ -24,5 +24,8 @@
 		<Button x:Name="bt2" Content="case2"/>
 		<Button x:Name="bt3" Content="case3"/>
 		<Button x:Name="focusbt" Content="focus"/>
+		<RadioButton x:Name="radio_disable" GroupName="radio" Content="Disable TextBox"/>
+		<RadioButton x:Name="radio_enable" GroupName="radio" Content="Enable TextBox"/>
+		<TextBlock x:Name="tb" Visibility="Collapsed"/>
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TreeView.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TreeView.xaml.cs
@@ -124,6 +124,22 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 				});
 			};
 
+			tv.DragItemsCompleted += (s, e) =>
+			{
+				tb.Text = "DragItemsCompleted is triggered";
+			};
+
+			radio_disable.Checked += (s, e) =>
+			{
+				tb.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+			};
+
+			radio_enable.Checked += (s, e) =>
+			{
+				tb.Visibility = Windows.UI.Xaml.Visibility.Visible;
+			};
+
+			radio_disable.IsChecked = true;
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TreeView.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TreeView.xaml.cs
@@ -131,12 +131,12 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 
 			radio_disable.Checked += (s, e) =>
 			{
-				tb.Visibility = Visibility.Collapsed;
+				tb.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
 			};
 
 			radio_enable.Checked += (s, e) =>
 			{
-				tb.Visibility = Visibility.Visible;
+				tb.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
 			};
 
 			radio_disable.IsChecked = true;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TreeView.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_TreeView.xaml.cs
@@ -131,12 +131,12 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 
 			radio_disable.Checked += (s, e) =>
 			{
-				tb.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+				tb.Visibility = Visibility.Collapsed;
 			};
 
 			radio_enable.Checked += (s, e) =>
 			{
-				tb.Visibility = Windows.UI.Xaml.Visibility.Visible;
+				tb.Visibility = Visibility.Visible;
 			};
 
 			radio_disable.IsChecked = true;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -96,11 +96,9 @@ namespace Windows.UI.Xaml.Controls
 			// Known issue: the ContainerClearedForItem might not be invoked properly for all items on some platforms.
 			// This patch is acceptable as event handlers are static (so they won't leak).
 			itemContainer.DragStarting -= OnItemContainerDragStarting;
-			itemContainer.DropCompleted -= OnItemContainerDragCompleted;
 
 			itemContainer.CanDrag = true;
 			itemContainer.DragStarting += OnItemContainerDragStarting;
-			itemContainer.DropCompleted += OnItemContainerDragCompleted;
 		}
 
 		private static void ClearContainerForDragDrop(UIElement itemContainer)
@@ -112,7 +110,6 @@ namespace Windows.UI.Xaml.Controls
 
 			itemContainer.CanDrag = false;
 			itemContainer.DragStarting -= OnItemContainerDragStarting;
-			itemContainer.DropCompleted -= OnItemContainerDragCompleted;
 
 			itemContainer.DragEnter -= OnReorderDragUpdated;
 			itemContainer.DragOver -= OnReorderDragUpdated;
@@ -124,6 +121,9 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (ItemsControlFromItemContainer(sender) is ListViewBase that && that.CanDragItems)
 			{
+				// only raise DragItemsCompleted if DragItemsStarting was raised
+				sender.DropCompleted -= OnItemContainerDragCompleted;
+				sender.DropCompleted += OnItemContainerDragCompleted;
 				// The items contains all selected items ONLY if the draggedItem is selected.
 				var draggedItem = that.ItemFromContainer(sender);
 				var items =
@@ -166,6 +166,7 @@ namespace Windows.UI.Xaml.Controls
 					that.ChangeSelectorItemsVisualState(true);
 				}
 			}
+
 		}
 
 		private static void OnItemContainerDragCompleted(UIElement sender, DropCompletedEventArgs innerArgs)
@@ -191,6 +192,7 @@ namespace Windows.UI.Xaml.Controls
 				// (eg if drag was released outside bounds of list)
 				that.CleanupReordering();
 			}
+			sender.DropCompleted -= OnItemContainerDragCompleted;
 		}
 
 		private static void OnReorderDragUpdated(object sender, _DragEventArgs dragEventArgs)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14498 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cd57369</samp>

Added a UI test and improved the drag and drop functionality of the tree view control. Fixed the web assembly port number for the SamplesApp project. Added UI elements to toggle the visibility of a text box that displays drag and drop events.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
