### PR TITLE
feat(textblock): IsTextTrimmed & IsTextTrimmedChanged

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -14,6 +14,7 @@ using Windows.UI.Xaml.Documents;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using static Private.Infrastructure.TestServices;
+using System.Collections.Generic;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -367,5 +368,63 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				previousOrigin = textBlockOrigin;
 			}
 		}
+
+#if !__MACOS__
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_TextTrimming()
+		{
+			var sut = new TextBlock
+			{
+				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+				TextTrimming = TextTrimming.Clip,
+			};
+			var container = new Border
+			{
+				BorderThickness = new Thickness(1),
+				BorderBrush = new SolidColorBrush(Colors.Red),
+				Width = 100,
+				Child = sut,
+			};
+
+			var states = new List<bool>();
+			sut.IsTextTrimmedChanged += (s, e) => states.Add(sut.IsTextTrimmed);
+
+			WindowHelper.WindowContent = container;
+			await WindowHelper.WaitForLoaded(container);
+			await WindowHelper.WaitForIdle(); // necessary on ios, since the container finished loading before the text is drawn
+
+			Assert.IsTrue(sut.IsTextTrimmed, "IsTextTrimmed should be trimmed.");
+			Assert.IsTrue(states.Count == 1 && states[0] == true, $"IsTextTrimmedChanged should only proc once for IsTextTrimmed=true. states: {(string.Join(", ", states) is string { Length: > 0 } tmp ? tmp : "(-empty-)")}");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_TextTrimmingNone()
+		{
+			var sut = new TextBlock
+			{
+				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+				TextTrimming = TextTrimming.None,
+			};
+			var container = new Border
+			{
+				BorderThickness = new Thickness(1),
+				BorderBrush = new SolidColorBrush(Colors.Red),
+				Width = 100,
+				Child = sut,
+			};
+
+			var states = new List<bool>();
+			sut.IsTextTrimmedChanged += (s, e) => states.Add(sut.IsTextTrimmed);
+
+			WindowHelper.WindowContent = container;
+			await WindowHelper.WaitForLoaded(container);
+			await WindowHelper.WaitForIdle(); // necessary on ios, since the container finished loading before the text is drawn
+
+			Assert.IsFalse(sut.IsTextTrimmed, "IsTextTrimmed should not be trimmed.");
+			Assert.IsTrue(states.Count == 0, $"IsTextTrimmedChanged should not proc at all. states: {(string.Join(", ", states) is string { Length: > 0 } tmp ? tmp : "(-empty-)")}");
+		}
+#endif
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TextBlock.cs
@@ -184,16 +184,7 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		// Skipping already declared property TextDecorations
 		// Skipping already declared property HorizontalTextAlignment
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public bool IsTextTrimmed
-		{
-			get
-			{
-				return (bool)this.GetValue(IsTextTrimmedProperty);
-			}
-		}
-#endif
+		// Skipping already declared property IsTextTrimmed
 #if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public global::System.Collections.Generic.IList<global::Windows.UI.Xaml.Documents.TextHighlighter> TextHighlighters
@@ -299,14 +290,7 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		// Skipping already declared property TextDecorationsProperty
 		// Skipping already declared property HorizontalTextAlignmentProperty
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public static global::Windows.UI.Xaml.DependencyProperty IsTextTrimmedProperty { get; } =
-		Windows.UI.Xaml.DependencyProperty.Register(
-			nameof(IsTextTrimmed), typeof(bool),
-			typeof(global::Windows.UI.Xaml.Controls.TextBlock),
-			new Windows.UI.Xaml.FrameworkPropertyMetadata(default(bool)));
-#endif
+		// Skipping already declared property IsTextTrimmed
 #if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Windows.UI.Xaml.DependencyProperty SelectionFlyoutProperty { get; } =
@@ -470,21 +454,6 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 #endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-		public event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.Controls.TextBlock, global::Windows.UI.Xaml.Controls.IsTextTrimmedChangedEventArgs> IsTextTrimmedChanged
-		{
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBlock", "event TypedEventHandler<TextBlock, IsTextTrimmedChangedEventArgs> TextBlock.IsTextTrimmedChanged");
-			}
-			[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TextBlock", "event TypedEventHandler<TextBlock, IsTextTrimmedChangedEventArgs> TextBlock.IsTextTrimmedChanged");
-			}
-		}
-#endif
+		// Skipping already declared event Microsoft.UI.Xaml.Controls.TextBlock.IsTextTrimmedChanged
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -388,6 +388,8 @@ namespace Windows.UI.Xaml.Controls
 					UpdateNativeTextBlockLayout();
 				}
 
+				UpdateIsTextTrimmed();
+
 				return finalSize;
 			}
 		}
@@ -458,6 +460,14 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			return layout.MeasuredSize;
+		}
+
+		partial void UpdateIsTextTrimmed()
+		{
+			IsTextTrimmed = IsTextTrimmable && (
+				_measureLayout.MeasuredSize.Width > _arrangeLayout.MeasuredSize.Width ||
+				_measureLayout.MeasuredSize.Height > _arrangeLayout.MeasuredSize.Height
+			);
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Uno.Disposables;
 using Uno.Extensions;
@@ -672,6 +673,40 @@ namespace Windows.UI.Xaml.Controls
 
 		#endregion
 
+		#region DependencyProperty: IsTextTrimmed
+#if false || false || IS_UNIT_TESTS || false || false || __NETSTD_REFERENCE__ || __MACOS__
+		[NotImplemented("IS_UNIT_TESTS", "__NETSTD_REFERENCE__", "__MACOS__")]
+#endif
+		public event TypedEventHandler<TextBlock, IsTextTrimmedChangedEventArgs> IsTextTrimmedChanged;
+
+#if false || false || IS_UNIT_TESTS || false || false || __NETSTD_REFERENCE__ || __MACOS__
+		[NotImplemented("IS_UNIT_TESTS", "__NETSTD_REFERENCE__", "__MACOS__")]
+#endif
+		public static DependencyProperty IsTextTrimmedProperty { get; } = DependencyProperty.Register(
+			nameof(IsTextTrimmed),
+			typeof(bool),
+			typeof(TextBlock),
+			new FrameworkPropertyMetadata(false, propertyChangedCallback: (s, e) => ((TextBlock)s).OnIsTextTrimmedChanged()));
+
+#if false || false || IS_UNIT_TESTS || false || false || __NETSTD_REFERENCE__ || __MACOS__
+		[NotImplemented("IS_UNIT_TESTS", "__NETSTD_REFERENCE__", "__MACOS__")]
+#endif
+		public bool IsTextTrimmed
+		{
+			get => (bool)GetValue(IsTextTrimmedProperty);
+			private set => SetValue(IsTextTrimmedProperty, value);
+		}
+
+		private void OnIsTextTrimmedChanged()
+		{
+			OnIsTextTrimmedChangedPartial();
+			IsTextTrimmedChanged?.Invoke(this, new());
+		}
+
+		partial void OnIsTextTrimmedChangedPartial();
+
+		#endregion
+
 		/// <summary>
 		/// Gets whether the TextBlock is using the fast path in which Inlines
 		/// have not been initialized and don't need to be synchronized.
@@ -1080,5 +1115,13 @@ namespace Windows.UI.Xaml.Controls
 			IsVisible() &&
 			/*IsEnabled() &&*/ (IsTextSelectionEnabled || IsTabStop) &&
 			AreAllAncestorsVisible();
+
+		[SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used only by some platforms")]
+		private bool IsTextTrimmable =>
+			TextTrimming != TextTrimming.None ||
+			MaxLines != 0;
+
+		[SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used only by some platforms")]
+		partial void UpdateIsTextTrimmed();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
@@ -68,6 +68,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_attributedString?.DrawString(_drawRect, NSStringDrawingOptions.UsesLineFragmentOrigin, null);
 			}
+
+			UpdateIsTextTrimmed();
 		}
 
 		/// <summary>
@@ -343,6 +345,14 @@ namespace Windows.UI.Xaml.Controls
 
 
 			return characterIndex;
+		}
+
+		partial void UpdateIsTextTrimmed()
+		{
+			IsTextTrimmed = IsTextTrimmable && (
+				_attributedString.Size.Width > _drawRect.Size.Width ||
+				_attributedString.Size.Height > _drawRect.Size.Height
+			);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -88,7 +88,11 @@ namespace Windows.UI.Xaml.Controls
 			_textVisual.Size = new Vector2((float)arrangedSizeWithoutPadding.Width, (float)arrangedSizeWithoutPadding.Height);
 			_textVisual.Offset = new Vector3((float)padding.Left, (float)padding.Top, 0);
 			ApplyFlowDirection((float)finalSize.Width);
-			return base.ArrangeOverride(finalSize);
+
+			var result = base.ArrangeOverride(finalSize);
+			UpdateIsTextTrimmed();
+
+			return result;
 		}
 
 		/// <summary>
@@ -168,6 +172,14 @@ namespace Windows.UI.Xaml.Controls
 		partial void OnLineStackingStrategyChangedPartial()
 		{
 			Inlines.InvalidateMeasure();
+		}
+
+		partial void UpdateIsTextTrimmed()
+		{
+			IsTextTrimmed = IsTextTrimmable && (
+				(_textVisual.Size.X + Padding.Left + Padding.Right) > ActualWidth ||
+				(_textVisual.Size.Y + Padding.Top + Padding.Bottom) > ActualHeight
+			);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Media;
 using Uno.UI;
+using Uno.UI.Xaml;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -150,6 +151,13 @@ namespace Windows.UI.Xaml.Controls
 			return base.ArrangeOverride(arrangeSize);
 		}
 
+		internal override void OnLayoutUpdated()
+		{
+			base.OnLayoutUpdated();
+
+			UpdateIsTextTrimmed();
+		}
+
 		partial void OnFontStyleChangedPartial() => _fontStyleChanged = true;
 
 		partial void OnFontWeightChangedPartial() => _fontWeightChanged = true;
@@ -196,5 +204,12 @@ namespace Windows.UI.Xaml.Controls
 		partial void OnTextWrappingChangedPartial() => _textWrappingChanged = true;
 
 		partial void OnPaddingChangedPartial() => _paddingChangedChanged = true;
+
+		partial void UpdateIsTextTrimmed()
+		{
+			IsTextTrimmed =
+				IsTextTrimmable &&
+				WindowManagerInterop.GetIsOverflowing(HtmlId);
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -1056,6 +1056,9 @@ namespace Uno.UI.Xaml
 			NativeMethods.WindowActivate();
 		}
 
+		internal static bool GetIsOverflowing(IntPtr htmlId)
+			=> NativeMethods.GetIsOverflowing(htmlId);
+
 		#region Pointers
 		[Flags]
 		internal enum HtmlPointerButtonsState
@@ -1082,6 +1085,7 @@ namespace Uno.UI.Xaml
 			Eraser = 5
 		}
 		#endregion
+
 		internal static partial class NativeMethods
 		{
 			[JSImport("globalThis.Uno.UI.WindowManager.current.arrangeElementNativeFast")]
@@ -1177,6 +1181,9 @@ namespace Uno.UI.Xaml
 
 			[JSImport("globalThis.Uno.UI.WindowManager.current.activate")]
 			internal static partial void WindowActivate();
+
+			[JSImport("globalThis.Uno.UI.WindowManager.current.getIsOverflowing")]
+			internal static partial bool GetIsOverflowing(IntPtr htmlId);
 		}
 	}
 }

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -1780,6 +1780,11 @@ namespace Uno.UI {
 			(this.getView(elementId) as HTMLInputElement).setSelectionRange(start, start + length);
 		}
 
+		public getIsOverflowing(elementId: number): boolean {
+			const element = this.getView(elementId) as HTMLElement;
+			
+			return element.clientWidth < element.scrollWidth || element.clientHeight < element.scrollHeight;
+		}
 	}
 
 	if (typeof define === "function") {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14266

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?
## What is the new behavior?
implemented TextBlock.IsTextTrimmed & .IsTextTrimmedChanged for skia,ios,droid,wasm

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->