### PR TITLE
fix(macOS): Let the Metal texture be used for sampling

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -22,6 +22,7 @@
         mtkView.colorPixelFormat = MTLPixelFormatBGRA8Unorm;
         mtkView.depthStencilPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
         mtkView.sampleCount = 1;
+        mtkView.framebufferOnly = false;
 #if DEBUG
         NSLog(@"initWithMetalKitView: paused %s enableSetNeedsDisplay %s", mtkView.paused ? "true" : "false", mtkView.enableSetNeedsDisplay ? "true" : "false");
 #endif

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -22,6 +22,7 @@
         mtkView.colorPixelFormat = MTLPixelFormatBGRA8Unorm;
         mtkView.depthStencilPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
         mtkView.sampleCount = 1;
+        // this property has no effect on x86_64, only on arm64, and is required for sampling (which acrylicbrush does)
         mtkView.framebufferOnly = false;
 #if DEBUG
         NSLog(@"initWithMetalKitView: paused %s enableSetNeedsDisplay %s", mtkView.paused ? "true" : "false", mtkView.enableSetNeedsDisplay ? "true" : "false");

--- a/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.skia.cs
@@ -81,7 +81,7 @@ public partial class AcrylicBrush
 		if (_isConnected)
 		{
 			// TODO: Currently we are force recreating the brush even if it exists because Composition animations aren't implemented yet
-			CreateAcrylicBrush(false /* useCrossFadeEffect */, true /* forceCreateAcrylicBrush */);
+			CreateAcrylicBrush(useCrossFadeEffect: false, forceCreateAcrylicBrush: true);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/AcrylicBrush.skia.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using Windows.UI;
 using Microsoft.UI;
 using Microsoft.UI.Composition;
@@ -77,15 +76,12 @@ public partial class AcrylicBrush
 		}
 	}
 
-	// issue specific to macOSarm64 https://github.com/unoplatform/uno/issues/16853
-	static bool macOSarm64 = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture is Architecture.Arm64;
-
 	private void UpdateAcrylicBrush()
 	{
 		if (_isConnected)
 		{
 			// TODO: Currently we are force recreating the brush even if it exists because Composition animations aren't implemented yet
-			CreateAcrylicBrush(useCrossFadeEffect: false, forceCreateAcrylicBrush: !macOSarm64);
+			CreateAcrylicBrush(false /* useCrossFadeEffect */, true /* forceCreateAcrylicBrush */);
 		}
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #16853

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When using Material some background have a pinkish colour instead of the expected grey.

## What is the new behavior?

The correct colour is used.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

The fact that this worked on `x86_64` really threw me off.

So it was not (now removed) the Uno `Color.cs` parsing an invalid string, nor was it something from the MS SDK, nor was it a bad RGBA to ARGB conversion inside Uno (or Skia) code.

The pink colour comes from the uninitialized texture as Metal defaults to red and some transparency was applied (over the normal grey colour). Sadly this does not report any error in the Metal API (even when special debugging/performance-affected code is used).

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
