### PR TITLE
fix(pointers): Fix pointer exit not raised on wasm

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Exit_Tests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Input/Nested_Exit_Tests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.Devices.Input;
+using FluentAssertions;
+using NUnit.Framework;
+using SamplesApp.UITests.TestFramework;
+using Uno.Testing;
+using Uno.UITest.Helpers;
+using Uno.UITest.Helpers.Queries;
+
+namespace SamplesApp.UITests.Windows_UI_Xaml_Input
+{
+	[TestFixture]
+	internal class Nested_Exit_Tests : SampleControlUITestBase
+	{
+		private const string _sample = "UITests.Windows_UI_Input.PointersTests.Nested_Exit";
+
+		[Test]
+		[AutoRetry]
+		[ActivePlatforms(Platform.Browser)] // Needs pointer over events, i.e mouse only
+		[InjectedPointer(PointerDeviceType.Mouse)]
+		public async Task When_ExitNestedWithIntermediateNonHitTestableElement()
+		{
+			await RunAsync(_sample);
+
+			var blue = App.WaitForElement("Case1_Blue").Single().Rect;
+			App.TapCoordinates(blue.CenterX, blue.CenterY);
+			App.DragCoordinates(blue.CenterX, blue.CenterY, blue.Right + 10, blue.CenterY);
+
+			var result = App.Marked("Case1_out").GetDependencyPropertyValue<string>("Text");
+
+			result.Should().Be("Success");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -842,6 +842,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Nested_Exit.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\PointersOriginalSource.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5961,6 +5965,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Nested_Sequence.xaml.cs">
       <DependentUpon>Nested_Sequence.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\Nested_Exit.xaml.cs">
+      <DependentUpon>Nested_Exit.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Input\PointersTests\PointersOriginalSource.xaml.cs">
       <DependentUpon>PointersOriginalSource.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Exit.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Exit.xaml
@@ -1,0 +1,34 @@
+﻿<Page
+	x:Class="UITests.Windows_UI_Input.PointersTests.Nested_Exit"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Input.PointersTests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition />
+			<ColumnDefinition />
+		</Grid.ColumnDefinitions>
+
+		<Grid.RowDefinitions>
+			<RowDefinition />
+			<RowDefinition />
+		</Grid.RowDefinitions>
+
+		<TextBlock Text="With intermediate non hit-testable object" />
+
+		<Border Background="DeepPink" Width="128" Height="128" PointerExited="Case1_OnPointerExited" x:Name="Case1_Pink">
+			<Border Background="{x:Null}" Width="160" Height="160" Margin="-32">
+				<Border Background="DeepSkyBlue" Width="128" Height="128" Tapped="Case1_InitTest" PointerExited="Case1_OnPointerExited" x:Name="Case1_Blue">
+					<TextBlock Text="Click here to reset/init, then move out of the blue square." TextWrapping="Wrap" />
+				</Border>
+			</Border>
+		</Border>
+
+		<TextBlock Text="--none--" VerticalAlignment="Bottom" x:Name="Case1_out" />
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Exit.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Exit.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Input.PointersTests;
+
+[Sample("Pointers", "Nested_Exit")]
+public sealed partial class Nested_Exit : Page
+{
+	private bool _case1_exitedBlue;
+
+	public Nested_Exit()
+	{
+		this.InitializeComponent();
+	}
+
+	private void Case1_InitTest(object sender, RoutedEventArgs e)
+	{
+		Case1_out.Text = "--init--";
+		_case1_exitedBlue = false;
+	}
+
+	private void Case1_OnPointerExited(object sender, PointerRoutedEventArgs e)
+	{
+		switch((sender as FrameworkElement)?.Name)
+		{
+			case "Case1_Blue":
+				_case1_exitedBlue = true;
+				break;
+
+			case "Case1_Pink" when _case1_exitedBlue:
+				Case1_out.Text = "Success";
+				break;
+
+			case "Case1_Pink":
+				Case1_out.Text = "Failed"; // Note: common failure case is to remain in "--init--" !
+				break;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Exit.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/PointersTests/Nested_Exit.xaml.cs
@@ -25,7 +25,7 @@ public sealed partial class Nested_Exit : Page
 
 	private void Case1_OnPointerExited(object sender, PointerRoutedEventArgs e)
 	{
-		switch((sender as FrameworkElement)?.Name)
+		switch ((sender as FrameworkElement)?.Name)
 		{
 			case "Case1_Blue":
 				_case1_exitedBlue = true;

--- a/src/Uno.UI.RuntimeTests/UITestsImport.props
+++ b/src/Uno.UI.RuntimeTests/UITestsImport.props
@@ -7,8 +7,9 @@
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\Capture_Tests.cs" />
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\HitTest_Clipping_Tests.cs" />
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\Nested_Sequence_Tests.cs" />
+		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\Nested_Exit_Tests.cs" />
 		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\NestedHandling_Tests.cs" />
-	  <UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\PointersOriginalSource_Tests.cs" />
+		<UITests Include="$(MSBuildThisFileDirectory)..\SamplesApp\SamplesApp.UITests\**\Windows_UI_Xaml_Input\PointersOriginalSource_Tests.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI/ts/Windows/UI/Xaml/UIElement.Pointers.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/UIElement.Pointers.ts
@@ -167,20 +167,22 @@
 			}
 
 			// Finally, here we filter out the events that are being raised when the pointer is leaving a nested element (which is bubbling in browser)
-			const elementBounds = (evt.target as HTMLElement | SVGElement).getBoundingClientRect();
+			const targetBounds = (evt.target as HTMLElement | SVGElement).getBoundingClientRect();
 			elt = evt.target as HTMLElement | SVGElement;
 			while (elt && elt != element) {
-				const bounds = elt.getBoundingClientRect();
-				if (
-					(evt.clientY > bounds.top && (Math.abs(elementBounds.top - bounds.top) > 1))
-					&& (evt.clientY < bounds.bottom && (Math.abs(elementBounds.bottom - bounds.bottom) > 1))
-					&& (evt.clientX > bounds.left && (Math.abs(elementBounds.left - bounds.left) > 1))
-					&& (evt.clientX < bounds.right && (Math.abs(elementBounds.right - bounds.right) > 1))
-				) {
-					// There is child that is still under the pointer, so we should not propagate the event.
-					// Note: If the child is sharing the bounds with the target, we consider that the pointer is also leaving the intermediate child.
-					evt.stopPropagation();
-					return;
+				if (elt.style.pointerEvents != "none") {
+					const bounds = elt.getBoundingClientRect();
+					if (
+						(evt.clientY > bounds.top && (Math.abs(targetBounds.top - bounds.top) > 1))
+						&& (evt.clientY < bounds.bottom && (Math.abs(targetBounds.bottom - bounds.bottom) > 1))
+						&& (evt.clientX > bounds.left && (Math.abs(targetBounds.left - bounds.left) > 1))
+						&& (evt.clientX < bounds.right && (Math.abs(targetBounds.right - bounds.right) > 1))
+					) {
+						// There is child that is still under the pointer (and which will raise pointer events), so we should not propagate the event.
+						// Note: If the child is sharing the bounds with the target, we consider that the pointer is also leaving the intermediate child.
+						evt.stopPropagation();
+						return;
+					}
 				}
 				elt = elt.parentElement;
 			}


### PR DESCRIPTION


closes https://github.com/unoplatform/uno/issues/15968

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## Bugfix
Fix pointer exit not raised on wasm if intermediate element is larger than parent and not hit-testable

## What is the current behavior?
We stop exit event bubbling on wasm if we determine that pointer is still over current element or a child.

## What is the new behavior?
We make sure to validate that child can raise pointer events.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
