### PR TITLE
feat: Implement `GetConnectionProfiles`

### DIFF
--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/NetworkInformation.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Networking.Connectivity/NetworkInformation.cs
@@ -15,7 +15,7 @@ namespace Windows.Networking.Connectivity
 			throw new global::System.NotImplementedException("The member IAsyncOperation<IReadOnlyList<ConnectionProfile>> NetworkInformation.FindConnectionProfilesAsync(ConnectionProfileFilter pProfileFilter) is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=IAsyncOperation%3CIReadOnlyList%3CConnectionProfile%3E%3E%20NetworkInformation.FindConnectionProfilesAsync%28ConnectionProfileFilter%20pProfileFilter%29");
 		}
 #endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false || false || IS_UNIT_TESTS || false || false || false || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::System.Collections.Generic.IReadOnlyList<global::Windows.Networking.Connectivity.ConnectionProfile> GetConnectionProfiles()
 		{

--- a/src/Uno.UWP/Networking/Connectivity/NetworkInformation.cs
+++ b/src/Uno.UWP/Networking/Connectivity/NetworkInformation.cs
@@ -1,6 +1,7 @@
 #if !IS_UNIT_TESTS
 #nullable enable
 
+using System.Collections.Generic;
 using Uno.Helpers;
 
 namespace Windows.Networking.Connectivity;
@@ -25,6 +26,12 @@ public static partial class NetworkInformation
 	/// <returns>The profile for the connection currently used to connect the machine to the Internet,
 	/// or null if there is no connection profile with a suitable connection.</returns>
 	public static ConnectionProfile GetInternetConnectionProfile() => ConnectionProfile.GetInternetConnectionProfile();
+
+	/// <summary>
+	/// Gets a list of profiles for connections, active or otherwise, on the local machine.
+	/// </summary>
+	/// <returns>An array of ConnectionProfile objects.</returns>
+	public static IReadOnlyList<ConnectionProfile> GetConnectionProfiles() => [ConnectionProfile.GetInternetConnectionProfile()];
 
 	/// <summary>
 	/// Occurs when the network status changes for a connection.

--- a/src/Uno.UWP/Networking/Connectivity/NetworkInformation.cs
+++ b/src/Uno.UWP/Networking/Connectivity/NetworkInformation.cs
@@ -30,7 +30,7 @@ public static partial class NetworkInformation
 	/// <summary>
 	/// Gets a list of profiles for connections, active or otherwise, on the local machine.
 	/// </summary>
-	/// <returns>An array of ConnectionProfile objects.</returns>
+	/// <returns>An array of <see cref="ConnectionProfile" /> objects.</returns>
 	public static IReadOnlyList<ConnectionProfile> GetConnectionProfiles() => [ConnectionProfile.GetInternetConnectionProfile()];
 
 	/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the new behavior?

Adds support for GetConnectionProfiles in NetworkInformation class.
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

Internal Issue (If applicable):
Internal Teams discussion with @MartinZikmund 
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
