### PR TITLE
fix(sdk): Don't reorder using a non-existing TargetFramework

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Sdk.After.targets
+++ b/src/Uno.Sdk/targets/Uno.Sdk.After.targets
@@ -38,7 +38,8 @@
 				OR $([MSBuild]::GetTargetPlatformIdentifier($(_UnoSelectedTargetFramework))) == 'windows'
 			)
 			AND '$(TargetFrameworks)' != ''
-			AND '$(_UnoFirstOriginalTargetFramework)' != '$(_UnoSelectedTargetFramework)'">
+			AND '$(_UnoFirstOriginalTargetFramework)' != '$(_UnoSelectedTargetFramework)'
+			AND $(TargetFrameworks.Contains($(_UnoSelectedTargetFramework)))">
 
 		<_UnoTargetFrameworksFiltered>
 			$(TargetFrameworks


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/16507

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that a active selected `TargetFramework` is removed from the `TargetFrameworks`, it's not getting reused by `_UnoSelectedTargetFramework` from the `.csproj.user` file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
