### PR TITLE
fix(commandbar): Avoid NSObject_Disposer:Drain with custom AppBar content

### DIFF
--- a/src/Uno.UI/Controls/CommandBar/CommandBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBar/CommandBarNavigationItemRenderer.iOS.cs
@@ -162,6 +162,10 @@ namespace Uno.UI.Controls
 		private Size _childSize;
 		private Size? _lastAvailableSize;
 
+#pragma warning disable IDE0052 // Remove unread private members
+		private UIView? _superView;
+#pragma warning restore IDE0052 // Remove unread private members
+
 		public override void SetSuperviewNeedsLayout()
 		{
 			// Skip the base invocation because the base fetches the native parent
@@ -170,6 +174,17 @@ namespace Uno.UI.Controls
 			// to fail to release an already released native reference.
 			//
 			// See https://github.com/unoplatform/uno/issues/7012 for more details.
+		}
+
+		public override void MovedToSuperview()
+		{
+			// Store an explicit reference to the superview in order to avoid 
+			// generic access from the framework element infrastructure.
+			// This will avoid the superview from being natively released
+			// while this view may still try to use it and corrupt the heap, then
+			// cause NSObject_Disposer:Drain to fail randomly.
+			_superView = Superview;
+			base.MovedToSuperview();
 		}
 
 		internal TitleView()


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes possible `NSObject_Disposer:Drain` crashes when UINavigationBar is natively collected. This ensures that any possible interaction with the `Superview` of `TitleView` will not corrupt memory when using a dangling pointer.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):

Related to https://github.com/xamarin/xamarin-macios/issues/19493#issuecomment-1820591127.

