### PR TITLE
fix: Fix IR not reflecting CollectionChanged.Update raised while being unloaded

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.Foundation;
 using Windows.UI;
 using Microsoft/* UWP don't rename */.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -309,6 +310,183 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 			source.Clear();
 			await TestServices.WindowHelper.WaitForIdle();
 			sut.Children.Count(elt => elt.ActualOffset.X >= 0).Should().Be(0);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#elif __ANDROID__ || __SKIA__
+		[Ignore("Currently fails https://github.com/unoplatform/uno/issues/9080")]
+#endif
+		public async Task When_UnloadAndReload_Then_ReMaterializeItems()
+		{
+			var sut = SUT.Create(5000, new Size(250, 500));
+
+			await sut.Load();
+
+			var topItems = sut.MaterializedItems.ToArray();
+
+			sut.Scroller.ChangeView(null, sut.Scroller.ExtentHeight / 2, null, disableAnimation: true);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var middleItems = sut.MaterializedItems.ToArray();
+			middleItems.Should().NotContain(topItems);
+
+			await sut.Unload();
+			await sut.Load();
+
+			var reloadedItems = sut.MaterializedItems.ToArray();
+			reloadedItems.Count(item => middleItems.Contains(item)).Should().BeGreaterThan(2);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task When_AddItemWhileUnloaded_Then_MaterializeItems()
+		{
+			var sut = SUT.Create();
+
+			await sut.Load();
+
+			sut.Materialized.Should().Be(3);
+
+			await sut.Unload();
+
+			sut.Source.Add("Additional item");
+
+			await sut.Load();
+
+			sut.Materialized.Should().Be(4);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task When_RemoveItemWhileUnloaded_Then_MaterializeItems()
+		{
+			var sut = SUT.Create();
+
+			await sut.Load();
+
+			sut.Materialized.Should().Be(3);
+
+			await sut.Unload();
+
+			sut.Source.RemoveAt(1);
+
+			await sut.Load();
+
+			sut.Materialized.Should().Be(2);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task When_EditItemWhileUnloaded_Then_MaterializeItems()
+		{
+			var sut = SUT.Create();
+
+			await sut.Load();
+
+			sut.Materialized.Should().Be(3);
+
+			await sut.Unload();
+
+			sut.Source[1] = "Item #1 - Edited";
+
+			await sut.Load();
+
+			sut.Repeater.Children.FirstOrDefault(g => g.DataContext as string == "Item #1 - Edited").Should().NotBeNull();
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task When_ClearItemsWhileUnloaded_Then_MaterializeItems()
+		{
+			var sut = SUT.Create();
+
+			await sut.Load();
+
+			sut.Materialized.Should().Be(3);
+
+			await sut.Unload();
+
+			sut.Source.Clear();
+
+			await sut.Load();
+
+			sut.Materialized.Should().Be(0);
+		}
+
+		private record SUT(Border Root, ScrollViewer Scroller, ItemsRepeater Repeater, ObservableCollection<string> Source)
+		{
+			public static SUT Create(int itemsCount = 3, Size? viewport = default)
+			{
+				var repeater = default(ItemsRepeater);
+				var scroller = default(ScrollViewer);
+				var source = new ObservableCollection<string>(Enumerable.Range(0, itemsCount).Select(i => $"Item #{i}"));
+				var root = new Border
+				{
+					BorderThickness = new Thickness(5),
+					BorderBrush = new SolidColorBrush(Colors.Purple),
+					Child = (scroller = new ScrollViewer
+					{
+						Content = (repeater = new ItemsRepeater
+						{
+							ItemsSource = source,
+							Layout = new StackLayout(),
+							ItemTemplate = new DataTemplate(() => new Border
+							{
+								Width = 100,
+								Height = 100,
+								Background = new SolidColorBrush(Colors.DeepSkyBlue),
+								Margin = new Thickness(10),
+								Child = new TextBlock().Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding()))
+							})
+						})
+					})
+				};
+
+				if (viewport is not null)
+				{
+					root.Height = viewport.Value.Height;
+					root.Width = viewport.Value.Width;
+				}
+
+				return new(root, scroller, repeater, source);
+			}
+
+			public int Materialized => Repeater.Children.Count(elt => elt.ActualOffset.X >= 0);
+
+			public IEnumerable<string> MaterializedItems => Repeater.Children.Where(elt => elt.ActualOffset.X >= 0).Select(elt => elt.DataContext?.ToString());
+
+			public async ValueTask Load()
+			{
+				Root.Child = Scroller;
+				if (TestServices.WindowHelper.WindowContent != Root)
+				{
+					TestServices.WindowHelper.WindowContent = Root;
+				}
+				await TestServices.WindowHelper.WaitForIdle();
+				Repeater.IsLoaded.Should().BeTrue();
+			}
+
+			public async ValueTask Unload()
+			{
+				Root.Child = new TextBlock { Text = "IR unloaded" };
+				await TestServices.WindowHelper.WaitForIdle();
+				Repeater.IsLoaded.Should().BeFalse();
+			}
 		}
 #endif
 	}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
@@ -662,6 +662,15 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 			// because ItemsRepeater uses a "singleton" instance of default StackLayout.
 			_layoutSubscriptionsRevoker.Disposable = null;
 			_dataSourceSubscriptionsRevoker.Disposable = null;
+			if (m_itemsSourceView is not null)
+			{
+				// We will no longer receive the element changes until next load.
+				// While add and remove will be detected on next layout pass, a replace would not be reflected in the UI.
+				// To fix that, we send a fake reset collection changed in order to mark all containers as recyclable.
+				// Note: We do it on unload rather than on load because we want to avoid multiple layout-pass on next load.
+				//		 This is expected to only flag containers as recyclable and should not have any significant perf impact.
+				OnItemsSourceViewChanged(m_itemsSourceView, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+			}
 #endif
 		}
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.extensions/issues/2123

## Bugfix
Fix IR not reflecting CollectionChanged.Update raised while being unloaded

## What is the current behavior?
Add and Remove changes raised while being unloaded are detected, but not update.

## What is the new behavior?
We mark all containers as recyclable on unload, driving the IR to assign all containers on reload.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
