### PR TITLE
feat(hrui): Merge dev-server status into HR status + make sure to always have a valid status

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -60,7 +60,7 @@ public partial class ClientHotReloadProcessor
 	private class StatusSink(ClientHotReloadProcessor owner)
 	{
 #if HAS_UNO_WINUI
-		private readonly DiagnosticView<HotReloadStatusView, Status> _view = DiagnosticView.Register<HotReloadStatusView, Status>("Hot reload", ctx => new HotReloadStatusView(ctx), static (view, status) => view.Update(status));
+		private readonly DiagnosticView<HotReloadStatusView, Status> _view = DiagnosticView.Register<HotReloadStatusView, Status>("Hot reload", ctx => new HotReloadStatusView(ctx), static (view, status) => view.OnHotReloadStatusChanged(status));
 #endif
 
 		private HotReloadState? _serverState;

--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.xaml
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:devServer="using:Uno.UI.RemoteControl"
 	xmlns:local="using:Uno.UI.RemoteControl.HotReload"
 	xmlns:diag="using:Uno.Diagnostics.UI"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -122,6 +123,10 @@
 								<Flyout>
 									<StackPanel Margin="-5" Spacing="8">
 										<TextBlock Text="{TemplateBinding HeadLine}" FontSize="10" TextWrapping="WrapWholeWords" />
+										<StackPanel Orientation="Horizontal" Spacing="8">
+											<devServer:RemoteControlStatusView x:Name="PART_DevServerStatus" VerticalAlignment="Center" />
+											<TextBlock Text="{Binding ElementName=PART_DevServerStatus, Path=HeadLine}" FontSize="10" TextWrapping="WrapWholeWords" VerticalAlignment="Center" />
+										</StackPanel>
 										<ScrollViewer MaxHeight="400">
 											<mux:ItemsRepeater
 												ItemsSource="{TemplateBinding History}"

--- a/src/Uno.UI.RemoteControl/HotReload/WindowExtensions.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/WindowExtensions.cs
@@ -14,8 +14,15 @@ public static class WindowExtensions
 	/// Enables the UI Update cycle of HotReload to be handled by Uno
 	/// </summary>
 	/// <param name="window">The window of the application where UI updates will be applied</param>
+	public static void EnableHotReload(this Window window)
+		=> ClientHotReloadProcessor.SetWindow(window, false);
+
+	/// <summary>
+	/// Enables the UI Update cycle of HotReload to be handled by Uno
+	/// </summary>
+	/// <param name="window">The window of the application where UI updates will be applied</param>
 	/// <param name="disableIndicator">Request to not show the on-canvas indicator by default.</param>
-	public static void EnableHotReload(this Window window, bool disableIndicator = true)
+	public static void EnableHotReload(this Window window, bool disableIndicator)
 		=> ClientHotReloadProcessor.SetWindow(window, disableIndicator);
 
 	/// <summary>

--- a/src/Uno.UI.RemoteControl/HotReload/WindowExtensions.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/WindowExtensions.cs
@@ -15,7 +15,8 @@ public static class WindowExtensions
 	/// </summary>
 	/// <param name="window">The window of the application where UI updates will be applied</param>
 	/// <param name="disableIndicator">Request to not show the on-canvas indicator by default.</param>
-	public static void EnableHotReload(this Window window, bool disableIndicator = false) => ClientHotReloadProcessor.SetWindow(window, disableIndicator);
+	public static void EnableHotReload(this Window window, bool disableIndicator = true)
+		=> ClientHotReloadProcessor.SetWindow(window, disableIndicator);
 
 	/// <summary>
 	/// Forces the layout of the window to be update with any HotReload changes
@@ -24,5 +25,6 @@ public static class WindowExtensions
 	/// <param name="window">The window of the application to be updated</param>
 	/// <remarks>Currently this method doesn't use the window instance. However, with the addition of multi-window
 	/// support it's likely that the instance will be needed to determine the window where updates will be applied</remarks>
-	public static void ForceHotReloadUpdate(this Window window) => ClientHotReloadProcessor.ForceHotReloadUpdate();
+	public static void ForceHotReloadUpdate(this Window window)
+		=> ClientHotReloadProcessor.ForceHotReloadUpdate();
 }

--- a/src/Uno.UI.RemoteControl/HotReload/WindowExtensions.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/WindowExtensions.cs
@@ -14,7 +14,8 @@ public static class WindowExtensions
 	/// Enables the UI Update cycle of HotReload to be handled by Uno
 	/// </summary>
 	/// <param name="window">The window of the application where UI updates will be applied</param>
-	public static void EnableHotReload(this Window window) => ClientHotReloadProcessor.CurrentWindow = window;
+	/// <param name="disableIndicator">Request to not show the on-canvas indicator by default.</param>
+	public static void EnableHotReload(this Window window, bool disableIndicator = false) => ClientHotReloadProcessor.SetWindow(window, disableIndicator);
 
 	/// <summary>
 	/// Forces the layout of the window to be update with any HotReload changes

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -21,6 +21,7 @@ using Uno.UI.RemoteControl.HotReload;
 using Uno.UI.RemoteControl.HotReload.Messages;
 using Uno.UI.RemoteControl.Messages;
 using Windows.Networking.Sockets;
+using static Uno.UI.RemoteControl.RemoteControlStatus;
 
 namespace Uno.UI.RemoteControl;
 

--- a/src/Uno.UI.RemoteControl/RemoteControlStatus.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlStatus.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace Uno.UI.RemoteControl;
+
+internal record RemoteControlStatus(
+	RemoteControlStatus.ConnectionState State,
+	bool? IsVersionValid,
+	(RemoteControlStatus.KeepAliveState State, long RoundTrip) KeepAlive,
+	ImmutableHashSet<RemoteControlStatus.MissingProcessor> MissingRequiredProcessors,
+	(long Count, ImmutableHashSet<Type> Types) InvalidFrames)
+{
+	public (Classification kind, string message) GetSummary()
+	{
+		var (kind, message) = State switch
+		{
+			ConnectionState.Idle => (Classification.Info, "Initializing..."),
+			ConnectionState.NoServer => (Classification.Error, "No server configured, cannot initialize connection."),
+			ConnectionState.Connecting => (Classification.Info, "Connecting to dev-server."),
+			ConnectionState.ConnectionTimeout => (Classification.Error, "Failed to connect to dev-server (timeout)."),
+			ConnectionState.ConnectionFailed => (Classification.Error, "Failed to connect to dev-server (error)."),
+			ConnectionState.Reconnecting => (Classification.Info, "Connection to dev-server has been lost, reconnecting."),
+			ConnectionState.Disconnected => (Classification.Error, "Connection to dev-server has been lost, will retry later."),
+
+			ConnectionState.Connected when IsVersionValid is false => (Classification.Warning, "Connected to dev-server, but version mis-match with client."),
+			ConnectionState.Connected when InvalidFrames.Count is not 0 => (Classification.Warning, $"Connected to dev-server, but received {InvalidFrames.Count} invalid frames from the server."),
+			ConnectionState.Connected when MissingRequiredProcessors is { IsEmpty: false } => (Classification.Warning, "Connected to dev-server, but some required processors are missing on server."),
+			ConnectionState.Connected when KeepAlive.State is KeepAliveState.Late => (Classification.Info, "Connected to dev-server, but keep-alive messages are taking longer than expected."),
+			ConnectionState.Connected when KeepAlive.State is KeepAliveState.Lost => (Classification.Warning, "Connected to dev-server, but last keep-alive messages have been lost."),
+			ConnectionState.Connected when KeepAlive.State is KeepAliveState.Aborted => (Classification.Warning, "Connected to dev-server, but keep-alive has been aborted."),
+			ConnectionState.Connected => (Classification.Ok, "Connected to dev-server."),
+
+			_ => (Classification.Warning, State.ToString()),
+		};
+
+		if (KeepAlive.RoundTrip >= 0)
+		{
+			message += $" (ping {KeepAlive.RoundTrip}ms)";
+		}
+
+		return (kind, message);
+	}
+
+	internal string GetDescription()
+	{
+		var details = new StringBuilder(GetSummary().message);
+
+		if (MissingRequiredProcessors is { Count: > 0 } missing)
+		{
+			details.AppendLine();
+			details.AppendLine();
+			details.AppendLine("Some processor(s) requested by the client are missing on the server:");
+
+			foreach (var m in missing)
+			{
+				details.AppendLine($"- {m.TypeFullName} v{m.Version}: {m.Details}");
+				if (m.Error is not null)
+				{
+					details.AppendLine($"  {m.Error}");
+				}
+			}
+		}
+
+		if (InvalidFrames.Types is { Count: > 0 } invalidFrameTypes)
+		{
+			details.AppendLine();
+			details.AppendLine();
+			details.AppendLine($"Received {InvalidFrames.Count} invalid frames from the server. Failing frame types ({invalidFrameTypes.Count}):");
+
+			foreach (var type in invalidFrameTypes)
+			{
+				details.AppendLine($"- {type.FullName}");
+			}
+		}
+
+		return details.ToString();
+	}
+
+	internal record struct MissingProcessor(string TypeFullName, string Version, string Details, string? Error = null);
+
+	internal enum KeepAliveState
+	{
+		Idle,
+		Ok, // Got ping/pong in expected delays
+		Late, // Sent ping without response within delay
+		Lost, // Got an invalid pong response
+		Aborted // KeepAlive was aborted
+	}
+
+	internal enum ConnectionState
+	{
+		/// <summary>
+		/// Client as not been started yet
+		/// </summary>
+		Idle,
+
+		/// <summary>
+		/// No server information to connect to.
+		/// </summary>
+		NoServer,
+
+		/// <summary>
+		/// Attempting to connect to the server.
+		/// </summary>
+		Connecting,
+
+		/// <summary>
+		/// Reach timeout while trying to connect to the server.
+		/// Connection HAS NOT been established.
+		/// </summary>
+		ConnectionTimeout,
+
+		/// <summary>
+		/// Connection to the server failed.
+		/// Connection HAS NOT been established.
+		/// </summary>
+		ConnectionFailed,
+
+		/// <summary>
+		/// Connection to the server has been established.
+		/// </summary>
+		Connected,
+
+		/// <summary>
+		/// Reconnecting to the server.
+		/// Connection has been established once but lost since then, reconnecting to the SAME server.
+		/// </summary>
+		Reconnecting,
+
+		/// <summary>
+		/// Disconnected from the server.
+		/// Connection has been established once but lost since then and cannot be restored for now but will be retried later.
+		/// </summary>
+		Disconnected
+	}
+
+	internal enum Classification
+	{
+		Ok,
+		Info,
+		Warning,
+		Error
+	}
+}

--- a/src/Uno.UI.RemoteControl/RemoteControlStatusView.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlStatusView.cs
@@ -1,42 +1,100 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.UI;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
-using static Uno.UI.RemoteControl.RemoteControlClient;
+using static Uno.UI.RemoteControl.RemoteControlStatus;
 
 namespace Uno.UI.RemoteControl;
 
 internal sealed partial class RemoteControlStatusView : Ellipse
 {
-	public RemoteControlStatusView()
+	private readonly RemoteControlClient? _devServer;
+
+	public const string Id = nameof(RemoteControlStatusView);
+
+	#region Status (DP)
+	public static readonly DependencyProperty StatusProperty = DependencyProperty.Register(
+		nameof(Status),
+		typeof(RemoteControlStatus),
+		typeof(RemoteControlStatusView),
+		new PropertyMetadata(default(RemoteControlStatus), (snd, args) => ((RemoteControlStatusView)snd).OnStatusChanged((RemoteControlStatus)args.NewValue)));
+
+	public RemoteControlStatus Status
 	{
+		get => (RemoteControlStatus)GetValue(StatusProperty);
+		private set => SetValue(StatusProperty, value);
+	}
+	#endregion
+
+	#region HeadLine (DP)
+	public static readonly DependencyProperty HeadLineProperty = DependencyProperty.Register(
+		nameof(HeadLine),
+		typeof(string),
+		typeof(RemoteControlStatusView),
+		new PropertyMetadata(default(string)));
+
+	public string HeadLine
+	{
+		get => (string)GetValue(HeadLineProperty);
+		private set => SetValue(HeadLineProperty, value);
+	}
+	#endregion
+
+	internal bool HasServer => _devServer is not null;
+
+	public RemoteControlStatusView()
+		: this(RemoteControlClient.Instance)
+	{
+	}
+
+	public RemoteControlStatusView(RemoteControlClient? devServer)
+	{
+		_devServer = devServer;
+
 		Fill = new SolidColorBrush(Colors.Gray);
 		Width = 20;
 		Height = 20;
+
+		if (_devServer is null)
+		{
+			return;
+		}
+
+		Loading += static (snd, _) =>
+		{
+			if (snd is RemoteControlStatusView that)
+			{
+				that._devServer!.StatusChanged += that.OnDevServerStatusChanged;
+				that.Status = that._devServer.Status;
+			}
+		};
+		Unloaded += static (snd, _) =>
+		{
+			if (snd is RemoteControlStatusView that)
+			{
+				that._devServer!.StatusChanged -= that.OnDevServerStatusChanged;
+			}
+		};
 	}
 
-	public bool IsAutoHideEnabled { get; set; }
+	private void OnDevServerStatusChanged(object? sender, RemoteControlStatus status)
+		=> DispatcherQueue.TryEnqueue(() => Status = status);
 
-	public void Update(Status status)
+	private void OnStatusChanged(RemoteControlStatus status)
 	{
 		var (kind, message) = status.GetSummary();
 		((SolidColorBrush)Fill).Color = kind switch
 		{
-			StatusClassification.Ok => Colors.Green,
-			StatusClassification.Info => Colors.Yellow,
-			StatusClassification.Warning => Colors.Orange,
-			StatusClassification.Error => Colors.Red,
+			Classification.Ok => Colors.Green,
+			Classification.Info => Colors.Yellow,
+			Classification.Warning => Colors.Orange,
+			Classification.Error => Colors.Red,
 			_ => Colors.Gray
 		};
+		HeadLine = message;
 		ToolTipService.SetToolTip(this, message);
-
-		if (IsAutoHideEnabled)
-		{
-			Visibility = kind is StatusClassification.Ok
-				? Microsoft.UI.Xaml.Visibility.Collapsed
-				: Microsoft.UI.Xaml.Visibility.Visible;
-		}
 	}
 }

--- a/src/Uno.UI.RemoteControl/RemoteControlStatusView.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlStatusView.cs
@@ -13,7 +13,11 @@ internal sealed partial class RemoteControlStatusView : Ellipse
 {
 	private readonly RemoteControlClient? _devServer;
 
+#if __IOS__
+	public new const string Id = nameof(RemoteControlStatusView);
+#else
 	public const string Id = nameof(RemoteControlStatusView);
+#endif
 
 	#region Status (DP)
 	public static readonly DependencyProperty StatusProperty = DependencyProperty.Register(

--- a/src/Uno.UI.RemoteControl/RemoteControlStatusView.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlStatusView.cs
@@ -13,7 +13,7 @@ internal sealed partial class RemoteControlStatusView : Ellipse
 {
 	private readonly RemoteControlClient? _devServer;
 
-#if __IOS__
+#if __ANDROID__
 	public new const string Id = nameof(RemoteControlStatusView);
 #else
 	public const string Id = nameof(RemoteControlStatusView);

--- a/src/Uno.UI/Diagnostics/DiagnosticView.Factories.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticView.Factories.cs
@@ -9,37 +9,95 @@ namespace Uno.Diagnostics.UI;
 
 internal partial class DiagnosticView
 {
-	public static DiagnosticView<TView> Register<TView>(string name, Action<TView> update)
-		where TView : FrameworkElement, new()
+	/// <summary>
+	/// Registers a dedicated diagnostic view to be displayed by the diagnostic overlay.
+	/// </summary>
+	/// <remarks>
+	/// This is a designed for a control dedicated to render the status of a specific diagnostic information.
+	/// The control is expected to internally listen to an event to updates itself.
+	/// </remarks>
+	/// <remarks>
+	/// This only registers the diagnostic, it does not open the overlay.
+	/// </remarks>
+	/// <typeparam name="TView">Type of the control.</typeparam>
+	/// <param name="friendlyName">The user-friendly name of the diagnostics view.</param>
+	public static DiagnosticView<TView> Register<TView>(string friendlyName)
+		where TView : UIElement, new()
 	{
-		var provider = new DiagnosticView<TView>(typeof(TView).Name, name, () => new TView());
+		var provider = new DiagnosticView<TView>(typeof(TView).Name, friendlyName, () => new TView());
 		DiagnosticViewRegistry.Register(provider);
 		return provider;
 	}
 
+	/// <summary>
+	/// Registers a dedicated diagnostic view.
+	/// </summary>
+	/// <remarks>
+	/// This is a designed for a control dedicated to render the status of a specific diagnostic information.
+	/// The control is expected to internally listen to an event to updates itself.
+	/// </remarks>
+	/// <remarks>
+	/// This only registers the diagnostic, it does not open the overlay.
+	/// </remarks>
+	/// <typeparam name="TView">Type of the control.</typeparam>
+	/// <param name="friendlyName">The user-friendly name of the diagnostics view.</param>
+	/// <param name="factory">Factory to create an instance of the control.</param>
+	public static DiagnosticView<TView> Register<TView>(string friendlyName, Func<TView> factory)
+		where TView : UIElement
+	{
+		var provider = new DiagnosticView<TView>(typeof(TView).Name, friendlyName, factory);
+		DiagnosticViewRegistry.Register(provider);
+		return provider;
+	}
+
+	/// <summary>
+	/// Registers a generic FrameworkElement as diagnostic view.
+	/// </summary>
+	/// <remarks>
+	/// This only registers the diagnostic, it does not open the overlay.
+	/// </remarks>
+	/// <typeparam name="TView">Type if the generic FrameworkElement to use.</typeparam>
+	/// <typeparam name="TState">Type of the state used to update the <typeparamref name="TView"/>.</typeparam>
+	/// <param name="friendlyName">The user-friendly name of the diagnostics view.</param>
+	/// <param name="update">Delegate to use to update the <typeparamref name="TView"/> when the <typeparamref name="TState"/> is being updated.</param>
+	/// <param name="details">Optional delegate used to show more details about the diagnostic info when user taps on the view.</param>
+	/// <returns>A diagnostic view helper class which can be used to push updates of the state (cf. <see cref="DiagnosticView{TView,TState}.Update"/>).</returns>
 	public static DiagnosticView<TView, TState> Register<TView, TState>(
-		string name,
+		string friendlyName,
 		Action<TView, TState> update,
 		Func<TState, object?>? details = null)
 		where TView : FrameworkElement, new()
 	{
 		var provider = details is null
-			? new DiagnosticView<TView, TState>(typeof(TView).Name, name, _ => new TView(), update)
-			: new DiagnosticView<TView, TState>(typeof(TView).Name, name, _ => new TView(), update, (ctx, state, ct) => new(details(state)));
+			? new DiagnosticView<TView, TState>(typeof(TView).Name, friendlyName, _ => new TView(), update)
+			: new DiagnosticView<TView, TState>(typeof(TView).Name, friendlyName, _ => new TView(), update, (ctx, state, ct) => new(details(state)));
 		DiagnosticViewRegistry.Register(provider);
 		return provider;
 	}
 
+	/// <summary>
+	/// Registers a generic FrameworkElement as diagnostic view.
+	/// </summary>
+	/// <remarks>
+	/// This only registers the diagnostic, it does not open the overlay.
+	/// </remarks>
+	/// <typeparam name="TView">Type if the generic FrameworkElement to use.</typeparam>
+	/// <typeparam name="TState">Type of the state used to update the <typeparamref name="TView"/>.</typeparam>
+	/// <param name="friendlyName">The user-friendly name of the diagnostics view.</param>
+	/// <param name="factory">Factory to create an instance of the generic element.</param>
+	/// <param name="update">Delegate to use to update the <typeparamref name="TView"/> when the <typeparamref name="TState"/> is being updated.</param>
+	/// <param name="details">Optional delegate used to show more details about the diagnostic info when user taps on the view.</param>
+	/// <returns>A diagnostic view helper class which can be used to push updates of the state (cf. <see cref="DiagnosticView{TView,TState}.Update"/>).</returns>
 	public static DiagnosticView<TView, TState> Register<TView, TState>(
-		string name,
+		string friendlyName,
 		Func<IDiagnosticViewContext, TView> factory,
 		Action<TView, TState> update,
 		Func<TState, object?>? details = null)
 		where TView : FrameworkElement
 	{
 		var provider = details is null
-			? new DiagnosticView<TView, TState>(typeof(TView).Name, name, factory, update)
-			: new DiagnosticView<TView, TState>(typeof(TView).Name, name, factory, update, (ctx, state, ct) => new(details(state)));
+			? new DiagnosticView<TView, TState>(typeof(TView).Name, friendlyName, factory, update)
+			: new DiagnosticView<TView, TState>(typeof(TView).Name, friendlyName, factory, update, (ctx, state, ct) => new(details(state)));
 		DiagnosticViewRegistry.Register(provider);
 		return provider;
 	}

--- a/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.TState.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.TState.cs
@@ -5,6 +5,13 @@ using Microsoft.UI.Xaml;
 
 namespace Uno.Diagnostics.UI;
 
+/// <summary>
+/// A helper class used to create instances and propagate updates to a diagnostic view.
+/// </summary>
+/// <typeparam name="TView">Type of FrameworkElement used as diagnostic view.</typeparam>
+/// <typeparam name="TState">Type of the state used to update the <typeparamref name="TView"/>.</typeparam>
+/// <param name="factory">Factory to create an instance of the <typeparamref name="TView"/>.</param>
+/// <param name="update">Delegate to use to update the <typeparamref name="TView"/> on <see cref="NotifyChanged"/>.</param>
 internal class DiagnosticViewManager<TView, TState>(Func<IDiagnosticViewContext, TView> factory, Action<IDiagnosticViewContext, TView, TState> update)
 	where TView : FrameworkElement
 {

--- a/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.cs
@@ -7,6 +7,12 @@ using Microsoft.UI.Xaml;
 
 namespace Uno.Diagnostics.UI;
 
+/// <summary>
+/// A helper class used to create instances and propagate updates to a diagnostic view.
+/// </summary>
+/// <typeparam name="TView">Type of FrameworkElement used as diagnostic view.</typeparam>
+/// <param name="factory">Factory to create an instance of the <typeparamref name="TView"/>.</param>
+/// <param name="update">Delegate to use to update the <typeparamref name="TView"/> on <see cref="NotifyChanged"/>.</param>
 internal class DiagnosticViewManager<TView>(Func<IDiagnosticViewContext, TView> factory, Action<IDiagnosticViewContext, TView> update)
 	where TView : FrameworkElement
 {


### PR DESCRIPTION
## Feature
* Merge dev-server status into HR status
* Make sure to always have a valid status

## What is the current behavior?
Dev-server status might appear separated from the HR status

## What is the new behavior?
Merged into a single indicator

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
