### PR TITLE
fix(catalyst): load required mono component for HR

### DIFF
--- a/src/Uno.Sdk/targets/Uno.SingleProject.MacCatalyst.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.MacCatalyst.targets
@@ -11,6 +11,11 @@
 		<!-- https://github.com/xamarin/xamarin-macios/issues/14812 -->
 		<MtouchExtraArgs Condition="!$(MtouchExtraArgs.Contains('--marshal-objectivec-exceptions'))">$(MtouchExtraArgs) --marshal-objectivec-exceptions:disable</MtouchExtraArgs>
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(Optimize)'!='true'">
+		<!-- Required for C# Hot Reload -->
+		<UseInterpreter>True</UseInterpreter>
+		<MtouchInterpreter>True</MtouchInterpreter>
+	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)xamarin-ios-maccatalyst-workarounds.targets" />
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Current Catalyst builds do not link against the real (only the stub) library for the mono component `hot_reload`.

Logs shows that the process has no capabilities 
```
default	17:10:11.369868-0400	unoapp.Mobile	trce: Uno.UI.RemoteControl.HotReload.ClientHotReloadProcessor[0]
      Metadata Updates runtime capabilities:
```

## What is the new behavior?

Catalyst builds now links against the real library for the mono component `hot_reload`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

`<UseInterpreter>True</UseInterpreter>` is needed, like it's already present for iOS and Android.

`<MtouchInterpreter>True</MtouchInterpreter>` is a bit odd, when setting `UseInterpreter` to true the logic sets `MtouchInterpreter` to `all` but...

```xml
<_MonoComponent Include="hot_reload" Condition="'$(MtouchInterpreter)' == 'true'" />
```

that's not what `_MonoComponent` is looking for (the iOS logic is likely different).

Sadly there remain other issue(s) preventing C# hot-reload to work for Catalyst.

Internal Issue (If applicable):

https://github.com/unoplatform/uno.vscode/issues/638#issuecomment-2000799989
https://github.com/unoplatform/uno-private/issues/354
