### PR TITLE
ci: Pin idb to avoid breaking 1.1.8

### DIFF
--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -126,8 +126,8 @@ then
 	brew install pipx
 	# # https://github.com/microsoft/appcenter/issues/2605#issuecomment-1854414963
 	brew tap facebook/fb
-	brew install idb-companion
-	pipx install fb-idb
+	brew install idb-companion@1.1.7
+	pipx install fb-idb@1.1.7
 else
 	echo "Using idb from:" `command -v idb`
 fi


### PR DESCRIPTION
Works around this error:

```
cp: /private/tmp/homebrew-unpack20240403-3987-t4w941/idb-companion.universal/./Frameworks/XCTestBootstrap.framework/Versions/A/Frameworks: unable to copy extended attributes to /private/tmp/idb-companion-20240403-3987-98678p/idb-companion.universal/Frameworks/XCTestBootstrap.framework/Versions/A/Frameworks: No such file or directory
cp: /private/tmp/homebrew-unpack20240403-3987-t4w941/idb-companion.universal/./Frameworks/XCTestBootstrap.framework/Versions/A/Frameworks: No such file or directory
Error: Failure while executing; `/usr/bin/env cp -pR /private/tmp/homebrew-unpack20240403-3987-t4w941/idb-companion.universal/. /private/tmp/idb-companion-20240403-3987-98678p/idb-companion.universal` exited with 1. Here's the output:
cp: /private/tmp/homebrew-unpack20240403-3987-t4w941/idb-companion.universal/./Frameworks/XCTestBootstrap.framework/Versions/A/Frameworks: unable to copy extended attributes to /private/tmp/idb-companion-20240403-3987-98678p/idb-companion.universal/Frameworks/XCTestBootstrap.framework/Versions/A/Frameworks: No such file or directory
cp: /private/tmp/homebrew-unpack20240403-3987-t4w941/idb-companion.universal/./Frameworks/XCTestBootstrap.framework/Versions/A/Frameworks: No such file or directory
```