### PR TITLE
fix: [iOS] Avoid crash when content size is negative

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.iOS.cs
@@ -296,8 +296,8 @@ namespace Microsoft.UI.Xaml.Controls
 						_content.Frame = new CGRect(
 							GetAdjustedArrangeX(iFwElt, adjustedMeasure, (nfloat)contentMargin.Horizontal()),
 							GetAdjustedArrangeY(iFwElt, adjustedMeasure, (nfloat)contentMargin.Vertical()),
-							adjustedMeasure.Width,
-							adjustedMeasure.Height
+							Math.Max(0, adjustedMeasure.Width),
+							Math.Max(0, adjustedMeasure.Height)
 						);
 					}
 				}

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -934,8 +934,8 @@ namespace Microsoft.UI.Xaml
 			get => Visibility == Visibility.Collapsed ? new Size() : _size;
 			internal set
 			{
-				global::System.Diagnostics.Debug.Assert(value.Width >= 0, "Invalid width");
-				global::System.Diagnostics.Debug.Assert(value.Height >= 0, "Invalid height");
+				global::System.Diagnostics.Debug.Assert(value.Width >= 0, $"Invalid width ({value.Width})");
+				global::System.Diagnostics.Debug.Assert(value.Height >= 0, $"Invalid height ({value.Height})");
 				var previousSize = _size;
 				_size = value;
 				if (_size != previousSize)


### PR DESCRIPTION
GitHub Issue (If applicable): Related to https://github.com/unoplatform/uno/issues/15254

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Avoids a crash when the `ScrollContentPresenter` content returns a negative size

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
