### PR TITLE
fix: initialize visiblebounds earlier on android

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Assertions.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Core;
+using Windows.UI.ViewManagement;
 
 #if __SKIA__
 using Uno.Foundation.Extensibility;
@@ -202,5 +203,12 @@ partial class App
 		{
 			Assert.Fail("Resuming should never be triggered unless the app is suspended.");
 		}
+	}
+
+	private void AssertIssue15521()
+	{
+#if __ANDROID__
+		Uno.UI.RuntimeTests.Tests.Windows_UI_ViewManagement_ApplicationView.Given_ApplicationView.StartupVisibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
+#endif
 	}
 }

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -132,6 +132,8 @@ namespace SamplesApp
 				AssertIssue12936();
 
 				AssertIssue12937();
+
+				AssertIssue15521();
 			}
 
 			var sw = Stopwatch.StartNew();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement_ApplicationView/Given_Control.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement_ApplicationView/Given_Control.cs
@@ -7,12 +7,16 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Private.Infrastructure;
+using Windows.Foundation;
+using Microsoft.UI.Xaml;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_ViewManagement_ApplicationView
 {
 	[TestClass]
 	public class Given_ApplicationView
 	{
+		public static Rect StartupVisibleBounds { get; set; }
+
 		public static string StartupTitle { get; set; }
 
 #if __SKIA__
@@ -25,6 +29,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_ViewManagement_ApplicationView
 			}
 
 			Assert.AreEqual(Windows.ApplicationModel.Package.Current.DisplayName, StartupTitle);
+		}
+#endif
+
+#if __ANDROID__
+		[TestMethod]
+		public void When_StartupVisibleBounds_Has_Value()
+		{
+			Assert.IsFalse(RectHelper.GetIsEmpty(StartupVisibleBounds), $"VisibleBounds should not be empty");
 		}
 #endif
 	}

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
@@ -102,6 +102,7 @@ internal abstract class BaseWindowImplementation : IWindowImplementation
 		nativeWindow.VisibleBoundsChanged += OnNativeVisibleBoundsChanged;
 
 		NativeWindowWrapper = nativeWindow;
+		SetVisibleBoundsFromNative();
 	}
 
 	private void OnNativeClosing(object? sender, Microsoft.UI.Windowing.AppWindowClosingEventArgs e) => Window.AppWindow.RaiseClosing(e);

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
@@ -76,7 +76,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase
 			return default;
 		}
 
-		var windowInsets = ViewCompat.GetRootWindowInsets(activity.Window.DecorView);
+		var windowInsets = GetWindowInsets(activity);
 
 		var insetsTypes = WindowInsetsCompat.Type.SystemBars(); // == WindowInsets.Type.StatusBars() | WindowInsets.Type.NavigationBars() | WindowInsets.Type.CaptionBar();
 
@@ -113,6 +113,17 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase
 		var flags = activity.Window.Attributes.Flags;
 		return flags.HasFlag(WindowManagerFlags.TranslucentNavigation)
 			|| flags.HasFlag(WindowManagerFlags.LayoutNoLimits);
+	}
+
+	private WindowInsetsCompat GetWindowInsets(Activity activity)
+	{
+		var decorView = activity.Window.DecorView;
+		if (decorView.IsAttachedToWindow)
+		{
+			return ViewCompat.GetRootWindowInsets(decorView);
+		}
+
+		return WindowInsetsCompat.ToWindowInsetsCompat(activity.WindowManager?.CurrentWindowMetrics.WindowInsets);
 	}
 
 	private Size GetDisplaySize()

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
@@ -3,6 +3,7 @@ using Android.App;
 using Android.Runtime;
 using Android.Util;
 using Android.Views;
+using AndroidX.AppCompat.App;
 using AndroidX.Core.View;
 using Uno.UI.Extensions;
 using Windows.ApplicationModel.Core;
@@ -123,7 +124,12 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase
 			return ViewCompat.GetRootWindowInsets(decorView);
 		}
 
-		return WindowInsetsCompat.ToWindowInsetsCompat(activity.WindowManager?.CurrentWindowMetrics.WindowInsets);
+		if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.R)
+		{
+			return WindowInsetsCompat.ToWindowInsetsCompat(activity.WindowManager?.CurrentWindowMetrics.WindowInsets);
+		}
+
+		return null;
 	}
 
 	private Size GetDisplaySize()


### PR DESCRIPTION
closes #15521 
closes #15520

`ViewCompat.GetRootWindowInsets` returns `null` if the view is not yet attached to the Android `Window`.

If you try and access the `ApplicationView.GetForCurrentView().VisibleBounds` early on in the app startup it can result in the window insets not being properly calculated.

The only other way to grab the `WindowInsets` is to use the `WindowMetrics` from the `Activity.WindowManager`, so we do that if the current root view is not attached to the `Window`