### PR TITLE
refactor: Make description part of `SampleChooserControl`

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -45,11 +45,11 @@
 			<Style x:Key="BaseTitleGridContainerStyle"
 				   TargetType="Grid">
 				<Setter Property="BorderBrush"
-						Value="{StaticResource Color05Brush}" />
+						Value="{ThemeResource Color05Brush}" />
 				<Setter Property="BorderThickness"
 						Value="0,0,0,1" />
 				<Setter Property="Background"
-						Value="{StaticResource ApplicationPageBackgroundThemeBrush}" />
+						Value="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
 				<Setter Property="Height"
 								Value="50" />
 			</Style>
@@ -603,6 +603,17 @@
 								HorizontalContentAlignment="Stretch"
 								VerticalContentAlignment="Stretch"
 								Grid.Row="1"/>
+
+				<StackPanel Grid.Row="2" 
+							Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+							Visibility="{Binding CurrentSelectedSample.Description, Converter={StaticResource StringEmptyToVisibilityConverter}}">
+					<TextBlock Text="Description"
+							Style="{StaticResource Typo03}"
+							Margin="0,0,0,4" />
+					<TextBlock Text="{Binding CurrentSelectedSample.Description}"
+							Style="{StaticResource Typo05}"
+							MaxHeight="80" />
+				</StackPanel>
 			</Grid>
 		</SplitView.Content>
 	</SplitView>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -604,7 +604,10 @@
 								VerticalContentAlignment="Stretch"
 								Grid.Row="1"/>
 
-				<StackPanel Grid.Row="2" 
+				<StackPanel Grid.Row="2"
+							Padding="8"
+							BorderThickness="0,1,0,0"
+							BorderBrush="{ThemeResource Color05Brush}"
 							Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
 							Visibility="{Binding CurrentSelectedSample.Description, Converter={StaticResource StringEmptyToVisibilityConverter}}">
 					<TextBlock Text="Description"

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Styles/SampleControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Styles/SampleControl.xaml
@@ -27,18 +27,6 @@
 											Content="{TemplateBinding Content}"
 											u:StarStackPanel.Size="*"
 											Padding="10,10,10,0"/>
-							<StackPanel Background="{StaticResource Color08Brush}"
-										Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SampleDescription, Converter={StaticResource StringEmptyToVisibilityConverter}}"
-										u:StarStackPanel.Size="Auto"
-										Padding="10,0">
-								<TextBlock Text="DESCRIPTION"
-											 Style="{StaticResource Typo03}"
-											 Margin="0,10,0,5" />
-								<TextBlock Text="{TemplateBinding SampleDescription}"
-											 Style="{StaticResource Typo05}"
-											 MaxHeight="80"
-											 Margin="0,0,0,10" />
-							</StackPanel>
 						</u:StarStackPanel>
 					</Border>
 				</ControlTemplate>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/14586


## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

The sample control contains the description, but when the sample is wrapped in a `Frame` this is not visible.

## What is the new behavior?

The description is always visible.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.