### PR TITLE
fix: workaround for AcrylicBrush pink background on macOS/arm64

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.skia.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using Windows.UI;
 using Microsoft.UI;
 using Microsoft.UI.Composition;
@@ -76,12 +77,15 @@ public partial class AcrylicBrush
 		}
 	}
 
+	// issue specific to macOSarm64 https://github.com/unoplatform/uno/issues/16853
+	static bool macOSarm64 = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture is Architecture.Arm64;
+
 	private void UpdateAcrylicBrush()
 	{
 		if (_isConnected)
 		{
 			// TODO: Currently we are force recreating the brush even if it exists because Composition animations aren't implemented yet
-			CreateAcrylicBrush(false /* useCrossFadeEffect */, true /* forceCreateAcrylicBrush */);
+			CreateAcrylicBrush(useCrossFadeEffect: false, forceCreateAcrylicBrush: !macOSarm64);
 		}
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

Workaround for https://github.com/unoplatform/uno/issues/16853

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

On macOS/arm64 when using the Metal renderer the AcrylicBrush (used for Fluent) gives a pinkish background to several UI elements.

## What is the new behavior?

On macOS/arm64 we instead use, **as a workaround**, the `FallbackColor` to create the color brush.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
