### PR TITLE
fix(xamlgen): MarkupExtensions parser context

### DIFF
--- a/src/SourceGenerators/SourceGeneratorHelpers/Helpers/SymbolExtensions.cs
+++ b/src/SourceGenerators/SourceGeneratorHelpers/Helpers/SymbolExtensions.cs
@@ -575,5 +575,26 @@ namespace Microsoft.CodeAnalysis
 			=> attribute.FindNamedArg(argName) is { IsNull: false, Kind: TypedConstantKind.Enum } arg && arg.Type!.Name == typeof(T).Name
 				? (T)arg.Value!
 				: default(T?);
+
+		/// <summary>
+		/// Returns the property type of a dependency-property or an attached dependency-property setter.
+		/// </summary>
+		/// <param name="propertyOrSetter">The dependency-property or the attached dependency-property setter</param>
+		/// <returns>The property type</returns>
+		public static INamedTypeSymbol? FindDependencyPropertyType(this ISymbol propertyOrSetter)
+		{
+			if (propertyOrSetter is IPropertySymbol dependencyProperty)
+			{
+				return dependencyProperty.Type.OriginalDefinition is { SpecialType: SpecialType.System_Nullable_T }
+					? (dependencyProperty.Type as INamedTypeSymbol)?.TypeArguments[0] as INamedTypeSymbol
+					: dependencyProperty.Type as INamedTypeSymbol;
+			}
+			else if (propertyOrSetter is IMethodSymbol { IsStatic: true, Parameters.Length: 2 } attachedPropertySetter)
+			{
+				return attachedPropertySetter.Parameters[1].Type as INamedTypeSymbol;
+			}
+
+			return null;
+		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
@@ -157,6 +157,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			// Markup
 			public const string MarkupHelper = "Uno.UI.Helpers.MarkupHelper";
+			public const string MarkupXamlBindingHelper = Markup + ".XamlBindingHelper";
 			public const string MarkupExtension = Markup + ".MarkupExtension";
 			public const string IMarkupExtensionOverrides = Markup + ".IMarkupExtensionOverrides";
 		}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4028,8 +4028,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		{
 			TryAnnotateWithGeneratorSource(writer);
 			var literalValue = isCustomMarkupExtension
-					? GetCustomMarkupExtensionValue(member)
-					: BuildLiteralValue(member, propertyType: propertyType, owner: member, objectUid: objectUid);
+				? GetCustomMarkupExtensionValue(member, closureName)
+				: BuildLiteralValue(member, propertyType: propertyType, owner: member, objectUid: objectUid);
 
 			var memberGlobalizedType = FindType(member.Member.DeclaringType)?.GetFullyQualifiedTypeIncludingGlobal() ?? GetGlobalizedTypeName(member.Member.DeclaringType.Name);
 			writer.AppendLineInvariantIndented(
@@ -4681,32 +4681,44 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private string GetCustomMarkupExtensionValue(XamlMemberDefinition member, string? target = null)
 		{
 			// Get the type of the custom markup extension
-			var markupTypeDef = member
+			var markup = member
 				.Objects
-				.FirstOrDefault(o => IsCustomMarkupExtensionType(o.Type));
-			var markupType = GetMarkupExtensionType(markupTypeDef?.Type);
-
-			if (markupType == null || markupTypeDef == null)
+				.Select(x => new { Value = x, Symbol = GetMarkupExtensionType(x.Type) })
+				.FirstOrDefault(x => x.Symbol != null);
+			if (markup == null)
 			{
-				throw new InvalidOperationException($"Unable to find markup extension type for ");
+				throw new InvalidOperationException($"Unable to find markup extension type: '{member.Objects.FirstOrDefault()?.Type}' on '{member.Member}'");
+			}
+
+			var property = FindProperty(member.Member);
+			var declaringType = property?.ContainingType;
+			var propertyType = property?.FindDependencyPropertyType();
+
+			if (declaringType == null || propertyType == null)
+			{
+#if DEBUG
+				Console.WriteLine($"Unable to determine the target dependency property for the markup extension ('{member.Member}' cannot be found).");
+#endif
+				return string.Empty;
 			}
 
 			// Get the full globalized names
 			var globalized = new
 			{
-				MarkupType = markupType.GetFullyQualifiedTypeIncludingGlobal(),
+				MarkupType = markup.Symbol!.GetFullyQualifiedTypeIncludingGlobal(),
 				MarkupHelper = $"global::{XamlConstants.Types.MarkupHelper}",
 				IMarkupExtensionOverrides = $"global::{XamlConstants.Types.IMarkupExtensionOverrides}",
-				PvtpDeclaringType = GetGlobalizedTypeName(member.Member.DeclaringType),
-				PvtpType = GetGlobalizedTypeName(member.Member.Type),
+				XamlBindingHelper = $"global::{XamlConstants.Types.MarkupXamlBindingHelper}",
+				PvtpDeclaringType = declaringType.GetFullyQualifiedTypeIncludingGlobal(),
+				PvtpType = propertyType.GetFullyQualifiedTypeIncludingGlobal(),
 			};
 
 			// Build a string of all its properties
-			var properties = markupTypeDef
+			var properties = markup.Value
 				.Members
 				.Select(m =>
 				{
-					var propertyType = markupType.GetPropertyWithName(m.Member.Name)?.Type as INamedTypeSymbol;
+					var propertyType = markup.Symbol.GetPropertyWithName(m.Member.Name)?.Type as INamedTypeSymbol;
 					var resourceName = GetSimpleStaticResourceRetrieval(m, propertyType);
 					var value = resourceName ?? BuildLiteralValue(m, propertyType: propertyType, owner: member);
 
@@ -4727,25 +4739,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var provider = $"{globalized.MarkupHelper}.CreateParserContext({providerDetails.JoinBy(", ")})";
 
 			var provideValue = $"(({globalized.IMarkupExtensionOverrides})new {globalized.MarkupType}{markupInitializer}).ProvideValue({provider})";
-
-			// Don't use the value from MarkupExtensionReturnType to match UWP behavior.
-			if (FindPropertyType(member.Member) is INamedTypeSymbol propertyType)
+			if (IsImplementingInterface(propertyType, Generation.IConvertibleSymbol.Value))
 			{
-				var propertyTypeFullyQualified = propertyType.GetFullyQualifiedTypeIncludingGlobal();
-				if (IsImplementingInterface(propertyType, Generation.IConvertibleSymbol.Value))
-				{
-					provideValue = $"Windows.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof({propertyTypeFullyQualified}), {provideValue})";
-				}
+				provideValue = $"{globalized.XamlBindingHelper}.ConvertValue(typeof({globalized.PvtpType}), {provideValue})";
+			}
+			var unboxed = $"({globalized.PvtpType}){provideValue}";
 
-				return "({0}){1}".InvariantCultureFormat(propertyTypeFullyQualified, provideValue);
-			}
-			else
-			{
-#if DEBUG
-				Console.WriteLine($"Unable to determine the return type needed for the markup extension ('{member.Member}' cannot be found).");
-#endif
-				return string.Empty;
-			}
+			return unboxed;
 		}
 
 		private (bool isInside, XamlObjectDefinition? xamlObject) IsMemberInsideDataTemplate(XamlObjectDefinition? xamlObject)

--- a/src/SourceGenerators/XamlGenerationTests/MarkupExtension_ParserContext.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/MarkupExtension_ParserContext.xaml
@@ -5,8 +5,11 @@
 
 	<StackPanel>
 
+		<!-- some of code below may not run, but we just care about the generated xaml source -->
+
 		<TextBlock x:Name="SimpleMarkupExtension" Text="{me:MyParserContextExtension}" />
 		<TextBlock x:Name="NestedMarkupExtension" Text="{Binding TargetNullValue={me:MyParserContextExtension}}" />
+		<TextBlock x:Name="AttachedMarkupExtension" Grid.Row="{me:MyParserContextExtension}" />
 
 	</StackPanel>
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/Attachable.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/Attachable.cs
@@ -1,0 +1,31 @@
+﻿using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls;
+
+public static class Attachable
+{
+	#region DependencyProperty: Value
+
+	public static DependencyProperty ValueProperty { get; } = DependencyProperty.RegisterAttached(
+		"Value",
+		typeof(object),
+		typeof(Attachable),
+		new PropertyMetadata(default(object)));
+
+	public static object GetValue(DependencyObject obj) => (object)obj.GetValue(ValueProperty);
+	public static void SetValue(DependencyObject obj, object value) => obj.SetValue(ValueProperty, value);
+
+	#endregion
+	#region DependencyProperty: Value2
+
+	public static DependencyProperty Value2Property { get; } = DependencyProperty.RegisterAttached(
+		"Value2",
+		typeof(int),
+		typeof(Attachable),
+		new PropertyMetadata(default(int)));
+
+	public static int GetValue2(DependencyObject obj) => (int)obj.GetValue(Value2Property);
+	public static void SetValue2(DependencyObject obj, int value) => obj.SetValue(Value2Property, value);
+
+	#endregion
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/DebugMarkupExtension.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/DebugMarkupExtension.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Markup;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls;
+
+internal partial class DebugMarkupExtension : MarkupExtension
+{
+	public enum DebugBehavior { ReturnProvider, AssignToTag, AssignToAttachableValue }
+
+	public DebugBehavior Behavior { get; set; } = DebugBehavior.ReturnProvider;
+
+	protected override object ProvideValue(IXamlServiceProvider serviceProvider)
+	{
+		if (Behavior == DebugBehavior.ReturnProvider)
+		{
+			return serviceProvider;
+		}
+		else
+		{
+			if (serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget pvt &&
+				pvt.TargetObject is FrameworkElement fe &&
+				pvt.TargetProperty is ProvideValueTargetProperty pvtp)
+			{
+				if (Behavior == DebugBehavior.AssignToTag)
+				{
+					fe.Tag = serviceProvider;
+				}
+				else
+				{
+					Attachable.SetValue(fe, serviceProvider);
+				}
+
+				return pvtp.Type.IsValueType ? Activator.CreateInstance(pvtp.Type) : null;
+			}
+
+			// shouldn't reach here if we generated the correct xaml source
+			// but if we do, then there is no recovery.
+			throw new InvalidOperationException("IProvideValueTarget is invalid or not provided.");
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_AttachedDP_Markup_Setup.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_AttachedDP_Markup_Setup.xaml
@@ -1,0 +1,6 @@
+﻿<UserControl x:Class="Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls.When_AttachedDP_Markup_Setup"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls"
+			 local:Attachable.Value="{local:DebugMarkupExtension}"
+			 local:Attachable.Value2="{local:DebugMarkupExtension Behavior=AssignToTag}" />

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_AttachedDP_Markup_Setup.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_AttachedDP_Markup_Setup.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls;
+public sealed partial class When_AttachedDP_Markup_Setup : UserControl
+{
+	public When_AttachedDP_Markup_Setup()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_DP_Markup_Setup.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_DP_Markup_Setup.xaml
@@ -1,0 +1,6 @@
+﻿<UserControl x:Class="Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls.When_DP_Markup_Setup"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls"
+			 Tag="{local:DebugMarkupExtension}"
+			 local:Attachable.Value2="{local:DebugMarkupExtension Behavior=AssignToAttachableValue}" />

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_DP_Markup_Setup.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_DP_Markup_Setup.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls;
+public sealed partial class When_DP_Markup_Setup : UserControl
+{
+	public When_DP_Markup_Setup()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Given_MarkupExtension.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Given_MarkupExtension.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests;
+
+[TestClass]
+public class Given_MarkupExtension
+{
+	[TestMethod]
+	public void When_DP_Markup()
+	{
+		var setup = new When_DP_Markup_Setup(); // Tag="{local:DebugMarkupExtension}"
+		var provider = setup.Tag as IXamlServiceProvider;
+		var pvt = provider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+		var target = pvt.TargetObject;
+		var pvtp = pvt.TargetProperty as ProvideValueTargetProperty;
+
+		var expectedDP = FrameworkElement.TagProperty;
+
+		Assert.AreEqual(setup, target);
+		Assert.AreEqual(expectedDP.OwnerType, pvtp.DeclaringType);
+		Assert.AreEqual(expectedDP.Name, pvtp.Name);
+		Assert.AreEqual(expectedDP.Type, pvtp.Type);
+	}
+
+	[TestMethod]
+	public void When_AttachedDP_Markup()
+	{
+		var setup = new When_AttachedDP_Markup_Setup(); // local:Attachable.Value="{local:DebugMarkupExtension}"
+		var provider = Attachable.GetValue(setup) as IXamlServiceProvider;
+		var pvt = provider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+		var target = pvt.TargetObject;
+		var pvtp = pvt.TargetProperty as ProvideValueTargetProperty;
+
+		var expectedDP = Attachable.ValueProperty;
+
+		Assert.AreEqual(setup, target);
+		Assert.AreEqual(expectedDP.OwnerType, pvtp.DeclaringType);
+		Assert.AreEqual(expectedDP.Name, pvtp.Name);
+		Assert.AreEqual(expectedDP.Type, pvtp.Type);
+	}
+
+	[TestMethod]
+	public void When_DP_Markup_PropertyType()
+	{
+		var setup = new When_DP_Markup_Setup(); // local:Attachable.Value2="{local:DebugMarkupExtension Behavior=AssignToAttachableValue}"
+		var provider = Attachable.GetValue(setup) as IXamlServiceProvider; // since target dp is an int, we are storing the provider in another dp
+		var pvt = provider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+		var target = pvt.TargetObject;
+		var pvtp = pvt.TargetProperty as ProvideValueTargetProperty;
+
+		var expectedDP = Attachable.Value2Property;
+
+		Assert.AreEqual(setup, target);
+		Assert.AreEqual(expectedDP.OwnerType, pvtp.DeclaringType);
+		Assert.AreEqual(expectedDP.Name, pvtp.Name);
+		Assert.AreEqual(expectedDP.Type, pvtp.Type);
+	}
+
+	[TestMethod]
+	public void When_AttachedDP_Markup_PropertyType()
+	{
+		var setup = new When_AttachedDP_Markup_Setup(); // local:Attachable.Value2="{local:DebugMarkupExtension Behavior=AssignToTag}"
+		var provider = setup.Tag as IXamlServiceProvider; // since target dp is an int, we are storing the provider in another dp
+		var pvt = provider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
+		var target = pvt.TargetObject;
+		var pvtp = pvt.TargetProperty as ProvideValueTargetProperty;
+
+		var expectedDP = Attachable.Value2Property;
+
+		Assert.AreEqual(setup, target);
+		Assert.AreEqual(expectedDP.OwnerType, pvtp.DeclaringType);
+		Assert.AreEqual(expectedDP.Name, pvtp.Name);
+		Assert.AreEqual(expectedDP.Type, pvtp.Type);
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14719, closes #14749

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
## What is the new behavior?
- custom `MarkupExtension` are now supported on attached properties
- fixed `ProvideValueTargetProperty` not providing the correct property info:
	- `.Type` were always of type `object`
	- `.DeclaringType` were the type of where the dp was assigned on, instead of the class that declared the dp
		^ `Button.Content={...}` previously returned `Button` instead of `ContentControl`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
