### PR TITLE
refactor: Make Samples app use Fluent styles by default

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -12,11 +12,9 @@ using Uno.UI.Samples.Controls;
 using Uno.UI.Samples.Entities;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Globalization;
-using Windows.UI.Core;
 using Windows.Storage;
 using Microsoft.UI.Xaml;
 using System.IO;
-using Windows.UI.Popups;
 using Uno.Extensions;
 using Uno.UI.Samples.Tests;
 
@@ -110,9 +108,7 @@ namespace SampleControl.Presentation
 			// Disable all pooling so that controls get collected quickly.
 			Microsoft.UI.Xaml.FrameworkTemplatePool.IsPoolingEnabled = false;
 #endif
-#if WINAPPSDK
 			UseFluentStyles = true;
-#endif
 			InitializeCommands();
 			ObserveChanges();
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleInfoControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleInfoControl.xaml
@@ -14,6 +14,7 @@
 			<Style TargetType="TextBlock">
 				<Setter Property="TextWrapping" Value="Wrap" />
 				<Setter Property="Margin" Value="0,0,0,8" />
+				<Setter Property="IsTextSelectionEnabled" Value="True" />
 			</Style>
 		</StackPanel.Resources>
 		<TextBlock>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/CornerRadiusControls.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/Clipping/CornerRadiusControls.xaml
@@ -23,7 +23,7 @@
 				<ToolTip x:Name="ctl3" Background="Green" Width="80" CornerRadius="{x:Bind ToRadius(cornerRadius.Value), Mode=OneWay}">
 					<TextBlock Foreground="Yellow" HorizontalAlignment="Center">ToolTip<LineBreak/>(Control)</TextBlock>
 				</ToolTip>
-				<Button x:Name="ctl4" Background="Green" Width="80" Height="100" CornerRadius="{x:Bind ToRadius(cornerRadius.Value), Mode=OneWay}">
+				<Button x:Name="ctl4" Background="Green" Width="80" Height="100" BorderThickness="0" CornerRadius="{x:Bind ToRadius(cornerRadius.Value), Mode=OneWay}">
 					<TextBlock Foreground="Yellow" HorizontalAlignment="Center">Button<LineBreak/>(Control)</TextBlock>
 				</Button>
 				<ScrollViewer x:Name="ctl5" Background="Green" Width="80" CornerRadius="{x:Bind ToRadius(cornerRadius.Value), Mode=OneWay}">

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/appbar/AppBarIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/appbar/AppBarIntegrationTests.cs
@@ -1638,8 +1638,8 @@ namespace Windows.UI.Tests.Enterprise
 
 			double expectedAppBarWidth = 400;
 
-			double expectedAppBarCompactClosedHeight = 40;
-			double expectedAppBarCompactOpenHeight = 40;
+			double expectedAppBarCompactClosedHeight = 48;
+			double expectedAppBarCompactOpenHeight = 48;
 
 			double expectedAppBarMinimalClosedHeight = 24;
 			double expectedAppBarMinimalOpenHeight = 24;

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
@@ -2551,8 +2551,8 @@ namespace Windows.UI.Tests.Enterprise
 				expectedCommandBarWidth = NativeWindowWrapper.Instance.GetWindowSize().Width;
 			});
 #endif
-			double expectedCommandBarCompactClosedHeight = 40;
-			double expectedCommandBarCompactOpenHeight = 40;
+			double expectedCommandBarCompactClosedHeight = 48;
+			double expectedCommandBarCompactOpenHeight = 48;
 
 			double expectedCommandBarMinimalClosedHeight = 24;
 			double expectedCommandBarMinimalOpenHeight = 24;

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Expander/ExpanderTests_APITests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Expander/ExpanderTests_APITests.cs
@@ -25,9 +25,6 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Tests.MUXControls.ApiTests
 		{
 			RunOnUIThread.Execute(() =>
 			{
-				// Uno specific: the control is fluent only
-				using var _ = StyleHelper.UseFluentStyles();
-
 				var root = (StackPanel)XamlReader.Load(
 					@"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' 
                              xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ProgressRing/ProgressRingTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ProgressRing/ProgressRingTests.cs
@@ -3,6 +3,7 @@ using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Microsoft.UI.Xaml.Controls;
+using Uno.Disposables;
 
 namespace Uno.UI.RuntimeTests.MUX.Microsoft_UI_Xaml_Controls.ProgressRingTests;
 
@@ -18,7 +19,7 @@ public class ProgressRingTests
 #endif
 	public async Task ProgressRingDefaultHeightShouldBe32(bool useFluent)
 	{
-		using (useFluent ? StyleHelper.UseFluentStyles() : null)
+		using (useFluent ? Disposable.Empty : StyleHelper.UseUwpStyles())
 		{
 			var grid = new Grid();
 			grid.Width = 100;

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/Given_SplitButton.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/Given_SplitButton.cs
@@ -1,10 +1,9 @@
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 using Common;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests;
-using Uno.UI.RuntimeTests.Helpers;
 using SplitButton = Microsoft/* UWP don't rename */.UI.Xaml.Controls.SplitButton;
 
 namespace Windows.UI.Xaml.Tests.MUXControls.ApiTests;
@@ -20,14 +19,11 @@ public class Given_SplitButton
 #endif
 	public void VerifyFontFamilyForChevron()
 	{
-		using (StyleHelper.UseFluentStyles())
-		{
-			var splitButton = new SplitButton();
-			TestServices.WindowHelper.WindowContent = splitButton;
+		var splitButton = new SplitButton();
+		TestServices.WindowHelper.WindowContent = splitButton;
 
-			var secondayButton = splitButton.GetTemplateChild("SecondaryButton");
-			var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
-			Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
-		}
+		var secondayButton = splitButton.GetTemplateChild("SecondaryButton");
+		var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
+		Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
 	}
 }

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TeachingTip/TeachingTipTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TeachingTip/TeachingTipTests.cs
@@ -179,186 +179,134 @@ public class TeachingTipTests
 	[TestMethod]
 	public void TeachingTipWithContentAndWithoutHeroContentDoesNotCrash()
 	{
-		IDisposable stylesDisposable = null;
+		var loadedEvent = new AutoResetEvent(false);
 		RunOnUIThread.Execute(() =>
 		{
-			stylesDisposable = StyleHelper.UseFluentStyles();
+			Grid contentGrid = new Grid();
+			SymbolIconSource iconSource = new SymbolIconSource();
+			iconSource.Symbol = Symbol.People;
+			TeachingTip teachingTip = new TeachingTip();
+			teachingTip.Content = contentGrid;
+			teachingTip.IconSource = (IconSource)iconSource;
+			teachingTip.Loaded += (object sender, RoutedEventArgs args) => { loadedEvent.Set(); };
+			TestServices.WindowHelper.WindowContent = teachingTip;
 		});
 
-		try
-		{
-			var loadedEvent = new AutoResetEvent(false);
-			RunOnUIThread.Execute(() =>
-			{
-				Grid contentGrid = new Grid();
-				SymbolIconSource iconSource = new SymbolIconSource();
-				iconSource.Symbol = Symbol.People;
-				TeachingTip teachingTip = new TeachingTip();
-				teachingTip.Content = contentGrid;
-				teachingTip.IconSource = (IconSource)iconSource;
-				teachingTip.Loaded += (object sender, RoutedEventArgs args) => { loadedEvent.Set(); };
-				TestServices.WindowHelper.WindowContent = teachingTip;
-			});
-
-			IdleSynchronizer.Wait();
-			loadedEvent.WaitOne();
-		}
-		finally
-		{
-			RunOnUIThread.Execute(() => stylesDisposable?.Dispose());
-		}
+		IdleSynchronizer.Wait();
+		loadedEvent.WaitOne();
 	}
 
 	[TestMethod]
 	public void TeachingTipWithContentAndWithoutIconSourceDoesNotCrash()
 	{
-		IDisposable stylesDisposable = null;
+		var loadedEvent = new AutoResetEvent(false);
 		RunOnUIThread.Execute(() =>
 		{
-			stylesDisposable = StyleHelper.UseFluentStyles();
+			Grid contentGrid = new Grid();
+			Grid heroGrid = new Grid();
+			TeachingTip teachingTip = new TeachingTip();
+			teachingTip.Content = contentGrid;
+			teachingTip.HeroContent = heroGrid;
+			teachingTip.Loaded += (object sender, RoutedEventArgs args) => { loadedEvent.Set(); };
+			TestServices.WindowHelper.WindowContent = teachingTip;
 		});
 
-		try
-		{
-			var loadedEvent = new AutoResetEvent(false);
-			RunOnUIThread.Execute(() =>
-			{
-				Grid contentGrid = new Grid();
-				Grid heroGrid = new Grid();
-				TeachingTip teachingTip = new TeachingTip();
-				teachingTip.Content = contentGrid;
-				teachingTip.HeroContent = heroGrid;
-				teachingTip.Loaded += (object sender, RoutedEventArgs args) => { loadedEvent.Set(); };
-				TestServices.WindowHelper.WindowContent = teachingTip;
-			});
-
-			IdleSynchronizer.Wait();
-			loadedEvent.WaitOne();
-		}
-		finally
-		{
-			RunOnUIThread.Execute(() => stylesDisposable?.Dispose());
-		}
+		IdleSynchronizer.Wait();
+		loadedEvent.WaitOne();
 	}
 
 	[TestMethod]
 	public void PropagatePropertiesDown()
 	{
-		IDisposable stylesDisposable = null;
+		TextBlock content = null;
+		TeachingTip tip = null;
 		RunOnUIThread.Execute(() =>
 		{
-			stylesDisposable = StyleHelper.UseFluentStyles();
+			content = new TextBlock()
+			{
+				Text = "Some text"
+			};
+
+			tip = new TeachingTip()
+			{
+				Content = content,
+				FontSize = 22,
+				Foreground = new SolidColorBrush()
+				{
+					Color = Colors.Red
+				}
+			};
+
+			TestServices.WindowHelper.WindowContent = tip;
+			tip.UpdateLayout();
+			tip.IsOpen = true;
+			tip.UpdateLayout();
 		});
 
-		try
+		IdleSynchronizer.Wait();
+
+		RunOnUIThread.Execute(() =>
 		{
-			TextBlock content = null;
-			TeachingTip tip = null;
-			RunOnUIThread.Execute(() =>
-			{
-				content = new TextBlock()
-				{
-					Text = "Some text"
-				};
-
-				tip = new TeachingTip()
-				{
-					Content = content,
-					FontSize = 22,
-					Foreground = new SolidColorBrush()
-					{
-						Color = Colors.Red
-					}
-				};
-
-				TestServices.WindowHelper.WindowContent = tip;
-				tip.UpdateLayout();
-				tip.IsOpen = true;
-				tip.UpdateLayout();
-			});
-
-			IdleSynchronizer.Wait();
-
-			RunOnUIThread.Execute(() =>
-			{
-				Verify.IsTrue(Math.Abs(22 - content.FontSize) < 1);
-				var foregroundBrush = content.Foreground as SolidColorBrush;
-				Verify.AreEqual(Colors.Red, foregroundBrush.Color);
-			});
-		}
-		finally
-		{
-			RunOnUIThread.Execute(() => stylesDisposable?.Dispose());
-		}
+			Verify.IsTrue(Math.Abs(22 - content.FontSize) < 1);
+			var foregroundBrush = content.Foreground as SolidColorBrush;
+			Verify.AreEqual(Colors.Red, foregroundBrush.Color);
+		});
 	}
 
 
 	[TestMethod]
 	public void TeachingTipHeroContentPlacementTest()
 	{
-		IDisposable stylesDisposable = null;
 		RunOnUIThread.Execute(() =>
 		{
-			stylesDisposable = StyleHelper.UseFluentStyles();
+			foreach (var iPlacementMode in Enum.GetValues(typeof(TeachingTipHeroContentPlacementMode)))
+			{
+				var placementMode = (TeachingTipHeroContentPlacementMode)iPlacementMode;
+
+				Log.Comment($"Verifying TeachingTipHeroContentPlacementMode [{placementMode}]");
+
+				TeachingTip teachingTip = new TeachingTip();
+				teachingTip.HeroContentPlacement = placementMode;
+
+				// Open the teaching tip to enter the correct visual state for the HeroContentPlacement.
+				teachingTip.IsOpen = true;
+
+				TestServices.WindowHelper.WindowContent = teachingTip;
+				teachingTip.UpdateLayout();
+
+				Verify.IsTrue(teachingTip.HeroContentPlacement == placementMode, $"HeroContentPlacement should have been [{placementMode}]");
+
+				var root = VisualTreeUtils.FindVisualChildByName(teachingTip, "Container") as FrameworkElement;
+
+				switch (placementMode)
+				{
+					case TeachingTipHeroContentPlacementMode.Auto:
+						Verify.IsTrue(IsVisualStateActive(root, "HeroContentPlacementStates", "HeroContentTop"),
+							"The [HeroContentTop] visual state should have been active");
+						break;
+					case TeachingTipHeroContentPlacementMode.Top:
+						Verify.IsTrue(IsVisualStateActive(root, "HeroContentPlacementStates", "HeroContentTop"),
+							"The [HeroContentTop] visual state should have been active");
+						break;
+					case TeachingTipHeroContentPlacementMode.Bottom:
+						Verify.IsTrue(IsVisualStateActive(root, "HeroContentPlacementStates", "HeroContentBottom"),
+							"The [HeroContentBottom] visual state should have been active");
+						break;
+				}
+			}
 		});
 
-		try
+		bool IsVisualStateActive(FrameworkElement root, string groupName, string stateName)
 		{
-			RunOnUIThread.Execute(() =>
+			foreach (var group in VisualStateManager.GetVisualStateGroups(root))
 			{
-				foreach (var iPlacementMode in Enum.GetValues(typeof(TeachingTipHeroContentPlacementMode)))
+				if (group.Name == groupName)
 				{
-					var placementMode = (TeachingTipHeroContentPlacementMode)iPlacementMode;
-
-					Log.Comment($"Verifying TeachingTipHeroContentPlacementMode [{placementMode}]");
-
-					TeachingTip teachingTip = new TeachingTip();
-					teachingTip.HeroContentPlacement = placementMode;
-
-					// Open the teaching tip to enter the correct visual state for the HeroContentPlacement.
-					teachingTip.IsOpen = true;
-
-					TestServices.WindowHelper.WindowContent = teachingTip;
-					teachingTip.UpdateLayout();
-
-					Verify.IsTrue(teachingTip.HeroContentPlacement == placementMode, $"HeroContentPlacement should have been [{placementMode}]");
-
-					var root = VisualTreeUtils.FindVisualChildByName(teachingTip, "Container") as FrameworkElement;
-
-					switch (placementMode)
-					{
-						case TeachingTipHeroContentPlacementMode.Auto:
-							Verify.IsTrue(IsVisualStateActive(root, "HeroContentPlacementStates", "HeroContentTop"),
-								"The [HeroContentTop] visual state should have been active");
-							break;
-						case TeachingTipHeroContentPlacementMode.Top:
-							Verify.IsTrue(IsVisualStateActive(root, "HeroContentPlacementStates", "HeroContentTop"),
-								"The [HeroContentTop] visual state should have been active");
-							break;
-						case TeachingTipHeroContentPlacementMode.Bottom:
-							Verify.IsTrue(IsVisualStateActive(root, "HeroContentPlacementStates", "HeroContentBottom"),
-								"The [HeroContentBottom] visual state should have been active");
-							break;
-					}
+					return group.CurrentState != null && group.CurrentState.Name == stateName;
 				}
-			});
-
-			bool IsVisualStateActive(FrameworkElement root, string groupName, string stateName)
-			{
-				foreach (var group in VisualStateManager.GetVisualStateGroups(root))
-				{
-					if (group.Name == groupName)
-					{
-						return group.CurrentState != null && group.CurrentState.Name == stateName;
-					}
-				}
-
-				return false;
 			}
-		}
-		finally
-		{
-			RunOnUIThread.Execute(() => stylesDisposable?.Dispose());
+
+			return false;
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TimePicker/TimePickerIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TimePicker/TimePickerIntegrationTests.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Markup;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Tests.Common;
 using Private.Infrastructure;
-using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.MUX.Helpers;
 using Windows.Foundation;
 using Windows.Globalization;
@@ -178,29 +175,24 @@ public class TimePickerIntegrationTests
 	[Ignore("This test is flaky in CI probably because Window size cannot be adjusted #9080")]
 	public async Task ValidateFootprint()
 	{
-		IDisposable fluentStylesDisposable = null;
-		await RunOnUIThread(() => fluentStylesDisposable = StyleHelper.UseFluentStyles());
-		try
+		TestServices.WindowHelper.SetWindowSizeOverride(new Size(500, 600));
+
+		const double expectedTimePickerWidth = 242;
+		const double expectedTimePickerWidth_WithWideHeader = 350;
+
+		const double expectedTimePickerHeight = 30;
+		const double expectedTimePickerHeight_WithHeader = 19 + 4 + expectedTimePickerHeight;
+
+		TimePicker timePicker = null;
+		TimePicker timePickerWithHeader = null;
+		TimePicker timePickerWithWideHeader = null;
+		TimePicker timePickerStretched = null;
+		TimePicker timePicker24Hour = null;
+
+		await RunOnUIThread(async () =>
 		{
-
-			TestServices.WindowHelper.SetWindowSizeOverride(new Size(500, 600));
-
-			const double expectedTimePickerWidth = 242;
-			const double expectedTimePickerWidth_WithWideHeader = 350;
-
-			const double expectedTimePickerHeight = 30;
-			const double expectedTimePickerHeight_WithHeader = 19 + 4 + expectedTimePickerHeight;
-
-			TimePicker timePicker = null;
-			TimePicker timePickerWithHeader = null;
-			TimePicker timePickerWithWideHeader = null;
-			TimePicker timePickerStretched = null;
-			TimePicker timePicker24Hour = null;
-
-			await RunOnUIThread(async () =>
-			{
-				var rootPanel = (StackPanel)XamlReader.Load(
-					@"<StackPanel xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" >
+			var rootPanel = (StackPanel)XamlReader.Load(
+				@"<StackPanel xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"" >
                         <TimePicker x:Name=""timePicker"" />
                         <TimePicker x:Name=""timePickerWithHeader"" Header=""H"" />
                         <TimePicker x:Name=""timePickerWithWideHeader"" >
@@ -212,42 +204,34 @@ public class TimePickerIntegrationTests
                         <TimePicker x:Name=""timePicker24Hour"" ClockIdentifier=""24HourClock"" />
                     </StackPanel>");
 
-				timePicker = (TimePicker)rootPanel.FindName("timePicker");
-				timePickerWithHeader = (TimePicker)rootPanel.FindName("timePickerWithHeader");
-				timePickerWithWideHeader = (TimePicker)rootPanel.FindName("timePickerWithWideHeader");
-				timePickerStretched = (TimePicker)rootPanel.FindName("timePickerStretched");
-				timePicker24Hour = (TimePicker)rootPanel.FindName("timePicker24Hour");
+			timePicker = (TimePicker)rootPanel.FindName("timePicker");
+			timePickerWithHeader = (TimePicker)rootPanel.FindName("timePickerWithHeader");
+			timePickerWithWideHeader = (TimePicker)rootPanel.FindName("timePickerWithWideHeader");
+			timePickerStretched = (TimePicker)rootPanel.FindName("timePickerStretched");
+			timePicker24Hour = (TimePicker)rootPanel.FindName("timePicker24Hour");
 
-				TestServices.WindowHelper.WindowContent = rootPanel;
-				await TestServices.WindowHelper.WaitForLoaded(rootPanel);
-			});
-			await TestServices.WindowHelper.WaitForIdle();
-			await RunOnUIThread(() =>
-			{
-				// Verify Footprint of TimePicker:
-				VERIFY_ARE_EQUAL(expectedTimePickerWidth, timePicker.ActualWidth);
-				VERIFY_ARE_EQUAL(expectedTimePickerHeight, timePicker.ActualHeight);
-
-				// Verify Footprint of TimePicker with Header:
-				VERIFY_ARE_EQUAL(expectedTimePickerWidth, timePickerWithHeader.ActualWidth);
-				VERIFY_ARE_EQUAL(expectedTimePickerHeight_WithHeader, timePickerWithHeader.ActualHeight);
-
-				// Verify Footprint of TimePicker with wide Header:
-				VERIFY_ARE_EQUAL(expectedTimePickerWidth_WithWideHeader, timePickerWithWideHeader.ActualWidth);
-				VERIFY_ARE_EQUAL(expectedTimePickerHeight_WithHeader, timePickerWithWideHeader.ActualHeight);
-
-				// Verify Footprint of TimePicker with 24Hour Clock:
-				VERIFY_ARE_EQUAL(expectedTimePickerWidth, timePicker24Hour.ActualWidth);
-				VERIFY_ARE_EQUAL(expectedTimePickerHeight, timePicker24Hour.ActualHeight);
-			});
-		}
-		finally
+			TestServices.WindowHelper.WindowContent = rootPanel;
+			await TestServices.WindowHelper.WaitForLoaded(rootPanel);
+		});
+		await TestServices.WindowHelper.WaitForIdle();
+		await RunOnUIThread(() =>
 		{
-			if (fluentStylesDisposable is not null)
-			{
-				await RunOnUIThread(() => fluentStylesDisposable.Dispose());
-			}
-		}
+			// Verify Footprint of TimePicker:
+			VERIFY_ARE_EQUAL(expectedTimePickerWidth, timePicker.ActualWidth);
+			VERIFY_ARE_EQUAL(expectedTimePickerHeight, timePicker.ActualHeight);
+
+			// Verify Footprint of TimePicker with Header:
+			VERIFY_ARE_EQUAL(expectedTimePickerWidth, timePickerWithHeader.ActualWidth);
+			VERIFY_ARE_EQUAL(expectedTimePickerHeight_WithHeader, timePickerWithHeader.ActualHeight);
+
+			// Verify Footprint of TimePicker with wide Header:
+			VERIFY_ARE_EQUAL(expectedTimePickerWidth_WithWideHeader, timePickerWithWideHeader.ActualWidth);
+			VERIFY_ARE_EQUAL(expectedTimePickerHeight_WithHeader, timePickerWithWideHeader.ActualHeight);
+
+			// Verify Footprint of TimePicker with 24Hour Clock:
+			VERIFY_ARE_EQUAL(expectedTimePickerWidth, timePicker24Hour.ActualWidth);
+			VERIFY_ARE_EQUAL(expectedTimePickerHeight, timePicker24Hour.ActualHeight);
+		});
 	}
 
 #if HAS_UNO

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ToggleSplitButton/ToggleSplitButtonTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/ToggleSplitButton/ToggleSplitButtonTests.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.UI.RuntimeTests.Helpers;
-using MUXControlsTestApp.Utilities;
-using Private.Infrastructure;
+﻿using Common;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
-using Common;
+using Private.Infrastructure;
 using Uno.UI.RuntimeTests;
 
 namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
@@ -21,15 +18,12 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 		public void VerifyFontFamilyForChevron()
 		{
 			Microsoft/* UWP don't rename */.UI.Xaml.Controls.ToggleSplitButton toggleSplitButton = null;
-			using (StyleHelper.UseFluentStyles())
-			{
-				toggleSplitButton = new Microsoft/* UWP don't rename */.UI.Xaml.Controls.ToggleSplitButton();
-				TestServices.WindowHelper.WindowContent = toggleSplitButton;
+			toggleSplitButton = new Microsoft/* UWP don't rename */.UI.Xaml.Controls.ToggleSplitButton();
+			TestServices.WindowHelper.WindowContent = toggleSplitButton;
 
-				var secondayButton = toggleSplitButton.GetTemplateChild("SecondaryButton");
-				var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
-				Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
-			}
+			var secondayButton = toggleSplitButton.GetTemplateChild("SecondaryButton");
+			var font = ((secondayButton as Button).Content as TextBlock).FontFamily;
+			Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/DropDownButtonTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/DropDownButtonTests.cs
@@ -1,11 +1,8 @@
 ﻿using Common;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MUXControlsTestApp.Utilities;
-using Private.Infrastructure;
-using Uno.UI.RuntimeTests;
-using Uno.UI.RuntimeTests.Helpers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests;
 
 namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -20,15 +17,12 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 		public void VerifyFontFamilyForChevron()
 		{
 			DropDownButton dropDownButton = null;
-			using (StyleHelper.UseFluentStyles())
-			{
-				dropDownButton = new DropDownButton();
-				TestServices.WindowHelper.WindowContent = dropDownButton;
+			dropDownButton = new DropDownButton();
+			TestServices.WindowHelper.WindowContent = dropDownButton;
 
-				var chevronTextBlock = dropDownButton.GetTemplateChild("ChevronTextBlock") as TextBlock;
-				var font = chevronTextBlock.FontFamily;
-				Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
-			}
+			var chevronTextBlock = dropDownButton.GetTemplateChild("ChevronTextBlock") as TextBlock;
+			var font = chevronTextBlock.FontFamily;
+			Verify.AreEqual((FontFamily)Application.Current.Resources["SymbolThemeFontFamily"], font);
 		}
 #endif
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
-using Uno.UI.RuntimeTests.ListViewPages;
+﻿using System.Threading.Tasks;
 #if WINAPPSDK
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -14,21 +6,13 @@ using UIKit;
 #elif __MACOS__
 using AppKit;
 #else
-using Uno.UI;
 #endif
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using static Private.Infrastructure.TestServices;
-using Windows.Foundation;
 using Windows.UI;
 using Microsoft.UI.Xaml.Media;
-using FluentAssertions;
-using FluentAssertions.Execution;
-using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using System.ComponentModel;
-using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 {
@@ -43,54 +27,50 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 #endif
 		public async Task When_SelectedItem_Set_Before_Load_And_Theme_Changed()
 		{
-			using (StyleHelper.UseFluentStyles())
+			var navView = new Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationView()
 			{
-
-				var navView = new Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationView()
-				{
-					MenuItems =
+				MenuItems =
 				{
 					new Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewItem {Content = "Item 1"},
 					new Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewItem {Content = "Item 2"},
 					new Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewItem {Content = "Item 3"},
 				},
-					PaneDisplayMode = Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal,
-					IsBackButtonVisible = Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed,
-				};
-				navView.SelectedItem = navView.MenuItems[1];
-				var hostGrid = new Grid() { MinWidth = 20, MinHeight = 20 };
+				PaneDisplayMode = Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal,
+				IsBackButtonVisible = Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed,
+			};
+			navView.SelectedItem = navView.MenuItems[1];
+			var hostGrid = new Grid() { MinWidth = 20, MinHeight = 20 };
 
-				WindowHelper.WindowContent = hostGrid;
+			WindowHelper.WindowContent = hostGrid;
 
-				await WindowHelper.WaitForLoaded(hostGrid);
+			await WindowHelper.WaitForLoaded(hostGrid);
 
-				hostGrid.Children.Add(navView);
+			hostGrid.Children.Add(navView);
 
-				await WindowHelper.WaitForLoaded(navView);
+			await WindowHelper.WaitForLoaded(navView);
 
-				navView.IsPaneOpen = true;
+			navView.IsPaneOpen = true;
 
+			await WindowHelper.WaitForIdle();
+
+			var togglePaneButton = navView.FindFirstChild<Button>(b => b.Name == "TogglePaneButton");
+			var icon = togglePaneButton?.FindFirstChild<FrameworkElement>(f => f.Name == "Icon");
+			var iconTextBlock = icon?.FindFirstChild<TextBlock>(includeCurrent: true);
+
+			Assert.IsNotNull(iconTextBlock);
+
+			ColorAssert.IsDark((iconTextBlock.Foreground as SolidColorBrush)?.Color);
+			using (ThemeHelper.UseDarkTheme())
+			{
 				await WindowHelper.WaitForIdle();
-
-				var togglePaneButton = navView.FindFirstChild<Button>(b => b.Name == "TogglePaneButton");
-				var icon = togglePaneButton?.FindFirstChild<FrameworkElement>(f => f.Name == "Icon");
-				var iconTextBlock = icon?.FindFirstChild<TextBlock>(includeCurrent: true);
-
-				Assert.IsNotNull(iconTextBlock);
-
-				ColorAssert.IsDark((iconTextBlock.Foreground as SolidColorBrush)?.Color);
-				using (ThemeHelper.UseDarkTheme())
-				{
-					await WindowHelper.WaitForIdle();
-					Assert.AreEqual(Colors.White, (iconTextBlock.Foreground as SolidColorBrush)?.Color);
-					ColorAssert.IsLight((iconTextBlock.Foreground as SolidColorBrush)?.Color);
+				Assert.AreEqual(Colors.White, (iconTextBlock.Foreground as SolidColorBrush)?.Color);
+				ColorAssert.IsLight((iconTextBlock.Foreground as SolidColorBrush)?.Color);
 #if __ANDROID__
-					// This is the meat of the test - we verify that the actual color of the TextBlock matches the managed Color, which will only be the
-					// case if it was correctly measured and arranged as requested after the theme changed.
-					Assert.AreEqual(false, iconTextBlock.IsLayoutRequested);
-					Assert.AreEqual((Android.Graphics.Color)((iconTextBlock.Foreground as SolidColorBrush).Color), iconTextBlock.NativeArrangedColor);
+				// This is the meat of the test - we verify that the actual color of the TextBlock matches the managed Color, which will only be the
+				// case if it was correctly measured and arranged as requested after the theme changed.
+				Assert.AreEqual(false, iconTextBlock.IsLayoutRequested);
+				Assert.AreEqual((Android.Graphics.Color)((iconTextBlock.Foreground as SolidColorBrush).Color), iconTextBlock.NativeArrangedColor);
 #endif
-				}
 			}
 		}
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/FrameworkElement_Opacity.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/FrameworkElement_Opacity.xaml
@@ -7,7 +7,9 @@
 	  mc:Ignorable="d"
 	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<StackPanel>
+	<!-- As the test is about opacity, the background can have effect on test outcome -->
+	<!-- To make the test stable when using UWP/Fluent styles, and when running with Light/Dark themes, we explicitly set the background -->
+	<StackPanel Background="White">
 		<TextBlock Text="Opacity 1.0 ██████████"
 				   x:Name="tbOpacity1_0"
 				   x:FieldModifier="public"

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -4,10 +4,14 @@
 
 #if !WINAPPSDK
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -15,6 +19,7 @@ using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
 using Windows.UI.Core;
+using Uno.Extensions;
 
 #if !HAS_UNO_WINUI
 using Microsoft/* UWP don't rename */.UI.Xaml.Controls;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -94,7 +94,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(typeof(SplitView), 15)]
 		[DataRow(typeof(Microsoft/* UWP don't rename */.UI.Xaml.Controls.AnimatedIcon), 15,
 #if __ANDROID__
-			LeakTestStyles.Default // Fluent styles disabled - #14341
+			LeakTestStyles.Uwp // Fluent styles disabled - #14341
 #else
 			LeakTestStyles.All
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_And_Leak.cs
@@ -4,23 +4,17 @@
 
 #if !WINAPPSDK
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
-using Uno.Extensions;
-using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
-using Windows.UI.Core;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+using Windows.UI.Core;
 
 #if !HAS_UNO_WINUI
 using Microsoft/* UWP don't rename */.UI.Xaml.Controls;
@@ -172,25 +166,23 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #if __IOS__
 			LeakTestStyles.None // Disabled - #10344
 #elif __ANDROID__
-			LeakTestStyles.Default // Fluent styles disabled - #14340
+			LeakTestStyles.Uwp // Fluent styles disabled - #14340
 #else
 			LeakTestStyles.All
 #endif
 			)]
 		public async Task When_Add_Remove(object controlTypeRaw, int count, LeakTestStyles leakTestStyles = LeakTestStyles.All)
 		{
-			if (leakTestStyles.HasFlag(LeakTestStyles.Default))
+			if (leakTestStyles.HasFlag(LeakTestStyles.Fluent))
 			{
 				// Test for leaks both without and with fluent styles
 				await When_Add_Remove_Inner(controlTypeRaw, count);
 			}
 
-			if (leakTestStyles.HasFlag(LeakTestStyles.Fluent))
+			if (leakTestStyles.HasFlag(LeakTestStyles.Uwp))
 			{
-				using (var themeHelper = StyleHelper.UseFluentStyles())
-				{
-					await When_Add_Remove_Inner(controlTypeRaw, count);
-				}
+				using var _ = StyleHelper.UseUwpStyles();
+				await When_Add_Remove_Inner(controlTypeRaw, count);
 			}
 		}
 
@@ -430,9 +422,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		public enum LeakTestStyles
 		{
 			None = 0,
-			Default = 1,
-			Fluent = 2,
-			All = Default | Fluent
+			Fluent = 1,
+			Uwp = 2,
+			All = Fluent | Uwp
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_ThemeResources.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_ThemeResources.cs
@@ -34,7 +34,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			WindowHelper.WindowContent = SUT;
 			await WindowHelper.WaitForLoaded(SUT);
 
-			Assert.AreEqual(Colors.Black, (SUT.Foreground as SolidColorBrush)?.Color);
+			Assert.AreEqual(Color.FromArgb(0xE4, 0, 0, 0), (SUT.Foreground as SolidColorBrush)?.Color);
 
 			WindowHelper.WindowContent = null;
 			await WindowHelper.WaitForIdle();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_ThemeResources.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement_ThemeResources.cs
@@ -75,7 +75,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			using (ThemeHelper.UseDarkTheme())
 			{
-				await OpenAndCheckComboBox(comboBox, Colors.White, Color.FromArgb(255, 43, 43, 43));
+				await OpenAndCheckComboBox(comboBox, Colors.White, Color.FromArgb(255, 44, 44, 44));
 
 			}
 		}
@@ -92,11 +92,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 
 			comboBox.ItemsSource = "abcdef".ToArray();
 
-			await OpenAndCheckComboBox(comboBox, Colors.Black, Color.FromArgb(255, 242, 242, 242));
+			await OpenAndCheckComboBox(comboBox, Color.FromArgb(228, 0, 0, 0), Color.FromArgb(255, 249, 249, 249));
 
 			using (ThemeHelper.UseDarkTheme())
 			{
-				await OpenAndCheckComboBox(comboBox, Colors.White, Color.FromArgb(255, 43, 43, 43));
+				await OpenAndCheckComboBox(comboBox, Colors.White, Color.FromArgb(255, 44, 44, 44));
 
 			}
 		}
@@ -114,7 +114,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				var popup = comboBox.FindFirstChild<Popup>();
 				var popupBorder = popup.Child as Border;
 				Assert.IsNotNull(popupBorder);
-				Assert.AreEqual(expectedBackground, (popupBorder.Background as SolidColorBrush)?.Color);
+				Assert.AreEqual(expectedBackground, (popupBorder.Background as AcrylicBrush)?.FallbackColorWithOpacity);
 			}
 			finally
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -1,19 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
-using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
-using Windows.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+using Windows.UI;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
@@ -70,7 +64,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif
-		public async Task When_DefaultForeground_Non_Fluent() => await When_DefaultForeground(Colors.Black, Colors.White);
+		public async Task When_DefaultForeground_Fluent() => await When_DefaultForeground(Colors.Black, Colors.White);
 #endif
 
 		[TestMethod]
@@ -78,92 +72,79 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif
-		public async Task When_DefaultForeground_Fluent()
+		public async Task When_DefaultForeground_Non_Fluent()
 		{
-			using (StyleHelper.UseFluentStyles())
-			{
-				await When_DefaultForeground(Color.FromArgb(228, 0, 0, 0), Colors.White);
-			}
+			using var _ = StyleHelper.UseUwpStyles();
+			await When_DefaultForeground(Color.FromArgb(228, 0, 0, 0), Colors.White);
 		}
 
 		[TestMethod]
 		public async Task When_AppLevel_Resource_CheckBox_Override()
 		{
 			// Use fluent styles to rely on known Theme Resources
-			using (StyleHelper.UseFluentStyles())
-			{
-				var SUT = new When_AppLevel_Resource_CheckBox_Override();
+			var SUT = new When_AppLevel_Resource_CheckBox_Override();
 
-				WindowHelper.WindowContent = SUT;
-				await WindowHelper.WaitForLoaded(SUT);
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
 
-				var normalRectangle = SUT.cb01.FindName("NormalRectangle") as Rectangle;
+			var normalRectangle = SUT.cb01.FindName("NormalRectangle") as Rectangle;
 
-				Assert.IsNotNull(normalRectangle);
+			Assert.IsNotNull(normalRectangle);
 
-				// Validation for early ThemeResource resolution in Storyboard timeline
-				Assert.AreEqual(Colors.Yellow, normalRectangle.Fill.GetValue(SolidColorBrush.ColorProperty));
+			// Validation for early ThemeResource resolution in Storyboard timeline
+			Assert.AreEqual(Colors.Yellow, normalRectangle.Fill.GetValue(SolidColorBrush.ColorProperty));
 
-				SUT.cb01.IsChecked = true;
+			SUT.cb01.IsChecked = true;
 
-				// Validation for late (OnLoaded) ThemeResource resolution in Storyboard timeline
-				Assert.AreEqual(Colors.Red, normalRectangle.Fill.GetValue(SolidColorBrush.ColorProperty));
-			}
+			// Validation for late (OnLoaded) ThemeResource resolution in Storyboard timeline
+			Assert.AreEqual(Colors.Red, normalRectangle.Fill.GetValue(SolidColorBrush.ColorProperty));
 		}
 
 		[TestMethod]
 		public async Task When_AppLevel_Resource_SplitButton_Override()
 		{
 			// Use fluent styles to rely on known Theme Resources
-			using (StyleHelper.UseFluentStyles())
-			{
-				var SUT = new When_AppLevel_Resource_SplitButton_Override();
+			var SUT = new When_AppLevel_Resource_SplitButton_Override();
 
-				WindowHelper.WindowContent = SUT;
-				await WindowHelper.WaitForLoaded(SUT);
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
 
-				var contentPresenter = SUT.sb01.FindName("ContentPresenter") as ContentPresenter;
+			var contentPresenter = SUT.sb01.FindName("ContentPresenter") as ContentPresenter;
 
-				Assert.IsNotNull(contentPresenter);
+			Assert.IsNotNull(contentPresenter);
 
-				var color = contentPresenter.Foreground.GetValue(SolidColorBrush.ColorProperty);
+			var color = contentPresenter.Foreground.GetValue(SolidColorBrush.ColorProperty);
 
-				SUT.sb01.IsEnabled = false;
+			SUT.sb01.IsEnabled = false;
 
-				// Validation for late (OnLoaded) ThemeResource resolution in Setter value
-				Assert.AreEqual(Colors.Yellow, contentPresenter.Foreground.GetValue(SolidColorBrush.ColorProperty));
-				Assert.AreNotEqual(color, contentPresenter.Foreground.GetValue(SolidColorBrush.ColorProperty));
-			}
+			// Validation for late (OnLoaded) ThemeResource resolution in Setter value
+			Assert.AreEqual(Colors.Yellow, contentPresenter.Foreground.GetValue(SolidColorBrush.ColorProperty));
+			Assert.AreNotEqual(color, contentPresenter.Foreground.GetValue(SolidColorBrush.ColorProperty));
 		}
 
 		[TestMethod]
 		public async Task When_ThemeResource_Style_Switch()
 		{
-			using (StyleHelper.UseFluentStyles())
-			{
-				var SUT = new When_ThemeResource_Style_Switch_Page();
-				WindowHelper.WindowContent = SUT;
-				await WindowHelper.WaitForLoaded(SUT);
+			var SUT = new When_ThemeResource_Style_Switch_Page();
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
 
-				var color = ((SolidColorBrush)SUT.TestButton.Background).Color;
+			var color = ((SolidColorBrush)SUT.TestButton.Background).Color;
 
-				Assert.AreEqual(Colors.Blue, color);
+			Assert.AreEqual(Colors.Blue, color);
 
-				SUT.TestButton.Style = (Style)SUT.Resources["SecondButtonStyle"];
+			SUT.TestButton.Style = (Style)SUT.Resources["SecondButtonStyle"];
 
-				await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitForIdle();
 
-				color = ((SolidColorBrush)SUT.TestButton.Background).Color;
+			color = ((SolidColorBrush)SUT.TestButton.Background).Color;
 
-				Assert.AreEqual(Colors.Red, color);
-			}
+			Assert.AreEqual(Colors.Red, color);
 		}
 
 		[TestMethod]
 		public async Task When_Theme_Changed()
 		{
-			using var _ = StyleHelper.UseFluentStyles();
-
 			var control = new ThemeResource_Theme_Changing_Override();
 			WindowHelper.WindowContent = control;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -64,7 +64,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif
-		public async Task When_DefaultForeground_Fluent() => await When_DefaultForeground(Colors.Black, Colors.White);
+		public async Task When_DefaultForeground_Non_Fluent()
+		{
+			using var _ = StyleHelper.UseUwpStyles();
+			await When_DefaultForeground(Colors.Black, Colors.White);
+		}
 #endif
 
 		[TestMethod]
@@ -72,9 +76,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif
-		public async Task When_DefaultForeground_Non_Fluent()
+		public async Task When_DefaultForeground_Fluent()
 		{
-			using var _ = StyleHelper.UseUwpStyles();
 			await When_DefaultForeground(Color.FromArgb(228, 0, 0, 0), Colors.White);
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -26,7 +26,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[DataRow(false)]
 		public async Task When_NavigationViewButtonStyles(bool useFluent)
 		{
-			using var _ = useFluent ? StyleHelper.UseFluentStyles() : null;
+			using var _ = useFluent ? null : StyleHelper.UseUwpStyles();
 
 			var normalBtn = (Button)XamlReader.Load("""
 				<Button xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Style="{StaticResource NavigationBackButtonNormalStyle}" />

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarDatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarDatePicker.cs
@@ -74,7 +74,7 @@ public class Given_CalendarDatePicker
 				{
 					continue;
 				}
-				var background = ((SolidColorBrush)backgroundBrush).Color;
+				var background = (backgroundBrush as SolidColorBrush)?.Color ?? ((RevealBackgroundBrush)backgroundBrush).Color;
 
 				// Skip colored dates (selected), or those with opacity of zero.
 				if (background.R == background.G && background.G == background.B && background.A != 0)
@@ -108,7 +108,7 @@ public class Given_CalendarDatePicker
 				{
 					continue;
 				}
-				var background = ((SolidColorBrush)backgroundBrush).Color;
+				var background = (backgroundBrush as SolidColorBrush)?.Color ?? ((RevealBackgroundBrush)backgroundBrush).Color;
 
 				// Skip colored dates (selected), or those with opacity of zero.
 				if (background.R == background.G && background.G == background.B && background.A != 0)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -109,7 +109,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		public async Task When_IsEditable_False()
 		{
 			// EditableText is only available in fluent style.
-			using var _ = StyleHelper.UseFluentStyles();
 			var SUT = new ComboBox();
 			await UITestHelper.Load(SUT);
 
@@ -121,7 +120,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		public async Task When_IsEditable_True()
 		{
 			// EditableText is only available in fluent style.
-			using var _ = StyleHelper.UseFluentStyles();
 			var SUT = new ComboBox() { IsEditable = true };
 			await UITestHelper.Load(SUT);
 
@@ -138,7 +136,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 
 			// EditableText is only available in fluent style.
-			using var _ = StyleHelper.UseFluentStyles();
 			var SUT = new ComboBox();
 			await UITestHelper.Load(SUT);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -452,33 +452,30 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		public async Task When_Fluent_And_Theme_Changed()
 		{
-			using (StyleHelper.UseFluentStyles())
+			var comboBox = new ComboBox
 			{
-				var comboBox = new ComboBox
-				{
-					ItemsSource = new[] { 1, 2, 3 },
-					PlaceholderText = "Select..."
-				};
+				ItemsSource = new[] { 1, 2, 3 },
+				PlaceholderText = "Select..."
+			};
 
-				WindowHelper.WindowContent = comboBox;
-				await WindowHelper.WaitForLoaded(comboBox);
+			WindowHelper.WindowContent = comboBox;
+			await WindowHelper.WaitForLoaded(comboBox);
 
-				var placeholderTextBlock = comboBox.FindFirstChild<TextBlock>(tb => tb.Name == "PlaceholderTextBlock");
+			var placeholderTextBlock = comboBox.FindFirstChild<TextBlock>(tb => tb.Name == "PlaceholderTextBlock");
 
-				Assert.IsNotNull(placeholderTextBlock);
+			Assert.IsNotNull(placeholderTextBlock);
 
-				var lightThemeForeground = TestsColorHelper.ToColor("#9E000000");
-				var darkThemeForeground = TestsColorHelper.ToColor("#C5FFFFFF");
+			var lightThemeForeground = TestsColorHelper.ToColor("#9E000000");
+			var darkThemeForeground = TestsColorHelper.ToColor("#C5FFFFFF");
 
-				Assert.AreEqual(lightThemeForeground, (placeholderTextBlock.Foreground as SolidColorBrush)?.Color);
+			Assert.AreEqual(lightThemeForeground, (placeholderTextBlock.Foreground as SolidColorBrush)?.Color);
 
-				using (ThemeHelper.UseDarkTheme())
-				{
-					Assert.AreEqual(darkThemeForeground, (placeholderTextBlock.Foreground as SolidColorBrush)?.Color);
-				}
-
-				Assert.AreEqual(lightThemeForeground, (placeholderTextBlock.Foreground as SolidColorBrush)?.Color);
+			using (ThemeHelper.UseDarkTheme())
+			{
+				Assert.AreEqual(darkThemeForeground, (placeholderTextBlock.Foreground as SolidColorBrush)?.Color);
 			}
+
+			Assert.AreEqual(lightThemeForeground, (placeholderTextBlock.Foreground as SolidColorBrush)?.Color);
 		}
 
 		[TestMethod]
@@ -1091,12 +1088,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if !HAS_INPUT_INJECTOR
 		[Ignore("Pointer injection supported only on skia for now.")]
 #endif
-		public async Task When_Mouse_Opened_And_Closed_Fluent()
+		public async Task When_Mouse_Opened_And_Closed_Uwp()
 		{
-			using (StyleHelper.UseFluentStyles())
-			{
-				await When_Mouse_Opened_And_Closed();
-			}
+			using var _ = StyleHelper.UseUwpStyles();
+			await When_Mouse_Opened_And_Closed();
 		}
 
 		private async Task<RawBitmap> TakeScreenshot(FrameworkElement SUT)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.cs
@@ -1,19 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
-using Uno.Extensions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Controls.Primitives;
-using System.Linq;
-using static Private.Infrastructure.TestServices;
+using Microsoft.UI.Xaml.Data;
+using Private.Infrastructure;
+using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ContentControlPages;
 using Windows_UI_Xaml_Controls;
+using static Private.Infrastructure.TestServices;
 #if WINAPPSDK
 using Uno.UI.Extensions;
 #elif __IOS__
@@ -21,7 +18,6 @@ using UIKit;
 #elif __MACOS__
 using AppKit;
 #else
-using Uno.UI;
 #endif
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -127,12 +123,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 
 		[TestMethod]
-		public async Task When_ContentTemplateSelector_And_Default_Style_And_Fluent()
+		public async Task When_ContentTemplateSelector_And_Default_Style_And_Uwp()
 		{
-			using (StyleHelper.UseFluentStyles())
-			{
-				await When_ContentTemplateSelector_And_Default_Style();
-			}
+			using var _ = StyleHelper.UseUwpStyles();
+			await When_ContentTemplateSelector_And_Default_Style();
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -40,7 +40,6 @@ using TabViewItem = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TabViewItem
 
 using static Private.Infrastructure.TestServices;
 using static Uno.UI.Extensions.ViewExtensions;
-using Point = Windows.Foundation.Point;
 using MUXControlsTestApp.Utilities;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -40,6 +40,8 @@ using TabViewItem = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TabViewItem
 
 using static Private.Infrastructure.TestServices;
 using static Uno.UI.Extensions.ViewExtensions;
+using Point = Windows.Foundation.Point;
+using MUXControlsTestApp.Utilities;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -19,14 +19,12 @@ using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
 using Uno.Extensions;
 using Uno.UI.Helpers;
 using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.ListViewPages;
-using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 
 #if !WINAPPSDK
 using Uno.UI;
@@ -2923,12 +2921,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-		public async Task When_ItemTemplateSelector_Set_And_Fluent()
+		public async Task When_ItemTemplateSelector_Set_And_Uwp()
 		{
-			using (StyleHelper.UseFluentStyles())
-			{
-				await When_ItemTemplateSelector_Set();
-			}
+			using var _ = StyleHelper.UseUwpStyles();
+			await When_ItemTemplateSelector_Set();
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -1984,10 +1984,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// since this is originally a virtualization issue and references
 			// could be to different things than those shown on the screen.
 			var si = await UITestHelper.ScreenShot(list, true);
-			ImageAssert.HasColorAt(si, 70, 65, Colors.FromARGB("#66AEE7")); // selected
+			ImageAssert.HasColorAt(si, 70, 65, Colors.FromARGB("#1A69A6")); // selected
 
 			// check starting from below the second item that nothing looks selected or hovered
-			ImageAssert.DoesNotHaveColorInRectangle(si, new Rectangle(100, 110, si.Width - 100, si.Height - 110), Colors.FromARGB("#66AEE7")); // selected
+			ImageAssert.DoesNotHaveColorInRectangle(si, new Rectangle(100, 110, si.Width - 100, si.Height - 110), Colors.FromARGB("#1A69A6")); // selected
 			ImageAssert.DoesNotHaveColorInRectangle(si, new Rectangle(100, 110, si.Width - 100, si.Height - 110), Colors.FromARGB("#FFE6E6E6")); // hovered
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -1,28 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
-using Uno.Extensions;
-using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.MUX.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.MenuFlyoutPages;
 using Windows.UI;
-using Windows.UI.ViewManagement;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.UI.Xaml.Shapes;
 using static Private.Infrastructure.TestServices;
 
 #if !HAS_UNO_WINUI
@@ -79,73 +66,70 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RequiresFullWindow]
 		public async Task When_Add_MenuFlyoutSeparator_To_MenuBarItem()
 		{
-			using (StyleHelper.UseFluentStyles())
+			var menuBarItem = new MenuBarItem
 			{
-				var menuBarItem = new MenuBarItem
-				{
-					Title = "File",
-				};
+				Title = "File",
+			};
 
-				var flyoutItem1 = new MenuFlyoutItem { Text = "Open..." };
-				var flyoutItem2 = new MenuFlyoutItem { Text = "Save..." };
-				var flyoutSeparator = new MenuFlyoutSeparator();
+			var flyoutItem1 = new MenuFlyoutItem { Text = "Open..." };
+			var flyoutItem2 = new MenuFlyoutItem { Text = "Save..." };
+			var flyoutSeparator = new MenuFlyoutSeparator();
 
-				var menuBar = new MenuBar
-				{
-					Items =
+			var menuBar = new MenuBar
+			{
+				Items =
 				{
 					menuBarItem
 				}
-				};
+			};
 
-				var contentSpacer = new Border { Background = new SolidColorBrush(Colors.Tomato), Margin = new Thickness(20) };
-				Grid.SetRow(contentSpacer, 1);
+			var contentSpacer = new Border { Background = new SolidColorBrush(Colors.Tomato), Margin = new Thickness(20) };
+			Grid.SetRow(contentSpacer, 1);
 
-				var hostPanel = new Grid
-				{
-					Children =
+			var hostPanel = new Grid
+			{
+				Children =
 				{
 					menuBar,
 					contentSpacer
 				},
-					RowDefinitions =
+				RowDefinitions =
 				{
 					new RowDefinition {Height = GridLength.Auto},
 					new RowDefinition {Height = new GridLength(1, GridUnitType.Star)}
 				}
-				};
+			};
 
-				WindowHelper.WindowContent = hostPanel;
-				await WindowHelper.WaitForLoaded(hostPanel);
+			WindowHelper.WindowContent = hostPanel;
+			await WindowHelper.WaitForLoaded(hostPanel);
 
-				menuBarItem.Items.Add(flyoutItem1);
-				menuBarItem.Items.Add(flyoutSeparator);
-				menuBarItem.Items.Add(flyoutItem2);
+			menuBarItem.Items.Add(flyoutItem1);
+			menuBarItem.Items.Add(flyoutSeparator);
+			menuBarItem.Items.Add(flyoutItem2);
 
-				var peer = new MenuBarItemAutomationPeer(menuBarItem);
-				try
-				{
-					peer.Invoke();
+			var peer = new MenuBarItemAutomationPeer(menuBarItem);
+			try
+			{
+				peer.Invoke();
 
-					await WindowHelper.WaitForLoaded(flyoutItem1);
-					await WindowHelper.WaitForLoaded(flyoutSeparator);
-					await WindowHelper.WaitForLoaded(flyoutItem2);
+				await WindowHelper.WaitForLoaded(flyoutItem1);
+				await WindowHelper.WaitForLoaded(flyoutSeparator);
+				await WindowHelper.WaitForLoaded(flyoutItem2);
 
-					var flyoutItem1Bounds = flyoutItem1.GetRelativeBounds(menuBarItem);
-					var flyoutSeparatorBounds = flyoutSeparator.GetRelativeBounds(menuBarItem);
-					var flyoutItem2Bounds = flyoutItem2.GetRelativeBounds(menuBarItem);
+				var flyoutItem1Bounds = flyoutItem1.GetRelativeBounds(menuBarItem);
+				var flyoutSeparatorBounds = flyoutSeparator.GetRelativeBounds(menuBarItem);
+				var flyoutItem2Bounds = flyoutItem2.GetRelativeBounds(menuBarItem);
 
-					Assert.IsTrue(flyoutItem1Bounds.Height > 0);
-					Assert.IsTrue(flyoutSeparatorBounds.Height > 0);
-					Assert.IsTrue(flyoutItem2Bounds.Height > 0);
+				Assert.IsTrue(flyoutItem1Bounds.Height > 0);
+				Assert.IsTrue(flyoutSeparatorBounds.Height > 0);
+				Assert.IsTrue(flyoutItem2Bounds.Height > 0);
 
-					Assert.IsTrue(flyoutItem1Bounds.Y < flyoutSeparatorBounds.Y);
-					Assert.IsTrue(flyoutSeparatorBounds.Y < flyoutItem2Bounds.Y);
-				}
-				finally
-				{
-					peer.Collapse();
-				}
+				Assert.IsTrue(flyoutItem1Bounds.Y < flyoutSeparatorBounds.Y);
+				Assert.IsTrue(flyoutSeparatorBounds.Y < flyoutItem2Bounds.Y);
+			}
+			finally
+			{
+				peer.Collapse();
 			}
 		}
 
@@ -153,78 +137,75 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RequiresFullWindow]
 		public async Task Verify_MenuBarItem_Bounds()
 		{
-			using (StyleHelper.UseFluentStyles())
+			var flyoutItem = new MenuFlyoutItem { Text = "Open..." };
+			var menuBarItem = new MenuBarItem
 			{
-				var flyoutItem = new MenuFlyoutItem { Text = "Open..." };
-				var menuBarItem = new MenuBarItem
-				{
-					Title = "File",
-					Items =
+				Title = "File",
+				Items =
 				{
 					flyoutItem,
 					new MenuFlyoutItem { Text = "Don't open..."}
 				}
-				};
+			};
 
-				var menuBar = new MenuBar
-				{
-					Items =
+			var menuBar = new MenuBar
+			{
+				Items =
 				{
 					menuBarItem
 				}
-				};
+			};
 
-				var contentSpacer = new Border { Background = new SolidColorBrush(Colors.Tomato), Margin = new Thickness(20) };
-				Grid.SetRow(contentSpacer, 1);
+			var contentSpacer = new Border { Background = new SolidColorBrush(Colors.Tomato), Margin = new Thickness(20) };
+			Grid.SetRow(contentSpacer, 1);
 
-				var hostPanel = new Grid
-				{
-					Children =
+			var hostPanel = new Grid
+			{
+				Children =
 				{
 					menuBar,
 					contentSpacer
 				},
-					RowDefinitions =
+				RowDefinitions =
 				{
 					new RowDefinition {Height = GridLength.Auto},
 					new RowDefinition {Height = new GridLength(1, GridUnitType.Star)}
 				}
-				};
+			};
 
-				WindowHelper.WindowContent = hostPanel;
-				await WindowHelper.WaitForLoaded(hostPanel);
+			WindowHelper.WindowContent = hostPanel;
+			await WindowHelper.WaitForLoaded(hostPanel);
 
-				var peer = new MenuBarItemAutomationPeer(menuBarItem);
-				try
-				{
-					peer.Invoke();
+			var peer = new MenuBarItemAutomationPeer(menuBarItem);
+			try
+			{
+				peer.Invoke();
 
-					await WindowHelper.WaitForLoaded(flyoutItem);
+				await WindowHelper.WaitForLoaded(flyoutItem);
 
-					var menuBarItemBounds = menuBarItem.GetOnScreenBounds();
+				var menuBarItemBounds = menuBarItem.GetOnScreenBounds();
 
-					var flyoutItemBounds = flyoutItem.GetOnScreenBounds();
+				var flyoutItemBounds = flyoutItem.GetOnScreenBounds();
 
-					var menuBarBounds = menuBar.GetOnScreenBounds();
+				var menuBarBounds = menuBar.GetOnScreenBounds();
 
-					Assert.AreEqual(32, menuBarItemBounds.Height, 1);
+				Assert.AreEqual(32, menuBarItemBounds.Height, 1);
 
-					var expectedY = 39.0;
+				var expectedY = 39.0;
 #if __ANDROID__
-					if (!FeatureConfiguration.Popup.UseNativePopup)
-					{
-						// If using managed popup, the expected offset must be adjusted for the status bar
-						expectedY += menuBarBounds.Y;
-					}
+				if (!FeatureConfiguration.Popup.UseNativePopup)
+				{
+					// If using managed popup, the expected offset must be adjusted for the status bar
+					expectedY += menuBarBounds.Y;
+				}
 #endif
 
-					Assert.AreEqual(5, flyoutItemBounds.X, 3);
-					Assert.AreEqual(expectedY, flyoutItemBounds.Y, 3);
-				}
-				finally
-				{
-					peer.Collapse();
-				}
+				Assert.AreEqual(5, flyoutItemBounds.X, 3);
+				Assert.AreEqual(expectedY, flyoutItemBounds.Y, 3);
+			}
+			finally
+			{
+				peer.Collapse();
 			}
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -1,15 +1,28 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Uno.Extensions;
+using Uno.UI.Extensions;
 using Uno.UI.RuntimeTests.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.MUX.Helpers;
 using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.MenuFlyoutPages;
 using Windows.UI;
+using Windows.UI.ViewManagement;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Shapes;
 using static Private.Infrastructure.TestServices;
 
 #if !HAS_UNO_WINUI

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -8,13 +8,12 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MUXControlsTestApp.Utilities;
 using Uno.UI.Helpers;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.ApplicationModel.DataTransfer;
+using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI;
-
 using static Private.Infrastructure.TestServices;
 
 #if WINAPPSDK
@@ -74,31 +73,28 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Fluent_And_Theme_Changed()
 		{
-			using (StyleHelper.UseFluentStyles())
+			var textBox = new TextBox
 			{
-				var textBox = new TextBox
-				{
-					PlaceholderText = "Enter..."
-				};
+				PlaceholderText = "Enter..."
+			};
 
-				WindowHelper.WindowContent = textBox;
-				await WindowHelper.WaitForLoaded(textBox);
+			WindowHelper.WindowContent = textBox;
+			await WindowHelper.WaitForLoaded(textBox);
 
-				var placeholderTextContentPresenter = textBox.FindFirstChild<TextBlock>(tb => tb.Name == "PlaceholderTextContentPresenter");
-				Assert.IsNotNull(placeholderTextContentPresenter);
+			var placeholderTextContentPresenter = textBox.FindFirstChild<TextBlock>(tb => tb.Name == "PlaceholderTextContentPresenter");
+			Assert.IsNotNull(placeholderTextContentPresenter);
 
-				var lightThemeForeground = TestsColorHelper.ToColor("#9E000000");
-				var darkThemeForeground = TestsColorHelper.ToColor("#C5FFFFFF");
+			var lightThemeForeground = TestsColorHelper.ToColor("#9E000000");
+			var darkThemeForeground = TestsColorHelper.ToColor("#C5FFFFFF");
 
-				Assert.AreEqual(lightThemeForeground, (placeholderTextContentPresenter.Foreground as SolidColorBrush)?.Color);
+			Assert.AreEqual(lightThemeForeground, (placeholderTextContentPresenter.Foreground as SolidColorBrush)?.Color);
 
-				using (ThemeHelper.UseDarkTheme())
-				{
-					Assert.AreEqual(darkThemeForeground, (placeholderTextContentPresenter.Foreground as SolidColorBrush)?.Color);
-				}
-
-				Assert.AreEqual(lightThemeForeground, (placeholderTextContentPresenter.Foreground as SolidColorBrush)?.Color);
+			using (ThemeHelper.UseDarkTheme())
+			{
+				Assert.AreEqual(darkThemeForeground, (placeholderTextContentPresenter.Foreground as SolidColorBrush)?.Color);
 			}
+
+			Assert.AreEqual(lightThemeForeground, (placeholderTextContentPresenter.Foreground as SolidColorBrush)?.Color);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -12,7 +12,6 @@ using MUXControlsTestApp.Utilities;
 using Uno.UI.Helpers;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.ApplicationModel.DataTransfer;
-using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI;
 using static Private.Infrastructure.TestServices;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -756,7 +756,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 			Assert.AreEqual(sv.ScrollableWidth, sv.HorizontalOffset);
 
-			for (var i = 0; i < 6; i++)
+			for (var i = 0; i < 7; i++)
 			{
 				SUT.SafeRaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Left, VirtualKeyModifiers.None));
 				await WindowHelper.WaitForIdle();
@@ -971,7 +971,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 
-			mouse.MoveBy(-50, 0);
+			mouse.MoveBy(-51, 0);
 
 			Assert.AreEqual(1, SUT.SelectionStart);
 			Assert.AreEqual(9, SUT.SelectionLength);
@@ -1240,7 +1240,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 
-			mouse.MoveBy(-50, 0);
+			mouse.MoveBy(-51, 0);
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(1, SUT.SelectionStart);
@@ -1302,7 +1302,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 
-			mouse.MoveBy(-50, 0);
+			mouse.MoveBy(-51, 0);
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(1, SUT.SelectionStart);
@@ -1350,7 +1350,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 
-			mouse.MoveBy(-50, 0);
+			mouse.MoveBy(-51, 0);
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(1, SUT.SelectionStart);
@@ -1409,7 +1409,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 
-			mouse.MoveBy(-50, 0);
+			mouse.MoveBy(-51, 0);
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(1, SUT.SelectionStart);
@@ -1462,7 +1462,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(10, SUT.SelectionStart);
 			Assert.AreEqual(0, SUT.SelectionLength);
 
-			mouse.MoveBy(-50, 0);
+			mouse.MoveBy(-51, 0);
 			await WindowHelper.WaitForIdle();
 
 			Assert.AreEqual(1, SUT.SelectionStart);
@@ -2152,7 +2152,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(12, SUT.SelectionStart);
 			Assert.AreEqual(6, SUT.SelectionLength);
 
-			mouse.MoveBy(-40, 10);
+			mouse.MoveBy(-41, 10);
 			mouse.Release();
 			await WindowHelper.WaitForIdle();
 
@@ -2172,7 +2172,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(22, SUT.SelectionStart);
 			Assert.AreEqual(5, SUT.SelectionLength);
 
-			mouse.MoveBy(40, -10);
+			mouse.MoveBy(41, -10);
 			mouse.Release();
 			await WindowHelper.WaitForIdle();
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToggleSwitch.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToggleSwitch.cs
@@ -19,6 +19,6 @@ public class Given_ToggleSwitch
 		var minKnobTranslation = (double)typeof(ToggleSwitch).GetField("_minKnobTranslation", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(toggleSwitch);
 		var maxKnobTranslation = (double)typeof(ToggleSwitch).GetField("_maxKnobTranslation", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(toggleSwitch);
 		Assert.AreEqual(0, minKnobTranslation);
-		Assert.AreEqual(24, maxKnobTranslation);
+		Assert.AreEqual(20, maxKnobTranslation);
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
@@ -240,7 +240,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif
 		[TestMethod]
-		public Task When_Switch_Theme_Fluent() => When_Switch_Theme_Inner(brush => (brush as SolidColorBrush).Color);
+		public Task When_Switch_Theme_Fluent() => When_Switch_Theme_Inner(brush => (brush as AcrylicBrush).TintColor);
 
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
@@ -249,7 +249,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		public async Task When_Switch_Theme_Uwp()
 		{
 			using var _ = StyleHelper.UseUwpStyles();
-			await When_Switch_Theme_Inner(brush => (brush as AcrylicBrush).TintColor);
+			await When_Switch_Theme_Inner(brush => (brush as SolidColorBrush).Color);
 		}
 
 		private async Task When_Switch_Theme_Inner(Func<Brush, Color> backgroundColorGetter)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ToolTip.cs
@@ -240,15 +240,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif
 		[TestMethod]
-		public Task When_Switch_Theme_UWP() => When_Switch_Theme_Inner(brush => (brush as SolidColorBrush).Color);
+		public Task When_Switch_Theme_Fluent() => When_Switch_Theme_Inner(brush => (brush as SolidColorBrush).Color);
 
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
 #endif
 		[TestMethod]
-		public async Task When_Switch_Theme_Fluent()
+		public async Task When_Switch_Theme_Uwp()
 		{
-			using var _ = StyleHelper.UseFluentStyles();
+			using var _ = StyleHelper.UseUwpStyles();
 			await When_Switch_Theme_Inner(brush => (brush as AcrylicBrush).TintColor);
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_BitmapIcon.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_BitmapIcon.cs
@@ -1,10 +1,10 @@
 ﻿using System.Drawing;
-using Private.Infrastructure;
 using System.Threading.Tasks;
-using Windows.UI;
-using Uno.UI.RuntimeTests.Helpers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Icons;
 
@@ -46,12 +46,10 @@ public class Given_BitmapIcon
 	}
 
 	[TestMethod]
-	public async Task When_Themed_Fluent()
+	public async Task When_Themed_Uwp()
 	{
-		using (StyleHelper.UseFluentStyles())
-		{
-			await When_Themed();
-		}
+		using var _ = StyleHelper.UseUwpStyles();
+		await When_Themed();
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_FontIcon.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_FontIcon.cs
@@ -1,12 +1,11 @@
-﻿using System;
+﻿using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
-using System.Threading.Tasks;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI;
 using Windows.UI.Text;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Icons;
 
@@ -55,12 +54,10 @@ public class Given_FontIcon
 	}
 
 	[TestMethod]
-	public async Task When_Themed_Fluent()
+	public async Task When_Themed_Uwp()
 	{
-		using (StyleHelper.UseFluentStyles())
-		{
-			await When_Themed();
-		}
+		using var _ = StyleHelper.UseUwpStyles();
+		await When_Themed();
 	}
 
 	[TestMethod]
@@ -98,11 +95,9 @@ public class Given_FontIcon
 	}
 
 	[TestMethod]
-	public async Task When_Themed_TextBlock_Fluent()
+	public async Task When_Themed_TextBlock_Uwp()
 	{
-		using (StyleHelper.UseFluentStyles())
-		{
-			await When_Themed_TextBlock();
-		}
+		using var _ = StyleHelper.UseUwpStyles();
+		await When_Themed_TextBlock();
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_PathIcon.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_PathIcon.cs
@@ -1,11 +1,11 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
 using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Shapes;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Icons;
 
@@ -47,12 +47,10 @@ public class Given_PathIcon
 	}
 
 	[TestMethod]
-	public async Task When_Themed_Fluent()
+	public async Task When_Themed_Uwp()
 	{
-		using (StyleHelper.UseFluentStyles())
-		{
-			await When_Themed();
-		}
+		using var _ = StyleHelper.UseUwpStyles();
+		await When_Themed();
 	}
 
 	[TestMethod]
@@ -96,11 +94,9 @@ public class Given_PathIcon
 
 
 	[TestMethod]
-	public async Task When_Themed_Path_Fluent()
+	public async Task When_Themed_Path_Uwp()
 	{
-		using (StyleHelper.UseFluentStyles())
-		{
-			await When_Themed_Path();
-		}
+		using var _ = StyleHelper.UseUwpStyles();
+		await When_Themed_Path();
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_SymbolIcon.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Icons/Given_SymbolIcon.cs
@@ -1,10 +1,10 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.UI;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Icons;
 
@@ -64,12 +64,10 @@ public class Given_SymbolIcon
 	}
 
 	[TestMethod]
-	public async Task When_Themed_Fluent()
+	public async Task When_Themed_Uwp()
 	{
-		using (StyleHelper.UseFluentStyles())
-		{
-			await When_Themed();
-		}
+		using var _ = StyleHelper.UseUwpStyles();
+		await When_Themed();
 	}
 
 	[TestMethod]
@@ -107,11 +105,9 @@ public class Given_SymbolIcon
 	}
 
 	[TestMethod]
-	public async Task When_Themed_TextBlock_Fluent()
+	public async Task When_Themed_TextBlock_Uwp()
 	{
-		using (StyleHelper.UseFluentStyles())
-		{
-			await When_Themed_TextBlock();
-		}
+		using var _ = StyleHelper.UseUwpStyles();
+		await When_Themed_TextBlock();
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Documents/Given_Hyperlink.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Documents/Given_Hyperlink.cs
@@ -12,6 +12,7 @@ using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 using Uno.Extensions;
 using static Private.Infrastructure.TestServices;
+using Uno.Disposables;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Documents;
 
@@ -29,7 +30,7 @@ public class Given_Hyperlink
 		var expectedColor = (Color)XamlBindingHelper.ConvertValue(typeof(Color), expectedColorCode);
 		using (useDark ? ThemeHelper.UseDarkTheme() : null)
 		{
-			using (useFluent ? StyleHelper.UseFluentStyles() : null)
+			using (useFluent ? Disposable.Empty : StyleHelper.UseUwpStyles())
 			{
 				var tb = (TextBlock)XamlReader.Load("""
 				<TextBlock xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
@@ -61,7 +62,7 @@ public class Given_Hyperlink
 		var expectedHoveredColor = (Color)XamlBindingHelper.ConvertValue(typeof(Color), expectedHoveredColorCode);
 		using (useDark ? ThemeHelper.UseDarkTheme() : null)
 		{
-			using (useFluent ? StyleHelper.UseFluentStyles() : null)
+			using (useFluent ? Disposable.Empty : StyleHelper.UseUwpStyles())
 			{
 				var stackPanel = (StackPanel)XamlReader.Load("""
 				<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
@@ -114,7 +115,7 @@ public class Given_Hyperlink
 
 		using (useDark ? ThemeHelper.UseDarkTheme() : null)
 		{
-			using (useFluent ? StyleHelper.UseFluentStyles() : null)
+			using (useFluent ? Disposable.Empty : StyleHelper.UseUwpStyles())
 			{
 				var stackPanel = (StackPanel)XamlReader.Load("""
 					<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
@@ -164,7 +165,7 @@ public class Given_Hyperlink
 		var expectedColor = (Color)XamlBindingHelper.ConvertValue(typeof(Color), expectedColorCode);
 		using (useDark ? ThemeHelper.UseDarkTheme() : null)
 		{
-			using (useFluent ? StyleHelper.UseFluentStyles() : null)
+			using (useFluent ? Disposable.Empty : StyleHelper.UseUwpStyles())
 			{
 				var tb = (TextBlock)XamlReader.Load("""
 					<TextBlock TextDecorations='Strikethrough' Foreground='Red' xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ObjectAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Animation/Given_ObjectAnimationUsingKeyFrames.cs
@@ -2,18 +2,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
-using Uno.UI.RuntimeTests.Helpers;
-using Windows.UI;
+using FluentAssertions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
-using FluentAssertions;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
 
 namespace Uno.UI.RuntimeTests
 {
@@ -25,25 +22,22 @@ namespace Uno.UI.RuntimeTests
 		[TestMethod]
 		public async Task When_Theme_Changed_Animated_Value()
 		{
-			using (UseFluentStyles())
+			var checkBox = new MyCheckBox() { Content = "CheckBox", IsEnabled = false };
+			TestServices.WindowHelper.WindowContent = checkBox;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.IsNotNull(checkBox.ContentPresenter);
+
+			var lightThemeForeground = TestsColorHelper.ToColor("#5C000000");
+			var darkThemeForeground = TestsColorHelper.ToColor("#5DFFFFFF");
+
+			Assert.AreEqual(lightThemeForeground, (checkBox.ContentPresenter.Foreground as SolidColorBrush).Color);
+
+			using (UseDarkTheme())
 			{
-				var checkBox = new MyCheckBox() { Content = "CheckBox", IsEnabled = false };
-				TestServices.WindowHelper.WindowContent = checkBox;
 				await TestServices.WindowHelper.WaitForIdle();
 
-				Assert.IsNotNull(checkBox.ContentPresenter);
-
-				var lightThemeForeground = TestsColorHelper.ToColor("#5C000000");
-				var darkThemeForeground = TestsColorHelper.ToColor("#5DFFFFFF");
-
-				Assert.AreEqual(lightThemeForeground, (checkBox.ContentPresenter.Foreground as SolidColorBrush).Color);
-
-				using (UseDarkTheme())
-				{
-					await TestServices.WindowHelper.WaitForIdle();
-
-					Assert.AreEqual(darkThemeForeground, (checkBox.ContentPresenter.Foreground as SolidColorBrush).Color);
-				}
+				Assert.AreEqual(darkThemeForeground, (checkBox.ContentPresenter.Foreground as SolidColorBrush).Color);
 			}
 		}
 
@@ -333,11 +327,6 @@ namespace Uno.UI.RuntimeTests
 		/// Ensure dark theme is applied for the course of a single test.
 		/// </summary>
 		private IDisposable UseDarkTheme() => ThemeHelper.UseDarkTheme();
-
-		/// <summary>
-		/// Ensure Fluent styles are available for the course of a single test.
-		/// </summary>
-		private IDisposable UseFluentStyles() => StyleHelper.UseFluentStyles();
 
 		// Intentionally nested to test NativeCtorsGenerator handling of nested classes.
 		public partial class MyCheckBox : CheckBox


### PR DESCRIPTION
GitHub Issue (If applicable): closes #15005

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

UWP by default


## What is the new behavior?

Fluent by default

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.