### PR TITLE
docs: Fix table markdown formatting in Windowing docs

### DIFF
--- a/doc/articles/features/windows-ui-xaml-window.md
+++ b/doc/articles/features/windows-ui-xaml-window.md
@@ -123,4 +123,3 @@ This feature can help blend the background of the window with the background of 
 |                              | Skia Desktop | iOS | Android | macOS | Catalyst | WebAssembly |
 | ---------------------------- | :----------: | :-: | :-----: | :---: | :------: | :---------: |
 | `WindowHelper.SetBackground` |      ✔️     | ❌  |   ❌    |  ❌  |    ❌    |     ❌     |
-

--- a/doc/articles/features/windows-ui-xaml-window.md
+++ b/doc/articles/features/windows-ui-xaml-window.md
@@ -98,9 +98,9 @@ var nativeWindow = Uno.UI.Xaml.WindowHelper.GetNativeWindow(MainWindow);
 
 The `nativeWindow` is an `object`, so you need to cast it to the specific type on the given platform. See the table below:
 
-|                            | Skia+GTK | Skia+WPF | iOS   | Android | macOS | Catalyst | WebAssembly |
-| -------------------------- | :------: | :------: | :---: | :-----: | :---: | :------: | :---------: |
-| `WindowHelper.GetNativeWindow`` |`Gtk.Window`|`System.Windows.Window`|`UIKit.UIWindow`|`Android.View.Window`|`AppKit.NSWindow`|`UIKit.UIWindow`|`null`         |
+|                                |   Skia+GTK   |        Skia+WPF         |       iOS        |        Android        |       macOS       |     Catalyst     | WebAssembly |
+| ------------------------------ | :----------: | :---------------------: | :--------------: | :-------------------: | :---------------: | :--------------: | :---------: |
+| `WindowHelper.GetNativeWindow` | `Gtk.Window` | `System.Windows.Window` | `UIKit.UIWindow` | `Android.View.Window` | `AppKit.NSWindow` | `UIKit.UIWindow` |   `null`    |
 
 ## Avoiding `Window.Current`
 
@@ -120,6 +120,7 @@ This feature can help blend the background of the window with the background of 
 
 ### Supported platforms
 
-|                            | Skia Desktop | iOS   | Android | macOS | Catalyst | WebAssembly |
-| -------------------------- | :------: | :---: | :-----: | :---: | :------: | :---------: |
-| `WindowHelper.SetBackground` |   ✔️     | ❌    |  ❌     |  ❌  |   ❌     |  ❌         |
+|                              | Skia Desktop | iOS | Android | macOS | Catalyst | WebAssembly |
+| ---------------------------- | :----------: | :-: | :-----: | :---: | :------: | :---------: |
+| `WindowHelper.SetBackground` |      ✔️     | ❌  |   ❌    |  ❌  |    ❌    |     ❌     |
+


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Documentation content changes


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

![image](https://github.com/unoplatform/uno/assets/78549750/547bf289-d315-4211-a9f6-69c618a11519)


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
