### PR TITLE
fix: Fix ItemsRepeater might not listening on collection changed when re-loaded

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
@@ -633,12 +633,12 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 				});
 			}
 
-			if (_dataSourceSubscriptionsRevoker.Disposable is null && ItemsSource is ItemsSourceView itemsSource)
+			if (_dataSourceSubscriptionsRevoker.Disposable is null && m_itemsSourceView is not null)
 			{
-				itemsSource.CollectionChanged += OnItemsSourceViewChanged;
+				m_itemsSourceView.CollectionChanged += OnItemsSourceViewChanged;
 				_dataSourceSubscriptionsRevoker.Disposable = Disposable.Create(() =>
 				{
-					itemsSource.CollectionChanged -= OnItemsSourceViewChanged;
+					m_itemsSourceView.CollectionChanged -= OnItemsSourceViewChanged;
 				});
 			}
 #endif


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/2123

## Bugfix
Fix `ItemsRepeater` might not listening on collection changed when re-loaded

## What is the current behavior?
We re-subscribe only of the `ItemsSource` is a `ItemsSourceView`.

## What is the new behavior?
We use the private cached field of the collection wrapper (which is the expected implementation of the `ItemsSourceView`)

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
