### PR TITLE
fix(macos): Let the managed side know about the pointerDeviceType

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -716,6 +716,7 @@ void* uno_window_get_metal_context(UNOWindow* window)
                 }
             }
 #endif
+            data.pointerDeviceType = pdt;
             // mouse
             data.mouseButtons = (uint32)NSEvent.pressedMouseButtons;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #16820

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The skia/macOS code knows which `pointerDeviceType` is being used but this is not copied back to the managed structure. This means the default `0` value is used and that means a `Touch` event. Any code that depends on this value could misbehave.

## What is the new behavior?

The correct value is shared with the managed code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
