### PR TITLE
fix(droid): Flipview Native View clipping

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FlipView/FlipView_Images.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/FlipView/FlipView_Images.xaml.cs
@@ -16,7 +16,7 @@ using Microsoft.UI.Xaml.Navigation;
 
 namespace UITests.Windows_UI_Xaml_Controls.FlipView
 {
-	[SampleControlInfo("FlipView", "FlipView_Images")]
+	[SampleControlInfo("FlipView", "FlipView_Images", description: "User should see a single image at the time")]
 	public sealed partial class FlipView_Images : UserControl
 	{
 		public FlipView_Images()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
@@ -176,6 +176,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		}
 
+#if __ANDROID__
+		[TestMethod]
+		public async Task When_NativeChild_Clipped()
+		{
+			var flipView = new FlipView
+			{
+				Items =
+				{
+					new FlipViewItem {Content = "Inline item 1"},
+					new FlipViewItem {Content = "Inline item 2"},
+				}
+			};
+
+			WindowHelper.WindowContent = flipView;
+
+			await WindowHelper.WaitForLoaded(flipView);
+
+			var nativeChild = flipView.FindFirstChild<NativePagedView>();
+
+			Assert.IsNotNull(nativeChild);
+			Assert.IsTrue(flipView.ClipChildren);
+		}
+#endif
+
 		private async Task<RawBitmap> TakeScreenshot(FrameworkElement SUT)
 		{
 			var renderer = new RenderTargetBitmap();

--- a/src/Uno.UI/UI/Xaml/Controls/FlipView/FlipView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/FlipView/FlipView.Android.cs
@@ -15,8 +15,14 @@ namespace Microsoft.UI.Xaml.Controls
 	{
 		private NativePagedView PagedView { get { return InternalItemsPanelRoot as NativePagedView; } }
 
+		partial void InitializePartial()
+		{
+			SetClipChildren(true);
+		}
+
 		private protected override void UpdateItems(NotifyCollectionChangedEventArgs args)
 		{
+
 			if (PagedView != null && PagedView.Adapter == null)
 			{
 				PagedView.Adapter = new FlipViewAdapter()
@@ -27,8 +33,11 @@ namespace Microsoft.UI.Xaml.Controls
 				//Set CurrentItem in case SelectedIndex has changed prior to FlipView becoming visible
 				PagedView.CurrentItem = SelectedIndex;
 			}
+
 			PagedView?.Adapter.NotifyDataSetChanged();
+
 			base.UpdateItems(args);
+
 			RequestLayout();
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -24,7 +24,7 @@ namespace Microsoft.UI.Xaml
 	public partial class UIElement : BindableView
 	{
 		/// <summary>
-		/// Keeps the count of native children (non-UIElements), for clipping purpoess.
+		/// Keeps the count of native children (non-UIElements), for clipping purposes.
 		/// </summary>
 		private int _nativeChildrenCount;
 		private bool _nativeClipChildren;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14551 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation-related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behaviour?
FlipVIew NativeView is not clipping correctly to its parent, causing more than one FlipViewItem to be displayed simultaneously.

<!-- Please describe the current behaviour that you are modifying, or link to a relevant issue. -->


## What is the new behaviour?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
