### PR TITLE
feat: Add net7 backward compatibility for msbuild getProperty

### DIFF
--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.UI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.UI.DevServer.targets
@@ -27,6 +27,15 @@
 		<Message Text="&lt;IsRCClientRemote&gt;$(_IsRCClientRemote)&lt;/IsRCClientRemote&gt;" Importance="High" />
 	</Target>
 
+	<!-- .NET 7 and earlier compatibility for .NET8 msbuild CLI `getProperty` equivalent -->
+	<Target Name="UnoVSCodeGetProjectProperties">
+		<Message Text='{%0a  "Properties": {%0a    "TargetFramework": "$(TargetFramework)",' Importance="High" />
+		<Message Text='    "TargetFrameworks": "$(TargetFrameworks)",' Importance="High" />
+		<Message Text='    "OutputPath": "$(OutputPath)",' Importance="High" />
+		<Message Text='    "AssemblyName": "$(AssemblyName)",' Importance="High" />
+		<Message Text='    "Configuration": "$(Configuration)"%0a  }%0a}' Importance="High" />
+	</Target>
+
 	<Target Name="InjectRemoteControlHost"
 			BeforeTargets="BeforeBuild"
 			Condition="exists('$(IntermediateOutputPath)\RemoteControlHost.config') and '$(IsRunningInsideVisualStudio)'!='true'">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Add net7 backward compatibility for msbuild CLI `--getProperty` for vscode.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
