### PR TITLE
StorageFileHelper - Add GetFilesInDirectoryAsync

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Uno.Extensions.Specialized;
 using Windows.Storage;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
@@ -7,6 +8,32 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 	[TestClass]
 	public class Given_ApplicationStorage
 	{
+
+		[TestMethod]
+		public async Task When_ExistFilesInPackage()
+		{
+			var fileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage(null);
+
+			Assert.IsTrue(fileExists.Any());
+		}
+
+		[TestMethod]
+		public async Task When_ExtensionsFilterCountDifferentFromAllInPackage()
+		{
+			var filteredFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage([".png"]);
+			var allFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage(null);
+
+			Assert.IsFalse(allFileExists.Count() == filteredFileExists.Count());
+		}
+
+		[TestMethod]
+		public async Task When_ExtensionsFilterOnlyPathsForPngFiles()
+		{
+			var filteredFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage([".png"]);
+			var allFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage(null);
+
+			Assert.IsTrue(filteredFileExists.Count() == filteredFileExists.Where(e => e.ToString().EndsWith(".png")).Count());
+		}
 
 		[TestMethod]
 		public async Task When_FileDoesNotExistsInPackage()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Storage/Given_ApplicationStorage.cs
@@ -12,7 +12,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		[TestMethod]
 		public async Task When_ExistFilesInPackage()
 		{
-			var fileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage(null);
+			var fileExists = await Uno.UI.Toolkit.StorageFileHelper.GetFilesInDirectoryAsync(null);
 
 			Assert.IsTrue(fileExists.Any());
 		}
@@ -20,8 +20,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		[TestMethod]
 		public async Task When_ExtensionsFilterCountDifferentFromAllInPackage()
 		{
-			var filteredFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage([".png"]);
-			var allFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage(null);
+			var filteredFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetFilesInDirectoryAsync([".png"]);
+			var allFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetFilesInDirectoryAsync(null);
 
 			Assert.IsFalse(allFileExists.Count() == filteredFileExists.Count());
 		}
@@ -29,8 +29,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Storage
 		[TestMethod]
 		public async Task When_ExtensionsFilterOnlyPathsForPngFiles()
 		{
-			var filteredFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage([".png"]);
-			var allFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetAllFilesPathInPackage(null);
+			var filteredFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetFilesInDirectoryAsync([".png"]);
+			var allFileExists = await Uno.UI.Toolkit.StorageFileHelper.GetFilesInDirectoryAsync(null);
 
 			Assert.IsTrue(filteredFileExists.Count() == filteredFileExists.Where(e => e.ToString().EndsWith(".png")).Count());
 		}

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.Android.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.Android.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using Android.Content.Res;
 using System.Threading.Tasks;
+using System;
 
 namespace Uno.UI.Toolkit;
 
@@ -90,21 +91,24 @@ partial class StorageFileHelper
 	}
 
 	/// <summary>
-	/// This method will return all the assets within current package
+	/// Retrieves the paths of assets within the current Android application package based on the specified filter predicate.
 	/// </summary>
-	/// <param name="extensionsFilter">Extensions list for filter files</param>
-	private static Task<string[]> GetFilesInPackage(string[]? extensionsFilter)
+	/// <param name="predicate">A predicate function determining whether a file should be included in the result.</param>
+	/// <returns>
+	/// Returns an array of strings containing the paths of the filtered assets.
+	/// </returns>
+	private static Task<string[]> GetFilesInDirectory(Func<string, bool> predicate)
 	{
 		var context = global::Android.App.Application.Context;
 
-		if (ScannedFiles is null)
+		if (_scannedFiles is null)
 		{
-			ScannedFiles = new List<string>();
-			_ = ScanPackageAssetsAsync(ScannedFiles);
+			_scannedFiles = new List<string>();
+			_ = ScanPackageAssets(_scannedFiles);
 		}
 
-		var results = ScannedFiles?.ToList()
-			.Where(e => extensionsFilter == null || extensionsFilter.Any(filter => e.EndsWith(filter, StringComparison.OrdinalIgnoreCase)))
+		var results = _scannedFiles?.Where(e => predicate(e))
+			.Select(e => e.Replace('\\', '/'))
 			.ToArray() ?? Array.Empty<string>();
 
 		return Task.FromResult(results);

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.Android.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.Android.cs
@@ -88,5 +88,26 @@ partial class StorageFileHelper
 			return false;
 		}
 	}
+
+	/// <summary>
+	/// This method will return all the assets within current package
+	/// </summary>
+	/// <param name="extensionsFilter">Extensions list for filter files</param>
+	private static Task<string[]> GetFilesInPackage(string[]? extensionsFilter)
+	{
+		var context = global::Android.App.Application.Context;
+
+		if (ScannedFiles is null)
+		{
+			ScannedFiles = new List<string>();
+			_ = ScanPackageAssetsAsync(ScannedFiles);
+		}
+
+		var results = ScannedFiles?.ToList()
+			.Where(e => extensionsFilter == null || extensionsFilter.Any(filter => e.EndsWith(filter, StringComparison.OrdinalIgnoreCase)))
+			.ToArray() ?? Array.Empty<string>();
+
+		return Task.FromResult(results);
+	}
 }
 

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.Android.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.Android.cs
@@ -94,9 +94,7 @@ partial class StorageFileHelper
 	/// Retrieves the paths of assets within the current Android application package based on the specified filter predicate.
 	/// </summary>
 	/// <param name="predicate">A predicate function determining whether a file should be included in the result.</param>
-	/// <returns>
-	/// Returns an array of strings containing the paths of the filtered assets.
-	/// </returns>
+	/// <returns>Returns an array of strings containing the paths of the filtered assets.</returns>
 	private static Task<string[]> GetFilesInDirectory(Func<string, bool> predicate)
 	{
 		var context = global::Android.App.Application.Context;

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.cs
@@ -6,6 +6,7 @@ using Uno;
 using System.Reflection;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Uno.UI.Toolkit;
 
@@ -18,8 +19,17 @@ public partial class StorageFileHelper
 	/// <returns>A task that will complete with a result of true if file exists, otherwise with a result of false.</returns>
 	public static async Task<bool> ExistsInPackage(string fileName) => await FileExistsInPackage(fileName);
 
+	/// <summary>
+	/// Get all files in the package
+	/// </summary>
+	/// <returns>List of string with the Paths - Filtered by extensionsFilter list</returns>
+	public static async Task<string[]> GetAllFilesPathInPackage(string[] extensionsFilter) => await GetFilesInPackage(extensionsFilter);
+
 #if IS_UNIT_TESTS || __NETSTD_REFERENCE__
 	private static Task<bool> FileExistsInPackage(string fileName)
+		=> throw new NotImplementedException();
+
+	private static Task<string[]> GetAllFilesPathInPackage(string[] extensionsFilter)
 		=> throw new NotImplementedException();
 #endif
 
@@ -38,6 +48,24 @@ public partial class StorageFileHelper
 		}
 
 		return Task.FromResult(false);
+	}
+
+	private static Task<string[]> GetFilesInPackage(string[]? extensionsFilter)
+	{
+		List<string> assetsFiles = new();
+		string path = string.Empty;
+		var executingPath = Assembly.GetExecutingAssembly().Location;
+		if (!string.IsNullOrEmpty(executingPath))
+		{
+			path = Path.GetDirectoryName(executingPath) + string.Empty;
+			if (!string.IsNullOrEmpty(path))
+			{
+				assetsFiles = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories)
+										.Where(e => extensionsFilter == null || extensionsFilter.Any(filter => e.EndsWith(filter, StringComparison.OrdinalIgnoreCase)))
+										.ToList();
+			}
+		}
+		return Task.FromResult(assetsFiles.ToArray());
 	}
 #endif
 }

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.cs
@@ -52,6 +52,11 @@ public partial class StorageFileHelper
 		return Task.FromResult(false);
 	}
 
+	/// <summary>
+	/// Retrieves the paths of assets within the current application based on the specified filter predicate.
+	/// </summary>
+	/// <param name="predicate">A predicate function determining whether a file should be included in the result.</param>
+	/// <returns>Returns an array of strings containing the paths of the filtered assets.</returns>
 	private static Task<string[]> GetFilesInDirectory(Func<string, bool> predicate)
 	{
 		List<string> assetsFiles = new();
@@ -64,7 +69,7 @@ public partial class StorageFileHelper
 			{
 				assetsFiles = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories)
 										.Where(e => predicate(e))
-										.Select(e => e.Replace(path, string.Empty).Replace('\\', '/'))
+										.Select(e => e.Replace(path, string.Empty).Replace('\\', '/').TrimStart('/'))
 										.ToList();
 			}
 		}

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.iOSmacOS.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.iOSmacOS.cs
@@ -23,6 +23,11 @@ partial class StorageFileHelper
 		return Task.FromResult(resourcePathname != null);
 	}
 
+	/// <summary>
+	/// Retrieves the paths of assets within the current application based on the specified filter predicate.
+	/// </summary>
+	/// <param name="predicate">A predicate function determining whether a file should be included in the result.</param>
+	/// <returns>Returns an array of strings containing the paths of the filtered assets.</returns>
 	private static Task<string[]> GetFilesInDirectory(Func<string, bool> predicate)
 	{
 		string rootPath = AppDomain.CurrentDomain.BaseDirectory;

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.iOSmacOS.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.iOSmacOS.cs
@@ -22,4 +22,15 @@ partial class StorageFileHelper
 
 		return Task.FromResult(resourcePathname != null);
 	}
+
+	private static Task<string[]> GetFilesInPackage(string[]? extensionsFilter)
+	{
+		string[] files = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*", SearchOption.AllDirectories);
+
+		var results = files?.ToList()
+			.Where(e => extensionsFilter == null || extensionsFilter.Any(filter => e.EndsWith(filter, StringComparison.OrdinalIgnoreCase)))
+			.ToArray() ?? Array.Empty<string>();
+
+		return Task.FromResult(results);
+	}
 }

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.iOSmacOS.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.iOSmacOS.cs
@@ -23,12 +23,13 @@ partial class StorageFileHelper
 		return Task.FromResult(resourcePathname != null);
 	}
 
-	private static Task<string[]> GetFilesInPackage(string[]? extensionsFilter)
+	private static Task<string[]> GetFilesInDirectory(Func<string, bool> predicate)
 	{
-		string[] files = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*", SearchOption.AllDirectories);
+		string rootPath = AppDomain.CurrentDomain.BaseDirectory;
+		string[] files = Directory.GetFiles(rootPath, "*", SearchOption.AllDirectories);
 
-		var results = files?.ToList()
-			.Where(e => extensionsFilter == null || extensionsFilter.Any(filter => e.EndsWith(filter, StringComparison.OrdinalIgnoreCase)))
+		var results = files?.Where(e => predicate(e))
+			.Select(e => e.Replace(rootPath, string.Empty).Replace('\\', '/'))
 			.ToArray() ?? Array.Empty<string>();
 
 		return Task.FromResult(results);

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.wasm.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.wasm.cs
@@ -15,6 +15,11 @@ partial class StorageFileHelper
 		return assets?.Contains(fileName) ?? false;
 	}
 
+	/// <summary>
+	/// Retrieves the paths of assets within the current application based on the specified filter predicate.
+	/// </summary>
+	/// <param name="predicate">A predicate function determining whether a file should be included in the result.</param>
+	/// <returns>Returns an array of strings containing the paths of the filtered assets.</returns>
 	private static async Task<string[]> GetFilesInDirectory(Func<string, bool> predicate)
 	{
 		var assets = await AssetsManager.Assets.Value;

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.wasm.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.wasm.cs
@@ -12,4 +12,12 @@ partial class StorageFileHelper
 		var assets = await AssetsManager.Assets.Value;
 		return assets?.Contains(fileName) ?? false;
 	}
+
+	private static async Task<string[]> GetFilesInPackage(string[]? extensionsFilter)
+	{
+		var assets = await AssetsManager.Assets.Value;
+		return assets?.ToList()
+						.Where(e => extensionsFilter == null || extensionsFilter.Any(filter => e.EndsWith(filter, StringComparison.OrdinalIgnoreCase)))
+						.ToArray() ?? Array.Empty<string>();
+	}
 }

--- a/src/Uno.UI.Toolkit/Storage/StorageFileHelper.wasm.cs
+++ b/src/Uno.UI.Toolkit/Storage/StorageFileHelper.wasm.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage.Helpers;
@@ -13,11 +15,12 @@ partial class StorageFileHelper
 		return assets?.Contains(fileName) ?? false;
 	}
 
-	private static async Task<string[]> GetFilesInPackage(string[]? extensionsFilter)
+	private static async Task<string[]> GetFilesInDirectory(Func<string, bool> predicate)
 	{
 		var assets = await AssetsManager.Assets.Value;
-		return assets?.ToList()
-						.Where(e => extensionsFilter == null || extensionsFilter.Any(filter => e.EndsWith(filter, StringComparison.OrdinalIgnoreCase)))
-						.ToArray() ?? Array.Empty<string>();
+
+		return assets?.Where(e => predicate(e))
+			.Select(e => e.Replace('\\', '/'))
+			.ToArray() ?? Array.Empty<string>();
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #


## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

The StorageFileHelper  just have one method for Determines if an asset or resource exists within application package.
But could be a nice feature to retrieves the paths of files within a directory.

## What is the new behavior?

So this PR is for allow to retrieves the paths of files within a directory based on a specified filter for file extensions (If null, all files in the directory are considered.)
And the result is an array of strings containing the paths of the filtered files within the directory.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
