### PR TITLE
fix: Adjust desktop hot load under linux

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/MetadataUpdater/HotReloadAgent.cs
@@ -71,24 +71,34 @@ internal sealed class HotReloadAgent : IDisposable
 		var handlerActions = new UpdateHandlerActions();
 		foreach (var assembly in sortedAssemblies)
 		{
-			foreach (var attr in assembly.GetCustomAttributesData())
+			try
 			{
-				// Look up the attribute by name rather than by type. This would allow netstandard targeting libraries to
-				// define their own copy without having to cross-compile.
-				if (attr.AttributeType.FullName != "System.Reflection.Metadata.MetadataUpdateHandlerAttribute")
+				foreach (var attr in assembly.GetCustomAttributesData())
 				{
-					continue;
-				}
+					// Look up the attribute by name rather than by type. This would allow netstandard targeting libraries to
+					// define their own copy without having to cross-compile.
+					if (attr.AttributeType.FullName != "System.Reflection.Metadata.MetadataUpdateHandlerAttribute")
+					{
+						continue;
+					}
 
-				IList<CustomAttributeTypedArgument> ctorArgs = attr.ConstructorArguments;
-				if (ctorArgs.Count != 1 ||
-					ctorArgs[0].Value is not Type handlerType)
-				{
-					_log($"'{attr}' found with invalid arguments.");
-					continue;
-				}
+					IList<CustomAttributeTypedArgument> ctorArgs = attr.ConstructorArguments;
+					if (ctorArgs.Count != 1 ||
+						ctorArgs[0].Value is not Type handlerType)
+					{
+						_log($"'{attr}' found with invalid arguments.");
+						continue;
+					}
 
-				GetHandlerActions(handlerActions, handlerType);
+					GetHandlerActions(handlerActions, handlerType);
+				}
+			}
+			catch (Exception e)
+			{
+				// The handlers enumeration may fail for WPF assemblies that are part of the modified assemblies
+				// when building under linux, but which are loaded in that context. We can ignore those assemblies
+				// and continue the processing.
+				_log($"Unable to process assembly {assembly}, ({e.Message})");
 			}
 		}
 


### PR DESCRIPTION
This change ensures that delta updates do not fail on missing assemblies, which can happen when performing HR reload on linux and HR picks up WPF assemblies that are not loaded in the current process.