### PR TITLE
fix(tooltip): prevent multiple nested tooltips from displaying all at once

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2734,6 +2734,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Nested.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_CollapsedHost.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -7324,6 +7328,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Long_Text.xaml.cs">
       <DependentUpon>ToolTip_Long_Text.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_Nested.xaml.cs">
+      <DependentUpon>ToolTip_Nested.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToolTip\ToolTip_CollapsedHost.xaml.cs">
       <DependentUpon>ToolTip_CollapsedHost.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Nested.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Nested.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml_Controls.ToolTip.ToolTip_Nested"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<Border ToolTipService.ToolTip="QweQweQweQweQweQwe" Margin="50" Background="SkyBlue">
+		<Border ToolTipService.ToolTip="AsdAsdAsd" Margin="50" Background="Pink">
+			<Border ToolTipService.ToolTip="Zxc" Margin="50" Background="SkyBlue" Width="50" Height="50" />
+		</Border>
+	</Border>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Nested.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToolTip/ToolTip_Nested.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.ToolTip;
+
+[SampleControlInfo(nameof(ToolTip), nameof(ToolTip_Nested), description: SampleDescription, isManualTest: true)]
+public sealed partial class ToolTip_Nested : UserControl
+{
+	private const string SampleDescription =
+		"Hovering over any of the colored elements should only open a single tooltip, not multiple overlapping ones.";
+
+	public ToolTip_Nested()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ToolTip/ToolTip.cs
@@ -49,8 +49,6 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		internal long CurrentHoverId { get; set; }
-
 		internal IDisposable? OwnerEventSubscriptions { get; set; }
 
 		internal IDisposable? OwnerVisibilitySubscription { get; set; }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #15792 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Hovering nested elements with ToolTipService.ToolTip display multiple overlapping tooltips at once

## What is the new behavior?
Aligned the behavior to windows: only the inner-most under-cursor element's tooltip is displayed.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] ~~Docs have been added/updated which fit [documentation template]~~(https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] ~~Validated PR `Screenshots Compare Test Run` results.~~
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->