### PR TITLE
Fix Skia / SVG package references

### DIFF
--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -35,11 +35,16 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 		{
 			AddPackageWhen(!IsPackable, "Uno.WinUI.Lottie", null);
 
-			if (HasFeature(UnoFeature.Skia) && TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead())
+			if (HasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Skottie) || HasFeature(UnoFeature.Svg))
+			{
+				AddPackageForFeature(UnoFeature.Skia, "SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);
+			}
+
+			AddPackageForFeatureWhen(IsExecutable, UnoFeature.Svg, "Uno.WinUI.Svg", null);
+
+			if (HasFeature(UnoFeature.Skottie) && TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead())
 			{
 				AddPackage("SkiaSharp.Skottie", SkiaSharpVersion);
-				AddPackage("SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);
-				AddPackageWhen(IsExecutable, "Uno.WinUI.Svg", null);
 			}
 
 			if (TargetRuntime == UnoTarget.Wasm || IsLegacyWasmHead())
@@ -54,6 +59,13 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 			AddPackage("Microsoft.WindowsAppSDK", WinAppSdkVersion);
 			AddPackage("Microsoft.Windows.SDK.BuildTools", WinAppSdkBuildToolsVersion);
 			AddPackageWhen(IsExecutable, "Uno.Core.Extensions.Logging.Singleton", UnoCoreLoggingSingletonVersion);
+
+			// Match the conditions to Uno so that we have the reference across all targets
+			if (HasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Skottie) || HasFeature(UnoFeature.Svg))
+			{
+				// NOTE: This will change to come through transitively in SkiaSharp 3
+				AddPackageForFeature(UnoFeature.Skia, "SkiaSharp.Views.WinUI", SkiaSharpVersion);
+			}
 		}
 	}
 

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -33,19 +33,15 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 
 		if (TargetRuntime != UnoTarget.Windows)
 		{
-			AddPackageWhen(!IsPackable, "Uno.WinUI.Lottie", null);
+			AddPackageForFeature(UnoFeature.Lottie, "Uno.WinUI.Lottie", null);
+			AddPackageForFeatureWhen(TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead(), UnoFeature.Lottie, "SkiaSharp.Skottie", null);
 
-			if (HasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Skottie) || HasFeature(UnoFeature.Svg))
+			if (HasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Lottie) || HasFeature(UnoFeature.Svg))
 			{
 				AddPackageForFeature(UnoFeature.Skia, "SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);
 			}
 
 			AddPackageForFeatureWhen(IsExecutable, UnoFeature.Svg, "Uno.WinUI.Svg", null);
-
-			if (HasFeature(UnoFeature.Skottie) && TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead())
-			{
-				AddPackage("SkiaSharp.Skottie", SkiaSharpVersion);
-			}
 
 			if (TargetRuntime == UnoTarget.Wasm || IsLegacyWasmHead())
 			{
@@ -61,7 +57,7 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 			AddPackageWhen(IsExecutable, "Uno.Core.Extensions.Logging.Singleton", UnoCoreLoggingSingletonVersion);
 
 			// Match the conditions to Uno so that we have the reference across all targets
-			if (HasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Skottie) || HasFeature(UnoFeature.Svg))
+			if (HasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Lottie) || HasFeature(UnoFeature.Svg))
 			{
 				// NOTE: This will change to come through transitively in SkiaSharp 3
 				AddPackageForFeature(UnoFeature.Skia, "SkiaSharp.Views.WinUI", SkiaSharpVersion);

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -35,10 +35,11 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 		{
 			AddPackageWhen(!IsPackable, "Uno.WinUI.Lottie", null);
 
-			if (TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead() && !IsPackable)
+			if (HasFeature(UnoFeature.Skia) && TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead() && !IsPackable)
 			{
 				AddPackage("SkiaSharp.Skottie", SkiaSharpVersion);
 				AddPackage("SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);
+				AddPackageWhen(IsExecutable, "Uno.WinUI.Svg", null);
 			}
 
 			if (TargetRuntime == UnoTarget.Wasm || IsLegacyWasmHead())

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -35,7 +35,7 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 		{
 			AddPackageWhen(!IsPackable, "Uno.WinUI.Lottie", null);
 
-			if (HasFeature(UnoFeature.Skia) && TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead() && !IsPackable)
+			if (HasFeature(UnoFeature.Skia) && TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead())
 			{
 				AddPackage("SkiaSharp.Skottie", SkiaSharpVersion);
 				AddPackage("SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);

--- a/src/Uno.Sdk/UnoFeature.cs
+++ b/src/Uno.Sdk/UnoFeature.cs
@@ -80,5 +80,11 @@ public enum UnoFeature
 	Prism,
 
 	[UnoArea(UnoArea.Core)]
-	Skia
+	Skia,
+
+	[UnoArea(UnoArea.Core)]
+	Skottie,
+
+	[UnoArea(UnoArea.Core)]
+	Svg
 }

--- a/src/Uno.Sdk/UnoFeature.cs
+++ b/src/Uno.Sdk/UnoFeature.cs
@@ -83,7 +83,7 @@ public enum UnoFeature
 	Skia,
 
 	[UnoArea(UnoArea.Core)]
-	Skottie,
+	Lottie,
 
 	[UnoArea(UnoArea.Core)]
 	Svg

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -75,6 +75,7 @@
 		"packages": [
 			"SkiaSharp.Skottie",
 			"SkiaSharp.Views.Uno.WinUI",
+			"SkiaSharp.Views.WinUI",
 			"SkiaSharp.NativeAssets.Linux",
 			"SkiaSharp.NativeAssets.macOS",
 			"SkiaSharp.NativeAssets.Win32"

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -16,6 +16,7 @@
 			"Uno.WinUI.Skia.MacOS",
 			"Uno.WinUI.Skia.Wpf",
 			"Uno.WinUI.Skia.X11",
+			"Uno.WinUI.Svg",
 			"Uno.WinUI.WebAssembly",
 			"Uno.WinUI.MediaPlayer.WebAssembly"
 		]

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Uno.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Uno.targets
@@ -4,16 +4,16 @@
 		in order for VS and C# Dev Kit to show nuget references in their respective solution explorers.
 		The version is not required, and VS/Code waits for some design-time targets to be executed to evaluate it.
 	-->
-	<ItemGroup Condition="$(IsPackable) != 'true'">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Lottie;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Lottie" ProjectSystem="true" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(UnoFeatures.Contains(';Skia;')) OR $(UnoFeatures.Contains(';Skottie;')) OR $(UnoFeatures.Contains(';Svg;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Skia;')) OR $(UnoFeatures.Contains(';Lottie;')) OR $(UnoFeatures.Contains(';Svg;'))">
 		<_UnoProjectSystemPackageReference Include="SkiaSharp.Views.Uno.WinUI" ProjectSystem="true"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="$(IsBrowserWasm) != 'true' AND '$(IsPackable)' != 'true'">
-		<_UnoProjectSystemPackageReference Include="SkiaSharp.Skottie" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Skottie;'))" />
+		<_UnoProjectSystemPackageReference Include="SkiaSharp.Skottie" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Lottie;'))" />
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Svg" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Svg;')) AND $(IsUnoHead) == 'true'" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Uno.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Uno.targets
@@ -8,8 +8,12 @@
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Lottie" ProjectSystem="true" />
 	</ItemGroup>
 
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Skia;')) OR $(UnoFeatures.Contains(';Skottie;')) OR $(UnoFeatures.Contains(';Svg;'))">
+		<_UnoProjectSystemPackageReference Include="SkiaSharp.Views.Uno.WinUI" ProjectSystem="true"/>
+	</ItemGroup>
+
 	<ItemGroup Condition="$(IsBrowserWasm) != 'true' AND '$(IsPackable)' != 'true'">
-		<_UnoProjectSystemPackageReference Include="SkiaSharp.Skottie" ProjectSystem="true" />
-		<_UnoProjectSystemPackageReference Include="SkiaSharp.Views.Uno.WinUI" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="SkiaSharp.Skottie" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Skottie;'))" />
+		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Svg" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Svg;')) AND $(IsUnoHead) == 'true'" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.WinAppSdk.targets
@@ -10,7 +10,7 @@
 		<_UnoProjectSystemPackageReference Include="Uno.Core.Extensions.Logging.Singleton" ProjectSystem="true" Condition="$(_IsExecutable) == 'true'"/>
 	</ItemGroup>
 
-	<ItemGroup Condition="$(UnoFeatures.Contains(';Skia;')) OR $(UnoFeatures.Contains(';Skottie;')) OR $(UnoFeatures.Contains(';Svg;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Skia;')) OR $(UnoFeatures.Contains(';Lottie;')) OR $(UnoFeatures.Contains(';Svg;'))">
 		<_UnoProjectSystemPackageReference Include="SkiaSharp.Views.WinUI" ProjectSystem="true" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.WinAppSdk.targets
@@ -9,4 +9,8 @@
 		<_UnoProjectSystemPackageReference Include="Microsoft.Windows.SDK.BuildTools" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.Core.Extensions.Logging.Singleton" ProjectSystem="true" Condition="$(_IsExecutable) == 'true'"/>
 	</ItemGroup>
+
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Skia;')) OR $(UnoFeatures.Contains(';Skottie;')) OR $(UnoFeatures.Contains(';Svg;'))">
+		<_UnoProjectSystemPackageReference Include="SkiaSharp.Views.WinUI" ProjectSystem="true" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- unoplatform/uno-private#455

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

Uno.WinUI.Svg is never included
SkiaSharp packages are always included for Non-Windows/WASM heads

## What is the new behavior?

SVG and SkiaSharp packages are only included when building non-Windows/WASM projects when the `Skia` UnoFeature has been specified. The SVG package is only included on a Head project and is not included for libraries.