### PR TITLE
chore: Bump SkiaSharp to 2.88.7

### DIFF
--- a/.github/workflows/uwp-autoconvert.yml
+++ b/.github/workflows/uwp-autoconvert.yml
@@ -11,7 +11,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   UnoCheck_Version: '1.18.1'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/8a14128754833984a0c83398e7dda6d995199e1b/manifests/uno.ui.manifest.json'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/3728e150e4e148789302dcc00baaeae63e0c7eae/manifests/uno.ui.manifest.json'
 
   # Only convert using NetPrevious
   UnoDisableNetCurrentMobile: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -54,11 +54,11 @@ variables:
   windowsScaledPool: 'Windows2022-20230918'
   linuxVMImage: 'ubuntu-latest'
   linuxScaledPool: 'Ubuntu2204-20230918'
-  macOSVMImage: 'macOS-12'
-  macOSVMImage_UITests: 'macOS-12'
-  xCodeRoot: '/Applications/Xcode_14.3.app'
+  macOSVMImage: 'macOS-13'
+  macOSVMImage_UITests: 'macOS-13'
+  xCodeRoot: '/Applications/Xcode_15.2.app'
   XamarinSDKVersion: 6_12_24
-  xCodeRoot_iOS_UITests: '/Applications/Xcode_14.3.app'
+  xCodeRoot_iOS_UITests: '/Applications/Xcode_15.2.app'
   XamarinSDKVersion_iOS_UITests: 6_12_24
 
   # Offline validation to improve build performance

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -55,10 +55,10 @@ variables:
   linuxVMImage: 'ubuntu-latest'
   linuxScaledPool: 'Ubuntu2204-20230918'
   macOSVMImage: 'macOS-13'
-  macOSVMImage_UITests: 'macOS-13'
+  macOSVMImage_UITests: 'macOS-12'
   xCodeRoot: '/Applications/Xcode_15.2.app'
   XamarinSDKVersion: 6_12_24
-  xCodeRoot_iOS_UITests: '/Applications/Xcode_15.2.app'
+  xCodeRoot_iOS_UITests: '/Applications/Xcode_14.1.app'
   XamarinSDKVersion_iOS_UITests: 6_12_24
 
   # Offline validation to improve build performance

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -56,9 +56,9 @@ variables:
   linuxScaledPool: 'Ubuntu2204-20230918'
   macOSVMImage: 'macOS-12'
   macOSVMImage_UITests: 'macOS-12'
-  xCodeRoot: '/Applications/Xcode_14.1.app'
+  xCodeRoot: '/Applications/Xcode_14.3.app'
   XamarinSDKVersion: 6_12_24
-  xCodeRoot_iOS_UITests: '/Applications/Xcode_14.1.app'
+  xCodeRoot_iOS_UITests: '/Applications/Xcode_14.3.app'
   XamarinSDKVersion_iOS_UITests: 6_12_24
 
   # Offline validation to improve build performance

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -58,7 +58,7 @@ variables:
   macOSVMImage_UITests: 'macOS-13'
   xCodeRoot: '/Applications/Xcode_15.2.app'
   XamarinSDKVersion: 6_12_24
-  xCodeRoot_iOS_UITests: '/Applications/Xcode_15.2.app'
+  xCodeRoot_iOS_UITests: '/Applications/Xcode_14.1.app'
   XamarinSDKVersion_iOS_UITests: 6_12_24
 
   # Offline validation to improve build performance

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -58,7 +58,7 @@ variables:
   macOSVMImage_UITests: 'macOS-13'
   xCodeRoot: '/Applications/Xcode_15.2.app'
   XamarinSDKVersion: 6_12_24
-  xCodeRoot_iOS_UITests: '/Applications/Xcode_14.1.app'
+  xCodeRoot_iOS_UITests: '/Applications/Xcode_15.2.app'
   XamarinSDKVersion_iOS_UITests: 6_12_24
 
   # Offline validation to improve build performance

--- a/build/ci/.azure-devops-android-tests.yml
+++ b/build/ci/.azure-devops-android-tests.yml
@@ -102,7 +102,7 @@ jobs:
           SAMPLEAPP_ARTIFACT_NAME: uitests-android-netcoremobile-build
           TARGETPLATFORM_NAME: net7
           FAILBUILD_ON_FAILURE: true
-          ALLOW_RERUN: false
+          ALLOW_RERUN: true
           UITEST_TEST_TIMEOUT: '270s'
 
       ${{ each testGroup in parameters.runtimeTestsGroups }}:
@@ -125,7 +125,7 @@ jobs:
         SAMPLEAPP_ARTIFACT_NAME: uitests-android-netcoremobile-build
         TARGETPLATFORM_NAME: net7
         FAILBUILD_ON_FAILURE: true
-        ALLOW_RERUN: false
+        ALLOW_RERUN: true
         UITEST_TEST_TIMEOUT: '270s'
 
       # Android 10 testing is disabled because of https://github.com/microsoft/appcenter/issues/1451

--- a/build/ci/.azure-devops-android-tests.yml
+++ b/build/ci/.azure-devops-android-tests.yml
@@ -76,7 +76,7 @@ jobs:
   dependsOn:
   - Android_Build_NetCoreMobile_For_Tests
 
-  timeoutInMinutes: 90
+  timeoutInMinutes: 45
   variables:
     CI_Build: true
     SourceLinkEnabled: false
@@ -102,7 +102,7 @@ jobs:
           SAMPLEAPP_ARTIFACT_NAME: uitests-android-netcoremobile-build
           TARGETPLATFORM_NAME: net7
           FAILBUILD_ON_FAILURE: true
-          ALLOW_RERUN: true
+          ALLOW_RERUN: false
           UITEST_TEST_TIMEOUT: '270s'
 
       ${{ each testGroup in parameters.runtimeTestsGroups }}:
@@ -125,7 +125,7 @@ jobs:
         SAMPLEAPP_ARTIFACT_NAME: uitests-android-netcoremobile-build
         TARGETPLATFORM_NAME: net7
         FAILBUILD_ON_FAILURE: true
-        ALLOW_RERUN: true
+        ALLOW_RERUN: false
         UITEST_TEST_TIMEOUT: '270s'
 
       # Android 10 testing is disabled because of https://github.com/microsoft/appcenter/issues/1451

--- a/build/ci/.azure-devops-ios-tests-run.yml
+++ b/build/ci/.azure-devops-ios-tests-run.yml
@@ -34,6 +34,11 @@ jobs:
   - checkout: self
     clean: true
 
+  - script: |
+      cp global.json global-net7.json
+      cp global-net8.json global.json
+    displayName: Replace global.json with .NET 8
+
   - task: DownloadBuildArtifacts@0
     displayName: 'Download iOS Samples App'
     inputs:

--- a/build/ci/.azure-devops-ios-tests-run.yml
+++ b/build/ci/.azure-devops-ios-tests-run.yml
@@ -34,11 +34,6 @@ jobs:
   - checkout: self
     clean: true
 
-  - script: |
-      cp global.json global-net7.json
-      cp global-net8.json global.json
-    displayName: Replace global.json with .NET 8
-
   - task: DownloadBuildArtifacts@0
     displayName: 'Download iOS Samples App'
     inputs:

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -175,6 +175,7 @@ jobs:
 
     env:
       BUILD_SOURCESDIRECTORY: "$(build.sourcesdirectory)"
+      AGENT_TEMPDIRECTORY: "$(Agent.TempDirectory)"
       BUILD_ARTIFACTSTAGINGDIRECTORY: "$(build.artifactstagingdirectory)"
 
   - task: CopyFiles@2

--- a/build/ci/templates/dotnet7-mobile-install-mac.yml
+++ b/build/ci/templates/dotnet7-mobile-install-mac.yml
@@ -1,6 +1,6 @@
 parameters:
-  UnoCheck_Version: '1.14.1'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/146b0b4b23d866bef455494a12ad7ffd2f6f2d20/manifests/uno.ui.manifest.json'
+  UnoCheck_Version: '1.18.1'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/3728e150e4e148789302dcc00baaeae63e0c7eae/manifests/uno.ui.manifest.json'
 
 steps:
 

--- a/build/nuget/Uno.WinUI.Lottie.nuspec
+++ b/build/nuget/Uno.WinUI.Lottie.nuspec
@@ -28,33 +28,33 @@
 
 
 			<group targetFramework="net8.0-android">
-				<dependency id="SkiaSharp.Skottie" version="2.88.3" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.android" version="2.88.3" />
+				<dependency id="SkiaSharp.Skottie" version="2.88.7" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.android" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="Newtonsoft.Json" version="13.0.2" />
 			</group>
 			<group targetFramework="net8.0-ios">
-				<dependency id="SkiaSharp.Skottie" version="2.88.3" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.ios" version="2.88.3" />
+				<dependency id="SkiaSharp.Skottie" version="2.88.7" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.ios" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="System.Json" version="4.7.1" />
 			</group>
 			<group targetFramework="net8.0-maccatalyst">
-				<dependency id="SkiaSharp.Skottie" version="2.88.3" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.maccatalyst" version="2.88.3" />
+				<dependency id="SkiaSharp.Skottie" version="2.88.7" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.maccatalyst" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="System.Json" version="4.7.1" />
 			</group>
 			<group targetFramework="net8.0-macos">
-				<dependency id="SkiaSharp.Skottie" version="2.88.3" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.macos" version="2.88.3" />
+				<dependency id="SkiaSharp.Skottie" version="2.88.7" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.macos" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 				<dependency id="System.Json" version="4.7.1" />

--- a/build/nuget/Uno.WinUI.Svg.nuspec
+++ b/build/nuget/Uno.WinUI.Svg.nuspec
@@ -29,44 +29,44 @@
 
 			<group targetFramework="net8.0-android">
 				<dependency id="Svg.Skia" version="1.0.0.1" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.android" version="2.88.3" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.android" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>
 			<group targetFramework="net8.0-ios">
 				<dependency id="Svg.Skia" version="1.0.0.1" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.ios" version="2.88.3" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.ios" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>
 			<group targetFramework="net8.0-maccatalyst">
 				<dependency id="Svg.Skia" version="1.0.0.1" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.maccatalyst" version="2.88.3" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.maccatalyst" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>
 
 			<group targetFramework="net7.0-android">
 				<dependency id="Svg.Skia" version="1.0.0.1" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.android" version="2.88.3" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.android" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>
 			<group targetFramework="net7.0-ios">
 				<dependency id="Svg.Skia" version="1.0.0.1" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.ios" version="2.88.3" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.ios" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>
 			<group targetFramework="net7.0-maccatalyst">
 				<dependency id="Svg.Skia" version="1.0.0.1" />
-				<dependency id="SkiaSharp.Views.Uno" version="2.88.3" />
-				<dependency id="SkiaSharp.NativeAssets.maccatalyst" version="2.88.3" />
+				<dependency id="SkiaSharp.Views.Uno" version="2.88.7" />
+				<dependency id="SkiaSharp.NativeAssets.maccatalyst" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
 			</group>

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -123,7 +123,7 @@ then
 	echo "Installing idb"
 	brew install pipx
 	# # https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
-	# brew tap facebook/fb
+	brew tap facebook/fb
 	brew install idb-companion
 	pipx install fb-idb
 	export PATH=$PATH:~/.local/bin

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -219,6 +219,7 @@ else
 		--logger "nunit;LogFileName=$UNO_ORIGINAL_TEST_RESULTS" \
 		--filter "$UNO_TESTS_FILTER" \
 		--blame-hang-timeout $UITEST_TEST_TIMEOUT \
+		--arch x64 \
 		-v m \
 		|| true
 fi

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -230,7 +230,8 @@ export LOG_FILEPATH_FULL=$LOG_FILEPATH/DeviceLog-$UITEST_AUTOMATED_GROUP-${UITES
 cp -fv "$UNO_ORIGINAL_TEST_RESULTS" $LOG_FILEPATH/Test-Results-$LOG_PREFIX.xml || true
 
 # Copy all the dotnet test dmp files to the log directory
-cp -Rv $AGENT_TEMPDIRECTORY/**/*.dmp $LOG_FILEPATH || true
+find $AGENT_TEMPDIRECTORY -name "*.dmp" -exec cp -v {} $LOG_FILEPATH \;
+find $UNO_TESTS_LOCAL_TESTS_FILE -name "*.dmp" -exec cp -v {} $LOG_FILEPATH \;
 
 ## Take a screenshot
 xcrun simctl io "$UITEST_IOSDEVICE_ID" screenshot $LOG_FILEPATH/capture-$LOG_PREFIX.png

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -122,6 +122,7 @@ xcrun simctl boot "$UITEST_IOSDEVICE_ID" || true
 
 # echo "Install app on simulator: $UITEST_IOSDEVICE_ID"
 # xcrun simctl install "$UITEST_IOSDEVICE_ID" "$UNO_UITEST_IOSBUNDLE_PATH" || true
+idb install --udid "$UITEST_IOSDEVICE_ID" "$UNO_UITEST_IOSBUNDLE_PATH"
 
 ## Pre-build the transform tool to get early warnings
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -217,7 +217,7 @@ else
 	dotnet test \
 		-c Release \
 		-l:"console;verbosity=normal" \
-		-p:UnoTargetFrameworkOverride=net8.0 \
+		-f net8.0 \
 		--logger "nunit;LogFileName=$UNO_ORIGINAL_TEST_RESULTS" \
 		--filter "$UNO_TESTS_FILTER" \
 		--blame-hang-timeout $UITEST_TEST_TIMEOUT \

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -230,7 +230,7 @@ export LOG_FILEPATH_FULL=$LOG_FILEPATH/DeviceLog-$UITEST_AUTOMATED_GROUP-${UITES
 cp -fv "$UNO_ORIGINAL_TEST_RESULTS" $LOG_FILEPATH/Test-Results-$LOG_PREFIX.xml || true
 
 # Copy all the dotnet test dmp files to the log directory
-cp -Rv $UNO_TESTS_LOCAL_TESTS_FILE/**/*.d, $LOG_FILEPATH || true
+cp -Rv $UNO_TESTS_LOCAL_TESTS_FILE/**/*.dmp $LOG_FILEPATH || true
 
 ## Take a screenshot
 xcrun simctl io "$UITEST_IOSDEVICE_ID" screenshot $LOG_FILEPATH/capture-$LOG_PREFIX.png

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -230,7 +230,7 @@ export LOG_FILEPATH_FULL=$LOG_FILEPATH/DeviceLog-$UITEST_AUTOMATED_GROUP-${UITES
 cp -fv "$UNO_ORIGINAL_TEST_RESULTS" $LOG_FILEPATH/Test-Results-$LOG_PREFIX.xml || true
 
 # Copy all the dotnet test dmp files to the log directory
-cp -Rv $UNO_TESTS_LOCAL_TESTS_FILE/**/*.dmp $LOG_FILEPATH || true
+cp -Rv $AGENT_TEMPDIRECTORY/**/*.dmp $LOG_FILEPATH || true
 
 ## Take a screenshot
 xcrun simctl io "$UITEST_IOSDEVICE_ID" screenshot $LOG_FILEPATH/capture-$LOG_PREFIX.png

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -194,11 +194,19 @@ then
 
 else
 
-	echo "Installing idb"
-	# https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
-	brew tap facebook/fb
-	brew install idb-companion
-	pip3 install fb-idb
+	# check for the presence of idb, and install it if it's not present
+	if ! command -v idb &> /dev/null
+	then
+		echo "Installing idb"
+		brew install pipx
+		# https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
+		brew tap facebook/fb
+		brew install idb-companion
+		pipx install fb-idb
+		export PATH=$PATH:~/.local/bin
+	else
+		echo "Using idb from:" `command -v idb`
+	fi
 
 	echo "Test Parameters:"
 	echo "  Timeout=$UITEST_TEST_TIMEOUT"

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -92,8 +92,8 @@ export UNO_TESTS_LOCAL_TESTS_FILE=$BUILD_SOURCESDIRECTORY/src/SamplesApp/Samples
 export UNO_UITEST_BENCHMARKS_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/benchmarks/ios-automated
 export UNO_UITEST_RUNTIMETESTS_RESULTS_FILE_PATH=$BUILD_SOURCESDIRECTORY/build/RuntimeTestResults-ios-automated.xml
 
-export UNO_UITEST_SIMULATOR_VERSION="com.apple.CoreSimulator.SimRuntime.iOS-17-2"
-export UNO_UITEST_SIMULATOR_NAME="iPad Pro (12.9-inch) (6th generation)"
+export UNO_UITEST_SIMULATOR_VERSION="com.apple.CoreSimulator.SimRuntime.iOS-16-1"
+export UNO_UITEST_SIMULATOR_NAME="iPad Pro (12.9-inch) (5th generation)"
 
 UITEST_IGNORE_RERUN_FILE="${UITEST_IGNORE_RERUN_FILE:=false}"
 
@@ -118,6 +118,8 @@ export UITEST_IOSDEVICE_ID=`xcrun simctl list -j | jq -r --arg sim "$UNO_UITEST_
 export UITEST_IOSDEVICE_DATA_PATH=`xcrun simctl list -j | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" --arg name "$UNO_UITEST_SIMULATOR_NAME" '.devices[$sim] | .[] | select(.name==$name) | .dataPath'`
 
 # check for the presence of idb, and install it if it's not present
+export PATH=$PATH:~/.local/bin
+
 if ! command -v idb &> /dev/null
 then
 	echo "Installing idb"
@@ -126,7 +128,6 @@ then
 	brew tap facebook/fb
 	brew install idb-companion
 	pipx install fb-idb
-	export PATH=$PATH:~/.local/bin
 else
 	echo "Using idb from:" `command -v idb`
 fi
@@ -217,11 +218,9 @@ else
 	dotnet test \
 		-c Release \
 		-l:"console;verbosity=normal" \
-		-p:NetPrevious=net8.0 \
 		--logger "nunit;LogFileName=$UNO_ORIGINAL_TEST_RESULTS" \
 		--filter "$UNO_TESTS_FILTER" \
 		--blame-hang-timeout $UITEST_TEST_TIMEOUT \
-		--arch x64 \
 		-v m \
 		|| true
 fi

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -217,7 +217,7 @@ else
 	dotnet test \
 		-c Release \
 		-l:"console;verbosity=normal" \
-		-f net8.0 \
+		-p:NetPrevious=net8.0 \
 		--logger "nunit;LogFileName=$UNO_ORIGINAL_TEST_RESULTS" \
 		--filter "$UNO_TESTS_FILTER" \
 		--blame-hang-timeout $UITEST_TEST_TIMEOUT \

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -217,6 +217,7 @@ else
 	dotnet test \
 		-c Release \
 		-l:"console;verbosity=normal" \
+		-p:UnoTargetFrameworkOverride=net8.0 \
 		--logger "nunit;LogFileName=$UNO_ORIGINAL_TEST_RESULTS" \
 		--filter "$UNO_TESTS_FILTER" \
 		--blame-hang-timeout $UITEST_TEST_TIMEOUT \

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -120,8 +120,8 @@ export UITEST_IOSDEVICE_DATA_PATH=`xcrun simctl list -j | jq -r --arg sim "$UNO_
 echo "Starting simulator: [$UITEST_IOSDEVICE_ID] ($UNO_UITEST_SIMULATOR_VERSION / $UNO_UITEST_SIMULATOR_NAME)"
 xcrun simctl boot "$UITEST_IOSDEVICE_ID" || true
 
-echo "Install app on simulator: $UITEST_IOSDEVICE_ID"
-xcrun simctl install "$UITEST_IOSDEVICE_ID" "$UNO_UITEST_IOSBUNDLE_PATH" || true
+# echo "Install app on simulator: $UITEST_IOSDEVICE_ID"
+# xcrun simctl install "$UITEST_IOSDEVICE_ID" "$UNO_UITEST_IOSBUNDLE_PATH" || true
 
 ## Pre-build the transform tool to get early warnings
 pushd $BUILD_SOURCESDIRECTORY/src/Uno.NUnitTransformTool

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -124,7 +124,7 @@ then
 	brew install pipx
 	# # https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
 	# brew tap facebook/fb
-	# brew install idb-companion
+	brew install idb-companion
 	pipx install fb-idb
 	export PATH=$PATH:~/.local/bin
 else

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -117,6 +117,20 @@ xcrun simctl list devices --json > $DEVICELIST_FILEPATH
 export UITEST_IOSDEVICE_ID=`xcrun simctl list -j | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" --arg name "$UNO_UITEST_SIMULATOR_NAME" '.devices[$sim] | .[] | select(.name==$name) | .udid'`
 export UITEST_IOSDEVICE_DATA_PATH=`xcrun simctl list -j | jq -r --arg sim "$UNO_UITEST_SIMULATOR_VERSION" --arg name "$UNO_UITEST_SIMULATOR_NAME" '.devices[$sim] | .[] | select(.name==$name) | .dataPath'`
 
+# check for the presence of idb, and install it if it's not present
+if ! command -v idb &> /dev/null
+then
+	echo "Installing idb"
+	brew install pipx
+	# # https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
+	# brew tap facebook/fb
+	# brew install idb-companion
+	pipx install fb-idb
+	export PATH=$PATH:~/.local/bin
+else
+	echo "Using idb from:" `command -v idb`
+fi
+
 echo "Starting simulator: [$UITEST_IOSDEVICE_ID] ($UNO_UITEST_SIMULATOR_VERSION / $UNO_UITEST_SIMULATOR_NAME)"
 xcrun simctl boot "$UITEST_IOSDEVICE_ID" || true
 
@@ -194,20 +208,6 @@ then
 	fi
 
 else
-
-	# check for the presence of idb, and install it if it's not present
-	if ! command -v idb &> /dev/null
-	then
-		echo "Installing idb"
-		brew install pipx
-		# https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
-		brew tap facebook/fb
-		brew install idb-companion
-		pipx install fb-idb
-		export PATH=$PATH:~/.local/bin
-	else
-		echo "Using idb from:" `command -v idb`
-	fi
 
 	echo "Test Parameters:"
 	echo "  Timeout=$UITEST_TEST_TIMEOUT"

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -92,7 +92,7 @@ export UNO_TESTS_LOCAL_TESTS_FILE=$BUILD_SOURCESDIRECTORY/src/SamplesApp/Samples
 export UNO_UITEST_BENCHMARKS_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/benchmarks/ios-automated
 export UNO_UITEST_RUNTIMETESTS_RESULTS_FILE_PATH=$BUILD_SOURCESDIRECTORY/build/RuntimeTestResults-ios-automated.xml
 
-export UNO_UITEST_SIMULATOR_VERSION="com.apple.CoreSimulator.SimRuntime.iOS-16-1"
+export UNO_UITEST_SIMULATOR_VERSION="com.apple.CoreSimulator.SimRuntime.iOS-17-2"
 export UNO_UITEST_SIMULATOR_NAME="iPad Pro (12.9-inch) (6th generation)"
 
 UITEST_IGNORE_RERUN_FILE="${UITEST_IGNORE_RERUN_FILE:=false}"

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -93,7 +93,7 @@ export UNO_UITEST_BENCHMARKS_PATH=$BUILD_ARTIFACTSTAGINGDIRECTORY/benchmarks/ios
 export UNO_UITEST_RUNTIMETESTS_RESULTS_FILE_PATH=$BUILD_SOURCESDIRECTORY/build/RuntimeTestResults-ios-automated.xml
 
 export UNO_UITEST_SIMULATOR_VERSION="com.apple.CoreSimulator.SimRuntime.iOS-16-1"
-export UNO_UITEST_SIMULATOR_NAME="iPad Pro (12.9-inch) (5th generation)"
+export UNO_UITEST_SIMULATOR_NAME="iPad Pro (12.9-inch) (6th generation)"
 
 UITEST_IGNORE_RERUN_FILE="${UITEST_IGNORE_RERUN_FILE:=false}"
 

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -229,6 +229,9 @@ export LOG_FILEPATH_FULL=$LOG_FILEPATH/DeviceLog-$UITEST_AUTOMATED_GROUP-${UITES
 
 cp -fv "$UNO_ORIGINAL_TEST_RESULTS" $LOG_FILEPATH/Test-Results-$LOG_PREFIX.xml || true
 
+# Copy all the dotnet test dmp files to the log directory
+cp -Rv $UNO_TESTS_LOCAL_TESTS_FILE/**/*.d, $LOG_FILEPATH || true
+
 ## Take a screenshot
 xcrun simctl io "$UITEST_IOSDEVICE_ID" screenshot $LOG_FILEPATH/capture-$LOG_PREFIX.png
 

--- a/doc/articles/features/Lottie.md
+++ b/doc/articles/features/Lottie.md
@@ -39,8 +39,8 @@ On all Uno Platform targets, you'll need the following packages:
 
 Additionally, on Skia targets (Gtk, WPF, FrameBuffer), you'll need the following packages:
 
-* `SkiaSharp.Views.Uno.WinUI` version 2.88.3 or later
-* `SkiaSharp.Skottie` version 2.88.3 or later
+* `SkiaSharp.Views.Uno.WinUI` version 2.88.7 or later
+* `SkiaSharp.Skottie` version 2.88.7 or later
 
 On Windows/WinAppSDK, use the [`CommunityToolkit.WinUI.Lottie` NuGet package](https://www.nuget.org/packages/CommunityToolkit.WinUI.Lottie).
 
@@ -72,8 +72,8 @@ On all Uno Platform targets, you'll need the following packages:
 
 Additionally, on Skia targets (Gtk, WPF, FrameBuffer), you'll need the following packages:
 
-* `SkiaSharp.Views.Uno` version 2.88.3 or later
-* `SkiaSharp.Skottie` version 2.88.3 or later
+* `SkiaSharp.Views.Uno` version 2.88.7 or later
+* `SkiaSharp.Skottie` version 2.88.7 or later
 
 On UWP, you'll need to reference the following packages in your head project:
 

--- a/doc/articles/features/using-skia-gtk.md
+++ b/doc/articles/features/using-skia-gtk.md
@@ -89,10 +89,10 @@ If you want to upgrade **SkiaSharp** to a later version, you'll need to specify 
 
 ```xml
 <ItemGroup>
-   <PackagReference Include="SkiaSharp" Version="2.88.3" />
-   <PackagReference Include="SkiaSharp.Harfbuzz" Version="2.88.3" />
-   <PackagReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
-   <PackageReference Update="SkiaSharp.NativeAssets.macOS" Version="2.88.3" />
+   <PackagReference Include="SkiaSharp" Version="2.88.7" />
+   <PackagReference Include="SkiaSharp.Harfbuzz" Version="2.88.7" />
+   <PackagReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.7" />
+   <PackageReference Update="SkiaSharp.NativeAssets.macOS" Version="2.88.7" />
 </ItemGroup>
 ```
 

--- a/doc/articles/features/using-skia-wpf.md
+++ b/doc/articles/features/using-skia-wpf.md
@@ -54,11 +54,11 @@ If you want to upgrade **SkiaSharp** to a later version, you'll need to specify 
 
 ```xml
 <ItemGroup>
-   <PackagReference Include="SkiaSharp" Version="2.88.3" /> 
-   <PackagReference Include="SkiaSharp.Harfbuzz" Version="2.88.3" /> 
-   <PackagReference Include="SkiaSharp.Views.WPF" Version="2.88.3" /> 
-   <PackagReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" /> 
-   <PackageReference Update="SkiaSharp.NativeAssets.macOS" Version="2.88.3" />
+   <PackagReference Include="SkiaSharp" Version="2.88.7" /> 
+   <PackagReference Include="SkiaSharp.Harfbuzz" Version="2.88.7" /> 
+   <PackagReference Include="SkiaSharp.Views.WPF" Version="2.88.7" /> 
+   <PackagReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.7" /> 
+   <PackageReference Update="SkiaSharp.NativeAssets.macOS" Version="2.88.7" />
 </ItemGroup>
 ```
 

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
 	"sdk": {
-		"version": "7.0.302",
+		"version": "7.0.406",
 		"allowPrerelease": false,
 		"rollForward": "latestFeature"
 	},
 	"tools": {
-		"dotnet": "7.0.302"
+		"dotnet": "7.0.406"
 	},
 	"msbuild-sdks": {
 		"MSBuild.Sdk.Extras": "3.0.44",

--- a/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.UI.Lottie.targets
+++ b/src/AddIns/Uno.UI.Lottie/buildTransitive/Uno.UI.Lottie.targets
@@ -25,7 +25,7 @@
 			<_SkottieRefs Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)' == 'SkiaSharp.Skottie'" />
 		</ItemGroup>
 
-		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Lottie support, the '$(_SkiaSharpPackageName)' NuGet Package (2.88.3 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;2.88.3&quot; /> to your project." />
-		<Error Condition="'@(_SkottieRefs)'==''" Text="The 'SkiaSharp.Skottie' NuGet Package (2.88.3 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;SkiaSharp.Skottie&quot; Version=&quot;2.88.3&quot; /> to your project." />
+		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Lottie support, the '$(_SkiaSharpPackageName)' NuGet Package (2.88.7 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;2.88.7&quot; /> to your project." />
+		<Error Condition="'@(_SkottieRefs)'==''" Text="The 'SkiaSharp.Skottie' NuGet Package (2.88.7 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;SkiaSharp.Skottie&quot; Version=&quot;2.88.7&quot; /> to your project." />
 	</Target>
 </Project>

--- a/src/AddIns/Uno.UI.Svg/buildTransitive/Uno.UI.Svg.targets
+++ b/src/AddIns/Uno.UI.Svg/buildTransitive/Uno.UI.Svg.targets
@@ -25,7 +25,7 @@
 			<_SvgSkiaRefs Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)' == 'Svg.Skia' AND '%(ReferencePath.NuGetPackageVersion)' >= '1.0.0.1'" />
 		</ItemGroup>
 
-		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Svg support, the '$(_SkiaSharpPackageName)' NuGet Package (2.88.3 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;2.88.3&quot; /> to your project." />
+		<Error Condition="'@(_SkiaSharpViewsRefs)'==''" Text="In order to use Uno Svg support, the '$(_SkiaSharpPackageName)' NuGet Package (2.88.7 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;$(_SkiaSharpPackageName)&quot; Version=&quot;2.88.7&quot; /> to your project." />
 		<Error Condition="'@(_SvgSkiaRefs)'==''" Text="In order to use Uno Svg support, the 'Svg.Skia' NuGet Package (1.0.0.1 or later) must be referenced in the project. You can add &lt;PackageReference Include=&quot;Svg.Skia&quot; Version=&quot;1.0.0.1&quot; /> to your project." />
 	</Target>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -86,7 +86,7 @@
 		<PackageReference Update="Uno.Fonts.Fluent" Version="2.3.0" />
 		<PackageReference Update="Uno.Resizetizer" Version="1.2.0-dev.72" />
 		<PackageReference Update="Xamarin.DuoSdk" Version="0.0.3.4" />
-		<PackageReference Update="Xamarin.UITest" Version="4.3.3" />
+		<PackageReference Update="Xamarin.UITest" Version="4.3.4" />
 		<PackageReference Update="Xamarin.TestCloud.Agent" Version="0.23.2" />
 		<PackageReference Update="System.Numerics.Vectors" Version="4.5.0" />
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -90,30 +90,23 @@
 		<PackageReference Update="Xamarin.TestCloud.Agent" Version="0.23.2" />
 		<PackageReference Update="System.Numerics.Vectors" Version="4.5.0" />
 
-		<!-- 
-			NoWarn="NU1903" is added to avoid .NET 7 discrepancies added when workloads
-			are incorrectly upgraded by dependencies. This will change in .NET 8, at which
-			time we'll be able to upgrade SkiaSharp.
-			Note that project templats are updated, which means that end users won't
-			be affected.
-		-->
-		<PackageReference Update="SkiaSharp.Views" Version="2.88.3" NoWarn="NU1903" />
-		<PackageReference Update="SkiaSharp.Views.Uno" Version="2.88.3" NoWarn="NU1903" />
-		<PackageReference Update="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" NoWarn="NU1903" />
-		<PackageReference Update="SkiaSharp.Views.WPF" Version="2.88.3" NoWarn="NU1903"  />
-		<PackageReference Update="SkiaSharp" Version="2.88.3" NoWarn="NU1903"  />
-		<PackageReference Update="SkiaSharp.NativeAssets.Linux" Version="2.88.3" NoWarn="NU1903" />
-		<PackageReference Update="SkiaSharp.Harfbuzz" Version="2.88.3" NoWarn="NU1903" />
-		<PackageReference Update="SkiaSharp.Skottie" Version="2.88.3" NoWarn="NU1903" />
-		<PackageReference Update="SkiaSharp.NativeAssets.Android" Version="2.88.3" NoWarn="NU1903"  />
-		<PackageReference Update="SkiaSharp.NativeAssets.iOS" Version="2.88.3" NoWarn="NU1903" />
-		<PackageReference Update="SkiaSharp.NativeAssets.MacCatalyst" Version="2.88.3" NoWarn="NU1903" />
-		<PackageReference Update="SkiaSharp.NativeAssets.macos" Version="2.88.3" NoWarn="NU1903" />
+		<PackageReference Update="SkiaSharp.Views" Version="2.88.7" />
+		<PackageReference Update="SkiaSharp.Views.Uno" Version="2.88.7" />
+		<PackageReference Update="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
+		<PackageReference Update="SkiaSharp.Views.WPF" Version="2.88.7"  />
+		<PackageReference Update="SkiaSharp" Version="2.88.7"  />
+		<PackageReference Update="SkiaSharp.NativeAssets.Linux" Version="2.88.7" />
+		<PackageReference Update="SkiaSharp.Harfbuzz" Version="2.88.7" />
+		<PackageReference Update="SkiaSharp.Skottie" Version="2.88.7" />
+		<PackageReference Update="SkiaSharp.NativeAssets.Android" Version="2.88.7"  />
+		<PackageReference Update="SkiaSharp.NativeAssets.iOS" Version="2.88.7" />
+		<PackageReference Update="SkiaSharp.NativeAssets.MacCatalyst" Version="2.88.7" />
+		<PackageReference Update="SkiaSharp.NativeAssets.macos" Version="2.88.7" />
+
+		<PackageReference Update="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.1" />
+		<PackageReference Update="SkiaSharp.HarfBuzz" Version="2.88.7" />
 
 		<PackageReference Update="Svg.Skia" Version="1.0.0.1" />
-
-		<PackageReference Update="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
-		<PackageReference Update="SkiaSharp.HarfBuzz" Version="2.88.3" />
 		<PackageReference Update="GtkSharp" Version="3.24.24.38" />
 		<PackageReference Update="System.Json" Version="4.7.1" />
 		<PackageReference Update="FluentAssertions" Version="5.10.3" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -102,7 +102,8 @@
 		<PackageReference Update="SkiaSharp.NativeAssets.iOS" Version="2.88.7" />
 		<PackageReference Update="SkiaSharp.NativeAssets.MacCatalyst" Version="2.88.7" />
 		<PackageReference Update="SkiaSharp.NativeAssets.macos" Version="2.88.7" />
-
+		
+		<PackageReference Update="HarfBuzzSharp.NativeAssets.macOS" Version="7.3.0.1" />
 		<PackageReference Update="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.1" />
 		<PackageReference Update="SkiaSharp.HarfBuzz" Version="2.88.7" />
 

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -439,6 +439,10 @@ namespace SamplesApp
 				builder.AddConsole();
 #endif
 
+#if __IOS__
+				builder.AddProvider(new Uno.Extensions.Logging.OSLogLoggerProvider());
+#endif
+
 #if !DEBUG
 				// Exclude logs below this level
 				builder.SetMinimumLevel(LogLevel.Information);

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -69,7 +69,7 @@ namespace SamplesApp.UITests
 				var coldStartTask = Task.Run(() => AppInitializer.ColdStartApp());
 
 				// Force an explicit timeout to avoid excessive waiting on iOS
-				var timeout = TimeSpan.FromSeconds(30);
+				var timeout = TimeSpan.FromMinutes(5);
 				var timeoutTask = Task.Delay(timeout);
 
 				var allTasks = Task.WhenAny(coldStartTask, timeoutTask);

--- a/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
+++ b/src/SamplesApp/SamplesApp.UITests/SampleControlUITestBase.cs
@@ -66,7 +66,19 @@ namespace SamplesApp.UITests
 			{
 				// Start the app only once, so the tests runs don't restart it
 				// and gain some time for the tests.
-				AppInitializer.ColdStartApp();
+				var coldStartTask = Task.Run(() => AppInitializer.ColdStartApp());
+
+				// Force an explicit timeout to avoid excessive waiting on iOS
+				var timeout = TimeSpan.FromSeconds(30);
+				var timeoutTask = Task.Delay(timeout);
+
+				var allTasks = Task.WhenAny(coldStartTask, timeoutTask);
+				allTasks.Wait();
+
+				if (allTasks.Result == timeoutTask)
+				{
+					throw new Exception("Cold start timeout after timeout");
+				}
 			}
 			catch
 			{

--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -6,6 +6,9 @@
 		<DefineConstants Condition="$(UnoTargetFrameworkOverride.ToLowerInvariant().EndsWith('-android'))">$(DefineConstants);TARGET_FRAMEWORK_OVERRIDE_ANDROID</DefineConstants>
 
 		<DefineConstants Condition="$(UnoTargetFrameworkOverride.ToLowerInvariant().EndsWith('-ios'))">$(DefineConstants);TARGET_FRAMEWORK_OVERRIDE_IOS</DefineConstants>
+
+		<!-- Use 'GeneratedRegexAttribute' to generate the regular expression -->
+		<NoWarn>$(NoWarn);SYSLIB1045</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/UnoIslandsSamplesApp.Skia.Wpf.csproj
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/UnoIslandsSamplesApp.Skia.Wpf.csproj
@@ -30,7 +30,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-		<PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.3" />
+		<PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.7" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net8.0-windows'">

--- a/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Skia.Gtk/UnoAppWinUI.Skia.Gtk.csproj
+++ b/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Skia.Gtk/UnoAppWinUI.Skia.Gtk.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="$(GITVERSION_SemVer)" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(GITVERSION_SemVer)" />
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(GITVERSION_SemVer)" />
-    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.7" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Skia.Linux.FrameBuffer/UnoAppWinUI.Skia.Linux.FrameBuffer.csproj
+++ b/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Skia.Linux.FrameBuffer/UnoAppWinUI.Skia.Linux.FrameBuffer.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="$(GITVERSION_SemVer)" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(GITVERSION_SemVer)" />
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(GITVERSION_SemVer)" />
-    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\UnoAppWinUI\UnoAppWinUI.csproj" />

--- a/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Skia.WPF/UnoAppWinUI.Skia.WPF.csproj
+++ b/src/SolutionTemplate/UnoAppWinUI/UnoAppWinUI.Skia.WPF/UnoAppWinUI.Skia.WPF.csproj
@@ -23,8 +23,8 @@
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="$(GITVERSION_SemVer)" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(GITVERSION_SemVer)" />
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(GITVERSION_SemVer)" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.Skia.Gtk/UnoAppWinUILinuxValidation.Skia.Gtk.csproj
+++ b/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.Skia.Gtk/UnoAppWinUILinuxValidation.Skia.Gtk.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="$(GITVERSION_SemVer)" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(GITVERSION_SemVer)" />
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(GITVERSION_SemVer)" />
-    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.7" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.Skia.Linux.FrameBuffer/UnoAppWinUILinuxValidation.Skia.Linux.FrameBuffer.csproj
+++ b/src/SolutionTemplate/UnoAppWinUILinuxValidation/UnoAppWinUILinuxValidation.Skia.Linux.FrameBuffer/UnoAppWinUILinuxValidation.Skia.Linux.FrameBuffer.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="$(GITVERSION_SemVer)" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="$(GITVERSION_SemVer)" />
     <PackageReference Include="Uno.WinUI.Lottie" Version="$(GITVERSION_SemVer)" />
-    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\UnoAppWinUILinuxValidation\UnoAppWinUILinuxValidation.csproj" />

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.Gtk.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.Gtk.csproj
@@ -36,16 +36,16 @@
 		<PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
 		<PackageReference Include="Microsoft.Win32.SystemEvents" Version="6.0.1" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-		<PackageReference Include="SkiaSharp" Version="2.88.3" />
-		<PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
+		<PackageReference Include="SkiaSharp" Version="2.88.7" />
+		<PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.7" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.15.0-dev.56" />
 
 		<!--
 		<PackageReference Include="Uno.Resizetizer" Version="1.0.4" />
 		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.8.33" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
-		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
+		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
+		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.7" />
 		<PackageReference Include="Uno.WinUI.DevServer" Version="4.8.33" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.33" />
 		-->


### PR DESCRIPTION
The SkiaSharp update is possible since 5.1, as Uno for net7-ios is depending on Microsoft 16.4 after a forced workloads update, and SkiaSharp for net7-ios is depending on Microsoft 16.2.

We're still dependent on https://github.com/dotnet/sdk/issues/30103 for future updates, if the workloads end up changing on SkiaSharp's end.