### PR TITLE
fix: Adjust SamplesApp WinUI launch to avoid using `XamlRoot` too early

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -809,7 +809,7 @@ namespace SampleControl.Presentation
 			}
 		}
 
-		private async Task UpdateFavorites(CancellationToken ct, bool getAllSamples = false, List<SampleChooserContent> favoriteSamples = null)
+		private void UpdateFavorites(bool getAllSamples = false, List<SampleChooserContent> favoriteSamples = null)
 		{
 			// If true, load all samples and not just those of a selected category
 			var samples = getAllSamples
@@ -822,7 +822,7 @@ namespace SampleControl.Presentation
 
 			foreach (var sample in samples)
 			{
-				await UpdateFavoriteForSample(ct, sample, favorites.Contains(sample));
+				UpdateFavoriteForSample(sample, favorites.Contains(sample));
 			}
 
 			SampleContents = samples;
@@ -838,7 +838,7 @@ namespace SampleControl.Presentation
 			}
 			else
 			{
-				await UpdateFavoriteForSample(ct, sample, true);
+				UpdateFavoriteForSample(sample, true);
 				favorites.Add(sample);
 			}
 
@@ -846,7 +846,7 @@ namespace SampleControl.Presentation
 
 			FavoriteSamples = favorites;
 
-			await UpdateFavorites(ct);
+			UpdateFavorites();
 		}
 
 		private async Task LoadPreviousTest(CancellationToken ct)
@@ -873,14 +873,10 @@ namespace SampleControl.Presentation
 			}
 		}
 
-		private async Task UpdateFavoriteForSample(CancellationToken ct, SampleChooserContent sample, bool isFavorite)
+		private void UpdateFavoriteForSample(SampleChooserContent sample, bool isFavorite)
 		{
 			// Have to update favorite on UI thread for the INotifyPropertyChanged in SampleChooserControl
-			_ = UnitTestDispatcherCompat
-				.From(Owner.XamlRoot.Content)
-				.RunAsync(() => sample.IsFavorite = isFavorite);
-
-			await Task.Yield();
+			sample.IsFavorite = isFavorite;
 		}
 
 		/// <summary>
@@ -896,7 +892,7 @@ namespace SampleControl.Presentation
 				var favoriteSamples = await GetFile(SampleChooserFavoriteConstant, () => new List<SampleChooserContent>());
 
 				// Update the Sample List to set the IsFavorite to True
-				await UpdateFavorites(ct, getAllSamples, favoriteSamples);
+				UpdateFavorites(getAllSamples, favoriteSamples);
 
 				return favoriteSamples;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
