### PR TITLE
SDK ignores GeneratePackageOnBuild

### DIFF
--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -248,6 +248,11 @@ $projects =
     @("5.2/uno52Lib/uno52Lib.csproj", @("-f", "net8.0-maccatalyst"), $true, $true),
     @("5.2/uno52Lib/uno52Lib.csproj", @("-f", "net8.0-desktop"), $true, $true),
 
+     #
+    # 5.2 Uno NuGet Lib
+    #
+    @("5.2/uno52Lib/uno52Lib.csproj", @(), $true, $true),
+
     # Default mode for the template is WindowsAppSDKSelfContained=true, which requires specifying a target platform.
     @("5.2/uno52Lib/uno52Lib.csproj", @("-p:Platform=x86" , "-p:TargetFramework=net8.0-windows10.0.19041"), $false, $true),
 

--- a/src/SolutionTemplate/5.1/uno51blank/Directory.Build.targets
+++ b/src/SolutionTemplate/5.1/uno51blank/Directory.Build.targets
@@ -1,2 +1,7 @@
 ﻿<Project>
+  <Target Name="ValidateIsPackable"
+          AfterTargets="CoreCompile;Build">
+    <Error Text="Expected IsPackable='false', however it actually equals '$(IsPackable)'."
+      Condition="$(IsPackable) == 'true'" />
+  </Target>
 </Project>

--- a/src/SolutionTemplate/5.1/uno51recommended/Directory.Build.targets
+++ b/src/SolutionTemplate/5.1/uno51recommended/Directory.Build.targets
@@ -1,2 +1,7 @@
 ﻿<Project>
+  <Target Name="ValidateIsPackable"
+          AfterTargets="CoreCompile;Build">
+    <Error Text="Expected IsPackable='false', however it actually equals '$(IsPackable)'."
+      Condition="$(IsPackable) == 'true'" />
+  </Target>
 </Project>

--- a/src/SolutionTemplate/5.1/uno51recommended/Directory.Build.targets
+++ b/src/SolutionTemplate/5.1/uno51recommended/Directory.Build.targets
@@ -1,6 +1,7 @@
 ﻿<Project>
   <Target Name="ValidateIsPackable"
-          AfterTargets="CoreCompile;Build">
+          AfterTargets="CoreCompile;Build"
+          Condition="$(UsingUnoSdk) == 'true'">
     <Error Text="Expected IsPackable='false', however it actually equals '$(IsPackable)'."
       Condition="$(IsPackable) == 'true'" />
   </Target>

--- a/src/SolutionTemplate/5.2/uno52AppWithLib/Directory.Build.targets
+++ b/src/SolutionTemplate/5.2/uno52AppWithLib/Directory.Build.targets
@@ -1,2 +1,7 @@
 ﻿<Project>
+  <Target Name="ValidateIsPackable"
+          AfterTargets="CoreCompile;Build">
+    <Error Text="Expected IsPackable='false', however it actually equals '$(IsPackable)'."
+      Condition="$(IsPackable) == 'true'" />
+  </Target>
 </Project>

--- a/src/SolutionTemplate/5.2/uno52AppWithLib/Directory.Build.targets
+++ b/src/SolutionTemplate/5.2/uno52AppWithLib/Directory.Build.targets
@@ -1,6 +1,7 @@
 ﻿<Project>
   <Target Name="ValidateIsPackable"
-          AfterTargets="CoreCompile;Build">
+          AfterTargets="CoreCompile;Build"
+          Condition="$(UsingUnoSdk) == 'true'">
     <Error Text="Expected IsPackable='false', however it actually equals '$(IsPackable)'."
       Condition="$(IsPackable) == 'true'" />
   </Target>

--- a/src/SolutionTemplate/5.2/uno52Lib/uno52Lib.csproj
+++ b/src/SolutionTemplate/5.2/uno52Lib/uno52Lib.csproj
@@ -28,4 +28,9 @@
 		<!-- <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
 		<FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" /> -->
 	</ItemGroup>
+	<Target Name="ValidateIsPackable"
+			AfterTargets="CoreCompile;Build">
+		<Error Text="Expected IsPackable='false', however it actually equals '$(IsPackable)'."
+			Condition="$(IsPackable) == 'true'" />
+	</Target>
 </Project>

--- a/src/SolutionTemplate/5.2/uno52NuGetLib/Class1.cs
+++ b/src/SolutionTemplate/5.2/uno52NuGetLib/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace uno52Lib;
+
+public class Class1
+{
+}
+

--- a/src/SolutionTemplate/5.2/uno52NuGetLib/global.json
+++ b/src/SolutionTemplate/5.2/uno52NuGetLib/global.json
@@ -1,0 +1,5 @@
+{
+  "msbuild-sdks": {
+    "Uno.Sdk": "5.2.0-dev.2002"
+  }
+}

--- a/src/SolutionTemplate/5.2/uno52NuGetLib/uno52NuGetLib.csproj
+++ b/src/SolutionTemplate/5.2/uno52NuGetLib/uno52NuGetLib.csproj
@@ -9,10 +9,10 @@
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<UnoSingleProject>true</UnoSingleProject>
-		<OutputType>Library</OutputType>
 		<UnoSdkDebugging>true</UnoSdkDebugging>
+		<OutputType>Library</OutputType>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
@@ -31,7 +31,7 @@
 	</ItemGroup>
 	<Target Name="ValidateIsPackable"
 			AfterTargets="CoreCompile;Build">
-		<Error Text="Expected IsPackable='false', however it actually equals '$(IsPackable)'."
-		Condition="$(IsPackable) == 'true'" />
+		<Error Text="Expected IsPackable='true', however it actually equals '$(IsPackable)'."
+			Condition="$(IsPackable) != 'true'" />
 	</Target>
 </Project>

--- a/src/SolutionTemplate/5.2/uno52NuGetLib/uno52NuGetLib.csproj
+++ b/src/SolutionTemplate/5.2/uno52NuGetLib/uno52NuGetLib.csproj
@@ -34,4 +34,75 @@
 		<Error Text="Expected IsPackable='true', however it actually equals '$(IsPackable)'."
 			Condition="$(IsPackable) != 'true'" />
 	</Target>
+
+	<Target Name="ValidatePackageDependencies"
+		AfterTargets="GenerateNuspec">
+		<ItemGroup>
+			<ExpectedReference Include="Uno.WinUI" />
+			<ExpectedReference Include="Microsoft.WindowsAppSDK" />
+			<ExpectedReference Include="Microsoft.Windows.SDK.BuildTools" />
+			<ExpectedMissingReference Include="Uno.Resizetizer" />
+			<ExpectedMissingReference Include="Uno.Core.Extensions.Logging.Singleton" />
+		</ItemGroup>
+
+		<ValidatePackageReferences
+			NuGetPackOutputFiles="@(NuGetPackOutput)"
+			ExpectedReferences="@(ExpectedReference)"
+			ExpectedMissingReferences="@(ExpectedMissingReference)" />
+	</Target>
+
+	<UsingTask TaskName="ValidatePackageReferences" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+		<ParameterGroup>
+			<NuGetPackOutputFiles ParameterType="System.String[]" Required="true" />
+			<ExpectedReferences ParameterType="System.String[]" Required="true" />
+			<ExpectedMissingReferences ParameterType="System.String[]" Required="true" />
+		</ParameterGroup>
+		<Task>
+			<Using Namespace="System" />
+			<Using Namespace="System.IO" />
+			<Code Type="Fragment" Language="cs">
+				<![CDATA[
+					foreach (var outputFile in NuGetPackOutputFiles)
+					{
+						if (Path.GetExtension(outputFile) != ".nuspec" || outputFile.Contains(".symbols."))
+						{
+							continue;
+						}
+
+						if (!File.Exists(outputFile))
+						{
+							Log.LogError("The nuspec file '{0}' does not exist on the disk.", outputFile);
+						}
+
+						var nuspec = File.ReadAllText(outputFile);
+						var dependencyStringFormat = "<dependency id=\"{0}\"";
+
+						foreach (var expectedReference in ExpectedReferences)
+						{
+							if (!nuspec.Contains(string.Format(System.Globalization.CultureInfo.InvariantCulture, dependencyStringFormat, expectedReference)))
+							{
+								Log.LogError("Missing expected package dependency: {0}", expectedReference);
+							}
+							else
+							{
+								Log.LogMessage(MessageImportance.High, "Found package dependency for: {0}.", expectedReference);
+							}
+						}
+
+						foreach (var expectedMissingReference in ExpectedMissingReferences)
+						{
+							if (nuspec.Contains(string.Format(System.Globalization.CultureInfo.InvariantCulture, dependencyStringFormat, expectedMissingReference)))
+							{
+								Log.LogError("Found package dependency for: {0}.", expectedMissingReference);
+							}
+							else
+							{
+								Log.LogMessage(MessageImportance.High, "Confirmed no package dependency for: {0}", expectedMissingReference);
+							}
+						}
+					}
+				]]>
+			</Code>
+		</Task>
+	</UsingTask>
 </Project>

--- a/src/SolutionTemplate/5.2/uno52blank/Directory.Build.targets
+++ b/src/SolutionTemplate/5.2/uno52blank/Directory.Build.targets
@@ -1,2 +1,7 @@
 ﻿<Project>
+  <Target Name="ValidateIsPackable"
+          AfterTargets="CoreCompile;Build">
+    <Error Text="Expected IsPackable='false', however it actually equals '$(IsPackable)'."
+      Condition="$(IsPackable) == 'true'" />
+  </Target>
 </Project>

--- a/src/Uno.Sdk/Models/PackageReference.cs
+++ b/src/Uno.Sdk/Models/PackageReference.cs
@@ -15,7 +15,7 @@ internal record PackageReference(string PackageId, string Version, IDictionary<s
 			ItemSpec = PackageId,
 		};
 
-		foreach(var data in MetaData)
+		foreach (var data in MetaData)
 		{
 			if (data.Key == "ProjectSystem")
 				continue;

--- a/src/Uno.Sdk/Models/PackageReference.cs
+++ b/src/Uno.Sdk/Models/PackageReference.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.Build.Framework;
+﻿using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 #nullable enable
 namespace Uno.Sdk.Models;
 
-internal record PackageReference(string PackageId, string Version, string? ExcludeAssets = null)
+internal record PackageReference(string PackageId, string Version, IDictionary<string, string> MetaData)
 {
 	public ITaskItem ToTaskItem()
 	{
@@ -12,13 +14,18 @@ internal record PackageReference(string PackageId, string Version, string? Exclu
 		{
 			ItemSpec = PackageId,
 		};
+
+		foreach(var data in MetaData)
+		{
+			if (data.Key == "ProjectSystem")
+				continue;
+
+			taskItem.SetMetadata(data.Key, data.Value);
+		}
+
 		taskItem.SetMetadata(nameof(Version), Version);
 		taskItem.SetMetadata("IsImplicitlyDefined", bool.TrueString);
 		taskItem.SetMetadata("Sdk", "Uno");
-		if (!string.IsNullOrEmpty(ExcludeAssets))
-		{
-			taskItem.SetMetadata(nameof(ExcludeAssets), ExcludeAssets);
-		}
 		return taskItem;
 	}
 }

--- a/src/Uno.Sdk/Sdk/Sdk.props
+++ b/src/Uno.Sdk/Sdk/Sdk.props
@@ -36,9 +36,6 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 		<_UnoSdkTargetsDirectory>$([MSBuild]::EnsureTrailingSlash($(_UnoSdkTargetsDirectory)))</_UnoSdkTargetsDirectory>
 		<CustomAfterDirectoryBuildProps>$(CustomAfterDirectoryBuildProps);$(_UnoSdkTargetsDirectory)Uno.Import.SolutionConfig.props</CustomAfterDirectoryBuildProps>
 		<CustomAfterDirectoryBuildProps>$(CustomAfterDirectoryBuildProps);$(_UnoSdkTargetsDirectory)Uno.IsPlatform.props</CustomAfterDirectoryBuildProps>
-
-		<!-- We do this to make sure that we include Resizetizer by default. Libraries using Uno.Sdk should have this set to true -->
-		<IsPackable Condition=" '$(IsPackable)' == '' ">false</IsPackable>
 	</PropertyGroup>
 
 	<!-- We want to try to avoid having AnyCPU passed-->

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -175,7 +175,9 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 			foreach (var reference in ImplicitPackageReferences)
 			{
 				var packageId = reference.ItemSpec;
-				var metadata = reference.MetadataNames.Cast<string>()
+				var metadata = reference.CloneCustomMetadata()
+					.Keys
+					.Cast<string>()
 					.ToDictionary(x => x, x => reference.GetMetadata(x));
 				AddPackage(packageId, metadata);
 			}

--- a/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
+++ b/src/Uno.Sdk/Tasks/ImplicitPackagesResolver.cs
@@ -26,8 +26,6 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 	[Required]
 	public string OutputType { get; set; } = null!;
 
-	public bool IsPackable { get; set; }
-
 	public bool Optimize { get; set; }
 
 	[Required]
@@ -177,8 +175,9 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 			foreach (var reference in ImplicitPackageReferences)
 			{
 				var packageId = reference.ItemSpec;
-				var excludeAssets = packageId == "Uno.WinUI.DevServer" && Optimize ? "all" : null;
-				AddPackage(packageId, excludeAssets);
+				var metadata = reference.MetadataNames.Cast<string>()
+					.ToDictionary(x => x, x => reference.GetMetadata(x));
+				AddPackage(packageId, metadata);
 			}
 		}
 		catch (Exception ex)
@@ -350,7 +349,7 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 		}
 	}
 
-	private void AddPackage(string packageId, string? excludeAssets = null)
+	private void AddPackage(string packageId, IDictionary<string, string> metadata)
 	{
 		// 1) Check for Existing References
 		var existingReference = PackageReferences.SingleOrDefault(x => x.ItemSpec == packageId);
@@ -399,7 +398,7 @@ public sealed class ImplicitPackagesResolver_v0 : Task
 
 		// 5) Add the Implicit Package Reference
 		Debug("Adding Implicit Reference for '{0}' with version: '{1}'.", packageId, version);
-		_implicitPackages.Add(new PackageReference(packageId, version, excludeAssets));
+		_implicitPackages.Add(new PackageReference(packageId, version, metadata));
 	}
 
 	private void Debug(string message, params object[] args)

--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -1,6 +1,9 @@
 <Project>
 
 	<PropertyGroup>
+		<!-- We do this to make sure that we include Resizetizer by default. Libraries using Uno.Sdk should have this set to true -->
+		<IsPackable Condition=" '$(IsPackable)' == '' ">$([MSBuild]::ValueOrDefault('$(GeneratePackageOnBuild)', 'false'))</IsPackable>
+
 		<_IsUnoSingleProjectAndLegacy>false</_IsUnoSingleProjectAndLegacy>
 		<_IsUnoSingleProjectAndLegacy Condition=" $(SingleProject) == 'true' OR $(UnoSingleProject) == 'true' ">true</_IsUnoSingleProjectAndLegacy>
 

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
@@ -6,17 +6,28 @@
 	-->
 	<ItemGroup>
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Uno.Resizetizer" ProjectSystem="true" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(_ImplicitRestoreOutputType) == 'Exe'">
-		<_UnoProjectSystemPackageReference Include="Uno.WinUI.DevServer" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Uno.WinUI.DevServer" ProjectSystem="true" Condition="$(Optimize) != 'true'" />
+		<_UnoProjectSystemPackageReference Include="Uno.WinUI.DevServer" ProjectSystem="true" Exclude="all" Condition="$(Optimize) == 'true'" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(IsPackable) != 'true'">
-		<_UnoProjectSystemPackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" ProjectSystem="true" />
-		<_UnoProjectSystemPackageReference Include="Uno.Resizetizer" ProjectSystem="true" />
-		<_UnoProjectSystemPackageReference Include="Microsoft.Extensions.Logging.Console" ProjectSystem="true" />
-	</ItemGroup>
+	<Choose>
+		<When Condition="$(UnoSingleProject) == 'true'">
+			<ItemGroup Condition="$(IsUnoHead) == 'true'">
+				<_UnoProjectSystemPackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" ProjectSystem="true" />
+				<_UnoProjectSystemPackageReference Include="Microsoft.Extensions.Logging.Console" ProjectSystem="true" />
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup Condition="$(IsPackable) != 'true'">
+				<_UnoProjectSystemPackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" ProjectSystem="true" />
+				<_UnoProjectSystemPackageReference Include="Microsoft.Extensions.Logging.Console" ProjectSystem="true" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
 
 	<ItemGroup Condition="$(UnoFeatures.Contains(';Maps;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.Maps" ProjectSystem="true" />

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.targets
@@ -37,7 +37,6 @@
 				Optimize="$(Optimize)"
 				OutputType="$(_ImplicitRestoreOutputType)"
 				UnoFeatures="$(UnoFeatures)"
-				IsPackable="$(IsPackable)"
 				TargetFramework="$(TargetFramework)"
 				ProjectName="$(MSBuildProjectName)"
 				ImplicitPackageReferences="@(_UnoProjectSystemPackageReference)"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #16572

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

We set the value of IsPackable to false by default 

## What is the new behavior?

We wait until the props have / csproj are loaded and evaluate IsPackable in the targets. This allows us to further evaluate whether `GeneratePackageOnBuild` has been set. If it has we will provide the value of that property or a default of `false`.