### PR TITLE
fix(TextBox): Fix TwoWay binding on TextBox.Text not updating properly when unfocused

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/When_TwoWay_Text_Binding.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/When_TwoWay_Text_Binding.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.When_TwoWay_Text_Binding"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<TextBox x:Name="tbTwoWay_triggerDefault" Text="{Binding VMProperty, Mode=TwoWay, UpdateSourceTrigger=Default}" x:FieldModifier="public" />
+		<TextBox x:Name="tbTwoWay_triggerLostFocus" Text="{Binding VMProperty, Mode=TwoWay, UpdateSourceTrigger=LostFocus}" x:FieldModifier="public" />
+		<TextBox x:Name="tbTwoWay_triggerPropertyChanged" Text="{Binding VMProperty, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" x:FieldModifier="public" />
+		<TextBox x:Name="tbTwoWay_triggerExplicit" Text="{Binding VMProperty, Mode=TwoWay, UpdateSourceTrigger=Explicit}" x:FieldModifier="public" />
+		<Button x:Name="dummyButton" Content="Dummy" x:FieldModifier="public" />
+	</StackPanel>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/When_TwoWay_Text_Binding.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/When_TwoWay_Text_Binding.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System.ComponentModel;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+public sealed partial class When_TwoWay_Text_Binding : Page
+{
+	public class VM : INotifyPropertyChanged
+	{
+		private string _vmProperty;
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public string VMProperty
+		{
+			get => _vmProperty;
+			set
+			{
+				_vmProperty = value;
+				SetCount++;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(VMProperty)));
+			}
+		}
+
+		public int SetCount { get; private set; }
+	}
+
+	public When_TwoWay_Text_Binding()
+	{
+		this.InitializeComponent();
+		tbTwoWay_triggerDefault.DataContext = new VM();
+		tbTwoWay_triggerLostFocus.DataContext = new VM();
+		tbTwoWay_triggerPropertyChanged.DataContext = new VM();
+		tbTwoWay_triggerExplicit.DataContext = new VM();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -320,7 +320,7 @@ namespace Microsoft.UI.Xaml.Controls
 			OnTextChangedPartial();
 
 			var focusManager = VisualTree.GetFocusManagerForElement(this);
-			if (focusManager.FocusedElement != this &&
+			if (focusManager?.FocusedElement != this &&
 				GetBindingExpression(TextProperty) is { ParentBinding.UpdateSourceTrigger: UpdateSourceTrigger.Default or UpdateSourceTrigger.LostFocus } bindingExpression)
 			{
 				bindingExpression.UpdateSource(Text);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -26,6 +26,7 @@ using Uno.UI;
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;
 using PointerDeviceType = Microsoft.UI.Input.PointerDeviceType;
+using Uno.UI.Xaml.Core;
 #else
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 #endif
@@ -317,6 +318,13 @@ namespace Microsoft.UI.Xaml.Controls
 			UpdateButtonStates();
 
 			OnTextChangedPartial();
+
+			var focusManager = VisualTree.GetFocusManagerForElement(this);
+			if (focusManager.FocusedElement != this &&
+				GetBindingExpression(TextProperty) is { ParentBinding.UpdateSourceTrigger: UpdateSourceTrigger.Default or UpdateSourceTrigger.LostFocus } bindingExpression)
+			{
+				bindingExpression.UpdateSource(Text);
+			}
 
 			var isUserModifyingText = _isInputModifyingText | _isInputClearingText;
 			_textChangedPendingCount++;
@@ -918,11 +926,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (!initial && newValue == FocusState.Unfocused && _hasTextChangedThisFocusSession)
 			{
-				if (!_wasTemplateRecycled)
+				if (!_wasTemplateRecycled &&
+					GetBindingExpression(TextProperty) is { ParentBinding.UpdateSourceTrigger: UpdateSourceTrigger.LostFocus or UpdateSourceTrigger.Default } bindingExpression)
 				{
 					// Manually update Source when losing focus because TextProperty's default UpdateSourceTrigger is Explicit
-					var bindingExpression = GetBindingExpression(TextProperty);
-					bindingExpression?.UpdateSource(Text);
+					bindingExpression.UpdateSource(Text);
 				}
 
 				_wasTemplateRecycled = false;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -19,6 +19,7 @@ using Microsoft.UI.Xaml.Media;
 using Uno.Foundation.Logging;
 using Uno.Disposables;
 using Uno.UI.Helpers;
+using Uno.UI.Xaml.Core;
 using Uno.UI.Xaml.Media;
 using Windows.ApplicationModel.DataTransfer;
 using Uno.UI;
@@ -26,7 +27,6 @@ using Uno.UI;
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;
 using PointerDeviceType = Microsoft.UI.Input.PointerDeviceType;
-using Uno.UI.Xaml.Core;
 #else
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 #endif


### PR DESCRIPTION
GitHub Issue (If applicable): closes #16951

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
