### PR TITLE
ci: build docfx intermediary assets

### DIFF
--- a/build/ci/.azure-devops-docs.yml
+++ b/build/ci/.azure-devops-docs.yml
@@ -30,6 +30,8 @@ jobs:
   - template: templates/gitversion.yml
   - template: templates/jdk-setup.yml
 
+  - template: templates/docfx-intermediary-assets.yml
+
   - task: MSBuild@1
     inputs:
       solution: Build/Uno.UI.Build.csproj

--- a/build/ci/templates/docfx-intermediary-assets.yml
+++ b/build/ci/templates/docfx-intermediary-assets.yml
@@ -1,0 +1,15 @@
+steps:
+  - task: NodeTool@0
+    displayName: "Install Node 14.7.1"
+    inputs:
+      versionSpec: "14.17.1"
+
+  - bash: |
+      cd "$(Build.SourcesDirectory)/doc/"
+      npm install
+    displayName: Install Dependencies
+
+  - bash: |
+      cd "$(Build.SourcesDirectory)/doc/"
+      npm run build
+    displayName: Build intermediary assets


### PR DESCRIPTION
GitHub Issue: closes #15077

## PR Type

- Build or CI related changes

## What is the current behavior?

The intermediary assets for docfx are built manually

## What is the new behavior?

The intermediary assets for docfx are built automatically by the pipeline.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.