### PR TITLE
Adding Cross Targeting and default Includes

### DIFF
--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -22,6 +22,8 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<IsIOSOrCatalyst>false</IsIOSOrCatalyst>
 		<IsWinAppSdk>false</IsWinAppSdk>
 		<UnoVersion>DefaultUnoVersion</UnoVersion>
+
+    	<EnableDefaultUnoItems Condition=" '$(EnableDefaultUnoItems)' == '' ">$(EnableDefaultItems)</EnableDefaultUnoItems>
 	</PropertyGroup>
 
 	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props"  Condition=" $(_UnoImportMicrosoftNETSdkTargets) " />
@@ -74,7 +76,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		</When>
 	</Choose>
 
-	<ItemGroup>
+	<ItemGroup Condition=" $(EnableDefaultUnoItems) == 'true' ">
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 	</ItemGroup>
 

--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -19,6 +19,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<IsIOS>false</IsIOS>
 		<IsMac>false</IsMac>
 		<IsMacCatalyst>false</IsMacCatalyst>
+		<IsIOSOrCatalyst>false</IsIOSOrCatalyst>
 		<IsWinAppSdk>false</IsWinAppSdk>
 		<UnoVersion>DefaultUnoVersion</UnoVersion>
 	</PropertyGroup>
@@ -41,6 +42,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
 			<PropertyGroup>
+				<IsIOSOrCatalyst>true</IsIOSOrCatalyst>
 				<IsIOS>true</IsIOS>
 				<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">14.2</SupportedOSPlatformVersion>
 			</PropertyGroup>
@@ -53,6 +55,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
 			<PropertyGroup>
+				<IsIOSOrCatalyst>true</IsIOSOrCatalyst>
 				<IsMacCatalyst>true</IsMacCatalyst>
 				<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">14.0</SupportedOSPlatformVersion>
 			</PropertyGroup>

--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -74,6 +74,10 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		</When>
 	</Choose>
 
+	<ItemGroup>
+		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+	</ItemGroup>
+
 	<!-- Taken from: https://github.com/dotnet/maui/blob/c02a6706534888ccea577d771c9edfc820bfc001/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets#L16C3-L26C15 -->
 	<!-- SingleProject-specific features -->
 	<ItemGroup Condition=" '$(SingleProject)' == 'true' ">

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -76,7 +76,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<Error Condition=" '$(UnoVersion)' != 'DefaultUnoVersion' " Text="Do not override the '%24(UnoVersion)'. The '%24(UnoVersion)' must match the version of the Uno.Sdk." />
 
 		<!-- Check if the Uno.WinUI version matches DefaultUnoVersion -->
-		<Error Text="The resolved version of Uno.WinUI does not match DefaultUnoVersion. The Version of Uno.WinUI must match the version of the Uno.Sdk."
+		<Error Text="The resolved version of Uno.WinUI does not match DefaultUnoVersion. The Version of Uno.WinUI must match the version of the Uno.Sdk.  For more information about updating Uno Platform versions, visit https://aka.platform.uno/migrate-from-previous"
 			Condition="$([System.IO.Path]::GetFileName($(PkgUno_WinUI))) != 'DefaultUnoVersion'" />
 	</Target>
 </Project>

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -29,6 +29,8 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<Using Remove="@(Using->HasMetadata('Platform'))" />
 	</ItemGroup>
 
+	<Import Project="$(MSBuildThisFileDirectory)../targets/Uno.CrossTargeting.targets" />
+
 	<Choose>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
 

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -69,11 +69,14 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 	</Choose>
 
 	<!-- Uno Developers should comment this target out if they need to override UnoVersion for dev testing -->
-	<Target Name="UnoSdkVersionCheck">
-		<Error Condition=" '$(UnoVersion)' != 'DefaultUnoVersion' " Text="Do not override the 'UnoVersion'. The 'UnoVersion' must match the version of the Uno.Sdk." />
+	<Target Name="UnoSdkVersionCheck"
+			AfterTargets="ResolveReferences"
+			BeforeTargets="Build"
+			Condition="'$(PkgUno_WinUI)' != ''">
+		<Error Condition=" '$(UnoVersion)' != 'DefaultUnoVersion' " Text="Do not override the '%24(UnoVersion)'. The '%24(UnoVersion)' must match the version of the Uno.Sdk." />
 
 		<!-- Check if the Uno.WinUI version matches DefaultUnoVersion -->
-		<Error Text="Resolved version of Uno.WinUI does not match DefaultUnoVersion."
-			Condition="'@(UnoWinUIPackageReference->'%(Version)')' != 'DefaultUnoVersion'" />
+		<Error Text="The resolved version of Uno.WinUI does not match DefaultUnoVersion. The Version of Uno.WinUI must match the version of the Uno.Sdk."
+			Condition="$([System.IO.Path]::GetFileName($(PkgUno_WinUI))) != 'DefaultUnoVersion'" />
 	</Target>
 </Project>

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -41,7 +41,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(PkgUno_Resizetizer)'!='' ">
-		<UnoImage Include="Assets\**\*.svg" Exclude="$(UnoImage)" />
+		<UnoImage Include="Assets\**\*.svg" Exclude="@(UnoImage)" />
 	</ItemGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)../targets/Uno.CrossTargeting.targets" />

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -29,6 +29,21 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<Using Remove="@(Using->HasMetadata('Platform'))" />
 	</ItemGroup>
 
+	<ItemGroup Condition=" !$(IsWinAppSdk) ">
+		<!-- Include all images by default - matches the __WindowsAppSdkDefaultImageIncludes property in the WindowsAppSDK -->
+		<Content Include="Assets\**;**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif" 
+			Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);**\*.svg" />
+		<Page Include="**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Update="**\*.xaml.cs">
+			<DependentUpon>%(Filename)</DependentUpon>
+		</Compile>
+		<PRIResource Include="**\*.resw" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(PkgUno_Resizetizer)'!='' ">
+		<UnoImage Include="Assets\**\*.svg" Exclude="$(UnoImage)" />
+	</ItemGroup>
+
 	<Import Project="$(MSBuildThisFileDirectory)../targets/Uno.CrossTargeting.targets" />
 
 	<Choose>
@@ -53,14 +68,9 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		</When>
 	</Choose>
 
-
 	<!-- Uno Developers should comment this target out if they need to override UnoVersion for dev testing -->
 	<Target Name="UnoSdkVersionCheck">
 		<Error Condition=" '$(UnoVersion)' != 'DefaultUnoVersion' " Text="Do not override the 'UnoVersion'. The 'UnoVersion' must match the version of the Uno.Sdk." />
-		<ItemGroup>
-			<UnoWinUIPackageReference Include="@(PackageReference)"
-				Condition=" '%(PackageReference.Identity)' == 'Uno.WinUI' " />
-		</ItemGroup>
 
 		<!-- Check if the Uno.WinUI version matches DefaultUnoVersion -->
 		<Error Text="Resolved version of Uno.WinUI does not match DefaultUnoVersion."

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -29,7 +29,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<Using Remove="@(Using->HasMetadata('Platform'))" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" !$(IsWinAppSdk) ">
+	<ItemGroup Condition=" !$(IsWinAppSdk) AND $(EnableDefaultUnoItems) == 'true' ">
 		<!-- Include all images by default - matches the __WindowsAppSdkDefaultImageIncludes property in the WindowsAppSDK -->
 		<Content Include="Assets\**;**/*.png;**/*.bmp;**/*.jpg;**/*.dds;**/*.tif;**/*.tga;**/*.gif" 
 			Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);**\*.svg" />

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -47,24 +47,28 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)../targets/Uno.CrossTargeting.targets" />
 
 	<Choose>
-		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-
+		<!-- <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
-
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-
-		</When>
+		</When> -->
 		<When Condition="$(TargetFramework.Contains('windows10'))">
+			<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.WinAppSdk.targets"
+					Condition=" $(SingleProject) == 'true' " />
 			<!-- Workaround to avoid including Project XBFs in the PRI file: https://github.com/microsoft/microsoft-ui-xaml/issues/8857 -->
 			<Import Project="$(MSBuildThisFileDirectory)..\targets\winappsdk-workaround.targets"
 					Condition="'$(SingleProject)' != 'true' and '$(DisableWinUI8857_Workaround)' != 'true' "/>
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browser'">
+			<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.Wasm.targets"
+					Condition=" $(SingleProject) == 'true' " />
+		</When>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'skia'">
+			<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.Skia.targets"
+					Condition=" $(SingleProject) == 'true' " />
 		</When>
 	</Choose>
 

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -53,4 +53,17 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		</When>
 	</Choose>
 
+
+	<!-- Uno Developers should comment this target out if they need to override UnoVersion for dev testing -->
+	<Target Name="UnoSdkVersionCheck">
+		<Error Condition=" '$(UnoVersion)' != 'DefaultUnoVersion' " Text="Do not override the 'UnoVersion'. The 'UnoVersion' must match the version of the Uno.Sdk." />
+		<ItemGroup>
+			<UnoWinUIPackageReference Include="@(PackageReference)"
+				Condition=" '%(PackageReference.Identity)' == 'Uno.WinUI' " />
+		</ItemGroup>
+
+		<!-- Check if the Uno.WinUI version matches DefaultUnoVersion -->
+		<Error Text="Resolved version of Uno.WinUI does not match DefaultUnoVersion."
+			Condition="'@(UnoWinUIPackageReference->'%(Version)')' != 'DefaultUnoVersion'" />
+	</Target>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.CrossTargetting.targets
+++ b/src/Uno.Sdk/targets/Uno.CrossTargetting.targets
@@ -5,7 +5,7 @@
 		<IsCrossruntime Condition="'$(UnoRuntimeIdentifier)'=='Skia' or '$(UnoRuntimeIdentifier)'=='WebAssembly' or '$(UnoRuntimeIdentifier)'=='Reference'">true</IsCrossruntime>
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition=" $(EnableDefaultUnoItems) == 'true' ">
 		<None Include="**\*.crossruntime.cs" Exclude="bin\**\*.crossruntime.cs;obj\**\*.crossruntime.cs" Condition="!$(IsCrossruntime)" />
 		<Compile Remove="**\*.crossruntime.cs" Condition="!$(IsCrossruntime)" />
 

--- a/src/Uno.Sdk/targets/Uno.CrossTargetting.targets
+++ b/src/Uno.Sdk/targets/Uno.CrossTargetting.targets
@@ -1,0 +1,34 @@
+﻿<Project>
+
+	<PropertyGroup Condition="'$(IsCrossruntime)' == ''">
+		<IsCrossruntime>false</IsCrossruntime>
+		<IsCrossruntime Condition="'$(UnoRuntimeIdentifier)'=='Skia' or '$(UnoRuntimeIdentifier)'=='WebAssembly' or '$(UnoRuntimeIdentifier)'=='Reference'">true</IsCrossruntime>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="**\*.crossruntime.cs" Exclude="bin\**\*.crossruntime.cs;obj\**\*.crossruntime.cs" Condition="!$(IsCrossruntime)" />
+		<Compile Remove="**\*.crossruntime.cs" Condition="!$(IsCrossruntime)" />
+
+		<None Include="**\*.wasm.cs" Exclude="bin\**\*.wasm.cs;obj\**\*.wasm.cs" Condition="'$(UnoRuntimeIdentifier)'!='WebAssembly'" />
+		<Compile Remove="**\*.wasm.cs" Condition="'$(UnoRuntimeIdentifier)'!='WebAssembly'" />
+
+		<None Include="**\*.skia.cs" Exclude="bin\**\*.skia.cs;obj\**\*.skia.cs" Condition="'$(UnoRuntimeIdentifier)'!='Skia'" />
+		<Compile Remove="**\*.skia.cs" Condition="'$(UnoRuntimeIdentifier)'!='Skia'" />
+
+		<None Include="**\*.reference.cs" Exclude="bin\**\*.reference.cs;obj\**\*.reference.cs" Condition="'$(UnoRuntimeIdentifier)'!='Reference'" />
+		<Compile Remove="**\*.reference.cs" Condition="'$(UnoRuntimeIdentifier)'!='Reference'" />
+
+		<None Include="**\*.iOS.cs" Exclude="bin\**\*.iOS.cs;obj\**\*.iOS.cs" Condition="!$(IsIOSOrCatalyst)" />
+		<Compile Remove="**\*.iOS.cs" Condition="!$(IsIOSOrCatalyst)" />
+
+		<None Include="**\*.macOS.cs" Exclude="bin\**\*.macOS.cs;obj\**\*.macOS.cs" Condition="!$(IsMacOS)" />
+		<Compile Remove="**\*.macOS.cs" Condition="!$(IsMacOS)" />
+
+		<None Include="**\*.iOSmacOS.cs" Exclude="bin\**\*.iOSmacOS.cs;obj\**\*.iOSmacOS.cs" Condition="!$(IsMacOS) and !$(IsIOSOrCatalyst)" />
+		<Compile Remove="**\*.iOSmacOS.cs" Condition="!$(IsMacOS) and !$(IsIOSOrCatalyst)" />
+
+		<None Include="**\*.Android.cs" Exclude="bin\**\*.Android.cs;obj\**\*.Android.cs" Condition="!$(IsAndroid)" />
+		<Compile Remove="**\*.Android.cs" Condition="!$(IsAndroid)" />
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Skia.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Skia.targets
@@ -1,0 +1,3 @@
+<Project>
+
+</Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Wasm.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Wasm.targets
@@ -1,0 +1,3 @@
+<Project>
+
+</Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.WinAppSdk.targets
@@ -1,0 +1,3 @@
+<Project>
+
+</Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Project must provide includes for Pages, file nesting for XAML files 

## What is the new behavior?

The Sdk now automatically provides correct default includes matching what WinUI does. Also adds the Cross Targeting includes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


## Other information

n/a

Internal Issue (If applicable):

n/a
