### PR TITLE
fix: Square around `ColorPicker` `Thumb`

### DIFF
--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/ColorPicker.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/ColorPicker.xaml
@@ -510,6 +510,7 @@
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Thumb">
+                                            <!-- Uno specific (LinearGradientBrush borders): Use solid border brush #6457 -->
                                             <Border 
                                                 win:BorderBrush="{ThemeResource SliderThumbBorderBrush}"
                                                 not_win:BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"

--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/ColorPicker.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/ColorPicker.xaml
@@ -5,7 +5,9 @@
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:primitives="using:Microsoft.UI.Xaml.Controls.Primitives"
     xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
-    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)">
+    xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
+    xmlns:not_win="http://uno.ui/not_win"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
     <Style TargetType="controls:ColorPicker" BasedOn="{StaticResource DefaultColorPickerStyle}"/>
     
@@ -508,7 +510,9 @@
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="Thumb">
-                                            <Border BorderBrush="{ThemeResource SliderThumbBorderBrush}"
+                                            <Border 
+                                                win:BorderBrush="{ThemeResource SliderThumbBorderBrush}"
+                                                not_win:BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                                                 BorderThickness="{TemplateBinding BorderThickness}"
                                                 Background="{ThemeResource SliderOuterThumbBackground}"
                                                 CornerRadius="{ThemeResource SliderThumbCornerRadius}">

--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/Slider_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/Slider_themeresources.xaml
@@ -199,7 +199,7 @@
         <Setter Property="Background" Value="{ThemeResource SliderTrackFill}" />
         <Setter Property="BorderThickness" Value="{ThemeResource SliderBorderThemeThickness}" />
         
-        <!-- Uno specific (LinearGradientBrush borders): Use solid border brush -->
+        <!-- Uno specific (LinearGradientBrush borders): Use solid border brush #6457 -->
         <win:Setter Property="BorderBrush" Value="{ThemeResource SliderThumbBorderBrush}"/>
         <not_win:Setter Property="BorderBrush" Value="{ThemeResource ControlStrokeColorDefaultBrush}" />
        


### PR DESCRIPTION
GitHub Issue (If applicable): related to #15448

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Square around thumbs

## What is the new behavior?

No square around thumbs

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.