### PR TITLE
Improve samples app info dialog

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Commands.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Commands.cs
@@ -49,7 +49,6 @@ namespace SampleControl.Presentation
 			LoadPreviousTestCommand = new DelegateCommand(() => _ = LoadPreviousTest(CancellationToken.None)) { CanExecuteEnabled = false };
 			ReloadCurrentTestCommand = new DelegateCommand(() => _ = ReloadCurrentTest(CancellationToken.None)) { CanExecuteEnabled = false };
 			LoadNextTestCommand = new DelegateCommand(() => _ = LoadNextTest(CancellationToken.None)) { CanExecuteEnabled = false };
-			ShowTestInformationCommand = new DelegateCommand(() => _ = ShowTestInformation(CancellationToken.None)) { CanExecuteEnabled = false };
 			OpenRuntimeTestsCommand = new DelegateCommand(() => _ = OpenRuntimeTests(CancellationToken.None));
 		}
 
@@ -61,7 +60,6 @@ namespace SampleControl.Presentation
 		public ICommand LoadPreviousTestCommand { get; private set; }
 		public ICommand ReloadCurrentTestCommand { get; private set; }
 		public ICommand LoadNextTestCommand { get; private set; }
-		public ICommand ShowTestInformationCommand { get; private set; }
 		public ICommand OpenRuntimeTestsCommand { get; private set; }
 	}
 }

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
@@ -242,7 +242,6 @@ namespace SampleControl.Presentation
 				_currentSelectedSample = value;
 				RaisePropertyChanged();
 				(ReloadCurrentTestCommand as DelegateCommand).CanExecuteEnabled = true;
-				(ShowTestInformationCommand as DelegateCommand).CanExecuteEnabled = true;
 
 				var currentTextIndex = SelectedCategory?.SamplesContent.IndexOf(value);
 				// Set Previous

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -829,21 +829,6 @@ namespace SampleControl.Presentation
 			}
 		}
 
-		private async Task ShowTestInformation(CancellationToken ct)
-		{
-			var sample = CurrentSelectedSample;
-			if (sample != null)
-			{
-				var text = $@"
-query string: ?sample={sample.Categories.FirstOrDefault() ?? ""}/{sample.ControlName}
-view: {sample.ControlType.FullName}
-categories: {sample.Categories?.JoinBy(", ")}
-description: {sample.Description}";
-
-				await new MessageDialog(text.Trim(), sample.ControlName).ShowAsync();
-			}
-		}
-
 		private async Task UpdateFavoriteForSample(CancellationToken ct, SampleChooserContent sample, bool isFavorite)
 		{
 			// Have to update favorite on UI thread for the INotifyPropertyChanged in SampleChooserControl

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserContent.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserContent.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Uno;
+using Uno.Extensions;
 using Uno.UI.Samples.Controls;
 
 namespace SampleControl.Entities
@@ -15,7 +17,9 @@ namespace SampleControl.Entities
 		public Type ViewModelType { get; set; }
 		public Type ControlType { get; set; }
 		public string[] Categories { get; set; }
+		public string CategoriesString => Categories?.JoinBy(", ");
 		public string Description { get; set; }
+		public string QueryString => $"?sample={Categories.FirstOrDefault() ?? ""}/{ControlName}";
 		public bool IgnoreInSnapshotTests { get; internal set; }
 		public bool IsManualTest { get; internal set; }
 		public bool UsesFrame { get; internal set; }

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -483,16 +483,24 @@
 
 					<!-- Info Button -->
 					<Button Style="{StaticResource IconButtonStyle}"
+							x:Name="InfoButton"
 							Grid.Column="2"
-							Command="{Binding ShowTestInformationCommand}"
-							Content="i"
 							FontWeight="SemiBold"
 							FontSize="24"
 							VerticalAlignment="Center"
 							VerticalContentAlignment="Center"
 							HorizontalContentAlignment="Center"
 							Foreground="{StaticResource Color06Brush}"
-							Visibility="{Binding IsDebug}" />
+							Visibility="{Binding IsDebug}">
+						<Button.Content>
+							<SymbolIcon Symbol="Help" />
+						</Button.Content>
+						<Button.Flyout>
+							<Flyout>
+								<u:SampleInfoControl DataContext="{Binding CurrentSelectedSample}" />
+							</Flyout>
+						</Button.Flyout>
+					</Button>
 
 					<!-- Previous Button -->
 					<Button Style="{StaticResource IconButtonStyle}"

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleInfoControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleInfoControl.xaml
@@ -13,6 +13,7 @@
 		<StackPanel.Resources>
 			<Style TargetType="TextBlock">
 				<Setter Property="TextWrapping" Value="Wrap" />
+				<Setter Property="Margin" Value="0,0,0,8" />
 			</Style>
 		</StackPanel.Resources>
 		<TextBlock>
@@ -27,7 +28,7 @@
 			<Run FontWeight="Bold" Text="Description: " />
 			<LineBreak /><Run Text="{Binding Description}" />
 		</TextBlock>
-		<TextBlock FontWeight="Bold" Text="Control type:" />
+		<TextBlock FontWeight="Bold" Text="Control type:" Margin="0" />
 		<Grid ColumnSpacing="8">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="Auto" />
@@ -39,6 +40,7 @@
 			<TextBlock Grid.Column="1" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding ControlType.FullName}" />
 		</Grid>
 
+		<TextBlock FontWeight="Bold" Text="Query string:" Margin="0" />
 		<Grid ColumnSpacing="8">
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="Auto" />

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleInfoControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleInfoControl.xaml
@@ -1,0 +1,53 @@
+﻿<UserControl
+    x:Class="Uno.UI.Samples.Controls.SampleInfoControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Samples.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel Orientation="Vertical" MaxWidth="320">
+		<StackPanel.Resources>
+			<Style TargetType="TextBlock">
+				<Setter Property="TextWrapping" Value="Wrap" />
+			</Style>
+		</StackPanel.Resources>
+		<TextBlock>
+			<Run FontWeight="Bold" Text="Name: " />
+			<Run Text="{Binding ControlName}" />
+		</TextBlock>
+		<TextBlock>
+			<Run FontWeight="Bold" Text="Categories: " />
+			<Run Text="{Binding CategoriesString}" />
+		</TextBlock>
+		<TextBlock>
+			<Run FontWeight="Bold" Text="Description: " />
+			<LineBreak /><Run Text="{Binding Description}" />
+		</TextBlock>
+		<TextBlock FontWeight="Bold" Text="Control type:" />
+		<Grid ColumnSpacing="8">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+			<Button Click="CopyContentClick" CommandParameter="{Binding ControlType.FullName}">
+				<SymbolIcon Symbol="Copy" />
+			</Button>
+			<TextBlock Grid.Column="1" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding ControlType.FullName}" />
+		</Grid>
+
+		<Grid ColumnSpacing="8">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+			<Button Click="CopyContentClick" CommandParameter="{Binding QueryString}">
+				<SymbolIcon Symbol="Copy" />
+			</Button>
+			<TextBlock Grid.Column="1" TextWrapping="Wrap" VerticalAlignment="Center" Text="{Binding QueryString}" />
+		</Grid>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleInfoControl.xaml.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleInfoControl.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using SampleControl.Entities;
+using Uno.Extensions;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+namespace Uno.UI.Samples.Controls;
+
+public sealed partial class SampleInfoControl : UserControl
+{
+	public SampleInfoControl()
+	{
+		this.InitializeComponent();
+	}
+
+	public void CopyContentClick(object sender, RoutedEventArgs e)
+	{
+		var button = (Button)sender;
+		var content = (string)button.CommandParameter;
+		var dataPackage = new DataPackage();
+		dataPackage.SetText(content);
+		Clipboard.SetContent(dataPackage);
+	}
+}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/SamplesApp.UnitTests.Shared.projitems
@@ -30,6 +30,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Controls\SampleControl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Controls\SampleControlInfoAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Controls\SampleInfoControl.xaml.cs">
+      <DependentUpon>SampleInfoControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Controls\StarStackPanel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Converters\FromBoolToBrushConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Converters\FromBoolToObjectConverter.cs" />
@@ -61,6 +64,10 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Controls\SampleChooserControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Controls\UITests\Views\Controls\SampleInfoControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Previously the dialog was a non-interactive `MessageDialog`

## What is the new behavior?

![image](https://github.com/unoplatform/uno/assets/1075116/72c920f9-433e-43af-93ab-bc709c214216)



- Flyout
- Interactive copy buttons for type name and query string

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.