### PR TITLE
fix: `TimePickerFlyout` is not visible if not opened from `TimePicker`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -149,9 +149,18 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var popup = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot).FirstOrDefault();
 			var datePickerFlyoutPresenter = popup?.Child as DatePickerFlyoutPresenter;
 
-			Assert.IsNotNull(datePickerFlyoutPresenter);
-			Assert.AreEqual(1, datePickerFlyoutPresenter.Opacity);
-			datePickerFlyout.Close();
+			try
+			{
+				Assert.IsNotNull(datePickerFlyoutPresenter);
+				Assert.AreEqual(1, datePickerFlyoutPresenter.Opacity);
+			}
+			finally
+			{
+				if (popup is not null)
+				{
+					popup.IsOpen = false;
+				}
+			}
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_DatePicker.cs
@@ -1,9 +1,12 @@
 ﻿#if !WINAPPSDK
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
@@ -119,6 +122,36 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			CheckDateTimeTextBlockPartPosition(datePicker, "YearTextBlock", expectedColumn: 0);
 			CheckDateTimeTextBlockPartPosition(datePicker, "MonthTextBlock", expectedColumn: 2);
 			CheckDateTimeTextBlockPartPosition(datePicker, "DayTextBlock", expectedColumn: 4);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[UnoWorkItem("https://github.com/unoplatform/uno/issues/15409")]
+		public async Task When_Opened_From_Button_Flyout()
+		{
+			var button = new Button();
+			var datePickerFlyout = new DatePickerFlyout();
+			button.Flyout = datePickerFlyout;
+
+			var root = new Grid();
+			root.Children.Add(button);
+
+			TestServices.WindowHelper.WindowContent = root;
+
+			await TestServices.WindowHelper.WaitForLoaded(root);
+
+			var buttonAutomationPeer = FrameworkElementAutomationPeer.CreatePeerForElement(button);
+			var invokePattern = buttonAutomationPeer.GetPattern(PatternInterface.Invoke) as IInvokeProvider;
+			invokePattern.Invoke();
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			var popup = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot).FirstOrDefault();
+			var datePickerFlyoutPresenter = popup?.Child as DatePickerFlyoutPresenter;
+
+			Assert.IsNotNull(datePickerFlyoutPresenter);
+			Assert.AreEqual(1, datePickerFlyoutPresenter.Opacity);
+			datePickerFlyout.Close();
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TimePicker.cs
@@ -88,9 +88,18 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var popup = VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot).FirstOrDefault();
 			var timePickerFlyoutPresenter = popup?.Child as TimePickerFlyoutPresenter;
 
-			Assert.IsNotNull(timePickerFlyoutPresenter);
-			Assert.AreEqual(1, timePickerFlyoutPresenter.Opacity);
-			timePickerFlyout.Close();
+			try
+			{
+				Assert.IsNotNull(timePickerFlyoutPresenter);
+				Assert.AreEqual(1, timePickerFlyoutPresenter.Opacity);
+			}
+			finally
+			{
+				if (popup is not null)
+				{
+					popup.IsOpen = false;
+				}
+			}
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePickerFlyout_Partial.cs
@@ -79,19 +79,12 @@ namespace Microsoft.UI.Xaml.Controls
 			_tpPresenter = spFlyoutPresenter;
 
 			// TODO: Uno specific: This is a workaround to avoid the popup to be shown at the wrong position briefly #15031
-			if (_tpPresenter is FrameworkElement presenter)
+			if (_tpPresenter is FrameworkElement presenter && _tpTarget is not null)
 			{
 				presenter.Opacity = 0.0;
 			}
 
 			return _tpPresenter as Control;
-		}
-
-		private protected override void ShowAtCore(FrameworkElement placementTarget, FlyoutShowOptions showOptions)
-		{
-			_tpTarget = placementTarget;
-			base.ShowAtCore(placementTarget, showOptions);
-			//_asyncOperationManager.Start(placementTarget);
 		}
 
 		public IAsyncOperation<DateTime?> ShowAtAsync(FrameworkElement target)

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.partial.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.partial.mux.cs
@@ -104,7 +104,10 @@ partial class TimePickerFlyout
 			_tpPresenter.Style = TimePickerFlyoutPresenterStyle;
 		}
 		// TODO: Uno specific: This is a workaround to avoid the popup to be shown at the wrong position briefly #15031
-		_tpPresenter.Opacity = 0.0;
+		if (_tpTarget is not null)
+		{
+			_tpPresenter.Opacity = 0.0;
+		}
 
 		return _tpPresenter;
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #15409 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
