### PR TITLE
test: Use working version of the mediaplayer test video

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_ManualTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_ManualTest.xaml
@@ -31,7 +31,7 @@
 		<MediaPlayerElement Grid.Row="3"
 					x:Name="mpe"
 					Stretch="UniformToFill"
-					Source="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/Big_Buck_Bunny_720_10s_5MB.mp4"
+					Source="https://uno-assets.platform.uno/tests/uno/big_buck_bunny_720p_5mb.mp4"
 					AreTransportControlsEnabled="True"
 					AutoPlay="False">
 			<MediaPlayerElement.TransportControls>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Original.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Original.xaml
@@ -5,10 +5,10 @@
              mc:Ignorable="">
 
 	<!--<MediaPlayerElement Source="http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_1080p_30fps_normal.mp4"-->
-	<!--<MediaPlayerElement x:Name="mediaPlayerElement" Source="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/Big_Buck_Bunny_720_10s_5MB.mp4"-->
+	<!--<MediaPlayerElement x:Name="mediaPlayerElement" Source="https://uno-assets.platform.uno/tests/uno/big_buck_bunny_720p_5mb.mp4"-->
 	<!--<MediaPlayerElement Source="https://www.youtube.com/embed/DDtzqzIqgdw"-->
 
-	<MediaPlayerElement x:Name="MpeOriginal" Source="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/Big_Buck_Bunny_720_10s_5MB.mp4"
+	<MediaPlayerElement x:Name="MpeOriginal" Source="https://uno-assets.platform.uno/tests/uno/big_buck_bunny_720p_5mb.mp4"
 						AreTransportControlsEnabled="True"
 		AutoPlay="True" />
 </UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
@@ -24,7 +24,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 [RunsOnUIThread]
 public partial class Given_MediaPlayerElement
 {
-	private static readonly Uri TestVideoUrl = new Uri("https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/Big_Buck_Bunny_720_10s_5MB.mp4");
+	private static readonly Uri TestVideoUrl = new Uri("https://uno-assets.platform.uno/tests/uno/big_buck_bunny_720p_5mb.mp4");
 
 	[TestMethod]
 	[Ignore("https://github.com/unoplatform/uno/issues/13384")]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Project automation

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## Copilot Summary

<!-- This allows GitHub Copilot to provide a summary for your PR -->
<!-- Please do not touch the next line, it will be replaced with the generated summary -->
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 80472e5</samp>

Changed the video source for the `MediaPlayerElement` control in the SamplesApp and Uno.UI.RuntimeTests projects. This improves the reliability and consistency of the manual and automated tests for the media playback functionality.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
