### PR TITLE
fix(hotreload): inverse Android and iOS/Catalyst versions

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -98,9 +98,9 @@ namespace Uno.UI.RemoteControl.HotReload
 					{
 						_isIssue93860Fixed = version >=
 #if __IOS__ || __CATALYST__
-							new Version(34, 0, 1, 52); //8.0.102
-#elif __ANDROID__
 							new Version(17, 2, 8022); // 8.0.200
+#elif __ANDROID__
+							new Version(34, 0, 1, 52); //8.0.102
 #endif
 
 						if (!_isIssue93860Fixed.Value && this.Log().IsEnabled(LogLevel.Warning))


### PR DESCRIPTION
GitHub Issue (If applicable): closes 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

For mobile platforms only Android works with C# hot-reload.

## What is the new behavior?

iOS and Catalyst should work too for C# hot-reload.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Versions were inverted inside https://github.com/unoplatform/uno/pull/15582/files

Internal Issue (If applicable):

https://github.com/unoplatform/uno.vscode/issues/638
