### PR TITLE
Bump uno.resizetizer

### DIFF
--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -33,6 +33,14 @@
 			"type": "string",
 			"description": "The version of the application."
 		},
+		"ApplicationPublisher": {
+			"type": "string",
+			"description": "Sets the Publisher Display Name in the Package.appxmanifest."
+		},
+		"Description": {
+			"type": "string",
+			"description": "The description of the application."
+		},
 		"AssetsFolder": {
 			"type": "folder-with-slash",
 			"description": "The folder containing the assets for this project."

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -65,7 +65,7 @@
 	},
 	{
 		"group": "Resizetizer",
-		"version": "1.4.9",
+		"version": "1.5.0-dev.78",
 		"packages": [
 			"Uno.Resizetizer"
 		]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -65,7 +65,7 @@
 	},
 	{
 		"group": "Resizetizer",
-		"version": "1.5.0-dev.78",
+		"version": "1.5.0-dev.87",
 		"packages": [
 			"Uno.Resizetizer"
 		]


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- #16618

## PR Type

What kind of change does this PR introduce?

- Other... Please describe: Package update

## What is the current behavior?

Uno.Resizetizer 1.4 does not properly handle ApplicationDisplayVersion and ApplicationVersion

## What is the new behavior?

Uses Uno.Resizetizer 1.5 dev which has been updated to properly handle the ApplicationDisplayVersion, ApplicationVersion, ApplicationId and a few other commonly used MSBuild properties to update the appxmanifest.