### PR TITLE
fix: `Grid` `Column`, `Row`, `ColumnSpan` and `RowSpan` can affect measure

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
@@ -291,6 +291,178 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		public async Task Change_Grid_Row_After_Load()
+		{
+			Border firstBorder;
+			Border secondBorder;
+			var SUT = new Grid
+			{
+				RowDefinitions =
+				{
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+				},
+				Children =
+				{
+					(firstBorder = new Border { Width = 100, Height = 100, Background = new SolidColorBrush(Colors.Red) }),
+					(secondBorder = new Border { Width = 100, Height = 100, Background = new SolidColorBrush(Colors.Green) }),
+				}
+			};
+
+			Grid.SetRow(firstBorder, 0);
+			Grid.SetRow(secondBorder, 1);
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForLoaded(SUT);
+
+			Point GetRelativePosition(FrameworkElement element)
+			{
+				var position = element.TransformToVisual(SUT).TransformPoint(new Point(0, 0));
+				return position;
+			}
+
+			var firstPosition = GetRelativePosition(firstBorder);
+			var secondPosition = GetRelativePosition(secondBorder);
+			Assert.AreEqual(0, firstPosition.Y);
+			Assert.AreEqual(100, secondPosition.Y);
+
+			Grid.SetRow(firstBorder, 2);
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			firstPosition = GetRelativePosition(firstBorder);
+			secondPosition = GetRelativePosition(secondBorder);
+
+			Assert.AreEqual(100, firstPosition.Y);
+			Assert.AreEqual(0, secondPosition.Y);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Change_Grid_Column_After_Load()
+		{
+			Border firstBorder;
+			Border secondBorder;
+			var SUT = new Grid
+			{
+				ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
+					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+				},
+				Children =
+				{
+					(firstBorder = new Border { Width = 100, Height = 100, Background = new SolidColorBrush(Colors.Red) }),
+					(secondBorder = new Border { Width = 100, Height = 100, Background = new SolidColorBrush(Colors.Green) }),
+				}
+			};
+
+			Grid.SetColumn(firstBorder, 0);
+			Grid.SetColumn(secondBorder, 1);
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForLoaded(SUT);
+
+			Point GetRelativePosition(FrameworkElement element)
+			{
+				var position = element.TransformToVisual(SUT).TransformPoint(new Point(0, 0));
+				return position;
+			}
+
+			var firstPosition = GetRelativePosition(firstBorder);
+			var secondPosition = GetRelativePosition(secondBorder);
+			Assert.AreEqual(0, firstPosition.X);
+			Assert.AreEqual(100, secondPosition.X);
+
+			Grid.SetColumn(firstBorder, 2);
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			firstPosition = GetRelativePosition(firstBorder);
+			secondPosition = GetRelativePosition(secondBorder);
+
+			Assert.AreEqual(100, firstPosition.X);
+			Assert.AreEqual(0, secondPosition.X);
+
+			await Task.Delay(1000);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Change_Grid_RowSpan_After_Load()
+		{
+			Border firstBorder;
+			var SUT = new Grid
+			{
+				Background = new SolidColorBrush(Colors.Blue),
+				RowSpacing = 10,
+				RowDefinitions =
+				{
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
+					new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) }
+				},
+				Children =
+				{
+					(firstBorder = new Border { Width = 100, Height = 100, Background = new SolidColorBrush(Colors.Red) }),
+				}
+			};
+
+			Grid.SetRowSpan(firstBorder, 2);
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForLoaded(SUT);
+
+			Assert.AreEqual(100, SUT.ActualHeight);
+
+			Grid.SetRowSpan(firstBorder, 1);
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(110, SUT.ActualHeight);
+
+			await Task.Delay(1000);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task Change_Grid_ColumnSpan_After_Load()
+		{
+			Border firstBorder;
+			var SUT = new Grid
+			{
+				Background = new SolidColorBrush(Colors.Blue),
+				ColumnSpacing = 10,
+				ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
+					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) }
+				},
+				Children =
+				{
+					(firstBorder = new Border { Width = 100, Height = 100, Background = new SolidColorBrush(Colors.Red) }),
+				}
+			};
+
+			Grid.SetColumnSpan(firstBorder, 2);
+
+			TestServices.WindowHelper.WindowContent = SUT;
+			await TestServices.WindowHelper.WaitForLoaded(SUT);
+
+			Assert.AreEqual(100, SUT.ActualWidth);
+
+			Grid.SetColumnSpan(firstBorder, 1);
+
+			await TestServices.WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(110, SUT.ActualWidth);
+
+			await Task.Delay(1000);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282! epic")]
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
@@ -291,12 +291,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[RequiresFullWindow]
 		public async Task Change_Grid_Row_After_Load()
 		{
 			Border firstBorder;
 			Border secondBorder;
+			var container = new Grid();
 			var SUT = new Grid
 			{
+				HorizontalAlignment = HorizontalAlignment.Left,
+				VerticalAlignment = VerticalAlignment.Top,
 				RowDefinitions =
 				{
 					new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) },
@@ -312,8 +316,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Grid.SetRow(firstBorder, 0);
 			Grid.SetRow(secondBorder, 1);
-
-			TestServices.WindowHelper.WindowContent = SUT;
+			container.Children.Add(SUT);
+			TestServices.WindowHelper.WindowContent = container;
 			await TestServices.WindowHelper.WaitForLoaded(SUT);
 
 			Point GetRelativePosition(FrameworkElement element)
@@ -340,12 +344,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[RequiresFullWindow]
 		public async Task Change_Grid_Column_After_Load()
 		{
 			Border firstBorder;
 			Border secondBorder;
+			var container = new Grid();
 			var SUT = new Grid
 			{
+				HorizontalAlignment = HorizontalAlignment.Left,
+				VerticalAlignment = VerticalAlignment.Top,
 				ColumnDefinitions =
 				{
 					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Auto) },
@@ -361,8 +369,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Grid.SetColumn(firstBorder, 0);
 			Grid.SetColumn(secondBorder, 1);
-
-			TestServices.WindowHelper.WindowContent = SUT;
+			container.Children.Add(SUT);
+			TestServices.WindowHelper.WindowContent = container;
 			await TestServices.WindowHelper.WaitForLoaded(SUT);
 
 			Point GetRelativePosition(FrameworkElement element)
@@ -391,11 +399,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[RequiresFullWindow]
 		public async Task Change_Grid_RowSpan_After_Load()
 		{
 			Border firstBorder;
+			var container = new Grid();
 			var SUT = new Grid
 			{
+				HorizontalAlignment = HorizontalAlignment.Left,
+				VerticalAlignment = VerticalAlignment.Top,
 				Background = new SolidColorBrush(Colors.Blue),
 				RowSpacing = 10,
 				RowDefinitions =
@@ -410,8 +422,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			};
 
 			Grid.SetRowSpan(firstBorder, 2);
-
-			TestServices.WindowHelper.WindowContent = SUT;
+			container.Children.Add(SUT);
+			TestServices.WindowHelper.WindowContent = container;
 			await TestServices.WindowHelper.WaitForLoaded(SUT);
 
 			Assert.AreEqual(100, SUT.ActualHeight);
@@ -427,11 +439,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
+		[RequiresFullWindow]
 		public async Task Change_Grid_ColumnSpan_After_Load()
 		{
 			Border firstBorder;
+			var container = new Grid();
 			var SUT = new Grid
 			{
+				HorizontalAlignment = HorizontalAlignment.Left,
+				VerticalAlignment = VerticalAlignment.Top,
 				Background = new SolidColorBrush(Colors.Blue),
 				ColumnSpacing = 10,
 				ColumnDefinitions =
@@ -446,8 +462,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			};
 
 			Grid.SetColumnSpan(firstBorder, 2);
-
-			TestServices.WindowHelper.WindowContent = SUT;
+			container.Children.Add(SUT);
+			TestServices.WindowHelper.WindowContent = container;
 			await TestServices.WindowHelper.WaitForLoaded(SUT);
 
 			Assert.AreEqual(100, SUT.ActualWidth);

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Properties.cs
@@ -142,7 +142,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (instance is IFrameworkElement { Parent: IFrameworkElement parent })
 			{
-				parent.InvalidateArrange();
+				parent.InvalidateMeasure();
 			}
 		}
 		#endregion
@@ -159,7 +159,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (instance is IFrameworkElement { Parent: IFrameworkElement parent })
 			{
-				parent.InvalidateArrange();
+				parent.InvalidateMeasure();
 			}
 		}
 
@@ -185,7 +185,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (instance is IFrameworkElement { Parent: IFrameworkElement parent })
 			{
-				parent.InvalidateArrange();
+				parent.InvalidateMeasure();
 			}
 		}
 		#endregion
@@ -210,7 +210,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (instance is IFrameworkElement { Parent: IFrameworkElement parent })
 			{
-				parent.InvalidateArrange();
+				parent.InvalidateMeasure();
 			}
 		}
 		#endregion


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/15753

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?


The original assumption was that `Column`, `Row`, `ColumnSpan` and `RowSpan` only affect arrange of the `Grid`


## What is the new behavior?

They can and should also affect measure of the `Grid`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.