### PR TITLE
revert: "fix: explicit Measure calls should invalidate parents if DesiredSize changes"

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -284,12 +284,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			TestServices.WindowHelper.WindowContent = sut;
 			await TestServices.WindowHelper.WaitForIdle();
 
-			// count == 1 on WinUI
-#if __SKIA__ || __WASM__
-			Assert.AreEqual(1, count);
-#else
 			Assert.AreEqual(2, count);
-#endif
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
@@ -13,14 +13,11 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Private.Infrastructure;
 using Windows.Foundation;
-using Windows.Foundation.Metadata;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
-using Uno.UI.RuntimeTests.Helpers;
-using Point = System.Drawing.Point;
 
 #if __IOS__
 using UIKit;
@@ -31,6 +28,7 @@ using Uno.UI;
 using Windows.UI;
 using Windows.ApplicationModel.Appointments;
 using Microsoft.UI.Xaml.Hosting;
+using Uno.UI.RuntimeTests.Helpers;
 using Uno.Extensions;
 using Windows.UI.Input.Preview.Injection;
 using Uno.UI.Toolkit.Extensions;
@@ -680,58 +678,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				sut.IsArrangeDirty.Should().BeFalse("IsArrangeDirty");
 				sut.IsArrangeDirtyPath.Should().BeFalse("IsArrangeDirtyPath");
 			}
-		}
-
-		[TestMethod]
-		[RunsOnUIThread]
-		public async Task When_Measure_Explicitly_Called()
-		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
-			{
-				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
-			}
-
-			var tb = new TextBlock
-			{
-				Text = "Small"
-			};
-
-			var SUT = new StackPanel
-			{
-				Children =
-				{
-					tb,
-					new ContentControl
-					{
-						HorizontalContentAlignment = HorizontalAlignment.Center,
-						Content = new TextBlock
-						{
-							Text = "Small",
-							Foreground = new SolidColorBrush(Microsoft.UI.Colors.Yellow)
-						}
-					}
-				}
-			};
-
-			var sp = new Grid
-			{
-				ColumnDefinitions =
-				{
-					new ColumnDefinition { Width = 200 }
-				},
-				Children = { SUT }
-			};
-
-			await UITestHelper.Load(sp);
-
-			tb.Text = "very very very very very very very very very very very very very very very very very very very very very very very very wide";
-			await TestServices.WindowHelper.WaitForIdle();
-
-			SUT.Measure(LayoutInformation.GetAvailableSize(SUT) with { Width = 1000 });
-			await TestServices.WindowHelper.WaitForIdle();
-
-			var bitmap = await UITestHelper.ScreenShot(sp);
-			ImageAssert.HasColorInRectangle(bitmap, new System.Drawing.Rectangle(new Point(0, 0), bitmap.Size), Microsoft.UI.Colors.Yellow);
 		}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Layout.cs
@@ -104,7 +104,7 @@ namespace Microsoft.UI.Xaml
 #endif
 
 		[Flags]
-		internal enum LayoutFlag : short
+		internal enum LayoutFlag : byte
 		{
 			/// <summary>
 			/// Means the Measure is dirty for the current element
@@ -116,16 +116,6 @@ namespace Microsoft.UI.Xaml
 			/// Means the Measure is dirty on at least one child of this element
 			/// </summary>
 			MeasureDirtyPath = 0b0000_0010,
-
-			/// <summary>
-			/// Indicates that the element is currently being measured during the Arrange cycle.
-			/// </summary>
-			MeasureDuringArrange = 0b0000_0001_0000_0000,
-
-			/// <summary>
-			/// Indicates that the element is currently being measured.
-			/// </summary>
-			MeasuringSelf = 0b0000_0010_0000_0000,
 #endif
 
 			/// <summary>
@@ -177,8 +167,6 @@ namespace Microsoft.UI.Xaml
 			LayoutFlag.MeasureDirty |
 #if IMPLEMENTS_MANAGED_MEASURE_DIRTY_PATH
 			LayoutFlag.MeasureDirtyPath |
-			LayoutFlag.MeasureDuringArrange |
-			LayoutFlag.MeasuringSelf |
 #endif
 #if !__ANDROID__
 			LayoutFlag.ArrangeDirty |

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -164,11 +164,6 @@ namespace Microsoft.UI.Xaml
 			return result;
 		}
 
-		private protected virtual void OnChildDesiredSizeChanged(UIElement child)
-		{
-			InvalidateMeasure();
-		}
-
 		private protected static bool GetIsEventOverrideImplemented(Type type, string name, Type[] args)
 		{
 			var method = type


### PR DESCRIPTION
#15748 broke screenshot comparisons (kudos to@Youssef1313 for the heads up). Let's revert until I can take a look at it.