### PR TITLE
feat: Enable `ToolTips` on Skia by default

### DIFF
--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -87,7 +87,7 @@ WinRTFeatureConfiguration.MessageDialog.StyleOverride = "CustomMessageDialogStyl
 
 ## ToolTips
 
-By default, `ToolTips` are disabled on all platforms except for WebAssembly (see [#10791](https://github.com/unoplatform/uno/issues/10791)). To enable them on a specific platform, set the `UseToolTips` configuration flag to `true`. You can add the following in the end of the `App` constructor:
+By default, `ToolTips` are disabled on all platforms except for WebAssembly and Skia (see [#10791](https://github.com/unoplatform/uno/issues/10791)). To enable them on a specific platform, set the `UseToolTips` configuration flag to `true`. You can add the following in the end of the `App` constructor:
 
 ```csharp
 Uno.UI.FeatureConfiguration.ToolTip.UseToolTips = true;

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -572,7 +572,7 @@ namespace Uno.UI
 		public static class ToolTip
 		{
 			public static bool UseToolTips { get; set; }
-#if __WASM__
+#if __WASM__ || __SKIA__
 				= true;
 #endif
 


### PR DESCRIPTION
GitHub Issue (If applicable): related to https://github.com/unoplatform/uno/issues/10791

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Tooltips are disabled on Skia by default

## What is the new behavior?

Enabled

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.