### PR TITLE
fix: Handle cases where `_entries` change while default value is retrieved

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -193,11 +193,11 @@ namespace Microsoft.UI.Xaml
 					_entries = entries = newEntries;
 				}
 
-				ref var propertyEntry = ref entries[offset + bucketRemainder];
-
-				if (propertyEntry == null)
+				var propertyEntry = entries[offset + bucketRemainder];
+				if (propertyEntry is null)
 				{
 					propertyEntry = new DependencyPropertyDetails(property, _ownerType, property == _dataContextProperty || property == _templatedParentProperty);
+					_entries[offset + bucketRemainder] = propertyEntry;
 
 					if (TryResolveDefaultValueFromProviders(property, out var value))
 					{

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -193,6 +193,10 @@ namespace Microsoft.UI.Xaml
 					_entries = entries = newEntries;
 				}
 
+				// Avoid using ref here, as TryResolveDefaultValueFromProviders execution could execute code which
+				// could cause the entries array to be expanded by bucket size and to be reallocated, which would
+				// cause the reference to be invalidated. Example of this is a child property which calls child.SetParent(this).
+				// Even though the _entries size may change, the offset and bucketRemainder will still be valid.
 				var propertyEntry = entries[offset + bucketRemainder];
 				if (propertyEntry is null)
 				{


### PR DESCRIPTION
It can happen the collection changes while the default value is being created, hence changing the ref we were originally working with.

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
