### PR TITLE
fix: use the correct path for a scale icon

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowNative.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowNative.cs
@@ -91,7 +91,7 @@ internal class MacOSWindowNative
 					this.Log().Info($"Loading icon file [{scaledPath}] scaled logo from Package.appxmanifest file");
 				}
 
-				NativeUno.uno_application_set_icon(iconPath);
+				NativeUno.uno_application_set_icon(scaledPath);
 			}
 			else
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #17002

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

If the exact icon (file) is not found we try to look for a scale version - but still try to load the original file name (copy/paste error).

## What is the new behavior?

If the exact icon (file) is not found we try to look for a scale version and load that scaled version.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

https://github.com/unoplatform/uno/issues/17002