### PR TITLE
chore: Disable flaky test When_ReMeasure_After_Changing_MaxDate

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
@@ -26,6 +26,7 @@ public class Given_CalendarView
 {
 	[TestMethod]
 	[UnoWorkItem("https://github.com/unoplatform/uno/issues/16123")]
+	[Ignore("Test is unstable on CI: https://github.com/unoplatform/uno/issues/16123")]
 	public async Task When_ReMeasure_After_Changing_MaxDate()
 	{
 		var contentDialog = new ContentDialog();


### PR DESCRIPTION
Related to https://github.com/unoplatform/uno/issues/16123 and https://github.com/unoplatform/uno/pull/16136

Temporarily disables test for:

```
Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException: Assert.Fail failed. The bitmaps are not the same
   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.HandleFail(String assertionName, String message, Object[] parameters)
   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.Fail(String message, Object[] parameters)
   at Microsoft.VisualStudio.TestTools.UnitTesting.Assert.Fail(String message)
   at Uno.UI.RuntimeTests.Helpers.ImageAssert.AreEqualAsync(RawBitmap actual, RawBitmap expected)
   at Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Given_CalendarView.When_ReMeasure_After_Changing_MaxDate()
   at Uno.UI.Samples.Tests.UnitTestsControl.<>c__DisplayClass63_1.<<ExecuteTestsForInstance>g__InvokeTestMethod|3>d.MoveNext()
```