### PR TITLE
fix: Bypass keyboard closing behavior on iOS

### DIFF
--- a/src/Uno.UI/UI/Xaml/Window/Native/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/Window.iOS.cs
@@ -29,7 +29,7 @@ namespace Uno.UI.Controls;
 public partial class Window : UIWindow
 {
 	//Impediment # 19821 A way the bypass the processing done in the HitTest override when third party controls are used.
-	public static bool BypassCheckToCloseKeyboard { get; set; }
+	public static bool BypassCheckToCloseKeyboard { get; set; } = true;
 
 	private readonly static IEventProvider _trace = Tracing.Get(TraceProvider.Id);
 


### PR DESCRIPTION
GitHub Issue (If applicable): related to private issue

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The BypassCheckToCloseKeyboard behavior defaulted to false, which meant the keyboard would close on each native window hit test, which is not in line with other targets

## What is the new behavior?

Aligned

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
