### PR TITLE
docs: ios retrive device error message

### DIFF
--- a/build/cSpell.json
+++ b/build/cSpell.json
@@ -109,7 +109,8 @@
 	"webservices",
 	"webapps",
 	"Haptics",
-	"autoplay"
+	"autoplay",
+	"Xcodes"
   ],
   "ignoreWords": [
 	"ADAL",

--- a/doc/articles/common-issues-ioscatalyst.md
+++ b/doc/articles/common-issues-ioscatalyst.md
@@ -27,5 +27,5 @@ When switching to an iOS debugging target in VS Code, you might encounter an err
 [Info]: Project reload forced to switch to net8.0-ios | Debug
 [Error] Could not retrieve ios devices within 10 seconds. Aborting...
 ```
-To resolve this issue, you can download [Xcodes](https://www.xcodes.app). Inside Xcodes.app, select the correct version of Xcode and click the **Make Active** button to make it the default Xcode for your Mac. After completing this step, you can speed up the process and use the new default Xcode for simulators, open the Command Palette and select `Developer: Reload Window`. This should resolve the error when switching to an IOS debugging target in VS Code.
+To resolve this issue, you can download [Xcodes](https://www.xcodes.app). Inside Xcodes.app, select the correct version of Xcode and click the **Make Active** button to make it the default Xcode for your Mac. After completing this step, you can speed up the process and use the new default Xcode for simulators, open the Command Palette and select `Developer: Reload Window`. This should resolve the error when switching to an iOS debugging target in VS Code.
 

--- a/doc/articles/common-issues-ioscatalyst.md
+++ b/doc/articles/common-issues-ioscatalyst.md
@@ -24,7 +24,7 @@ In order to fix this, add the following to your csproj (Xamarin, `net6.0-ios`, `
 
 When switching to an iOS debugging target in VS Code, you might encounter an error stating that the iOS device could not be retrieved. The error message may appear as follows:
 
-```
+```error
 [Info]: Project reload forced to switch to net8.0-ios | Debug
 [Error] Could not retrieve ios devices within 10 seconds. Aborting...
 ```

--- a/doc/articles/common-issues-ioscatalyst.md
+++ b/doc/articles/common-issues-ioscatalyst.md
@@ -27,5 +27,5 @@ When switching to an iOS debugging target in VS Code, you might encounter an err
 [Info]: Project reload forced to switch to net8.0-ios | Debug
 [Error] Could not retrieve ios devices within 10 seconds. Aborting...
 ```
-To resolve this issue, you can download [Xcodes](https://www.xcodes.app). Inside Xcodes.app, select the correct version of Xcode and click the **Make Active** button to make it the default Xcode for your Mac. After completing this step, you can speed up the process and use the new default Xcode for simulators, open the Command Palette and select `Developer: Reload Window`. This should resolve the error when switching to an iOS debugging target in VS Code.
+To resolve this issue, download [Xcodes](https://www.xcodes.app). Inside Xcodes.app, select the correct version of Xcode and click the **Make Active** button to make it the default Xcode for your Mac. After completing this step, you can speed up the process and use the new default Xcode for simulators. On VS Code, open the Command Palette and select `Developer: Reload Window`. This should resolve the error when switching to an iOS debugging target in VS Code.
 

--- a/doc/articles/common-issues-ioscatalyst.md
+++ b/doc/articles/common-issues-ioscatalyst.md
@@ -19,6 +19,7 @@ In order to fix this, add the following to your csproj (Xamarin, `net6.0-ios`, `
   <MtouchExtraArgs>$(MtouchExtraArgs) --registrar=static</MtouchExtraArgs>
 </PropertyGroup>
 ```
+
 ## Error while retrieving IOS device in VS code
 
 When switching to an iOS debugging target in VS Code, you might encounter an error stating that the iOS device could not be retrieved. The error message may appear as follows:

--- a/doc/articles/common-issues-ioscatalyst.md
+++ b/doc/articles/common-issues-ioscatalyst.md
@@ -20,7 +20,7 @@ In order to fix this, add the following to your csproj (Xamarin, `net6.0-ios`, `
 </PropertyGroup>
 ```
 
-## Error while retrieving IOS device in VS code
+## Error while retrieving iOS device in VS code
 
 When switching to an iOS debugging target in VS Code, you might encounter an error stating that the iOS device could not be retrieved. The error message may appear as follows:
 
@@ -30,4 +30,3 @@ When switching to an iOS debugging target in VS Code, you might encounter an err
 ```
 
 To resolve this issue, download [Xcodes](https://www.xcodes.app). Inside Xcodes.app, select the correct version of Xcode and click the **Make Active** button to make it the default Xcode for your Mac. After completing this step, you can speed up the process and use the new default Xcode for simulators. On VS Code, open the Command Palette and select `Developer: Reload Window`. This should resolve the error when switching to an iOS debugging target in VS Code.
-

--- a/doc/articles/common-issues-ioscatalyst.md
+++ b/doc/articles/common-issues-ioscatalyst.md
@@ -19,3 +19,13 @@ In order to fix this, add the following to your csproj (Xamarin, `net6.0-ios`, `
   <MtouchExtraArgs>$(MtouchExtraArgs) --registrar=static</MtouchExtraArgs>
 </PropertyGroup>
 ```
+## Error while retreving IOS device in VS code
+
+When switching to an iOS debugging target in VS Code, you might encounter an error stating that the iOS device could not be retrieved. The error message may appear as follows:
+
+```
+[Info]: Project reload forced to switch to net8.0-ios | Debug
+[Error] Could not retrieve ios devices within 10 seconds. Aborting...
+```
+To resolve this issue, you can download Xcodes. Open the latest version of Xcode and click the Make Active button. After completing this step, restart your machine. This should resolve the error when switching to an iOS debugging target in VS Code.
+

--- a/doc/articles/common-issues-ioscatalyst.md
+++ b/doc/articles/common-issues-ioscatalyst.md
@@ -27,5 +27,5 @@ When switching to an iOS debugging target in VS Code, you might encounter an err
 [Info]: Project reload forced to switch to net8.0-ios | Debug
 [Error] Could not retrieve ios devices within 10 seconds. Aborting...
 ```
-To resolve this issue, you can download Xcodes. Open the latest version of Xcode and click the Make Active button. After completing this step, restart your machine. This should resolve the error when switching to an iOS debugging target in VS Code.
+To resolve this issue, you can download [Xcodes](https://www.xcodes.app). Inside Xcodes.app, select the correct version of Xcode and click the **Make Active** button to make it the default Xcode for your Mac. After completing this step, you can speed up the process and use the new default Xcode for simulators, open the Command Palette and select `Developer: Reload Window`. This should resolve the error when switching to an IOS debugging target in VS Code.
 

--- a/doc/articles/common-issues-ioscatalyst.md
+++ b/doc/articles/common-issues-ioscatalyst.md
@@ -19,7 +19,7 @@ In order to fix this, add the following to your csproj (Xamarin, `net6.0-ios`, `
   <MtouchExtraArgs>$(MtouchExtraArgs) --registrar=static</MtouchExtraArgs>
 </PropertyGroup>
 ```
-## Error while retreving IOS device in VS code
+## Error while retrieving IOS device in VS code
 
 When switching to an iOS debugging target in VS Code, you might encounter an error stating that the iOS device could not be retrieved. The error message may appear as follows:
 

--- a/doc/articles/common-issues-ioscatalyst.md
+++ b/doc/articles/common-issues-ioscatalyst.md
@@ -28,5 +28,6 @@ When switching to an iOS debugging target in VS Code, you might encounter an err
 [Info]: Project reload forced to switch to net8.0-ios | Debug
 [Error] Could not retrieve ios devices within 10 seconds. Aborting...
 ```
+
 To resolve this issue, download [Xcodes](https://www.xcodes.app). Inside Xcodes.app, select the correct version of Xcode and click the **Make Active** button to make it the default Xcode for your Mac. After completing this step, you can speed up the process and use the new default Xcode for simulators. On VS Code, open the Command Palette and select `Developer: Reload Window`. This should resolve the error when switching to an iOS debugging target in VS Code.
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
 

- Documentation content changes




## What is the current behavior?

There might be a error message coming related to loading IOS devices

## What is the new behavior?

This PR gives an documentation update how to troubeshoot in case if we get a error message in loading IOS devices.
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
