### PR TITLE
Fix issue with libraries not getting correct resource path

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
@@ -4,12 +4,17 @@
 		<TargetPlatformMinVersion Condition=" $(TargetPlatformMinVersion) == '' ">10.0.18362.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
 		<RuntimeIdentifiers Condition=" $(RuntimeIdentifiers) == '' ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
-		<EnableCoreMrtTooling Condition=" $(EnableCoreMrtTooling) == '' AND '$(BuildingInsideVisualStudio)' != 'true' ">false</EnableCoreMrtTooling>
 
 		<!-- Set EnableMsixTooling to true only for executables - setting this on class libraries prevents assets from being correctly copied to windows target -->
 		<EnableMsixTooling Condition=" $(EnableMsixTooling) == '' AND ('$(OutputType)' == 'WinExe' OR '$(OutputType)' == 'Exe') ">true</EnableMsixTooling>
 
 		<EnableWindowsTargeting Condition=" $(EnableWindowsTargeting) == '' ">true</EnableWindowsTargeting>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+		<!-- Workaround Uno Issue 15492 - This must be set to true for the Library so that the generated files use the Library name in the path -->
+		<EnableCoreMrtTooling Condition=" $(EnableCoreMrtTooling) == '' AND $(OutputType) != 'WinExe' AND $(OutputType) != 'Exe' ">true</EnableCoreMrtTooling>
+		<EnableCoreMrtTooling Condition=" $(EnableCoreMrtTooling) == '' AND '$(MSBuildRuntimeType)' == 'Core' ">false</EnableCoreMrtTooling>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(SingleProject)!='true' and $(OutputType)=='WinExe'">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #15492

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

We will always default setting EnableCoreMrtTooling to false when we set it

## What is the new behavior?

We now set EnableCoreMrtTooling to true when building for a library