### PR TITLE
ci: iOS Wait 2 seconds if test results file isn't found

### DIFF
--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -199,6 +199,7 @@ then
 	done
 
 	if ! [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
+ 		echo "The file $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE is not available, waiting 2 seconds"
  		sleep 2
  	fi
   

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -198,6 +198,10 @@ then
 		fi
 	done
 
+	if ! [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
+ 		sleep 2
+ 	fi
+  
 	# if the file exists, show a message
 	if [ -f "$SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE" ]; then
 		echo "The file $SIMCTL_CHILD_UITEST_RUNTIME_AUTOSTART_RESULT_FILE is available, the test run is complete."


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Not very sure but looks like there is a race condition. Sometimes, test runs fail with logs like:

```
Starting tests in mode RuntimeTests
uno.platform.samplesdev: 5456
App PID: 5456
Waiting for /tmp/TestResult-20240311063700.xml to be available...
The app is not running anymore
The file /tmp/TestResult-20240311063700.xml is not available, the test run has timed out.
cp: /Users/runner/work/1/s/build/TestResult-original.xml: No such file or directory
```

Looking at Device Logs, the tests actually executed to completion successfully, then the app exited:

```
2024-03-11 06:44:04.134189+0000  localhost SamplesApp[6112]: (libSystem.Native.dylib) \^[[40m\^[[32minfo\^[[39m\^[[22m\^[[49m: Uno.UI.Samples.Tests.UnitTestsControl[0]
      Running 1 test methods
2024-03-11 06:44:04.134427+0000  localhost SamplesApp[6112]: (libSystem.Native.dylib) \^[[40m\^[[32minfo\^[[39m\^[[22m\^[[49m: Uno.UI.Samples.Tests.UnitTestsControl[0]
      Running test When_Shape_Stretch_None()
2024-03-11 06:44:04.245679+0000  localhost SamplesApp[6112]: (libxamarin-dotnet.dylib) info: Uno.UI.Samples.Tests.UnitTestsControl[0] Tests finished running.
2024-03-11 06:44:04.255034+0000  localhost SamplesApp[6112]: (libSystem.Native.dylib) \^[[40m\^[[32minfo\^[[39m\^[[22m\^[[49m: Uno.UI.Samples.Tests.UnitTestsControl[0]
      Tests finished running.
2024-03-11 06:44:04.272871+0000  localhost runningboardd[4362]: (RunningBoard) Created Activity ID: 0x1b0fb, Description: timer
2024-03-11 06:44:04.397489+0000  localhost SamplesApp[6112]: (CoreAnalytics) [com.apple.CoreAnalytics:client] Entering exit handler.
2024-03-11 06:44:04.397567+0000  localhost SamplesApp[6112]: (CoreAnalytics) [com.apple.CoreAnalytics:client] Exiting exit handler.
```

I'm guessing that if we waited, we may find the file?

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
