### PR TITLE
docs: add vscode error codes

### DIFF
--- a/build/cSpell.json
+++ b/build/cSpell.json
@@ -161,6 +161,7 @@
 	"UADO",
 	"Udemy",
 	"UNOB",
+	"UVSC",
 	"uitest",
 	"userprofile",
 	"winui",

--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -108,3 +108,18 @@ A member is not implemented, see [this page](xref:Uno.Development.NotImplemented
 On iOS and Catalyst, calling `Dispose()` or `Dispose(bool)` on a type inheriting directly from `UIKit.UIView` can lead to unstable results. It is not needed to call `Dispose` as the runtime will do so automatically during garbage collection.
 
 Invocations to `Dispose` can cause the application to crash in `__NSObject_Disposer drain`, cause `ObjectDisposedException` exception to be thrown. More information can be found in [xamarin/xamarin-macios#19493](https://github.com/xamarin/xamarin-macios/issues/19493).
+
+## VS Code Errors
+
+### UVSC0001
+
+Building for the specified target framework is not supported on the current platform or architecture. For examples:
+
+- a Mac computer is required to build iOS, Mac Catalyst and macOS applications
+- a Windows computer is required to build WinUI applications
+
+### UVSC0002
+
+Building WinUI application requires the use of `msbuild` and the extension must be able to find it. This is done by using the `vswhere` utility.
+
+Installing the latest stable Visual Studio release should provide both tools.

--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -120,6 +120,6 @@ Building for the specified target framework is not supported on the current plat
 
 ### UVSC0002
 
-Building WinUI application requires the use of `msbuild` and the extension must be able to find it. This is done by using the `vswhere` utility.
+Building WinUI applications requires the use of `msbuild` and the extension must be able to find it. This is done by using the `vswhere` utility.
 
 Installing the latest stable Visual Studio release should provide both tools.


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

The Uno extension for VS Code error codes are not included in the existing list of build errors.

## What is the new behavior?

Added both errors to the documentation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
