### PR TITLE
docs: Added missing details about the Svg.Skia package needed for the Skia Head

### DIFF
--- a/doc/articles/features/svg.md
+++ b/doc/articles/features/svg.md
@@ -12,15 +12,15 @@ Uno Platform supports using vector SVG graphics inside of your cross-platform ap
 
 To use SVG, install the following NuGet packages into the iOS, macOS, Mac Catalyst, Android, and Skia projects:
 
-* `Svg.Skia` (required only for the Skia project)
 * `Uno.WinUI.Svg` (or `Uno.UI.Svg` if you are using a UWP-based app template)
 * `SkiaSharp.Views.Uno.WinUI` (or `SkiaSharp.Views.Uno` if you are using a UWP-based app template)
+* `Svg.Skia` (required only for the Skia project)
 
 > [!NOTE]
 > If the `Uno.[UI|WinUI].Svg` package is not installed, you will get a warning when an `.svg` image is loaded.
+> If the `Svg.Skia` package is not installed, you will get an error when an `.svg` image is loaded for the Skia project.
 > [!IMPORTANT]
-> The `Uno.[UI|WinUI].Svg` package is not needed for WebAssembly, and must only be installed on the Mobile and Skia heads. It must not in any other class libraries of your solution.
-> The `Svg.Skia` is only needed for the Skia projects.
+> The `Uno.[UI|WinUI].Svg` package is not needed for WebAssembly, and must only be installed on the Mobile and Skia heads. It must not be in any other class libraries of your solution.
 
 Add the SVG Image into the project's class library (or shared project) and make sure that the build action is set to Content.
 Now, you can display the SVG image in an `Image` by referencing it from the `Source` property. For example:

--- a/doc/articles/features/svg.md
+++ b/doc/articles/features/svg.md
@@ -20,6 +20,7 @@ To use SVG, install the following NuGet packages into the iOS, macOS, Mac Cataly
 > If the `Uno.[UI|WinUI].Svg` package is not installed, you will get a warning when an `.svg` image is loaded.
 > [!IMPORTANT]
 > The `Uno.[UI|WinUI].Svg` package is not needed for WebAssembly, and must only be installed on the Mobile and Skia heads. It must not in any other class libraries of your solution.
+> The `Svg.Skia` is only needed for the Skia projects.
 
 Add the SVG Image into the project's class library (or shared project) and make sure that the build action is set to Content.
 Now, you can display the SVG image in an `Image` by referencing it from the `Source` property. For example:

--- a/doc/articles/features/svg.md
+++ b/doc/articles/features/svg.md
@@ -12,6 +12,7 @@ Uno Platform supports using vector SVG graphics inside of your cross-platform ap
 
 To use SVG, install the following NuGet packages into the iOS, macOS, Mac Catalyst, Android, and Skia projects:
 
+* `Svg.Skia` (required in the Skia project)
 * `Uno.WinUI.Svg` (or `Uno.UI.Svg` if you are using a UWP-based app template)
 * `SkiaSharp.Views.Uno.WinUI` (or `SkiaSharp.Views.Uno` if you are using a UWP-based app template)
 

--- a/doc/articles/features/svg.md
+++ b/doc/articles/features/svg.md
@@ -12,7 +12,7 @@ Uno Platform supports using vector SVG graphics inside of your cross-platform ap
 
 To use SVG, install the following NuGet packages into the iOS, macOS, Mac Catalyst, Android, and Skia projects:
 
-* `Svg.Skia` (required in the Skia project)
+* `Svg.Skia` (required only for the Skia project)
 * `Uno.WinUI.Svg` (or `Uno.UI.Svg` if you are using a UWP-based app template)
 * `SkiaSharp.Views.Uno.WinUI` (or `SkiaSharp.Views.Uno` if you are using a UWP-based app template)
 


### PR DESCRIPTION
Added missing details about the Svg.Skia package needed for the Skia Head

GitHub Issue (If applicable): closes #15864

https://github.com/unoplatform/uno/issues/15864

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

There is no information about the required package and you get an error when compiling.


## What is the new behavior?

There is no error when compiling.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
