### PR TITLE
fix: Undo custom `Margin` on `Slider` `Thumb`

### DIFF
--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/Slider_themeresources.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/Slider_themeresources.xaml
@@ -198,8 +198,7 @@
                                         <ControlTemplate TargetType="Thumb">
                                             <!-- Uno specific (LinearGradientBrush borders): We need additional Grid here #6457 -->
                                             <Grid>
-                                                <!-- Uno specific: WinUI uses Margin -2 here, which causes clipping for us. #16484 -->
-                                                <Border x:Name="ThumbBorder" Margin="0" Background="{ThemeResource SliderOuterThumbBackground}" BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{ThemeResource SliderThumbCornerRadius}">
+                                                <Border x:Name="ThumbBorder" Margin="-2" Background="{ThemeResource SliderOuterThumbBackground}" BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{ThemeResource SliderThumbCornerRadius}">
                                                     <Ellipse x:Name="SliderInnerThumb" RenderTransformOrigin="0.5, 0.5" Fill="{TemplateBinding Background}" Width="{ThemeResource SliderInnerThumbWidth}" Height="{ThemeResource SliderInnerThumbHeight}">
                                                         <Ellipse.RenderTransform>
                                                             <CompositeTransform />

--- a/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
+++ b/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
@@ -21792,8 +21792,7 @@
                     <ControlTemplate TargetType="Thumb">
                       <!-- Uno specific (LinearGradientBrush borders): We need additional Grid here #6457 -->
                       <Grid>
-                        <!-- Uno specific: WinUI uses Margin -2 here, which causes clipping for us. #16484 -->
-                        <Border x:Name="ThumbBorder" Margin="0" Background="{ThemeResource SliderOuterThumbBackground}" BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{ThemeResource SliderThumbCornerRadius}">
+                        <Border x:Name="ThumbBorder" Margin="-2" Background="{ThemeResource SliderOuterThumbBackground}" BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="{ThemeResource SliderThumbCornerRadius}">
                           <Ellipse x:Name="SliderInnerThumb" RenderTransformOrigin="0.5, 0.5" Fill="{TemplateBinding Background}" Width="{ThemeResource SliderInnerThumbWidth}" Height="{ThemeResource SliderInnerThumbHeight}">
                             <Ellipse.RenderTransform>
                               <CompositeTransform />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #16484, closes #16900

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.