### PR TITLE
Miscellaneous scrolling fixes

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -2046,6 +2046,37 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		public async Task When_Arrow_keys_ListView_Only_Scrolled_As_Needed()
+		{
+			var SUT = new ListView
+			{
+				Height = 120, // fits 2 items and a bit
+				ItemsSource = "12345"
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var sv = (ScrollViewer)SUT.GetTemplateChild("ScrollViewer");
+			var lvi = (ListViewItem)SUT.ContainerFromIndex(0);
+
+			lvi.Focus(FocusState.Programmatic);
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, sv.VerticalOffset);
+
+			KeyboardHelper.Down();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(0, sv.VerticalOffset);
+
+			KeyboardHelper.Down();
+			await WindowHelper.WaitForIdle();
+
+			sv.VerticalOffset.Should().BeApproximately(lvi.ActualHeight * 3 - 120, 2);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
 #if __IOS__ || __ANDROID__
 		[Ignore("Disabled because of animated scrolling, even when explicitly requested")]
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -172,6 +172,8 @@ namespace Microsoft.UI.Xaml.Controls
 					throw new ArgumentOutOfRangeException();
 			}
 
+			// StartBringIntoView shouldn't be needed, since the internal ScrollViewer has BringIntoViewOnFocusChange
+			// but since that property isn't currently supported, we have to manually BringIntoView.
 			newContainer?.StartBringIntoView(new BringIntoViewOptions()
 			{
 				AnimationDesired = false

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -82,6 +82,10 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 		{
 			base.OnApplyTemplate();
 			m_tpScrollViewer = GetTemplateChild<ScrollViewer>("ScrollViewer");
+			if (m_tpScrollViewer is { })
+			{
+				m_tpScrollViewer.TemplatedParentHandlesScrolling = true;
+			}
 		}
 
 		public static DependencyProperty SelectedItemProperty { get; } =

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1322,6 +1322,16 @@ namespace Microsoft.UI.Xaml.Controls
 					}
 				}
 			}
+
+#if __WASM__
+			// On WASM, a large wheel scroll can be a large number of OnScroll events in sequence.
+			// In that case, the queue will be drowning with scroll events before any chance of layout
+			// updates. The ScrollContentPresenter will scroll smoothly since the native scrolling/rendering
+			// is on a separate thread, but the ScrollBars will be frozen until the end of the (long) scrolling
+			// duration.
+			_horizontalScrollbar?.Arrange(_horizontalScrollbar.LayoutSlot);
+			_verticalScrollbar?.Arrange(_verticalScrollbar.LayoutSlot);
+#endif
 		}
 
 		// Presenter to Control, i.e. OnPresenterZoomed

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1599,7 +1599,10 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-#if !__ANDROID__ && !__IOS__ // ScrollContentPresenter.[Horizontal|Vertical]Offset not implemented on Android and iOS
+// On WASM, we could choose to scroll in the managed layer and suppress the native scrolling
+// but it can lead to some chaotic scenarios where it's really difficult to reconcile the
+// numbers between ScrollViewer and ScrollContentPresenter, so we choose to keep the scrolling native
+#if UNO_HAS_MANAGED_SCROLL_PRESENTER
 		protected override void OnKeyDown(KeyRoutedEventArgs args)
 		{
 			var key = args.Key;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1617,7 +1617,10 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			var key = args.Key;
 
-			if (Presenter is null)
+			// WinUI stops keyboard scrolling if TemplatedParentHandlesScrolling
+			// but interestingly that doesn't seem to affect pointer wheel scrolling
+			// despite the generic name implying that it would stop all scrolling
+			if (Presenter is null || TemplatedParentHandlesScrolling)
 			{
 				return;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1609,9 +1609,9 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-// On WASM, we could choose to scroll in the managed layer and suppress the native scrolling
-// but it can lead to some chaotic scenarios where it's really difficult to reconcile the
-// numbers between ScrollViewer and ScrollContentPresenter, so we choose to keep the scrolling native
+		// On WASM, we could choose to scroll in the managed layer and suppress the native scrolling
+		// but it can lead to some chaotic scenarios where it's really difficult to reconcile the
+		// numbers between ScrollViewer and ScrollContentPresenter, so we choose to keep the scrolling native
 #if UNO_HAS_MANAGED_SCROLL_PRESENTER
 		protected override void OnKeyDown(KeyRoutedEventArgs args)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1609,12 +1609,15 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		// On WASM, we could choose to scroll in the managed layer and suppress the native scrolling
-		// but it can lead to some chaotic scenarios where it's really difficult to reconcile the
-		// numbers between ScrollViewer and ScrollContentPresenter, so we choose to keep the scrolling native
-#if UNO_HAS_MANAGED_SCROLL_PRESENTER
+#if !__ANDROID__ && !__IOS__ // ScrollContentPresenter.[Horizontal|Vertical]Offset not implemented on Android and iOS
 		protected override void OnKeyDown(KeyRoutedEventArgs args)
 		{
+			base.OnKeyDown(args);
+
+			// On WASM, we could choose to scroll in the managed layer and suppress the native scrolling
+			// but it can lead to some chaotic scenarios where it's really difficult to reconcile the
+			// numbers between ScrollViewer and ScrollContentPresenter, so we choose to keep the scrolling native
+#if !__WASM__
 			var key = args.Key;
 
 			// WinUI stops keyboard scrolling if TemplatedParentHandlesScrolling
@@ -1691,6 +1694,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 				return result;
 			}
+#endif
 		}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.wasm.cs
@@ -94,9 +94,13 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			base.OnUnloaded();
 			RemoveHandler(KeyDownEvent, new KeyEventHandler(OnKeyDown));
-			RemoveHandler(PointerWheelChangedEvent, new KeyEventHandler(OnKeyDown));
+			RemoveHandler(PointerWheelChangedEvent, new PointerEventHandler(OnPointerWheelChanged));
 		}
 
-		private void OnKeyDown(object sender, KeyRoutedEventArgs args) => CancelNextNativeScroll = args.Handled;
+		private void OnKeyDown(object sender, KeyRoutedEventArgs args)
+		{
+			// event got handled before it reached ScrollViewer, cancel scrolling
+			CancelNextNativeScroll = args.Handled;
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.wasm.cs
@@ -73,6 +73,10 @@ namespace Microsoft.UI.Xaml.Input
 			}
 		}
 
+		// The way focus management works natively (HTML live standard) is fundamentally different from
+		// WinUI focus management. In WinUI, elements gets focus when an explicit call is made (e.g.
+		// when a button is pressed, it focuses itself, etc.). However, in a browser, clicking on an
+		// html element will simply focus that element (assuming it's focusable).
 		internal static bool FocusNative(UIElement element)
 		{
 			if (_log.Value.IsEnabled(LogLevel.Debug))


### PR DESCRIPTION
GitHub Issue (If applicable): closes #14832, closes #14965

Fixes multiple problems:
1. ScrollBar not moving as the ScrollViewer gets scrolled with keyboard on WASM (#14832)
2. ListView scrolling instead of changing selection when arrow keys are pressed (regression from #13850).
3. Keyboard scrolling on WASM scrolling incorrectly when arrow keys are held longer than needed due to discrepancy between the native ScrollContentPresenter scrolling and the managed keyboard scrolling. I've decided to turn managed keyboard scrolling off for WASM as matching the numbers precisely isn't worth the hassle.
4. On WASM, the scrollbars would freeze in place if a long scroll occurs (either violent pointer wheel scrolling or arrow key held) until the end of the scrolling duration. This is due to event processing and layoutting happening on one thread, while rendering is done on another.