### PR TITLE
docs: Adujust PasswordVault

### DIFF
--- a/doc/articles/features/PasswordVault.md
+++ b/doc/articles/features/PasswordVault.md
@@ -72,5 +72,5 @@ vault.Add(new Windows.Security.Credentials.PasswordCredential(
 var vault = new Windows.Security.Credentials.PasswordVault();
 var credential = vault.Retrieve("My App", userName);
 credential.RetrievePassword();
-var password = loginCredential.Password;
+var password = credential.Password;
 ```


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Documentation content changes

## What is the current behavior?
loginCredential variable used while vault.Retrieve() is set in the variable credential

## What is the new behavior?
Updated loginCredential to credential

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
