### PR TITLE
chore: Implement `AutoSuggestBoxAutomationPeer`

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Automation.Peers/AutoSuggestBoxAutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Automation.Peers/AutoSuggestBoxAutomationPeer.cs
@@ -3,12 +3,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Xaml.Automation.Peers
 {
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class AutoSuggestBoxAutomationPeer : global::Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer, global::Microsoft.UI.Xaml.Automation.Provider.IInvokeProvider
 	{
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public AutoSuggestBoxAutomationPeer(global::Microsoft.UI.Xaml.Controls.AutoSuggestBox owner) : base(owner)
 		{
@@ -16,7 +16,7 @@ namespace Microsoft.UI.Xaml.Automation.Peers
 		}
 #endif
 		// Forced skipping of method Microsoft.UI.Xaml.Automation.Peers.AutoSuggestBoxAutomationPeer.AutoSuggestBoxAutomationPeer(Microsoft.UI.Xaml.Controls.AutoSuggestBox)
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void Invoke()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -537,5 +537,14 @@ namespace Microsoft.UI.Xaml.Controls
 				descriptionPresenter.Visibility = Description != null ? Visibility.Visible : Visibility.Collapsed;
 			}
 		}
+
+		internal void ProgrammaticSubmitQuery()
+		{
+			//UNO TODO: Implement ProgrammaticSubmitQuery on AutoSuggestBox
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().Warn($"ProgrammaticSubmitQuery on AutoSuggestBox is not yet implemented.");
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxAutomationPeer.cs
@@ -35,10 +35,5 @@ public partial class AutoSuggestBoxAutomationPeer
 	/// Sends a request to submit the auto-suggest query to the AutoSuggestBox associated with the automation peer.
 	/// </summary>
 	public void Invoke()
-	{
-		//UNO TODO: Implement ProgrammaticSubmitQuery on AutoSuggestBox
-
-		//IUIElement owner = Owner;
-		//(owner as AutoSuggestBox).ProgrammaticSubmitQuery();
-	}
+		=> (Owner as AutoSuggestBox).ProgrammaticSubmitQuery();
 }

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxAutomationPeer.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX reference AutoSuggestBoxAutomationPeer_Partial.cpp, tag winui3/release/1.4.2
 
-using Windows.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 
-namespace Windows.UI.Xaml.Automation.Peers;
+namespace Microsoft.UI.Xaml.Automation.Peers;
 
 /// <summary>
 /// Exposes AutoSuggestBox types to Microsoft UI Automation.

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxAutomationPeer.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference AutoSuggestBoxAutomationPeer_Partial.cpp, tag winui3/release/1.4.2
+
+using Windows.UI.Xaml.Controls;
+
+namespace Windows.UI.Xaml.Automation.Peers;
+
+/// <summary>
+/// Exposes AutoSuggestBox types to Microsoft UI Automation.
+/// </summary>
+/// <param name="owner"></param>
+public partial class AutoSuggestBoxAutomationPeer(AutoSuggestBox owner)
+	: FrameworkElementAutomationPeer(owner), Provider.IInvokeProvider
+{
+	protected override string GetClassNameCore() => nameof(AutoSuggestBox);
+
+	protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Group;
+
+	protected override object GetPatternCore(PatternInterface patternInterface)
+	{
+		if (patternInterface is PatternInterface.Invoke)
+		{
+			return this;
+		}
+
+		return base.GetPatternCore(patternInterface);
+	}
+
+	/// <summary>
+	/// Sends a request to submit the auto-suggest query to the AutoSuggestBox associated with the automation peer.
+	/// </summary>
+	public void Invoke()
+	{
+		//UNO TODO: Implement ProgrammaticSubmitQuery on AutoSuggestBox
+
+		//IUIElement owner = Owner;
+		//(owner as AutoSuggestBox).ProgrammaticSubmitQuery();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxAutomationPeer.cs
@@ -10,9 +10,13 @@ namespace Microsoft.UI.Xaml.Automation.Peers;
 /// Exposes AutoSuggestBox types to Microsoft UI Automation.
 /// </summary>
 /// <param name="owner"></param>
-public partial class AutoSuggestBoxAutomationPeer(AutoSuggestBox owner)
-	: FrameworkElementAutomationPeer(owner), Provider.IInvokeProvider
+public partial class AutoSuggestBoxAutomationPeer
+	: FrameworkElementAutomationPeer, Provider.IInvokeProvider
 {
+	public AutoSuggestBoxAutomationPeer(AutoSuggestBox owner) : base(owner)
+	{
+	}
+
 	protected override string GetClassNameCore() => nameof(AutoSuggestBox);
 
 	protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Group;


### PR DESCRIPTION
GitHub Issue (If applicable): part of #14344

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the new behavior?
The `AutoSuggestBoxAutomationPeer` is implemented

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.