### PR TITLE
[Performance] Replaced FindIndex in RecyclePool.TryGetElementCore with For loop

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/RecyclePool.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/RecyclePool.cs
@@ -68,8 +68,15 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 					// the enter/leave cost during recycling.
 					// TODO: prioritize elements with the same owner to those without an owner.
 					var winrtOwner = owner;
-					var iter = elements.FindIndex(elemInfo => elemInfo.Owner == winrtOwner || elemInfo.Owner == null);
-
+					var iter=-1;
+					for (int i = 0; i < elements.Count; i++)
+					{
+						if ((elemInfo.Owner == winrtOwner) || (elemInfo.Owner == null))
+						{
+							iter=i;
+							break;
+						}
+					}
 					if (iter < 0)
 					{
 						iter = elements.Count - 1;

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/RecyclePool.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/RecyclePool.cs
@@ -74,11 +74,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 						var elemInfo = elements[i];
 						if ((elemInfo.Owner == winrtOwner) || (elemInfo.Owner == null))
 						{
-							iter=i;
+							iter = i;
 							break;
 						}
 					}
-					
+
 					if (iter < 0)
 					{
 						iter = elements.Count - 1;

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/RecyclePool.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/Repeater/RecyclePool.cs
@@ -68,15 +68,17 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 					// the enter/leave cost during recycling.
 					// TODO: prioritize elements with the same owner to those without an owner.
 					var winrtOwner = owner;
-					var iter=-1;
+					var iter = -1;
 					for (int i = 0; i < elements.Count; i++)
 					{
+						var elemInfo = elements[i];
 						if ((elemInfo.Owner == winrtOwner) || (elemInfo.Owner == null))
 						{
 							iter=i;
 							break;
 						}
 					}
+					
 					if (iter < 0)
 					{
 						iter = elements.Count - 1;


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/15806

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- -->
- Other... Please describe: Performance


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In RecyclePool when an iterator is created it uses a FindIndex expression which is inefficient

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Replaced FindIndex with a For loop
`var iter = elements.FindIndex(elemInfo => elemInfo.Owner == winrtOwner || elemInfo.Owner == null);`
with
`for (int i = 0; i < elements.Count; i++)
{
	if ((elemInfo.Owner == winrtOwner) || (elemInfo.Owner == null))
	{
		iter=i;
		break;
	}
}`
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
