### PR TITLE
fix: builds fail with latest MSAL updates

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -125,9 +125,10 @@
 	},
 	{
 		"group": "MsalClient",
-		"version": "4.61.1",
+		"version": "4.61.3",
 		"packages": [
-			"Microsoft.Identity.Client"
+			"Microsoft.Identity.Client",
+			"Microsoft.Identity.Client.Extensions.Msal"
 		]
 	},
 	{

--- a/src/Uno.Sdk/targets/Uno.Common.Android.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Android.targets
@@ -5,6 +5,8 @@
 		<EnableDefaultAndroidItems Condition="$(EnableDefaultAndroidItems) == ''">false</EnableDefaultAndroidItems>
 
 		<AndroidManifest Condition=" $(AndroidManifest) == '' AND $(_IsUnoSingleProjectAndLegacy) == 'true' AND Exists('$(AndroidProjectFolder)AndroidManifest.xml') ">$(AndroidProjectFolder)AndroidManifest.xml</AndroidManifest>
+
+		<IsMSALSupported>true</IsMSALSupported>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)Uno.SingleProject.Android.targets" Condition=" $(_IsUnoSingleProjectAndLegacy) == 'true' " />

--- a/src/Uno.Sdk/targets/Uno.Common.Wasm.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Wasm.targets
@@ -14,6 +14,8 @@
 		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">8.0</SupportedOSPlatformVersion>
 
 		<OutputType Condition=" $(OutputType) == 'Exe' AND $(OutputType) != $(_InitialOutputType)">$([MSBuild]::ValueOrDefault('$(_InitialOutputType)', 'Library'))</OutputType>
+
+		<IsMSALSupported>true</IsMSALSupported>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
@@ -13,6 +13,8 @@
 
 		<!-- Required to override the `win10-xxx` identifiers that cannot work with class libraries -->
 		<RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)'==''">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+
+		<IsMSALSupported>true</IsMSALSupported>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" $(_IsExecutable) == 'true' ">

--- a/src/Uno.Sdk/targets/Uno.Common.iOS.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.iOS.targets
@@ -5,6 +5,8 @@
 		<SupportedOSPlatformVersion Condition=" $(SupportedOSPlatformVersion) == '' ">14.2</SupportedOSPlatformVersion>
 
 		<EnableDefaultiOSItems Condition="$(EnableDefaultiOSItems) == ''">false</EnableDefaultiOSItems>
+
+		<IsMSALSupported>true</IsMSALSupported>
 	</PropertyGroup>
 
 	<Import Project="$(MSBuildThisFileDirectory)Uno.SingleProject.iOS.targets" Condition=" $(_IsUnoSingleProjectAndLegacy) == 'true' " />

--- a/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Extensions.Implicit.Packages.ProjectSystem.targets
@@ -10,8 +10,9 @@
 
 	<ItemGroup Condition="$(UnoFeatures.Contains(';authenticationmsal;'))">
 		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Authentication.MSAL.WinUI" ProjectSystem="true" />
-		<_UnoProjectSystemPackageReference Include="Microsoft.Identity.Client" ProjectSystem="true" />
-		<_UnoProjectSystemPackageReference Include="Uno.WinUI.MSAL" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Microsoft.Identity.Client" ProjectSystem="true" Condition="$(IsMSALSupported) == 'true'" />
+		<_UnoProjectSystemPackageReference Include="Microsoft.Identity.Client.Extensions.Msal" ProjectSystem="true" Condition="$(IsMSALSupported) == 'true'" />
+		<_UnoProjectSystemPackageReference Include="Uno.WinUI.MSAL" ProjectSystem="true" Condition="$(IsMSALSupported) == 'true'" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(UnoFeatures.Contains(';authenticationoidc;'))">


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- unoplatform/uno.templates#743 - Build Failure

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

We do not add Microsoft.Identity.Client.Extensions.MSAL
We add MSAL packages across all TFMs when the `AuthenticationMSAL` UnoFeature is present

## What is the new behavior?

We now also provide the top level dependency for Microsoft.Identity.Client.Extensions.MSAL
We exclude the MSAL packages but not the Extensions package from unsupported targets.