### PR TITLE
perf: Misc perf improvement to ResourceDictionary

### DIFF
--- a/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceDictionary.cs
@@ -201,11 +201,7 @@ namespace Microsoft.UI.Xaml
 			=> TryGetValue(new ResourceKey(resourceKey), out value, shouldCheckSystem);
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal bool TryGetValue(in ResourceKey resourceKey, out object value, bool shouldCheckSystem) =>
-			TryGetValue(resourceKey, ResourceKey.Empty, out value, shouldCheckSystem);
-
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private bool TryGetValue(in ResourceKey resourceKey, ResourceKey activeTheme, out object value, bool shouldCheckSystem)
+		internal bool TryGetValue(in ResourceKey resourceKey, out object value, bool shouldCheckSystem)
 		{
 			if (_values.TryGetValue(resourceKey, out value))
 			{
@@ -226,12 +222,7 @@ namespace Microsoft.UI.Xaml
 				return true;
 			}
 
-			if (activeTheme.IsEmpty)
-			{
-				activeTheme = Themes.Active;
-			}
-
-			if (GetFromTheme(resourceKey, activeTheme, out value))
+			if (GetFromTheme(resourceKey, GetActiveThemeDictionary(Themes.Active), out value))
 			{
 				return true;
 			}
@@ -434,25 +425,23 @@ namespace Microsoft.UI.Xaml
 			return null;
 		}
 
-		private bool GetFromTheme(in ResourceKey resourceKey, in ResourceKey activeTheme, out object value)
+		private bool GetFromTheme(in ResourceKey resourceKey, ResourceDictionary activeThemeDictionary, out object value)
 		{
-			var dict = GetActiveThemeDictionary(activeTheme);
-
-			if (dict != null && dict.TryGetValue(resourceKey, out value, shouldCheckSystem: false))
+			if (activeThemeDictionary != null && activeThemeDictionary.TryGetValue(resourceKey, out value, shouldCheckSystem: false))
 			{
 				return true;
 			}
 
-			return GetFromThemeMerged(resourceKey, activeTheme, out value);
+			return GetFromThemeMerged(resourceKey, activeThemeDictionary, out value);
 		}
 
-		private bool GetFromThemeMerged(in ResourceKey resourceKey, in ResourceKey activeTheme, out object value)
+		private bool GetFromThemeMerged(in ResourceKey resourceKey, ResourceDictionary activeThemeDictionary, out object value)
 		{
 			var count = _mergedDictionaries.Count;
 
 			for (int i = count - 1; i >= 0; i--)
 			{
-				if (_mergedDictionaries[i].GetFromTheme(resourceKey, activeTheme, out value))
+				if (_mergedDictionaries[i].GetFromTheme(resourceKey, activeThemeDictionary, out value))
 				{
 					return true;
 				}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Performance

## What is the current behavior?

Current numbers gathered with @ebariche (numbers are from Wasm interpreted build):

GetFromMerged: 314ms
GetFromThemeMerged: 457ms
GetActiveThemeDictionary: 517ms
GetFromTheme: 1.07s


## What is the new behavior?

New numbers:

GetFromMerged: 265ms
GetFromThemeMerged: 299ms
GetActiveThemeDictionary: 144ms
GetFromTheme: 299ms

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
