### PR TITLE
fix: Remove longer relevant `Launcher` test

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_Launcher.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_Launcher.cs
@@ -25,14 +25,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_System
 		}
 
 		[TestMethod]
-		public async Task When_LaunchUriAsync_From_Non_UI_Thread()
-		{
-			await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-				() => Task.Run(
-					() => Launcher.LaunchUriAsync(new Uri("https://platform.uno"))));
-		}
-
-		[TestMethod]
 		public async Task When_Valid_Uri_Is_Queried()
 		{
 			var result = await Launcher.QueryUriSupportAsync(


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

In WinUI Launcher no longer has to run on the UI thread


## What is the new behavior?

Test removed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
