### PR TITLE
SkiaSharp Views not referenced

### DIFF
--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -41,7 +41,7 @@ public sealed class ImplicitPackagesResolver_v0 : ImplicitPackagesResolverBase
 
 			if (HasFeature(UnoFeature.Material) || HasFeature(UnoFeature.Skia) || HasFeature(UnoFeature.Lottie) || HasFeature(UnoFeature.Svg) || HasFeature(UnoFeature.Cupertino))
 			{
-				AddPackageForFeature(UnoFeature.Skia, "SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);
+				AddPackage("SkiaSharp.Views.Uno.WinUI", SkiaSharpVersion);
 			}
 
 			AddPackageForFeatureWhen(IsExecutable, UnoFeature.Svg, "Uno.WinUI.Svg", null);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- TBD

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

SkiaSharp Views is not actually brought in by the Implicit Packages Task

## What is the new behavior?

SkiaSharp Views no longer has 2nd invalid condition that prevents it from being brought in as a reference.