### PR TITLE
Ensure Manifest has version for Feature validation

### DIFF
--- a/src/Uno.Sdk/Services/PackageManifest.cs
+++ b/src/Uno.Sdk/Services/PackageManifest.cs
@@ -117,7 +117,7 @@ internal class PackageManifest
 		return this;
 	}
 
-	private string? GetGroupVersion(string groupName)
+	public string GetGroupVersion(string groupName)
 	{
 		var group = Manifest.SingleOrDefault(x => x.Group.Equals(groupName, StringComparison.InvariantCultureIgnoreCase));
 		return GetGroupVersion(group);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes unoplatform/uno.templates#697

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

We Validate the UnoFeatures first requiring that the MSBuild property is set for Extensions, Toolkit, Themes and C# Markup.

## What is the new behavior?

We update the Manifest and validate that the updated Manifest has a version for Extensions, Themes, Toolkit and C# Markup when validating the Uno Features.