### PR TITLE
fix(surfacebrush): check that the final size isn't empty before resizing images.

### DIFF
--- a/src/Uno.UI.Composition/Composition/CompositionSurfaceBrush.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSurfaceBrush.skia.cs
@@ -83,36 +83,38 @@ namespace Microsoft.UI.Composition
 
 				if (backgroundArea.Width <= 0 || backgroundArea.Height <= 0)
 				{
-					return;
-				}
-
-				// Adding image downscaling in the shader matrix directly is very blurry
-				// since the default downsampler in Skia is really low quality (but really fast).
-				// We force Lanczos instead.
-				// https://github.com/mono/SkiaSharp/issues/520#issuecomment-444973518
-#pragma warning disable CS0612 // Type or member is obsolete
-				var resizedBitmap = scs.Image.ToSKBitmap().Resize(scs.Image.Info.WithSize((int)backgroundArea.Size.Width, (int)backgroundArea.Size.Height), SKBitmapResizeMethod.Lanczos3.ToFilterQuality());
-#pragma warning restore CS0612 // Type or member is obsolete
-				var resizedImage = SKImage.FromBitmap(resizedBitmap);
-
-				var matrix = Matrix3x2.CreateTranslation((float)backgroundArea.Left, (float)backgroundArea.Top);
-				matrix *= TransformMatrix;
-				var imageShader = SKShader.CreateImage(resizedImage, SKShaderTileMode.Decal, SKShaderTileMode.Decal, matrix.ToSKMatrix());
-
-				if (UsePaintColorToColorSurface)
-				{
-					// use the set color instead of the image pixel values. This is what happens on WinUI.
-					var blendedShader = SKShader.CreateColorFilter(imageShader, SKColorFilter.CreateBlendMode(fillPaint.Color, SKBlendMode.SrcIn));
-
-					fillPaint.Shader = blendedShader;
+					fillPaint.Shader = null;
 				}
 				else
 				{
-					fillPaint.Shader = imageShader;
-				}
+					// Adding image downscaling in the shader matrix directly is very blurry
+					// since the default downsampler in Skia is really low quality (but really fast).
+					// We force Lanczos instead.
+					// https://github.com/mono/SkiaSharp/issues/520#issuecomment-444973518
+#pragma warning disable CS0612 // Type or member is obsolete
+					var resizedBitmap = scs.Image.ToSKBitmap().Resize(scs.Image.Info.WithSize((int)backgroundArea.Size.Width, (int)backgroundArea.Size.Height), SKBitmapResizeMethod.Lanczos3.ToFilterQuality());
+#pragma warning restore CS0612 // Type or member is obsolete
+					var resizedImage = SKImage.FromBitmap(resizedBitmap);
 
-				fillPaint.IsAntialias = true;
-				fillPaint.FilterQuality = SKFilterQuality.High;
+					var matrix = Matrix3x2.CreateTranslation((float)backgroundArea.Left, (float)backgroundArea.Top);
+					matrix *= TransformMatrix;
+					var imageShader = SKShader.CreateImage(resizedImage, SKShaderTileMode.Decal, SKShaderTileMode.Decal, matrix.ToSKMatrix());
+
+					if (UsePaintColorToColorSurface)
+					{
+						// use the set color instead of the image pixel values. This is what happens on WinUI.
+						var blendedShader = SKShader.CreateColorFilter(imageShader, SKColorFilter.CreateBlendMode(fillPaint.Color, SKBlendMode.SrcIn));
+
+						fillPaint.Shader = blendedShader;
+					}
+					else
+					{
+						fillPaint.Shader = imageShader;
+					}
+
+					fillPaint.IsAntialias = true;
+					fillPaint.FilterQuality = SKFilterQuality.High;
+				}
 			}
 			else if (Surface is ISkiaSurface skiaSurface)
 			{
@@ -127,7 +129,9 @@ namespace Microsoft.UI.Composition
 					fillPaint.IsDither = true;
 				}
 				else
+				{
 					fillPaint.Shader = null;
+				}
 			}
 			else
 			{

--- a/src/Uno.UI.Composition/Composition/CompositionSurfaceBrush.skia.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionSurfaceBrush.skia.cs
@@ -81,6 +81,11 @@ namespace Microsoft.UI.Composition
 			{
 				var backgroundArea = GetArrangedImageRect(new Size(scs.Image!.Width, scs.Image.Height), bounds);
 
+				if (backgroundArea.Width <= 0 || backgroundArea.Height <= 0)
+				{
+					return;
+				}
+
 				// Adding image downscaling in the shader matrix directly is very blurry
 				// since the default downsampler in Skia is really low quality (but really fast).
 				// We force Lanczos instead.


### PR DESCRIPTION
GitHub Issue (If applicable): #17033
Let's see if this is the problem. My guess is that we might try to render the image right before a needed layout cycle. Looking at SkiaSharp's source, it returns null if you try to resize to a zero rectangle.