### PR TITLE
Adding better support for Libraries

### DIFF
--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -16,6 +16,8 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 
 		<_DefaultMicrosoftNETSdk Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm'" >Microsoft.NET.Sdk.Web</_DefaultMicrosoftNETSdk>
 		<_DefaultMicrosoftNETSdk Condition=" $(_DefaultMicrosoftNETSdk) == '' ">Microsoft.NET.Sdk</_DefaultMicrosoftNETSdk>
+
+		<_DefaultWasmOutputType Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm'">$(OutputType)</_DefaultWasmOutputType>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.Sdk/targets/Uno.Common.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Desktop.targets
@@ -25,4 +25,16 @@
 
 	<Import Project="$(MSBuildThisFileDirectory)..\targets\Uno.SingleProject.Desktop.targets"
 			Condition=" $(SingleProject) == 'true' " />
+
+	<Target Name="RemoveTransitiveWindowsDesktopDependencies"
+		AfterTargets="ResolvePackageAssets"
+		BeforeTargets="_CheckForTransitiveWindowsDesktopDependencies"
+		Condition="$(OutputType) == 'Library'">
+		<ItemGroup>
+		<TransitiveFrameworkReference Remove="@(TransitiveFrameworkReference)"
+			Condition="'%(Identity)' == 'Microsoft.WindowsDesktop.App' Or
+					'%(Identity)' == 'Microsoft.WindowsDesktop.App.WPF' Or
+					'%(Identity)' == 'Microsoft.WindowsDesktop.App.WindowsForms'" />
+		</ItemGroup>
+	</Target>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.Common.Wasm.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Wasm.targets
@@ -12,6 +12,8 @@
 		<TargetPlatformSupported>true</TargetPlatformSupported>
 		<TargetPlatformVersion>$([System.Text.RegularExpressions.Regex]::Match($(TargetFramework), '\d+.\d+'))</TargetPlatformVersion>
 		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">8.0</SupportedOSPlatformVersion>
+
+		<OutputType Condition=" $(OutputType) == 'Exe' AND $(OutputType) != $(_DefaultWasmOutputType)">$([MSBuild]::ValueOrDefault('$(_DefaultWasmOutputType)', 'Library'))</OutputType>
 	</PropertyGroup>
 
 	<!-- Enable the netx.0-browserwasm target -->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- unoplatform/uno-private#354

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

browserwasm sets output type of Exe for Library
desktop adds Windows Desktop Framework Reference for Library build

## What is the new behavior?

Resets the OutputType on browserwasm to counter the Web ProjectSystem Sdk
Removes the Windows Desktop Framework Reference for for Library builds

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
