### PR TITLE
fix(combobox): Don't reset SelectedIndex when changing the itemsource

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ComboBoxTests/Given_ComboBox.cs
@@ -10,6 +10,7 @@ using Microsoft.UI.Xaml;
 using Uno.UI.Tests.App.Xaml;
 using Uno.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
+using Uno.UI.Tests.Helpers;
 
 namespace Uno.UI.Tests.ComboBoxTests
 {
@@ -158,6 +159,125 @@ namespace Uno.UI.Tests.ComboBoxTests
 
 			Assert.AreEqual(3, test[0].SelectedNumber);
 			Assert.AreEqual(3, comboBox.SelectedItem);
+		}
+
+		[TestMethod]
+		public void When_SelectedItem_PreSelected()
+		{
+			var comboBox = new ComboBox();
+			string[] items = new string[] { "string1", "string2", "string3", "string4" };
+
+			int selectionChangedCount = 0;
+			comboBox.SelectionChanged += (s, e) =>
+			{
+				selectionChangedCount++;
+			};
+
+			comboBox.SelectedIndex = 2;
+			Assert.AreEqual<int>(-1, comboBox.SelectedIndex);
+
+			comboBox.ItemsSource = items;
+
+			Assert.AreEqual<int>(2, comboBox.SelectedIndex);
+			Assert.AreEqual<int>(1, selectionChangedCount);
+		}
+
+		[TestMethod]
+		public void When_SelectedItem_PreSelected_OutOfBounds()
+		{
+			var comboBox = new ComboBox();
+			string[] items = new string[] { "string1", "string2", "string3", "string4" };
+
+			int selectionChangedCount = 0;
+			comboBox.SelectionChanged += (s, e) =>
+			{
+				selectionChangedCount++;
+			};
+
+			comboBox.SelectedIndex = 10;
+			Assert.AreEqual<int>(-1, comboBox.SelectedIndex);
+
+			comboBox.ItemsSource = items;
+
+			Assert.AreEqual<int>(-1, comboBox.SelectedIndex);
+			Assert.AreEqual<int>(0, selectionChangedCount);
+		}
+
+		[TestMethod]
+		public void When_Index_Set_With_No_Items_Repeated()
+		{
+			var comboBox = new ComboBox();
+			comboBox.SelectedIndex = 1;
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(1, comboBox.SelectedIndex);
+			comboBox.Items.Clear();
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.SelectedIndex = 2;
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(2, comboBox.SelectedIndex);
+		}
+
+		[TestMethod]
+		public void When_Index_Set_Out_Of_Range_When_Items_Exist()
+		{
+			var comboBox = new ComboBox();
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.ThrowsException<ArgumentException>(() => comboBox.SelectedIndex = 2);
+		}
+
+		[TestMethod]
+		public void When_Index_Set_Negative_Out_Of_Range_When_Items_Exist()
+		{
+			var comboBox = new ComboBox();
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.ThrowsException<ArgumentException>(() => comboBox.SelectedIndex = -2);
+		}
+
+		[TestMethod]
+		public void When_Index_Set_Negative_Out_Of_Range_When_Items_Do_Not_Exist()
+		{
+			var comboBox = new ComboBox();
+			comboBox.SelectedIndex = -2;
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+			comboBox.Items.Add(new ComboBoxItem());
+			Assert.AreEqual(-1, comboBox.SelectedIndex);
+		}
+
+		[TestMethod]
+		public void When_SelectedItem_And_CollectionView_Then_Array()
+		{
+			var comboBox = new ComboBox();
+			string[] items = new string[] { "string1", "string2", "string3", "string4" };
+
+			int selectionChangedCount = 0;
+			comboBox.SelectionChanged += (s, e) =>
+			{
+				selectionChangedCount++;
+			};
+
+			comboBox.SelectedIndex = 2;
+			Assert.AreEqual<int>(-1, comboBox.SelectedIndex);
+
+			var cvs = new CollectionViewSource();
+			cvs.Source = new string[] { "string1_cv", "string2_cv", "string3_cv", "string4_cv" };
+			cvs.View.MoveCurrentToPosition(2);
+
+			comboBox.ItemsSource = cvs.View;
+
+			Assert.AreEqual<int>(2, comboBox.SelectedIndex);
+			Assert.AreEqual<int>(1, selectionChangedCount);
+
+			comboBox.ItemsSource = items;
+
+			Assert.AreEqual<int>(-1, comboBox.SelectedIndex);
+			Assert.AreEqual<int>(2, selectionChangedCount);
 		}
 
 		public class TwoWayBindingItem : System.ComponentModel.INotifyPropertyChanged

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -470,6 +470,11 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			else
 			{
 				_collectionViewSubscription.Disposable = null;
+
+				if (IsSynchronizedWithCurrentItem is { } value && !value)
+				{
+					ResetIndexIfNeeded();
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -470,7 +470,6 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			else
 			{
 				_collectionViewSubscription.Disposable = null;
-				ResetIndexIfNeeded();
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/15881

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

This change allows for keeping a SelectedIndex that was set out of bounds before the itemssource was set

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
