### PR TITLE
feat: Provide Intent access for Android pickers

### DIFF
--- a/doc/articles/features/windows-storage-pickers.md
+++ b/doc/articles/features/windows-storage-pickers.md
@@ -352,6 +352,19 @@ The `SuggestedStartLocation` property has no effect on certain Android devices, 
 
 The `FileSavePicker` API, which uses `ACTION_CREATE_DOCUMENT` on Android, has various limitations. To allow for the best possible compatibility across different Android versions, you should always add your file type extension to `FileTypeChoices`, and, if possible, provide only one such file type. In addition, if the `SuggestedFileName` or the user-typed file name matches an existing file, the resulting file will be renamed with `(1)` in the name, e.g., `test.txt` will become `test (1).txt` and the existing file will not be overwritten. However, if the user explicitly taps an existing file in the file browser, the system will show a dialog allowing the app to overwrite the existing file. This inconsistent behavior is caused by Android itself, so there is, unfortunately, no way to work around it from our side. See [this issue](https://issuetracker.google.com/issues/37136466) for more information.
 
+If you want to have further influence on the pickers and, for example, create permanent access to the file for the `FileOpenPicker` (flag with GrantPersistableUriPermission), you can do this with the `FilePickerHelper`.
+
+```csharp
+FileOpenPicker fileOpenPicker = new FileOpenPicker
+{
+    SuggestedStartLocation = PickerLocationId.ComputerFolder
+};
+var intent = new Android.Content.Intent(Android.Content.Intent.ActionOpenDocument);
+intent.AddFlags(Android.Content.ActivityFlags.GrantPersistableUriPermission);
+FilePickerHelper.RegisterOnBeforeStartActivity(fileOpenPicker, intent);
+var result = await fileOpenPicker.PickSingleFileAsync();
+```
+
 ## iOS
 
 iOS does not offer a built-in `FileSavePicker` experience. Luckily, it is possible to implement this functionality, for example, using a combination of a `FolderPicker` and `ContentDialog`.

--- a/doc/articles/features/windows-storage-pickers.md
+++ b/doc/articles/features/windows-storage-pickers.md
@@ -359,9 +359,12 @@ FileOpenPicker fileOpenPicker = new FileOpenPicker
 {
     SuggestedStartLocation = PickerLocationId.ComputerFolder
 };
-var intent = new Android.Content.Intent(Android.Content.Intent.ActionOpenDocument);
-intent.AddFlags(Android.Content.ActivityFlags.GrantPersistableUriPermission);
-FilePickerHelper.RegisterOnBeforeStartActivity(fileOpenPicker, intent);
+FilePickerHelper.RegisterOnBeforeStartActivity(fileOpenPicker, (intent) =>
+{
+	// your code...
+	// for example
+	intent.AddFlags(Android.Content.ActivityFlags.GrantPersistableUriPermission);
+});
 var result = await fileOpenPicker.PickSingleFileAsync();
 ```
 

--- a/doc/articles/features/windows-storage-pickers.md
+++ b/doc/articles/features/windows-storage-pickers.md
@@ -352,19 +352,22 @@ The `SuggestedStartLocation` property has no effect on certain Android devices, 
 
 The `FileSavePicker` API, which uses `ACTION_CREATE_DOCUMENT` on Android, has various limitations. To allow for the best possible compatibility across different Android versions, you should always add your file type extension to `FileTypeChoices`, and, if possible, provide only one such file type. In addition, if the `SuggestedFileName` or the user-typed file name matches an existing file, the resulting file will be renamed with `(1)` in the name, e.g., `test.txt` will become `test (1).txt` and the existing file will not be overwritten. However, if the user explicitly taps an existing file in the file browser, the system will show a dialog allowing the app to overwrite the existing file. This inconsistent behavior is caused by Android itself, so there is, unfortunately, no way to work around it from our side. See [this issue](https://issuetracker.google.com/issues/37136466) for more information.
 
-If you want to have further influence on the pickers and, for example, create permanent access to the file for the `FileOpenPicker` (flag with GrantPersistableUriPermission), you can do this with the `FilePickerHelper`.
+If you want to have further influence on the pickers and, for example, create permanent access to the file for the `FileOpenPicker` (flag with GrantPersistableUriPermission), you can do this with the `FilePickerHelper`. The `FolderPicker` can be extended analogue, the `FolderPickerHelper` is available for this purpose.
 
 ```csharp
 FileOpenPicker fileOpenPicker = new FileOpenPicker
 {
     SuggestedStartLocation = PickerLocationId.ComputerFolder
 };
+
+#if __ANDROID__
 FilePickerHelper.RegisterOnBeforeStartActivity(fileOpenPicker, (intent) =>
 {
-	// your code...
-	// for example
-	intent.AddFlags(Android.Content.ActivityFlags.GrantPersistableUriPermission);
+    // your code... for example
+    intent.AddFlags(Android.Content.ActivityFlags.GrantPersistableUriPermission);
 });
+#endif
+
 var result = await fileOpenPicker.PickSingleFileAsync();
 ```
 

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
@@ -21,7 +21,7 @@ namespace Windows.Storage.Pickers
 		private const string AnyWildcard = "*/*";
 		private const string ImageWildcard = "image/*";
 		private const string VideoWildcard = "video/*";
-		private Action<Intent> _intentAction;
+		private Action<Intent>? _intentAction;
 
 		internal static bool TryHandleIntent(Intent intent, Result resultCode)
 		{

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
@@ -21,6 +21,7 @@ namespace Windows.Storage.Pickers
 		private const string AnyWildcard = "*/*";
 		private const string ImageWildcard = "image/*";
 		private const string VideoWildcard = "video/*";
+		private ActivityFlags _activityFlags;
 
 		internal static bool TryHandleIntent(Intent intent, Result resultCode)
 		{
@@ -73,11 +74,22 @@ namespace Windows.Storage.Pickers
 					// apps related to Photos and Videos to be suggested on the picker.
 					var intent = new Intent(Intent.ActionGetContent);
 					intent.AddCategory(Intent.CategoryOpenable);
+					// additional flags are added
+					if (_activityFlags != 0)
+					{
+						intent.AddFlags(_activityFlags);
+					}
 
 					return intent;
 				}
+				var openDocumentIntent = new Intent(Intent.ActionOpenDocument);
+				// additional flags are added
+				if (_activityFlags != 0)
+				{
+					openDocumentIntent.AddFlags(_activityFlags);
+				}
 
-				return new Intent(Intent.ActionOpenDocument);
+				return openDocumentIntent;
 			}
 
 			var intent = GetIntent();
@@ -234,5 +246,8 @@ namespace Windows.Storage.Pickers
 
 			return mimeTypes.ToArray();
 		}
+
+		internal void RegisterOnBeforeStartActivity(Intent intent)
+			=> _activityFlags = intent.Flags;
 	}
 }

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.Android.cs
@@ -21,7 +21,7 @@ namespace Windows.Storage.Pickers
 		private const string AnyWildcard = "*/*";
 		private const string ImageWildcard = "image/*";
 		private const string VideoWildcard = "video/*";
-		private ActivityFlags _activityFlags;
+		private Action<Intent> _intentAction;
 
 		internal static bool TryHandleIntent(Intent intent, Result resultCode)
 		{
@@ -74,22 +74,11 @@ namespace Windows.Storage.Pickers
 					// apps related to Photos and Videos to be suggested on the picker.
 					var intent = new Intent(Intent.ActionGetContent);
 					intent.AddCategory(Intent.CategoryOpenable);
-					// additional flags are added
-					if (_activityFlags != 0)
-					{
-						intent.AddFlags(_activityFlags);
-					}
 
 					return intent;
 				}
-				var openDocumentIntent = new Intent(Intent.ActionOpenDocument);
-				// additional flags are added
-				if (_activityFlags != 0)
-				{
-					openDocumentIntent.AddFlags(_activityFlags);
-				}
 
-				return openDocumentIntent;
+				return new Intent(Intent.ActionOpenDocument);
 			}
 
 			var intent = GetIntent();
@@ -114,6 +103,8 @@ namespace Windows.Storage.Pickers
 			}
 
 			_currentFileOpenPickerRequest = new TaskCompletionSource<Intent?>();
+
+			_intentAction?.Invoke(intent);
 
 			var pickerIntent = Intent.CreateChooser(intent, "");
 
@@ -247,7 +238,7 @@ namespace Windows.Storage.Pickers
 			return mimeTypes.ToArray();
 		}
 
-		internal void RegisterOnBeforeStartActivity(Intent intent)
-			=> _activityFlags = intent.Flags;
+		internal void RegisterOnBeforeStartActivity(Action<Intent> intentAction)
+			=> _intentAction = intentAction;
 	}
 }

--- a/src/Uno.UWP/Storage/Pickers/FilePickerHelper.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FilePickerHelper.Android.cs
@@ -9,14 +9,14 @@ using Android.Content;
 namespace Windows.Storage.Pickers
 {
 	/// <summary>
-	/// Enables the user to extend the flags of the used intent
+	/// Enables the user to extend the internal intent
 	/// </summary>
 	public static class FilePickerHelper
 	{
-		public static void RegisterOnBeforeStartActivity(FileOpenPicker picker, Intent intent)
-		   => picker.RegisterOnBeforeStartActivity(intent);
+		public static void RegisterOnBeforeStartActivity(FileOpenPicker picker, Action<Intent> intentAction)
+		   => picker.RegisterOnBeforeStartActivity(intentAction);
 
-		public static void RegisterOnBeforeStartActivity(FileSavePicker picker, Intent intent)
-			=> picker.RegisterOnBeforeStartActivity(intent);
+		public static void RegisterOnBeforeStartActivity(FileSavePicker picker, Action<Intent> intentAction)
+			=> picker.RegisterOnBeforeStartActivity(intentAction);
 	}
 }

--- a/src/Uno.UWP/Storage/Pickers/FilePickerHelper.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FilePickerHelper.Android.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+
+namespace Windows.Storage.Pickers
+{
+	/// <summary>
+	/// Enables the user to extend the flags of the used intent
+	/// </summary>
+	public static class FilePickerHelper
+	{
+		public static void RegisterOnBeforeStartActivity(FileOpenPicker picker, Intent intent)
+		   => picker.RegisterOnBeforeStartActivity(intent);
+
+		public static void RegisterOnBeforeStartActivity(FileSavePicker picker, Intent intent)
+			=> picker.RegisterOnBeforeStartActivity(intent);
+	}
+}

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.Android.cs
@@ -18,7 +18,7 @@ public partial class FileSavePicker
 {
 	private const string XmlCorrectMimeToActionCreateDocument = "application/xhtml+xml";
 	private const string XmlIncorrectMimeToActionCreateDocument = "application/xml";
-	private Action<Intent> _intentAction;
+	private Action<Intent>? _intentAction;
 
 	private async Task<StorageFile?> PickSaveFileTaskAsync(CancellationToken token)
 	{

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.Android.cs
@@ -18,6 +18,7 @@ public partial class FileSavePicker
 {
 	private const string XmlCorrectMimeToActionCreateDocument = "application/xhtml+xml";
 	private const string XmlIncorrectMimeToActionCreateDocument = "application/xml";
+	private ActivityFlags _activityFlags;
 
 	private async Task<StorageFile?> PickSaveFileTaskAsync(CancellationToken token)
 	{
@@ -30,6 +31,11 @@ public partial class FileSavePicker
 
 		var intent = new Intent(action);
 		intent.AddCategory(Intent.CategoryOpenable);
+		// additional flags are added
+		if (_activityFlags != 0)
+		{
+			intent.AddFlags(_activityFlags);
+		}
 		var mimeTypes = GetMimeTypes();
 		this.AdjustInvalidMimeTypes(mimeTypes);
 
@@ -109,4 +115,7 @@ public partial class FileSavePicker
 		AdjustInvalidMimeTypes(mimes);
 		return mimes ?? Array.Empty<string>();
 	}
+
+	internal void RegisterOnBeforeStartActivity(Intent intent)
+		=> _activityFlags = intent.Flags;
 }

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.Android.cs
@@ -18,7 +18,7 @@ public partial class FileSavePicker
 {
 	private const string XmlCorrectMimeToActionCreateDocument = "application/xhtml+xml";
 	private const string XmlIncorrectMimeToActionCreateDocument = "application/xml";
-	private ActivityFlags _activityFlags;
+	private Action<Intent> _intentAction;
 
 	private async Task<StorageFile?> PickSaveFileTaskAsync(CancellationToken token)
 	{
@@ -31,11 +31,7 @@ public partial class FileSavePicker
 
 		var intent = new Intent(action);
 		intent.AddCategory(Intent.CategoryOpenable);
-		// additional flags are added
-		if (_activityFlags != 0)
-		{
-			intent.AddFlags(_activityFlags);
-		}
+
 		var mimeTypes = GetMimeTypes();
 		this.AdjustInvalidMimeTypes(mimeTypes);
 
@@ -66,6 +62,8 @@ public partial class FileSavePicker
 			}
 			intent.PutExtra(Intent.ExtraTitle, defaultFileName);
 		}
+
+		_intentAction?.Invoke(intent);
 
 		var activity = await AwaitableResultActivity.StartAsync();
 		var result = await activity.StartActivityForResultAsync(intent, cacellationToken: token);
@@ -116,6 +114,6 @@ public partial class FileSavePicker
 		return mimes ?? Array.Empty<string>();
 	}
 
-	internal void RegisterOnBeforeStartActivity(Intent intent)
-		=> _activityFlags = intent.Flags;
+	internal void RegisterOnBeforeStartActivity(Action<Intent> intentAction)
+		=> _intentAction = intentAction;
 }

--- a/src/Uno.UWP/Storage/Pickers/FolderPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPicker.Android.cs
@@ -12,7 +12,7 @@ namespace Windows.Storage.Pickers
 	public partial class FolderPicker
 	{
 		internal const int RequestCode = 6001;
-		private Action<Intent> _intentAction;
+		private Action<Intent>? _intentAction;
 
 		private static TaskCompletionSource<Intent?>? _currentFolderPickerRequest;
 

--- a/src/Uno.UWP/Storage/Pickers/FolderPicker.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPicker.Android.cs
@@ -12,6 +12,7 @@ namespace Windows.Storage.Pickers
 	public partial class FolderPicker
 	{
 		internal const int RequestCode = 6001;
+		private Action<Intent> _intentAction;
 
 		private static TaskCompletionSource<Intent?>? _currentFolderPickerRequest;
 
@@ -41,6 +42,8 @@ namespace Windows.Storage.Pickers
 			var intent = new Intent(Intent.ActionOpenDocumentTree);
 			_currentFolderPickerRequest = new TaskCompletionSource<Intent?>();
 
+			_intentAction?.Invoke(intent);
+
 			appActivity.StartActivityForResult(intent, RequestCode);
 
 			var resultIntent = await _currentFolderPickerRequest.Task;
@@ -64,5 +67,8 @@ namespace Windows.Storage.Pickers
 
 			return null;
 		}
+
+		internal void RegisterOnBeforeStartActivity(Action<Intent> intentAction)
+			=> _intentAction = intentAction;
 	}
 }

--- a/src/Uno.UWP/Storage/Pickers/FolderPickerHelper.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPickerHelper.Android.cs
@@ -8,6 +8,9 @@ using Android.Content;
 
 namespace Windows.Storage.Pickers
 {
+	/// <summary>
+	/// Enables the user to extend the internal intent
+	/// </summary>
 	public static class FolderPickerHelper
 	{
 		public static void RegisterOnBeforeStartActivity(FolderPicker picker, Action<Intent> intentAction)

--- a/src/Uno.UWP/Storage/Pickers/FolderPickerHelper.Android.cs
+++ b/src/Uno.UWP/Storage/Pickers/FolderPickerHelper.Android.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+
+namespace Windows.Storage.Pickers
+{
+	public static class FolderPickerHelper
+	{
+		public static void RegisterOnBeforeStartActivity(FolderPicker picker, Action<Intent> intentAction)
+			=> picker.RegisterOnBeforeStartActivity(intentAction);
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #10550

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Feature


## What is the current behavior?
Currently it is not possible to access the intent for Android pickers.



## What is the new behavior?
It is now possible to address the intent that is called by the picker user-defined before execution. As an example, the setting of the flag 'GrantPersistableUriPermission'.

```csharp
FileOpenPicker fileOpenPicker = new FileOpenPicker
{
    SuggestedStartLocation = PickerLocationId.ComputerFolder
};
FilePickerHelper.RegisterOnBeforeStartActivity(fileOpenPicker, (intent) =>
{
	// your code...
	// for example
	intent.AddFlags(Android.Content.ActivityFlags.GrantPersistableUriPermission);
});
var result = await fileOpenPicker.PickSingleFileAsync();
```


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Of course, you could just transfer the flags to set and not a new `Intent`, but that would have to be changed if desired.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
