### PR TITLE
docs(HotReload): Remove RemoteControl.g.cs details as it is not visible anymore

### DIFF
--- a/doc/articles/features/working-with-xaml-hot-reload.md
+++ b/doc/articles/features/working-with-xaml-hot-reload.md
@@ -137,9 +137,6 @@ Hot Reload is supported by Visual Studio for WinAppSDK and provides support in u
 - The output window in VS has an output named `Uno Platform` in its drop-down. Diagnostics messages from the VS integration appear there. Changing the MSBuild build output verbosity in `Tools/Options/Projects and Solutions/Build And Run` controls the log level.
 - When a file is reloaded, XAML parsing errors will appear in the application's logs, on device or in browser.
 - If there are multiple versions of the Uno.WinUI Package present in the solution, the newest will be used, regardless of the started application
-- The app does not update its XAML, because the port number in `RemoteControl.g.cs` is `0`.
-  - Ensure you have the latest version of the Visual Studio extension installed.
-  - Rebuild the app until the number is different than zero.
 
 ### VS Code
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

Current documentation mentions details regarding RemoteControl.g.cs but it's not visible anymore as that file only exists in memory now because it's generated by Roslyn C# generators.

## What is the new behavior?

Remove RemoteControl.g.cs details as it is not visible anymore

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

