### PR TITLE
fix: Fix DragDrop not working properly with multi window

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/Extensions/WpfDragDropExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Extensions/WpfDragDropExtension.cs
@@ -85,6 +85,7 @@ namespace Uno.UI.Runtime.Skia.Wpf
 			var allowedOperations = ToDataPackageOperation(e.AllowedEffects);
 			var info = new CoreDragInfo(src, data.GetView(), allowedOperations);
 
+			// TODO: Adjust for multi window. Using GetForCurrentView doesn't look right.
 			CoreDragDropManager.GetForCurrentView()?.DragStarted(info);
 
 			// Note: No needs to _manager.ProcessMove, the DragStarted will actually have the same effect

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.DragDrop.cs
@@ -15,14 +15,16 @@ partial class InputManager
 	#region Drag and Drop
 	private DragRoot _dragRoot;
 
-	internal DragDropManager DragDrop { get; private set; }
+	internal CoreDragDropManager CoreDragDrop { get; private set; }
+
+	internal CoreDragDropManager.IDragDropManager DragDrop => CoreDragDrop.DragDrop;
 
 	private void InitDragAndDrop()
 	{
-		var coreManager = CoreDragDropManager.CreateForCurrentView(); // So it's ready to be accessed by ui manager and platform extension
-		var uiManager = DragDrop = new DragDropManager(this);
+		CoreDragDrop = CoreDragDropManager.CreateForCurrentView(); // So it's ready to be accessed by ui manager and platform extension
+		var uiManager = new DragDropManager(this);
 
-		coreManager.SetUIManager(uiManager);
+		CoreDragDrop.SetUIManager(uiManager);
 	}
 
 	internal IDisposable OpenDragAndDrop(DragView dragView)

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -775,7 +775,7 @@ namespace Microsoft.UI.Xaml
 				asyncResult.SetResult(result);
 			});
 
-			CoreDragDropManager.GetForCurrentView()!.DragStarted(dragInfo);
+			XamlRoot.VisualTree.ContentRoot.InputManager.CoreDragDrop.DragStarted(dragInfo);
 
 			var result = await asyncResult.Task;
 

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DragDrop/Core/CoreDragDropManager.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DragDrop/Core/CoreDragDropManager.cs
@@ -41,6 +41,8 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 		{
 		}
 
+		internal IDragDropManager DragDrop => _manager ?? throw new InvalidOperationException("The DragDropManager has not been initialized.");
+
 		internal void SetUIManager(IDragDropManager manager)
 			=> _manager ??= manager ?? throw new ArgumentNullException(nameof(manager));
 


### PR DESCRIPTION
Unblocks https://github.com/unoplatform/uno/pull/16567

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Locally, if you run `Given_Window` then `When_DragOver_Fires_Along_DragEnter_Drop`, the `When_DragOver_Fires_Along_DragEnter_Drop` will fail. The root cause is that the created windows will do `CoreDragDropManager.CreateForCurrentView` which sets `_current`, then `CoreDragDropManager.GetForCurrentView` use in UIElement will use the wrong `CoreDragDropManager`

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
`CoreDragDropManager.GetForCurrentView` is avoided (there is one remaining usage I left as a TODO)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
