### PR TITLE
perf: Avoid boxing in ContainerVisual.SetMatrixDirty

### DIFF
--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -61,7 +61,9 @@ public partial class ContainerVisual : Visual
 	{
 		if (base.SetMatrixDirty())
 		{
-			foreach (var child in Children)
+			// We use InnerList to avoid boxing the enumerator.
+			// Currently, VisualCollection.GetEnumerator returns IEnumerator<Visual> instead of a concrete struct type to match WinUI API surface.
+			foreach (var child in Children.InnerList)
 			{
 				child.SetMatrixDirty();
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

The scenario being profiled is rapid window resizing, which will keep invalidating render.

Previously, this caused a lot of boxing and also SetMatrixDirty is taking up a lot of CPU time.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://github.com/unoplatform/uno/assets/31348972/4b162de7-19a6-4dc6-ab8e-714f966d8374)

![image](https://github.com/unoplatform/uno/assets/31348972/728bc3a2-96b2-4a04-b915-839479b08f3e)

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

![image](https://github.com/unoplatform/uno/assets/31348972/5ac838f1-9aab-4094-b646-48037b2dad05)

Boxings are gone completely, and SetMatrixDirty is taking much less CPU time.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
