### PR TITLE
Adding Manifest defaults for WinUI

### DIFF
--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -68,6 +68,18 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 				<EnableWindowsTargeting Condition=" $(EnableWindowsTargeting) == '' ">true</EnableWindowsTargeting>
 			</PropertyGroup>
 
+			<PropertyGroup Condition="$(SingleProject)!='true' and $(OutputType)=='WinExe'">
+				<ApplicationManifest Condition=" $(ApplicationManifest) == '' ">app.manifest</ApplicationManifest>
+				<Platforms Condition=" $(Platforms) == '' ">x86;x64;arm64</Platforms>
+				<PublishProfile Condition=" $(PublishProfile) == '' ">win-$(Platform).pubxml</PublishProfile>
+				<UseWinUI Condition=" $(UseWinUI) == '' ">true</UseWinUI>
+			</PropertyGroup>
+
+			<ItemGroup Condition="$(SingleProject)!='true' and $(OutputType)=='WinExe'">
+				<!-- Exclude Manifest items that have already been added to avoid duplicates -->
+				<Manifest Include="$(ApplicationManifest)" Exclude="@(Manifest)" />
+			</ItemGroup>
+
 			<!--
 				Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
 				Tools extension to be activated for this project even if the Windows App SDK Nuget


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

A number of properties for the Manifest and setting the default platforms, etc all exist within the project head.


## What is the new behavior?

We now provide default values for this in the SDK

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
