### PR TITLE
fix(itemsRepeater): Fix an issue where IR might re-position first items if items below are significantly taller

### DIFF
--- a/src/SamplesApp/UITests.Shared/ItemExclusions.props
+++ b/src/SamplesApp/UITests.Shared/ItemExclusions.props
@@ -13,6 +13,11 @@
 		<Compile Remove="$(MSBuildThisFileDirectory)Windows_Phone\**" />
 		<None Include="$(MSBuildThisFileDirectory)Windows_Phone\**" />
 
+		<Page Remove="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Repeater\FlowLayout_Simple.xaml" />
+		<Compile Remove="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Repeater\FlowLayout_Simple.xaml.cs" />
+		<None Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Repeater\FlowLayout_Simple.xaml" />
+		<None Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Repeater\FlowLayout_Simple.xaml.cs" />
+
 		<Page Remove="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\PagerControlTests\**" />
 		<Compile Remove="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\PagerControlTests\**" />
 		<None Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\PagerControlTests\**" />

--- a/src/SamplesApp/UITests.Shared/ItemExclusions.props
+++ b/src/SamplesApp/UITests.Shared/ItemExclusions.props
@@ -17,10 +17,6 @@
 		<Compile Remove="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\PagerControlTests\**" />
 		<None Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\PagerControlTests\**" />
 
-		<Page Remove="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Repeater\**" />
-		<Compile Remove="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Repeater\**" />
-		<None Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Repeater\**" />
-
 		<Page Remove="$(MSBuildThisFileDirectory)Lottie\**" />
 		<Compile Remove="$(MSBuildThisFileDirectory)Lottie\**" />
 		<None Include="$(MSBuildThisFileDirectory)Lottie\**" />

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ItemsViewTests/ItemsViewSummaryPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ItemsViewTests/ItemsViewSummaryPage.xaml.cs
@@ -18,8 +18,9 @@ using Windows.Foundation;
 
 namespace UITests.Microsoft_UI_Xaml_Controls.ItemsViewTests;
 
-// Samples times out on iOS.
+#if DEBUG || !__IOS__ // Samples times out on iOS.
 [Sample("ItemsView", IgnoreInSnapshotTests = true)]
+#endif
 public sealed partial class ItemsViewSummaryPage : Page
 {
 	private enum QueuedOperationType

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/FlowLayout_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/FlowLayout_Simple.xaml.cs
@@ -39,7 +39,7 @@ namespace UITests.Windows_UI_Xaml_Controls.Repeater
 
 		private void Tree(object server, RoutedEventArgs routedEventArgs)
 		{
-#if HAS_UNO || HAS_UNO_WINUI
+#if !WINAPPSDK && (HAS_UNO || HAS_UNO_WINUI)
 
 			var txt = this.ShowLocalVisualTree(0);
 			Console.WriteLine(txt);

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/StackLayout_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/StackLayout_Simple.xaml.cs
@@ -39,7 +39,7 @@ namespace UITests.Windows_UI_Xaml_Controls.Repeater
 
 		private void Tree(object server, RoutedEventArgs routedEventArgs)
 		{
-#if HAS_UNO || HAS_UNO_WINUI
+#if !WINAPPSDK && (HAS_UNO || HAS_UNO_WINUI)
 			var txt = this.ShowLocalVisualTree(0);
 			Console.WriteLine(txt);
 #endif

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/UniformGridLayout_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/UniformGridLayout_Simple.xaml.cs
@@ -39,7 +39,7 @@ namespace UITests.Windows_UI_Xaml_Controls.Repeater
 
 		private void Tree(object server, RoutedEventArgs routedEventArgs)
 		{
-#if HAS_UNO || HAS_UNO_WINUI
+#if !WINAPPSDK && (HAS_UNO || HAS_UNO_WINUI)
 			var txt = this.ShowLocalVisualTree(0);
 			Console.WriteLine(txt);
 #endif

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/TestUI/Samples/AnimationSamples/DefaultElementAnimator.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/Repeater/TestUI/Samples/AnimationSamples/DefaultElementAnimator.cs
@@ -92,6 +92,7 @@ namespace MUXControlsTestApp.Utils
 
 		protected override void StartBoundsChangeAnimation(UIElement element, AnimationContext context, Rect oldBounds, Rect newBounds)
 		{
+#if false // CreateVector2KeyFrameAnimation not supported by uno yet
 			var visual = ElementCompositionPreview.GetElementVisual(element);
 			var compositor = visual.Compositor;
 			var batch = compositor.CreateScopedBatch(CompositionBatchTypes.Animation);
@@ -125,6 +126,7 @@ namespace MUXControlsTestApp.Utils
 				DefaultAnimationDurationInMs * ((HasHideAnimationsPending ? 1 : 0) + 1) * AnimationSlowdownFactor);
 
 			visual.StartAnimation("TransformMatrix._41_42", offsetAnimation);
+#endif
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -435,6 +435,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 		[RunsOnUIThread]
 #if __MACOS__
 		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#elif !__SKIA__
+		[Ignore("Fails due to async native scrolling.")]
 #endif
 		public async Task When_ItemSignificantlyHigher_Then_VirtualizeProperly()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -438,7 +438,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 #elif !__SKIA__
 		[Ignore("Fails due to async native scrolling.")]
 #endif
-		public async Task When_ItemSignificantlyHigher_Then_VirtualizeProperly()
+		public async Task When_ItemSignificantlyTaller_Then_VirtualizeProperly()
 		{
 			var sut = SUT.Create(
 				new ObservableCollection<MyItem>
@@ -452,7 +452,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 				},
 				new DataTemplate(() => new Border
 				{
-					Width = 100,
+					Width = 120,
 					Margin = new Thickness(10),
 					Child = new ItemsControl
 					{
@@ -461,7 +461,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 				}
 				.Apply(b => b.SetBinding(FrameworkElement.HeightProperty, new Binding { Path = nameof(MyItem.Height) }))
 				.Apply(b => b.SetBinding(FrameworkElement.BackgroundProperty, new Binding { Path = nameof(MyItem.Color) }))),
-				new Size(100, 500)
+				new Size(120, 500)
 			);
 
 			await sut.Load();
@@ -489,8 +489,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 			var item3UpdatedVerticalOffset = sut.Repeater.Children.First(elt => ReferenceEquals(elt.DataContext, sut.Source[3])).ActualOffset.Y;
 
 			item3UpdatedVerticalOffset.Should().Be(item3OriginalVerticalOffset); // Confirm that item #3 has not been moved down
-			var result = await UITestHelper.ScreenShot(sut.Repeater);
-			ImageAssert.HasColorAt(result, 10, 10, Colors.FromARGB("#008000")); // For safety also check it's effectively the item 3 that is visible
+			var result = await UITestHelper.ScreenShot(sut.Root);
+			ImageAssert.HasColorAt(result, 100, 10, Colors.FromARGB("#008000")); // For safety also check it's effectively the item 3 that is visible
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -430,13 +430,82 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 			sut.Materialized.Should().Be(0);
 		}
 
-		private record SUT(Border Root, ScrollViewer Scroller, ItemsRepeater Repeater, ObservableCollection<string> Source)
+
+		[TestMethod]
+		[RunsOnUIThread]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#endif
+		public async Task When_ItemSignificantlyHigher_Then_VirtualizeProperly()
 		{
-			public static SUT Create(int itemsCount = 3, Size? viewport = default)
+			var sut = SUT.Create(
+				new ObservableCollection<MyItem>
+				{
+					new (0, 200, Colors.FromARGB("#FF0000")),
+					new (1, 400, Colors.FromARGB("#FF8000")),
+					new (2, 200, Colors.FromARGB("#FFFF00")),
+					new (3, 5000, Colors.FromARGB("#008000")),
+					new (4, 100, Colors.FromARGB("#0000FF")),
+					new (5, 100, Colors.FromARGB("#A000C0"))
+				},
+				new DataTemplate(() => new Border
+				{
+					Width = 100,
+					Margin = new Thickness(10),
+					Child = new TextBlock().Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding()))
+				}
+				.Apply(b => b.SetBinding(FrameworkElement.HeightProperty, new Binding{Path = nameof(MyItem.Height)}))
+				.Apply(b => b.SetBinding(FrameworkElement.BackgroundProperty, new Binding { Path = nameof(MyItem.Color) }))),
+				new Size(100, 500)
+			);
+
+			await sut.Load();
+			sut.Scroller.ViewChanged += (s, e) => Console.WriteLine($"Vertical: {sut.Scroller.VerticalOffset}");
+
+			var originalEstimatedExtent = sut.Scroller.ExtentHeight;
+
+			sut.Scroller.ChangeView(null, 800, null, disableAnimation: true); // First scroll enough to get item #3 to be materialized
+			await TestServices.WindowHelper.WaitForIdle();
+
+			sut.MaterializedItems.Should().Contain(sut.Source[3]); // Confirm that item has been materialized!
+			sut.Scroller.ExtentHeight.Should().BeGreaterThan(originalEstimatedExtent); // Confirm that the extent has increased due to item #3
+
+			var item3OriginalVerticalOffset = sut.Repeater.Children.First(elt => ReferenceEquals(elt.DataContext, sut.Source[3])).ActualOffset.Y;
+
+			sut.Scroller.ChangeView(null, 1500, null, disableAnimation: true); // Then scroll enough for first items to be DE-materialized
+			await TestServices.WindowHelper.WaitForIdle();
+
+			sut.MaterializedItems.Should().NotContain(sut.Source[0]); // Confirm that first items has been removed!
+			sut.MaterializedItems.Should().NotContain(sut.Source[1]);
+
+			var item3UpdatedVerticalOffset = sut.Repeater.Children.First(elt => ReferenceEquals(elt.DataContext, sut.Source[3])).ActualOffset.Y;
+
+			item3UpdatedVerticalOffset.Should().Be(item3OriginalVerticalOffset); // Confirm that item #3 has not been moved down
+			var result = await UITestHelper.ScreenShot(sut.Repeater);
+			ImageAssert.HasColorAt(result, 10, 10, Colors.FromARGB("#008000")); // For safety also check it's effectively the item 3 that is visible
+		}
+
+		private record MyItem(int Id, double Height, Color Color)
+		{
+			public string Title => $"Item {Id}";
+		}
+
+#nullable enable
+		private static class SUT
+		{
+			public static SUT<T> Create<T>(ObservableCollection<T> source, DataTemplate? itemTemplate = null, Size? viewport = default)
 			{
+				itemTemplate ??= new DataTemplate(() => new Border
+				{
+					Width = 100,
+					Height = 100,
+					Background = new SolidColorBrush(Colors.DeepSkyBlue),
+					Margin = new Thickness(10),
+					Child = new TextBlock().Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding()))
+				});
+
 				var repeater = default(ItemsRepeater);
 				var scroller = default(ScrollViewer);
-				var source = new ObservableCollection<string>(Enumerable.Range(0, itemsCount).Select(i => $"Item #{i}"));
 				var root = new Border
 				{
 					BorderThickness = new Thickness(5),
@@ -447,14 +516,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 						{
 							ItemsSource = source,
 							Layout = new StackLayout(),
-							ItemTemplate = new DataTemplate(() => new Border
-							{
-								Width = 100,
-								Height = 100,
-								Background = new SolidColorBrush(Colors.DeepSkyBlue),
-								Margin = new Thickness(10),
-								Child = new TextBlock().Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding()))
-							})
+							ItemTemplate = itemTemplate
 						})
 					})
 				};
@@ -468,9 +530,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 				return new(root, scroller, repeater, source);
 			}
 
+			public static SUT<string> Create(int itemsCount = 3, Size? viewport = default)
+				=> Create(new ObservableCollection<string>(Enumerable.Range(0, itemsCount).Select(i => $"Item #{i}")), viewport: viewport);
+		}
+
+		private record SUT<T>(Border Root, ScrollViewer Scroller, ItemsRepeater Repeater, ObservableCollection<T> Source)
+		{
 			public int Materialized => Repeater.Children.Count(elt => elt.ActualOffset.X >= 0);
 
-			public IEnumerable<string> MaterializedItems => Repeater.Children.Where(elt => elt.ActualOffset.X >= 0).Select(elt => elt.DataContext?.ToString());
+			public IEnumerable<T> MaterializedItems => Repeater.Children.Where(elt => elt.ActualOffset.X >= 0).Select(elt => (T)elt.DataContext);
 
 			public async ValueTask Load()
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -454,7 +454,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 					Margin = new Thickness(10),
 					Child = new TextBlock().Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding()))
 				}
-				.Apply(b => b.SetBinding(FrameworkElement.HeightProperty, new Binding{Path = nameof(MyItem.Height)}))
+				.Apply(b => b.SetBinding(FrameworkElement.HeightProperty, new Binding { Path = nameof(MyItem.Height) }))
 				.Apply(b => b.SetBinding(FrameworkElement.BackgroundProperty, new Binding { Path = nameof(MyItem.Color) }))),
 				new Size(100, 500)
 			);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Repeater/Given_ItemsRepeater.cs
@@ -454,7 +454,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 				{
 					Width = 100,
 					Margin = new Thickness(10),
-					Child = new TextBlock().Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding()))
+					Child = new ItemsControl
+					{
+						ItemTemplate = new DataTemplate(() => new TextBlock().Apply(tb => tb.SetBinding(TextBlock.TextProperty, new Binding())))
+					}.Apply(tb => tb.SetBinding(ItemsControl.ItemsSourceProperty, new Binding { Path = nameof(MyItem.Lines) }))
 				}
 				.Apply(b => b.SetBinding(FrameworkElement.HeightProperty, new Binding { Path = nameof(MyItem.Height) }))
 				.Apply(b => b.SetBinding(FrameworkElement.BackgroundProperty, new Binding { Path = nameof(MyItem.Color) }))),
@@ -480,6 +483,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 			sut.MaterializedItems.Should().NotContain(sut.Source[0]); // Confirm that first items has been removed!
 			sut.MaterializedItems.Should().NotContain(sut.Source[1]);
 
+			sut.Scroller.ChangeView(null, 2940, null, disableAnimation: true); // Then scroll enough for first items to be DE-materialized
+			await TestServices.WindowHelper.WaitForIdle();
+
 			var item3UpdatedVerticalOffset = sut.Repeater.Children.First(elt => ReferenceEquals(elt.DataContext, sut.Source[3])).ActualOffset.Y;
 
 			item3UpdatedVerticalOffset.Should().Be(item3OriginalVerticalOffset); // Confirm that item #3 has not been moved down
@@ -487,9 +493,43 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 			ImageAssert.HasColorAt(result, 10, 10, Colors.FromARGB("#008000")); // For safety also check it's effectively the item 3 that is visible
 		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+#if __MACOS__
+		[Ignore("Currently fails on macOS, part of #9282 epic")]
+#elif !__SKIA__
+		[Ignore("Fails due to async native scrolling.")]
+#endif
+		public async Task When_UnloadReload_Then_MaterializeItemsForCurrentViewport()
+		{
+			var sut = SUT.Create(30, new Size(100, 500));
+
+			await sut.Load();
+
+			// Only few first items should have been materialized so far
+			sut.MaterializedItems.Should().Contain(sut.Source[0]);
+			sut.MaterializedItems.Should().Contain(sut.Source[5]);
+			sut.MaterializedItems.Should().NotContain(sut.Source[10]);
+			sut.MaterializedItems.Should().NotContain(sut.Source[15]);
+
+			await sut.Unload();
+			await sut.Load();
+
+			// Confirm that first items has been re-materialized
+			sut.MaterializedItems.Should().Contain(sut.Source[0]);
+			sut.MaterializedItems.Should().Contain(sut.Source[5]);
+			sut.MaterializedItems.Should().NotContain(sut.Source[10]);
+			sut.MaterializedItems.Should().NotContain(sut.Source[15]);
+
+			// Item 0 should be at offset 0
+			sut.MaterializedElements.OrderBy(e => e.DataContext).First().LayoutSlot.Y.Should().Be(0, "Item #0 should be at the origin of the IR (negative offset means we are in trouble!)");
+		}
+
 		private record MyItem(int Id, double Height, Color Color)
 		{
 			public string Title => $"Item {Id}";
+
+			public string[] Lines { get; } = Enumerable.Range(0, (int)(Height / 10)).Select(i => $"Line {i:D3}").ToArray();
 		}
 
 #nullable enable
@@ -540,7 +580,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.Repeater
 		{
 			public int Materialized => Repeater.Children.Count(elt => elt.ActualOffset.X >= 0);
 
-			public IEnumerable<T> MaterializedItems => Repeater.Children.Where(elt => elt.ActualOffset.X >= 0).Select(elt => (T)elt.DataContext);
+			public IEnumerable<T> MaterializedItems => MaterializedElements.Select(elt => (T)elt.DataContext);
+
+			public IEnumerable<UIElement> MaterializedElements => Repeater.Children.Where(elt => elt.ActualOffset.X >= 0);
 
 			public async ValueTask Load()
 			{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayout.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayout.cs
@@ -144,8 +144,12 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 					realizationWindowOffsetInExtent + MajorSize(realizationRect) >= 0 && realizationWindowOffsetInExtent <= majorSize)
 				{
 					anchorIndex = (int)(realizationWindowOffsetInExtent / averageElementSize);
-					offset = anchorIndex * averageElementSize + MajorStart(lastExtent);
+					// Uno workaround [BEGIN]: Make sure items at index 0 is always at offset 0
 					anchorIndex = Math.Max(0, Math.Min(itemsCount - 1, anchorIndex));
+					// Uno workaround [END]
+
+					offset = anchorIndex * averageElementSize + MajorStart(lastExtent);
+					//anchorIndex = Math.Max(0, Math.Min(itemsCount - 1, anchorIndex)); // Line moved before computation of the offset for uno
 				}
 			}
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayout.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayout.cs
@@ -176,7 +176,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 				if (firstRealized != null)
 				{
 					MUX_ASSERT(lastRealized != null);
-					SetMajorStart(ref extent, (float)(MajorStart(firstRealizedLayoutBounds) - firstRealizedItemIndex * averageElementSize));
+					var firstRealizedMajor = (float)(MajorStart(firstRealizedLayoutBounds) - firstRealizedItemIndex * averageElementSize);
+					// Uno workaround [BEGIN]: Make sure to not move items above the viewport. This can be the case if an items is significantly higher than previous items (will increase the average items size)
+					firstRealizedMajor = Math.Max(0.0f, firstRealizedMajor);
+					// Uno workaround [END]
+					SetMajorStart(ref extent, firstRealizedMajor);
 					var remainingItems = itemsCount - lastRealizedItemIndex - 1;
 					SetMajorSize(ref extent, MajorEnd(lastRealizedLayoutBounds) - MajorStart(extent) + (float)(remainingItems * averageElementSize));
 				}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/16176

Restore https://github.com/unoplatform/uno/pull/15946 that was reverted by https://github.com/unoplatform/uno/pull/16253 due to the regression reported by https://github.com/unoplatform/uno/issues/16176

This adds a patch over the previous patch to workaround the found regression: https://github.com/unoplatform/uno/pull/16472/commits/5538eea0774a122d8cf3b938997148134680aaae

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [?] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
