### PR TITLE
bump AndroidX versions used for MAUI Embedding

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -187,7 +187,7 @@
 	},
 	{
 		"group": "AndroidXNavigation",
-		"version": "2.6.0.1",
+		"version": "2.7.7.1",
 		"packages": [
 			"Xamarin.AndroidX.Navigation.UI",
 			"Xamarin.AndroidX.Navigation.Fragment",
@@ -197,7 +197,7 @@
 	},
 	{
 		"group": "AndroidXCollection",
-		"version": "1.3.0.1",
+		"version": "1.4.0.2",
 		"packages": [
 			"Xamarin.AndroidX.Collection",
 			"Xamarin.AndroidX.Collection.Ktx"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- unoplatform/uno.extensions#2223

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

```
error NU1605: Warning As Error: Detected package downgrade: Xamarin.AndroidX.Collection from 1.4.0.1 to 1.3.0.1. Reference the package directly from the project to select a different version. 
error NU1605:  TestNewProjectMauiEmbeddingVsixVersion108 -> Xamarin.AndroidX.Activity 1.8.2.1 -> Xamarin.AndroidX.Collection (>= 1.4.0.1) 
error NU1605:  TestNewProjectMauiEmbeddingVsixVersion108 -> Xamarin.AndroidX.Collection (>= 1.3.0.1)
```

## What is the new behavior?

Package Downgrade will not occur.
