### PR TITLE
feat: Restore support for C# Hot Reload for XAML for mobile targets

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.PartialReload.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.PartialReload.cs
@@ -40,12 +40,13 @@ namespace Uno.UI.RemoteControl.HotReload
 					//
 					// Disabled until https://github.com/dotnet/runtime/issues/93860 is fixed
 					//
-					//(Debugger.IsAttached
-					//	&& (targetFramework.Contains("-android") || targetFramework.Contains("-ios")))
-					//||
+					(Debugger.IsAttached
+						&& IsIssue93860Fixed()
+						&& (targetFramework.Contains("-android")
+							|| targetFramework.Contains("-ios")))
 
 					// WebAssembly does not support sending updated types, and does not support debugger based hot reload.
-					(unoRuntimeIdentifier?.Equals("WebAssembly", StringComparison.OrdinalIgnoreCase) ?? false));
+					|| (unoRuntimeIdentifier?.Equals("WebAssembly", StringComparison.OrdinalIgnoreCase) ?? false));
 
 			if (this.Log().IsEnabled(LogLevel.Trace))
 			{
@@ -53,7 +54,8 @@ namespace Uno.UI.RemoteControl.HotReload
 					$"unoRuntimeIdentifier:{unoRuntimeIdentifier} " +
 					$"targetFramework:{targetFramework} " +
 					$"buildingInsideVisualStudio:{targetFramework} " +
-					$"debuggerAttached:{Debugger.IsAttached}");
+					$"debuggerAttached:{Debugger.IsAttached} " +
+					$"IsIssue93860Fixed:{IsIssue93860Fixed()}");
 			}
 
 			_mappedTypes = _supportsLightweightHotReload

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -40,7 +40,10 @@ namespace Uno.UI.RemoteControl.HotReload
 	{
 		private string? _lastUpdatedFilePath;
 		private bool _supportsXamlReader;
+
+#if __IOS__ || __CATALYST__ || __ANDROID__
 		private bool? _isIssue93860Fixed;
+#endif
 
 		private void InitializeXamlReader()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/discussions/15044

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores support for C# HotReload for builds after 8.0.101

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
