### PR TITLE
Include winappsdk-workaround for non-Single Project

### DIFF
--- a/global-net8.json
+++ b/global-net8.json
@@ -8,6 +8,7 @@
 		"dotnet": "8.0.100"
 	},
 	"msbuild-sdks": {
-		"MSBuild.Sdk.Extras": "3.0.44"
+		"MSBuild.Sdk.Extras": "3.0.44",
+		"Microsoft.Build.NoTargets": "3.7.56"
 	}
 }

--- a/global.json
+++ b/global.json
@@ -8,6 +8,7 @@
 		"dotnet": "7.0.302"
 	},
 	"msbuild-sdks": {
-		"MSBuild.Sdk.Extras": "3.0.44"
+		"MSBuild.Sdk.Extras": "3.0.44",
+		"Microsoft.Build.NoTargets": "3.7.56"
 	}
 }

--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -67,6 +67,8 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 				<EnableCoreMrtTooling Condition=" $(EnableCoreMrtTooling) == '' AND '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
 			</PropertyGroup>
 		</When>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browser'">
+		</When>
 	</Choose>
 
 	<!-- Taken from: https://github.com/dotnet/maui/blob/c02a6706534888ccea577d771c9edfc820bfc001/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets#L16C3-L26C15 -->

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -43,8 +43,9 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 
 		</When>
 		<When Condition="$(TargetFramework.Contains('windows10'))">
+			<!-- Workaround to avoid including Project XBFs in the PRI file: https://github.com/microsoft/microsoft-ui-xaml/issues/8857 -->
 			<Import Project="$(MSBuildThisFileDirectory)..\targets\winappsdk-workaround.targets"
-					Condition="'$(SingleProject)' != 'true'"/>
+					Condition="'$(SingleProject)' != 'true' and '$(DisableWinUI8857_Workaround)' != 'true' "/>
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browser'">
 		</When>

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -28,4 +28,26 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<!-- Removes native usings to avoid Ambiguous reference -->
 		<Using Remove="@(Using->HasMetadata('Platform'))" />
 	</ItemGroup>
+
+	<Choose>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+
+		</When>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+
+		</When>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
+
+		</When>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+
+		</When>
+		<When Condition="$(TargetFramework.Contains('windows10'))">
+			<Import Project="$(MSBuildThisFileDirectory)..\targets\winappsdk-workaround.targets"
+					Condition="'$(SingleProject)' != 'true'"/>
+		</When>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browser'">
+		</When>
+	</Choose>
+
 </Project>

--- a/src/Uno.Sdk/Uno.Sdk.csproj
+++ b/src/Uno.Sdk/Uno.Sdk.csproj
@@ -11,6 +11,7 @@
 
 	<ItemGroup>
 		<SdkFile Include="Sdk\**\*.targets;Sdk\**\*.props" />
+		<None Include="targets\**\*.props;targets\**\*.targets" Pack="true" PackagePath="targets/" />
 	</ItemGroup>
 
 	<Target Name="CopySdkFiles" BeforeTargets="Pack;ReplacePackageVersion">

--- a/src/Uno.Sdk/Uno.Sdk.csproj
+++ b/src/Uno.Sdk/Uno.Sdk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets/3.7.56">
+<Project Sdk="Microsoft.Build.NoTargets">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackageId>Uno.Sdk</PackageId>

--- a/src/Uno.Sdk/targets/winappsdk-workaround.targets
+++ b/src/Uno.Sdk/targets/winappsdk-workaround.targets
@@ -1,0 +1,21 @@
+<Project>
+	<!-- Workaround to avoid including Project XBFs in the PRI file -->
+	<Target Name="AdjustGetPackagingOutput1" AfterTargets="GetMrtPackagingOutputs">
+		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
+		<ItemGroup>
+			<_OtherPriFiles Include="@(PackagingOutputs)" Condition="'%(Extension)' == '.pri' and ('%(PackagingOutputs.ReferenceSourceTarget)' == 'ProjectReference' or '%(PackagingOutputs.NugetSourceType)'=='Package')" />
+			<PackagingOutputs Remove="@(_OtherPriFiles)" />
+		</ItemGroup>
+	</Target>
+	
+	<Target Name="AdjustGetPackagingOutput2" BeforeTargets="AddPriPayloadFilesToCopyToOutputDirectoryItems">
+		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
+		<ItemGroup>
+			<_OtherPriFiles1 Include="@(_ReferenceRelatedPaths)" Condition="'%(Extension)' == '.pri' and ('%(_ReferenceRelatedPaths.ReferenceSourceTarget)' == 'ProjectReference' or '%(_ReferenceRelatedPaths.NugetSourceType)'=='Package')" />
+			<_ReferenceRelatedPaths Remove="@(_OtherPriFiles1)" />
+
+			<_OtherPriFiles2 Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.pri' and ('%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference' or '%(ReferenceCopyLocalPaths.NugetSourceType)'=='Package')" />
+			<ReferenceCopyLocalPaths Remove="@(_OtherPriFiles2)" />
+		</ItemGroup>
+	</Target>
+</Project>

--- a/src/Uno.Sdk/targets/winappsdk-workaround.targets
+++ b/src/Uno.Sdk/targets/winappsdk-workaround.targets
@@ -1,6 +1,6 @@
 <Project>
-	<!-- Workaround to avoid including Project XBFs in the PRI file -->
-	<Target Name="AdjustGetPackagingOutput1" AfterTargets="GetMrtPackagingOutputs">
+	<!-- Workaround to avoid including Project XBFs in the PRI file: https://github.com/microsoft/microsoft-ui-xaml/issues/8857 -->
+	<Target Name="WinUI8857_AdjustGetPackagingOutput1" AfterTargets="GetMrtPackagingOutputs">
 		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
 		<ItemGroup>
 			<_OtherPriFiles Include="@(PackagingOutputs)" Condition="'%(Extension)' == '.pri' and ('%(PackagingOutputs.ReferenceSourceTarget)' == 'ProjectReference' or '%(PackagingOutputs.NugetSourceType)'=='Package')" />
@@ -8,7 +8,7 @@
 		</ItemGroup>
 	</Target>
 	
-	<Target Name="AdjustGetPackagingOutput2" BeforeTargets="AddPriPayloadFilesToCopyToOutputDirectoryItems">
+	<Target Name="WinUI8857_AdjustGetPackagingOutput2" BeforeTargets="AddPriPayloadFilesToCopyToOutputDirectoryItems">
 		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
 		<ItemGroup>
 			<_OtherPriFiles1 Include="@(_ReferenceRelatedPaths)" Condition="'%(Extension)' == '.pri' and ('%(_ReferenceRelatedPaths.ReferenceSourceTarget)' == 'ProjectReference' or '%(_ReferenceRelatedPaths.NugetSourceType)'=='Package')" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

n/a

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Projects using Uno.Sdk do not apply the winappsdk workarounds and may have issues with the PRI resources

## What is the new behavior?

We now include the winappsdk workarounds when SingleProject is not true, and the target framework is windows10

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
