### PR TITLE
fix: Make maui caps conditional to mobile targets

### DIFF
--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.SingleProject.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.SingleProject.targets
@@ -1,7 +1,11 @@
 <Project>
 	<!-- Taken from: https://github.com/dotnet/maui/blob/c02a6706534888ccea577d771c9edfc820bfc001/src/Workload/Microsoft.Maui.Sdk/Sdk/Microsoft.Maui.Sdk.After.targets#L16C3-L26C15 -->
 	<!-- SingleProject-specific features -->
-	<ItemGroup>
+	<ItemGroup Condition="
+		 $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'
+		 OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'
+		 OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'
+		 ">
 		<ProjectCapability Include="Msix" Exclude="@(ProjectCapability)" />
 		<ProjectCapability Include="MauiSingleProject" Exclude="@(ProjectCapability)" />
 		<ProjectCapability Include="LaunchProfiles" Exclude="@(ProjectCapability)" />


### PR DESCRIPTION
This restores hot reload for desktop target on windows