### PR TITLE
fix: `TimePicker` and `DatePicker` native flyouts closing and unload

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using Private.Infrastructure;
 using Uno.Disposables;
@@ -121,13 +122,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
-		public async Task When_Opened_DatePicker_Unloaded_Native() => await When_Opened_DatePicker_Unloaded(true);
+		public async Task When_Opened_And_Unloaded_Native() => await When_Opened_And_Unloaded(true);
 
 		[TestMethod]
 		[RunsOnUIThread]
-		public async Task When_Opened_DatePicker_Unloaded_Managed() => await When_Opened_DatePicker_Unloaded(false);
+		public async Task When_Opened_And_Unloaded_Managed() => await When_Opened_And_Unloaded(false);
 
-		private async Task When_Opened_DatePicker_Unloaded(bool useNative)
+		private async Task When_Opened_And_Unloaded(bool useNative)
 		{
 			var datePicker = new Microsoft.UI.Xaml.Controls.DatePicker();
 #if HAS_UNO
@@ -140,10 +141,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await DateTimePickerHelper.OpenDateTimePicker(datePicker);
 
-			var openFlyouts = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot);
-			var flyoutBase = openFlyouts[0];
-			var associatedFlyout = flyoutBase.AssociatedFlyout;
+#if HAS_UNO // FlyoutBase.OpenFlyouts also includes native popups like NativeDatePickerFlyout
+			var openFlyouts = FlyoutBase.OpenFlyouts;
+			Assert.AreEqual(1, openFlyouts.Count);
+			var associatedFlyout = openFlyouts[0];
 			Assert.IsInstanceOfType(associatedFlyout, typeof(Microsoft.UI.Xaml.Controls.DatePickerFlyout));
+#endif
 
 			bool unloaded = false;
 			datePicker.Unloaded += (s, e) => unloaded = true;
@@ -154,6 +157,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var openFlyoutsCount = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot).Count;
 			openFlyoutsCount.Should().Be(0, "There should be no open flyouts");
+
+#if HAS_UNO // FlyoutBase.OpenFlyouts also includes native popups like NativeDatePickerFlyout
+			openFlyoutsCount = FlyoutBase.OpenFlyouts.Count;
+			openFlyoutsCount.Should().Be(0, "There should be no open flyouts");
+#endif
 
 #if __ANDROID__ || __IOS__
 			if (useNative)
@@ -166,13 +174,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
-		public async Task When_DatePicker_Flyout_Closed_Native() => await When_DatePicker_Flyout_Closed_FlyoutBase_Closed_Invoked(true);
+		public async Task When_Flyout_Closed_FlyoutBase_Closed_Invoked_Native() => await When_Flyout_Closed_FlyoutBase_Closed_Invoked(true);
 
 		[TestMethod]
 		[RunsOnUIThread]
-		public async Task When_DatePicker_Flyout_Closed_Managed() => await When_DatePicker_Flyout_Closed_FlyoutBase_Closed_Invoked(false);
+		public async Task When_Flyout_Closed_FlyoutBase_Closed_Invoked_Managed() => await When_Flyout_Closed_FlyoutBase_Closed_Invoked(false);
 
-		private async Task When_DatePicker_Flyout_Closed_FlyoutBase_Closed_Invoked(bool useNative)
+		private async Task When_Flyout_Closed_FlyoutBase_Closed_Invoked(bool useNative)
 		{
 			// Open flyout, close it via method or via native dismiss, check if event on flyoutbase was invoked
 			var datePicker = new Microsoft.UI.Xaml.Controls.DatePicker();
@@ -186,9 +194,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await DateTimePickerHelper.OpenDateTimePicker(datePicker);
 
+#if !HAS_UNO
 			var openFlyouts = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot);
 			var flyoutBase = openFlyouts[0];
 			var associatedFlyout = flyoutBase.AssociatedFlyout;
+#else // FlyoutBase.OpenFlyouts also includes native popups like NativeDatePickerFlyout
+			var openFlyouts = FlyoutBase.OpenFlyouts;
+			Assert.AreEqual(1, openFlyouts.Count);
+			var associatedFlyout = openFlyouts[0];
+#endif
 			Assert.IsInstanceOfType(associatedFlyout, typeof(Microsoft.UI.Xaml.Controls.DatePickerFlyout));
 			var datePickerFlyout = (DatePickerFlyout)associatedFlyout;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using Private.Infrastructure;
+using SamplesApp.UITests;
 using Uno.Disposables;
 using Uno.UI.RuntimeTests.MUX.Helpers;
 using Windows.Globalization;
@@ -122,10 +123,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
 		public async Task When_Opened_And_Unloaded_Native() => await When_Opened_And_Unloaded(true);
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
 		public async Task When_Opened_And_Unloaded_Managed() => await When_Opened_And_Unloaded(false);
 
 		private async Task When_Opened_And_Unloaded(bool useNative)
@@ -174,10 +177,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
 		public async Task When_Flyout_Closed_FlyoutBase_Closed_Invoked_Native() => await When_Flyout_Closed_FlyoutBase_Closed_Invoked(true);
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
 		public async Task When_Flyout_Closed_FlyoutBase_Closed_Invoked_Managed() => await When_Flyout_Closed_FlyoutBase_Closed_Invoked(false);
 
 		private async Task When_Flyout_Closed_FlyoutBase_Closed_Invoked(bool useNative)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -1,17 +1,15 @@
 ﻿#if !WINAPPSDK
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Windows.Globalization;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
-using Microsoft.UI.Xaml.Controls;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Private.Infrastructure;
 using Uno.Disposables;
+using Uno.UI.RuntimeTests.MUX.Helpers;
+using Windows.Globalization;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -119,6 +117,72 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			CheckDateTimeTextBlockPartPosition(datePicker, "YearTextBlock", expectedColumn: 0);
 			CheckDateTimeTextBlockPartPosition(datePicker, "MonthTextBlock", expectedColumn: 2);
 			CheckDateTimeTextBlockPartPosition(datePicker, "DayTextBlock", expectedColumn: 4);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Opened_DatePicker_Unloaded_Native() => await When_Opened_DatePicker_Unloaded(true);
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Opened_DatePicker_Unloaded_Managed() => await When_Opened_DatePicker_Unloaded(false);
+
+		private async Task When_Opened_DatePicker_Unloaded(bool useNative)
+		{
+			var datePicker = new Microsoft.UI.Xaml.Controls.DatePicker();
+#if HAS_UNO
+			datePicker.UseNativeStyle = useNative;
+#endif
+
+			TestServices.WindowHelper.WindowContent = datePicker;
+
+			await TestServices.WindowHelper.WaitForLoaded(datePicker);
+
+			await DateTimePickerHelper.OpenDateTimePicker(datePicker);
+
+			bool unloaded = false;
+			datePicker.Unloaded += (s, e) => unloaded = true;
+
+			TestServices.WindowHelper.WindowContent = null;
+
+			await TestServices.WindowHelper.WaitFor(() => unloaded, message: "DatePicker did not unload");
+
+			var openFlyouts = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot).Count;
+			openFlyouts.Should().Be(0, "There should be no open flyouts");
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_DatePicker_Flyout_Closed_Native() => await When_DatePicker_Flyout_Closed_FlyoutBase_Closed_Invoked(true);
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_DatePicker_Flyout_Closed_Managed() => await When_DatePicker_Flyout_Closed_FlyoutBase_Closed_Invoked(false);
+
+		private async Task When_DatePicker_Flyout_Closed_FlyoutBase_Closed_Invoked(bool useNative)
+		{
+			// Open flyout, close it via method or via native dismiss, check if event on flyoutbase was invoked
+			var datePicker = new Microsoft.UI.Xaml.Controls.DatePicker();
+#if HAS_UNO
+			datePicker.UseNativeStyle = useNative;
+#endif
+
+			TestServices.WindowHelper.WindowContent = datePicker;
+
+			await TestServices.WindowHelper.WaitForLoaded(datePicker);
+
+			await DateTimePickerHelper.OpenDateTimePicker(datePicker);
+
+			var openFlyouts = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot);
+			var flyoutBase = openFlyouts[0];
+			var associatedFlyout = flyoutBase.AssociatedFlyout;
+			Assert.IsInstanceOfType(associatedFlyout, typeof(Microsoft.UI.Xaml.Controls.DatePickerFlyout));
+			var datePickerFlyout = (DatePickerFlyout)associatedFlyout;
+			bool flyoutClosed = false;
+			datePickerFlyout.Closed += (s, e) => flyoutClosed = true;
+			datePickerFlyout.Close();
+
+			await TestServices.WindowHelper.WaitFor(() => flyoutClosed, message: "Flyout did not close");
 		}
 
 		private static IDisposable SetAmbiantLanguage(string language)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -66,11 +66,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
-		public async Task When_Opened_And_Unloaded_Unloaded_Native() => await When_Opened_TimePicker_Unloaded(true);
+		public async Task When_Opened_And_Unloaded_Unloaded_Native() => await When_Opened_And_Unloaded_Unloaded(true);
 
 		[TestMethod]
 		[RunsOnUIThread]
-		public async Task When_Opened_And_Unloaded_Managed() => await When_Opened_TimePicker_Unloaded(false);
+		public async Task When_Opened_And_Unloaded_Managed() => await When_Opened_And_Unloaded_Unloaded(false);
 
 		private async Task When_Opened_And_Unloaded_Unloaded(bool useNative)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -68,14 +68,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		[RunsOnUIThread]
 		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
-		public async Task When_Opened_And_Unloaded_Unloaded_Native() => await When_Opened_And_Unloaded_Unloaded(true);
+		public async Task When_Opened_And_Unloaded_Unloaded_Native() => await When_Opened_And_Unloaded(true);
 
 		[TestMethod]
 		[RunsOnUIThread]
 		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
-		public async Task When_Opened_And_Unloaded_Managed() => await When_Opened_And_Unloaded_Unloaded(false);
+		public async Task When_Opened_And_Unloaded_Managed() => await When_Opened_And_Unloaded(false);
 
-		private async Task When_Opened_And_Unloaded_Unloaded(bool useNative)
+		private async Task When_Opened_And_Unloaded(bool useNative)
 		{
 			var timePicker = new Microsoft.UI.Xaml.Controls.TimePicker();
 #if HAS_UNO
@@ -119,6 +119,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		}
 
+#if HAS_UNO
 		[TestMethod]
 		[RunsOnUIThread]
 		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
@@ -133,9 +134,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		{
 			// Open flyout, close it via method or via native dismiss, check if event on flyoutbase was invoked
 			var timePicker = new Microsoft.UI.Xaml.Controls.TimePicker();
-#if HAS_UNO
 			timePicker.UseNativeStyle = useNative;
-#endif
 
 			TestServices.WindowHelper.WindowContent = timePicker;
 
@@ -143,15 +142,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await DateTimePickerHelper.OpenDateTimePicker(timePicker);
 
-#if !HAS_UNO
-			var openFlyouts = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot);
-			var flyoutBase = openFlyouts[0];
-			var associatedFlyout = flyoutBase.AssociatedFlyout;
-#else // FlyoutBase.OpenFlyouts also includes native popups like NativeTimePickerFlyout
 			var openFlyouts = FlyoutBase.OpenFlyouts;
 			Assert.AreEqual(1, openFlyouts.Count);
 			var associatedFlyout = openFlyouts[0];
-#endif
+
 			Assert.IsInstanceOfType(associatedFlyout, typeof(Microsoft.UI.Xaml.Controls.TimePickerFlyout));
 			var timePickerFlyout = (TimePickerFlyout)associatedFlyout;
 			bool flyoutClosed = false;
@@ -168,6 +162,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 #endif
 		}
+#endif
 	}
 
 	class MyContext

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -84,6 +84,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await DateTimePickerHelper.OpenDateTimePicker(timePicker);
 
+			var openFlyouts = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot);
+			var flyoutBase = openFlyouts[0];
+			var associatedFlyout = flyoutBase.AssociatedFlyout;
+			Assert.IsInstanceOfType(associatedFlyout, typeof(Microsoft.UI.Xaml.Controls.TimePickerFlyout));
+
 			bool unloaded = false;
 			timePicker.Unloaded += (s, e) => unloaded = true;
 
@@ -91,8 +96,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await TestServices.WindowHelper.WaitFor(() => unloaded, message: "DatePicker did not unload");
 
-			var openFlyouts = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot).Count;
-			openFlyouts.Should().Be(0, "There should be no open flyouts");
+			var openFlyoutsCount = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot).Count;
+			openFlyoutsCount.Should().Be(0, "There should be no open flyouts");
+
+#if __ANDROID__ || __IOS__
+			if (useNative)
+			{
+				var nativeTimePickerFlyout = (NativeTimePickerFlyout)associatedFlyout;
+				Assert.IsFalse(nativeTimePickerFlyout.IsNativeDialogOpen);
+			}
+#endif
 		}
 
 		[TestMethod]
@@ -127,6 +140,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			timePickerFlyout.Close();
 
 			await TestServices.WindowHelper.WaitFor(() => flyoutClosed, message: "Flyout did not close");
+
+#if __ANDROID__ || __IOS__
+			if (useNative)
+			{
+				var nativeTimePickerFlyout = (NativeTimePickerFlyout)timePickerFlyout;
+				Assert.IsFalse(nativeTimePickerFlyout.IsNativeDialogOpen);
+			}
+#endif
 		}
 	}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -13,6 +13,7 @@ using Uno.UI.RuntimeTests.MUX.Helpers;
 using Microsoft.UI.Xaml.Media;
 using FluentAssertions;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using SamplesApp.UITests;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -66,10 +67,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
 		public async Task When_Opened_And_Unloaded_Unloaded_Native() => await When_Opened_And_Unloaded_Unloaded(true);
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
 		public async Task When_Opened_And_Unloaded_Managed() => await When_Opened_And_Unloaded_Unloaded(false);
 
 		private async Task When_Opened_And_Unloaded_Unloaded(bool useNative)
@@ -118,10 +121,12 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
 		public async Task When_Flyout_Closed_FlyoutBase_Closed_Native() => await When_Flyout_Closed_FlyoutBase_Closed_Invoked(true);
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15256")]
 		public async Task When_Flyout_Closed_FlyoutBase_Closed_Managed() => await When_Flyout_Closed_FlyoutBase_Closed_Invoked(false);
 
 		private async Task When_Flyout_Closed_FlyoutBase_Closed_Invoked(bool useNative)

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.Flyout.cs
@@ -76,7 +76,6 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private DatePickerFlyout _flyout => _lazyFlyout.Value;
 
-
 		private void InitPartial()
 		{
 #if __IOS__ || __ANDROID__

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -884,8 +884,15 @@ namespace Microsoft.UI.Xaml.Controls
 				var asyncOperation = _flyout.ShowAtAsync(this);
 				m_tpAsyncSelectionInfo = asyncOperation;
 				var getOperation = asyncOperation.AsTask();
-				await getOperation;
-				OnGetDatePickerSelectionAsyncCompleted(getOperation, asyncOperation.Status);
+				try
+				{
+					await getOperation;
+					OnGetDatePickerSelectionAsyncCompleted(getOperation, asyncOperation.Status);
+				}
+				catch (TaskCanceledException)
+				{
+					// The user canceled the flyout or the control was unloaded. We don't need to do anything.
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.Android.cs
@@ -12,6 +12,7 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class NativeDatePickerFlyout : DatePickerFlyout
 	{
+		private bool _programmaticallyDismissed;
 		private DatePickerDialog _dialog;
 
 		public static DependencyProperty UseNativeMinMaxDatesProperty { get; } = DependencyProperty.Register(
@@ -33,6 +34,8 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			this.RegisterPropertyChangedCallback(DateProperty, OnDateChanged);
 		}
+
+		internal bool IsNativeDialogOpen => _dialog?.IsShowing ?? false;
 
 		protected internal override void Open()
 		{
@@ -82,6 +85,8 @@ namespace Microsoft.UI.Xaml.Controls
 
 			_dialog.DismissEvent += OnDismiss;
 			_dialog.Show();
+
+			AddToOpenFlyouts();
 		}
 
 		private void OnDateChanged(DependencyObject sender, DependencyProperty dp)
@@ -92,12 +97,19 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private void OnDismiss(object sender, EventArgs e)
 		{
-			Hide(canCancel: false);
+			if (!_programmaticallyDismissed)
+			{
+				Hide(canCancel: false);
+				RemoveFromOpenFlyouts();
+			}
 		}
 
-		internal protected override void Close()
+		private protected override void OnClosed()
 		{
+			_programmaticallyDismissed = true;
 			_dialog?.Dismiss();
+			base.OnClosed();
+			_programmaticallyDismissed = false;
 		}
 
 		private void OnDateSet(object sender, DatePickerDialog.DateSetEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
@@ -27,13 +27,15 @@ namespace Microsoft.UI.Xaml.Controls
 		private readonly SerialDisposable _presenterLoadedDisposable = new SerialDisposable();
 		private readonly SerialDisposable _presenterUnloadedDisposable = new SerialDisposable();
 		private bool _isInitialized;
+		private DatePickerSelector _selector;
 
 		private NativeDatePickerFlyoutPresenter _presenter
 		{
 			get => _tpPresenter as NativeDatePickerFlyoutPresenter;
 			set => _tpPresenter = value;
 		}
-		private DatePickerSelector _selector;
+
+		internal bool IsNativeDialogOpen { get; private set; }
 
 		public static DependencyProperty UseNativeMinMaxDatesProperty { get; } = DependencyProperty.Register(
 			"UseNativeMinMaxDates",
@@ -168,12 +170,14 @@ namespace Microsoft.UI.Xaml.Controls
 			AttachFlyoutCommand(DismissButtonPartName, x => x.Dismiss());
 
 			_presenterLoadedDisposable.Disposable = null;
+			IsNativeDialogOpen = true;
 		}
 
 		private void OnPresenterUnloaded(object sender, RoutedEventArgs e)
 		{
 			_presenterLoadedDisposable.Disposable = null;
 			_presenterUnloadedDisposable.Disposable = null;
+			IsNativeDialogOpen = false;
 		}
 
 		private void OnDateChanged(DependencyObject sender, DependencyProperty dp)

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutBase.cs
@@ -18,6 +18,8 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.Xaml.Core;
 using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
+using System.Runtime.CompilerServices;
+
 
 #if __IOS__
 using View = UIKit.UIView;
@@ -64,6 +66,8 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 		protected FlyoutBase()
 		{
 		}
+
+		internal static IReadOnlyList<FlyoutBase> OpenFlyouts => _openFlyouts.AsReadOnly();
 
 		private void EnsurePopupCreated()
 		{
@@ -308,20 +312,25 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 
 				OnClosed();
 
-				if (_openFlyouts.Count > 0 && _openFlyouts[0] == this)
-				{
-					_openFlyouts.Remove(this);
-
-					Closed?.Invoke(this, EventArgs.Empty);
-
-					if (_openFlyouts.Count > 0)
-					{
-						_openFlyouts[0].Hide();
-					}
-				}
+				RemoveFromOpenFlyouts();
 			}
 
 			return cancel;
+		}
+
+		private protected void RemoveFromOpenFlyouts()
+		{
+			if (_openFlyouts.Count > 0 && _openFlyouts[0] == this)
+			{
+				_openFlyouts.Remove(this);
+
+				Closed?.Invoke(this, EventArgs.Empty);
+
+				if (_openFlyouts.Count > 0)
+				{
+					_openFlyouts[0].Hide();
+				}
+			}
 		}
 
 		public void ShowAt(FrameworkElement placementTarget)
@@ -519,6 +528,11 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 
 			_popup.IsOpen = true;
 
+			AddToOpenFlyouts();
+		}
+
+		private protected void AddToOpenFlyouts()
+		{
 			if (!_openFlyouts.Contains(this))
 			{
 				_openFlyouts.Add(this);

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.Android.cs
@@ -10,8 +10,11 @@ namespace Microsoft.UI.Xaml.Controls;
 
 partial class NativeTimePickerFlyout
 {
+	private bool _programmaticallyDismissed;
 	private UnoTimePickerDialog _dialog;
 	private TimeSpan _initialTime;
+
+	internal bool IsNativeDialogOpen => _dialog?.IsShowing ?? false;
 
 	internal protected override void Open()
 	{
@@ -26,11 +29,11 @@ partial class NativeTimePickerFlyout
 		var tryEnforceSpinnerStyle = isSamsungAndMarshmellow || MinuteIncrement > 1;
 
 		ShowTimePicker(tryEnforceSpinnerStyle);
+
+		AddToOpenFlyouts();
 	}
 
 	private void SaveInitialTime() => _initialTime = Time;
-
-	internal protected override void Close() { base.Close(); }
 
 	private void SaveTime(TimeSpan time)
 	{
@@ -82,7 +85,19 @@ partial class NativeTimePickerFlyout
 
 	private void OnDismiss(object sender, EventArgs e)
 	{
-		Hide(canCancel: false);
+		if (!_programmaticallyDismissed)
+		{
+			Hide(canCancel: false);
+			RemoveFromOpenFlyouts();
+		}
+	}
+
+	private protected override void OnClosed()
+	{
+		_programmaticallyDismissed = true;
+		_dialog?.Dismiss();
+		base.OnClosed();
+		_programmaticallyDismissed = false;
 	}
 
 	//partial void OnTimeChangedPartialNative(TimeSpan oldTime, TimeSpan newTime) { }

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.iOS.cs
@@ -32,6 +32,8 @@ partial class NativeTimePickerFlyout
 		};
 	}
 
+	internal bool IsNativeDialogOpen { get; private set; }
+
 	/// <summary>
 	/// This method sets the Content property of the Flyout.
 	/// </summary>
@@ -155,6 +157,8 @@ partial class NativeTimePickerFlyout
 			_headerUntapZone.PointerPressed += OnTap;
 		}
 
+		IsNativeDialogOpen = true;
+
 		base.Open();
 	}
 
@@ -166,6 +170,8 @@ partial class NativeTimePickerFlyout
 		}
 
 		_timeSelector?.Cancel();
+
+		IsNativeDialogOpen = false;
 
 		base.Close();
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.iOS.cs
@@ -123,12 +123,14 @@ partial class NativeTimePickerFlyout
 			}
 
 			_onLoad.Disposable = null;
+			IsNativeDialogOpen = true;
 		}
 
 		void onUnload(object sender, RoutedEventArgs e)
 		{
 			_onUnloaded.Disposable = null;
 			_onLoad.Disposable = null;
+			IsNativeDialogOpen = false;
 		}
 
 		if (_timePickerPresenter != null)
@@ -157,8 +159,6 @@ partial class NativeTimePickerFlyout
 			_headerUntapZone.PointerPressed += OnTap;
 		}
 
-		IsNativeDialogOpen = true;
-
 		base.Open();
 	}
 
@@ -170,8 +170,6 @@ partial class NativeTimePickerFlyout
 		}
 
 		_timeSelector?.Cancel();
-
-		IsNativeDialogOpen = false;
 
 		base.Close();
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.partial.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.partial.mux.cs
@@ -413,34 +413,20 @@ partial class TimePicker
 
 	private async void ShowPickerFlyout()
 	{
-		//if (m_tpAsyncSelectionInfo is null)
-		//{
-		//	object spAsyncAsInspectable;
-		//	IAsyncOperation<TimeSpan?> spAsyncOperation;
-		//	var wpThis = WeakReferencePool.RentSelfWeakReference(this);
-		//	var callbackPtr = (IAsyncOperation<TimeSpan?> getOperation, AsyncStatus status) =>
-		//	{
-		//		if (wpThis.IsAlive && wpThis.Target is TimePicker spThis)
-		//		{
-		//			spThis.OnGetTimePickerSelectionAsyncCompleted(getOperation, status);
-		//		}
-		//	};
-
-		//	var xamlControlsGetTimePickerSelectionPtr = reinterpret_cast < decltype(&XamlControlsGetTimePickerSelection) > (.GetProcAddress(GetPhoneModule(), "XamlControlsGetTimePickerSelection"));
-		//	xamlControlsGetTimePickerSelectionPtr(as_iinspectable(this), as_iinspectable(m_tpFlyoutButton), spAsyncAsInspectable.GetAddressOf());
-
-		//	spAsyncOperation = spAsyncAsInspectable.AsOrNull<IAsyncOperation<IReference<TimeSpan>*>>();
-		//	IFCEXPECT(spAsyncOperation);
-		//	spAsyncOperation.Completed = callbackPtr;
-		//	m_tpAsyncSelectionInfo = sp);
-		//}
-
 		if (m_tpAsyncSelectionInfo == null)
 		{
 			var asyncOperation = SelectionExports.XamlControls_GetTimePickerSelection(this, m_tpFlyoutButton);
+			m_tpAsyncSelectionInfo = asyncOperation;
 			var getOperation = asyncOperation.AsTask();
-			await getOperation;
-			OnGetTimePickerSelectionAsyncCompleted(getOperation, asyncOperation.Status);
+			try
+			{
+				await getOperation;
+				OnGetTimePickerSelectionAsyncCompleted(getOperation, asyncOperation.Status);
+			}
+			catch (TaskCanceledException)
+			{
+				// The user canceled the flyout or the control was unloaded. We don't need to do anything.
+			}
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -53,7 +53,6 @@ namespace Microsoft.UI.Xaml.Controls
 				parent.RemoveChild(_picker);
 				parent.AddSubview(_picker);
 			}
-
 		}
 
 		private void OnEditingDidBegin(object sender, EventArgs e)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/15256, fixes https://github.com/unoplatform/uno/issues/15267

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- App crashes when the `DatePicker` is unloaded

## What is the new behavior?

- Behavior of `TimePicker` and `DatePicker` native flyouts is more aligned with managed flyouts
- Pickers do not throw when the control has open flyout and is unloaded
- Unloading controls automatically closes associated flyouts

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.