### PR TITLE
perf: Make `_childrenBinable` lazy and avoid unnecessary insertions

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -102,7 +102,7 @@ namespace Microsoft.UI.Xaml
 
 			// The property value may be an enumerable of providers
 			var isValidEnumerable = child is not string;
-			return isValidEnumerable && child is IList or IEnumerable;
+			return isValidEnumerable && child is IEnumerable;
 		}
 
 		private void ApplyChildrenBindable(object? inheritedValue, bool isTemplatedParent)

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -127,6 +127,10 @@ namespace Microsoft.UI.Xaml
 			for (int i = 0; i < _childrenBindable.Count; i++)
 			{
 				var child = _childrenBindable[i];
+				if (child is null)
+				{
+					continue;
+				}
 
 				Debug.Assert(IsCandidateChild(child));
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -1,21 +1,23 @@
 ﻿#nullable enable
 
 using System;
-using System.Linq;
-using Uno.Disposables;
-using System.Runtime.CompilerServices;
-using Uno.Foundation.Logging;
-using Uno.Extensions;
-using Uno.UI.DataBinding;
-using Uno.UI;
-using Microsoft.UI.Xaml.Data;
-using System.Collections.Generic;
-using Microsoft.UI.Xaml;
-using System.Globalization;
-using System.Threading;
-using Uno.Diagnostics.Eventing;
 using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
 using Uno.Collections;
+using Uno.Diagnostics.Eventing;
+using Uno.Disposables;
+using Uno.Extensions;
+using Uno.Foundation.Logging;
+using Uno.UI;
+using Uno.UI.DataBinding;
 
 #if !IS_UNIT_TESTS
 using Uno.UI.Controls;
@@ -35,8 +37,11 @@ namespace Microsoft.UI.Xaml
 
 		private readonly object _gate = new object();
 
-		private readonly HashtableEx _childrenBindableMap = new HashtableEx(DependencyPropertyComparer.Default);
-		private readonly List<object?> _childrenBindable = new List<object?>();
+		private HashtableEx? _childrenBindableMap;
+		private List<object>? _childrenBindable;
+
+		private HashtableEx ChildrenBindableMap => _childrenBindableMap ??= new HashtableEx(DependencyPropertyComparer.Default);
+		private List<object> ChildrenBindable => _childrenBindable ??= new List<object>();
 
 		private bool _isApplyingTemplateBindings;
 		private bool _isApplyingDataContextBindings;
@@ -88,6 +93,18 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
+		private bool IsCandidateChild([NotNullWhen(true)] object? child)
+		{
+			if (child is IDependencyObjectStoreProvider)
+			{
+				return true;
+			}
+
+			// The property value may be an enumerable of providers
+			var isValidEnumerable = child is not string;
+			return isValidEnumerable && child is IList or IEnumerable;
+		}
+
 		private void ApplyChildrenBindable(object? inheritedValue, bool isTemplatedParent)
 		{
 			static void SetInherited(IDependencyObjectStoreProvider provider, object? inheritedValue, bool isTemplatedParent)
@@ -102,9 +119,16 @@ namespace Microsoft.UI.Xaml
 				}
 			}
 
+			if (_childrenBindable is null)
+			{
+				return;
+			}
+
 			for (int i = 0; i < _childrenBindable.Count; i++)
 			{
 				var child = _childrenBindable[i];
+
+				Debug.Assert(IsCandidateChild(child));
 
 				var childAsStoreProvider = child as IDependencyObjectStoreProvider;
 
@@ -127,36 +151,31 @@ namespace Microsoft.UI.Xaml
 				{
 					SetInherited(childAsStoreProvider, inheritedValue, isTemplatedParent);
 				}
-				else
+				else if (child is IList list)
 				{
-					// The property value may be an enumerable of providers
-					var isValidEnumerable = !(child is string);
+					// Special case for IList where the child may not be enumerable
 
-					if (isValidEnumerable)
+					for (int childIndex = 0; childIndex < list.Count; childIndex++)
 					{
-						if (child is IList list)
+						if (list[childIndex] is IDependencyObjectStoreProvider provider2)
 						{
-							// Special case for IList where the child may not be enumerable
-
-							for (int childIndex = 0; childIndex < list.Count; childIndex++)
-							{
-								if (list[childIndex] is IDependencyObjectStoreProvider provider2)
-								{
-									SetInherited(provider2, inheritedValue, isTemplatedParent);
-								}
-							}
-						}
-						else if (child is IEnumerable enumerable)
-						{
-							foreach (var item in enumerable)
-							{
-								if (item is IDependencyObjectStoreProvider provider2)
-								{
-									SetInherited(provider2, inheritedValue, isTemplatedParent);
-								}
-							}
+							SetInherited(provider2, inheritedValue, isTemplatedParent);
 						}
 					}
+				}
+				else if (child is IEnumerable enumerable)
+				{
+					foreach (var item in enumerable)
+					{
+						if (item is IDependencyObjectStoreProvider provider2)
+						{
+							SetInherited(provider2, inheritedValue, isTemplatedParent);
+						}
+					}
+				}
+				else
+				{
+					throw new Exception("This cannot be reached. IsCandidateChild would have returned false if none of the conditions were true.");
 				}
 			}
 		}
@@ -248,7 +267,7 @@ namespace Microsoft.UI.Xaml
 			}
 
 			_properties.Dispose();
-			_childrenBindableMap.Dispose();
+			_childrenBindableMap?.Dispose();
 		}
 
 		private void OnDataContextChanged(object? providedDataContext, object? actualDataContext, DependencyPropertyValuePrecedences precedence)
@@ -569,7 +588,10 @@ namespace Microsoft.UI.Xaml
 		}
 
 		private void SetChildrenBindableValue(DependencyPropertyDetails propertyDetails, object? value)
-			=> _childrenBindable[GetOrCreateChildBindablePropertyIndex(propertyDetails.Property)] = value;
+		{
+			if (IsCandidateChild(value))
+				ChildrenBindable[GetOrCreateChildBindablePropertyIndex(propertyDetails.Property)] = value;
+		}
 
 		/// <summary>
 		/// Gets or create an index in the <see cref="_childrenBindable"/> list, to avoid enumerating <see cref="_childrenBindableMap"/>.
@@ -578,10 +600,10 @@ namespace Microsoft.UI.Xaml
 		{
 			int index;
 
-			if (!_childrenBindableMap.TryGetValue(property, out var indexRaw))
+			if (!ChildrenBindableMap.TryGetValue(property, out var indexRaw))
 			{
-				_childrenBindableMap[property] = index = _childrenBindableMap.Count;
-				_childrenBindable.Add(null);
+				ChildrenBindableMap[property] = index = ChildrenBindableMap.Count;
+				ChildrenBindable.Add(null!); // The caller will replace null with a non-null value.
 			}
 			else
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Performance

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Some insertions happen that have no effect because we end up skipping them in `ApplyChildrenBindable`
- Hashtable and List are created for each DependencyObject.

## What is the new behavior?

- Only insert things that we will use in `ApplyChildrenBindable`.
- With the limited insertions, it's now common to end up with `DependencyObjectStore`s with empty hash tables and lists. So, it now makes sense to make these lazy. This not only reduces allocation, but reduces pressure on the ArrayPool used by HashtableEx.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
