### PR TITLE
Adjustment to Implicit Packages

### DIFF
--- a/src/Uno.Sdk/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/ImplicitPackagesResolver.cs
@@ -228,10 +228,10 @@ public sealed class ImplicitPackagesResolver : ImplicitPackagesResolverBase
 			AddPackageForFeature(UnoFeature.Toolkit, "Uno.Extensions.Navigation.Toolkit.WinUI", UnoExtensionsVersion);
 		}
 
-		if ((useExtensions || HasFeature(UnoFeature.Mvux))
-			&& !HasFeature(UnoFeature.Mvvm))
+		if (useExtensions || HasFeature(UnoFeature.Mvux))
 		{
 			AddPackage("Uno.Extensions.Reactive.WinUI", UnoExtensionsVersion);
+			AddPackage("Uno.Extensions.Reactive.Messaging", UnoExtensionsVersion);
 			AddPackageForFeature(UnoFeature.CSharpMarkup, "Uno.Extensions.Reactive.WinUI.Markup", UnoExtensionsVersion);
 		}
 

--- a/src/Uno.Sdk/ImplicitPackagesResolverBase.cs
+++ b/src/Uno.Sdk/ImplicitPackagesResolverBase.cs
@@ -54,6 +54,11 @@ public abstract class ImplicitPackagesResolverBase : Task
 		try
 		{
 			_unoFeatures = GetFeatures();
+			if (Log.HasLoggedErrors)
+			{
+				return false;
+			}
+
 			var cachedReferences = CachedReferences.Load(IntermediateOutput);
 			if (cachedReferences.NeedsUpdate(_unoFeatures, UnoVersion))
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

You can specify Mvvm or Mvux but will only get one of the two

## What is the new behavior?

You can now specify both Mvvm and Mvux as UnoFeatures