### PR TITLE
feat: Port `ComboBoxAutomationPeer`

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Automation.Peers/ItemsControlAutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Automation.Peers/ItemsControlAutomationPeer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.UI.Xaml.Automation.Peers
 #endif
 	public partial class ItemsControlAutomationPeer : global::Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer, global::Microsoft.UI.Xaml.Automation.Provider.IItemContainerProvider
 	{
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public ItemsControlAutomationPeer(global::Microsoft.UI.Xaml.Controls.ItemsControl owner) : base(owner)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Automation.Peers/SelectorAutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Automation.Peers/SelectorAutomationPeer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.UI.Xaml.Automation.Peers
 			}
 		}
 #endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public SelectorAutomationPeer(global::Microsoft.UI.Xaml.Controls.Primitives.Selector owner) : base(owner)
 		{

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX reference ComboBoxAutomationPeer_Partial.cpp, tag winui3/release/1.4.2
 
+using System;
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Controls;
 
@@ -63,7 +64,7 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 	public void SetValue(string value)
 	{
 		// UIA_E_INVALIDOPERATION
-		throw new System.InvalidOperationException();
+		throw new InvalidOperationException();
 	}
 
 	public void Close()
@@ -92,7 +93,6 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 
 		return returnValue;
 	}
-
 
 	protected override AutomationControlType GetAutomationControlTypeCore()
 		=> AutomationControlType.ComboBox;

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -18,84 +18,33 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 
 	}
 
-	public ExpandCollapseState ExpandCollapseState
-		=> (Owner as ComboBox).IsDropDownOpen ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
-
-	public bool IsReadOnly => (Owner as ComboBox).IsEnabled || (Owner as ComboBox).IsEditable;
-
-	public string Value => (Owner as ComboBox).SelectionBoxItem?.ToString();
-
-	public WindowInteractionState InteractionState => WindowInteractionState.Running;
-
-	public bool IsModal => true;
-
-	public bool IsTopmost => true;
-
-	public bool Maximizable => false;
-
-	public bool Minimizable => false;
-
-	public WindowVisualState VisualState => WindowVisualState.Normal;
-
-	public void Collapse()
+	protected override object GetPatternCore(PatternInterface patternInterface)
 	{
-		if (!IsEnabled())
-		{
-			// UIA_E_ELEMENTNOTENABLED
-			throw new ElementNotEnabledException();
-		}
-
 		var pOwner = Owner as ComboBox;
-		pOwner.IsDropDownOpen = false;
-	}
 
-	public void Expand()
-	{
-		if (!IsEnabled())
+		switch (patternInterface)
 		{
-			// UIA_E_ELEMENTNOTENABLED;
-			throw new ElementNotEnabledException();
+			case PatternInterface.Value:
+				if (pOwner.IsEditable)
+				{
+					return this;
+				}
+				break;
+
+			case PatternInterface.ExpandCollapse:
+				return this;
+
+			case PatternInterface.Window:
+				if (pOwner.IsDropDownOpen)
+				{
+					return this;
+				}
+				break;
+			default:
+				return base.GetPatternCore(patternInterface);
 		}
-
-		var pOwner = Owner as ComboBox;
-		pOwner.IsDropDownOpen = true;
+		return null;
 	}
-
-	public void SetValue(string value)
-	{
-		// UIA_E_INVALIDOPERATION
-		throw new InvalidOperationException();
-	}
-
-	public void Close()
-	{
-
-	}
-
-	public void SetVisualState(WindowVisualState state)
-	{
-
-	}
-	public bool WaitForInputIdle(int milliseconds) => false;
-
-	protected override string GetClassNameCore() => nameof(ComboBox);
-
-	protected override string GetNameCore()
-	{
-		var returnValue = base.GetNameCore();
-
-		// If the Name property wasn't explicitly set on this AP, then we will
-		// return the combo header.
-		if (string.IsNullOrEmpty(returnValue))
-		{
-			return (Owner as ComboBox).Header.ToString();
-		}
-
-		return returnValue;
-	}
-
-	protected override AutomationControlType GetAutomationControlTypeCore()
-		=> AutomationControlType.ComboBox;
 
 	protected override IList<AutomationPeer> GetChildrenCore()
 	{
@@ -134,6 +83,25 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 		return apChildren;
 	}
 
+	protected override string GetClassNameCore() => nameof(ComboBox);
+
+	protected override string GetNameCore()
+	{
+		var returnValue = base.GetNameCore();
+
+		// If the Name property wasn't explicitly set on this AP, then we will
+		// return the combo header.
+		if (string.IsNullOrEmpty(returnValue))
+		{
+			return (Owner as ComboBox).Header.ToString();
+		}
+
+		return returnValue;
+	}
+
+	protected override AutomationControlType GetAutomationControlTypeCore()
+		=> AutomationControlType.ComboBox;
+
 	protected override string GetHelpTextCore()
 	{
 		var returnValue = base.GetHelpTextCore();
@@ -152,35 +120,42 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 		return returnValue;
 	}
 
-	protected override object GetPatternCore(PatternInterface patternInterface)
+	public bool IsReadOnly => (Owner as ComboBox).IsEnabled || (Owner as ComboBox).IsEditable;
+
+	public string Value => (Owner as ComboBox).SelectionBoxItem?.ToString();
+
+	public void SetValue(string value)
 	{
-		var pOwner = Owner as ComboBox;
-
-		switch (patternInterface)
-		{
-			case PatternInterface.Value:
-				if (pOwner.IsEditable)
-				{
-					return this;
-				}
-				break;
-
-			case PatternInterface.ExpandCollapse:
-				return this;
-
-			case PatternInterface.Window:
-				if (pOwner.IsDropDownOpen)
-				{
-					return this;
-				}
-				break;
-			default:
-				return base.GetPatternCore(patternInterface);
-		}
-		return null;
+		// UIA_E_INVALIDOPERATION
+		throw new InvalidOperationException();
 	}
 
-	public new bool IsSelectionRequired => true;
+	public void Expand()
+	{
+		if (!IsEnabled())
+		{
+			// UIA_E_ELEMENTNOTENABLED;
+			throw new ElementNotEnabledException();
+		}
+
+		var pOwner = Owner as ComboBox;
+		pOwner.IsDropDownOpen = true;
+	}
+
+	public void Collapse()
+	{
+		if (!IsEnabled())
+		{
+			// UIA_E_ELEMENTNOTENABLED
+			throw new ElementNotEnabledException();
+		}
+
+		var pOwner = Owner as ComboBox;
+		pOwner.IsDropDownOpen = false;
+	}
+
+	public ExpandCollapseState ExpandCollapseState
+		=> (Owner as ComboBox).IsDropDownOpen ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
 
 	// Raise events for ExpandCollapseState changes to UIAutomation Clients.
 	public void RaiseExpandCollapseAutomationEvent(bool isOpen)
@@ -202,4 +177,30 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 
 		RaisePropertyChangedEvent(ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty, oldValue, newValue);
 	}
+
+	public new bool IsSelectionRequired => true;
+
+	public bool IsModal => true;
+
+	public bool IsTopmost => true;
+
+	public bool Maximizable => false;
+
+	public bool Minimizable => false;
+
+	public WindowInteractionState InteractionState => WindowInteractionState.Running;
+
+	public WindowVisualState VisualState => WindowVisualState.Normal;
+
+	public void SetVisualState(WindowVisualState state)
+	{
+
+	}
+
+	public void Close()
+	{
+
+	}
+
+	public bool WaitForInputIdle(int milliseconds) => false;
 }

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -19,7 +19,7 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 
 	protected override object GetPatternCore(PatternInterface patternInterface)
 	{
-		var pOwner = Owner as ComboBox;
+		var pOwner = (ComboBox)Owner;
 
 		switch (patternInterface)
 		{
@@ -93,7 +93,7 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 		// return the combo header.
 		if (string.IsNullOrEmpty(returnValue))
 		{
-			return (Owner as ComboBox).Header?.ToString();
+			return ((ComboBox)Owner).Header?.ToString();
 		}
 
 		return returnValue;
@@ -110,19 +110,19 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 		// then we'll return the placeholder text.
 		if (string.IsNullOrEmpty(returnValue))
 		{
-			var selectedIndex = (Owner as ComboBox).SelectedIndex;
+			var selectedIndex = ((ComboBox)Owner).SelectedIndex;
 			if (selectedIndex < 0)
 			{
-				return (Owner as ComboBox).PlaceholderText;
+				return ((ComboBox)Owner).PlaceholderText;
 			}
 		}
 
 		return returnValue;
 	}
 
-	public bool IsReadOnly => !(Owner as ComboBox).IsEnabled || !(Owner as ComboBox).IsEditable;
+	public bool IsReadOnly => !((ComboBox)Owner).IsEnabled || !((ComboBox)Owner).IsEditable;
 
-	public string Value => FrameworkElement.GetStringFromObject((Owner as ComboBox).SelectedItem); // TODO Uno: this is different from WinUI
+	public string Value => FrameworkElement.GetStringFromObject(((ComboBox)Owner).SelectedItem); // TODO Uno: this is different from WinUI
 
 	public void SetValue(string value)
 	{
@@ -155,7 +155,7 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 	}
 
 	public ExpandCollapseState ExpandCollapseState
-		=> (Owner as ComboBox).IsDropDownOpen ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
+		=> ((ComboBox)Owner).IsDropDownOpen ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
 
 	// Raise events for ExpandCollapseState changes to UIAutomation Clients.
 	public void RaiseExpandCollapseAutomationEvent(bool isOpen)

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -1,131 +1,205 @@
-﻿using Uno;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// MUX reference ComboBoxAutomationPeer_Partial.cpp, tag winui3/release/1.4.2
+
+using System.Collections.Generic;
 using Microsoft.UI.Xaml.Controls;
 
-namespace Microsoft.UI.Xaml.Automation.Peers
+namespace Microsoft.UI.Xaml.Automation.Peers;
+
+/// <summary>
+/// Exposes ComboBox types to Microsoft UI Automation.
+/// </summary>
+public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.IExpandCollapseProvider, Provider.IValueProvider, Provider.IWindowProvider
 {
-	public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.IExpandCollapseProvider, Provider.IValueProvider, Provider.IWindowProvider
+	public ComboBoxAutomationPeer(ComboBox owner) : base(owner)
 	{
-		[NotImplemented]
-		public ExpandCollapseState ExpandCollapseState
+
+	}
+
+	public ExpandCollapseState ExpandCollapseState
+		=> (Owner as ComboBox).IsDropDownOpen ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
+
+	public bool IsReadOnly => (Owner as ComboBox).IsEnabled || (Owner as ComboBox).IsEditable;
+
+	public string Value => (Owner as ComboBox).SelectionBoxItem?.ToString();
+
+	public WindowInteractionState InteractionState => WindowInteractionState.Running;
+
+	public bool IsModal => true;
+
+	public bool IsTopmost => true;
+
+	public bool Maximizable => false;
+
+	public bool Minimizable => false;
+
+	public WindowVisualState VisualState => WindowVisualState.Normal;
+
+	public void Collapse()
+	{
+		if (!IsEnabled())
 		{
-			get
+			// UIA_E_ELEMENTNOTENABLED
+			throw new ElementNotEnabledException();
+		}
+
+		var pOwner = Owner as ComboBox;
+		pOwner.IsDropDownOpen = false;
+	}
+
+	public void Expand()
+	{
+		if (!IsEnabled())
+		{
+			// UIA_E_ELEMENTNOTENABLED;
+			throw new ElementNotEnabledException();
+		}
+
+		var pOwner = Owner as ComboBox;
+		pOwner.IsDropDownOpen = true;
+	}
+
+	public void SetValue(string value)
+	{
+		// UIA_E_INVALIDOPERATION
+		throw new System.InvalidOperationException();
+	}
+
+	public void Close()
+	{
+
+	}
+
+	public void SetVisualState(WindowVisualState state)
+	{
+
+	}
+	public bool WaitForInputIdle(int milliseconds) => false;
+
+	protected override string GetClassNameCore() => nameof(ComboBox);
+
+	protected override string GetNameCore()
+	{
+		var returnValue = base.GetNameCore();
+
+		// If the Name property wasn't explicitly set on this AP, then we will
+		// return the combo header.
+		if (string.IsNullOrEmpty(returnValue))
+		{
+			return (Owner as ComboBox).Header.ToString();
+		}
+
+		return returnValue;
+	}
+
+
+	protected override AutomationControlType GetAutomationControlTypeCore()
+		=> AutomationControlType.ComboBox;
+
+	protected override IList<AutomationPeer> GetChildrenCore()
+	{
+		UIElement spOwner = Owner as UIElement;
+		ComboBox spComboBox = spOwner as ComboBox;
+
+		if (spComboBox == null || !spComboBox.IsDropDownOpen)
+		{
+			return base.GetChildrenCore();
+		}
+
+		IList<AutomationPeer> apChildren = new DirectUI.TrackerCollection<AutomationPeer>();
+
+		//UNO TODO: Implement GetLightDismissElement on ComboBox
+
+		//var spLightDismissElement;
+		//spComboBox.GetLightDismissElement(out spLightDismissElement);
+
+		//if (spLightDismissElement != null)
+		//{
+		//	var ap = spLightDismissElement.GetOrCreateAutomationPeer();
+		//	apChildren.Add(ap);
+		//}
+
+		//UNO TODO: Implement GetEditableTextPart and IsEditable on ComboBox
+
+		//bool isEditable = spComboBox.IsEditable;
+		//UIElement spEditableTextElement;
+
+		//if (isEditable && spComboBox.GetEditableTextPart(out spEditableTextElement))
+		//{
+		//	IAutomationPeer ap = spEditableTextElement.GetOrCreateAutomationPeer();
+		//	apChildren.Insert(0, ap);
+		//}
+
+		return apChildren;
+	}
+
+	protected override string GetHelpTextCore()
+	{
+		var returnValue = base.GetHelpTextCore();
+
+		// If the HelpText property wasn't explicitly set on this AP and no item is selected,
+		// then we'll return the placeholder text.
+		if (string.IsNullOrEmpty(returnValue))
+		{
+			var selectedIndex = (Owner as ComboBox).SelectedIndex;
+			if (selectedIndex < 0)
 			{
-				throw new global::System.NotImplementedException("The member ExpandCollapseState ComboBoxAutomationPeer.ExpandCollapseState is not implemented in Uno.");
+				return (Owner as ComboBox).PlaceholderText;
 			}
 		}
 
-		[NotImplemented]
-		public bool IsReadOnly
+		return returnValue;
+	}
+
+	protected override object GetPatternCore(PatternInterface patternInterface)
+	{
+		var pOwner = Owner as ComboBox;
+
+		switch (patternInterface)
 		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool ComboBoxAutomationPeer.IsReadOnly is not implemented in Uno.");
-			}
+			case PatternInterface.Value:
+				if (pOwner.IsEditable)
+				{
+					return this;
+				}
+				break;
+
+			case PatternInterface.ExpandCollapse:
+				return this;
+
+			case PatternInterface.Window:
+				if (pOwner.IsDropDownOpen)
+				{
+					return this;
+				}
+				break;
+			default:
+				return base.GetPatternCore(patternInterface);
+		}
+		return null;
+	}
+
+	public new bool IsSelectionRequired => true;
+
+	// Raise events for ExpandCollapseState changes to UIAutomation Clients.
+	public void RaiseExpandCollapseAutomationEvent(bool isOpen)
+	{
+		ExpandCollapseState oldValue;
+		ExpandCollapseState newValue;
+
+		// Converting isOpen to appropriate enumerations
+		if (isOpen)
+		{
+			oldValue = ExpandCollapseState.Collapsed;
+			newValue = ExpandCollapseState.Expanded;
+		}
+		else
+		{
+			oldValue = ExpandCollapseState.Expanded;
+			newValue = ExpandCollapseState.Collapsed;
 		}
 
-		[NotImplemented]
-		public string Value
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member string ComboBoxAutomationPeer.Value is not implemented in Uno.");
-			}
-		}
-
-		[NotImplemented]
-		public global::Microsoft.UI.Xaml.Automation.WindowInteractionState InteractionState
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member WindowInteractionState ComboBoxAutomationPeer.InteractionState is not implemented in Uno.");
-			}
-		}
-
-		[NotImplemented]
-		public bool IsModal
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool ComboBoxAutomationPeer.IsModal is not implemented in Uno.");
-			}
-		}
-
-		[NotImplemented]
-		public bool IsTopmost
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool ComboBoxAutomationPeer.IsTopmost is not implemented in Uno.");
-			}
-		}
-
-		[NotImplemented]
-		public bool Maximizable
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool ComboBoxAutomationPeer.Maximizable is not implemented in Uno.");
-			}
-		}
-
-		[NotImplemented]
-		public bool Minimizable
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool ComboBoxAutomationPeer.Minimizable is not implemented in Uno.");
-			}
-		}
-
-		[NotImplemented]
-		public global::Microsoft.UI.Xaml.Automation.WindowVisualState VisualState
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member WindowVisualState ComboBoxAutomationPeer.VisualState is not implemented in Uno.");
-			}
-		}
-
-		[NotImplemented]
-		public ComboBoxAutomationPeer(global::Microsoft.UI.Xaml.Controls.ComboBox owner) : base(owner)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Automation.Peers.ComboBoxAutomationPeer", "ComboBoxAutomationPeer.ComboBoxAutomationPeer(ComboBox owner)");
-		}
-
-		[NotImplemented]
-		public void Collapse()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Automation.Peers.ComboBoxAutomationPeer", "void ComboBoxAutomationPeer.Collapse()");
-		}
-
-		[NotImplemented]
-		public void Expand()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Automation.Peers.ComboBoxAutomationPeer", "void ComboBoxAutomationPeer.Expand()");
-		}
-
-		[NotImplemented]
-		public void SetValue(string value)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Automation.Peers.ComboBoxAutomationPeer", "void ComboBoxAutomationPeer.SetValue(string value)");
-		}
-
-		[NotImplemented]
-		public void Close()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Automation.Peers.ComboBoxAutomationPeer", "void ComboBoxAutomationPeer.Close()");
-		}
-
-		[NotImplemented]
-		public void SetVisualState(global::Microsoft.UI.Xaml.Automation.WindowVisualState state)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.Automation.Peers.ComboBoxAutomationPeer", "void ComboBoxAutomationPeer.SetVisualState(WindowVisualState state)");
-		}
-
-		[NotImplemented]
-		public bool WaitForInputIdle(int milliseconds)
-		{
-			throw new global::System.NotImplementedException("The member bool ComboBoxAutomationPeer.WaitForInputIdle(int milliseconds) is not implemented in Uno.");
-		}
+		RaisePropertyChangedEvent(ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty, oldValue, newValue);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -93,7 +93,7 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 		// return the combo header.
 		if (string.IsNullOrEmpty(returnValue))
 		{
-			return (Owner as ComboBox).Header.ToString();
+			return (Owner as ComboBox).Header?.ToString();
 		}
 
 		return returnValue;

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ComboBoxAutomationPeer.cs
@@ -15,7 +15,6 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 {
 	public ComboBoxAutomationPeer(ComboBox owner) : base(owner)
 	{
-
 	}
 
 	protected override object GetPatternCore(PatternInterface patternInterface)
@@ -30,7 +29,6 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 					return this;
 				}
 				break;
-
 			case PatternInterface.ExpandCollapse:
 				return this;
 
@@ -43,22 +41,24 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 			default:
 				return base.GetPatternCore(patternInterface);
 		}
+
 		return null;
 	}
 
 	protected override IList<AutomationPeer> GetChildrenCore()
 	{
-		UIElement spOwner = Owner as UIElement;
-		ComboBox spComboBox = spOwner as ComboBox;
-
-		if (spComboBox == null || !spComboBox.IsDropDownOpen)
-		{
-			return base.GetChildrenCore();
-		}
-
-		IList<AutomationPeer> apChildren = new DirectUI.TrackerCollection<AutomationPeer>();
+		return base.GetChildrenCore();
 
 		//UNO TODO: Implement GetLightDismissElement on ComboBox
+		//UIElement spOwner = Owner as UIElement;
+		//ComboBox spComboBox = spOwner as ComboBox;
+
+		//if (spComboBox == null || !spComboBox.IsDropDownOpen)
+		//{
+		//	return base.GetChildrenCore();
+		//}
+
+		//IList<AutomationPeer> apChildren = new DirectUI.TrackerCollection<AutomationPeer>();
 
 		//var spLightDismissElement;
 		//spComboBox.GetLightDismissElement(out spLightDismissElement);
@@ -80,7 +80,7 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 		//	apChildren.Insert(0, ap);
 		//}
 
-		return apChildren;
+		//return apChildren;
 	}
 
 	protected override string GetClassNameCore() => nameof(ComboBox);
@@ -120,9 +120,9 @@ public partial class ComboBoxAutomationPeer : SelectorAutomationPeer, Provider.I
 		return returnValue;
 	}
 
-	public bool IsReadOnly => (Owner as ComboBox).IsEnabled || (Owner as ComboBox).IsEditable;
+	public bool IsReadOnly => !(Owner as ComboBox).IsEnabled || !(Owner as ComboBox).IsEditable;
 
-	public string Value => (Owner as ComboBox).SelectionBoxItem?.ToString();
+	public string Value => FrameworkElement.GetStringFromObject((Owner as ComboBox).SelectedItem); // TODO Uno: this is different from WinUI
 
 	public void SetValue(string value)
 	{

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ItemsControlAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ItemsControlAutomationPeer.cs
@@ -10,4 +10,12 @@ public partial class ItemsControlAutomationPeer : FrameworkElementAutomationPeer
 	public ItemsControlAutomationPeer(ItemsControl owner) : base(owner)
 	{
 	}
+
+	public ItemsControlAutomationPeer(FrameworkElement e)
+	{
+	}
+
+	public ItemsControlAutomationPeer(object e)
+	{
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/ItemsControlAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/ItemsControlAutomationPeer.cs
@@ -1,17 +1,13 @@
 ﻿#pragma warning disable 108 // new keyword hiding
 using System;
+using Microsoft.UI.Xaml.Automation.Provider;
+using Microsoft.UI.Xaml.Controls;
 
-namespace Microsoft.UI.Xaml.Automation.Peers
+namespace Microsoft.UI.Xaml.Automation.Peers;
+
+public partial class ItemsControlAutomationPeer : FrameworkElementAutomationPeer, IItemContainerProvider
 {
-	public partial class ItemsControlAutomationPeer : global::Microsoft.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer, global::Microsoft.UI.Xaml.Automation.Provider.IItemContainerProvider
+	public ItemsControlAutomationPeer(ItemsControl owner) : base(owner)
 	{
-		public ItemsControlAutomationPeer(FrameworkElement e)
-		{
-			throw new NotImplementedException();
-		}
-		public ItemsControlAutomationPeer(object e)
-		{
-			throw new NotImplementedException();
-		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/SelectorAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/SelectorAutomationPeer.cs
@@ -10,4 +10,8 @@ public partial class SelectorAutomationPeer : ItemsControlAutomationPeer, ISelec
 	public SelectorAutomationPeer(Selector owner) : base(owner)
 	{
 	}
+
+	public SelectorAutomationPeer(object o) : base(null)
+	{
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/SelectorAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/SelectorAutomationPeer.cs
@@ -1,13 +1,13 @@
 ﻿#pragma warning disable 108 // new keyword hiding
 using System;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Automation.Provider;
 
-namespace Microsoft.UI.Xaml.Automation.Peers
+namespace Microsoft.UI.Xaml.Automation.Peers;
+
+public partial class SelectorAutomationPeer : ItemsControlAutomationPeer, ISelectionProvider
 {
-	public partial class SelectorAutomationPeer : global::Microsoft.UI.Xaml.Automation.Peers.ItemsControlAutomationPeer, global::Microsoft.UI.Xaml.Automation.Provider.ISelectionProvider
+	public SelectorAutomationPeer(Selector owner) : base(owner)
 	{
-		public SelectorAutomationPeer(object o) : base(null)
-		{
-			throw new NotImplementedException();
-		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): part of #14344 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the new behavior?
Ported the `ComboBoxAutomationPeer` from WinUI.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.