### PR TITLE
fix: Run UnoAssetsGeneration at design time

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -123,12 +123,16 @@
 		</ItemGroup>
 	</Target>
 
+	<!-- 
+		The UnoAssetsGeneration must be run at design time as well, as it 
+		interacts with the `.R` generation on android. If not run, temporary
+		resource files may be deleted incorrectly by design time builds.
+	-->
 	<Target Name="UnoAssetsGeneration"
 				BeforeTargets="_GetLibraryImports;_CheckForContent;_CollectBundleResources;_CompileAppManifest;_ComputeAndroidResourcePaths"
 				DependsOnTargets="ResolveProjectReferences;GetCopyToOutputDirectoryItems;_UnoLangSetup"
 				Condition="
-				'$(DesignTimeBuild)' != 'true'
-				and '$(BuildingInsideUnoSourceGenerator)' == ''
+				'$(BuildingInsideUnoSourceGenerator)' == ''
 				and ('$(IsUnoHead)'=='true'
 					or '$(AndroidApplication)'=='true'
 					or '$(ProjectTypeGuids)'!='')">


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.resizetizer/issues/232

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that assets items are filled at design time, in order to avoid file to be deleted incorrectly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
