### PR TITLE
TreeView should start with SelectedItem selected

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml
@@ -26,6 +26,7 @@
 					</DataTemplate>
 				</muxcontrols:TreeView.ItemTemplate>
 			</muxcontrols:TreeView>
+			<StackPanel x:Name="SecondTreeView"/>
 		</StackPanel>
 	</Grid>
 </utilities:MUXTestPage>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml
@@ -26,7 +26,24 @@
 					</DataTemplate>
 				</muxcontrols:TreeView.ItemTemplate>
 			</muxcontrols:TreeView>
-			<StackPanel x:Name="SecondTreeView"/>
+
+			<TextBlock Text="TreeView to Test SelectedItem"/>
+			<muxcontrols:TreeView 
+				HorizontalAlignment="Left"
+				ItemsSource="{Binding TestTreeViewItemsSource}"
+				SelectedItem="{Binding TestTreeViewSelectedItem}">
+				<muxcontrols:TreeView.ItemTemplate>
+					<DataTemplate>
+						<muxcontrols:TreeViewItem 
+								ItemsSource="{Binding Children}"
+								Content="{Binding Content}"
+								IsExpanded="True"/>
+					</DataTemplate>
+				</muxcontrols:TreeView.ItemTemplate>
+			</muxcontrols:TreeView>
+
+			<TextBlock Text="TreeView to Test Content"/>
+			<StackPanel HorizontalAlignment="Left" x:Name="SecondTreeView"/>
 		</StackPanel>
 	</Grid>
 </utilities:MUXTestPage>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml
@@ -1,0 +1,31 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<utilities:MUXTestPage
+	xmlns:local="using:UITests.Shared.Microsoft_UI_Xaml_Controls.TreeViewTests"
+	xmlns:utilities="using:MUXControlsTestApp.Utilities"
+    x:Class="UITests.Shared.Microsoft_UI_Xaml_Controls.TreeViewTests.TreeViewIsSelectedPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Margin="12">
+		<StackPanel>
+			<TextBlock Text="TreeView to Test IsSelected"/>
+			<muxcontrols:TreeView 
+				HorizontalAlignment="Left"
+				ItemsSource="{Binding TestTreeViewItemsSource}">
+				<muxcontrols:TreeView.ItemTemplate>
+					<DataTemplate>
+						<muxcontrols:TreeViewItem 
+							ItemsSource="{Binding Children}"
+							Content="{Binding Content}"
+							IsExpanded="True"
+							IsSelected="{Binding IsSelected, Mode=TwoWay}"/>
+					</DataTemplate>
+				</muxcontrols:TreeView.ItemTemplate>
+			</muxcontrols:TreeView>
+		</StackPanel>
+	</Grid>
+</utilities:MUXTestPage>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml.cs
@@ -32,6 +32,19 @@ namespace UITests.Shared.Microsoft_UI_Xaml_Controls.TreeViewTests
 				}
 			}
 		}
+		private TreeViewItemSource m_testTreeViewSelectedItem;
+		public TreeViewItemSource TestTreeViewSelectedItem
+		{
+			get { return m_testTreeViewSelectedItem; }
+			set
+			{
+				if (m_testTreeViewSelectedItem != value)
+				{
+					m_testTreeViewSelectedItem = value;
+					NotifyPropertyChanged(nameof(TestTreeViewSelectedItem));
+				}
+			}
+		}
 
 		private void NotifyPropertyChanged(String propertyName)
 		{
@@ -46,16 +59,17 @@ namespace UITests.Shared.Microsoft_UI_Xaml_Controls.TreeViewTests
 			this.DataContext = this;
 			this.InitializeComponent();
 
-			//var child1 = new TreeViewItemSource() { Content = "child1" };
-			//var children1 = new ObservableCollection<TreeViewItemSource>() { child1 };
-			//var item1 = new TreeViewItemSource() { Content = "item1", Children = children1 };
+			var child1 = new TreeViewItemSource() { Content = "child1" };
+			var children1 = new ObservableCollection<TreeViewItemSource>() { child1 };
+			var item1 = new TreeViewItemSource() { Content = "item1", Children = children1 };
 
-			var child2 = new TreeViewItemSource() { Content = "child1", IsSelected = true };
+			var child2 = new TreeViewItemSource() { Content = "child2", IsSelected = true };
 			var children2 = new ObservableCollection<TreeViewItemSource>() { child2 };
 			var item2 = new TreeViewItemSource() { Content = "item2", Children = children2 };
 
-			TestTreeViewItemsSource = new ObservableCollection<TreeViewItemSource>() { /*item1,*/ item2 };
+			TestTreeViewItemsSource = new ObservableCollection<TreeViewItemSource>() { item1, item2 };
 
+			//TestTreeViewSelectedItem = item1;
 
 			StackPanel panel = new StackPanel
 			{

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Windows.ApplicationModel.DataTransfer;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Media;
+using System.Collections.ObjectModel;
+
+using TreeViewSelectionMode = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewSelectionMode;
+using TreeViewNode = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewNode;
+using TreeView = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeView;
+using TreeViewItemInvokedEventArgs = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewItemInvokedEventArgs;
+using TreeViewExpandingEventArgs = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewExpandingEventArgs;
+using TreeViewDragItemsStartingEventArgs = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewDragItemsStartingEventArgs;
+using TreeViewDragItemsCompletedEventArgs = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewDragItemsCompletedEventArgs;
+using TreeViewList = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewList;
+using TreeViewItem = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewItem;
+//using MaterialHelperTestApi = Microsoft.UI.Private.Media.MaterialHelperTestApi;
+using System.Threading.Tasks;
+
+// Uno specific
+using Uno.UI.Samples.Controls;
+using MUXControlsTestApp.Utilities;
+using Uno.Extensions.Specialized;
+using System.ComponentModel;
+
+// Replace listControl.GetItems().Count() with listControl.GetItems().Count()
+
+namespace UITests.Shared.Microsoft_UI_Xaml_Controls.TreeViewTests
+{
+	[Sample("MUX", "TreeView")]
+	public sealed partial class TreeViewIsSelectedPage : MUXTestPage, INotifyPropertyChanged
+	{
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		private ObservableCollection<TreeViewItemSource> m_testTreeViewItemsSource;
+		public ObservableCollection<TreeViewItemSource> TestTreeViewItemsSource
+		{
+			get { return m_testTreeViewItemsSource; }
+			set
+			{
+				if (m_testTreeViewItemsSource != value)
+				{
+					m_testTreeViewItemsSource = value;
+					NotifyPropertyChanged(nameof(TestTreeViewItemsSource));
+				}
+			}
+		}
+
+		private void NotifyPropertyChanged(String propertyName)
+		{
+			if (PropertyChanged != null)
+			{
+				PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+			}
+		}
+
+		public TreeViewIsSelectedPage()
+		{
+			this.DataContext = this;
+			this.InitializeComponent();
+
+			//var child1 = new TreeViewItemSource() { Content = "child1" };
+			//var children1 = new ObservableCollection<TreeViewItemSource>() { child1 };
+			//var item1 = new TreeViewItemSource() { Content = "item1", Children = children1 };
+
+			var child2 = new TreeViewItemSource() { Content = "child1", IsSelected = true };
+			var children2 = new ObservableCollection<TreeViewItemSource>() { child2 };
+			var item2 = new TreeViewItemSource() { Content = "item2", Children = children2 };
+
+			TestTreeViewItemsSource = new ObservableCollection<TreeViewItemSource>() { /*item1,*/ item2 };
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TreeView/TreeViewIsSelectedPage.xaml.cs
@@ -2,37 +2,15 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Windows.ApplicationModel.DataTransfer;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Automation;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Navigation;
-using Microsoft.UI.Xaml.Media;
 using System.Collections.ObjectModel;
-
-using TreeViewSelectionMode = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewSelectionMode;
-using TreeViewNode = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewNode;
-using TreeView = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeView;
-using TreeViewItemInvokedEventArgs = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewItemInvokedEventArgs;
-using TreeViewExpandingEventArgs = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewExpandingEventArgs;
-using TreeViewDragItemsStartingEventArgs = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewDragItemsStartingEventArgs;
-using TreeViewDragItemsCompletedEventArgs = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewDragItemsCompletedEventArgs;
-using TreeViewList = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewList;
-using TreeViewItem = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewItem;
-//using MaterialHelperTestApi = Microsoft.UI.Private.Media.MaterialHelperTestApi;
-using System.Threading.Tasks;
-
-// Uno specific
-using Uno.UI.Samples.Controls;
-using MUXControlsTestApp.Utilities;
-using Uno.Extensions.Specialized;
 using System.ComponentModel;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MUXControlsTestApp.Utilities;
 
-// Replace listControl.GetItems().Count() with listControl.GetItems().Count()
+using Uno.UI.Samples.Controls;
+using TreeView = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeView;
+using TreeViewNode = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TreeViewNode;
 
 namespace UITests.Shared.Microsoft_UI_Xaml_Controls.TreeViewTests
 {
@@ -77,6 +55,42 @@ namespace UITests.Shared.Microsoft_UI_Xaml_Controls.TreeViewTests
 			var item2 = new TreeViewItemSource() { Content = "item2", Children = children2 };
 
 			TestTreeViewItemsSource = new ObservableCollection<TreeViewItemSource>() { /*item1,*/ item2 };
+
+
+			StackPanel panel = new StackPanel
+			{
+				HorizontalAlignment = HorizontalAlignment.Center,
+				VerticalAlignment = VerticalAlignment.Center,
+			};
+
+			TreeView treeView = new TreeView
+			{
+				RootNodes =
+			{
+				new TreeViewNode
+				{
+					Content = "1111",
+				},
+				new TreeViewNode
+				{
+					Content = "2222"
+				},
+				new TreeViewNode
+				{
+					Content = "333"
+				}
+			}
+			};
+
+			treeView.Loaded += (s, e) =>
+			{
+				treeView.SelectedItem = treeView.RootNodes[1];
+			};
+
+			panel.Children.Add(treeView);
+			SecondTreeView.Children.Add(panel);
+
+
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2602,6 +2602,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+	<Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\TreeView\TreeViewIsSelectedPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_DynamicContent.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7086,6 +7090,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\TreeView\TreeViewPage.xaml.cs">
       <DependentUpon>TreeViewPage.xaml</DependentUpon>
+    </Compile>
+	<Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\TreeView\TreeViewIsSelectedPage.xaml.cs">
+      <DependentUpon>TreeViewIsSelectedPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ViewBoxTests\ViewBox_Alignment.xaml.cs">
       <DependentUpon>ViewBox_Alignment.xaml</DependentUpon>

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/SelectedTreeNodeVector.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/SelectedTreeNodeVector.cs
@@ -103,7 +103,7 @@ internal class SelectedTreeNodeVector : ObservableVector<TreeViewNode>
 					var item = listControl?.ItemFromNode(node);
 					if (item != null)
 					{
-						selectedItems.Insert(index, item);
+						selectedItems.Append(item);
 						viewModel.TrackItemSelected(item);
 					}
 				}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeView.cs
@@ -3,6 +3,7 @@
 // MUX Reference TreeView.cpp, tag winui3/release/1.4.2
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
@@ -295,7 +296,7 @@ public partial class TreeView : Control
 		DragItemsCompleted?.Invoke(this, treeViewArgs);
 	}
 
-	private void OnListControlSelectionChanged(object sender, SelectionChangedEventArgs args)
+	private async void OnListControlSelectionChanged(object sender, SelectionChangedEventArgs args)
 	{
 		if (SelectionMode == TreeViewSelectionMode.Single)
 		{
@@ -324,7 +325,12 @@ public partial class TreeView : Control
 
 			if (SelectedItem != newSelectedItem)
 			{
+				//This Yield is necessary here, to allow selection of items that have children.
+				//Preventing errors in UIElement PointerReleasedEvent
+				//The given key 'UITests.Shared.Microsoft_UI_Xaml_Controls.TreeViewTests.TreeViewItemSource' was not present in the dictionary.
+				await Task.Yield();
 				SelectedItem = newSelectedItem;
+
 			}
 		}
 	}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeViewList.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeViewList.cs
@@ -365,6 +365,13 @@ public partial class TreeViewList : ListView
 		templateSettings.CollapsedGlyphVisibility = !itemNode.IsExpanded ? Visibility.Visible : Visibility.Collapsed;
 
 		base.PrepareContainerForItemOverride(element, item);
+		//Commented, because when initializing the method,
+		//itemNodeImplNoRef.SelectionState does not have the updated state
+		//and was reverting the correct state
+		//if (selectionState != itemNodeImplNoRef.SelectionState)
+		//{
+		//	ListViewModel.UpdateSelection(itemNodeImplNoRef, selectionState);
+		//}
 	}
 
 	protected override DependencyObject GetContainerForItemOverride()

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeViewList.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeViewList.cs
@@ -365,11 +365,6 @@ public partial class TreeViewList : ListView
 		templateSettings.CollapsedGlyphVisibility = !itemNode.IsExpanded ? Visibility.Visible : Visibility.Collapsed;
 
 		base.PrepareContainerForItemOverride(element, item);
-
-		if (selectionState != itemNodeImplNoRef.SelectionState)
-		{
-			ListViewModel.UpdateSelection(itemNodeImplNoRef, selectionState);
-		}
 	}
 
 	protected override DependencyObject GetContainerForItemOverride()

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TreeView/TreeViewViewModel.cs
@@ -88,7 +88,7 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 			}
 			if (item != null)
 			{
-				selectedItems.Add(item);
+				selectedItems.Append(item);
 			}
 		}
 		finally
@@ -110,12 +110,12 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 				{
 					selectedNodes.Clear();
 				}
-				selectedNodes.Add(node);
+				selectedNodes.Append(node);
 			}
 			else
 			{
 				int index;
-				if ((index = selectedNodes.IndexOf(node)) > -1)
+				if ((index = SelectedNodes.IndexOf(node)) > -1)
 				{
 					selectedNodes.RemoveAt(index);
 				}
@@ -647,9 +647,9 @@ internal partial class TreeViewViewModel : ObservableVector<object>
 		}
 	}
 
-	internal IList<TreeViewNode> SelectedNodes => m_selectedNodes;
+	internal SelectedTreeNodeVector SelectedNodes => m_selectedNodes;
 
-	internal IList<object> SelectedItems => m_selectedItems;
+	internal SelectedItemsVector SelectedItems => m_selectedItems;
 
 	internal void TrackItemSelected(object item)
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #15214 


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The treeview is not starting with the selected item.
What is expected is that when TreeViewItem.IsSelected is True, it started selected, as it works in Windows.

## What is the new behavior?

Now I added a new example that shows it is working (TreeViewItem.IsSelected true and started selected).

![image](https://github.com/unoplatform/uno/assets/116665025/240ac721-0a71-418a-91ae-2671b675ea26)

And I added a change to make selected elements with children selectable ( we was getting and error in UIElement PointerReleasedEvent: The given key 'UITests.Shared.Microsoft_UI_Xaml_Controls.TreeViewTests.TreeViewItemSource' was not present in the dictionary.).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
