### PR TITLE
fix: Make Android `WebView2.NavigationStarting` more reliable

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -160,9 +160,9 @@ namespace SamplesApp
 
 			HandleLaunchArguments(e);
 
-			if (SampleControl.Presentation.SampleChooserViewModel.Instance.CurrentSelectedSample is null)
+			if (SampleControl.Presentation.SampleChooserViewModel.Instance is { } vm && vm.CurrentSelectedSample is null)
 			{
-				SampleControl.Presentation.SampleChooserViewModel.Instance.SetSelectedSample(CancellationToken.None, "Playground", "Playground");
+				vm.SetSelectedSample(CancellationToken.None, "Playground", "Playground");
 			}
 
 			Console.WriteLine("Done loading " + sw.Elapsed);

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_WebView2.cs
@@ -42,10 +42,13 @@ public class Given_WebView2
 		await TestServices.WindowHelper.WaitForLoaded(border);
 		var uri = new Uri("https://example.com/");
 		await webView.EnsureCoreWebView2Async();
+		bool navigationStarting = false;
 		bool navigationDone = false;
+		webView.NavigationStarting += (s, e) => navigationStarting = true;
 		webView.NavigationCompleted += (s, e) => navigationDone = true;
 		webView.CoreWebView2.Navigate(uri.ToString());
 		Assert.IsNull(webView.Source);
+		await TestServices.WindowHelper.WaitFor(() => navigationStarting, 1000);
 		await TestServices.WindowHelper.WaitFor(() => navigationDone, 3000);
 		Assert.IsNotNull(webView.Source);
 		Assert.IsTrue(webView.Source.OriginalString.StartsWith("https://example.com/", StringComparison.OrdinalIgnoreCase));
@@ -63,10 +66,13 @@ public class Given_WebView2
 		await TestServices.WindowHelper.WaitForLoaded(border);
 		var uri = new Uri("https://example.com/");
 		await webView.EnsureCoreWebView2Async();
+		bool navigationStarting = false;
 		bool navigationDone = false;
+		webView.NavigationStarting += (s, e) => navigationStarting = true;
 		webView.NavigationCompleted += (s, e) => navigationDone = true;
 		webView.Source = uri;
 		Assert.IsNotNull(webView.Source);
+		await TestServices.WindowHelper.WaitFor(() => navigationStarting, 1000);
 		await TestServices.WindowHelper.WaitFor(() => navigationDone, 3000);
 		Assert.IsNotNull(webView.Source);
 		navigationDone = false;

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/InternalWebClient.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/InternalWebClient.Android.cs
@@ -44,9 +44,7 @@ internal class InternalClient : Android.Webkit.WebViewClient
 			return true;
 		}
 
-		_coreWebView.RaiseNavigationStarting(url, out var cancel);
-
-		return cancel;
+		return false;
 	}
 
 	public override void OnPageStarted(Android.Webkit.WebView view, string url, Bitmap favicon)

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/InternalWebClient.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/InternalWebClient.Android.cs
@@ -44,7 +44,9 @@ internal class InternalClient : Android.Webkit.WebViewClient
 			return true;
 		}
 
-		return false;
+		_coreWebView.RaiseNavigationStarting(url, out var cancel);
+
+		return cancel;
 	}
 
 	public override void OnPageStarted(Android.Webkit.WebView view, string url, Bitmap favicon)

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebViewWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebViewWrapper.Android.cs
@@ -126,13 +126,13 @@ internal class NativeWebViewWrapper : INativeWebView
 		if (uri.Scheme.Equals("local", StringComparison.OrdinalIgnoreCase))
 		{
 			var path = $"file:///android_asset/{uri.PathAndQuery}";
-			_webView.LoadUrl(path);
+			ScheduleNavigationStarting(path, () => _webView.LoadUrl(path));
 			return;
 		}
 
 		if (uri.Scheme.Equals(Uri.UriSchemeMailto, StringComparison.OrdinalIgnoreCase))
 		{
-			CreateAndLaunchMailtoIntent(_webView.Context, uri.AbsoluteUri);
+			ScheduleNavigationStarting(uri.AbsoluteUri, () => CreateAndLaunchMailtoIntent(_webView.Context, uri.AbsoluteUri));
 			return;
 		}
 
@@ -155,7 +155,8 @@ internal class NativeWebViewWrapper : INativeWebView
 
 		//The replace is present because the URI cuts off any slashes that are more than two when it creates the URI.
 		//Therefore we add the final forward slash manually in Android because the file:/// requires 3 slashes.
-		_webView.LoadUrl(uri.AbsoluteUri.Replace("file://", "file:///"));
+		var actualUri = uri.AbsoluteUri.Replace("file://", "file:///");
+		ScheduleNavigationStarting(actualUri, () => _webView.LoadUrl(actualUri));
 	}
 
 	public void ProcessNavigation(HttpRequestMessage requestMessage)
@@ -169,14 +170,27 @@ internal class NativeWebViewWrapper : INativeWebView
 			);
 
 		_wasLoadedFromString = false;
-		_webView.LoadUrl(uri.AbsoluteUri, headers);
+		ScheduleNavigationStarting(uri.AbsoluteUri, () => _webView.LoadUrl(uri.AbsoluteUri, headers));
 	}
 
 	public void ProcessNavigation(string html)
 	{
 		_wasLoadedFromString = true;
 		//Note : _webView.LoadData does not work properly on Android 10 even when we encode to base64.
-		_webView.LoadDataWithBaseURL(null, html, "text/html; charset=utf-8", "utf-8", null);
+		ScheduleNavigationStarting(null, () => _webView.LoadDataWithBaseURL(null, html, "text/html; charset=utf-8", "utf-8", null));
+	}
+
+	private void ScheduleNavigationStarting(string url, Action loadAction)
+	{
+		_ = _coreWebView.Owner.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
+		{
+			_coreWebView.RaiseNavigationStarting(url, out var cancel);
+
+			if (!cancel)
+			{
+				loadAction?.Invoke();
+			}
+		});
 	}
 
 	async Task<string> INativeWebView.ExecuteScriptAsync(string script, CancellationToken token)

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebViewWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebViewWrapper.Android.cs
@@ -182,6 +182,9 @@ internal class NativeWebViewWrapper : INativeWebView
 
 	private void ScheduleNavigationStarting(string url, Action loadAction)
 	{
+		// For programmatically-triggered navigations the ShouldOverrideUrlLoading method is not called,
+		// to workaround this, we raise the NavigationStarting event here, asynchronously to be in line with
+		// the WinUI behavior.
 		_ = _coreWebView.Owner.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
 		{
 			_coreWebView.RaiseNavigationStarting(url, out var cancel);


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/nventive-private/issues/508

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.