### PR TITLE
fix: Call Dispose instead of Destroy on `_videoWindow`

### DIFF
--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/VideoView.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Gtk/VideoView.cs
@@ -391,7 +391,7 @@ namespace Uno.UI.Media
 			if (_videoWindow is not null)
 			{
 				_videoWindow.Hide();
-				_videoWindow.Destroy();
+				_videoWindow.Dispose();
 				_videoWindow = null;
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

Somehow, there are still issues with MPE where the `ToggleRef` (internal Gtk# type) of `_videoWindow` can be freed twice. First free is unknown, but suspicion is it happens while destroying? Second free is from finalizer.

## What is the new behavior?

By calling Dispose, `Destroy` will internally be done properly, but also it will suppress finalization, which avoids the second free.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
