### PR TITLE
Don't specify Google Android Material with MAUI Embedding

### DIFF
--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -66,8 +66,12 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 
 		if (TargetRuntime == UnoTarget.Android)
 		{
+			if (!HasFeature(UnoFeature.MauiEmbedding))
+			{
+				AddPackage("Xamarin.Google.Android.Material", AndroidMaterialVersion);
+			}
+
 			AddPackage("Uno.UniversalImageLoader", UnoUniversalImageLoaderVersion);
-			AddPackage("Xamarin.Google.Android.Material", AndroidMaterialVersion);
 			AddPackage("Xamarin.AndroidX.Legacy.Support.V4", AndroidXLegacySupportV4Version);
 			AddPackage("Xamarin.AndroidX.AppCompat", AndroidXAppCompatVersion);
 			AddPackage("Xamarin.AndroidX.RecyclerView", AndroidXRecyclerViewVersion);
@@ -197,7 +201,6 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 
 			if (TargetRuntime == UnoTarget.Android)
 			{
-				AddPackage("Xamarin.Google.Android.Material", AndroidMaterialVersion);
 				AddPackage("Xamarin.AndroidX.Navigation.UI", AndroidXNavigationVersion);
 				AddPackage("Xamarin.AndroidX.Navigation.Fragment", AndroidXNavigationVersion);
 				AddPackage("Xamarin.AndroidX.Navigation.Runtime", AndroidXNavigationVersion);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- unblocks unoplatform/uno.extensions#2223
- unblocks unoplatform/uno.templates#608

## PR Type

- Bugfix

## What is the current behavior?

Xamarin.Google.Android.Material is provided as a top level package all the time. This causes a conflict with the AndroidX packages for MAUI Embedding.

## What is the new behavior?

We let Xamarin.Google.Android.Material come through transitively with MAUI Embedding.
