### PR TITLE
Include uno.ui.websassembly for wasm class lib

### DIFF
--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -41,6 +41,11 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 				AddPackage("SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);
 			}
 
+			if (TargetRuntime == UnoTarget.Wasm || IsLegacyWasmHead())
+			{
+				AddPackage("Uno.WinUI.WebAssembly", null);
+			}
+
 			AddCorePackagesForExecutable();
 		}
 		else
@@ -103,7 +108,6 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 		}
 		else if (TargetRuntime == UnoTarget.Wasm || IsLegacyWasmHead())
 		{
-			AddPackage("Uno.WinUI.WebAssembly", null);
 			AddPackageForFeature(UnoFeature.MediaElement, "Uno.WinUI.MediaPlayer.WebAssembly", null);
 			AddPackage("Microsoft.Windows.Compatibility", WindowsCompatibilityVersion);
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes unoplatform/uno-private#415

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Uno.WinUI.WebAssembly is excluded as a direct reference for the BrowserWasm class library

## What is the new behavior?

Uno.WinUI.WebAssembly is now included regardless of whether we are building an Executable or Class Library