### PR TITLE
fix(textbox): set Handled so it does not beep on macOS

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -449,14 +449,17 @@ public partial class TextBox
 				}
 				return;
 			case VirtualKey.X when ctrl:
+				args.Handled = selectionLength != 0;
 				CutSelectionToClipboard();
 				selectionLength = 0;
 				text = Text;
 				break;
 			case VirtualKey.V when ctrl:
 				PasteFromClipboard(); // async so doesn't actually do anything right now
+				args.Handled = true;
 				break;
 			case VirtualKey.C when ctrl:
+				args.Handled = selectionLength != 0;
 				CopySelectionToClipboard();
 				break;
 			case VirtualKey.Escape:
@@ -476,6 +479,7 @@ public partial class TextBox
 					text = text[..start] + c + text[end..];
 					selectionStart = start + 1;
 					selectionLength = 0;
+					args.Handled = true;
 				}
 				break;
 		}
@@ -506,6 +510,7 @@ public partial class TextBox
 		{
 			return;
 		}
+		args.Handled = true;
 		if (selectionLength != 0)
 		{
 			TrySetCurrentlyTyping(false);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Unhandled keyboard events (most keys) are making macOS beep.

## What is the new behavior?

* Cut (Cmd+X) and Copy (Cmd+C) beep if selection is empty (!Handled) otherwise silence
* Paste (Cmd+V) never beeps - even if the clipboard is empty
* Back (Delete) never beeps - even if there's nothing to delete
* Other keys (default) if we modify the text then it's handled
