### PR TITLE
fix: Force disable template pooling for all platforms

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/FeatureConfigurationHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/FeatureConfigurationHelper.cs
@@ -24,12 +24,12 @@ namespace Uno.UI.RuntimeTests.Helpers
 #if WINAPPSDK
 			return null;
 #else
-			var originallyEnabled = FrameworkTemplatePool.IsPoolingEnabled;
-			FrameworkTemplatePool.IsPoolingEnabled = true;
+			var originallyEnabled = FrameworkTemplatePool.InternalIsPoolingEnabled;
+			FrameworkTemplatePool.InternalIsPoolingEnabled = true;
 			FrameworkTemplatePool.Instance.SetPlatformProvider(new MockProvider());
 			return Disposable.Create(() =>
 			{
-				FrameworkTemplatePool.IsPoolingEnabled = originallyEnabled;
+				FrameworkTemplatePool.InternalIsPoolingEnabled = originallyEnabled;
 				FrameworkTemplatePool.Instance.SetPlatformProvider(null);
 			});
 #endif

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
@@ -524,7 +524,7 @@ namespace Uno.UI.Tests.ItemsControlTests
 			}
 
 			Assert.AreEqual(SUT.Items.Count, 5);
-			Assert.AreEqual(count, 5);
+			Assert.AreEqual(count, FrameworkTemplatePool.IsPoolingEnabled ? 5 : 8);
 			Assert.IsNotNull(SUT.ContainerFromItem("One"));
 			Assert.IsNotNull(SUT.ContainerFromItem("Four"));
 			Assert.IsNotNull(SUT.ContainerFromItem("Five"));

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
@@ -803,23 +803,23 @@ namespace Uno.UI.Tests.ListViewBaseTests
 			Assert.AreEqual(0, containerCount);
 
 			SUT.ItemsSource = source;
-			Assert.AreEqual(3, count);
+			Assert.AreEqual(FrameworkTemplatePool.IsPoolingEnabled ? 3 : 4, count);
 			Assert.AreEqual(3, containerCount);
 			Assert.AreEqual(3, containerCount);
 
 			source.Add("4");
-			Assert.AreEqual(4, count);
+			Assert.AreEqual(FrameworkTemplatePool.IsPoolingEnabled ? 4 : 6, count);
 			Assert.AreEqual(4, containerCount);
 			Assert.AreEqual(4, containerCount);
 
 			source.Remove("1");
-			Assert.AreEqual(4, count);
+			Assert.AreEqual(FrameworkTemplatePool.IsPoolingEnabled ? 4 : 6, count);
 			Assert.AreEqual(4, containerCount);
 			Assert.AreEqual(4, containerCount);
 
 			source[0] = "5";
 			// Data template is not recreated because of pooling
-			Assert.AreEqual(4, count);
+			Assert.AreEqual(FrameworkTemplatePool.IsPoolingEnabled ? 4 : 8, count);
 			// The item container style is reapplied (not cached)
 			Assert.AreEqual(5, containerCount);
 		}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase_CustomContainer.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase_CustomContainer.cs
@@ -118,23 +118,23 @@ namespace Uno.UI.Tests.ItemsControlTests_CustomContainer
 
 			collection.Add(1);
 
-			Assert.AreEqual(1, count);
+			Assert.AreEqual(FrameworkTemplatePool.IsPoolingEnabled ? 1 : 2, count);
 
 			collection.Add(42);
 
-			Assert.AreEqual(2, count);
+			Assert.AreEqual(FrameworkTemplatePool.IsPoolingEnabled ? 2 : 4, count);
 
 			collection.Add(43);
 
-			Assert.AreEqual(3, count);
+			Assert.AreEqual(FrameworkTemplatePool.IsPoolingEnabled ? 3 : 6, count);
 
 			collection.RemoveAt(0);
 
-			Assert.AreEqual(3, count);
+			Assert.AreEqual(FrameworkTemplatePool.IsPoolingEnabled ? 3 : 6, count);
 
 			collection[0] = 44;
 
-			Assert.AreEqual(FeatureConfiguration.FrameworkTemplate.IsPoolingEnabled ? 3 : 4, count);
+			Assert.AreEqual(FeatureConfiguration.FrameworkTemplate.IsPoolingEnabled ? 3 : 8, count);
 		}
 	}
 

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_FrameworkTemplate.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_FrameworkTemplate.cs
@@ -30,13 +30,13 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			_previousPoolingEnabled = FrameworkTemplatePool.IsPoolingEnabled;
 			FrameworkTemplatePool.Instance.SetPlatformProvider(_mockProvider = new());
 
-			FrameworkTemplatePool.IsPoolingEnabled = true;
+			FrameworkTemplatePool.InternalIsPoolingEnabled = true;
 		}
 
 		[TestCleanup]
 		public void Cleanup()
 		{
-			FrameworkTemplatePool.IsPoolingEnabled = _previousPoolingEnabled;
+			FrameworkTemplatePool.InternalIsPoolingEnabled = _previousPoolingEnabled;
 			FrameworkTemplatePool.Instance.SetPlatformProvider(null);
 			FrameworkTemplatePool.Scavenge();
 		}

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -45,6 +45,8 @@ using Microsoft.UI.Xaml.Markup;
 #else
 using View = Microsoft.UI.Xaml.UIElement;
 using ViewGroup = Microsoft.UI.Xaml.UIElement;
+using System.Text;
+using System.Runtime.CompilerServices;
 #endif
 
 
@@ -87,6 +89,7 @@ namespace Microsoft.UI.Xaml
 
 		private readonly Dictionary<FrameworkTemplate, List<TemplateEntry>> _pooledInstances = new Dictionary<FrameworkTemplate, List<TemplateEntry>>(FrameworkTemplate.FrameworkTemplateEqualityComparer.Default);
 		private IFrameworkTemplatePoolPlatformProvider _platformProvider = new FrameworkTemplatePoolDefaultPlatformProvider();
+		private static bool _isPoolingEnabled;
 
 #if USE_HARD_REFERENCES
 		/// <summary>
@@ -112,12 +115,28 @@ namespace Microsoft.UI.Xaml
 		/// Determines if the pooling is enabled. If false, all requested instances are new.
 		/// </summary>
 		/// <remarks>
-		/// Disabled by default on Android. See: https://github.com/unoplatform/uno/issues/13969
+		/// This feature is currently disabled and has no effect. See: https://github.com/unoplatform/uno/issues/13969
 		/// </remarks>
-		public static bool IsPoolingEnabled { get; set; }
-#if !__ANDROID__
-			 = true;
-#endif
+		public static bool IsPoolingEnabled
+		{
+			// Pooling is forced disabled, see InternalIsPoolingEnabled.
+			get => false;
+			set
+			{
+				if (typeof(FrameworkTemplatePool).Log().IsEnabled(LogLevel.Warning))
+				{
+					typeof(FrameworkTemplatePool).Log().LogWarn($"Template pooling is disabled in this build of Uno Platform. See https://github.com/unoplatform/uno/issues/13969");
+				}
+			}
+		}
+
+		// Pooling is disabled until https://github.com/unoplatform/uno/issues/13969 is fixed, but we
+		// allow some runtime tests to use it.
+		internal static bool InternalIsPoolingEnabled
+		{
+			get => _isPoolingEnabled;
+			set => _isPoolingEnabled = value;
+		}
 
 		/// <summary>
 		/// Gets a value indicating whether the pool is currently recycling a template.
@@ -240,12 +259,12 @@ namespace Microsoft.UI.Xaml
 
 				if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 				{
-					this.Log().Debug($"Creating new template, id={GetTemplateDebugId(template)} IsPoolingEnabled:{IsPoolingEnabled}");
+					this.Log().Debug($"Creating new template, id={GetTemplateDebugId(template)} IsPoolingEnabled:{_isPoolingEnabled}");
 				}
 
 				instance = ((IFrameworkTemplateInternal)template).LoadContent();
 
-				if (IsPoolingEnabled && instance is IFrameworkElement)
+				if (_isPoolingEnabled && instance is IFrameworkElement)
 				{
 					DependencyObjectExtensions.RegisterParentChangedCallback((DependencyObject)instance, template, OnParentChanged);
 				}
@@ -268,7 +287,7 @@ namespace Microsoft.UI.Xaml
 			}
 
 #if USE_HARD_REFERENCES
-			if (IsPoolingEnabled && instance is { })
+			if (_isPoolingEnabled && instance is { })
 			{
 				_activeInstances.Add(instance);
 			}
@@ -366,7 +385,7 @@ namespace Microsoft.UI.Xaml
 
 		private void TryReuseTemplateRoot(object instance, object? key, object? newParent, bool shouldCleanUpTemplateRoot)
 		{
-			if (!IsPoolingEnabled)
+			if (!_isPoolingEnabled)
 			{
 				return;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/13969

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Force disable `FrameworkTemplatePool` to avoid race condition effects introduced recently.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
