### PR TITLE
fix(wasm): lottie animation event leak

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.wasm.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSourceBase.wasm.cs
@@ -30,6 +30,14 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
 		private readonly SerialDisposable _animationDataSubscription = new SerialDisposable();
 
+		~LottieVisualSourceBase()
+		{
+			if (_initializedPlayer is { })
+			{
+				NativeMethods.Kill(_initializedPlayer.HtmlId);
+			}
+		}
+
 		async Task InnerUpdate(CancellationToken ct)
 		{
 			var player = _player;
@@ -278,6 +286,9 @@ namespace Microsoft.Toolkit.Uwp.UI.Lottie
 
 			[JSImport($"{JsType}.stop")]
 			internal static partial void Stop(nint htmlId);
+
+			[JSImport($"{JsType}.kill")]
+			internal static partial void Kill(nint Handle);
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #17090

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
on wasm, Lottie animation would sometime be unproperly disposed, and spam the console with:
> No UIElement found for htmlId "118674"

## What is the new behavior?
no more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->