### PR TITLE
fix: Remove ApplyDataContext method (deprecated) that's causing invalid data context

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
@@ -76,6 +76,10 @@ namespace Uno.UI.RemoteControl.HotReload
 			parentAsContentControl = parentAsContentControl ?? (VisualTreeHelper.GetParent(oldView) as ContentPresenter)?.FindFirstParent<ContentControl>();
 #endif
 
+#if !HAS_UNO
+			var parentDataContext = (parentAsContentControl as FrameworkElement)?.DataContext;
+			var oldDataContext = oldView.DataContext;
+#endif
 			if ((parentAsContentControl?.Content as FrameworkElement) == oldView)
 			{
 				parentAsContentControl.Content = newView;
@@ -108,6 +112,37 @@ namespace Uno.UI.RemoteControl.HotReload
 				VisualTreeHelper.SwapViews(oldView, newView);
 			}
 #endif
+
+#if !HAS_UNO
+			if (oldView is FrameworkElement oldViewAsFE && newView is FrameworkElement newViewAsFE)
+			{
+				ApplyDataContext(parentDataContext, oldViewAsFE, newViewAsFE, oldDataContext);
+			}
+#endif
 		}
+
+#if !HAS_UNO
+		private static void ApplyDataContext(
+			object? parentDataContext,
+			FrameworkElement oldView,
+			FrameworkElement newView,
+			object? oldDataContext)
+		{
+			if (oldView == null || newView == null)
+			{
+				return;
+			}
+
+			if ((newView.DataContext is null || newView.DataContext == parentDataContext)
+				&& (oldDataContext is not null && oldDataContext != parentDataContext))
+			{
+				// If the DataContext is not provided by the page itself, it may
+				// have been provided by an external actor. Copy the value as is
+				// in the DataContext of the new element.
+
+				newView.DataContext = oldDataContext;
+			}
+		}
+#endif
 	}
 }

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
@@ -76,8 +76,6 @@ namespace Uno.UI.RemoteControl.HotReload
 			parentAsContentControl = parentAsContentControl ?? (VisualTreeHelper.GetParent(oldView) as ContentPresenter)?.FindFirstParent<ContentControl>();
 #endif
 
-			var parentDataContext = (parentAsContentControl as FrameworkElement)?.DataContext;
-
 			if ((parentAsContentControl?.Content as FrameworkElement) == oldView)
 			{
 				parentAsContentControl.Content = newView;
@@ -110,29 +108,6 @@ namespace Uno.UI.RemoteControl.HotReload
 				VisualTreeHelper.SwapViews(oldView, newView);
 			}
 #endif
-
-			if (oldView is FrameworkElement oldViewAsFE && newView is FrameworkElement newViewAsFE)
-			{
-				ApplyDataContext(parentDataContext, oldViewAsFE, newViewAsFE);
-			}
-		}
-
-		private static void ApplyDataContext(object? parentDataContext, FrameworkElement oldView, FrameworkElement newView)
-		{
-			if (oldView == null || newView == null)
-			{
-				return;
-			}
-
-			if ((newView.DataContext is null || newView.DataContext == parentDataContext)
-				&& (oldView.DataContext is not null && oldView.DataContext != parentDataContext))
-			{
-				// If the DataContext is not provided by the page itself, it may
-				// have been provided by an external actor. Copy the value as is
-				// in the DataContext of the new element.
-
-				newView.DataContext = oldView.DataContext;
-			}
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/17237

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

DataContext is being set to null on the new instance, despite code that clones properties correctly updating the DataContext

## What is the new behavior?

ApplyDataContext method has been removed to avoid incorrectly setting the DataContext

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
