### PR TITLE
fix(droid): FileOpenPicker ignoring suggested PicturesLibrary

### DIFF
--- a/doc/articles/features/windows-storage-pickers.md
+++ b/doc/articles/features/windows-storage-pickers.md
@@ -18,24 +18,26 @@ Legend
   - 💬 Partially supported (see below for more details)
   - ✖ Not supported
 
-| Picker         | UWP   | WebAssembly | Android | iOS   | macOS | WPF | GTK |
-|----------------|-------|-------------|---------|-------|-------|-----|-----|
-| FileOpenPicker | ✔   | ✔  (1)     | ✔     | ✔    | ✔   | ✔  | ✔  |
-| FileSavePicker | ✔   | ✔  (1)     | ✔     | ✔    | ✔   | ✔  | ✔  |
-| FolderPicker   | ✔   | ✔          | ✔     | 💬 (2)| ✔   | ✖  | ✔  |
+| Picker         | UWP   | WebAssembly | Android | iOS    | macOS | WPF | GTK |
+|----------------|-------|-------------|---------|--------|-------|-----|-----|
+| FileOpenPicker | ✔    | ✔ (1)       | ✔      | ✔      | ✔    | ✔   | ✔  |
+| FileSavePicker | ✔    | ✔ (1)       | ✔      | ✔      | ✔    | ✔   | ✔  |
+| FolderPicker   | ✔    | ✔           | ✔      | 💬 (2) | ✔    | ✖   | ✔  |
 
 *(1) - Multiple implementations supported - see WebAssembly section below*
 *(2) - See iOS section below*
 
 On some platforms, you can further customize the file picking experience by utilizing additional properties:
 
-| Feature                 | UWP  | WebAssembly | Android | iOS | macOS | WPF | GTK |
-|-------------------------|------|-------------|---------|-----|-------|-----|-----|
-| SuggestedFileName       | ✔   | ✔         | ✖      | ✖ | ✔   | ✔  | ✔ |
-| SuggestedStartLocation  | ✔   | ✔  (1)    | ✖      | ✖ | ✔   | ✔  | ✔ |
-| SettingsIdentifier      | ✔   | ✔  (1)    | ✔      | ✖ | ✖   | ✖  | ✖ |
+| Feature                 | UWP  | WebAssembly | Android | iOS   | macOS | WPF | GTK |
+|-------------------------|------|-------------|---------|-------|-------|-----|-----|
+| SuggestedFileName       | ✔   | ✔           | ✖      | ✖     | ✔    | ✔   | ✔  |
+| SuggestedStartLocation  | ✔   | ✔ (1)       | 💬     | ✔ (3) | ✔    | ✔   | ✔  |
+| SettingsIdentifier      | ✔   | ✔ (1)       | ✔      | ✖     | ✖    | ✖   | ✖  |
 
 *(1) - Only for the native file pickers - see WebAssembly section below*
+*(2) - For FileOpenPicker, VideosLibrary and PicturesLibrary are used apply `image/*` and `video/*` filters*
+*(3) - PicturesLibrary opens the picture library with the image picker controller*
 
 On platforms where the additional features are not supported yet, setting them will not have any effect.
 
@@ -148,7 +150,7 @@ else
 }
 ```
 
-**Notes**: While the `SuggestedStartLocation` has currently no effect in Uno Platform targets, it must be set, otherwise the dialog crashes on UWP. `FileTypes` must include at least one item. You can add extensions in the format `.extension`, with the exception of `*` (asterisk) which allows picking any type of file.
+**Notes**: `SuggestedStartLocation` should be set to prevent crashes on UWP. `FileTypes` must include at least one item. You can add extensions in the format `.extension`, with the exception of `*` (asterisk) which allows picking any type of file.
 
 ### FileSavePicker
 

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
@@ -19,6 +19,9 @@ namespace Windows.Storage.Pickers
 		private static TaskCompletionSource<Intent?>? _currentFileOpenPickerRequest;
 
 		private const string StorageIdentifierFormatString = "Uno.FileOpenPicker.{0}";
+		private const string AnyWildcard = "*/*";
+		private const string ImageWildcard = "image/*";
+		private const string VideoWildcard = "image/*";
 
 		internal static bool TryHandleIntent(Intent intent, Result resultCode)
 		{
@@ -72,10 +75,15 @@ namespace Windows.Storage.Pickers
 				intent.PutExtra(Android.Provider.DocumentsContract.ExtraInitialUri, uri);
 			}
 
-			intent.SetType("*/*");
-
-			var mimeTypes = GetMimeTypes();
-			intent.PutExtra(Intent.ExtraMimeTypes, mimeTypes);
+			intent.SetType(GetMimeType());
+			// We have already set the intent type based on the SuggestedStartLocation from above,
+			// which constraints to the broad category of any-file, any-image or any-video.
+			// To preserve the picture or video ones, we must not include any extra mime type,
+			// that is less restrictive than what is suggested by SuggestedStartLocation.
+			if (GetExtraMimeTypes() is { } extraMimeTypes)
+			{
+				intent.PutExtra(Intent.ExtraMimeTypes, extraMimeTypes);
+			}
 
 			_currentFileOpenPickerRequest = new TaskCompletionSource<Intent?>();
 
@@ -122,11 +130,22 @@ namespace Windows.Storage.Pickers
 			return FilePickerSelectedFilesArray.Empty;
 		}
 
-		private string[] GetMimeTypes()
+		private string GetMimeType()
+		{
+			return SuggestedStartLocation switch
+			{
+				PickerLocationId.PicturesLibrary => ImageWildcard,
+				PickerLocationId.VideosLibrary => VideoWildcard,
+
+				_ => AnyWildcard,
+			};
+		}
+
+		private string[]? GetExtraMimeTypes()
 		{
 			if (FileTypeFilter.Contains("*"))
 			{
-				return new[] { "*/*" };
+				return null;
 			}
 
 			List<string> mimeTypes = new List<string>();
@@ -135,7 +154,7 @@ namespace Windows.Storage.Pickers
 			if (mimeTypeMap is null)
 			{
 				// when map is unavailable (probably never happens, but Singleton returns nullable)
-				return new[] { "*/*" };
+				return null;
 			}
 
 			foreach (string oneExtensionForLoop in FileTypeFilter)
@@ -181,7 +200,7 @@ namespace Windows.Storage.Pickers
 
 					if (!mimeTypesFromUno.Any())
 					{
-						return new[] { "*/*" };
+						return null;
 					}
 
 					foreach (var oneUnoMimeType in mimeTypesFromUno)
@@ -191,11 +210,8 @@ namespace Windows.Storage.Pickers
 							mimeTypes.Add(oneUnoMimeType);
 						}
 					}
-
 				}
-
 			}
-
 
 			return mimeTypes.ToArray();
 		}

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
@@ -21,7 +21,7 @@ namespace Windows.Storage.Pickers
 		private const string StorageIdentifierFormatString = "Uno.FileOpenPicker.{0}";
 		private const string AnyWildcard = "*/*";
 		private const string ImageWildcard = "image/*";
-		private const string VideoWildcard = "image/*";
+		private const string VideoWildcard = "video/*";
 
 		internal static bool TryHandleIntent(Intent intent, Result resultCode)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14658

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On android, FileOpenPicker.SuggestedStartLocation has no effect.

## What is the new behavior?
On android, setting FileOpenPicker.SuggestedStartLocation to PicturesLibrary or VideosLibrary now adds the relevant filter for the picker.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->