### PR TITLE
feat(sdk): Add support for Apple Privacy Manifest

### DIFF
--- a/build/cSpell.json
+++ b/build/cSpell.json
@@ -186,7 +186,8 @@
 	"winapp",
 	"wapproj's",
 	"xamlmerge",
-	"xbind"
+	"xbind",
+	"xcprivacy"
   ],
   "patterns": [
 	{

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -244,9 +244,9 @@ As discussed above setting `EnableDefaultUnoItems` to false will disable these i
 
 ## Apple Privacy Manifest Support
 
-Apple is introducing a [Privacy Manifest file](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) (named `PrivacyInfo.xcprivacy`) that needs to be included as of May 1st 2024.
+Starting May 1st, 2024, Apple requires the inclusion of a new file, the [Privacy Manifest file](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) (named `PrivacyInfo.xcprivacy`), in app bundles. This file is crucial for complying with updated privacy regulations.
 
-The Uno.Sdk (5.2 or later) automatically includes the `Platforms/iOS/PrivacyInfo.xcprivacy` file in the app bundle. You can find an example of this file in the [Uno.Templates](https://aka.platform.uno/apple-privacy-manifest-sample) repository.
+For projects using the Uno.Sdk (version 5.2 or later), the `Platforms/iOS/PrivacyInfo.xcprivacy` file is automatically integrated within the app bundle. An example of this manifest file can be found in the [Uno.Templates](https://aka.platform.uno/apple-privacy-manifest-sample) repository.
 
 For more information on how to include privacy entries in this file, see the [Microsoft .NET documentation](https://learn.microsoft.com/dotnet/maui/ios/privacy-manifest) on the subject, as well as [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
 

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -241,3 +241,20 @@ By Default when using the Uno.Sdk you get the added benefit of default includes 
 - `*.Android.cs`
 
 As discussed above setting `EnableDefaultUnoItems` to false will disable these includes.
+
+## Apple Privacy Manifest Support
+
+Apple is introducing a [Privacy Manifest file](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) (named `PrivacyInfo.xcprivacy`) that needs to be included as of May 1st 2024.
+
+The Uno.Sdk (5.2 or later) automatically includes the `Platforms/iOS/PrivacyInfo.xcprivacy` file in the app bundle. You can find an example of this file in the [Uno.Templates](https://aka.platform.uno/apple-privacy-manifest-sample) repository
+
+For more information on how to include privacy entries in this file, see the [Microsoft .NET documentation](https://learn.microsoft.com/en-us/dotnet/maui/ios/privacy-manifest) on the subject, as well as [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
+
+> [!NOTE]
+> If your application is not using the Uno Platform 5.1 or earlier, you can include the file using the following:
+>
+> ```xml
+>  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">
+>    <BundleResource Include="iOS\PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
+>  </ItemGroup>
+> ```

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -248,10 +248,10 @@ Apple is introducing a [Privacy Manifest file](https://developer.apple.com/docum
 
 The Uno.Sdk (5.2 or later) automatically includes the `Platforms/iOS/PrivacyInfo.xcprivacy` file in the app bundle. You can find an example of this file in the [Uno.Templates](https://aka.platform.uno/apple-privacy-manifest-sample) repository
 
-For more information on how to include privacy entries in this file, see the [Microsoft .NET documentation](https://learn.microsoft.com/en-us/dotnet/maui/ios/privacy-manifest) on the subject, as well as [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
+For more information on how to include privacy entries in this file, see the [Microsoft .NET documentation](https://learn.microsoft.com/dotnet/maui/ios/privacy-manifest) on the subject, as well as [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
 
 > [!NOTE]
-> If your application is not using the Uno Platform 5.1 or earlier, you can include the file using the following:
+> If your application is using the Uno Platform 5.1 or earlier, or is not using the Uno.Sdk, you can include the file using the following:
 >
 > ```xml
 >  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -246,7 +246,7 @@ As discussed above setting `EnableDefaultUnoItems` to false will disable these i
 
 Apple is introducing a [Privacy Manifest file](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) (named `PrivacyInfo.xcprivacy`) that needs to be included as of May 1st 2024.
 
-The Uno.Sdk (5.2 or later) automatically includes the `Platforms/iOS/PrivacyInfo.xcprivacy` file in the app bundle. You can find an example of this file in the [Uno.Templates](https://aka.platform.uno/apple-privacy-manifest-sample) repository
+The Uno.Sdk (5.2 or later) automatically includes the `Platforms/iOS/PrivacyInfo.xcprivacy` file in the app bundle. You can find an example of this file in the [Uno.Templates](https://aka.platform.uno/apple-privacy-manifest-sample) repository.
 
 For more information on how to include privacy entries in this file, see the [Microsoft .NET documentation](https://learn.microsoft.com/dotnet/maui/ios/privacy-manifest) on the subject, as well as [Apple's documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
 

--- a/src/SolutionTemplate/5.2/uno52blank/uno52blank/Platforms/iOS/PrivacyInfo.xcprivacy
+++ b/src/SolutionTemplate/5.2/uno52blank/uno52blank/Platforms/iOS/PrivacyInfo.xcprivacy
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<!-- see https://aka.platform/uno/apple-privacy-manifest for more information -->
+	
+	<!-- .NET Runtime/BCL -->
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>C617.1</string>
+		</array>
+	</dict>
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>35F9.1</string>
+		</array>
+	</dict>
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>E174.1</string>
+		</array>
+	</dict>
+
+	<!-- NSUserDefaults -->
+	<dict>
+		<key>NSPrivacyAccessedAPIType</key>
+		<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		<key>NSPrivacyAccessedAPITypeReasons</key>
+		<array>
+			<string>CA92.1</string>
+		</array>
+	</dict>
+</plist>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.iOS.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.iOS.targets
@@ -20,6 +20,16 @@
 		<SceneKitAsset Include="$(iOSProjectFolder)**/*.scnassets/*" Exclude="$(_SingleProjectiOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
 		<InterfaceDefinition Include="$(iOSProjectFolder)**/*.storyboard;$(iOSProjectFolder)**/*.xib" Exclude="$(_SingleProjectiOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
 		<BundleResource Include="$(iOSProjectFolder)Resources\**" Exclude="$(_SingleProjectiOSExcludes)" Link="%(RecursiveDir)%(FileName)%(Extension)" IsDefaultItem="true" />
+				
+		<!-- Apple privacy manifest support https://learn.microsoft.com/en-us/dotnet/maui/ios/privacy-manifest -->
+		<None 
+			Include="$(iOSProjectFolder)PrivacyInfo.xcprivacy"
+			LogicalName="PrivacyInfo.xcprivacy"
+			Condition="exists('$(iOSProjectFolder)PrivacyInfo.xcprivacy')" />
+		<BundleResource 
+			Include="$(iOSProjectFolder)PrivacyInfo.xcprivacy"
+			LogicalName="PrivacyInfo.xcprivacy"
+			Condition="exists('$(iOSProjectFolder)PrivacyInfo.xcprivacy')" />
 	</ItemGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)xamarin-ios-maccatalyst-workarounds.targets" />


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/discussions/16257, https://github.com/unoplatform/uno.templates/issues/639

Updates the SDK to automatically include a `PrivacyInfo.xcprivacy` file in the iOS platform folder.