### PR TITLE
fix: Workaround MPE tests with MTC not enabled

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
@@ -135,7 +135,7 @@ public partial class Given_MediaPlayerElement
 		WindowHelper.WindowContent = sut;
 		await WindowHelper.WaitForLoaded(sut, timeoutMS: 6000);
 
-		sut.AreTransportControlsEnabled = false;
+		sut.MediaPlayer.Play();
 
 		try
 		{
@@ -154,6 +154,7 @@ public partial class Given_MediaPlayerElement
 		finally
 		{
 			sut.IsFullWindow = false;
+			sut.MediaPlayer.Stop();
 		}
 	}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
@@ -118,6 +118,9 @@ public partial class Given_MediaPlayerElement
 	// [Ignore("https://github.com/unoplatform/uno/issues/13384")]
 	[Ignore("https://github.com/unoplatform/uno/issues/13384")]
 #endif
+#if __SKIA__
+	[Ignore("https://github.com/unoplatform/uno/issues/14735")]
+#endif
 	[TestMethod]
 	public async Task When_MediaPlayerElement_SetIsFullWindow_Check_Fullscreen()
 	{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
@@ -94,6 +94,9 @@ public partial class Given_MediaPlayerElement
 		var sut = new MediaPlayerElement()
 		{
 			AutoPlay = true,
+
+			// Workaround to get the control loaded https://github.com/unoplatform/uno/issues/14735
+			AreTransportControlsEnabled = true,
 			Source = MediaSource.CreateFromUri(TestVideoUrl),
 		};
 
@@ -122,6 +125,9 @@ public partial class Given_MediaPlayerElement
 		var sut = new MediaPlayerElement()
 		{
 			AutoPlay = true,
+
+			// Workaround to get the control loaded https://github.com/unoplatform/uno/issues/14735
+			AreTransportControlsEnabled = true,
 			Source = MediaSource.CreateFromUri(TestVideoUrl),
 		};
 
@@ -156,6 +162,9 @@ public partial class Given_MediaPlayerElement
 		var sut = new MediaPlayerElement()
 		{
 			AutoPlay = true,
+
+			// Workaround to get the control loaded https://github.com/unoplatform/uno/issues/14735
+			AreTransportControlsEnabled = true,
 			Source = MediaSource.CreateFromUri(TestVideoUrl),
 		};
 
@@ -258,12 +267,17 @@ public partial class Given_MediaPlayerElement
 		var sut = new MediaPlayerElement()
 		{
 			AutoPlay = true,
+
+			// Workaround to get the control loaded https://github.com/unoplatform/uno/issues/14735
+			AreTransportControlsEnabled = true,
 			Source = MediaSource.CreateFromUri(TestVideoUrl),
 		};
 
 		//Load Player
 		WindowHelper.WindowContent = sut;
 		await WindowHelper.WaitForLoaded(sut, timeoutMS: 6000);
+
+		sut.AreTransportControlsEnabled = false;
 
 		var root = (WindowHelper.XamlRoot?.Content as FrameworkElement)!;
 		var tcp = (FrameworkElement)root.FindName("TransportControlsPresenter");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MediaPlayerElement.cs
@@ -135,6 +135,8 @@ public partial class Given_MediaPlayerElement
 		WindowHelper.WindowContent = sut;
 		await WindowHelper.WaitForLoaded(sut, timeoutMS: 6000);
 
+		sut.AreTransportControlsEnabled = false;
+
 		try
 		{
 			var root = (WindowHelper.XamlRoot?.Content as FrameworkElement)!;


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/uno/issues/14735

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Build or CI related changes

## What is the new behavior?

Fixes unstable mediaplayer tests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
