### PR TITLE
chore: add extra native logging for macOS/metal rendering

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -45,10 +45,47 @@
     // call managed code
     uno_get_metal_draw_callback()((__bridge void*) view.window, size.width, size.height, (__bridge void*) drawable.texture);
 
+#if DEBUG
+    id<MTLCommandBuffer> commandBuffer = nil;
+    if (@available(macOS 11.0, *)) {
+        MTLCommandBufferDescriptor* desc = [[MTLCommandBufferDescriptor alloc] init];
+        desc.errorOptions = MTLCommandBufferErrorOptionEncoderExecutionStatus; // this has a performance impact
+        commandBuffer = [self.queue commandBufferWithDescriptor:desc];
+        [commandBuffer addCompletedHandler:^(id <MTLCommandBuffer> commandbuf) {
+            [self trace:commandbuf withPrefix:@"addCompletedHandler"]; // status should be 4 (Completed)
+        }];
+    } else {
+        commandBuffer = [self.queue commandBuffer];
+    }
+    NSLog (@"drawInMTKView MTLCommandBuffer: %@", commandBuffer);
+#else
     id<MTLCommandBuffer> commandBuffer = [self.queue commandBuffer];
+#endif
+
+#if DEBUG_METAL
+    [self trace:commandBuffer withPrefix:@"prePresentDrawable"]; // status should be 0 (NotEnqueued)
+#endif
     [commandBuffer presentDrawable:drawable];
+
+#if DEBUG_METAL
+    [self trace:commandBuffer withPrefix:@"preCommit"]; // status should be 0 (NotEnqueued)
+#endif
     [commandBuffer commit];
+#if DEBUG_METAL
+    [self trace:commandBuffer withPrefix:@"postCommit"]; // status should be 2 (Committed)
+#endif
 }
+
+#if DEBUG
+- (void)trace:(id <MTLCommandBuffer>) commandBuffer withPrefix:(NSString*) prefix
+{
+    id logs = nil;
+    if (@available(macOS 11.0, *)) {
+        logs = commandBuffer.logs;
+    }
+    NSLog (@"drawInMTKView %@ status %lu LOG %@ ERROR %@", prefix, commandBuffer.status, logs, commandBuffer.error);
+}
+#endif
 
 - (void)mtkView:(nonnull MTKView *)view drawableSizeWillChange:(CGSize)size
 {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

Related to https://github.com/unoplatform/uno/issues/16853

## PR Type

What kind of change does this PR introduce?

- Other... Please describe: extra logging on debug builds

## What is the current behavior?

Current logging for Metal rendering do not show the status, logs and errors.

## What is the new behavior?

Under `DEBUG` (native lib) Metal logging now includes status, logs and errors.
Even more logging can be enabled by defining `DEBUG_METAL`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
