### PR TITLE
docs: fix iOS entry in Windows.Storage.Pickers table

### DIFF
--- a/doc/articles/features/windows-storage-pickers.md
+++ b/doc/articles/features/windows-storage-pickers.md
@@ -22,8 +22,8 @@ Legend
 | Picker         | UWP   | WebAssembly | Android | iOS    | macOS | Skia Desktop (Windows) | Skia Desktop (X11) |
 |----------------|-------|-------------|---------|--------|-------|----------------------- |-----|
 | FileOpenPicker | ✔    | ✔ (1)       | ✔      | ✔      | ✔    | ✔                      | ✔  |
-| FileSavePicker | ✔    | ✔ (1)       | ✔      | ✔      | ✔    | ✔                      | ✔  |
-| FolderPicker   | ✔    | ✔           | ✔      | 💬 (2) | ✔    | ✖                      | ✔  |
+| FileSavePicker | ✔    | ✔ (1)       | ✔      | 💬 (2) | ✔    | ✔                      | ✔  |
+| FolderPicker   | ✔    | ✔           | ✔      | ✔      | ✔    | ✖                      | ✔  |
 
 *(1) - Multiple implementations supported - see WebAssembly section below*\
 *(2) - See iOS section below*


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Documentation content fix

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Contains **NO** breaking changes
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

The iOS section in [the File and Folder Pickers page](/unoplatform/uno/blob/master/doc/articles/features/windows-storage-pickers.md) talks about iOS not offering "a built-in `FileSavePicker` experience." However, the table suggests that it's about the `FolderPicker`. Thus, I swapped them in the table.