### PR TITLE
feat: InstanceTracker for FrameworkTemplatePool

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.InstanceTracker.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.InstanceTracker.cs
@@ -1,0 +1,127 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Runtime;
+using System.Runtime.InteropServices;
+
+namespace Windows.UI.Xaml
+{
+	public partial class FrameworkTemplatePool
+	{
+		/// <summary>
+		/// The InstanceTracker allows children to be returned to the <see cref="FrameworkTemplatePool"/>.
+		/// It does so by tying the lifetime of the parent to their children using <see cref="DependentHandle"/>
+		/// and <see cref="TrackerCookie">TrackerCookie</see> without creating strong references.
+		/// Once a parent is collected, the cookie becomes eligible for gc, its finalizer will run,
+		/// the child will set its parent to null, making itself available to the pool.
+		/// </summary>
+		private static class InstanceTracker
+		{
+			private static readonly Stack<TrackerCookie> _cookiePool = new();
+
+			private static readonly List<DependentHandle> _handles = new();
+			private static readonly Stack<int> _handlesFreeList = new();
+
+			private static int _counter;
+
+			private const int HandleCleanupInterval = 1024;
+			private const int MaxCookiePoolSize = 256;
+
+			public static void Add(object parent, object instance)
+			{
+				TrackerCookie? cookie;
+
+				lock (_cookiePool)
+				{
+					// Cookies are pooled because we create lots of them.
+					if (_cookiePool.TryPop(out cookie))
+					{
+						cookie.Update(instance);
+					}
+					else
+					{
+						cookie = new TrackerCookie(instance);
+					}
+				}
+
+				// Try to get a free slot in the list, this avoids scanning the list everytime
+				if (_handlesFreeList.TryPop(out var index))
+				{
+					ref var handle = ref CollectionsMarshal.AsSpan(_handles)[index];
+
+					handle = new DependentHandle(parent, cookie);
+				}
+				else
+				{
+					// No slots are available, try to scrub the list, this is necessary because
+					// we don't want to leak handles (coreclr) or ephemerons (mono)
+					if ((_counter++ % HandleCleanupInterval) == 0)
+					{
+						var handles = CollectionsMarshal.AsSpan(_handles);
+
+						for (var x = 0; x < handles.Length; x++)
+						{
+							ref var handle = ref handles[x];
+
+							if (handle.IsAllocated && handle.Target == null)
+							{
+								handle.Dispose();
+
+								_handlesFreeList.Push(x);
+							}
+						}
+
+						// Maybe a slot is available now
+						if (_handlesFreeList.TryPop(out index))
+						{
+							ref var handle = ref handles[index];
+
+							handle = new DependentHandle(parent, cookie);
+
+							return;
+						}
+					}
+
+					// No slots are available
+					_handles.Add(new DependentHandle(parent, cookie));
+				}
+			}
+
+			public static void TryReturnCookie(TrackerCookie cookie)
+			{
+				lock (_cookiePool)
+				{
+					// The pool isn't full, resurrect the cookie so its finalizer will run again
+					if (_cookiePool.Count < MaxCookiePoolSize)
+					{
+						GC.ReRegisterForFinalize(cookie);
+
+						_cookiePool.Push(cookie);
+					}
+				}
+			}
+
+			public class TrackerCookie
+			{
+				private object? _instance;
+
+				public TrackerCookie(object instance)
+				{
+					_instance = instance;
+				}
+
+				~TrackerCookie()
+				{
+					Instance.RaiseOnParentCollected(_instance!);
+
+					_instance = null;
+
+					TryReturnCookie(this);
+				}
+
+				public void Update(object instance) => _instance = instance;
+			}
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -6,12 +6,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Diagnostics;
-using System.Threading.Tasks;
-using System.Linq;
 using Uno.Diagnostics.Eventing;
 using Windows.UI.Xaml;
+using Uno.Buffers;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI;
@@ -72,7 +69,7 @@ namespace Windows.UI.Xaml
 	///	are strictly databound, but not if the control is using stateful code-behind. This is why this behavior can be disabled via <see cref="IsPoolingEnabled"/>
 	///	if the pooling interferes with the normal behavior of a control.
 	/// </remarks>
-	public class FrameworkTemplatePool
+	public partial class FrameworkTemplatePool
 	{
 		internal static FrameworkTemplatePool Instance { get; } = new FrameworkTemplatePool();
 		public static class TraceProvider
@@ -284,6 +281,63 @@ namespace Windows.UI.Xaml
 			return instances;
 		}
 
+		private Stack<object> _instancesToRecycle = new();
+
+		private void RaiseOnParentCollected(object instance)
+		{
+			var shouldEnqueue = false;
+
+			lock (_instancesToRecycle)
+			{
+				_instancesToRecycle.Push(instance);
+
+				shouldEnqueue = _instancesToRecycle.Count == 1;
+			}
+
+			if (shouldEnqueue)
+			{
+				NativeDispatcher.Main.Enqueue(Recycle);
+			}
+		}
+
+		private const int RecycleBatchSize = 32;
+
+		private void Recycle()
+		{
+			var array = ArrayPool<object>.Shared.Rent(RecycleBatchSize);
+
+			var count = 0;
+
+			var shouldRequeue = false;
+
+			lock (_instancesToRecycle)
+			{
+				while (_instancesToRecycle.TryPop(out var instance) && count < RecycleBatchSize)
+				{
+					array[count++] = instance;
+				}
+
+				shouldRequeue = _instancesToRecycle.Count > 0;
+			}
+
+			try
+			{
+				for (var x = 0; x < count; x++)
+				{
+					array[x].SetParent(null);
+				}
+			}
+			finally
+			{
+				ArrayPool<object>.Shared.Return(array, clearArray: true);
+			}
+
+			if (shouldRequeue)
+			{
+				NativeDispatcher.Main.Enqueue(Recycle);
+			}
+		}
+
 		/// <summary>
 		/// Manually return an unused template root to the pool.
 		/// </summary>
@@ -355,6 +409,8 @@ namespace Windows.UI.Xaml
 			}
 			else
 			{
+				InstanceTracker.Add(newParent, instance);
+
 				var index = list.FindIndex(e => ReferenceEquals(e.Control, instance));
 
 				if (index != -1)

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -46,11 +46,6 @@ namespace Windows.UI.Xaml
 			UpdateHitTest();
 		}
 
-		~UIElement()
-		{
-			Cleanup();
-		}
-
 		public bool UseLayoutRounding
 		{
 			get => (bool)this.GetValue(UseLayoutRoundingProperty);
@@ -375,17 +370,6 @@ namespace Windows.UI.Xaml
 			=> Visual.IsVisible = false;
 
 		Visual IVisualElement2.GetVisualInternal() => ElementCompositionPreview.GetElementVisual(this);
-
-		private void Cleanup()
-		{
-			NativeDispatcher.Main.Enqueue(() =>
-			{
-				for (var i = 0; i < _children.Count; i++)
-				{
-					_children[i].SetParent(null);
-				}
-			}, NativeDispatcherPriority.Idle);
-		}
 
 #if DEBUG
 		public string ShowLocalVisualTree() => this.ShowLocalVisualTree(1000);

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -87,8 +87,6 @@ namespace Windows.UI.Xaml
 					this.Log().Debug($"Collecting UIElement for [{HtmlId}]");
 				}
 
-				Cleanup();
-
 				Uno.UI.Xaml.WindowManagerInterop.DestroyView(HtmlId);
 			}
 			catch (Exception e)
@@ -513,28 +511,6 @@ namespace Windows.UI.Xaml
 			if (childParent != null)
 			{
 				Uno.UI.Xaml.WindowManagerInterop.RemoveView(HtmlId, child.HtmlId);
-			}
-		}
-
-		private void Cleanup()
-		{
-			if (this.GetParent() is UIElement originalParent)
-			{
-				originalParent.RemoveChild(this);
-			}
-
-			if (this is Windows.UI.Xaml.Controls.Panel panel)
-			{
-				panel.Children.Clear();
-			}
-			else
-			{
-				for (var i = 0; i < _children.Count; i++)
-				{
-					RemoveNativeView(_children[i]);
-				}
-
-				_children.Clear();
 			}
 		}
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## Copilot Summary

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9a3c4e3</samp>

Improved memory management and performance for XAML templates on Skia by using weak references and moving recycling logic to `FrameworkTemplatePool` and `InstanceTracker`. Removed finalizer and `Cleanup` method from `UIElement`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.