### PR TITLE
fix(reg): Fix SelectorItem remains in pressed state when srcolling kicks-in

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -81,9 +81,12 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			// of a PointerPressed is a child that captures the pointer and may handle Pointer<Released/Exited|Canceled>
 			// without handling PointerPressed. In that case we wouldn't receive a PointerPressed without
 			// a matching Pointer<Released|Exited|Canceled> without handledEventsToo.
+			// Note: we also subscribe to PointerCaptureLostEvent to cleanup state also when pointer is canceled by scroller
+			//		 (i.e. with CanceledByDirectManipulation, in that case we only raise a CaptureLost event, not cancelled).
 			AddHandler(PointerReleasedEvent, _onPointerReleased, handledEventsToo: true);
 			AddHandler(PointerExitedEvent, _onPointerExitedOrCanceled, handledEventsToo: true);
 			AddHandler(PointerCanceledEvent, _onPointerExitedOrCanceled, handledEventsToo: true);
+			AddHandler(PointerCaptureLostEvent, _onPointerExitedOrCanceled, handledEventsToo: true);
 		}
 
 		private protected Selector Selector => ItemsControl.ItemsControlFromItemContainer(this) as Selector;


### PR DESCRIPTION
## Bugfix [REGRESSION]
Fix SelectorItem remains in pressed state when srcolling kicks-in on mobile targets using touch

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
