### PR TITLE
docs: remove duplicate references to themes articles

### DIFF
--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -76,10 +76,6 @@
         href: tutorials-intro.md
       - name: How to deploy a WebAssembly app on Azure Static Web Apps
         href: guides/azure-static-webapps.md
-      - name: How to integrate Uno.Material
-        href: external/uno.themes/doc/material-getting-started.md
-      - name: How to integrate Uno.Cupertino
-        href: external/uno.themes/doc/cupertino-getting-started.md
       - name: How to use Windows Community Toolkit
         href: uno-community-toolkit.md
       - name: How to manually add a splash screen


### PR DESCRIPTION
These articles are already under the Themes section and it causes an annoying behavior where opening the article from beneath the Themes section will cause the navigation bar on the left to jump to the other section where this article is referenced