### PR TITLE
fix: ensure ContentDialog arrange respects visiblebounds

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialogPopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialogPopupPanel.cs
@@ -89,9 +89,12 @@ namespace Microsoft.UI.Xaml.Controls
 			var actualWidth = Math.Min(desiredSize.Width, maximumWidth);
 			var actualHeight = Math.Min(desiredSize.Height, maximumHeight);
 
+			var xOffset = Math.Max((maximumWidth - actualWidth) / 2, visibleBounds.X);
+			var yOffset = Math.Max((maximumHeight - actualHeight) / 2, visibleBounds.Y);
+
 			var finalRect = new Rect(
-				(maximumWidth - actualWidth) / 2,
-				(maximumHeight - actualHeight) / 2,
+				xOffset,
+				yOffset,
 				actualWidth,
 				actualHeight
 			);


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/15712

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

With a forced VisibleBounds "unsafe" area of `Thickness(27, 38, 14, 72)`, you can see the `LayoutRoot` panel of the `ContentDialog` (red) still bleeds into the unsafe area:


![Screenshot_1710946569](https://github.com/unoplatform/uno/assets/4793020/81cabe3b-17c5-44be-9d4b-74fc515c2968)


## What is the new behavior?

Offsets are respected:

![Screenshot_1710946456](https://github.com/unoplatform/uno/assets/4793020/3def9c4e-8b0c-407c-aa30-8a84d70b5046)