### PR TITLE
Align Project Capabilities

### DIFF
--- a/build/nuget/uno.winui.single-project.targets
+++ b/build/nuget/uno.winui.single-project.targets
@@ -100,7 +100,7 @@
 	</ItemGroup>
 
 	<Choose>
-		<When Condition="'$(_UnoIsWinAppSDKDefined)'!='true'">
+		<When Condition="'$(_UnoIsWinAppSDKDefined)'!='true' and $(UsingUnoSdk) != 'true'">
 			<!-- IDE capabilities -->
 
 			<!-- Sync with https://github.com/dotnet/maui/blob/ffab30545ac146710a9ee61138be33e52ca4b326/src/Templates/src/templates/maui-mobile/Directory.Build.targets -->

--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -24,8 +24,8 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<UsingUnoSdk>true</UsingUnoSdk>
 		<UnoVersion>DefaultUnoVersion</UnoVersion>
 
-		<CustomAfterDirectoryBuildProps>$(CustomAfterDirectoryBuildProps);$(MSBuildThisFileDirectory)..\targets\Uno.Import.SolutionConfig.props</CustomAfterDirectoryBuildProps>
-		<CustomAfterDirectoryBuildProps>$(CustomAfterDirectoryBuildProps);$(MSBuildThisFileDirectory)..\targets\Uno.IsPlatform.props</CustomAfterDirectoryBuildProps>
+		<CustomAfterDirectoryBuildProps>$(CustomAfterDirectoryBuildProps);$([MSBuild]::GetPathOfFileAbove('Uno.Import.SolutionConfig.props', '$(MSBuildThisFileDirectory)..\targets'))</CustomAfterDirectoryBuildProps>
+		<CustomAfterDirectoryBuildProps>$(CustomAfterDirectoryBuildProps);$([MSBuild]::GetPathOfFileAbove('Uno.IsPlatform.props', '$(MSBuildThisFileDirectory)..\targets'))</CustomAfterDirectoryBuildProps>
 	</PropertyGroup>
 
 	<Import Sdk="$(_DefaultMicrosoftNETSdk)" Project="Sdk.props" />

--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -16,6 +16,12 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 	</PropertyGroup>
 
 	<PropertyGroup>
+		<!--
+			Indicate to other targets that Uno.Sdk is being used.
+			This should be set as early as possible to ensure that Uno.WinUI targets do not
+			override or add additional project capabilities.
+		-->
+		<UsingUnoSdk>true</UsingUnoSdk>
 		<UnoVersion>DefaultUnoVersion</UnoVersion>
 
 		<CustomAfterDirectoryBuildProps>$(CustomAfterDirectoryBuildProps);$(MSBuildThisFileDirectory)..\targets\Uno.Import.SolutionConfig.props</CustomAfterDirectoryBuildProps>

--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
@@ -1,8 +1,14 @@
 <Project>
+	<!-- Sync with https://github.com/dotnet/maui/blob/ffab30545ac146710a9ee61138be33e52ca4b326/src/Templates/src/templates/maui-mobile/Directory.Build.targets -->
+	<PropertyGroup Condition="!$(IsWinAppSdk)">
+		<!-- Required - Enable Launch Profiles for .NET 6 iOS/Android -->
+		<_KeepLaunchProfiles>true</_KeepLaunchProfiles>
+	</PropertyGroup>
+
 	<!-- Taken from: https://github.com/dotnet/maui/blob/c02a6706534888ccea577d771c9edfc820bfc001/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets#L16C3-L26C15 -->
 	<!-- SingleProject-specific features -->
 	<ItemGroup Condition=" '$(SingleProject)' == 'true' ">
-		<ProjectCapability Include="Msix" Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'"/>
+		<ProjectCapability Include="Msix" />
 		<ProjectCapability Include="MauiSingleProject" />
 		<ProjectCapability Include="LaunchProfiles" />
 		<!-- If VS is older than Dev17 -->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Project capabilities are defined by both Uno.WinUI and the Uno.Sdk

## What is the new behavior?

Uno.WinUI targets will not add additional capabilities when using the Uno.Sdk. Capabilities are aligned with each other.
