### PR TITLE
perf: Move Loaded/Unloaded to use OnLoaded/OnUnloaded to avoid delegate combine

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Android.cs
@@ -188,5 +188,8 @@ namespace Microsoft.UI.Xaml.Controls
 
 		bool ICustomClippingElement.AllowClippingToLayoutSlot => true;
 		bool ICustomClippingElement.ForceClippingToLayoutSlot => true; // force scrollviewer to always clip
+
+		private partial void OnLoadedPartial() { }
+		private partial void OnUnloadedPartial() { }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Managed.cs
@@ -23,6 +23,9 @@ namespace Microsoft.UI.Xaml.Controls
 		private bool ChangeViewNative(double? horizontalOffset, double? verticalOffset, double? zoomFactor, bool disableAnimation)
 			=> (_presenter as ScrollContentPresenter)?.Set(horizontalOffset, verticalOffset, disableAnimation: disableAnimation) ?? true;
 
+		private partial void OnLoadedPartial() { }
+		private partial void OnUnloadedPartial() { }
+
 		#region Over scroll support
 		/// <summary>
 		/// Trim excess scroll, which can be present if the content size is reduced.

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -44,8 +44,6 @@ using View = Microsoft.UI.Xaml.UIElement;
 using _ScrollContentPresenter = Microsoft.UI.Xaml.Controls.ScrollContentPresenter;
 #else
 using _ScrollContentPresenter = Microsoft.UI.Xaml.Controls.IScrollContentPresenter;
-using System.Security;
-
 #endif
 
 #if HAS_UNO_WINUI

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -44,6 +44,8 @@ using View = Microsoft.UI.Xaml.UIElement;
 using _ScrollContentPresenter = Microsoft.UI.Xaml.Controls.ScrollContentPresenter;
 #else
 using _ScrollContentPresenter = Microsoft.UI.Xaml.Controls.IScrollContentPresenter;
+using System.Security;
+
 #endif
 
 #if HAS_UNO_WINUI
@@ -135,9 +137,6 @@ namespace Microsoft.UI.Xaml.Controls
 			UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewer.GetUpdatesMode(this);
 			InitializePartial();
 
-			Loaded += AttachScrollBars;
-			Unloaded += DetachScrollBars;
-			Unloaded += ResetScrollIndicator;
 
 			this.RegisterParentChangedCallback(this, (_, _, args) =>
 			{
@@ -149,6 +148,29 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		partial void InitializePartial();
+
+		private protected override void OnLoaded()
+		{
+			base.OnLoaded();
+
+			EnsureAttachScrollBars();
+
+			OnLoadedPartial();
+		}
+
+		private partial void OnLoadedPartial();
+
+		private protected override void OnUnloaded()
+		{
+			base.OnUnloaded();
+
+			DetachScrollBars();
+			ResetScrollIndicator();
+
+			OnUnloadedPartial();
+		}
+		private partial void OnUnloadedPartial();
+
 
 		#region -- Common DP callbacks --
 		private static PropertyChangedCallback OnHorizontalScrollabilityPropertyChanged = (obj, _)
@@ -1180,13 +1202,10 @@ namespace Microsoft.UI.Xaml.Controls
 			PointerMoved -= ShowScrollIndicator;
 		}
 
-		private static void AttachScrollBars(object sender, RoutedEventArgs e) // OnLoaded
+		private void EnsureAttachScrollBars()
 		{
-			if (sender is ScrollViewer sv)
-			{
-				sv.DetachScrollBars(); // Avoid double subscribe due to OnApplyTemplate
-				sv.AttachScrollBars();
-			}
+			DetachScrollBars(); // Avoid double subscribe due to OnApplyTemplate
+			AttachScrollBars();
 		}
 
 		private void AttachScrollBars()

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.iOS.cs
@@ -43,6 +43,8 @@ namespace Microsoft.UI.Xaml.Controls
 			SetScrollableContainer();
 		}
 
+		private partial void OnUnloadedPartial() { }
+
 		private void SetScrollableContainer()
 		{
 			_scrollableContainer = _presenter;

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.iOS.cs
@@ -38,7 +38,7 @@ namespace Microsoft.UI.Xaml.Controls
 			SetScrollableContainer();
 		}
 
-		private protected override void OnLoaded()
+		private partial void OnLoadedPartial()
 		{
 			SetScrollableContainer();
 			base.OnLoaded();

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.iOS.cs
@@ -41,7 +41,6 @@ namespace Microsoft.UI.Xaml.Controls
 		private partial void OnLoadedPartial()
 		{
 			SetScrollableContainer();
-			base.OnLoaded();
 		}
 
 		private void SetScrollableContainer()

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.reference.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.reference.cs
@@ -4,6 +4,10 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	partial class ScrollViewer
 	{
+		private partial void OnLoadedPartial() { }
+
+		private partial void OnUnloadedPartial() { }
+
 		private bool ChangeViewNative(double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation)
 		{
 			throw new NotImplementedException();

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.unittests.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.unittests.cs
@@ -25,6 +25,9 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		private partial void OnLoadedPartial() { }
+
+		private partial void OnUnloadedPartial() { }
 		private void UpdateZoomedContentAlignment() { }
 
 		private bool ChangeViewNative(double? horizontalOffset, double? verticalOffset, float? zoomFactor, bool disableAnimation)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.wasm.cs
@@ -75,9 +75,8 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		private protected override void OnLoaded()
+		private partial void OnLoadedPartial()
 		{
-			base.OnLoaded();
 			AddHandler(KeyDownEvent, new KeyEventHandler(OnKeyDown), true);
 			AddHandler(PointerWheelChangedEvent, new PointerEventHandler(OnPointerWheelChanged), true);
 		}
@@ -90,9 +89,8 @@ namespace Microsoft.UI.Xaml.Controls
 			CancelNextNativeScroll = false;
 		}
 
-		private protected override void OnUnloaded()
+		private partial void OnUnloadedPartial()
 		{
-			base.OnUnloaded();
 			RemoveHandler(KeyDownEvent, new KeyEventHandler(OnKeyDown));
 			RemoveHandler(PointerWheelChangedEvent, new PointerEventHandler(OnPointerWheelChanged));
 		}


### PR DESCRIPTION
Reduces allocations for ScrollViewer constructor:
![image](https://github.com/unoplatform/uno/assets/5839577/5c2d4740-f71c-4984-b07f-7a6c10abcfad)
