### PR TITLE
[iOS] fix: `TimePicker` and `DatePicker` should follow application theme

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -273,6 +273,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if __IOS__
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15263")]
 		public async Task When_App_Theme_Dark_Native_Flyout_Theme()
 		{
 			using var _ = ThemeHelper.UseDarkTheme();
@@ -281,6 +282,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15263")]
 		public async Task When_App_Theme_Light_Native_Flyout_Theme() => await When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle.Light);
 
 		private async Task When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle expectedStyle)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
@@ -13,6 +14,7 @@ using Microsoft.UI.Xaml.Media;
 using Private.Infrastructure;
 using SamplesApp.UITests;
 using Uno.Disposables;
+using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.MUX.Helpers;
 using Windows.Globalization;
 
@@ -267,6 +269,43 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 #endif
 		}
+
+#if __IOS__
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_App_Theme_Dark_Native_Flyout_Theme()
+		{
+			using var _ = ThemeHelper.UseDarkTheme();
+			await When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle.Dark);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_App_Theme_Light_Native_Flyout_Theme() => await When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle.Light);
+
+		private async Task When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle expectedStyle)
+		{
+			var datePicker = new Microsoft.UI.Xaml.Controls.DatePicker();
+			datePicker.UseNativeStyle = true;
+
+			TestServices.WindowHelper.WindowContent = datePicker;
+
+			await TestServices.WindowHelper.WaitForLoaded(datePicker);
+
+			await DateTimePickerHelper.OpenDateTimePicker(datePicker);
+
+			var openFlyouts = FlyoutBase.OpenFlyouts;
+			Assert.AreEqual(1, openFlyouts.Count);
+			var associatedFlyout = openFlyouts[0];
+			Assert.IsInstanceOfType(associatedFlyout, typeof(Microsoft.UI.Xaml.Controls.DatePickerFlyout));
+			var datePickerFlyout = (DatePickerFlyout)associatedFlyout;
+
+			var nativeDatePickerFlyout = (NativeDatePickerFlyout)datePickerFlyout;
+
+			var nativeDatePicker = nativeDatePickerFlyout._selector;
+			Assert.AreEqual(expectedStyle, nativeDatePicker.OverrideUserInterfaceStyle);
+		}
+#endif
 
 		private static IDisposable SetAmbiantLanguage(string language)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -205,6 +205,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if __IOS__
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15263")]
 		public async Task When_App_Theme_Dark_Native_Flyout_Theme()
 		{
 			using var _ = ThemeHelper.UseDarkTheme();
@@ -213,6 +214,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15263")]
 		public async Task When_App_Theme_Light_Native_Flyout_Theme() => await When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle.Light);
 
 		private async Task When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle expectedStyle)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
 using Private.Infrastructure;
 using SamplesApp.UITests;
+using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.RuntimeTests.MUX.Helpers;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
@@ -198,6 +199,43 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.IsFalse(nativeTimePickerFlyout.IsNativeDialogOpen);
 			}
 #endif
+		}
+#endif
+
+#if __IOS__
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_App_Theme_Dark_Native_Flyout_Theme()
+		{
+			using var _ = ThemeHelper.UseDarkTheme();
+			await When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle.Dark);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_App_Theme_Light_Native_Flyout_Theme() => await When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle.Light);
+
+		private async Task When_Native_Flyout_Theme(UIKit.UIUserInterfaceStyle expectedStyle)
+		{
+			var timePicker = new Microsoft.UI.Xaml.Controls.TimePicker();
+			timePicker.UseNativeStyle = true;
+
+			TestServices.WindowHelper.WindowContent = timePicker;
+
+			await TestServices.WindowHelper.WaitForLoaded(timePicker);
+
+			await DateTimePickerHelper.OpenDateTimePicker(timePicker);
+
+			var openFlyouts = FlyoutBase.OpenFlyouts;
+			Assert.AreEqual(1, openFlyouts.Count);
+			var associatedFlyout = openFlyouts[0];
+			Assert.IsInstanceOfType(associatedFlyout, typeof(Microsoft.UI.Xaml.Controls.TimePickerFlyout));
+			var timePickerFlyout = (TimePickerFlyout)associatedFlyout;
+
+			var nativeTimePickerFlyout = (NativeTimePickerFlyout)timePickerFlyout;
+
+			var nativeTimePicker = nativeTimePickerFlyout._timeSelector;
+			Assert.AreEqual(expectedStyle, nativeTimePicker.OverrideUserInterfaceStyle);
 		}
 #endif
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -64,7 +64,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_picker.Calendar = new NSCalendar(NSCalendarType.Gregorian);
 
 			UpdatePickerStyle();
-			OverrideUIDatePickerTheme(_picker);
+			OverrideUIDatePickerTheme(this);
 
 			UpdatePickerValue(Date, animated: false);
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerSelector.iOS.cs
@@ -10,6 +10,7 @@ using Uno.Foundation.Logging;
 using Uno.UI;
 using Windows.Globalization;
 using Uno.Helpers.Theming;
+using Windows.ApplicationModel.Core;
 
 namespace Microsoft.UI.Xaml.Controls
 {
@@ -63,7 +64,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_picker.Calendar = new NSCalendar(NSCalendarType.Gregorian);
 
 			UpdatePickerStyle();
-			OverrideUIDatePickerTheme();
+			OverrideUIDatePickerTheme(_picker);
 
 			UpdatePickerValue(Date, animated: false);
 
@@ -236,14 +237,18 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		internal static void OverrideUIDatePickerTheme()
+		internal static void OverrideUIDatePickerTheme(UIView picker)
 		{
 			// Force the background of the UIDatePicker to allow for proper
 			// readability.
 			UIDatePicker.Appearance.BackgroundColor =
-				SystemThemeHelper.SystemTheme == SystemTheme.Dark
+				CoreApplication.RequestedTheme == SystemTheme.Dark
 				? UIColor.Black
 				: UIColor.White;
+
+			picker.OverrideUserInterfaceStyle = CoreApplication.RequestedTheme == SystemTheme.Dark
+				? UIUserInterfaceStyle.Dark
+				: UIUserInterfaceStyle.Light;
 
 			// UIDatePicker does not allow for fine-grained control of its appearance:
 			// https://developer.apple.com/documentation/uikit/uidatepicker

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/NativeDatePickerFlyout.iOS.cs
@@ -27,7 +27,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private readonly SerialDisposable _presenterLoadedDisposable = new SerialDisposable();
 		private readonly SerialDisposable _presenterUnloadedDisposable = new SerialDisposable();
 		private bool _isInitialized;
-		private DatePickerSelector _selector;
+		internal DatePickerSelector _selector;
 
 		private NativeDatePickerFlyoutPresenter _presenter
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -38,7 +38,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_picker.Mode = UIDatePickerMode.Time;
 
 			UpdatePickerStyle();
-			DatePickerSelector.OverrideUIDatePickerTheme(_picker);
+			DatePickerSelector.OverrideUIDatePickerTheme(this);
 			SetPickerTime(Time.RoundToNextMinuteInterval(MinuteIncrement));
 			SetPickerClockIdentifier(ClockIdentifier);
 			SaveInitialTime();

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -38,7 +38,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_picker.Mode = UIDatePickerMode.Time;
 
 			UpdatePickerStyle();
-			DatePickerSelector.OverrideUIDatePickerTheme();
+			DatePickerSelector.OverrideUIDatePickerTheme(_picker);
 			SetPickerTime(Time.RoundToNextMinuteInterval(MinuteIncrement));
 			SetPickerClockIdentifier(ClockIdentifier);
 			SaveInitialTime();
@@ -69,7 +69,6 @@ namespace Microsoft.UI.Xaml.Controls
 		public void Initialize()
 		{
 			UpdatePickerStyle();
-			DatePickerSelector.OverrideUIDatePickerTheme();
 			SetPickerClockIdentifier(ClockIdentifier);
 			SetPickerMinuteIncrement(MinuteIncrement);
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #15263 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- `TimePicker`	 and `DatePicker` always use system theme

## What is the new behavior?

- `TimePicker` and `DatePicker` switch theme along with application

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.