### PR TITLE
fxi: Move IR patches state from Layout to LayoutState

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/MyItem.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/MyItem.xaml
@@ -1,14 +1,14 @@
 ﻿<Page
-    x:Class="UITests.Windows_UI_Xaml_Controls.Repeater.MyItem"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.Repeater"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	x:Class="UITests.Windows_UI_Xaml_Controls.Repeater.MyItem"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml_Controls.Repeater"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<Border Margin="10" Background="{x:Bind GetColor(DataContext)}" Padding="10" MinHeight="30">
-		<TextBlock FontSize="30">This is item #<Run Text="{Binding}" /> which is using template #<Run Text="{x:Bind InstanceId}" /></TextBlock>
+		<TextBlock FontSize="30">This is item #<Run Text="{Binding}" /> which is using template #<Run Text="{x:Bind InstanceId}" />(of <Run Text="{x:Bind InstanceCount}" />)</TextBlock>
 	</Border>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/MyItem.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Repeater/MyItem.xaml.cs
@@ -1,18 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.UI;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
 
 namespace UITests.Windows_UI_Xaml_Controls.Repeater
 {
@@ -21,6 +11,8 @@ namespace UITests.Windows_UI_Xaml_Controls.Repeater
 		private static int _count;
 
 		private int InstanceId { get; } = _count++;
+
+		private int InstanceCount => _count;
 
 		public MyItem()
 		{
@@ -31,15 +23,15 @@ namespace UITests.Windows_UI_Xaml_Controls.Repeater
 		{
 			if (int.TryParse(value?.ToString(), out var id))
 			{
-				switch (id % 6)
+				return (id % 6) switch
 				{
-					case 0: return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00));
-					case 1: return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0x7F, 0x00));
-					case 2: return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xFF, 0x00));
-					case 3: return new SolidColorBrush(Color.FromArgb(0xFF, 0x00, 0xFF, 0x00));
-					case 4: return new SolidColorBrush(Color.FromArgb(0xFF, 0x00, 0x00, 0xFF));
-					case 5: return new SolidColorBrush(Color.FromArgb(0xFF, 0x94, 0x00, 0xD3));
-				}
+					0 => new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0x00, 0x00)),
+					1 => new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0x7F, 0x00)),
+					2 => new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xFF, 0x00)),
+					3 => new SolidColorBrush(Color.FromArgb(0xFF, 0x00, 0xFF, 0x00)),
+					4 => new SolidColorBrush(Color.FromArgb(0xFF, 0x00, 0x00, 0xFF)),
+					_ => new SolidColorBrush(Color.FromArgb(0xFF, 0x94, 0x00, 0xD3))
+				};
 			}
 
 			return new SolidColorBrush(Colors.Black);

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/FlowLayout.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/FlowLayout.cs
@@ -429,25 +429,27 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 			avgCountInLine = Math.Max(1.0, flowState.TotalItemsPerLine / flowState.TotalLinesMeasured);
 			avgLineSize = Math.Round(flowState.TotalLineSize / flowState.TotalLinesMeasured);
 
-			return _uno_lastKnownAverageLineSize = avgLineSize;
+			flowState.Uno_LastKnownAverageLineSize = avgLineSize;
+
+			return avgLineSize;
 		}
 
 		#endregion
 
 		#region Uno workaround
-		private double _uno_lastKnownAverageLineSize;
-
 		/// <inheritdoc />
-		protected internal override bool IsSignificantViewportChange(Rect oldViewport, Rect newViewport)
+		protected internal override bool IsSignificantViewportChange(object state, Rect oldViewport, Rect newViewport)
 		{
-			var elementSize = _uno_lastKnownAverageLineSize;
-			if (elementSize <= 0)
+			if (state is FlowLayoutState { Uno_LastKnownAverageLineSize: > 0 } flowState)
 			{
-				return base.IsSignificantViewportChange(oldViewport, newViewport);
+				var elementSize = flowState.Uno_LastKnownAverageLineSize;
+				return Math.Abs(MajorStart(oldViewport) - MajorStart(newViewport)) > elementSize * 1.5
+					|| Math.Abs(MajorEnd(oldViewport) - MajorEnd(newViewport)) > elementSize * 1.5;
 			}
-
-			return Math.Abs(MajorStart(oldViewport) - MajorStart(newViewport)) > elementSize * 1.5
-				|| Math.Abs(MajorEnd(oldViewport) - MajorEnd(newViewport)) > elementSize * 1.5;
+			else
+			{
+				return base.IsSignificantViewportChange(state, oldViewport, newViewport);
+			}
 		}
 		#endregion
 	}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/FlowLayoutState.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/FlowLayoutState.cs
@@ -29,6 +29,8 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 			set => m_specialElementDesiredSize = value;
 		}
 
+		internal double Uno_LastKnownAverageLineSize;
+
 		internal void InitializeForContext(VirtualizingLayoutContext context, IFlowLayoutAlgorithmDelegates callbacks)
 		{
 			m_flowAlgorithm.InitializeForContext(context, callbacks);

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayout.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayout.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using Windows.Foundation;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Uno.Collections;
 using Uno.Extensions;
 using static Microsoft/* UWP don't rename */.UI.Xaml.Controls._Tracing;
 
@@ -72,7 +74,8 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 
 		protected internal override Size MeasureOverride(VirtualizingLayoutContext context, Size availableSize)
 		{
-			GetAsStackState(context.LayoutState).OnMeasureStart();
+			var state = GetAsStackState(context.LayoutState);
+			state.OnMeasureStart();
 
 			var algo = GetFlowAlgorithm(context);
 			var desiredSize = algo.Measure(
@@ -87,9 +90,9 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 				LayoutId);
 
 			// Uno workaround [BEGIN]: Keep track of realized items count for viewport invalidation optimization
-			_uno_lastKnownItemsCount = context.ItemCount;
-			_uno_lastKnownRealizedElementsCount = algo.RealizedElementCount;
-			_uno_lastKnownDesiredSize = desiredSize;
+			state.Uno_LastKnownItemsCount = context.ItemCount;
+			state.Uno_LastKnownRealizedElementsCount = algo.RealizedElementCount;
+			state.Uno_LastKnownDesiredSize = desiredSize;
 			// Uno workaround [END]
 
 			return desiredSize;
@@ -117,10 +120,8 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		#endregion
 
 		#region IStackLayoutOverrides
-
 		FlowLayoutAnchorInfo GetAnchorForRealizationRect(Size availableSize, VirtualizingLayoutContext context)
 		{
-
 			int anchorIndex = -1;
 			double offset = double.NaN;
 
@@ -147,8 +148,8 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 					// Uno workaround [BEGIN]: Make sure items at index 0 is always at offset 0
 					anchorIndex = Math.Max(0, Math.Min(itemsCount - 1, anchorIndex));
 					// Uno workaround [END]
-
-					offset = anchorIndex * averageElementSize + MajorStart(lastExtent);
+					offset = EstimateMajor(state._uno_realizedItemsCache.AsSpan(..Math.Min(anchorIndex, state._uno_realizedItemsCache.Length)), averageElementSize);
+					//offset = anchorIndex * averageElementSize + MajorStart(lastExtent);
 					//anchorIndex = Math.Max(0, Math.Min(itemsCount - 1, anchorIndex)); // Line moved before computation of the offset for uno
 				}
 			}
@@ -180,13 +181,19 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 				if (firstRealized != null)
 				{
 					MUX_ASSERT(lastRealized != null);
-					var firstRealizedMajor = (float)(MajorStart(firstRealizedLayoutBounds) - firstRealizedItemIndex * averageElementSize);
-					// Uno workaround [BEGIN]: Make sure to not move items above the viewport. This can be the case if an items is significantly higher than previous items (will increase the average items size)
-					firstRealizedMajor = Math.Max(0.0f, firstRealizedMajor);
+
+					// var firstRealizedMajor = (float)(MajorStart(firstRealizedLayoutBounds) - firstRealizedItemIndex * averageElementSize);
+					// Uno workaround [BEGIN]: Make sure to not move items above the viewport. This can be the case if an items is significantly taller than previous items (will increase the average items size)
+					// We try to estimate only items that as not been realized yet.
+					var before = Aggregate(stackState._uno_realizedItemsCache.AsSpan(..firstRealizedItemIndex));
+					var after = Aggregate(stackState._uno_realizedItemsCache.AsSpan((lastRealizedItemIndex + 1)..Math.Min(itemsCount, stackState._uno_realizedItemsCache.Length)));
+					var realizedSize = MajorEnd(lastRealizedLayoutBounds) - MajorStart(firstRealizedLayoutBounds);
+					var neverRealizedItemsEstimatedSize = (before.notRealized + after.notRealized) * averageElementSize;
+					var previouslyRealizedItemsSize = Major(before.total) + Major(after.total);
+
+					// Note: We do NOT set the MajorStart as with uno we assume it to always be 0.
+					SetMajorSize(ref extent, realizedSize + previouslyRealizedItemsSize + neverRealizedItemsEstimatedSize);
 					// Uno workaround [END]
-					SetMajorStart(ref extent, firstRealizedMajor);
-					var remainingItems = itemsCount - lastRealizedItemIndex - 1;
-					SetMajorSize(ref extent, MajorEnd(lastRealizedLayoutBounds) - MajorStart(extent) + (float)(remainingItems * averageElementSize));
 				}
 				else
 				{
@@ -207,6 +214,30 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 			return extent;
 		}
 
+		private double EstimateMajor(Span<Size> span, double averageElementSize)
+		{
+			var info = Aggregate(span);
+			return Major(info.total) + info.notRealized * averageElementSize;
+		}
+
+		private static (Size total, uint notRealized) Aggregate(Span<Size> span)
+		{
+			var total = default(Size);
+			var notRealized = 0u;
+			for (var i = 0; i < span.Length; i++)
+			{
+				ref var size = ref span[i];
+				total.Width += size.Width;
+				total.Height += size.Height;
+				if (size == default)
+				{
+					notRealized++;
+				}
+			}
+
+			return (total, notRealized);
+		}
+
 		void OnElementMeasured(
 			UIElement element,
 			int index,
@@ -224,6 +255,18 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 					index,
 					Major(provisionalArrangeSizeWinRt),
 					Minor(provisionalArrangeSizeWinRt));
+
+				if (index < StackLayoutState._uno_realizedItemsCacheMaxLength)
+				{
+					if (stackState._uno_realizedItemsCache.Length <= index)
+					{
+						var currentLength = stackState._uno_realizedItemsCache.Length;
+						var newLength = (int)Math.Ceiling((index + 1) / (double)currentLength) * currentLength;
+						Array.Resize(ref stackState._uno_realizedItemsCache, newLength);
+					}
+
+					stackState._uno_realizedItemsCache[index] = provisionalArrangeSize;
+				}
 			}
 		}
 
@@ -358,7 +401,9 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 				averageElementSize = Math.Round(stackLayoutState.TotalElementSize / stackLayoutState.TotalElementsMeasured);
 			}
 
-			return _uno_lastKnownAverageElementSize = averageElementSize;
+			stackLayoutState.Uno_LastKnownAverageElementSize = averageElementSize;
+
+			return averageElementSize;
 		}
 
 
@@ -366,42 +411,38 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		#endregion
 
 		#region Uno workaround
-		private double _uno_lastKnownAverageElementSize;
-		private int _uno_lastKnownRealizedElementsCount;
-		private int _uno_lastKnownItemsCount;
-		private Size _uno_lastKnownDesiredSize;
-
 		/// <inheritdoc />
-		protected internal override bool IsSignificantViewportChange(Rect oldViewport, Rect newViewport)
+		protected internal override bool IsSignificantViewportChange(object state, Rect oldViewport, Rect newViewport)
 		{
-			var elementSize = _uno_lastKnownAverageElementSize;
-			if (elementSize <= 0)
+			if (state is StackLayoutState { Uno_LastKnownAverageElementSize: > 0 } stackState)
 			{
-				return base.IsSignificantViewportChange(oldViewport, newViewport);
-			}
+				var neededElementsCountToFillNewViewport = Math.Min(stackState.Uno_LastKnownItemsCount, MajorSize(newViewport) / stackState.Uno_LastKnownAverageElementSize);
+				if (stackState.Uno_LastKnownRealizedElementsCount < neededElementsCountToFillNewViewport)
+				{
+					// Only a few first items have been measured so far (usually 1 or 2), this might be because the IR is within a SV and not visible yet.
+					// Note: In that case we have to make sure to not only validate the Major axis since the parent SV could be vertical while local layout itself is horizontal.
+					// Note2: Depending of the platform (Android), we might be invoked with empty viewport, make sure to consider out-of-bound in such case.
+					// Test case: When_NestedInSVAndOutOfViewportOnInitialLoad_Then_MaterializedEvenWhenScrollingOnMinorAxis
+					const int threshold = 100; // Allows 100px above and after to trigger loading even before IR is visible.
+					var isOutOfBounds = newViewport is { Width: 0 } or { Height: 0 }
+						|| MajorEnd(newViewport) < -threshold
+						|| MajorStart(newViewport) > Major(stackState.Uno_LastKnownDesiredSize) + threshold
+						|| MinorEnd(newViewport) < -threshold
+						|| MinorStart(newViewport) > Minor(stackState.Uno_LastKnownDesiredSize) + threshold;
 
-			var neededElementsCountToFillNewViewport = Math.Min(_uno_lastKnownItemsCount, MajorSize(newViewport) / _uno_lastKnownAverageElementSize);
-			if (_uno_lastKnownRealizedElementsCount < neededElementsCountToFillNewViewport)
+					return !isOutOfBounds;
+				}
+
+				var size = Math.Max(MajorSize(oldViewport), MajorSize(newViewport));
+				var minDelta = Math.Min(stackState.Uno_LastKnownAverageElementSize * 5, size);
+
+				return Math.Abs(MajorStart(oldViewport) - MajorStart(newViewport)) > minDelta
+					|| Math.Abs(MajorEnd(oldViewport) - MajorEnd(newViewport)) > minDelta;
+			}
+			else
 			{
-				// Only a few first items have been measured so far (usually 1 or 2), this might be because the IR is within a SV and not visible yet.
-				// Note: In that case we have to make sure to not only validate the Major axis since the parent SV could be vertical while local layout itself is horizontal.
-				// Note2: Depending of the platform (Android), we might be invoked with empty viewport, make sure to consider out-of-bound in such case.
-				// Test case: When_NestedInSVAndOutOfViewportOnInitialLoad_Then_MaterializedEvenWhenScrollingOnMinorAxis
-				const int threshold = 100; // Allows 100px above and after to trigger loading even before IR is visible.
-				var isOutOfBounds = newViewport is { Width: 0 } or { Height: 0 }
-					|| MajorEnd(newViewport) < -threshold
-					|| MajorStart(newViewport) > Major(_uno_lastKnownDesiredSize) + threshold
-					|| MinorEnd(newViewport) < -threshold
-					|| MinorStart(newViewport) > Minor(_uno_lastKnownDesiredSize) + threshold;
-
-				return !isOutOfBounds;
+				return base.IsSignificantViewportChange(state, oldViewport, newViewport);
 			}
-
-			var size = Math.Max(MajorSize(oldViewport), MajorSize(newViewport));
-			var minDelta = Math.Min(elementSize * 5, size);
-
-			return Math.Abs(MajorStart(oldViewport) - MajorStart(newViewport)) > minDelta
-				|| Math.Abs(MajorEnd(oldViewport) - MajorEnd(newViewport)) > minDelta;
 		}
 		#endregion
 	}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayoutState.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayoutState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Windows.Foundation;
 
 namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 {
@@ -23,6 +24,16 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		internal double TotalElementSize => m_totalElementSize;
 		internal double MaxArrangeBounds => m_maxArrangeBounds;
 		internal int TotalElementsMeasured => m_totalElementsMeasured;
+
+		// Uno workaround [BEGIN]: Backing field for uno workarounds
+		internal double Uno_LastKnownAverageElementSize;
+		internal int Uno_LastKnownRealizedElementsCount;
+		internal int Uno_LastKnownItemsCount;
+		internal Size Uno_LastKnownDesiredSize;
+
+		internal Size[] _uno_realizedItemsCache = new Size[256];
+		internal const int _uno_realizedItemsCacheMaxLength = 4096;
+		// Uno workaround [END]
 
 		public StackLayoutState()
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayoutState.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/StackLayoutState.cs
@@ -30,9 +30,6 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		internal int Uno_LastKnownRealizedElementsCount;
 		internal int Uno_LastKnownItemsCount;
 		internal Size Uno_LastKnownDesiredSize;
-
-		internal Size[] _uno_realizedItemsCache = new Size[256];
-		internal const int _uno_realizedItemsCacheMaxLength = 4096;
 		// Uno workaround [END]
 
 		public StackLayoutState()

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ViewportManagerWithPlatformFeatures.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/ViewportManagerWithPlatformFeatures.cs
@@ -595,7 +595,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 			// Uno workaround [BEGIN]: For perf considerations, do not invalidate the tree on each viewport update
 			// (Viewport updates are quite frequent, this would cause lot of unnecessary layout pass which would impact scroll perf, especially on Android).
 			if (m_owner.Layout is VirtualizingLayout vl // If not a VirtualizingLayout, we actually don't have to re-measure items!
-				&& vl.IsSignificantViewportChange(_uno_viewportUsedInLastMeasure, m_visibleWindow))
+				&& vl.IsSignificantViewportChange(m_owner.LayoutState, _uno_viewportUsedInLastMeasure, m_visibleWindow))
 			// Uno workaround [END]
 #endif
 			{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/VirtualizingLayout.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/VirtualizingLayout.cs
@@ -42,10 +42,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		/// However a too high threshold would cause longer passes (as more items would been added / removed at once).
 		/// Note: this is used only for viewport, if the size of the ItemsRepeater changes it will still be re-layouted.
 		/// </summary>
+		/// <param name="state">The layout state</param>
 		/// <param name="oldViewport">Previous viewport</param>
 		/// <param name="newViewport">Updated viewport</param>
 		[UnoOnly]
-		protected internal virtual bool IsSignificantViewportChange(Rect oldViewport, Rect newViewport)
+		protected internal virtual bool IsSignificantViewportChange(object state, Rect oldViewport, Rect newViewport)
 		{
 			const double delta = 50;
 			return Math.Abs(oldViewport.Width - newViewport.Width) > delta


### PR DESCRIPTION
## Bugfix
Move `ItemsRepeater` patches state from `Layout` to `LayoutState`

## What is the current behavior?
State is persisted in `Layout`, which is a problematic as this can be reused on multiple `ItemsRepeater`.

## What is the new behavior?
State is persisted in the `LayoutState`

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
