### PR TITLE
docs: Improve `NetworkInformation` page

### DIFF
--- a/doc/articles/features/windows-networking.md
+++ b/doc/articles/features/windows-networking.md
@@ -22,14 +22,14 @@ uid: Uno.Features.WNetworking
 
 Android can recognize all values of `NetworkConnectivityLevel`. iOS, macOS and WASM return either `None` or `InternetAccess`.
 
-**Note**: On Android, the `android.permission.ACCESS_NETWORK_STATE` permission is required. It can be added to the application manifest or with the following attribute in the Android platform head:
+The `android.permission.ACCESS_NETWORK_STATE` permission is required. It can be added to the application manifest or with the following attribute in the Android platform head:
 ```
 [assembly: UsesPermission(\"android.permission.ACCESS_NETWORK_STATE\")]
 ```
 
 ### iOS/macOS reachability host name
 
-On iOS and macOS, it is necessary to make an actual "ping" request, to verify that internet connection is accessible. The default domain that is checked is `www.example.com`, but you can change this to be any other domain by setting the `WinRTFeatureConfiguration.NetworkInformation.ReachabilityHostname` property.
+On iOS and macOS, it is required to make an actual "ping" request, to verify that internet connection is accessible. The default domain that is checked is `www.example.com`, but you can change this to be any other domain by setting the `WinRTFeatureConfiguration.NetworkInformation.ReachabilityHostname` property.
 
 ## Example
 

--- a/doc/articles/features/windows-networking.md
+++ b/doc/articles/features/windows-networking.md
@@ -9,7 +9,31 @@ uid: Uno.Features.WNetworking
 
 * The `Windows.Networking` namespace provides classes for accessing and managing network connections from your app.
 
-## Checking for internet connectivity
+## Supported features
+
+| Feature        |  Windows  | Android |  iOS  |  Web (WASM)  | macOS | Linux (Skia)  | Win 7 (Skia) | 
+|----------------------------------|-------|-------|-------|-------|-------|-------|-|
+| `GetInternetConnectionProfile`   | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| `NetworkStatusChanged`           | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+
+## Platform-specific
+
+### Android
+
+Android can recognize all values of `NetworkConnectivityLevel`. iOS, macOS and WASM return either `None` or `InternetAccess`.
+
+**Note**: On Android, the `android.permission.ACCESS_NETWORK_STATE` permission is required. It can be added to the application manifest or with the following attribute in the Android platform head:
+```
+[assembly: UsesPermission(\"android.permission.ACCESS_NETWORK_STATE\")]
+```
+
+### iOS/macOS reachability host name
+
+On iOS and macOS, it is necessary to make an actual "ping" request, to verify that internet connection is accessible. The default domain that is checked is `www.example.com`, but you can change this to be any other domain by setting the `WinRTFeatureConfiguration.NetworkInformation.ReachabilityHostname` property.
+
+## Example
+
+### Checking for internet connectivity
 
 You can use the following snippet to check for internet connectivity level in a cross-platform manner:
 
@@ -26,15 +50,17 @@ else
 }
 ```
 
+### Observing changes in connectivity
 
-Android can recognize all values of `NetworkConnectivityLevel`. iOS, macOS and WASM return either `None` or `InternetAccess`.
+You can use the following snippet to observe changes in connectivity:
 
-
-**Note**: On Android, the `android.permission.ACCESS_NETWORK_STATE` permission is required. It can be added to the application manifest or with the following attribute in the Android platform head:
+``` C#
+var profile = NetworkInformation.GetInternetConnectionProfile();
+profile.NetworkStatusChanged += NetworkInformation_NetworkStatusChanged;
 ```
-[assembly: UsesPermission(\"android.permission.ACCESS_NETWORK_STATE\")]
+
+### Unsubscribing from the changes
+
+``` C#
+profile.NetworkStatusChanged -= NetworkInformation_NetworkStatusChanged;
 ```
-
-### iOS/macOS reachability host name
-
-On iOS and macOS, it is necessary to make an actual "ping" request, to verify that internet connection is accessible. The default domain that is checked is `www.example.com`, but you can change this to be any other domain by setting the `WinRTFeatureConfiguration.NetworkInformation.ReachabilityHostname` property.


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/Uno.Gallery/issues/33

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Documentation content changes

## What is the new behavior?
Improved the `NetworkInformation` docs page with more details and samples for implementation.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.