### PR TITLE
fix: Don't fail build on an empty library

### DIFF
--- a/src/SolutionTemplate/5.2/uno52AppWithLib/uno52AppWithLib/uno52AppWithLib.csproj
+++ b/src/SolutionTemplate/5.2/uno52AppWithLib/uno52AppWithLib/uno52AppWithLib.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../uno52lib/uno52lib.csproj" />
+    <ProjectReference Include="../uno52emptylib/uno52emptylib.csproj" />
   </ItemGroup>
 
   <Target Name="_UnoValidateSelfAssets"

--- a/src/SolutionTemplate/5.2/uno52AppWithLib/uno52emptylib/uno52emptylib.csproj
+++ b/src/SolutionTemplate/5.2/uno52AppWithLib/uno52emptylib/uno52emptylib.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Uno.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-browserwasm;net8.0-desktop;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+
+    <UnoSingleProject>true</UnoSingleProject>
+    <OutputType>Library</OutputType>
+    <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!--
+      UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.
+      https://aka.platform.uno/singleproject-features
+    -->
+    <!--
+    <UnoFeatures></UnoFeatures>
+    -->
+  </PropertyGroup>
+
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+    <!--
+    If you encounter this error message:
+
+      error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
+      Please update to a newer .NET SDK in order to reference this assembly.
+
+    This means that the two packages below must be aligned with the "build" version number of
+    the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
+    must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
+    -->
+    <!-- <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" /> -->
+  </ItemGroup>
+</Project>

--- a/src/Uno.Sdk/targets/Uno.Common.Wasm.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Wasm.targets
@@ -42,7 +42,7 @@
 
 			See https://github.com/dotnet/sdk/blob/e3c62139dd25af2b7593a2cde702261f20822e47/src/StaticWebAssetsSdk/Sdk/Sdk.StaticWebAssets.StaticAssets.ProjectSystem.props#L36
 			-->
-			<_RemoveWebSDKConfigContent Include="@(Content)" Condition="$([System.String]::Copy(%(Content.DefiningProjectDirectory)).Contains('Microsoft.NET.Sdk.StaticWebAssets'))" />
+			<_RemoveWebSDKConfigContent Include="@(Content)" Condition="'%(Content.DefiningProjectDirectory)'!='' AND $([System.String]::Copy(%(Content.DefiningProjectDirectory)).Contains('Microsoft.NET.Sdk.StaticWebAssets'))" />
 			<Content Remove="@(_RemoveWebSDKConfigContent)" />
 			<_RemoveWebSDKConfigContent Remove="@(_RemoveWebSDKConfigContent)"/>
 		</ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/16524

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that a library without any eligible `Content` builds properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
