### PR TITLE
perf: Make `DrawingSession` readonly

### DIFF
--- a/src/Uno.UI.Composition/Composition/Uno/DrawingSession.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Uno/DrawingSession.skia.cs
@@ -10,7 +10,7 @@ namespace Uno.UI.Composition;
 
 // Accessing Surface.Canvas is slow due to SkiaSharp interop.
 // Avoid using .Surface.Canvas and use Surface.Canvas right away.
-internal record struct DrawingSession(SKSurface Surface, SKCanvas Canvas, in DrawingFilters Filters) : IDisposable
+internal readonly record struct DrawingSession(SKSurface Surface, SKCanvas Canvas, in DrawingFilters Filters) : IDisposable
 {
 	public static void PushOpacity(ref DrawingSession session, float opacity)
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In methods where `DrawingSession` is passed with `in` modifier and a method of `DrawingSession` is called (currently we only have `Dispose`), the compiler will still do a copy.

Simplified example:

```csharp
internal record struct R1 { public void M() { } }
internal readonly record struct R2 { public void M() { } }


class C
{
    void M1(in R1 r1)
    {
        r1.M();
    }
    
    void M2(in R2 r2)
    {
        r2.M();
    }
}
```

The above produces the following IL:

```il
    .method private hidebysig 
        instance void M1 (
            [in] valuetype R1& r1
        ) cil managed 
    {
        .param [1]
            .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = (
                01 00 00 00
            )
        // Method begins at RVA 0x2150
        // Code size 15 (0xf)
        .maxstack 1
        .locals init (
            [0] valuetype R1
        )

        IL_0000: ldarg.1
        IL_0001: ldobj R1
        IL_0006: stloc.0
        IL_0007: ldloca.s 0
        IL_0009: call instance void R1::M()
        IL_000e: ret
    } // end of method C::M1

    .method private hidebysig 
        instance void M2 (
            [in] valuetype R2& r2
        ) cil managed 
    {
        .param [1]
            .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = (
                01 00 00 00
            )
        // Method begins at RVA 0x216b
        // Code size 7 (0x7)
        .maxstack 8

        IL_0000: ldarg.1
        IL_0001: call instance void R2::M()
        IL_0006: ret
    } // end of method C::M2
```

Note how M2 is more efficient and doesn't do a defensive copy.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
