### PR TITLE
[SDK] Uno Theme transitive deps on Lottie

### DIFF
--- a/doc/articles/features/Lottie.md
+++ b/doc/articles/features/Lottie.md
@@ -35,7 +35,7 @@ Add the following namespaces:
 
 #### References in a Single Project
 
-In Uno Platform Single Project, you'll need to add the `Skottie` [Uno Feature](xref:Uno.Features.Uno.Sdk#uno-platform-features) as follows:
+In Uno Platform Single Project, you'll need to add the `Lottie` [Uno Feature](xref:Uno.Features.Uno.Sdk#uno-platform-features) as follows:
 
 ```xml
 <UnoFeatures>

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -44,7 +44,7 @@ Here are the supported features:
 - `MediaElement`, to enable MediaElement support
 - `CSharpMarkup`, to enable C# Markup
 - `Extensions`, to enable all Uno.Extensions
-- `Authentication`, to enable all Uno.Extensions.Authentication
+- `Authentication`, to enable Uno.Extensions.Authentication for Custom Authentication
 - `AuthenticationMsal`, to enable Uno.Extensions support for MSAL
 - `AuthenticationOidc`, to enable Uno.Extensions support for OIDC
 - `Configuration`, to enable Uno.Extensions.Configuration
@@ -65,7 +65,7 @@ Here are the supported features:
 - `Prism`, to enable Prism Library
 - `Skia`, to enable SkiaSharp
 - `Svg`, to enable Svg support for iOS, Android, and mac Catalyst. This option is not needed for WebAssembly, Desktop, and WinAppSDK.
-- `Skottie`, to enable lottie files playback
+- `Lottie`, to enable lottie files playback
 
 ## Implicit Packages
 

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -39,7 +39,6 @@ This allows for the SDK to selectively include references to relevant sets of Nu
 
 Here are the supported features:
 
-- `Maps`, to enable Maps support
 - `Foldable`, to enable Android foldable support
 - `MediaElement`, to enable MediaElement support
 - `CSharpMarkup`, to enable C# Markup

--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -305,6 +305,10 @@
 					"description": "Adds the Uno.Extensions.Core.WinUI package.",
 					"helpUrl": "https://aka.platform.uno/feature-extensions-core"
 				},
+				"ThemeService": {
+					"description": "Adds the Uno.Extensions.Core.WinUI package.",
+					"helpUrl": "https://aka.platform.uno/feature-extensions-core"
+				},
 				"Hosting": {
 					"description": "Adds support for Dependency Injection using Uno.Extensions.Hosting packages.",
 					"helpUrl": "https://aka.platform.uno/feature-hosting"

--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -286,7 +286,7 @@
 					"helpUrl": "https://aka.platform.uno/feature-extensions"
 				},
 				"Authentication": {
-					"description": "Adds all of the Uno.Extensions packages for Authentication.",
+					"description": "Adds the Uno.Extensions package for Custom Authentication.",
 					"helpUrl": "https://aka.platform.uno/feature-authentication"
 				},
 				"AuthenticationMsal": {

--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -282,7 +282,7 @@
 					"helpUrl": "https://aka.platform.uno/feature-csharp-markup"
 				},
 				"Extensions": {
-					"description": "Generally adds most of the Uno.Extensions packages.",
+					"description": "Adds the most commonly used Extensions Packages for Hosting, Configuration, & Logging.",
 					"helpUrl": "https://aka.platform.uno/feature-extensions"
 				},
 				"Authentication": {

--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -265,10 +265,6 @@
 			"allowUnknownValues": false,
 			"caseSensitive": true,
 			"values": {
-				"Maps": {
-					"description": "Adds a reference to Uno.WinUI.Maps.",
-					"helpUrl": "https://aka.platform.uno/feature-maps"
-				},
 				"Foldable": {
 					"description": "Adds a reference to Uno.WinUI.Foldable.",
 					"helpUrl": "https://aka.platform.uno/feature-foldable"

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -33,10 +33,13 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 
 		if (TargetRuntime != UnoTarget.Windows)
 		{
-			AddPackageForFeature(UnoFeature.Lottie, "Uno.WinUI.Lottie", null);
-			AddPackageForFeatureWhen(TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead(), UnoFeature.Lottie, "SkiaSharp.Skottie", null);
+			if (HasFeature(UnoFeature.Material) || HasFeature(UnoFeature.Lottie) || HasFeature(UnoFeature.Cupertino))
+			{
+				AddPackage("Uno.WinUI.Lottie", null);
+				AddPackageWhen(TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead(), "SkiaSharp.Skottie", SkiaSharpVersion);
+			}
 
-			if (HasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Lottie) || HasFeature(UnoFeature.Svg))
+			if (HasFeature(UnoFeature.Material) || HHasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Lottie) || HasFeature(UnoFeature.Svg) || asFeature(UnoFeature.Cupertino))
 			{
 				AddPackageForFeature(UnoFeature.Skia, "SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);
 			}

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -39,7 +39,7 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 				AddPackageWhen(TargetRuntime != UnoTarget.Wasm && !IsLegacyWasmHead(), "SkiaSharp.Skottie", SkiaSharpVersion);
 			}
 
-			if (HasFeature(UnoFeature.Material) || HHasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Lottie) || HasFeature(UnoFeature.Svg) || asFeature(UnoFeature.Cupertino))
+			if (HasFeature(UnoFeature.Material) || HasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Lottie) || HasFeature(UnoFeature.Svg) || HasFeature(UnoFeature.Cupertino))
 			{
 				AddPackageForFeature(UnoFeature.Skia, "SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);
 			}

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -147,13 +147,9 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 	public void AddUnoExtensionsPackages()
 	{
 		var useExtensions = HasFeature(UnoFeature.Extensions);
-		if (useExtensions || HasFeature(UnoFeature.Authentication))
+		if (HasFeature(UnoFeature.Authentication))
 		{
 			AddPackage("Uno.Extensions.Authentication.WinUI", UnoExtensionsVersion);
-			AddPackage("Uno.Extensions.Authentication.MSAL.WinUI", UnoExtensionsVersion);
-			AddPackage("Uno.Extensions.Authentication.Oidc.WinUI", UnoExtensionsVersion);
-			AddPackage("Microsoft.Identity.Client", MicrosoftIdentityClientVersion);
-			AddPackage("Uno.WinUI.MSAL", null);
 		}
 		else if (HasFeature(UnoFeature.AuthenticationMsal))
 		{

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -147,20 +147,16 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 	public void AddUnoExtensionsPackages()
 	{
 		var useExtensions = HasFeature(UnoFeature.Extensions);
-		if (HasFeature(UnoFeature.Authentication))
-		{
-			AddPackage("Uno.Extensions.Authentication.WinUI", UnoExtensionsVersion);
-		}
-		else if (HasFeature(UnoFeature.AuthenticationMsal))
+		AddPackageForFeature(UnoFeature.Authentication, "Uno.Extensions.Authentication.WinUI", UnoExtensionsVersion);
+
+		if (HasFeature(UnoFeature.AuthenticationMsal))
 		{
 			AddPackage("Uno.Extensions.Authentication.MSAL.WinUI", UnoExtensionsVersion);
 			AddPackage("Microsoft.Identity.Client", MicrosoftIdentityClientVersion);
 			AddPackage("Uno.WinUI.MSAL", null);
 		}
-		else if (HasFeature(UnoFeature.AuthenticationOidc))
-		{
-			AddPackage("Uno.Extensions.Authentication.Oidc.WinUI", UnoExtensionsVersion);
-		}
+
+		AddPackageForFeature(UnoFeature.AuthenticationOidc, "Uno.Extensions.Authentication.Oidc.WinUI", UnoExtensionsVersion);
 
 		if (useExtensions || HasFeature(UnoFeature.Configuration))
 		{
@@ -177,13 +173,13 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 			AddPackage("Uno.Extensions.Hosting.WinUI", UnoExtensionsVersion);
 		}
 
-		if (useExtensions || HasFeature(UnoFeature.Http))
+		if (HasFeature(UnoFeature.Http))
 		{
 			AddPackage("Uno.Extensions.Http.WinUI", UnoExtensionsVersion);
 			AddPackage("Uno.Extensions.Http.Refit", UnoExtensionsVersion);
 		}
 
-		if (useExtensions || HasFeature(UnoFeature.Localization))
+		if (HasFeature(UnoFeature.Localization))
 		{
 			AddPackage("Uno.Extensions.Localization.WinUI", UnoExtensionsVersion);
 		}
@@ -218,33 +214,32 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 			}
 		}
 
-		if ((useExtensions || HasFeature(UnoFeature.Navigation))
-			&& !HasFeature(UnoFeature.Prism))
+		if (HasFeature(UnoFeature.Navigation) && !HasFeature(UnoFeature.Prism))
 		{
 			AddPackage("Uno.Extensions.Navigation.WinUI", UnoExtensionsVersion);
 			AddPackageForFeature(UnoFeature.CSharpMarkup, "Uno.Extensions.Navigation.WinUI.Markup", UnoExtensionsVersion);
 			AddPackageForFeature(UnoFeature.Toolkit, "Uno.Extensions.Navigation.Toolkit.WinUI", UnoExtensionsVersion);
 		}
 
-		if (useExtensions || HasFeature(UnoFeature.Mvux))
+		if (HasFeature(UnoFeature.Mvux))
 		{
 			AddPackage("Uno.Extensions.Reactive.WinUI", UnoExtensionsVersion);
 			AddPackage("Uno.Extensions.Reactive.Messaging", UnoExtensionsVersion);
 			AddPackageForFeature(UnoFeature.CSharpMarkup, "Uno.Extensions.Reactive.WinUI.Markup", UnoExtensionsVersion);
 		}
 
-		if (useExtensions || HasFeature(UnoFeature.Serialization))
+		if (HasFeature(UnoFeature.Serialization))
 		{
 			AddPackage("Uno.Extensions.Serialization.Http", UnoExtensionsVersion);
 			AddPackage("Uno.Extensions.Serialization.Refit", UnoExtensionsVersion);
 		}
 
-		if (useExtensions || HasFeature(UnoFeature.Serilog))
+		if (HasFeature(UnoFeature.Serilog))
 		{
 			AddPackage("Uno.Extensions.Logging.Serilog", UnoExtensionsVersion);
 		}
 
-		if (useExtensions || HasFeature(UnoFeature.Storage))
+		if (HasFeature(UnoFeature.Storage))
 		{
 			AddPackage("Uno.Extensions.Storage.WinUI", UnoExtensionsVersion);
 		}

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -168,7 +168,7 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 			AddPackage("Uno.Extensions.Configuration", UnoExtensionsVersion);
 		}
 
-		if (useExtensions || HasFeature(UnoFeature.ExtensionsCore))
+		if (useExtensions || HasFeature(UnoFeature.ExtensionsCore) || HasFeature(UnoFeature.ThemeService))
 		{
 			AddPackage("Uno.Extensions.Core.WinUI", UnoExtensionsVersion);
 		}

--- a/src/Uno.Sdk/UnoFeature.cs
+++ b/src/Uno.Sdk/UnoFeature.cs
@@ -35,6 +35,9 @@ public enum UnoFeature
 	ExtensionsCore,
 
 	[UnoArea(UnoArea.Extensions)]
+	ThemeService,
+
+	[UnoArea(UnoArea.Extensions)]
 	Hosting,
 
 	[UnoArea(UnoArea.Extensions)]

--- a/src/Uno.Sdk/UnoFeature.cs
+++ b/src/Uno.Sdk/UnoFeature.cs
@@ -4,6 +4,7 @@ public enum UnoFeature
 {
 	Invalid = -1,
 
+	// NOTE: We are removing this from the public API but keeping it as a supported feature for now
 	[UnoArea(UnoArea.Core)]
 	Maps,
 

--- a/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
@@ -24,10 +24,6 @@
 		<When Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Authentication;'))">
 			<ItemGroup>
 				<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.WinUI" ProjectSystem="true" />
-				<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" ProjectSystem="true" />
-				<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" ProjectSystem="true" />
-				<_UnoProjectSystemPackageReference Include="Microsoft.Identity.Client" ProjectSystem="true" />
-				<_UnoProjectSystemPackageReference Include="Uno.WinUI.MSAL" ProjectSystem="true" />
 			</ItemGroup>
 		</When>
 	</Choose>

--- a/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
@@ -36,7 +36,7 @@
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Configuration" ProjectSystem="true" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';ExtensionsCore;'))">
+	<ItemGroup Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';ExtensionsCore;')) OR $(UnoFeatures.Contains(';ThemeService;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Core.WinUI" ProjectSystem="true" />
 	</ItemGroup>
 

--- a/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
@@ -8,25 +8,19 @@
 		<_UseUnoExtensions>$(UnoFeatures.Contains(';Extensions;'))</_UseUnoExtensions>
 	</PropertyGroup>
 
-	<Choose>
-		<When Condition="!$(_UseUnoExtensions) AND $(UnoFeatures.Contains(';AuthenticationMsal;'))">
-			<ItemGroup>
-				<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" ProjectSystem="true" />
-				<_UnoProjectSystemPackageReference Include="Microsoft.Identity.Client" ProjectSystem="true" />
-				<_UnoProjectSystemPackageReference Include="Uno.WinUI.MSAL" ProjectSystem="true" />
-			</ItemGroup>
-		</When>
-		<When Condition="!$(_UseUnoExtensions) AND $(UnoFeatures.Contains(';AuthenticationOidc;'))">
-			<ItemGroup>
-				<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" ProjectSystem="true" />
-			</ItemGroup>
-		</When>
-		<When Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Authentication;'))">
-			<ItemGroup>
-				<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.WinUI" ProjectSystem="true" />
-			</ItemGroup>
-		</When>
-	</Choose>
+	<ItemGroup Condition="$(UnoFeatures.Contains(';AuthenticationMsal;'))">
+		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Microsoft.Identity.Client" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Uno.WinUI.MSAL" ProjectSystem="true" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$(UnoFeatures.Contains(';AuthenticationOidc;'))">
+		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.Oidc.WinUI" ProjectSystem="true" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Authentication;'))">
+		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.WinUI" ProjectSystem="true" />
+	</ItemGroup>
 
 	<ItemGroup Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Configuration;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Configuration" ProjectSystem="true" />
@@ -40,12 +34,12 @@
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Hosting.WinUI" ProjectSystem="true" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Http;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Http;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Http.WinUI" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Http.Refit" ProjectSystem="true" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Localization;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Localization;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Localization.WinUI" ProjectSystem="true" />
 	</ItemGroup>
 
@@ -69,28 +63,28 @@
 		<_UnoProjectSystemPackageReference Include="Xamarin.AndroidX.Collection.Ktx" ProjectSystem="true" Condition="$(IsAndroid) == 'true'" />
 	</ItemGroup>
 
-	<ItemGroup Condition="($(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Navigation;'))) AND !$(UnoFeatures.Contains(';Prism;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Navigation;')) AND !$(UnoFeatures.Contains(';Prism;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Navigation.WinUI" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Navigation.WinUI.Markup" ProjectSystem="true" Condition="$(UnoFeatures.Contains('CSharpMarkup'))"/>
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" ProjectSystem="true" Condition="$(UnoFeatures.Contains('Toolkit'))"/>
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Mvux;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Mvux;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Reactive.WinUI" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Reactive.Messaging" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Reactive.WinUI.Markup" ProjectSystem="true" Condition="$(UnoFeatures.Contains('CSharpMarkup'))" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Serialization;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Serialization;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Serialization.Http" ProjectSystem="true" />
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Serialization.Refit" ProjectSystem="true" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Serilog;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Serilog;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Logging.Serilog" ProjectSystem="true" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_UseUnoExtensions) OR $(UnoFeatures.Contains(';Storage;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Storage;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Storage.WinUI" ProjectSystem="true" />
 	</ItemGroup>
 

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Uno.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Uno.targets
@@ -4,16 +4,16 @@
 		in order for VS and C# Dev Kit to show nuget references in their respective solution explorers.
 		The version is not required, and VS/Code waits for some design-time targets to be executed to evaluate it.
 	-->
-	<ItemGroup Condition="$(UnoFeatures.Contains(';Lottie;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Lottie;')) OR $(UnoFeatures.Contains(';Material;')) OR $(UnoFeatures.Contains(';Cupertino;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Lottie" ProjectSystem="true" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(UnoFeatures.Contains(';Skia;')) OR $(UnoFeatures.Contains(';Lottie;')) OR $(UnoFeatures.Contains(';Svg;'))">
+	<ItemGroup Condition="$(UnoFeatures.Contains(';Skia;')) OR $(UnoFeatures.Contains(';Lottie;')) OR $(UnoFeatures.Contains(';Svg;')) OR $(UnoFeatures.Contains(';Material;')) OR $(UnoFeatures.Contains(';Cupertino;'))">
 		<_UnoProjectSystemPackageReference Include="SkiaSharp.Views.Uno.WinUI" ProjectSystem="true"/>
 	</ItemGroup>
 
 	<ItemGroup Condition="$(IsBrowserWasm) != 'true' AND '$(IsPackable)' != 'true'">
-		<_UnoProjectSystemPackageReference Include="SkiaSharp.Skottie" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Lottie;'))" />
+		<_UnoProjectSystemPackageReference Include="SkiaSharp.Skottie" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Lottie;')) OR $(UnoFeatures.Contains(';Material;')) OR $(UnoFeatures.Contains(';Cupertino;'))" />
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Svg" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Svg;')) AND $(IsUnoHead) == 'true'" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- unoplatform/uno#16317

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Lottie and the associated Skia packages are only brought in if you add the Lottie UnoFeature

## What is the new behavior?

Lottie will be brought in automatically if you have `Material` or `Cupertino` defined in your UnoFeatures. as Uno.WinUI.Lottie is a transitive dependency of the themes packages.

- Removes Maps UnoFeature (public API only - this will still work as a feature)
- Fixes renamed references from `Skottie` to `Lottie` UnoFeature
- Changes behavior of `Extensions` feature to only include Hosting, Configuration, Logging and the ExtensionsCore