### PR TITLE
fix: Samples app won't display description when Frame navigated

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -936,21 +936,25 @@ namespace SampleControl.Presentation
 
 			FrameworkElement container = null;
 
-			var frameRequested =
-				newContent.UsesFrame &&
-				typeof(Page).IsAssignableFrom(newContent.ControlType);
-			if (frameRequested)
+			if (newContent.UsesFrame &&
+				typeof(Page).IsAssignableFrom(newContent.ControlType))
 			{
-				var frame = new Frame();
-				frame.Navigate(newContent.ControlType);
-				container = frame;
+				// Creating a new Frame with dynamically instantiated content based on newContent.ControlType
+				// and encapsulating it within a SampleControl along with a description
+				var frame = new Frame { Content = Activator.CreateInstance(newContent.ControlType) };
+				container = new Uno.UI.Samples.Controls.SampleControl
+				{
+					Content = frame,
+					SampleDescription = newContent.Description
+				};
 			}
 			else
 			{
-				//Activator is used here in order to generate the view and bind it directly with the proper view model
+				// Activator is used here in order to generate the view and bind it directly with the proper view model
 				var control = Activator.CreateInstance(newContent.ControlType);
 
-				if (control is ContentControl controlAsContentControl && !(controlAsContentControl.Content is Uno.UI.Samples.Controls.SampleControl))
+				if (control is ContentControl controlAsContentControl
+					&& controlAsContentControl.Content is not Uno.UI.Samples.Controls.SampleControl)
 				{
 					control = new Uno.UI.Samples.Controls.SampleControl
 					{

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -941,7 +941,9 @@ namespace SampleControl.Presentation
 			{
 				// Creating a new Frame with dynamically instantiated content based on newContent.ControlType
 				// and encapsulating it within a SampleControl along with a description
-				var frame = new Frame { Content = Activator.CreateInstance(newContent.ControlType) };
+				var frame = new Frame();
+				frame.Navigate(newContent.ControlType);
+
 				container = new Uno.UI.Samples.Controls.SampleControl
 				{
 					Content = frame,

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -955,8 +955,8 @@ namespace SampleControl.Presentation
 				// Activator is used here in order to generate the view and bind it directly with the proper view model
 				var control = Activator.CreateInstance(newContent.ControlType);
 
-				if (control is ContentControl controlAsContentControl
-					&& controlAsContentControl.Content is not Uno.UI.Samples.Controls.SampleControl)
+				if (control is ContentControl controlAsContentControl &&
+					controlAsContentControl.Content is not Uno.UI.Samples.Controls.SampleControl)
 				{
 					control = new Uno.UI.Samples.Controls.SampleControl
 					{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14586

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
The SamplesApp sometimes won't display the description of the Sample.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

