### PR TITLE
Load Wasm Project Capabilities from Sdk

### DIFF
--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -53,6 +53,14 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<EnableDefaultUnoItems Condition=" '$(EnableDefaultUnoItems)' == '' ">$(EnableDefaultItems)</EnableDefaultUnoItems>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<AvailableItemName Include="UnoAsset"/>
+		<AvailableItemName Include="UnoImage"/>
+		<AvailableItemName Include="UnoIcon"/>
+		<AvailableItemName Include="UnoSplashScreen"/>
+		<AvailableItemName Include="UnoDspImportColors"/>
+	</ItemGroup>
+
 	<!-- 
 		Remove the implicitly added FrameworkReference from the Web SDK. 
 

--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.Wasm.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.Wasm.targets
@@ -1,0 +1,12 @@
+<Project>
+	<ItemGroup>
+		<ProjectCapability Include="WebAssembly" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$(_IsExecutable) == 'true'">
+		<ProjectCapability Include="SupportsHotReload" />
+
+		<!-- Allow running/debugging from VS (see https://github.com/dotnet/runtime/pull/75986/files#diff-cace638214185dee3296b4f9f79db1f0187d338f393a75d9fb1fda13bf93d533R120) -->
+		<ProjectCapability Include="DotNetCoreWeb"/>
+	</ItemGroup>
+</Project>

--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
@@ -31,5 +31,7 @@
 
 	<Import Project="Uno.ProjectCapabilities.WinAppSdk.targets" Condition="$(IsWinAppSdk)" />
 
+	<Import Project="Uno.ProjectCapabilities.Wasm.targets" Condition="$(IsBrowserWasm)" />
+
 	<Import Project="Uno.ProjectCapabilities.SingleProject.targets" Condition=" '$(SingleProject)' == 'true' " />
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- related unoplatform/Uno.Wasm.Boostrap#831

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Project capabilities come from the Bootstrapper

## What is the new behavior?

We set the Project capabilities as early as possible for the Wasm target