### PR TITLE
fix: Fix ExpressionAnimation not working well with CompositionPropertySet

### DIFF
--- a/src/Uno.UI.Composition/Composition/CompositionObject.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionObject.cs
@@ -52,10 +52,10 @@ namespace Microsoft.UI.Composition
 		// Overrides are based on:
 		// https://learn.microsoft.com/en-us/uwp/api/windows.ui.composition.compositionobject.startanimation?view=winrt-22621
 		internal virtual object GetAnimatableProperty(string propertyName, string subPropertyName)
-			=> TryGetFromProperties(_properties, propertyName, subPropertyName);
+			=> TryGetFromProperties(_properties ?? this as CompositionPropertySet, propertyName, subPropertyName);
 
 		private protected virtual void SetAnimatableProperty(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> subPropertyName, object? propertyValue)
-			=> TryUpdateFromProperties(_properties, propertyName, subPropertyName, propertyValue);
+			=> TryUpdateFromProperties(Properties, propertyName, subPropertyName, propertyValue);
 
 		public void StartAnimation(string propertyName, CompositionAnimation animation)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ExpressionAnimation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_ExpressionAnimation.cs
@@ -196,6 +196,9 @@ internal partial class Given_ExpressionAnimation
 
 	[TestMethod]
 	[UnoWorkItem("https://github.com/unoplatform/uno/issues/16570")]
+#if !__SKIA__
+	[Ignore("Only supported on Skia")]
+#endif
 	public async Task When_Animating_CompositionPropertySet()
 	{
 		var border = new Border()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #16570

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
