### PR TITLE
Set the Version

### DIFF
--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -2,6 +2,12 @@
 	<PropertyGroup>
 		<ApplicationManifest Condition="$(ApplicationManifest) == '' AND Exists('$(DesktopProjectFolder)app.manifest')">$(DesktopProjectFolder)app.manifest</ApplicationManifest>
 		<ApplicationManifest Condition="$(ApplicationManifest) == '' AND Exists('app.manifest')">app.manifest</ApplicationManifest>
+
+		<!-- Follow the Android, iOS, & MacCatalyst SDK's -->
+		<!-- Default to 1, if blank -->
+		<ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">1</ApplicationVersion>
+		<Version Condition=" $([System.Version]::TryParse ('$(ApplicationDisplayVersion)', $([System.Version]::Parse('1.0')))) ">$(ApplicationDisplayVersion)</Version>
+		<ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="$(DesktopProjectFolder)Package.appxmanifest"

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Wasm.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Wasm.targets
@@ -7,6 +7,12 @@
 			https://aka.platform.uno/wasm-deeplink
 		-->
 		<WasmShellWebAppBasePath Condition="$(WasmShellWebAppBasePath) == ''">/</WasmShellWebAppBasePath>
+
+		<!-- Follow the Android, iOS, & MacCatalyst SDK's -->
+		<!-- Default to 1, if blank -->
+		<ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">1</ApplicationVersion>
+		<Version Condition=" $([System.Version]::TryParse ('$(ApplicationDisplayVersion)', $([System.Version]::Parse('1.0')))) ">$(ApplicationDisplayVersion)</Version>
+		<ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Optimize)'!='true'">

--- a/src/Uno.Sdk/targets/Uno.SingleProject.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.WinAppSdk.targets
@@ -1,6 +1,12 @@
 <Project>
 	<PropertyGroup>
 		<UseWinUI>true</UseWinUI>
+
+		<!-- Follow the Android, iOS, & MacCatalyst SDK's -->
+		<!-- Default to 1, if blank -->
+		<ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">1</ApplicationVersion>
+		<Version Condition=" $([System.Version]::TryParse ('$(ApplicationDisplayVersion)', $([System.Version]::Parse('1.0')))) ">$(ApplicationDisplayVersion)</Version>
+		<ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(IsUnoHead)' == 'true' ">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- #16618

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

We do not set the version based on the ApplicationDisplayVersion

## What is the new behavior?

We now mimic the behavior of the Android, iOS, & MacCatalyst SDK's in their handling of the ApplicationDisplayVersion in setting the Version.