### PR TITLE
fix(vsix): Don't close opened files when reloading the project

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks.Dataflow;
 using System.Xml;
 using EnvDTE;
 using EnvDTE80;
+using Microsoft;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.VisualStudio;
@@ -227,11 +228,9 @@ public partial class EntryPoint : IDisposable
 							// properly keeps the value.
 							await WriteProjectUserSettingsAsync(newFramework);
 
-							// Unload project
-							solution4.UnloadProject(ref projectGuid, (uint)_VSProjectUnloadStatus.UNLOADSTATUS_UnloadedByUser);
-
-							// Reload project
-							solution4.ReloadProject(ref projectGuid);
+							// Reload the project in-place. This allows to keep files related to
+							// this project opened even when reloading.
+							startupProject.ReloadProjectInSolution();
 
 							var sw2 = Stopwatch.StartNew();
 

--- a/src/Uno.UI.RemoteControl.VS/Helpers/VsHierarchyExtensions.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/VsHierarchyExtensions.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Globalization;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Uno.UI.RemoteControl.VS.Helpers;
+
+// Based on https://github.com/dotnet/project-system/blob/9257cbdc5f5ca92d4c8a325e6b4c206220741e1a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Reload/ProjectReloadManager.cs#L437
+internal static class VsHierarchyExtensions
+{
+	public static T? GetProperty<T>(this IVsHierarchy hierarchy, VsHierarchyPropID property, T? defaultValue = default)
+		=> hierarchy.GetProperty(-1, property, defaultValue);
+
+	public static T? GetProperty<T>(this IVsHierarchy hierarchy, int item, VsHierarchyPropID property, T? defaultValue = default)
+	{
+		HResult hResult = hierarchy.GetProperty(item, property, defaultValue, out var result);
+		if (hResult.Failed)
+		{
+			throw hResult.Exception ?? new Exception();
+		}
+		return result;
+	}
+
+	public static int GetProperty<T>(this IVsHierarchy hierarchy, int item, VsHierarchyPropID property, T? defaultValue, out T? result)
+		=> hierarchy.GetPropertyCore(item, property, defaultValue, out result);
+
+	private static int GetPropertyCore<T>(this IVsHierarchy hierarchy, int item, VsHierarchyPropID property, T? defaultValue, out T? result)
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+
+		HResult hResult = hierarchy.GetProperty((uint)item, (int)property, out var obj);
+		if (hResult.IsOK)
+		{
+			try
+			{
+				result = (T?)obj;
+			}
+			catch (InvalidCastException)
+			{
+				result = (T)Convert.ChangeType(obj, typeof(T), CultureInfo.InvariantCulture);
+			}
+			return HResult.OK;
+		}
+		if (hResult == -2147352573)
+		{
+			result = defaultValue;
+			return HResult.OK;
+		}
+		result = default;
+		return hResult;
+	}
+
+	internal static void ReloadProjectInSolution(this IVsHierarchy hierarchy)
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+
+		var parentHierarchy = hierarchy.GetProperty<IVsHierarchy>(VsHierarchyPropID.ParentHierarchy);
+		if (parentHierarchy == null)
+		{
+			throw new NotSupportedException("Unable to find parent");
+		}
+
+		var hierarchyItemId = hierarchy.GetProperty(VsHierarchyPropID.ParentHierarchyItemid, uint.MaxValue);
+
+		if (hierarchyItemId == uint.MaxValue)
+		{
+			throw new NotSupportedException("Unable to find parent item");
+		}
+		ErrorHandler.ThrowOnFailure(((IVsPersistHierarchyItem2)parentHierarchy).ReloadItem((uint)hierarchyItemId, 0u));
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/17029

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

When the active project is reloaded to adjust the first TFM, this change avoids closing opened files that are related to that project.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
