### PR TITLE
Bump MSAL version due to Security issue

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -64,7 +64,7 @@
 	},
 	{
 		"group": "Resizetizer",
-		"version": "1.4.4",
+		"version": "1.4.5",
 		"packages": [
 			"Uno.Resizetizer"
 		]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -117,7 +117,7 @@
 	},
 	{
 		"group": "MsalClient",
-		"version": "4.60.2",
+		"version": "4.60.3",
 		"packages": [
 			"Microsoft.Identity.Client"
 		]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a 

## PR Type

What kind of change does this PR introduce?

- Sdk Dependencies

## What is the current behavior?

Sdk adds a reference to MSAL 4.60.2 which was marked with a Security vulnerability this morning.
https://github.com/advisories/GHSA-x674-v45j-fwxw

## What is the new behavior?

The version provided by the SDK now targets the latest patched version