### PR TITLE
Enable warnings as errors

### DIFF
--- a/src/SolutionTemplate/5.1/uno51blank/Directory.Build.props
+++ b/src/SolutionTemplate/5.1/uno51blank/Directory.Build.props
@@ -6,6 +6,7 @@
 
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <UnoSdkDebugging>true</UnoSdkDebugging>
+    <WarningsAsErrors>true</WarningsAsErrors>
 
     <!--
       Adding NoWarn to remove build warnings

--- a/src/SolutionTemplate/5.1/uno51blank/Directory.Build.props
+++ b/src/SolutionTemplate/5.1/uno51blank/Directory.Build.props
@@ -6,7 +6,7 @@
 
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <UnoSdkDebugging>true</UnoSdkDebugging>
-    <WarningsAsErrors>true</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!--
       Adding NoWarn to remove build warnings

--- a/src/SolutionTemplate/5.1/uno51blank/Directory.Packages.props
+++ b/src/SolutionTemplate/5.1/uno51blank/Directory.Packages.props
@@ -19,6 +19,10 @@
     <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="2.88.7" />
     <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.7" />
     <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
+    <PackageVersion Include="SkiaSharp.Views" Version="2.88.7" />
+    <PackageVersion Include="SkiaSharp.Views.Gtk2" Version="2.88.7" />
+    <PackageVersion Include="OpenTK" Version="3.1.0" />
+    <PackageVersion Include="OpenTK.GLControl" Version="3.1.0" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Extensions.Logging.OSLog" Version="1.7.0" />
     <PackageVersion Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />

--- a/src/SolutionTemplate/5.1/uno51blank/uno51blank/uno51blank.csproj
+++ b/src/SolutionTemplate/5.1/uno51blank/uno51blank/uno51blank.csproj
@@ -48,10 +48,18 @@
         <PackageReference Include="SkiaSharp.NativeAssets.MacCatalyst" />
       </ItemGroup>
     </When>
+    <When Condition="$(TargetFramework.Contains('windows10'))">
+      <ItemGroup>
+        <PackageReference Include="SkiaSharp.Views" NoWarn="NU1701" />
+        <PackageReference Include="SkiaSharp.Views.Gtk2" NoWarn="NU1701" />
+        <PackageReference Include="OpenTK" NoWarn="NU1701" />
+        <PackageReference Include="OpenTK.GLControl" NoWarn="NU1701" />
+      </ItemGroup>
+    </When>
   </Choose>
 
-  <Target Name="_UnoValidateAssemblyResources" 
-          BeforeTargets="AfterBuild" 
+  <Target Name="_UnoValidateAssemblyResources"
+          BeforeTargets="AfterBuild"
           Condition="'$(TargetFramework)'=='$(DotNetVersion)-windows10.0.19041'">
 
     <!-- Related to https://github.com/unoplatform/uno/issues/15492 to ensure that library assets are properly generated -->

--- a/src/SolutionTemplate/5.1/uno51recommended/Directory.Build.props
+++ b/src/SolutionTemplate/5.1/uno51recommended/Directory.Build.props
@@ -6,6 +6,7 @@
 
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <UnoSdkDebugging>true</UnoSdkDebugging>
+    <WarningsAsErrors>true</WarningsAsErrors>
 
     <!--
       Adding NoWarn to remove build warnings

--- a/src/SolutionTemplate/5.1/uno51recommended/Directory.Build.props
+++ b/src/SolutionTemplate/5.1/uno51recommended/Directory.Build.props
@@ -6,7 +6,7 @@
 
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <UnoSdkDebugging>true</UnoSdkDebugging>
-    <WarningsAsErrors>true</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!--
       Adding NoWarn to remove build warnings

--- a/src/SolutionTemplate/5.1/uno51recommended/Directory.Packages.props
+++ b/src/SolutionTemplate/5.1/uno51recommended/Directory.Packages.props
@@ -26,6 +26,10 @@
     <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="2.88.7" />
     <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.7" />
     <PackageVersion Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.7" />
+    <PackageVersion Include="SkiaSharp.Views" Version="2.88.7" />
+    <PackageVersion Include="SkiaSharp.Views.Gtk2" Version="2.88.7" />
+    <PackageVersion Include="OpenTK" Version="3.1.0" />
+    <PackageVersion Include="OpenTK.GLControl" Version="3.1.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
     <PackageVersion Include="Uno.Extensions.Configuration" Version="4.0.0" />

--- a/src/SolutionTemplate/5.1/uno51recommended/uno51recommended/uno51recommended.csproj
+++ b/src/SolutionTemplate/5.1/uno51recommended/uno51recommended/uno51recommended.csproj
@@ -65,6 +65,14 @@
         <PackageReference Include="SkiaSharp.NativeAssets.MacCatalyst" />
       </ItemGroup>
     </When>
+    <When Condition="$(TargetFramework.Contains('windows10'))">
+      <ItemGroup>
+        <PackageReference Include="SkiaSharp.Views" NoWarn="NU1701" />
+        <PackageReference Include="SkiaSharp.Views.Gtk2" NoWarn="NU1701" />
+        <PackageReference Include="OpenTK" NoWarn="NU1701" />
+        <PackageReference Include="OpenTK.GLControl" NoWarn="NU1701" />
+      </ItemGroup>
+    </When>
   </Choose>
 
   <ItemGroup>

--- a/src/SolutionTemplate/5.2/uno52Lib/uno52Lib.csproj
+++ b/src/SolutionTemplate/5.2/uno52Lib/uno52Lib.csproj
@@ -11,6 +11,7 @@
 		<Nullable>enable</Nullable>
 		<UnoSdkDebugging>true</UnoSdkDebugging>
 		<OutputType>Library</OutputType>
+		<WarningsAsErrors>true</WarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/src/SolutionTemplate/5.2/uno52Lib/uno52Lib.csproj
+++ b/src/SolutionTemplate/5.2/uno52Lib/uno52Lib.csproj
@@ -11,7 +11,7 @@
 		<Nullable>enable</Nullable>
 		<UnoSdkDebugging>true</UnoSdkDebugging>
 		<OutputType>Library</OutputType>
-		<WarningsAsErrors>true</WarningsAsErrors>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/src/SolutionTemplate/5.2/uno52SingleProjectLib/uno52SingleProjectLib.csproj
+++ b/src/SolutionTemplate/5.2/uno52SingleProjectLib/uno52SingleProjectLib.csproj
@@ -12,7 +12,7 @@
 		<UnoSingleProject>true</UnoSingleProject>
 		<OutputType>Library</OutputType>
 		<UnoSdkDebugging>true</UnoSdkDebugging>
-		<WarningsAsErrors>true</WarningsAsErrors>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/src/SolutionTemplate/5.2/uno52SingleProjectLib/uno52SingleProjectLib.csproj
+++ b/src/SolutionTemplate/5.2/uno52SingleProjectLib/uno52SingleProjectLib.csproj
@@ -12,6 +12,7 @@
 		<UnoSingleProject>true</UnoSingleProject>
 		<OutputType>Library</OutputType>
 		<UnoSdkDebugging>true</UnoSdkDebugging>
+		<WarningsAsErrors>true</WarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/src/SolutionTemplate/5.2/uno52blank/Directory.Build.props
+++ b/src/SolutionTemplate/5.2/uno52blank/Directory.Build.props
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <UnoSdkDebugging>true</UnoSdkDebugging>
-    <WarningsAsErrors>true</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!--
       Adding NoWarn to remove build warnings

--- a/src/SolutionTemplate/5.2/uno52blank/Directory.Build.props
+++ b/src/SolutionTemplate/5.2/uno52blank/Directory.Build.props
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <UnoSdkDebugging>true</UnoSdkDebugging>
+    <WarningsAsErrors>true</WarningsAsErrors>
 
     <!--
       Adding NoWarn to remove build warnings


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?


- Project automation

## What is the current behavior?

Build Warnings are treated normally

## What is the new behavior?

Build Warnings in the 5.1/5.2 templates are now set to treat Warnings as Errors to help prevent regressions that result in build warnings.
