### PR TITLE
fix(GridView): 1st item fails to render

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -307,12 +307,7 @@ namespace Microsoft.UI.Xaml.Controls
 					HorizontalContentAlignment = HorizontalAlignment.Stretch,
 					IsTabStop = false
 				};
-
-				VisualTreeHelper.AddChild(this, HeaderContentControl);
 			}
-
-			SetItemsPanel(panel);
-
 			if (FooterContentControl is null && HeaderFooterEnabled)
 			{
 				FooterContentControl = new ContentControl
@@ -324,9 +319,14 @@ namespace Microsoft.UI.Xaml.Controls
 					HorizontalContentAlignment = HorizontalAlignment.Stretch,
 					IsTabStop = false
 				};
-
-				VisualTreeHelper.AddChild(this, FooterContentControl);
 			}
+
+			// We want FooterContentControl to be assigned before calling SetItemsPanel,
+			// because it may directly cause an ArrangeOverride to be called in some cases,
+			// where the value is expected to be non-null.
+			if (HeaderContentControl is { }) { VisualTreeHelper.AddChild(this, HeaderContentControl); }
+			SetItemsPanel(panel);
+			if (FooterContentControl is { }) { VisualTreeHelper.AddChild(this, FooterContentControl); }
 		}
 
 		private void PropagateLayoutValues()
@@ -383,7 +383,7 @@ namespace Microsoft.UI.Xaml.Controls
 					if (view == _itemsPanel)
 					{
 						// the panel should stretch to a width big enough such that the footer is at the very right
-						var footerWidth = HeaderFooterEnabled ? GetElementDesiredSize(FooterContentControl).Width : 0;
+						var footerWidth = (HeaderFooterEnabled && FooterContentControl is { }) ? GetElementDesiredSize(FooterContentControl).Width : 0;
 						childRect.Width = childRect.Width.AtLeast(finalSize.Width - footerWidth - childRect.X);
 					}
 
@@ -399,7 +399,7 @@ namespace Microsoft.UI.Xaml.Controls
 					if (view == _itemsPanel)
 					{
 						// the panel should stretch to a height big enough such that the footer is at the very bottom
-						var footerHeight = HeaderFooterEnabled ? GetElementDesiredSize(FooterContentControl).Height : 0;
+						var footerHeight = (HeaderFooterEnabled && FooterContentControl is { }) ? GetElementDesiredSize(FooterContentControl).Height : 0;
 						childRect.Height = childRect.Height.AtLeast(finalSize.Height - footerHeight - childRect.Y);
 					}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #16441

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
GridView would fail to render 1st item in the collection.

## What is the new behavior?
^ no more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->