### PR TITLE
fix(commandbar): Avoid NSObject_Disposer:Drain with custom AppBar content (bp #14695)

### DIFF
--- a/src/Uno.UI/Controls/CommandBar/CommandBarNavigationItemRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBar/CommandBarNavigationItemRenderer.iOS.cs
@@ -162,6 +162,10 @@ namespace Uno.UI.Controls
 		private Size _childSize;
 		private Size? _lastAvailableSize;
 
+#pragma warning disable IDE0052 // Remove unread private members
+		private UIView? _superView;
+#pragma warning restore IDE0052 // Remove unread private members
+
 		public override void SetSuperviewNeedsLayout()
 		{
 			// Skip the base invocation because the base fetches the native parent
@@ -170,6 +174,17 @@ namespace Uno.UI.Controls
 			// to fail to release an already released native reference.
 			//
 			// See https://github.com/unoplatform/uno/issues/7012 for more details.
+		}
+
+		public override void MovedToSuperview()
+		{
+			// Store an explicit reference to the superview in order to avoid 
+			// generic access from the framework element infrastructure.
+			// This will avoid the superview from being natively released
+			// while this view may still try to use it and corrupt the heap, then
+			// cause NSObject_Disposer:Drain to fail randomly.
+			_superView = Superview;
+			base.MovedToSuperview();
 		}
 
 		internal TitleView()


### PR DESCRIPTION
Backport of #14695