### PR TITLE
fix: Don't include uno binaries in netx.y-windows and uap builds

### DIFF
--- a/build/nuget/Uno.WinUI.Lottie.nuspec
+++ b/build/nuget/Uno.WinUI.Lottie.nuspec
@@ -155,6 +155,10 @@
 
 		<!-- net7.0 Skia -->
 		<file src="..\..\src\AddIns\Uno.UI.Lottie\Bin\Uno.UI.Lottie.Skia\Release\net7.0\Uno.UI.Lottie.*" target="uno-runtime\net7.0\skia" />
-
+		
+		<!-- Force UAP/netx-win to ignore netX.0 -->
+		<file src="_._" target="build\uap10.0.16299" />
+		<file src="_._" target="build\uap10.0.19041" />
+		<file src="_._" target="build\net7.0-windows" />
 	</files>
 </package>


### PR DESCRIPTION
Related https://github.com/unoplatform/uno.templates/pull/510

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Including the uno lottie package in windows and uap heads win't fail with invalid uno references.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
