### PR TITLE
fix: set unicode value on KeyEventArgs for macOS/skia

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
@@ -240,23 +240,23 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	public event TypedEventHandler<object, KeyEventArgs>? KeyDown;
 	public event TypedEventHandler<object, KeyEventArgs>? KeyUp;
 
-	private static KeyEventArgs CreateArgs(VirtualKey key, VirtualKeyModifiers mods, uint scanCode)
+	private static KeyEventArgs CreateArgs(VirtualKey key, VirtualKeyModifiers mods, uint scanCode, ushort unicode)
 	{
 		var status = new CorePhysicalKeyStatus
 		{
 			ScanCode = scanCode,
 		};
-		return new KeyEventArgs("keyboard", key, mods, status);
+		return new KeyEventArgs("keyboard", key, mods, status, unicode == 0 ? null : (char)unicode);
 	}
 
 	[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-	private static int OnRawKeyDown(nint handle, VirtualKey key, VirtualKeyModifiers mods, uint scanCode)
+	private static int OnRawKeyDown(nint handle, VirtualKey key, VirtualKeyModifiers mods, uint scanCode, ushort unicode)
 	{
 		try
 		{
 			if (typeof(MacOSWindowHost).Log().IsEnabled(LogLevel.Trace))
 			{
-				typeof(MacOSWindowHost).Log().Trace($"OnRawKeyDown '${key}', mods: '{mods}', scanCode: {scanCode}");
+				typeof(MacOSWindowHost).Log().Trace($"OnRawKeyDown '${key}', mods: '{mods}', scanCode: {scanCode}, unicode: {unicode}");
 			}
 
 			var window = GetWindowHost(handle);
@@ -265,7 +265,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			{
 				return 0;
 			}
-			var args = CreateArgs(key, mods, scanCode);
+			var args = CreateArgs(key, mods, scanCode, unicode);
 			keyDown.Invoke(window!, args);
 			// we tell macOS it's always handled as WinUI does not mark as handled some keys that would make it beep in common cases
 			return 1;
@@ -278,13 +278,13 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	}
 
 	[UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-	private static int OnRawKeyUp(nint handle, VirtualKey key, VirtualKeyModifiers mods, uint scanCode)
+	private static int OnRawKeyUp(nint handle, VirtualKey key, VirtualKeyModifiers mods, uint scanCode, ushort unicode)
 	{
 		try
 		{
 			if (typeof(MacOSWindowHost).Log().IsEnabled(LogLevel.Trace))
 			{
-				typeof(MacOSWindowHost).Log().Trace($"OnRawKeyUp '${key}', mods: '{mods}', scanCode: {scanCode}");
+				typeof(MacOSWindowHost).Log().Trace($"OnRawKeyUp '${key}', mods: '{mods}', scanCode: {scanCode}, unicode: {unicode}");
 			}
 
 			var window = GetWindowHost(handle);
@@ -293,7 +293,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			{
 				return 0;
 			}
-			var args = CreateArgs(key, mods, scanCode);
+			var args = CreateArgs(key, mods, scanCode, unicode);
 			keyUp.Invoke(window!, args);
 			return args.Handled ? 1 : 0;
 		}

--- a/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
@@ -185,8 +185,8 @@ internal static partial class NativeUno
 
 	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static unsafe partial void uno_set_window_events_callbacks(
-		delegate* unmanaged[Cdecl]<nint, VirtualKey, VirtualKeyModifiers, uint, int> keyDownCallback,
-		delegate* unmanaged[Cdecl]<nint, VirtualKey, VirtualKeyModifiers, uint, int> keyUpCallback,
+		delegate* unmanaged[Cdecl]<nint, VirtualKey, VirtualKeyModifiers, uint, ushort, int> keyDownCallback,
+		delegate* unmanaged[Cdecl]<nint, VirtualKey, VirtualKeyModifiers, uint, ushort, int> keyUpCallback,
 		delegate* unmanaged[Cdecl]<nint, NativeMouseEventData*, int> pointerCallback);
 
 	[LibraryImport("libUnoNativeMac.dylib")]

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -268,7 +268,7 @@ struct MouseEventData {
     uint32 pid;
 };
 
-typedef int32_t (*window_key_callback_fn_ptr)(UNOWindow* window, VirtualKey key, VirtualKeyModifiers mods, uint32 scanCode);
+typedef int32_t (*window_key_callback_fn_ptr)(UNOWindow* window, VirtualKey key, VirtualKeyModifiers mods, uint32 scanCode, UniChar unicode);
 typedef int32_t (*window_mouse_callback_fn_ptr)(UNOWindow* window, struct MouseEventData *data);
 void uno_set_window_events_callbacks(window_key_callback_fn_ptr keyDown, window_key_callback_fn_ptr keyUp, window_mouse_callback_fn_ptr pointer);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -358,6 +358,19 @@ VirtualKeyModifiers get_modifiers(NSEventModifierFlags mods)
     return vkm;
 }
 
+UniChar get_unicode(NSEvent *event)
+{
+    UniCharCount count = 1;
+    UniChar unicode[count];
+    CGEventKeyboardGetUnicodeString(event.CGEvent, count, &count, unicode);
+#if DEBUG
+    if (count > 1) {
+        NSLog(@"get_unicode - more than one unicode character returned");
+    }
+#endif
+    return unicode[0];
+}
+
 static window_mouse_callback_fn_ptr window_mouse_event;
 
 inline static window_mouse_callback_fn_ptr uno_get_window_mouse_event_callback(void)
@@ -484,17 +497,19 @@ void* uno_window_get_metal_context(UNOWindow* window)
         }
         case NSEventTypeKeyDown: {
             unsigned short scanCode = event.keyCode;
-            handled = uno_get_window_key_down_callback()(self, get_virtual_key(scanCode), get_modifiers(event.modifierFlags), scanCode);
+            UniChar unicode = get_unicode(event);
+            handled = uno_get_window_key_down_callback()(self, get_virtual_key(scanCode), get_modifiers(event.modifierFlags), scanCode, unicode);
 #if DEBUG
-            NSLog(@"NSEventTypeKeyDown: %@ window %p handled? %s", event, self, handled ? "true" : "false");
+            NSLog(@"NSEventTypeKeyDown: %@ window %p unicode %d handled? %s", event, self, unicode, handled ? "true" : "false");
 #endif
             break;
         }
         case NSEventTypeKeyUp: {
             unsigned short scanCode = event.keyCode;
-            handled = uno_get_window_key_up_callback()(self, get_virtual_key(scanCode), get_modifiers(event.modifierFlags), scanCode);
+            UniChar unicode = get_unicode(event);
+            handled = uno_get_window_key_up_callback()(self, get_virtual_key(scanCode), get_modifiers(event.modifierFlags), scanCode, unicode);
 #if DEBUG
-            NSLog(@"NSEventTypeKeyUp: %@ window %p handled? %s", event, self, handled ? "true" : "false");
+            NSLog(@"NSEventTypeKeyUp: %@ window %p unocode %d handled? %s", event, self, unicode, handled ? "true" : "false");
 #endif
             break;
         }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Some keys (e.g. `.`) were not processed correctly since there was no unicode mapping for the scan code.

## What is the new behavior?

A unicode value is always provided for key events.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
