### PR TITLE
Fixes Targets Imports

### DIFF
--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -17,16 +17,21 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 
 		<IsAndroid>false</IsAndroid>
 		<IsIOS>false</IsIOS>
-		<IsMac>false</IsMac>
+		<IsMacOS>false</IsMacOS>
 		<IsMacCatalyst>false</IsMacCatalyst>
 		<IsIOSOrCatalyst>false</IsIOSOrCatalyst>
 		<IsWinAppSdk>false</IsWinAppSdk>
+		<IsBrowser>false</IsBrowser>
+		<IsSkia>false</IsSkia>
 		<UnoVersion>DefaultUnoVersion</UnoVersion>
-
-    	<EnableDefaultUnoItems Condition=" '$(EnableDefaultUnoItems)' == '' ">$(EnableDefaultItems)</EnableDefaultUnoItems>
 	</PropertyGroup>
 
 	<Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props"  Condition=" $(_UnoImportMicrosoftNETSdkTargets) " />
+
+	<PropertyGroup>
+		<EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
+		<EnableDefaultUnoItems Condition=" '$(EnableDefaultUnoItems)' == '' ">$(EnableDefaultItems)</EnableDefaultUnoItems>
+	</PropertyGroup>
 
 	 <Choose>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
@@ -51,7 +56,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
 			<PropertyGroup>
-				<IsMac>true</IsMac>
+				<IsMacOS>true</IsMacOS>
 				<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">10.14</SupportedOSPlatformVersion>
 			</PropertyGroup>
 		</When>
@@ -73,6 +78,14 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 			</PropertyGroup>
 		</When>
 		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browser'">
+			<PropertyGroup>
+				<IsBrowser>true</IsBrowser>
+			</PropertyGroup>
+		</When>
+		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'skia'">
+			<PropertyGroup>
+				<IsSkia>true</IsSkia>
+			</PropertyGroup>
 		</When>
 	</Choose>
 

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -44,33 +44,23 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<UnoImage Include="Assets\**\*.svg" Exclude="@(UnoImage)" />
 	</ItemGroup>
 
-	<Import Project="$(MSBuildThisFileDirectory)../targets/Uno.CrossTargeting.targets" />
+	<!-- Cross Targetting -->
+	<Import Project="$(MSBuildThisFileDirectory)../targets/Uno.CrossTargetting.targets" />
 
-	<Choose>
-		<!-- <When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-		</When>
-		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
-		</When>
-		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
-		</When>
-		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-		</When> -->
-		<When Condition="$(TargetFramework.Contains('windows10'))">
-			<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.WinAppSdk.targets"
-					Condition=" $(SingleProject) == 'true' " />
-			<!-- Workaround to avoid including Project XBFs in the PRI file: https://github.com/microsoft/microsoft-ui-xaml/issues/8857 -->
-			<Import Project="$(MSBuildThisFileDirectory)..\targets\winappsdk-workaround.targets"
-					Condition="'$(SingleProject)' != 'true' and '$(DisableWinUI8857_Workaround)' != 'true' "/>
-		</When>
-		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browser'">
-			<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.Wasm.targets"
-					Condition=" $(SingleProject) == 'true' " />
-		</When>
-		<When Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'skia'">
-			<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.Skia.targets"
-					Condition=" $(SingleProject) == 'true' " />
-		</When>
-	</Choose>
+	<!-- WinUI -->
+	<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.WinAppSdk.targets"
+			Condition=" $(IsWinAppSdk) AND $(SingleProject) == 'true' " />
+	<!-- Workaround to avoid including Project XBFs in the PRI file: https://github.com/microsoft/microsoft-ui-xaml/issues/8857 -->
+	<!-- <Import Project="$(MSBuildThisFileDirectory)..\targets\winappsdk-workaround.targets"
+			Condition=" $(IsWinAppSdk) AND '$(SingleProject)' != 'true' and '$(DisableWinUI8857_Workaround)' != 'true' "/> -->
+
+	<!-- WASM -->
+	<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.Wasm.targets"
+			Condition=" $(IsBrowser) AND $(SingleProject) == 'true' " />
+
+	<!-- Skia -->
+	<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.Skia.targets"
+			Condition=" $(IsSkia) AND $(SingleProject) == 'true' " />
 
 	<!-- Uno Developers should comment this target out if they need to override UnoVersion for dev testing -->
 	<Target Name="UnoSdkVersionCheck"

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -51,8 +51,8 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.WinAppSdk.targets"
 			Condition=" $(IsWinAppSdk) AND $(SingleProject) == 'true' " />
 	<!-- Workaround to avoid including Project XBFs in the PRI file: https://github.com/microsoft/microsoft-ui-xaml/issues/8857 -->
-	<!-- <Import Project="$(MSBuildThisFileDirectory)..\targets\winappsdk-workaround.targets"
-			Condition=" $(IsWinAppSdk) AND '$(SingleProject)' != 'true' and '$(DisableWinUI8857_Workaround)' != 'true' "/> -->
+	<Import Project="$(MSBuildThisFileDirectory)..\targets\winappsdk-workaround.targets"
+			Condition=" $(IsWinAppSdk) AND '$(SingleProject)' != 'true' and '$(DisableWinUI8857_Workaround)' != 'true' "/>
 
 	<!-- WASM -->
 	<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.Wasm.targets"

--- a/src/Uno.Sdk/Uno.Sdk.csproj
+++ b/src/Uno.Sdk/Uno.Sdk.csproj
@@ -33,6 +33,18 @@
 		</ItemGroup>
 	</Target>
 
+	<Target Name="DeleteCachedPackage" Condition="'$(CI)' != 'true'" BeforeTargets="Pack">
+		<ItemGroup>
+			<ToDelete Include="$(PackageOutputPath)\$(PackageId).$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch)*.*" />
+			<ToDelete Include="$(LocalArtifactStagingDirectory)\$(PackageId).$(GitBaseVersionMajor).$(GitBaseVersionMinor).*" />
+		</ItemGroup>
+		<Delete Files="@(ToDelete)" />
+		<Exec Command='rd "$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())" /q /s'
+			Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())') And '$(OS)' == 'Windows_NT'" />
+		<Exec Command='rm -rf "$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())"'
+			Condition="Exists('$(NuGetPackageRoot)$(PackageId.ToLowerInvariant())') And '$(OS)' != 'Windows_NT'" />
+	</Target>
+
 	<!-- Using Regex Replace prevents XmlPoke from replacing Tabs with Spaces -->
 	<UsingTask TaskName="ReplaceFileText" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
 		<ParameterGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Targets are imported from within a Choose block

## What is the new behavior?

The Choose block has been removed and the targets are now imported based on the Platform variable set in the props

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


