### PR TITLE
fix: [Catalyst] Ensure LottieVisualSource is transparent

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSource.Skottie.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSource.Skottie.cs
@@ -214,6 +214,10 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 #else
 			_softwareCanvas = new();
 			_softwareCanvas.PaintSurface += OnSoftwareCanvas_PaintSurface;
+
+#if __IOS__
+			_softwareCanvas.Opaque = false;
+#endif
 			return _softwareCanvas;
 #endif
 		}

--- a/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
@@ -99,6 +99,9 @@
 
 				<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
 				<MtouchExtraArgs>$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
+
+				<!-- Only the invariant culture is support in globalization-invariant mode. See https://aka.ms/GlobalizationInvariantMode -->
+				<InvariantGlobalization>false</InvariantGlobalization>
 			</PropertyGroup>
 			
 			<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/15247

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures the LottieVisualPlayer on Catalyst has a transparent background.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
