### PR TITLE
fix: Thumb does not prevent scroll

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ThumbTests/Tumb_CapturePreventScroll_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/ThumbTests/Tumb_CapturePreventScroll_Tests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.ThumbTests;
+
+[TestFixture]
+public partial class Tumb_CapturePreventScroll_Tests : SampleControlUITestBase
+{
+	private const string _sample = "UITests.Windows_UI_Xaml_Controls.ThumbTests.Thumb_CapturePreventScroll";
+
+	[Test]
+	[AutoRetry]
+	[ActivePlatforms(Platform.iOS, Platform.Android)]
+	public void When_Drag_Then_DoesNotScroll()
+	{
+		Run(_sample);
+
+		var sut = _app.WaitForElement("SUT").Single().Rect;
+
+		_app.DragCoordinates(
+			sut.CenterX,
+			sut.CenterY,
+			sut.CenterX - 100,
+			sut.CenterY - 100);
+
+		var result = _app.Marked("Output").GetDependencyPropertyValue<string>("Text");
+
+		result.Should().Be("--none--");
+
+		// SANITY CHECK
+		// To validate that test is effectively testing something, let try to scroll bu clicking out of the thumb
+		_app.DragCoordinates(
+			sut.Right + 10,
+			sut.Bottom + 10,
+			sut.CenterX - 100,
+			sut.CenterY - 100);
+
+		result.Should().NotBe("--none--");
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2562,6 +2562,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_CapturePreventScroll.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_DragEvents.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7040,6 +7044,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\Width_Affects_Delete_Button.xaml.cs">
       <DependentUpon>Width_Affects_Delete_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_CapturePreventScroll.xaml.cs">
+      <DependentUpon>Thumb_CapturePreventScroll.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ThumbTests\Thumb_DragEvents.xaml.cs">
       <DependentUpon>Thumb_DragEvents.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_CapturePreventScroll.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_CapturePreventScroll.xaml
@@ -1,0 +1,27 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Xaml_Controls.ThumbTests.Thumb_CapturePreventScroll"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.ThumbTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<ScrollViewer 
+			HorizontalScrollMode="Enabled" 
+			HorizontalScrollBarVisibility="Auto" 
+			VerticalScrollMode="Enabled" 
+			VerticalScrollBarVisibility="Auto"
+			Width="256"
+			Height="256"
+			ViewChanged="OnScrolled">
+			<Grid Width="1024" Height="1024" Background="DeepPink">
+				<Thumb x:Name="SUT" Width="32" Height="32" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="64" Background="DeepSkyBlue" />
+			</Grid>
+		</ScrollViewer>
+
+		<TextBlock x:Name="Output" VerticalAlignment="Bottom" HorizontalAlignment="Center" Text="--none--" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_CapturePreventScroll.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_CapturePreventScroll.xaml.cs
@@ -1,0 +1,25 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.ThumbTests;
+
+[Sample("Thumb")]
+public sealed partial class Thumb_CapturePreventScroll : Page
+{
+	public Thumb_CapturePreventScroll()
+	{
+		this.InitializeComponent();
+	}
+
+	private void OnScrolled(object? sender, ScrollViewerViewChangedEventArgs e)
+	{
+		if (sender is ScrollViewer sv)
+		{
+			Output.Text = $"v: {sv.VerticalOffset:G2} | h: {sv.HorizontalOffset:G2}";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class Thumb_DragEvents : Page
 #if XAMARIN || __WASM__ // Total properties are uno only
 		DragDeltaOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}");
 #else
-			DragDeltaOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0");
+		DragDeltaOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0");
 #endif
 	}
 
@@ -33,7 +33,7 @@ public sealed partial class Thumb_DragEvents : Page
 #if XAMARIN || __WASM__ // Total properties are uno only
 		DragCompletedOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}");
 #else
-			DragCompletedOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0");
+		DragCompletedOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0");
 #endif
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ThumbTests/Thumb_DragEvents.xaml.cs
@@ -4,37 +4,36 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Uno.UI.Samples.Controls;
 
-namespace UITests.Windows_UI_Xaml_Controls.ThumbTests
+namespace UITests.Windows_UI_Xaml_Controls.ThumbTests;
+
+[Sample("Thumb", "Slider")]
+public sealed partial class Thumb_DragEvents : Page
 {
-	[Sample("Slider")]
-	public sealed partial class Thumb_DragEvents : Page
+	public Thumb_DragEvents()
 	{
-		public Thumb_DragEvents()
-		{
-			this.InitializeComponent();
-		}
+		this.InitializeComponent();
+	}
 
-		private void OnThumbDragStarted(object sender, DragStartedEventArgs e)
-		{
-			DragStartedOutput.Text = FormattableString.Invariant($"@x={e.HorizontalOffset:F2},@y={e.VerticalOffset:F2}");
-		}
+	private void OnThumbDragStarted(object sender, DragStartedEventArgs e)
+	{
+		DragStartedOutput.Text = FormattableString.Invariant($"@x={e.HorizontalOffset:F2},@y={e.VerticalOffset:F2}");
+	}
 
-		private void OnThumbDragDelta(object sender, DragDeltaEventArgs e)
-		{
+	private void OnThumbDragDelta(object sender, DragDeltaEventArgs e)
+	{
 #if XAMARIN || __WASM__ // Total properties are uno only
-			DragDeltaOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}");
+		DragDeltaOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}");
 #else
 			DragDeltaOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0");
 #endif
-		}
+	}
 
-		private void OnThumbDragCompleted(object sender, DragCompletedEventArgs e)
-		{
+	private void OnThumbDragCompleted(object sender, DragCompletedEventArgs e)
+	{
 #if XAMARIN || __WASM__ // Total properties are uno only
-			DragCompletedOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}");
+		DragCompletedOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx={e.TotalHorizontalChange:F2},Σy={e.TotalVerticalChange:F2}");
 #else
 			DragCompletedOutput.Text = FormattableString.Invariant($"Δx={e.HorizontalChange:F2},Δy={e.VerticalChange:F2}|Σx=0.0,Σy=0.0");
 #endif
-		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.mux.cs
@@ -8,6 +8,7 @@ using Windows.Foundation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
+using Uno.UI.Xaml.Core;
 
 namespace Microsoft.UI.Xaml.Controls.Primitives;
 
@@ -268,7 +269,7 @@ public sealed partial class Thumb
 				args.Handled = true;
 
 				var pointer = args.Pointer;
-				var pointerCaptured = CapturePointer(pointer);
+				var pointerCaptured = CapturePointer(pointer, /* UNO only */ options: PointerCaptureOptions.PreventOsStole);
 				IsDragging = true;
 
 				// If logical parent is a popup, TransformToVisual can fail because a popup's child

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Thumb.mux.cs
@@ -269,7 +269,7 @@ public sealed partial class Thumb
 				args.Handled = true;
 
 				var pointer = args.Pointer;
-				var pointerCaptured = CapturePointer(pointer, /* UNO only */ options: PointerCaptureOptions.PreventOsStole);
+				var pointerCaptured = CapturePointer(pointer, /* UNO only */ options: PointerCaptureOptions.PreventOSSteal);
 				IsDragging = true;
 
 				// If logical parent is a popup, TransformToVisual can fail because a popup's child

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
@@ -15,7 +15,6 @@ using Windows.UI.Core;
 using Windows.UI.Input;
 using Windows.UI.Input.Preview.Injection;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using static Microsoft.UI.Xaml.UIElement;
@@ -155,10 +154,6 @@ internal partial class InputManager
 		{
 			var (originalSource, _) = HitTest(args);
 
-			if (originalSource is ImplicitTextBlock)
-			{
-				global::System.Diagnostics.Debug.WriteLine("Entered");
-			}
 			// Even if impossible for the Enter, we are fallbacking on the RootElement for safety
 			// This is how UWP behaves: when out of the bounds of the Window, the root element is use.
 			// Note that if another app covers your app, then the OriginalSource on UWP is still the element of your app at the pointer's location.

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCapture.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCapture.Android.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+
+namespace Uno.UI.Xaml.Core;
+
+partial class PointerCapture
+{
+	partial void AddOptions(UIElement target, PointerCaptureOptions options)
+	{
+		if (options.HasFlag(PointerCaptureOptions.PreventOsStole))
+		{
+			target.RequestDisallowInterceptTouchEvent(true);
+		}
+	}
+
+	// Note: We don't have to implement RemoveOptions because the Android will clear the RequestDisallowInterceptTouchEvent by it's own on pointer release
+	//		 and forcefully doing it in RemoveOptions could conflict with handling in the GestureRecognizer.
+}

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCapture.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCapture.Android.cs
@@ -11,7 +11,7 @@ partial class PointerCapture
 {
 	partial void AddOptions(UIElement target, PointerCaptureOptions options)
 	{
-		if (options.HasFlag(PointerCaptureOptions.PreventOsStole))
+		if (options.HasFlag(PointerCaptureOptions.PreventOSSteal))
 		{
 			target.RequestDisallowInterceptTouchEvent(true);
 		}

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCapture.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCapture.iOS.cs
@@ -15,9 +15,9 @@ partial class PointerCapture
 
 	partial void AddOptions(UIElement target, PointerCaptureOptions options)
 	{
-		if (options.HasFlag(PointerCaptureOptions.PreventOsStole))
+		if (options.HasFlag(PointerCaptureOptions.PreventOSSteal))
 		{
-			RemoveOptions(target, PointerCaptureOptions.PreventOsStole);
+			RemoveOptions(target, PointerCaptureOptions.PreventOSSteal);
 			_currentManagers = TouchesManager.GetAllParents(target).ToList();
 
 			foreach (var manager in _currentManagers)
@@ -30,7 +30,7 @@ partial class PointerCapture
 
 	partial void RemoveOptions(UIElement target, PointerCaptureOptions options)
 	{
-		if (options.HasFlag(PointerCaptureOptions.PreventOsStole))
+		if (options.HasFlag(PointerCaptureOptions.PreventOSSteal))
 		{
 			// The 'target' will not change between Add and Remove, so we can use the same _currentManagers list.
 

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCapture.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCapture.iOS.cs
@@ -1,0 +1,51 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+
+namespace Uno.UI.Xaml.Core;
+
+partial class PointerCapture
+{
+	private IList<TouchesManager>? _currentManagers;
+
+	partial void AddOptions(UIElement target, PointerCaptureOptions options)
+	{
+		if (options.HasFlag(PointerCaptureOptions.PreventOsStole))
+		{
+			RemoveOptions(target, PointerCaptureOptions.PreventOsStole);
+			_currentManagers = TouchesManager.GetAllParents(target).ToList();
+
+			foreach (var manager in _currentManagers)
+			{
+				manager.RegisterChildListener();
+				manager.ManipulationStarted();
+			}
+		}
+	}
+
+	partial void RemoveOptions(UIElement target, PointerCaptureOptions options)
+	{
+		if (options.HasFlag(PointerCaptureOptions.PreventOsStole))
+		{
+			// The 'target' will not change between Add and Remove, so we can use the same _currentManagers list.
+
+			if (_currentManagers is null)
+			{
+				return;
+			}
+
+			foreach (var manager in _currentManagers)
+			{
+				manager.UnRegisterChildListener();
+				manager.ManipulationEnded();
+			}
+
+			_currentManagers = null;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCaptureOptions.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCaptureOptions.cs
@@ -12,5 +12,5 @@ internal enum PointerCaptureOptions : byte
 	/// <summary>
 	/// This applies mainly for iOS and Android, where the OS can steal the pointer when it detects a scroll gesture (touch and pen).
 	/// </summary>
-	PreventOsStole = 1,
+	PreventOSSteal = 1,
 }

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCaptureOptions.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCaptureOptions.cs
@@ -1,0 +1,16 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+
+namespace Uno.UI.Xaml.Core;
+
+[Flags]
+internal enum PointerCaptureOptions : byte
+{
+	None = 0,
+
+	/// <summary>
+	/// This applies mainly for iOS and Android, where the OS can steal the pointer when it detects a scroll gesture (touch and pen).
+	/// </summary>
+	PreventOsStole = 1,
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -967,7 +967,7 @@ namespace Microsoft.UI.Xaml
 #if NEEDS_IMPLICIT_CAPTURE
 				if (recognizer.PendingManipulation?.IsActive(point.Pointer) ?? false)
 				{
-					Capture(args.Pointer, PointerCaptureKind.Implicit, PointerCaptureOptions.PreventOsStole, args);
+					Capture(args.Pointer, PointerCaptureKind.Implicit, PointerCaptureOptions.PreventOSSteal, args);
 				}
 #endif
 			}

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1420,14 +1420,14 @@ namespace Microsoft.UI.Xaml
 		{
 			var pointer = value ?? throw new ArgumentNullException(nameof(value));
 
-			return Capture(pointer, PointerCaptureKind.Explicit, _pendingRaisedEvent.args) is PointerCaptureResult.Added;
+			return Capture(pointer, PointerCaptureKind.Explicit, PointerCaptureOptions.None, _pendingRaisedEvent.args) is PointerCaptureResult.Added;
 		}
 
-		private protected PointerCaptureResult CapturePointer(Pointer value, PointerCaptureKind kind)
+		private protected PointerCaptureResult CapturePointer(Pointer value, PointerCaptureKind kind = PointerCaptureKind.Explicit, PointerCaptureOptions options = PointerCaptureOptions.None)
 		{
 			var pointer = value ?? throw new ArgumentNullException(nameof(value));
 
-			return Capture(pointer, kind, _pendingRaisedEvent.args);
+			return Capture(pointer, kind, options, _pendingRaisedEvent.args);
 		}
 
 		public void ReleasePointerCapture(Pointer value)
@@ -1515,7 +1515,7 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-		private PointerCaptureResult Capture(Pointer pointer, PointerCaptureKind kind, PointerRoutedEventArgs relatedArgs)
+		private PointerCaptureResult Capture(Pointer pointer, PointerCaptureKind kind, PointerCaptureOptions opts, PointerRoutedEventArgs relatedArgs)
 		{
 			if (PointerCapturesBackingField == null)
 			{
@@ -1523,7 +1523,7 @@ namespace Microsoft.UI.Xaml
 				this.SetValue(PointerCapturesProperty, PointerCapturesBackingField); // Note: On UWP this is done only on first capture (like here)
 			}
 
-			return PointerCapture.GetOrCreate(pointer).TryAddTarget(this, kind, relatedArgs);
+			return PointerCapture.GetOrCreate(pointer).TryAddTarget(this, kind, opts, relatedArgs);
 		}
 
 		private void Release(PointerCaptureKind kinds, PointerRoutedEventArgs relatedArgs = null, bool muteEvent = false)

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -967,7 +967,7 @@ namespace Microsoft.UI.Xaml
 #if NEEDS_IMPLICIT_CAPTURE
 				if (recognizer.PendingManipulation?.IsActive(point.Pointer) ?? false)
 				{
-					Capture(args.Pointer, PointerCaptureKind.Implicit, args);
+					Capture(args.Pointer, PointerCaptureKind.Implicit, PointerCaptureOptions.PreventOsStole, args);
 				}
 #endif
 			}


### PR DESCRIPTION
closes https://github.com/unoplatform/kahua-private/issues/106

## Bugfix
Thumb does not prevent scroll

## What is the current behavior?
`Thumb` on windows captures the pointer, but this does not prevent the OS to "stole" the pointer (usually when it detects a scroll gesture)

## What is the new behavior?
When capturing pointer, uno controls are able to also request to prevent the OS to "stole" the pointer.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
