### PR TITLE
fix: Don't run PRI workaround for WinUI on the head project

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
@@ -5,7 +5,10 @@
 		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
 		<RuntimeIdentifiers Condition=" $(RuntimeIdentifiers) == '' ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
 		<EnableCoreMrtTooling Condition=" $(EnableCoreMrtTooling) == '' AND '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
-		<EnableMsixTooling Condition=" $(EnableMsixTooling) == '' ">true</EnableMsixTooling>
+
+		<!-- Set EnableMsixTooling to true only for executables - setting this on class libraries prevents assets from being correctly copied to windows target -->
+		<EnableMsixTooling Condition=" $(EnableMsixTooling) == '' AND ('$(OutputType)' == 'WinExe' OR '$(OutputType)' == 'Exe') ">true</EnableMsixTooling>
+
 		<EnableWindowsTargeting Condition=" $(EnableWindowsTargeting) == '' ">true</EnableWindowsTargeting>
 	</PropertyGroup>
 

--- a/src/Uno.Sdk/targets/winappsdk-workaround.targets
+++ b/src/Uno.Sdk/targets/winappsdk-workaround.targets
@@ -1,6 +1,8 @@
-<Project>
+	<Project>
 	<!-- Workaround to avoid including Project XBFs in the PRI file: https://github.com/microsoft/microsoft-ui-xaml/issues/8857 -->
-	<Target Name="WinUI8857_AdjustGetPackagingOutput1" AfterTargets="GetMrtPackagingOutputs">
+	<Target Name="WinUI8857_AdjustGetPackagingOutput1"
+			AfterTargets="GetMrtPackagingOutputs"
+			Condition="'$(OutputType)' != 'WinExe'">
 		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
 		<ItemGroup>
 			<_OtherPriFiles Include="@(PackagingOutputs)" Condition="'%(Extension)' == '.pri' and ('%(PackagingOutputs.ReferenceSourceTarget)' == 'ProjectReference' or '%(PackagingOutputs.NugetSourceType)'=='Package')" />
@@ -8,7 +10,9 @@
 		</ItemGroup>
 	</Target>
 	
-	<Target Name="WinUI8857_AdjustGetPackagingOutput2" BeforeTargets="AddPriPayloadFilesToCopyToOutputDirectoryItems">
+	<Target Name="WinUI8857_AdjustGetPackagingOutput2"
+			BeforeTargets="AddPriPayloadFilesToCopyToOutputDirectoryItems"
+			Condition="'$(OutputType)' != 'WinExe'">
 		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />
 		<ItemGroup>
 			<_OtherPriFiles1 Include="@(_ReferenceRelatedPaths)" Condition="'%(Extension)' == '.pri' and ('%(_ReferenceRelatedPaths.ReferenceSourceTarget)' == 'ProjectReference' or '%(_ReferenceRelatedPaths.NugetSourceType)'=='Package')" />

--- a/src/Uno.Sdk/targets/winappsdk-workaround.targets
+++ b/src/Uno.Sdk/targets/winappsdk-workaround.targets
@@ -1,4 +1,4 @@
-	<Project>
+<Project>
 	<!-- Workaround to avoid including Project XBFs in the PRI file: https://github.com/microsoft/microsoft-ui-xaml/issues/8857 -->
 	<Target Name="WinUI8857_AdjustGetPackagingOutput1"
 			AfterTargets="GetMrtPackagingOutputs"


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.templates/issues/547

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Disable WinAppSDK Workaround for wasdk project heads.
Also, only set EnableMsixTooling to true on wasdk project heads

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
