### PR TITLE
fix: ensure that not implemented events raise Uno0001

### DIFF
--- a/src/Uno.Analyzers.Tests/UnoNotImplementedTests.cs
+++ b/src/Uno.Analyzers.Tests/UnoNotImplementedTests.cs
@@ -81,6 +81,80 @@ namespace Uno.Analyzers.Tests
 		}
 
 		[TestMethod]
+		public async Task When_EventAddNotImplemented()
+		{
+			var test =
+				"""
+					using System;
+					using System.Collections.Generic;
+					using System.Linq;
+					using System.Text;
+					using System.Threading.Tasks;
+					using System.Diagnostics;
+
+					namespace Uno
+					{
+						public class TestClass 
+						{ 
+							[NotImplemented]
+							public event Action MyEvent;
+						}
+					}
+
+					namespace ConsoleApplication1
+					{
+					    class TypeName
+					    {
+					        public TypeName()
+					        {
+					           var a = new Uno.TestClass();
+							   [|a.MyEvent|] += delegate { };
+					        }
+					    }
+					}
+				""" + UnoNotImplementedAtribute;
+
+			await Verify.VerifyAnalyzerAsync(test);
+		}
+
+		[TestMethod]
+		public async Task When_EventRemoveNotImplemented()
+		{
+			var test =
+				"""
+					using System;
+					using System.Collections.Generic;
+					using System.Linq;
+					using System.Text;
+					using System.Threading.Tasks;
+					using System.Diagnostics;
+
+					namespace Uno
+					{
+						public class TestClass 
+						{ 
+							[NotImplemented]
+							public event Action MyEvent;
+						}
+					}
+
+					namespace ConsoleApplication1
+					{
+					    class TypeName
+					    {
+					        public TypeName()
+					        {
+					           var a = new Uno.TestClass();
+							   [|a.MyEvent|] -= delegate { };
+					        }
+					    }
+					}
+				""" + UnoNotImplementedAtribute;
+
+			await Verify.VerifyAnalyzerAsync(test);
+		}
+
+		[TestMethod]
 		public async Task When_SinglePlatform_Included()
 		{
 			var test = """

--- a/src/Uno.Analyzers/UnoNotImplementedAnalyzer.cs
+++ b/src/Uno.Analyzers/UnoNotImplementedAnalyzer.cs
@@ -47,7 +47,13 @@ namespace Uno.Analyzers
 					return;
 				}
 
-				context.RegisterOperationAction(c => AnalyzeOperation(c, notImplementedSymbol), OperationKind.Invocation, OperationKind.ObjectCreation, OperationKind.FieldReference, OperationKind.PropertyReference);
+				context.RegisterOperationAction(c =>
+					AnalyzeOperation(c, notImplementedSymbol)
+					, OperationKind.Invocation
+					, OperationKind.ObjectCreation
+					, OperationKind.FieldReference
+					, OperationKind.PropertyReference
+					, OperationKind.EventReference);
 			});
 		}
 
@@ -85,6 +91,7 @@ namespace Uno.Analyzers
 				IObjectCreationOperation objectCreation => objectCreation.Type,
 				IFieldReferenceOperation fieldReferenceOperation => fieldReferenceOperation.Field,
 				IPropertyReferenceOperation propertyReferenceOperation => propertyReferenceOperation.Property,
+				IEventReferenceOperation eventReferenceOperation => eventReferenceOperation.Event,
 				_ => throw new InvalidOperationException("This code path is unreachable.")
 			};
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/14702

## What is the new behavior?

Not implemented events are now flagged properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
