### PR TITLE
fix: Use `UIDocumentPickerViewController` if multiple files are picked

### DIFF
--- a/doc/articles/features/windows-storage-pickers.md
+++ b/doc/articles/features/windows-storage-pickers.md
@@ -156,7 +156,7 @@ else
 
 > [!NOTE]
 > `SuggestedStartLocation` should be set to prevent crashes on UWP. `FileTypes` must include at least one item. You can add extensions in the format `.extension`, with the exception of `*` (asterisk) which allows picking any type of file.
-
+>
 > [!NOTE]
 > On iOS, the built-in image picker does not support selection of multiple files. Therefore we fall back to the document picker instead. However, this requires you to specify not only the `SuggestedStartLocation` set to `PicturesLibrary`, but also specifying file type extensions in `FileTypeFilter` (e.g. `.jpg` and `.png`), otherwise OS will not display the Photos app as a file provider in the picker.
 

--- a/doc/articles/features/windows-storage-pickers.md
+++ b/doc/articles/features/windows-storage-pickers.md
@@ -2,7 +2,7 @@
 uid: Uno.Features.WSPickers
 ---
 
-# Storage Pickers
+# File and Folder Pickers
 
 > [!TIP]
 > This article covers Uno-specific information for the `Windows.Storage.Pickers` namespace. For a full description of the feature and instructions on using it, see [Windows.Storage.Pickers Namespace](https://learn.microsoft.com/uwp/api/windows.storage.pickers).
@@ -156,6 +156,9 @@ else
 
 > [!NOTE]
 > `SuggestedStartLocation` should be set to prevent crashes on UWP. `FileTypes` must include at least one item. You can add extensions in the format `.extension`, with the exception of `*` (asterisk) which allows picking any type of file.
+
+> [!NOTE]
+> On iOS, the built-in image picker does not support selection of multiple files. Therefore we fall back to the document picker instead. However, this requires you to specify not only the `SuggestedStartLocation` set to `PicturesLibrary`, but also specifying file type extensions in `FileTypeFilter` (e.g. `.jpg` and `.png`), otherwise OS will not display the Photos app as a file provider in the picker.
 
 ### FileSavePicker
 

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileOpenPickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileOpenPickerTests.xaml.cs
@@ -16,7 +16,6 @@ namespace UITests.Shared.Windows_Storage.Pickers
 	[Sample("Windows.Storage", ViewModelType = typeof(FileOpenPickerTestsViewModel), IsManualTest = true,
 		Description =
 """
-Allows testing all features of FileOpenPicker. Currently not supported on Android, iOS, and macOS.
 - Not selecting a file should not cause an exception.
 - Selecting a file should show information below the file picker buttons.
 - It should be possible to pick multiple files, even if PicturesLibrary is selected and .jpg is used as file type.

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileOpenPickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileOpenPickerTests.xaml.cs
@@ -14,7 +14,14 @@ using Microsoft.UI.Xaml.Controls;
 namespace UITests.Shared.Windows_Storage.Pickers
 {
 	[Sample("Windows.Storage", ViewModelType = typeof(FileOpenPickerTestsViewModel), IsManualTest = true,
-		Description = "Allows testing all features of FileOpenPicker. Currently not supported on Android, iOS, and macOS. Not selecting a file should not cause an exception. Selecting a file should show information below the file picker buttons")]
+		Description =
+"""
+Allows testing all features of FileOpenPicker. Currently not supported on Android, iOS, and macOS.
+- Not selecting a file should not cause an exception.
+- Selecting a file should show information below the file picker buttons.
+- It should be possible to pick multiple files, even if PicturesLibrary is selected and .jpg is used as file type.
+"""
+	)]
 	public sealed partial class FileOpenPickerTests : Page
 	{
 		public FileOpenPickerTests()

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.iOS.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.iOS.cs
@@ -54,7 +54,7 @@ namespace Windows.Storage.Pickers
 		{
 			switch (SuggestedStartLocation)
 			{
-				case PickerLocationId.PicturesLibrary:
+				case PickerLocationId.PicturesLibrary when !multiple: // As UIImagePickerController does not support multiple selection, we fall back to UIDocumentPickerViewController for multiple selection
 					return new UIImagePickerController()
 					{
 						SourceType = UIImagePickerControllerSourceType.PhotoLibrary,


### PR DESCRIPTION
GitHub Issue (If applicable): 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Documentation content changes

## What is the current behavior?

- When picking multiple images is requested, it is not possible on iOS

## What is the new behavior?

Possible on iOS

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.