### PR TITLE
fix: Ensures that Uno projects enable intellisense even if no wasdk project is present

### DIFF
--- a/build/nuget/uno.winui.single-project.targets
+++ b/build/nuget/uno.winui.single-project.targets
@@ -85,6 +85,9 @@
 		<PackageManifest Condition=" Exists('$(WindowsProjectFolder)Package.appxmanifest') ">$(WindowsProjectFolder)Package.appxmanifest</PackageManifest>
 		<_SingleProjectWindowsExcludes>$(WindowsProjectFolder)/**/.*/**</_SingleProjectWindowsExcludes>
 
+		<!-- Hint VS's XAML parser -->
+		<!-- https://github.com/unoplatform/uno/issues/15517 -->
+    	<DefaultXamlRuntime Condition="'$(DefaultXamlRuntime)'=='' and '$(TargetPlatformIdentifier)' != 'windows'">WinUI</DefaultXamlRuntime>
 	</PropertyGroup>
 
 	<!-- Removals -->

--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -99,6 +99,10 @@
 
 	<PropertyGroup Condition=" '$(TargetFramework)' != 'uap10.0.19041' and '$(TargetFramework)'!='net7.0-windows10.0.19041.0' and '$(TargetPlatformIdentifier)' != 'UAP'">
 		<DefineConstants>$(DefineConstants);HAS_UNO</DefineConstants>
+
+		<!-- Hint the VS's XAML parser -->
+		<!-- https://github.com/unoplatform/uno/issues/15517 -->
+    	<DefaultXamlRuntime>WinUI</DefaultXamlRuntime>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net7.0-windows10.0.19041.0'">

--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -102,7 +102,7 @@
 
 		<!-- Hint the VS's XAML parser -->
 		<!-- https://github.com/unoplatform/uno/issues/15517 -->
-    	<DefaultXamlRuntime>WinUI</DefaultXamlRuntime>
+    	<DefaultXamlRuntime Condition="'$(DefaultXamlRuntime)'==''">WinUI</DefaultXamlRuntime>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net7.0-windows10.0.19041.0'">

--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
@@ -6,7 +6,7 @@
 
 		<!-- Forces the VS Intellisense to detect uno projects as WinUI XAML -->
 		<!-- https://github.com/unoplatform/uno/issues/15517 -->
-    	<DefaultXamlRuntime>WinUI</DefaultXamlRuntime>
+    	<DefaultXamlRuntime Condition="'$(DefaultXamlRuntime)'==''">WinUI</DefaultXamlRuntime>
 	</PropertyGroup>
 
 	<!-- Taken from: https://github.com/dotnet/maui/blob/c02a6706534888ccea577d771c9edfc820bfc001/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets#L16C3-L26C15 -->

--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
@@ -1,8 +1,12 @@
 <Project>
-	<!-- Sync with https://github.com/dotnet/maui/blob/ffab30545ac146710a9ee61138be33e52ca4b326/src/Templates/src/templates/maui-mobile/Directory.Build.targets -->
 	<PropertyGroup Condition="!$(IsWinAppSdk)">
+		<!-- Sync with https://github.com/dotnet/maui/blob/ffab30545ac146710a9ee61138be33e52ca4b326/src/Templates/src/templates/maui-mobile/Directory.Build.targets -->
 		<!-- Required - Enable Launch Profiles for .NET 6 iOS/Android -->
 		<_KeepLaunchProfiles>true</_KeepLaunchProfiles>
+
+		<!-- Forces the VS Intellisense to detetect uno projects as WinUI XAML -->
+		<!-- https://github.com/unoplatform/uno/issues/15517 -->
+    	<DefaultXamlRuntime>WinUI</DefaultXamlRuntime>
 	</PropertyGroup>
 
 	<!-- Taken from: https://github.com/dotnet/maui/blob/c02a6706534888ccea577d771c9edfc820bfc001/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets#L16C3-L26C15 -->

--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
@@ -4,7 +4,7 @@
 		<!-- Required - Enable Launch Profiles for .NET 6 iOS/Android -->
 		<_KeepLaunchProfiles>true</_KeepLaunchProfiles>
 
-		<!-- Forces the VS Intellisense to detetect uno projects as WinUI XAML -->
+		<!-- Forces the VS Intellisense to detect uno projects as WinUI XAML -->
 		<!-- https://github.com/unoplatform/uno/issues/15517 -->
     	<DefaultXamlRuntime>WinUI</DefaultXamlRuntime>
 	</PropertyGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/15517

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Hints VS at the fact that an Uno project uses WinUI XAML to get intellisense working even if there's no WinUI project available.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
