### PR TITLE
fix: Adjust iOS min version for using hot reload

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -96,16 +96,16 @@ namespace Uno.UI.RemoteControl.HotReload
 
 					if (parts.Length > 0 && Version.TryParse(parts[0], out var version))
 					{
-						_isIssue93860Fixed = version >= 
+						_isIssue93860Fixed = version >=
 #if __IOS__ || __CATALYST__
 							new Version(34, 0, 1, 52); //8.0.102
 #elif __ANDROID__
 							new Version(17, 2, 8022); // 8.0.200
 #endif
 
-						if (!_isIssue93860Fixed && this.Log().IsEnabled(LogLevel.Warning))
+						if (!_isIssue93860Fixed.Value && this.Log().IsEnabled(LogLevel.Warning))
 						{
-							this.Log().Warning(
+							this.Log().Warn(
 								$"The .NET Platform Bindings version {version} is too old " +
 								$"and contains this issue: https://github.com/dotnet/runtime/issues/93860. " +
 								$"Make sure to upgrade to .NET 8.0.102 or later");

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -101,7 +101,7 @@ namespace Uno.UI.RemoteControl.HotReload
 							new Version(34, 0, 1, 52); //8.0.102
 #elif __ANDROID__
 							new Version(17, 2, 8022); // 8.0.200
-#else 
+#endif
 
 						if (!_isIssue93860Fixed && this.Log().IsEnabled(LogLevel.Warning))
 						{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -96,15 +96,20 @@ namespace Uno.UI.RemoteControl.HotReload
 
 					if (parts.Length > 0 && Version.TryParse(parts[0], out var version))
 					{
-						if (this.Log().IsEnabled(LogLevel.Trace))
+						_isIssue93860Fixed = version >= 
+#if __IOS__ || __CATALYST__
+							new Version(34, 0, 1, 52); //8.0.102
+#elif __ANDROID__
+							new Version(17, 2, 8022); // 8.0.200
+#else 
+
+						if (!_isIssue93860Fixed && this.Log().IsEnabled(LogLevel.Warning))
 						{
-							this.Log().Trace(
+							this.Log().Warning(
 								$"The .NET Platform Bindings version {version} is too old " +
 								$"and contains this issue: https://github.com/dotnet/runtime/issues/93860. " +
 								$"Make sure to upgrade to .NET 8.0.102 or later");
 						}
-
-						_isIssue93860Fixed = version >= new Version(34, 0, 1, 52);
 					}
 				}
 			}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adjust iOS/Catalyst hot reload using C# hotreload based on 8.0.200 workload version.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
