### PR TITLE
fix(droid): Geolocator listener crash

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_Devices/GeolocatorTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Devices/GeolocatorTests.xaml.cs
@@ -168,8 +168,10 @@ namespace UITests.Shared.Windows_Devices
 			}
 		}
 
-		private async void RequestAccess() =>
+		private async void RequestAccess()
+		{
 			GeolocationAccessStatus = await Geolocator.RequestAccessAsync();
+		}
 
 		private async void GetGeoposition()
 		{

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -298,6 +298,7 @@ public sealed partial class Geolocator
 
 	private LocationManager? InitializeLocationProvider()
 	{
+		_locationProvider = null;
 		var locationManager = (LocationManager?)Android.App.Application.Context.GetSystemService(Android.Content.Context.LocationService);
 
 		var criteriaForLocationService = new Criteria
@@ -305,15 +306,9 @@ public sealed partial class Geolocator
 			Accuracy = Accuracy.Coarse
 		};
 
-		var acceptableLocationProviders = locationManager?.GetProviders(criteriaForLocationService, true);
-
-		if (acceptableLocationProviders != null && acceptableLocationProviders.Any())
+		if (locationManager?.GetProviders(criteriaForLocationService, true) is { } acceptableLocationProviders)
 		{
-			_locationProvider = acceptableLocationProviders.First();
-		}
-		else
-		{
-			_locationProvider = string.Empty;
+			_locationProvider = acceptableLocationProviders.FirstOrDefault();
 		}
 
 		return locationManager;

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -132,6 +132,11 @@ public sealed partial class Geolocator
 
 	private static async Task<GeolocationAccessStatus> RequestAccessCore()
 	{
+		if (!IsLocationEnabled())
+		{
+			return GeolocationAccessStatus.Denied;
+		}
+
 		var status = GeolocationAccessStatus.Allowed;
 
 		if (!await PermissionsHelper.CheckFineLocationPermission(CancellationToken.None))
@@ -164,19 +169,14 @@ public sealed partial class Geolocator
 			}
 		}
 
-		if (!IsLocationProvidedEnabled())
-		{
-			status = GeolocationAccessStatus.Denied;
-		}
-
 		return status;
 	}
 
-	public static bool IsLocationProvidedEnabled()
+	public static bool IsLocationEnabled()
 	{
 		var locationManager = (LocationManager?)Android.App.Application.Context.GetSystemService(Android.Content.Context.LocationService);
 
-		return locationManager?.GetProviders(new Criteria { Accuracy = Accuracy.Coarse }, true)?.Count > 0;
+		return locationManager?.IsLocationEnabled ?? false;
 	}
 
 	/// <summary>

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -141,6 +141,7 @@ public sealed partial class Geolocator
 				: GeolocationAccessStatus.Denied;
 
 			BroadcastStatusChanged(PositionStatus.Initializing);
+
 			if (status == GeolocationAccessStatus.Allowed)
 			{
 				BroadcastStatusChanged(PositionStatus.Ready);
@@ -163,7 +164,19 @@ public sealed partial class Geolocator
 			}
 		}
 
+		if (!IsLocationProvidedEnabled())
+		{
+			status = GeolocationAccessStatus.Denied;
+		}
+
 		return status;
+	}
+
+	public static bool IsLocationProvidedEnabled()
+	{
+		var locationManager = (LocationManager?)Android.App.Application.Context.GetSystemService(Android.Content.Context.LocationService);
+
+		return locationManager?.GetProviders(new Criteria { Accuracy = Accuracy.Coarse }, true)?.Count > 0;
 	}
 
 	/// <summary>

--- a/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
+++ b/src/Uno.UWP/Devices/Geolocation/Geolocator.Android.cs
@@ -183,7 +183,7 @@ public sealed partial class Geolocator
 		{
 			TryInitialize();
 
-			if (_locationProvider is null || _locationManager is null)
+			if (string.IsNullOrWhiteSpace(_locationProvider) || _locationManager is null)
 			{
 				return Task.FromResult<Geoposition?>(null);
 			}
@@ -262,7 +262,7 @@ public sealed partial class Geolocator
 		if (_locationManager == null)
 		{
 			_locationManager = InitializeLocationProvider();
-			if (_locationManager is null || _locationProvider is null)
+			if (_locationManager is null || string.IsNullOrWhiteSpace(_locationProvider))
 			{
 				return;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14725 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Geolocator throws when subscribing to `PostitionChanged` events and GPS is not available.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
- Geolocator does NOT crash when subscribing to `PostitionChanged` event and GPS/Location is not enabled.
- `RequestAccessCore()` method returns `Denied` when no GPS/Location provider is available regardless of the permission. Mathing WinUI specs.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
