### PR TITLE
fix: Adjust default values types for `EntranceThemeTransition` DPs

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Animation/EntranceThemeTransition.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/EntranceThemeTransition.cs
@@ -28,7 +28,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		// Using a DependencyProperty as the backing store for FromHorizontalOffset.  This enables animation, styling, binding, etc...
 		public static DependencyProperty FromHorizontalOffsetProperty { get; } =
-			DependencyProperty.Register("FromHorizontalOffset", typeof(double), typeof(EntranceThemeTransition), new FrameworkPropertyMetadata(40f));
+			DependencyProperty.Register("FromHorizontalOffset", typeof(double), typeof(EntranceThemeTransition), new FrameworkPropertyMetadata(40.0));
 
 		#endregion
 
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 		// Using a DependencyProperty as the backing store for FromVerticalOffset.  This enables animation, styling, binding, etc...
 		public static DependencyProperty FromVerticalOffsetProperty { get; } =
-			DependencyProperty.Register("FromVerticalOffset", typeof(double), typeof(EntranceThemeTransition), new FrameworkPropertyMetadata(0f));
+			DependencyProperty.Register("FromVerticalOffset", typeof(double), typeof(EntranceThemeTransition), new FrameworkPropertyMetadata(0.0));
 
 		#endregion
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/14422

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Sets the proper `DependencyProperty` default value type for `EntranceThemeTransition`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
