### PR TITLE
fix(pointers): [iOS] Ensure to raise up/exit/capture-lost events in the right order

### DIFF
--- a/src/Uno.UI/Extensions/UIElementExtensions.Debug.cs
+++ b/src/Uno.UI/Extensions/UIElementExtensions.Debug.cs
@@ -198,7 +198,7 @@ static partial class UIElementExtensions
 			null => 0,
 #if __CROSSRUNTIME__
 			UIElement fwElt => fwElt.Depth,
-#else
+#elif HAS_UNO
 			UIElement { IsVisualTreeRoot: true } => 0,
 #endif
 #if __IOS__

--- a/src/Uno.UI/Extensions/UIElementExtensions.Debug.cs
+++ b/src/Uno.UI/Extensions/UIElementExtensions.Debug.cs
@@ -198,6 +198,15 @@ static partial class UIElementExtensions
 			null => 0,
 #if __CROSSRUNTIME__
 			UIElement fwElt => fwElt.Depth,
+#else
+			UIElement { IsVisualTreeRoot: true } => 0,
+#endif
+#if __IOS__
+			UIKit.UIView native => native.Superview?.GetDebugDepth() + 1 ?? 0,
+#elif __MACOS__
+			AppKit.NSView native => native.Superview?.GetDebugDepth() + 1 ?? 0,
+#elif __ANDROID__
+			Android.Views.View native => native.Parent?.GetDebugDepth() + 1 ?? 0,
 #endif
 #if HAS_UNO
 			_ => elt.GetParent()?.GetDebugDepth() + 1 ?? 0,

--- a/src/Uno.UI/UI/Xaml/Internal/UnoRootElementLogic.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/UnoRootElementLogic.cs
@@ -133,9 +133,9 @@ internal class UnoRootElementLogic
 #endif
 
 		// At the end of our "up" processing, we reset the flag to make sure that the native handler (iOS, Android and WASM)
-		// won't try to sent it to us again.
+		// won't try to sent it to us again (if not already the case ^^).
 		// (This could be the case if the args was flagged as handled in the ReleaseCaptures call above, like in RatingControl).
-		args.Handled = false; // == isHandled;
+		args.Handled = isAfterHandledUp;
 	}
 
 	private static void ReleaseCaptures(PointerRoutedEventArgs routedArgs)

--- a/src/Uno.UI/UI/Xaml/Internal/UnoRootElementLogic.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/UnoRootElementLogic.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Input;
-
+using Uno.Foundation.Logging;
 using PointerIdentifierPool = Windows.Devices.Input.PointerIdentifierPool; // internal type (should be in Uno namespace)
 
 #if HAS_UNO_WINUI
@@ -102,6 +102,11 @@ internal class UnoRootElementLogic
 			// since those platforms have "implicit capture" and captures are propagated to the OS,
 			// the OriginalSource will be the element that has capture (if any).
 
+			if (this.Log().IsEnabled(LogLevel.Trace))
+			{
+				this.Log().Trace($"Re-dispatching pointer {args.Pointer} to {src.GetDebugName()} to inject exit event.");
+			}
+
 			src.RedispatchPointerExited(args.Reset(canBubbleNatively: false));
 		}
 #endif
@@ -109,9 +114,9 @@ internal class UnoRootElementLogic
 		// Uno specific: To ensure focus is properly lost when clicking "outside" app's content,
 		// we set focus here. In case UWP, focus is set to the root ScrollViewer instead,
 		// but Uno does not have it on all targets yet.
-		var focusedElement = _rootElement.XamlRoot is null ?
-			FocusManager.GetFocusedElement() :
-			FocusManager.GetFocusedElement(_rootElement.XamlRoot);
+		var focusedElement = _rootElement.XamlRoot is null
+			? FocusManager.GetFocusedElement()
+			: FocusManager.GetFocusedElement(_rootElement.XamlRoot);
 		if (!isHandled // so isAfterHandledUp is false!
 			&& _canUnFocusOnNextLeftPointerRelease
 			&& args.GetCurrentPoint(null).Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonReleased
@@ -119,7 +124,6 @@ internal class UnoRootElementLogic
 			&& focusedElement is UIElement uiElement)
 		{
 			uiElement.Unfocus();
-			args.Handled = true;
 		}
 
 		ReleaseCaptures(args.Reset(canBubbleNatively: false));
@@ -127,6 +131,11 @@ internal class UnoRootElementLogic
 #if __WASM__
 		PointerIdentifierPool.ReleaseManaged(args.Pointer.UniqueId);
 #endif
+
+		// At the end of our "up" processing, we reset the flag to make sure that the native handler (iOS, Android and WASM)
+		// won't try to sent it to us again.
+		// (This could be the case if the args was flagged as handled in the ReleaseCaptures call above, like in RatingControl).
+		args.Handled = false; // == isHandled;
 	}
 
 	private static void ReleaseCaptures(PointerRoutedEventArgs routedArgs)

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -592,7 +592,7 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
-		private void UpdateRaisedEventFlags(PointerRoutedEventArgs args)
+		private void UpdateRaisedGestureEventsFlag(PointerRoutedEventArgs args)
 		{
 			if (!IsGestureRecognizerCreated)
 			{
@@ -916,7 +916,7 @@ namespace Microsoft.UI.Xaml
 				ctx = ctx.WithMode(ctx.Mode | BubblingMode.IgnoreElement);
 			}
 
-			UpdateRaisedEventFlags(args);
+			UpdateRaisedGestureEventsFlag(args);
 			var handledInManaged = SetOver(args, true, ctx);
 
 			return handledInManaged;
@@ -940,7 +940,7 @@ namespace Microsoft.UI.Xaml
 				ctx = ctx.WithMode(ctx.Mode | BubblingMode.IgnoreElement);
 			}
 
-			UpdateRaisedEventFlags(args);
+			UpdateRaisedGestureEventsFlag(args);
 			var handledInManaged = SetPressed(args, true, ctx);
 
 			if (PointerRoutedEventArgs.PlatformSupportsNativeBubbling && !ctx.IsInternal && !isOverOrCaptured)
@@ -1022,7 +1022,7 @@ namespace Microsoft.UI.Xaml
 			var handledInManaged = false;
 			var isOverOrCaptured = ValidateAndUpdateCapture(args);
 
-			UpdateRaisedEventFlags(args);
+			UpdateRaisedGestureEventsFlag(args);
 			if (!ctx.IsInternal && isOverOrCaptured)
 			{
 				// If this pointer was wrongly dispatched here (out of the bounds and not captured),
@@ -1066,7 +1066,7 @@ namespace Microsoft.UI.Xaml
 			if (IsGestureRecognizerCreated)
 			{
 				currentPoint = args.GetCurrentPoint(this);
-				UpdateRaisedEventFlags(args);
+				UpdateRaisedGestureEventsFlag(args);
 				GestureRecognizer.ProcessBeforeUpEvent(currentPoint, !ctx.IsInternal || isOverOrCaptured);
 			}
 
@@ -1087,16 +1087,6 @@ namespace Microsoft.UI.Xaml
 				}
 			}
 
-#if !UNO_HAS_MANAGED_POINTERS && !__ANDROID__ && !__WASM__ // Captures release are handled a root level (RootVisual for Android and WASM)
-			// We release the captures on up but only after the released event and processed the gesture
-			// Note: For a "Tap" with a finger the sequence is Up / Exited / Lost, so we let the Exit raise the capture lost
-			// Note: If '!isOver', that means that 'IsCaptured == true' otherwise 'isOverOrCaptured' would have been false.
-			if (!isOver || args.Pointer.PointerDeviceType != PointerDeviceType.Touch)
-			{
-				handledInManaged |= SetNotCaptured(args);
-			}
-#endif
-
 			return handledInManaged;
 		}
 
@@ -1114,22 +1104,13 @@ namespace Microsoft.UI.Xaml
 				ctx = ctx.WithMode(ctx.Mode | BubblingMode.IgnoreElement);
 			}
 
-			UpdateRaisedEventFlags(args);
+			UpdateRaisedGestureEventsFlag(args);
 			handledInManaged |= SetOver(args, false, ctx);
 
 			if (IsGestureRecognizerCreated && GestureRecognizer.IsDragging)
 			{
 				XamlRoot.VisualTree.ContentRoot.InputManager.DragDrop.ProcessMoved(args);
 			}
-
-#if !UNO_HAS_MANAGED_POINTERS && !__ANDROID__ && !__WASM__ // Captures release are handled a root level (RootVisual for Android and WASM)
-			// We release the captures on exit when pointer if not pressed
-			// Note: for a "Tap" with a finger the sequence is Up / Exited / Lost, so the lost cannot be raised on Up
-			if (!IsPressed(args.Pointer))
-			{
-				handledInManaged |= SetNotCaptured(args);
-			}
-#endif
 
 			return handledInManaged;
 		}
@@ -1151,7 +1132,7 @@ namespace Microsoft.UI.Xaml
 		{
 			var isOverOrCaptured = ValidateAndUpdateCapture(args); // Check this *before* updating the pressed / over states!
 
-			UpdateRaisedEventFlags(args);
+			UpdateRaisedGestureEventsFlag(args);
 
 			// When a pointer is cancelled / swallowed by the system, we don't even receive "Released" nor "Exited"
 			// We update only local state as the Cancel is bubbling itself

--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -836,6 +836,7 @@ namespace Microsoft.UI.Xaml
 			return bubblingMode;
 		}
 
+#nullable enable
 		// WARNING: When implementing one of those methods to maintain a local state, you should also opt-in for RoutedEvent.IsAlwaysBubbled
 		partial void PrepareManagedPointerEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref BubblingMode bubblingMode);
 		partial void PrepareManagedKeyEventBubbling(RoutedEvent routedEvent, ref RoutedEventArgs args, ref BubblingMode bubblingMode);
@@ -846,7 +847,9 @@ namespace Microsoft.UI.Xaml
 
 		internal struct BubblingContext
 		{
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 			public static readonly BubblingContext Bubble;
+#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
 
 			public static readonly BubblingContext NoBubbling = new() { Mode = BubblingMode.NoBubbling };
 
@@ -858,7 +861,7 @@ namespace Microsoft.UI.Xaml
 			/// </summary>
 			public static readonly BubblingContext OnManagedBubbling = new() { Mode = BubblingMode.NoBubbling, IsInternal = true };
 
-			public static BubblingContext BubbleUpTo(UIElement root)
+			public static BubblingContext BubbleUpTo(UIElement? root)
 				=> new() { Root = root };
 
 			/// <summary>
@@ -870,7 +873,7 @@ namespace Microsoft.UI.Xaml
 			/// An optional root element on which the bubbling should stop.
 			/// </summary>
 			/// <remarks>It's expected that the event is raised on this Root element.</remarks>
-			public UIElement Root { get; set; }
+			public UIElement? Root { get; set; }
 
 			/// <summary>
 			/// Indicates that the associated event should not be publicly raised.
@@ -891,6 +894,7 @@ namespace Microsoft.UI.Xaml
 			public override string ToString()
 				=> $"{Mode}{(IsInternal ? " *internal*" : "")}{(Root is { } r ? $" up to {Root.GetDebugName()}" : "")}";
 		}
+#nullable restore
 
 		/// <summary>
 		/// Defines the mode used to bubble an event.


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/15384

## Bugfix
Ensure to raise up/exit/capture-lost events in the right order

## What is the current behavior?
* On iOS, _CaptureLost_ event is raised before the pointer _Up_ reached the top of the visual tree.
* On iOS and Android, if _Up_ is not handled, but _CaptureLost_ is, the _Exit_  is raised twice.

Those drive the `RatingControl` to clear it's internal pointer state in wrong order so it skips UI refresh after value update.

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
