### PR TITLE
fix(Catalyst): File and folder Picker UIThread issue

### DIFF
--- a/src/Uno.UWP/Storage/Pickers/FolderPicker.iOS.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPicker.iOS.cs
@@ -9,6 +9,7 @@ using UIKit;
 using Uno.Helpers.Theming;
 using Windows.ApplicationModel.Core;
 using Uno.UI.Dispatching;
+using Uno.Foundation.Logging;
 
 namespace Windows.Storage.Pickers
 {
@@ -16,12 +17,17 @@ namespace Windows.Storage.Pickers
 	{
 		private Task<StorageFolder?> PickSingleFolderTaskAsync(CancellationToken token)
 		{
-			static async Task<StorageFolder?> PickFolderAsync()
+			async Task<StorageFolder?> PickFolderAsync()
 			{
 				var rootController = UIApplication.SharedApplication?.KeyWindow?.RootViewController;
-				if (rootController == null)
+				if (rootController is null)
 				{
 					throw new InvalidOperationException("Root controller not initialized yet. FolderPicker invoked too early.");
+				}
+
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug("Picking Folder.");
 				}
 
 				var documentTypes = new string[] { UTType.Folder };
@@ -44,10 +50,20 @@ namespace Windows.Storage.Pickers
 				var nsUrl = await completionSource.Task;
 				if (nsUrl is null)
 				{
+					if (this.Log().IsEnabled(LogLevel.Debug))
+					{
+						this.Log().Debug("User cancelled folder picking.");
+					}
 					return null;
 				}
 
-				return StorageFolder.GetFromSecurityScopedUrl(nsUrl, null);
+				var folder = StorageFolder.GetFromSecurityScopedUrl(nsUrl, null);
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().Debug($"Picked folder: {folder.Path} from Url: {nsUrl}.");
+				}
+
+				return folder;
 			}
 
 			var tcs = new TaskCompletionSource<StorageFolder?>();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #15504 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Getting: **UIKit Consistency error: you are calling a UIKit method that can only be invoked from the UI thread** when using FolderPicker and FileOpenPicker.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
