### PR TITLE
fix: tell macOS we handled all keydown events

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
@@ -267,7 +267,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			}
 			var args = CreateArgs(key, mods, scanCode);
 			keyDown.Invoke(window!, args);
-			return args.Handled ? 1 : 0;
+			// we tell macOS it's always handled as WinUI does not mark as handled some keys that would make it beep in common cases
+			return 1;
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On macOS non-handled key down events will make the Mac beep. 

However for WinUI compatibility the `Handled` property cannot be used to signal the actual key being handled (or not).

This replace PR https://github.com/unoplatform/uno/pull/15780

## What is the new behavior?

We always tell macOS that the key down event was handled.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
