### PR TITLE
chore: Move Uno.SDK to private package

### DIFF
--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -26,7 +26,7 @@ Get-ChildItem -Recurse -Filter global.json | ForEach-Object {
     Write-Host "Updated $globalJsonfilePath with $env:GITVERSION_SemVer"
 
     $globalJson = (Get-Content $globalJsonfilePath) -replace '^\s*//.*' | ConvertFrom-Json
-    $globalJson.'msbuild-sdks'.'Uno.Sdk' = $env:GITVERSION_SemVer
+    $globalJson.'msbuild-sdks'.'Uno.Sdk.Private' = $env:GITVERSION_SemVer
     $globalJson | ConvertTo-Json -Depth 100 | Set-Content $globalJsonfilePath
 }
 

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -206,7 +206,7 @@ Get-ChildItem -Recurse -Filter global.json | ForEach-Object {
     Write-Host "Updated $globalJsonfilePath with $env:GITVERSION_SemVer"
 
     $globalJson = (Get-Content $globalJsonfilePath) -replace '^\s*//.*' | ConvertFrom-Json
-    $globalJson.'msbuild-sdks'.'Uno.Sdk' = $env:GITVERSION_SemVer
+    $globalJson.'msbuild-sdks'.'Uno.Sdk.Private' = $env:GITVERSION_SemVer
     $globalJson | ConvertTo-Json -Depth 100 | Set-Content $globalJsonfilePath
 }
 

--- a/src/SolutionTemplate/5.1/uno51blank/global.json
+++ b/src/SolutionTemplate/5.1/uno51blank/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.1.50",
+    "Uno.Sdk.Private": "5.1.50",
     "Microsoft.Build.NoTargets": "3.7.56"
   }
 }

--- a/src/SolutionTemplate/5.1/uno51blank/uno51blank.Mobile/uno51blank.Mobile.csproj
+++ b/src/SolutionTemplate/5.1/uno51blank/uno51blank.Mobile/uno51blank.Mobile.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="'$(OverrideTargetFramework)'!=''">$(OverrideTargetFramework)</TargetFrameworks>

--- a/src/SolutionTemplate/5.1/uno51blank/uno51blank.Skia.Gtk/uno51blank.Skia.Gtk.csproj
+++ b/src/SolutionTemplate/5.1/uno51blank/uno51blank.Skia.Gtk/uno51blank.Skia.Gtk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>

--- a/src/SolutionTemplate/5.1/uno51blank/uno51blank.Skia.Linux.FrameBuffer/uno51blank.Skia.Linux.FrameBuffer.csproj
+++ b/src/SolutionTemplate/5.1/uno51blank/uno51blank.Skia.Linux.FrameBuffer/uno51blank.Skia.Linux.FrameBuffer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>

--- a/src/SolutionTemplate/5.1/uno51blank/uno51blank.Skia.WPF/uno51blank.Skia.WPF.csproj
+++ b/src/SolutionTemplate/5.1/uno51blank/uno51blank.Skia.WPF/uno51blank.Skia.WPF.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>

--- a/src/SolutionTemplate/5.1/uno51blank/uno51blank.Wasm/uno51blank.Wasm.csproj
+++ b/src/SolutionTemplate/5.1/uno51blank/uno51blank.Wasm/uno51blank.Wasm.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/SolutionTemplate/5.1/uno51blank/uno51blank.Windows/uno51blank.Windows.csproj
+++ b/src/SolutionTemplate/5.1/uno51blank/uno51blank.Windows/uno51blank.Windows.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>$(DotNetVersion)-windows10.0.19041.0</TargetFramework>

--- a/src/SolutionTemplate/5.1/uno51blank/uno51blank/uno51blank.csproj
+++ b/src/SolutionTemplate/5.1/uno51blank/uno51blank/uno51blank.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst</TargetFrameworks>

--- a/src/SolutionTemplate/5.1/uno51recommended/global.json
+++ b/src/SolutionTemplate/5.1/uno51recommended/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.1.50",
+    "Uno.Sdk.Private": "5.1.50",
     "Microsoft.Build.NoTargets": "3.7.56"
   }
 }

--- a/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Mobile/uno51recommended.Mobile.csproj
+++ b/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Mobile/uno51recommended.Mobile.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="'$(OverrideTargetFramework)'!=''">$(OverrideTargetFramework)</TargetFrameworks>

--- a/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Skia.Gtk/uno51recommended.Skia.Gtk.csproj
+++ b/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Skia.Gtk/uno51recommended.Skia.Gtk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>

--- a/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Skia.Linux.FrameBuffer/uno51recommended.Skia.Linux.FrameBuffer.csproj
+++ b/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Skia.Linux.FrameBuffer/uno51recommended.Skia.Linux.FrameBuffer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>

--- a/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Skia.WPF/uno51recommended.Skia.WPF.csproj
+++ b/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Skia.WPF/uno51recommended.Skia.WPF.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <OutputType Condition="'$(Configuration)'=='Release'">WinExe</OutputType>
     <OutputType Condition="'$(Configuration)'=='Debug'">Exe</OutputType>

--- a/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Wasm/uno51recommended.Wasm.csproj
+++ b/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Wasm/uno51recommended.Wasm.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Windows/uno51recommended.Windows.csproj
+++ b/src/SolutionTemplate/5.1/uno51recommended/uno51recommended.Windows/uno51recommended.Windows.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>$(DotNetVersion)-windows10.0.19041.0</TargetFramework>

--- a/src/SolutionTemplate/5.1/uno51recommended/uno51recommended/uno51recommended.csproj
+++ b/src/SolutionTemplate/5.1/uno51recommended/uno51recommended/uno51recommended.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);$(DotNetVersion)-windows10.0.19041</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);$(DotNetVersion)-android;$(DotNetVersion)-ios;$(DotNetVersion)-maccatalyst</TargetFrameworks>

--- a/src/SolutionTemplate/5.2/uno52AppWithLib/global.json
+++ b/src/SolutionTemplate/5.2/uno52AppWithLib/global.json
@@ -1,6 +1,6 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.2.0-dev.2002"
+    "Uno.Sdk.Private": "5.2.0-dev.2002"
   }
 }

--- a/src/SolutionTemplate/5.2/uno52AppWithLib/uno52AppWithLib/uno52AppWithLib.csproj
+++ b/src/SolutionTemplate/5.2/uno52AppWithLib/uno52AppWithLib/uno52AppWithLib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net8.0-browserwasm;net8.0-desktop;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop</TargetFrameworks>

--- a/src/SolutionTemplate/5.2/uno52AppWithLib/uno52emptylib/uno52emptylib.csproj
+++ b/src/SolutionTemplate/5.2/uno52AppWithLib/uno52emptylib/uno52emptylib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net8.0-browserwasm;net8.0-desktop;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop</TargetFrameworks>

--- a/src/SolutionTemplate/5.2/uno52AppWithLib/uno52lib/uno52lib.csproj
+++ b/src/SolutionTemplate/5.2/uno52AppWithLib/uno52lib/uno52lib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net8.0-browserwasm;net8.0-desktop;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop</TargetFrameworks>

--- a/src/SolutionTemplate/5.2/uno52Lib/global.json
+++ b/src/SolutionTemplate/5.2/uno52Lib/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "5.2.0-dev.2002"
+    "Uno.Sdk.Private": "5.2.0-dev.2002"
   }
 }

--- a/src/SolutionTemplate/5.2/uno52Lib/uno52Lib.csproj
+++ b/src/SolutionTemplate/5.2/uno52Lib/uno52Lib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop</TargetFrameworks>
 

--- a/src/SolutionTemplate/5.2/uno52NuGetLib/global.json
+++ b/src/SolutionTemplate/5.2/uno52NuGetLib/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "5.2.0-dev.2002"
+    "Uno.Sdk.Private": "5.2.0-dev.2002"
   }
 }

--- a/src/SolutionTemplate/5.2/uno52NuGetLib/uno52NuGetLib.csproj
+++ b/src/SolutionTemplate/5.2/uno52NuGetLib/uno52NuGetLib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop</TargetFrameworks>
 

--- a/src/SolutionTemplate/5.2/uno52SingleProjectLib/global.json
+++ b/src/SolutionTemplate/5.2/uno52SingleProjectLib/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "5.2.0-dev.2002"
+    "Uno.Sdk.Private": "5.2.0-dev.2002"
   }
 }

--- a/src/SolutionTemplate/5.2/uno52SingleProjectLib/uno52SingleProjectLib.csproj
+++ b/src/SolutionTemplate/5.2/uno52SingleProjectLib/uno52SingleProjectLib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop</TargetFrameworks>
 

--- a/src/SolutionTemplate/5.2/uno52blank/global.json
+++ b/src/SolutionTemplate/5.2/uno52blank/global.json
@@ -1,6 +1,6 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.2.0-dev.2002"
+    "Uno.Sdk.Private": "5.2.0-dev.2002"
   }
 }

--- a/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
+++ b/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net8.0-browserwasm;net8.0-desktop;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('linux'))">$(TargetFrameworks);net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-desktop</TargetFrameworks>

--- a/src/Uno.Sdk/Uno.Sdk.csproj
+++ b/src/Uno.Sdk/Uno.Sdk.csproj
@@ -16,7 +16,7 @@
 		<!-- <UnoSdkVersionSuffix Condition="$(GitVersion_Sha) != ''">_v$(GitVersion_Sha)</UnoSdkVersionSuffix> -->
 		<!-- Use the VersionSource SHA to avoid conflicts for PR builds that span merges on master -->
 		<!-- <UnoSdkVersionSuffix Condition="$(GITVERSION_INFORMATIONALVERSION.Contains('PullRequest'))">$(GITVERSION_VersionSourceSha)</UnoSdkVersionSuffix> -->
-		<AssemblyName>$(PackageId)$(UnoSdkVersionSuffix)</AssemblyName>
+		<AssemblyName>Uno.Sdk$(UnoSdkVersionSuffix)</AssemblyName>
 
 		<!-- Generate the nupkg only for WinUI, we do not support Uno.SDK for UWP -->
 		<GeneratePackageOnBuild Condition=" '$(UNO_UWP_BUILD)' != 'true' ">true</GeneratePackageOnBuild>

--- a/src/Uno.Sdk/Uno.Sdk.csproj
+++ b/src/Uno.Sdk/Uno.Sdk.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<BuildOutputTargetFolder>targets</BuildOutputTargetFolder>
 		<DevelopmentDependency>true</DevelopmentDependency>
-		<PackageId>Uno.Sdk</PackageId>
+		<PackageId>Uno.Sdk.Private</PackageId>
 		<LangVersion>latest</LangVersion>
 		<NoWarn>$(NoWarn);NU5128;NU5100</NoWarn>
 		<PackageType>MSBuildSdk</PackageType>


### PR DESCRIPTION
This change moves the Uno.Sdk to a private package used only for regression testing. The actual Uno.Sdk package generation is moved to uno.templates.