### PR TITLE
docs: sync vscode debug with new templates

### DIFF
--- a/doc/articles/create-an-app-vscode.md
+++ b/doc/articles/create-an-app-vscode.md
@@ -40,16 +40,12 @@ Uno Platform provides integrated support for debugging your app on Windows, mac 
 1. In the debugger section of the [activity bar](https://code.visualstudio.com/docs/getstarted/userinterface) select `Debug (Chrome, WebAssembly)`
 1. In the status bar, ensure the `MyApp.Wasm.csproj` project is selected - by default `MyApp.sln` is selected.
 1. Press `F5` to start the debugging session
-1. Place a breakpoint inside the `OnClick` method
-1. Click the button in the app, and the breakpoint will hit
 
 # [**Skia GTK**](#tab/skiagtk)
 
 1. In the debugger section of the [activity bar](https://code.visualstudio.com/docs/getstarted/userinterface) select `Skia.GTK (Debug)`
 1. In the status bar, ensure the `MyApp.Skia.Gtk.csproj` project is selected - by default `MyApp.sln` is selected.
 1. Press `F5` to start the debugging session
-1. Place a breakpoint inside the `OnClick` method
-1. Click the button in the app, and the breakpoint will hit
 
 Note that C# Hot Reload is not available when running with the debugger. In order to use C# Hot Reload, run the app using the following:
 


### PR DESCRIPTION
GitHub Issue (If applicable): 

https://github.com/unoplatform/uno/issues/12506#issuecomment-1852886135

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

The debug instructions for Wasm and Skia/Gtk refers to code that is not part of the latest templates.

## What is the new behavior?

The last 2 steps for Wasm and Skia/Gtk were removed. This match the mobile (iOS, Android, Catalyst) documentation for VS Code.

This also match the documents for VS 2022 and Rider.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
