### PR TITLE
fix: NRE on `PickImageFromFile `cancellation in SamplesApp

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Imaging/PickImageFromFile.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Imaging/PickImageFromFile.xaml
@@ -9,7 +9,12 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <StackPanel>
-		<Image x:Name="SelectedImage" Width="600" Height="600" />
-		<Button x:Name="SelectImageButton" Click="SelectImageButton_Click" Content="Pick image file" />
+		<Image Source="{x:Bind ViewModel.SelectedItemSource, Mode=OneWay}"
+			   Width="500"
+			   Height="500" />
+		<Button Click="{x:Bind ViewModel.SelectImageButton}"
+				Content="Pick image file" />
+		<TextBlock Foreground="Red"
+				   Text="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" TextWrapping="WrapWholeWords" />
 	</StackPanel>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Imaging/PickImageFromFile.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Imaging/PickImageFromFile.xaml.cs
@@ -5,27 +5,72 @@ using Windows.Storage.Pickers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Uno.UI.Samples.UITests.Helpers;
+using Microsoft.UI.Xaml.Media;
 
 namespace UITests.Windows_UI_Xaml_Media_Imaging;
 
-[Sample("Microsoft.UI.Xaml.Media", IsManualTest = true)]
 public sealed partial class PickImageFromFile : Page
 {
 	public PickImageFromFile()
 	{
 		this.InitializeComponent();
+		this.DataContextChanged += PickImageFromFile_DataContextChanged;
 	}
 
-	private async void SelectImageButton_Click(object sender, RoutedEventArgs e)
+	private void PickImageFromFile_DataContextChanged(DependencyObject sender, DataContextChangedEventArgs args)
 	{
-		var picker = new FileOpenPicker();
-		picker.FileTypeFilter.Add(".jpg");
+		ViewModel = args.NewValue as PickImageFromFileViewModel;
+	}
 
-		var fileName = $"{Guid.NewGuid()}.jpg";
-		StorageFile file = await picker.PickSingleFileAsync();
-		await file.CopyAsync(ApplicationData.Current.LocalFolder, fileName);
-		var uri = new Uri($"ms-appdata:///Local/{fileName}");
-		var bitmapImage = new BitmapImage(uri);
-		SelectedImage.Source = bitmapImage;
+	internal PickImageFromFileViewModel ViewModel { get; private set; }
+}
+
+internal class PickImageFromFileViewModel : ViewModelBase
+{
+	private string _errorMessage = string.Empty;
+	private ImageSource _selectedItemSource;
+
+	public string ErrorMessage
+	{
+		get => _errorMessage;
+		set
+		{
+			_errorMessage = value;
+			RaisePropertyChanged();
+		}
+	}
+
+	public ImageSource SelectedItemSource
+	{
+		get => _selectedItemSource;
+		set
+		{
+			_selectedItemSource = value;
+			RaisePropertyChanged();
+		}
+	}
+
+	public async void SelectImageButton()
+	{
+		try
+		{
+			var picker = new FileOpenPicker()
+			{
+				FileTypeFilter = { ".jpg" }
+			};
+
+			var fileName = $"{Guid.NewGuid()}.jpg";
+			var file = await picker.PickSingleFileAsync();
+			await file.CopyAsync(ApplicationData.Current.LocalFolder, fileName);
+			var uri = new Uri($"ms-appdata:///Local/{fileName}");
+			var bitmapImage = new BitmapImage(uri);
+			SelectedItemSource = bitmapImage;
+		}
+		catch (Exception ex)
+		{
+			ErrorMessage = $"Exception occurred: {ex}.";
+		}
 	}
 }
+

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Imaging/PickImageFromFile.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Imaging/PickImageFromFile.xaml.cs
@@ -10,6 +10,8 @@ using Microsoft.UI.Xaml.Media;
 
 namespace UITests.Windows_UI_Xaml_Media_Imaging;
 
+[Sample("Microsoft.UI.Xaml.Media", ViewModelType = typeof(PickImageFromFileViewModel), IsManualTest = true,
+	Description = "Allows for selecting .jpg image from storage and displaying it. Not selecting an image should not cause an exception.")]
 public sealed partial class PickImageFromFile : Page
 {
 	public PickImageFromFile()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #15737 , part of #15664

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Fixes crashing of the `PickImageFromFile` sample and adds a proper description

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->