### PR TITLE
fix: Invalid TIMEPICKER_MINUTEINCREMENT_MAX

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -16,8 +16,7 @@
 			<Member fullName="Uno.UI.Toolkit" reason="Android 12 support"/>
 			<Member fullName="Uno.Xaml" reason="Android 12 support"/>
 		</Assemblies>
-		<Methods>
-			<Member
+		<Methods><Member
 				fullName="System.Void Uno.Media.StreamGeometryContext.BeginFigure(Windows.Foundation.Point startPoint, System.Boolean isFilled, System.Boolean isClosed)"
 				reason="isClosed paramater is not used and is misleading" />
 			<Member
@@ -1791,6 +1790,32 @@
 			<Member fullName="System.Void Windows.UI.Xaml.Input.PointerRoutedEventArgs..ctor()" reason="Does not exist in WinUI" />
 		</Methods>
 	</IgnoreSet>
+
+	<IgnoreSet baseVersion="5.1">
+		<Types>
+		</Types>
+
+		<Events>
+		</Events>
+
+		<Fields>
+		</Fields>
+
+		<Properties>
+		</Properties>
+
+		<Methods>
+			<!-- Multiple XamlRoots -->
+			<Member fullName="System.Void Windows.UI.Core.CoreWindow..ctor(UIKit.UIWindow window)" reason="Does not exist in UWP" />
+			<Member fullName="System.Void Windows.UI.Core.CoreWindow..ctor(AppKit.NSWindow window)" reason="Does not exist in UWP" />
+			<Member fullName="System.Void Microsoft.UI.Xaml.Window.add_Closed(Microsoft.UI.Xaml.WindowClosedEventHandler value)" reason="The signature differs in MUX" />
+			<Member fullName="System.Void Microsoft.UI.Xaml.Window.remove_Closed(Microsoft.UI.Xaml.WindowClosedEventHandler value)" reason="The signature differs in MUX" />
+			<Member fullName="System.Void Windows.ApplicationModel.Activation.SplashScreen..ctor()" reason="The signature differs in MUX" />
+			<Member fullName="System.Void Microsoft.UI.Xaml.Input.PointerRoutedEventArgs..ctor()" reason="Does not exist in WinUI" />
+			<Member fullName="System.Void Windows.UI.Xaml.Input.PointerRoutedEventArgs..ctor()" reason="Does not exist in WinUI" />
+		</Methods>
+	</IgnoreSet>
+
 	  <!--
 	Supported nodes (please keep at the bottom of this file):
 	<IgnoreSet baseVersion="0.0">

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.partial.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.partial.mux.cs
@@ -50,7 +50,7 @@ partial class TimePicker
 	//private const int TIMEPICKER_PM_INDEX = 1;
 	private const int TIMEPICKER_RTL_CHARACTER_CODE = 8207;
 	private const int TIMEPICKER_MINUTEINCREMENT_MIN = 0;
-	private const int TIMEPICKER_MINUTEINCREMENT_MAX = 9;
+	private const int TIMEPICKER_MINUTEINCREMENT_MAX = 59;
 	// When the minute increment is set to 0, we want to only have 00 at the minute picker. This
 	// can be easily obtained by treating 0 as 60 with our existing logic. So during our logic, if we see
 	// that minute increment is zero we will use 60 in our calculations.


### PR DESCRIPTION
Restores the original value for TIMEPICKER_MINUTEINCREMENT_MAX from WinUI's sources
