### PR TITLE
Pack missing schema file

### DIFF
--- a/src/Uno.Sdk/Uno.Sdk.csproj
+++ b/src/Uno.Sdk/Uno.Sdk.csproj
@@ -26,6 +26,7 @@
 	<ItemGroup>
 		<SdkFile Include="Sdk\**\*.targets;Sdk\**\*.props" />
 		<TargetFile Include="targets\**\*.props;targets\**\*.targets" />
+		<None Include="**\*.buildschema.json" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
 
 		<None Include="..\Common\uno.png" Pack="true" PackagePath="\" />
 	</ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Schema File is missing from the generated nuget package

## What is the new behavior?

Schema File is added to the pack files.
