### PR TITLE
fix: Configure devserver log level, reduce verbosity

### DIFF
--- a/doc/articles/features/working-with-xaml-hot-reload.md
+++ b/doc/articles/features/working-with-xaml-hot-reload.md
@@ -133,7 +133,7 @@ Hot Reload is supported by Visual Studio for WinAppSDK and provides support in u
   - Search for **.NET / C++ Hot Reload**
   - Ensure that all three checkboxes are checked (_**Enable hot reload when debugging**_, _**Enable Hot Reload without debugging**_ and _**Apply Hot Reload on File Save**_)
 - Hot Reload for WebAssembly is not supported when using the debugger. Start your app using `Ctrl+F5`.
-- The output window in VS has an output named `Uno Platform` in its drop-down. Diagnostics messages from the VS integration appear there.
+- The output window in VS has an output named `Uno Platform` in its drop-down. Diagnostics messages from the VS integration appear there. Changing the MSBuild build output verbosity in `Tools/Options/Projects and Solutions/Build And Run` controls the log level.
 - When a file is reloaded, XAML parsing errors will appear in the application's logs, on device or in browser.
 - If there are multiple versions of the Uno.WinUI Package present in the solution, the newest will be used, regardless of the started application
 - The app does not update its XAML, because the port number in `RemoteControl.g.cs` is `0`.

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -47,6 +47,7 @@ public class EntryPoint : IDisposable
 	private Action<string>? _verboseAction;
 	private Action<string>? _warningAction;
 	private Action<string>? _errorAction;
+	private int _msBuildLogLevel;
 	private System.Diagnostics.Process? _process;
 
 	private int RemoteControlServerPort;
@@ -101,6 +102,8 @@ public class EntryPoint : IDisposable
 	{
 		var ow = _dte2.ToolWindows.OutputWindow;
 
+		_msBuildLogLevel = _dte2.GetMSBuildOutputVerbosity();
+
 		// Add a new pane to the Output window.
 		var owPane = ow
 			.OutputWindowPanes
@@ -116,35 +119,35 @@ public class EntryPoint : IDisposable
 
 		_debugAction = s =>
 		{
-			if (!_closing)
+			if (!_closing && _msBuildLogLevel >= 3 /* MSBuild Log Detailed */)
 			{
 				owPane.OutputString("[DEBUG] " + s + "\r\n");
 			}
 		};
 		_infoAction = s =>
 		{
-			if (!_closing)
+			if (!_closing && _msBuildLogLevel >= 2 /* MSBuild Log Normal */)
 			{
 				owPane.OutputString("[INFO] " + s + "\r\n");
 			}
 		};
 		_verboseAction = s =>
 		{
-			if (!_closing)
+			if (!_closing && _msBuildLogLevel >= 4 /* MSBuild Log Diagnostic */)
 			{
 				owPane.OutputString("[VERBOSE] " + s + "\r\n");
 			}
 		};
 		_warningAction = s =>
 		{
-			if (!_closing)
+			if (!_closing && _msBuildLogLevel >= 1 /* MSBuild Log Minimal */)
 			{
 				owPane.OutputString("[WARNING] " + s + "\r\n");
 			}
 		};
 		_errorAction = e =>
 		{
-			if (!_closing)
+			if (!_closing && _msBuildLogLevel >= 0 /* MSBuild Log Quiet */)
 			{
 				owPane.OutputString("[ERROR] " + e + "\r\n");
 			}

--- a/src/Uno.UI.RemoteControl.VS/Helpers/DTEHelper.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/DTEHelper.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell;
+
+namespace Uno.UI.RemoteControl.VS.Helpers;
+
+internal static class DTEHelper
+{
+	public static int GetMSBuildOutputVerbosity(this DTE2 dte)
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+		var properties = dte?.Properties["Environment", "ProjectsAndSolution"];
+		var logOutput = properties?.Item("MSBuildOutputVerbosity").Value is int log ? log : 0;
+		return logOutput;
+	}
+}

--- a/src/Uno.UI.RemoteControl.VS/IDEChannel/IDEChannelClient.cs
+++ b/src/Uno.UI.RemoteControl.VS/IDEChannel/IDEChannelClient.cs
@@ -84,7 +84,7 @@ internal class IdeChannelClient
 
 	private void ProcessDevServerMessage(object sender, IdeMessage devServerMessage)
 	{
-		_logger.Info($"IDE: IDEChannel message received {devServerMessage}");
+		_logger.Verbose($"IDE: IDEChannel message received {devServerMessage}");
 
 		if (devServerMessage is ForceHotReloadIdeMessage forceHotReloadMessage)
 		{
@@ -93,13 +93,11 @@ internal class IdeChannelClient
 		}
 		else if (devServerMessage is KeepAliveIdeMessage)
 		{
-#if DEBUG
 			_logger.Verbose($"Keep alive from Dev Server");
-#endif
 		}
 		else
 		{
-			_logger.Debug($"Unknown message type {devServerMessage?.GetType()} from DevServer");
+			_logger.Verbose($"Unknown message type {devServerMessage?.GetType()} from DevServer");
 		}
 	}
 

--- a/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
+++ b/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
@@ -17,6 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <UpToDateCheckInput Remove="Helpers\DTEHelper.cs" />
 	  <UpToDateCheckInput Remove="Helpers\ILogger.cs" />
 	  <UpToDateCheckInput Remove="IdeChannel\IDEChannelClient.cs" />
 	</ItemGroup>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Reduce devserver logging verbosity, make it configurable.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
