### PR TITLE
fix: apply clipping to the shapes of ShapeVisual on skia

### DIFF
--- a/src/Uno.UI.Composition/Composition/ShapeVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ShapeVisual.skia.cs
@@ -79,7 +79,7 @@ public partial class ShapeVisual
 
 		// Note: We don't apply the clip here, as it is already applied on the shapes (i.e. CornerRadius)
 		//		 The Clip property is only used to apply the clip on the children (i.e. the UIElement's content)
-		// Clip?.Apply(parentSession.Surface);
+		Clip?.Apply(parentSession.Surface);
 
 		var session = parentSession; // Creates a new session (clone the struct)
 


### PR DESCRIPTION
Let's see if this causes any screenshot regressions. This would partially fix #15585. I will close this in favor of more proper changes (+ a runtime test) if no regressions are present.