### PR TITLE
docs: Add Samples & Tutorials Overview Page

### DIFF
--- a/doc/articles/samples-tutorials-overview.md
+++ b/doc/articles/samples-tutorials-overview.md
@@ -1,0 +1,39 @@
+---
+uid: Uno.SamplesTutorials.Overview
+---
+
+# Samples & Tutorials
+
+Welcome to the Uno Platform Samples & Tutorials section!
+
+Here, you'll find a collection of resources designed to help you learn and explore the capabilities of Uno Platform. Whether you're a beginner looking to get started with your first app, or an experienced developer seeking to expand your knowledge, we have something for everyone.
+
+## Getting Started
+
+[**Counter App Tutorial**](xref:Uno.Workshop.Counter): Learn the basics of Uno Platform by creating a simple counter app. There are four variants of the Counter tutorial, combining markup language ([XAML](https://learn.microsoft.com/en-us/visualstudio/xaml-tools/xaml-overview) or [C# Markup](xref:Uno.Extensions.Markup.Overview)) and presentation framework ([MVVM](https://learn.microsoft.com/en-us/windows/apps/develop/data-binding/data-binding-and-mvvm) or [MVUX](xref:Uno.Extensions.Mvux.Overview)).
+
+## Workshops
+
+Dive into these hands-on workshops that guide you through building applications with the Uno Platform.
+These workshops will help you learn more about the tools, libraries, and patterns available in the Uno Platform, which are there to help you rapidly build high-quality applications. Finally, these workshops have been set up to provide you with optional content, allowing you to tailor the experience to your needs.
+
+- [**SimpleCalc Workshop**](xref:Workshop.SimpleCalc.Overview): A step-by-step tutorial to build a fully functional calculator. There are four paths possible for this workshop, combining markup language ([XAML](https://learn.microsoft.com/en-us/visualstudio/xaml-tools/xaml-overview) or [C# Markup](xref:Uno.Extensions.Markup.Overview)) and presentation framework ([MVVM](https://learn.microsoft.com/en-us/windows/apps/develop/data-binding/data-binding-and-mvvm) or [MVUX](xref:Uno.Extensions.Mvux.Overview)).
+- [**TubePlayer Workshop**](xref:Workshop.TubePlayer.Overview): A step-by-step tutorial to build an app that allows the user to search for, and stream, YouTube videos. By the end of this workshop, you'll have built a multi-platform application using Uno Platform features like [C# Markup](xref:Uno.Extensions.Markup.Overview) and [MVUX](xref:Uno.Extensions.Mvux.Overview). You'll have the option to import a UI from [Figma](https://aka.platform.uno/uno-figma) or to continue following the steps to build the UI for the application.
+
+## In-Depth Tutorials
+
+Expand your skills with these in-depth tutorials.
+
+[**Tutorials Overview**](xref:Uno.Tutorials.Intro): A collection of tutorials to delve deeper into specific features and concepts that will show you how to use Uno Platform and solve specific problems.
+
+## Sample Projects
+
+Explore a range of sample projects showcasing the versatility of Uno Platform.
+
+[**Samples Repository**](xref:Uno.Samples): A curated list of sample projects that demonstrate various functionalities and use cases ranging from small single-feature samples to larger showcase applications.
+
+## Additional Resources
+
+Further your knowledge and discover more about Uno Platform.
+
+[**Next Steps in Learning**](xref:Uno.GetStarted.NextSteps): Resources for advancing your understanding of Uno Platform, including documentation, community links, and more.

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -50,7 +50,10 @@
         href: xref:Build.Solution.error-codes
 
 - name: Samples & Tutorials
+  topicHref: xref:Uno.SamplesTutorials.Overview
   items:
+    - name: Overview
+      href: xref:Uno.SamplesTutorials.Overview
     - name: Counter
       href: xref:Uno.Workshop.Counter
       items:
@@ -71,48 +74,49 @@
       topicHref: xref:Workshop.TubePlayer.Overview
       href: external/workshops/tube-player/toc.yml
     - name: Tutorials
+      topicHref: xref:Uno.Tutorials.Intro
       items:
       - name: Overview
-        href: tutorials-intro.md
+        href: xref:Uno.Tutorials.Intro
       - name: How to deploy a WebAssembly app on Azure Static Web Apps
-        href: guides/azure-static-webapps.md
+        href: xref:Uno.Tutorials.AzureStaticWepApps
       - name: How to use Windows Community Toolkit
-        href: uno-community-toolkit.md
+        href: xref:Uno.Development.CommunityToolkit
       - name: How to manually add a splash screen
         href: xref:Uno.Development.SplashScreen
       - name: How to use native Frame navigation
-        href: guides/native-frame-nav-tutorial.md
+        href: xref:Uno.Tutorials.UseNativeFrameNav
       - name: How to consume a web API
-        href: howto-consume-webservices.md
+        href: xref:Uno.Development.ConsumeWebApi
       - name: How to localize text resources
-        href: guides/localization.md
+        href: xref:Uno.Tutorials.Localization
       - name: How to change app language at runtime
-        href: guides/hotswap-app-language.md
+        href: xref:Uno.Tutorials.ChangeAppLanguage
       - name: How to integrate SignalR
-        href: signalr.md
+        href: xref:Uno.Development.SignalR
       - name: How to update StatusBar color based on dark/light theme
-        href: guides/status-bar-theme-color.md
+        href: xref:Uno.Tutorials.StatusBarThemeColor
       - name: How to use MSAL for Azure Authentication
-        href: interop/MSAL.md
+        href: xref:Uno.Interop.MSAL
       - name: How to authenticate with OpenID Connect
-        href: guides/open-id-connect.md
+        href: xref:Uno.Tutorials.OpenIDConnect
       - name: Embed a JavaScript Component
-        topicHref: interop/wasm-javascript-1.md
+        topicHref: xref:Uno.Interop.WasmJavaScript1
         items:
           - name: Part 1
-            href: interop/wasm-javascript-1.md
+            href: xref:Uno.Interop.WasmJavaScript1
           - name: Part 2
-            href: interop/wasm-javascript-2.md
+            href: xref:Uno.Interop.WasmJavaScript2
           - name: Part 3
-            href: interop/wasm-javascript-3.md
+            href: xref:Uno.Interop.WasmJavaScript3
       - name: Deploy to Raspberry Pi
-        href: guides/raspberry-pi/raspberry-pi-intro.md
+        href: xref:Uno.RaspberryPi.Intro
       - name: (Wasm) Handling custom HTML events
-        href: wasm-custom-events.md
+        href: xref:Uno.Development.WasmCustomEvents
       - name: Community Tutorials
-        topicHref: guides/community-tutorials.md
+        topicHref: xref:Uno.Tutorials.CommunityTutorials
     - name: Samples
-      href: external/uno.samples/doc/samples.md
+      href: xref:Uno.Samples
     - name: Additional Resources
       href: xref:Uno.GetStarted.NextSteps
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #16427

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## Description

Add `Samples & Tutorials` Overview Page in the documentation
