### PR TITLE
fix(droid): RenderTargetBitmap SIGSEGV

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/RenderTargetBitmap.Android.cs
@@ -40,26 +40,9 @@ namespace Microsoft.UI.Xaml.Media.Imaging
 		/// <inheritdoc />
 		private protected override bool IsSourceReady => _buffer != null;
 
-		[StructLayout(LayoutKind.Explicit)]
-		private struct ByteArrayToIntArrayBridge
-		{
-			[FieldOffset(0)]
-			public byte[] ByteArray;
-
-			[FieldOffset(0)]
-			public int[] IntArray;
-
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-			public ByteArrayToIntArrayBridge(byte[] bytes)
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-			{
-				ByteArray = bytes;
-			}
-		}
-
 		private static ImageData Open(byte[] buffer, int bufferLength, int width, int height)
 		{
-			var bitmap = Bitmap.CreateBitmap(new ByteArrayToIntArrayBridge(buffer).IntArray, width, height, Bitmap.Config.Argb8888!);
+			var bitmap = Bitmap.CreateBitmap(MemoryMarshal.Cast<byte, int>(buffer).ToArray(), width, height, Bitmap.Config.Argb8888!);
 			return ImageData.FromBitmap(bitmap);
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/kahua-private#146

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On android, ListView drag-n-drop re-ordering would sometimes randomly crash the app with:
> [libc] Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0xadd00000 in tid 32079 (yname.UnoSample), pid 32079 (yname.UnoSample)

## What is the new behavior?
Should no longer crash for the same reason.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.