### PR TITLE
refactor: Remove reflection usage in Brush

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Helpers/Given_WeakEventManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Helpers/Given_WeakEventManager.cs
@@ -1,0 +1,103 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UI.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Helpers;
+
+[TestClass]
+public class Given_WeakEventManager
+{
+	private sealed class EventPublisher
+	{
+		private readonly WeakEventManager _manager = new();
+
+		internal event Action Event
+		{
+			add => _manager.AddEventHandler(value);
+			remove => _manager.RemoveEventHandler(value);
+		}
+	}
+
+	private sealed class EventSubscriber
+	{
+		public void M() { }
+	}
+
+	[TestMethod]
+	public void When_ManySubscriptions_Then_DoesNotLeak()
+	{
+		var publisher = new EventPublisher();
+		var weakRefs = new List<WeakReference<EventSubscriber>>();
+		Subscribe(publisher, weakRefs);
+
+		for (var i = 0; i < 10; i++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+		}
+
+		foreach (var x in weakRefs)
+		{
+			Assert.IsFalse(x.TryGetTarget(out _));
+		}
+	}
+
+	[TestMethod]
+	public void When_ReEnter_Then_AllHandlersInvokedProperly()
+	{
+		var sut = new WeakEventManager();
+		int handler1Count = 0, handler2Count = 0;
+
+		sut.AddEventHandler(Handler1, "Event1");
+		sut.AddEventHandler(Handler2, "Event1");
+		sut.AddEventHandler(Handler1_2, "Event2");
+		sut.AddEventHandler(Handler2_2, "Event2");
+
+		sut.HandleEvent("Event1");
+
+		Assert.AreEqual(3, handler1Count);
+		Assert.AreEqual(3, handler2Count);
+
+		sut.HandleEvent("Event2");
+
+		Assert.AreEqual(4, handler1Count);
+		Assert.AreEqual(4, handler2Count);
+
+		void Handler1()
+		{
+			handler1Count++;
+			sut.HandleEvent("Event2");
+		}
+
+		void Handler1_2()
+		{
+			handler1Count++;
+		}
+
+		void Handler2()
+		{
+			handler2Count++;
+			sut.HandleEvent("Event2");
+		}
+
+		void Handler2_2()
+		{
+			handler2Count++;
+		}
+	}
+
+	private void Subscribe(EventPublisher publisher, List<WeakReference<EventSubscriber>> weakRefs)
+	{
+		for (var i = 0; i < 1000; i++)
+		{
+			var subscriber = new EventSubscriber();
+			publisher.Event += subscriber.M;
+			weakRefs.Add(new WeakReference<EventSubscriber>(subscriber));
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Helpers/Given_WeakEventManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Helpers/Given_WeakEventManager.cs
@@ -21,6 +21,8 @@ public class Given_WeakEventManager
 			add => _manager.AddEventHandler(value);
 			remove => _manager.RemoveEventHandler(value);
 		}
+
+		public void RaiseEvent() => _manager.HandleEvent("Event");
 	}
 
 	private sealed class EventSubscriber
@@ -86,6 +88,60 @@ public class Given_WeakEventManager
 		}
 
 		void Handler2_2()
+		{
+			handler2Count++;
+		}
+	}
+
+	[TestMethod]
+	public void When_UnSubscribeInHandler()
+	{
+		var sut = new WeakEventManager();
+		int handler1Count = 0, handler2Count = 0;
+
+		sut.AddEventHandler(Handler1, "Event1");
+		sut.AddEventHandler(Handler2, "Event1");
+
+		sut.HandleEvent("Event1");
+		sut.HandleEvent("Event1");
+
+		Assert.AreEqual(1, handler1Count);
+		Assert.AreEqual(2, handler2Count);
+
+		void Handler1()
+		{
+			handler1Count++;
+			sut.RemoveEventHandler(Handler1, "Event1");
+		}
+
+		void Handler2()
+		{
+			handler2Count++;
+		}
+	}
+
+	[TestMethod]
+	public void When_UnSubscribeInHandler2()
+	{
+		var pub = new EventPublisher();
+		int handler1Count = 0, handler2Count = 0;
+
+		pub.Event += Handler1;
+		pub.Event += Handler2;
+
+		pub.RaiseEvent();
+		pub.RaiseEvent();
+
+		Assert.AreEqual(1, handler1Count);
+		Assert.AreEqual(2, handler2Count);
+
+		void Handler1()
+		{
+			handler1Count++;
+			pub.Event -= Handler1;
+		}
+
+		void Handler2()
 		{
 			handler2Count++;
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Helpers/Given_WeakEventManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Helpers/Given_WeakEventManager.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+#if HAS_UNO
 
 using System;
 using System.Collections.Generic;
@@ -157,3 +158,4 @@ public class Given_WeakEventManager
 		}
 	}
 }
+#endif

--- a/src/Uno.UI/Helpers/WeakEvents/WeakEventManager.cs
+++ b/src/Uno.UI/Helpers/WeakEvents/WeakEventManager.cs
@@ -102,7 +102,11 @@ internal sealed class WeakEventManager
 		{
 			if (_enumeratingHandlersOfEvent == eventName)
 			{
+#if NET8_0_OR_GREATER
 				handlers = handlers![..];
+#else
+				handlers = handlers!.ToArray();
+#endif
 			}
 
 			handlers!.Add(handler);
@@ -120,7 +124,11 @@ internal sealed class WeakEventManager
 		{
 			if (_enumeratingHandlersOfEvent == eventName)
 			{
+#if NET8_0_OR_GREATER
 				handlers = handlers[..];
+#else
+				handlers = handlers!.ToArray();
+#endif
 			}
 
 			handlers.Remove(handler);

--- a/src/Uno.UI/Helpers/WeakEvents/WeakEventManager.cs
+++ b/src/Uno.UI/Helpers/WeakEvents/WeakEventManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -105,7 +106,7 @@ internal sealed class WeakEventManager
 #if NET8_0_OR_GREATER
 				handlers = handlers![..];
 #else
-				handlers = handlers!.ToArray();
+				handlers = handlers!.ToList();
 #endif
 			}
 
@@ -127,7 +128,7 @@ internal sealed class WeakEventManager
 #if NET8_0_OR_GREATER
 				handlers = handlers[..];
 #else
-				handlers = handlers!.ToArray();
+				handlers = handlers!.ToList();
 #endif
 			}
 


### PR DESCRIPTION
## Refactoring (no functional changes, no api changes)
Remove reflection usage in Brush

## What is the current behavior?
We use reflection to invoke event handler

## What is the new behavior?
No reflection!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
