### PR TITLE
Desktop target should not launch console

### DIFF
--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -10,7 +10,7 @@
 		<ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition=" '$(IsUnoHead)' == 'true' ">
+	<PropertyGroup Condition=" '$(IsUnoHead)' == 'true' AND $(Optimize) == 'true' ">
 		<OutputType>WinExe</OutputType>
 	</PropertyGroup>
 

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -9,6 +9,11 @@
 		<Version Condition=" $([System.Version]::TryParse ('$(ApplicationDisplayVersion)', $([System.Version]::Parse('1.0')))) ">$(ApplicationDisplayVersion)</Version>
 		<ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
 	</PropertyGroup>
+	
+	<PropertyGroup Condition=" '$(IsUnoHead)' == 'true' ">
+		<OutputType>WinExe</OutputType>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<EmbeddedResource Include="$(DesktopProjectFolder)Package.appxmanifest"
 			Condition="Exists('$(DesktopProjectFolder)Package.appxmanifest')"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #16905 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When launching a Skia Desktop app a console is launched

## What is the new behavior?

We now build as a WinExe to prevent this behavior