### PR TITLE
fix: RatingControl events re-attachment

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RatingControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RatingControl.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
+using Windows.UI.Input.Preview.Injection;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
+
+[TestClass]
+public class Given_RatingControl
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_Loaded_Then_Unloaded_Tap()
+	{
+		// Create RatingControl
+		var ratingControl = new RatingControl();
+
+		TestServices.WindowHelper.WindowContent = ratingControl;
+		bool unloaded = false;
+		await TestServices.WindowHelper.WaitForLoaded(ratingControl);
+		ratingControl.Unloaded += (s, e) => unloaded = true;
+
+		// Unload RatingControl
+		TestServices.WindowHelper.WindowContent = null;
+		await TestServices.WindowHelper.WaitFor(() => unloaded);
+
+		// Re-add RatingControl
+		TestServices.WindowHelper.WindowContent = ratingControl;
+		await TestServices.WindowHelper.WaitForLoaded(ratingControl);
+
+		// Tap RatingControl
+		ratingControl.Value = 1;
+		var tapTarget = ratingControl.TransformToVisual(null).TransformPoint(new Point(ratingControl.ActualWidth * 0.9, ratingControl.ActualHeight / 2));
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var finger = injector.GetFinger();
+
+		finger.Press(tapTarget);
+		finger.Release();
+
+		Assert.AreEqual(5, ratingControl.Value);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RatingControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RatingControl.cs
@@ -18,6 +18,9 @@ public class Given_RatingControl
 {
 	[TestMethod]
 	[RunsOnUIThread]
+#if !__SKIA__
+	[Ignore("InputInjector is only supported on Skia #14948")]
+#endif
 	public async Task When_Loaded_Then_Unloaded_Tap()
 	{
 		// Create RatingControl

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RatingControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RatingControl.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.UI.Xaml.Controls;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
+using Microsoft/* UWP don't rename */.UI.Xaml.Controls;
+using RatingControl = Microsoft/* UWP don't rename */.UI.Xaml.Controls.RatingControl;
+
+#if !HAS_UNO_WINUI
+using Windows.UI.Xaml.Controls;
+#endif
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
 

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Automation.Peers/AutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Automation.Peers/AutomationPeer.cs
@@ -14,14 +14,14 @@ namespace Microsoft.UI.Xaml.Automation.Peers
 		// Forced skipping of method Microsoft.UI.Xaml.Automation.Peers.AutomationPeer.EventsSource.get
 		// Forced skipping of method Microsoft.UI.Xaml.Automation.Peers.AutomationPeer.EventsSource.set
 		// Skipping already declared method Microsoft.UI.Xaml.Automation.Peers.AutomationPeer.GetPattern(Microsoft.UI.Xaml.Automation.Peers.PatternInterface)
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void RaiseAutomationEvent(global::Microsoft.UI.Xaml.Automation.Peers.AutomationEvents eventId)
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Automation.Peers.AutomationPeer", "void AutomationPeer.RaiseAutomationEvent(AutomationEvents eventId)");
 		}
 #endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void RaisePropertyChangedEvent(global::Microsoft.UI.Xaml.Automation.AutomationProperty automationProperty, object oldValue, object newValue)
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/RatingControl/RatingControl.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/RatingControl/RatingControl.cs
@@ -57,7 +57,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 
 			DefaultStyleKey = typeof(RatingControl);
 
+#if HAS_UNO
+			// Ensure events are detached on Unload and reattached on Load
+			Loaded += RatingControl_Loaded;
 			Unloaded += RatingControl_Unloaded;
+#endif
 		}
 
 		// Uno specific: Unsubscribing events here instead of the destructor to ensure
@@ -1202,5 +1206,36 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 			_uiSettings = _uiSettings ?? new UISettings();
 			return _uiSettings;
 		}
+
+#if HAS_UNO
+		private void RatingControl_Loaded(object sender, RoutedEventArgs e)
+		{
+			RecycleEvents(true /* useSafeGet */);
+			AttachEvents();
+		}
+
+		private void AttachEvents()
+		{
+			if (m_backgroundStackPanel != null)
+			{
+				m_backgroundStackPanel.PointerCanceled += OnPointerCancelledBackgroundStackPanel;
+				m_backgroundStackPanel.PointerCaptureLost += OnPointerCaptureLostBackgroundStackPanel;
+				m_backgroundStackPanel.PointerMoved += OnPointerMovedOverBackgroundStackPanel;
+				m_backgroundStackPanel.PointerEntered += OnPointerEnteredBackgroundStackPanel;
+				m_backgroundStackPanel.PointerExited += OnPointerExitedBackgroundStackPanel;
+				m_backgroundStackPanel.PointerPressed += OnPointerPressedBackgroundStackPanel;
+				m_backgroundStackPanel.PointerReleased += OnPointerReleasedBackgroundStackPanel;
+			}
+
+			if (m_captionTextBlock != null)
+			{
+				m_captionTextBlock.SizeChanged += OnCaptionSizeChanged;
+			}
+
+			m_fontFamilyChangedToken = RegisterPropertyChangedCallback(Control.FontFamilyProperty, OnFontFamilyChanged);
+
+			IsEnabledChanged += OnIsEnabledChanged;
+		}
+#endif
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Automation.Provider;
+using Uno.Foundation.Logging;
 using Windows.Foundation;
 
 namespace Microsoft.UI.Xaml.Automation.Peers
@@ -251,6 +252,18 @@ namespace Microsoft.UI.Xaml.Automation.Peers
 		protected internal global::Microsoft.UI.Xaml.Automation.Provider.IRawElementProviderSimple ProviderFromPeer(global::Microsoft.UI.Xaml.Automation.Peers.AutomationPeer peer)
 		{
 			throw new global::System.NotImplementedException("The member IRawElementProviderSimple AutomationPeer.ProviderFromPeer(AutomationPeer peer) is not implemented in Uno.");
+		}
+
+		[global::Uno.NotImplemented]
+		public void RaiseAutomationEvent(global::Microsoft.UI.Xaml.Automation.Peers.AutomationEvents eventId)
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Automation.Peers.AutomationPeer", "void AutomationPeer.RaiseAutomationEvent(AutomationEvents eventId)", LogLevel.Warning);
+		}
+
+		[global::Uno.NotImplemented]
+		public void RaisePropertyChangedEvent(global::Microsoft.UI.Xaml.Automation.AutomationProperty automationProperty, object oldValue, object newValue)
+		{
+			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Automation.Peers.AutomationPeer", "void AutomationPeer.RaisePropertyChangedEvent(AutomationProperty automationProperty, object oldValue, object newValue)", LogLevel.Warning);
 		}
 		#endregion
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.extensions/issues/2113

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`RatingControl` detaches events on unload, but they are not re-attached afterwards.

## What is the new behavior?

Events are re-attached.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.