### PR TITLE
fix(droid): workaround for ItemsControl's ObjectDisposedException

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_XBind_TargetDisposed.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_XBind_TargetDisposed.xaml
@@ -1,0 +1,11 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.When_XBind_TargetDisposed"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<ItemsControl ItemsSource="{x:Bind ViewModel.Items}" />
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_XBind_TargetDisposed.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/When_XBind_TargetDisposed.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+
+public sealed partial class When_XBind_TargetDisposed : Page
+{
+	public When_XBind_TargetDisposed_VM ViewModel { get; }
+
+	public When_XBind_TargetDisposed()
+	{
+		ViewModel = new();
+		this.InitializeComponent();
+	}
+	//~When_XBind_TargetDisposed()
+	//{
+	//}
+
+	//protected override void Dispose(bool disposing)
+	//{
+	//	base.Dispose(disposing);
+	//}
+}
+
+public class When_XBind_TargetDisposed_VM
+{
+	public ObservableCollection<string> Items { get; }
+
+	public When_XBind_TargetDisposed_VM()
+	{
+		Items = new(Enumerable.Range(0, 10).Select(x => $"Item {x}"));
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xBind.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_xBind.cs
@@ -1,6 +1,10 @@
-﻿using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
-using Private.Infrastructure;
+﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
 
@@ -39,4 +43,64 @@ public class Given_xBind
 
 		Assert.AreEqual("Hello", SUT.tb.Text);
 	}
+
+#if __ANDROID__
+	[TestMethod]
+	public async Task When_XBind_TargetDisposed_Test()
+	{
+		// load the view with the x:Bind
+		var SUT = new When_XBind_TargetDisposed();
+		var vm = SUT.ViewModel;
+		var wrSUT = new WeakReference(SUT);
+		await UITestHelper.Load(SUT);
+
+		// remove references to the view
+		SUT = null;
+		await UITestHelper.Load(new Border { Width = 50, Height = 50 });
+
+		// make sure it is disposed
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		await Task.Delay(1000);
+		if (!await WaitUntilCollected())
+		{
+			Assert.Fail("Timed out on waiting the view to be disposed");
+		}
+
+		// trigger an INotifyCollectionChanged update via ObservableCollection
+		vm.Items.Clear();
+
+		// and, it should not throw:
+		/* System.ObjectDisposedException: Cannot access a disposed object. Object name: 'Microsoft.UI.Xaml.Controls.StackPanel'.
+			at Android.Views.ViewGroup.RemoveAllViews()
+			at Microsoft.UI.Xaml.Controls.UIElementCollection.ClearCore()
+			at Microsoft.UI.Xaml.Controls.UIElementCollection.Clear()
+			at Microsoft.UI.Xaml.Controls.ItemsControl.UpdateItems(NotifyCollectionChangedEventArgs args)
+			at Microsoft.UI.Xaml.Controls.ItemsControl.OnItemsSourceSingleCollectionChanged(Object sender, NotifyCollectionChangedEventArgs args, Int32 section)
+			at Microsoft.UI.Xaml.Controls.ItemsControl.OnItemsVectorChanged(IObservableVector`1 sender, IVectorChangedEventArgs e)
+			at Uno.UI.Extensions.VectorChangedEventHandlerExtensions.TryRaise(ValueTuple`2 handlers, IObservableVector`1 owner, IVectorChangedEventArgs args)
+			at Microsoft.UI.Xaml.Controls.ItemCollection.OnItemsSourceCollectionChanged(Object sender, NotifyCollectionChangedEventArgs args)
+			at Microsoft.UI.Xaml.Controls.ItemCollection.<>c__DisplayClass33_0.<ObserveCollectionChangedInner>g__handler|0(Object s, NotifyCollectionChangedEventArgs e)
+			at System.Collections.ObjectModel.ObservableCollection`1.OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+			at System.Collections.ObjectModel.ObservableCollection`1.OnCollectionReset()
+			at System.Collections.ObjectModel.ObservableCollection`1.ClearItems()
+			at System.Collections.ObjectModel.Collection`1.Clear()
+			at Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Given_xBind.When_XBind_TargetDisposed()
+		*/
+
+		async Task<bool> WaitUntilCollected()
+		{
+			var sw = Stopwatch.StartNew();
+			while (sw.ElapsedMilliseconds <= 1000 && wrSUT.Target is When_XBind_TargetDisposed)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+
+				await Task.Delay(100);
+			}
+
+			return wrSUT.Target is not When_XBind_TargetDisposed;
+		}
+	}
+#endif
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -995,7 +995,14 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private protected virtual void UpdateItems(NotifyCollectionChangedEventArgs args)
 		{
-			if (ItemsPanelRoot == null || !ShouldItemsControlManageChildren)
+			if (ItemsPanelRoot == null
+				|| !ShouldItemsControlManageChildren
+#if __ANDROID__
+				// workaround for INCC callback on disposed object
+				// see: Given_xBind.When_XBind_TargetDisposed_Test()
+				|| (Handle == nint.Zero || ItemsPanelRoot.Handle == nint.Zero)
+#endif
+				)
 			{
 				return;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): (linked from private issue)

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Leaked ItemsControl.ItemsSource subscription can cause ObjectDisposedException to be thrown when the said source is updated.

## What is the new behavior?
The exception is prevented.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information