### PR TITLE
fix: Adjust sdk invalid globbing

### DIFF
--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -19,8 +19,8 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(PlatformsProjectFolder) != '' and Exists($(PlatformsProjectFolder))">
-		<_TargetPlatformFiles Include="$([System.IO.Path]::Combine('$(DesktopProjectFolder)', '**', '*'))" />
-		<_AllPlatformFiles Include="$([System.IO.Path]::Combine('$(PlatformsProjectFolder)', '**', '*'))" />
+		<_TargetPlatformFiles Include="$(DesktopProjectFolder)/**/*" />
+		<_AllPlatformFiles Include="$(PlatformsProjectFolder)/**/*" />
 		<_IgnorePlatformFiles Include="@(_AllPlatformFiles)" Exclude="@(_TargetPlatformFiles)" />
 		<Compile Remove="@(_IgnorePlatformFiles)" />
 		<Content Remove="@(_IgnorePlatformFiles)" />


### PR DESCRIPTION
Avoids this particular visual glitch:

![image](https://github.com/unoplatform/uno/assets/5839577/6b4bf0d7-52c2-47b0-9016-b963f108156c)
