### PR TITLE
fix(Skia): Fix ineffective FillRule setting for StreamGeometry

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_Geometry.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_Geometry.cs
@@ -2,8 +2,15 @@
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.Foundation;
+using FluentAssertions;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+
+#if __SKIA__
+using SkiaSharp;
+using Uno.Media;
+#endif
+
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
@@ -132,5 +139,21 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 		{
 			Console.WriteLine(Geometry.Empty.Bounds);
 		}
+
+#if __SKIA__
+		[TestMethod]
+		public void StreamGeometry_GetSKPath_CheckFillType()
+		{
+			var streamGeometry = new StreamGeometry();
+			using (var context = streamGeometry.Open())
+			{
+				context.BeginFigure(new Point(0, 0), isFilled: true);
+				context.LineTo(new Point(10, 10), isStroked: true, isSmoothJoin: true);
+			}
+
+			var skPath = streamGeometry.GetSKPath();
+			skPath.FillType.Should().Be(SKPathFillType.EvenOdd);
+		}
+#endif
 	}
 }

--- a/src/Uno.UI/Media/StreamGeometry.cs
+++ b/src/Uno.UI/Media/StreamGeometry.cs
@@ -25,6 +25,7 @@ using Android.Graphics;
 #elif __SKIA__
 using Path = Microsoft.UI.Composition.SkiaGeometrySource2D;
 using SkiaSharp;
+using Uno.UI.UI.Xaml.Media;
 #else
 using Path = System.Object;
 #endif
@@ -51,10 +52,15 @@ namespace Uno.Media
 #if __SKIA__
 		internal override Path GetGeometrySource2D()
 		{
+			bezierPath.Geometry.FillType = FillRule.ToSkiaFillType();
 			return bezierPath;
 		}
 
-		internal override SKPath GetSKPath() => bezierPath.Geometry;
+		internal override SKPath GetSKPath()
+		{
+			bezierPath.Geometry.FillType = FillRule.ToSkiaFillType();
+			return bezierPath.Geometry;
+		}
 #endif
 
 #if __IOS__ || __MACOS__


### PR DESCRIPTION
This PR fixes the issue of ineffective FillRule setting for StreamGeometry on the Skia platform. The root cause is that the FillRule of StreamGeometry was not assigned to SKPath on the Skia platform, which resulted in SKPath always maintaining the default value. This would cause the Path's Data corresponding to the XAML code like `<Path Data="xxxxx"/>` used on the Skia platform to use the Nonzero FillRule method, instead of maintaining the default EvenOdd FillRule method consistent with WinUI.

GitHub Issue (If applicable): closes #15889, closes #15539

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Path's Data corresponding to the XAML code like `<Path Data="xxxxx"/>` used on the Skia platform to use the Nonzero FillRule method, instead of maintaining the default EvenOdd FillRule method consistent with WinUI.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

On the Skia platform, the FillRule of StreamGeometry can also be assigned to SKPath, thereby maintaining the same Path drawing effect as the WinUI platform.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
