### PR TITLE
ci: Adjust issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -78,14 +78,13 @@ body:
         - WebAssembly
         - Android
         - iOS
-        - macOS (AppKit)
         - Mac Catalyst
         - Skia (WPF)
-        - Skia (GTK on Linux/macOS/Windows)
-        - Skia (Linux Framebuffer)
         - Skia (Linux X11)
         - Skia (macOS)
-        - Windows
+        - Skia (Linux Framebuffer)
+        - Skia (GTK)
+        - Windows (WinAppSDK)
         - Build tasks
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/documentation-request.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-request.yml
@@ -40,12 +40,13 @@ body:
         - WebAssembly
         - Android
         - iOS
-        - macOS (AppKit)
         - Mac Catalyst
         - Skia (WPF)
-        - Skia (GTK on Linux/macOS/Windows)
+        - Skia (Linux X11)
+        - Skia (macOS)
         - Skia (Linux Framebuffer)
-        - Windows
+        - Skia (GTK)
+        - Windows (WinAppSDK)
 
   - type: textarea
     id: docs-request-additional-info

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -23,12 +23,13 @@ body:
         - WebAssembly
         - Android
         - iOS
-        - macOS (AppKit)
         - Mac Catalyst
         - Skia (WPF)
-        - Skia (GTK on Linux/macOS/Windows)
+        - Skia (Linux X11)
+        - Skia (macOS)
         - Skia (Linux Framebuffer)
-        - Windows
+        - Skia (GTK)
+        - Windows (WinAppSDK)
         - Build tasks
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/samples-request.yml
+++ b/.github/ISSUE_TEMPLATE/samples-request.yml
@@ -25,12 +25,13 @@ body:
         - WebAssembly
         - Android
         - iOS
-        - macOS (AppKit)
         - Mac Catalyst
         - Skia (WPF)
-        - Skia (GTK on Linux/macOS/Windows)
+        - Skia (Linux X11)
+        - Skia (macOS)
         - Skia (Linux Framebuffer)
-        - Windows
+        - Skia (GTK)
+        - Windows (WinAppSDK)
 
   - type: textarea
     id: samples-request-additional-info


### PR DESCRIPTION
Dropping macOS (AppKit) from the list and moving Skia (GTK) to the bottom. Replicating the list on all issue templates.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

- The platform list was not consistent everywhere
- macOS AppKit is not really supported

## What is the new behavior?

Adjusted

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
