### PR TITLE
Hot Restart fixes

### DIFF
--- a/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
+++ b/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
@@ -43,4 +43,11 @@
           Condition="!exists('$(OutputPath)\Assets\SharedAssets.md')" />
   </Target>
 
+  <!-- fail the build if a BundleResource.LogicalName contains a rooted path -->
+  <Target Name="ValidateBundleResourceLogicalName" AfterTargets="AfterBuild">
+    <Error 
+      Condition="'%(BundleResource.LogicalName)' != '' And $([System.IO.Path]::IsPathRooted('%(BundleResource.LogicalName)'))" 
+      Text="BundleResource.LogicalName must not contain a rooted path" />
+  </Target>
+
 </Project>

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -152,7 +152,7 @@
 							TargetPlatform="$(XamarinProjectType)"
 							DefaultLanguage="$(DefaultLanguage)"
 							IntermediateOutputPath="$(IntermediateOutputPath)"
-							ContentItems="@(Content);@(_SourceItemsToCopyToOutputDirectory)"
+							ContentItems="@(ContentWithTargetPath);@(_SourceItemsToCopyToOutputDirectory)"
 							AndroidAssetsPrefix="$(MonoAndroidAssetsPrefix)"
 							IosAppManifest="$(_UnoIosAppManifest)"
 							Condition="'$(XamarinProjectType)'!=''">

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -134,12 +134,14 @@
 		<ItemGroup Condition="'$(ProjectTypeGuids)'!=''">
 			<!-- Xamarin-based targets which don't set RuntimeCopyLocalItems must use  -->
 			<_UnoPriFiles Include="@(Reference->'%(RootDir)%(Directory)%(Filename).uprimarker')"
-						  Condition="$([System.IO.File]::Exists('%(RootDir)%(Directory)%(Filename).uprimarker'))"/>
+						  Condition="$([System.IO.File]::Exists('%(RootDir)%(Directory)%(Filename).uprimarker'))"
+						  PublishFolderType="None" />
 		</ItemGroup>
 
 		<ItemGroup Condition="'$(ProjectTypeGuids)'==''">
 			<_UnoPriFiles Include="@(RuntimeCopyLocalItems->'%(RootDir)%(Directory)%(Filename).uprimarker')"
-						  Condition="$([System.IO.File]::Exists('%(RootDir)%(Directory)%(Filename).uprimarker'))"/>
+						  Condition="$([System.IO.File]::Exists('%(RootDir)%(Directory)%(Filename).uprimarker'))"
+						  PublishFolderType="None" />
 		</ItemGroup>
 
 		<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/463

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Ensures that PublishFolderType is set to avoid `The file XXX does not specify a 'PublishFolderType' metadata, and a default value could not be calculated. The file will not be copied to the app bundle.`
- Ensures that assets generation properly sets and uses the `TargetPath` property to avoid HotRestart to write incorrect file paths