### PR TITLE
fix: Ensure `ToggleMenuFlyoutItem` is reported as toggle

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -423,6 +423,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 		}
 
+#if HAS_UNO
 		[TestMethod]
 		public async Task When_Toggle_Item_HasToggle()
 		{
@@ -462,5 +463,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				await TestServices.WindowHelper.WaitForIdle();
 			}
 		}
+#endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_MenuFlyout.cs
@@ -422,5 +422,45 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				}
 			}
 		}
+
+		[TestMethod]
+		public async Task When_Toggle_Item_HasToggle()
+		{
+			var toggleItem = new ToggleMenuFlyoutItem();
+			Assert.IsTrue(toggleItem.HasToggle());
+		}
+
+		[TestMethod]
+		public async Task When_Menu_Contains_Toggle()
+		{
+			var menu = new MenuFlyout();
+			menu.Items.Add(new MenuFlyoutItem() { Text = "Text" });
+
+			var trigger = new Button();
+			TestServices.WindowHelper.WindowContent = trigger;
+			await TestServices.WindowHelper.WaitForLoaded(trigger);
+
+			await ValidateToggleAsync(false);
+
+			var toggleItem = new ToggleMenuFlyoutItem() { Text = "Toggle!" };
+			menu.Items.Add(toggleItem);
+			await ValidateToggleAsync(true);
+
+			menu.Items.Remove(toggleItem);
+			await ValidateToggleAsync(false);
+
+			async Task ValidateToggleAsync(bool expected)
+			{
+				menu.ShowAt(trigger);
+				await TestServices.WindowHelper.WaitForIdle();
+				var popups = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot);
+				var popup = popups[0];
+				Assert.IsInstanceOfType(popup.Child, typeof(MenuFlyoutPresenter));
+				var presenter = (MenuFlyoutPresenter)popup.Child;
+				Assert.AreEqual(expected, presenter.GetContainsToggleItems());
+				popup.IsOpen = false;
+				await TestServices.WindowHelper.WaitForIdle();
+			}
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/ToggleMenuFlyoutItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/ToggleMenuFlyoutItem.cs
@@ -168,5 +168,7 @@ namespace Microsoft.UI.Xaml.Controls
 		// Create ToggleMenuFlyoutItemAutomationPeer to represent the 
 		protected override AutomationPeer OnCreateAutomationPeer()
 			=> new ToggleMenuFlyoutItemAutomationPeer(this);
+
+		internal override bool HasToggle() => true;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #15080

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Currently `ToggleMenuFlyoutItem` does not report as `HasToggle`

## What is the new behavior?

Fixed!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.