### PR TITLE
feat: Add support for quicky opening searched Sample in SamplesApp

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -620,6 +620,13 @@ namespace SampleControl.Presentation
 			return starts.Concat(contains).ToList();
 		}
 
+		public void TryOpenSample()
+		{
+			if (FilteredSamples.Count is 1)
+			{
+				SelectedSearchSample = FilteredSamples[0];
+			}
+		}
 
 		/// <summary>
 		/// This method is used to get the list of samplechoosercontent that is present in the settings.

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -183,6 +183,7 @@
 
 					<TextBox Text="{Binding SearchTerm, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
 							 Style="{StaticResource SearchTextBoxStyle}"
+							 KeyDown="OnSearchEnterKey_KeyDown"
 							 PlaceholderText="Search"
 							 Margin="8" />
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
@@ -14,7 +14,6 @@ using Windows.Foundation.Collections;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 #elif XAMARIN || UNO_REFERENCE_API

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
@@ -60,7 +60,7 @@ namespace Uno.UI.Samples.Controls
 		{
 			if (e.Key == Windows.System.VirtualKey.Enter)
 			{
-				(DataContext as SampleChooserViewModel).TryOpenSample();
+				((SampleChooserViewModel)DataContext).TryOpenSample();
 			}
 		}
 	}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml.cs
@@ -7,6 +7,8 @@ using SampleControl.Presentation;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml.Input;
+
 #if NETFX_CORE
 using Windows.Foundation.Collections;
 using Windows.UI.Xaml.Controls;
@@ -52,6 +54,14 @@ namespace Uno.UI.Samples.Controls
 				Assert.Fail("Initial Arrange should not be called with empty size");
 			}
 			return base.ArrangeOverride(availableSize);
+		}
+
+		private void OnSearchEnterKey_KeyDown(object sender, KeyRoutedEventArgs e)
+		{
+			if (e.Key == Windows.System.VirtualKey.Enter)
+			{
+				(DataContext as SampleChooserViewModel).TryOpenSample();
+			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): part of #13446, closes #14664

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?
Added support for quicky opening searched Sample in SamplesApp when there is only one found item.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.