### PR TITLE
Add missing Uno.Toolkit.Skia.WinUI reference

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
@@ -33,6 +33,7 @@
 
 	<ItemGroup Condition="$(UnoFeatures.Contains(';Toolkit;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Toolkit.WinUI" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Uno.Toolkit.Skia.WinUI" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Skia;'))" />
 		<_UnoProjectSystemPackageReference Include="Uno.Toolkit.WinUI.Cupertino" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Cupertino;'))" />
 		<_UnoProjectSystemPackageReference Include="Uno.Toolkit.WinUI.Material" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Material;'))" />
 		<_UnoProjectSystemPackageReference Include="Uno.Toolkit.WinUI.Material.Markup" ProjectSystem="true" Condition="$(UnoFeatures.Contains(';Material;')) AND $(UnoFeatures.Contains(';CSharpMarkup;'))" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- Teams discussion

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Uno.Toolkit.Skia.WinUI is not brought in

## What is the new behavior?

Uno.Toolkit.Skia.WinUI is now brought in with the Skia and Toolkit UnoFeatures
