### PR TITLE
fix(iOS): StorageFile information using PHPicker

### DIFF
--- a/src/Uno.UWP/Storage/StorageFile.iOS.cs
+++ b/src/Uno.UWP/Storage/StorageFile.iOS.cs
@@ -28,30 +28,24 @@ namespace Windows.Storage
 		{
 			private readonly NSItemProvider? _provider;
 			private readonly StorageFolder? _parent;
-			readonly string? _identifier;
+			private readonly string? _identifier;
 			public MediaScopedFile(NSItemProvider provider, StorageFolder? parent) :
-				base(SystemPath.Combine(parent?.Path ?? string.Empty, provider?.SuggestedName ?? string.Empty))
+				base(string.Empty)
 			{
 				_provider = provider;
 				_parent = parent;
 				_identifier = GetIdentifier(provider?.RegisteredTypeIdentifiers ?? []);
-			}
 
-			private string? GetIdentifier(string[] identifiers)
-			{
-				if (!(identifiers?.Length > 0))
-					return null;
-				if (identifiers.Any(i => i.StartsWith(UTType.LivePhoto, StringComparison.InvariantCultureIgnoreCase)) && identifiers.Contains(UTType.JPEG))
-					return identifiers.FirstOrDefault(i => i == UTType.JPEG);
-				if (identifiers.Contains(UTType.QuickTimeMovie))
-					return identifiers.FirstOrDefault(i => i == UTType.QuickTimeMovie);
-				return identifiers.FirstOrDefault();
+				var extension = !string.IsNullOrEmpty(_identifier) ? GetExtension(_identifier) : string.Empty;
+				var fileName = $"{provider?.SuggestedName}.{extension}";
+
+				Path = SystemPath.Combine(path1: parent?.Path ?? string.Empty,
+										  path2: fileName);
 			}
+			public override string ContentType => GetMIMEType(_identifier ?? string.Empty) ?? base.ContentType;
 
 			public override StorageProvider Provider => StorageProviders.IosItemProvider;
-
 			public override DateTimeOffset DateCreated => throw new NotImplementedException();
-
 			public override Task DeleteAsync(CancellationToken ct, StorageDeleteOption options) =>
 				throw new InvalidOperationException("Created date is not available from this source");
 
@@ -81,6 +75,32 @@ namespace Windows.Storage
 
 			public override Task<StorageStreamTransaction> OpenTransactedWriteAsync(CancellationToken ct, StorageOpenOptions option) => throw new NotImplementedException();
 			protected override bool IsEqual(ImplementationBase implementation) => throw new NotImplementedException();
+
+			private string? GetExtension(string identifier)
+				=> UTType.CopyAllTags(identifier, UTType.TagClassFilenameExtension)?.FirstOrDefault();
+
+			private string? GetMIMEType(string identifier)
+				=> UTType.CopyAllTags(identifier, UTType.TagClassMIMEType)?.FirstOrDefault();
+
+			private string? GetIdentifier(string[] identifiers)
+			{
+				if (!(identifiers?.Length > 0))
+				{
+					return null;
+				}
+
+				if (identifiers.Any(i => i.StartsWith(UTType.LivePhoto, StringComparison.InvariantCultureIgnoreCase)) && identifiers.Contains(UTType.JPEG))
+				{
+					return identifiers.FirstOrDefault(i => i == UTType.JPEG);
+				}
+
+				if (identifiers.Contains(UTType.QuickTimeMovie))
+				{
+					return identifiers.FirstOrDefault(i => i == UTType.QuickTimeMovie);
+				}
+
+				return identifiers.FirstOrDefault();
+			}
 		}
 		internal class SecurityScopedFile : ImplementationBase
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
StorageFile on iOS is not returning Path, Name and other information when using PHPicker Implementation

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
