### PR TITLE
fix(hr): Mix updates of HR

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -1,14 +1,12 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reactive.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -16,12 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Uno.Disposables;
-using Uno.Extensions;
 using Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates;
-using Uno.UI.RemoteControl.HotReload;
 using Uno.UI.RemoteControl.HotReload.Messages;
 using Uno.UI.RemoteControl.Messaging.HotReload;
 
@@ -32,7 +25,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 		private static readonly StringComparer _pathsComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
 		private FileSystemWatcher[]? _solutionWatchers;
-		private CompositeDisposable? _solutionWatcherEventsDisposable;
+		private IDisposable? _solutionWatcherEventsDisposable;
 
 		private Task<(Solution, WatchHotReloadService)>? _initializeTask;
 		private Solution? _currentSolution;
@@ -103,7 +96,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						.Select(d => d.FilePath)
 						.Concat(p.AdditionalDocuments
 							.Select(d => d.FilePath)))
-					.Select(p => Path.GetDirectoryName(p))
+					.Select(Path.GetDirectoryName)
 					.Distinct()
 					.ToArray();
 
@@ -126,155 +119,147 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				})
 				.ToArray();
 
-			_solutionWatcherEventsDisposable = new CompositeDisposable();
+			_solutionWatcherEventsDisposable = To2StepsObservable(_solutionWatchers, HasInterest).Subscribe(
+				filePaths => _ = ProcessMetadataChanges(filePaths),
+				e => Console.WriteLine($"Error {e}"));
 
-			foreach (var watcher in _solutionWatchers)
-			{
-				var disposable = ToObservable(watcher).Subscribe(
-					filePaths => _ = ProcessMetadataChanges(filePaths.Distinct()),
-					e => Console.WriteLine($"Error {e}"));
-
-				_solutionWatcherEventsDisposable.Add(disposable);
-			}
+			static bool HasInterest(string file)
+				=> Path.GetExtension(file).ToLowerInvariant() is not ".csproj" and not ".editorconfig";
 		}
 
-		private async Task ProcessMetadataChanges(IEnumerable<string> filePaths)
+		private async Task ProcessMetadataChanges(Task<ImmutableHashSet<string>> filesAsync)
 		{
-			if (_useRoslynHotReload) // Note: Always true here?!
+			// Notify the start of the hot-reload processing as soon as possible, even before the buffering of file change is completed
+			var hotReload = await StartOrContinueHotReload();
+			var files = await filesAsync;
+			if (!hotReload.TryMerge(files))
 			{
-				var files = filePaths.ToImmutableHashSet(_pathsComparer);
-				var hotReload = await StartOrContinueHotReload(files);
+				hotReload = await StartHotReload(files);
+			}
 
-				try
-				{
-					// Note: We should process all files at once here!
-					foreach (var file in files)
-					{
-						ProcessSolutionChanged(hotReload, file, CancellationToken.None).Wait();
-					}
+			try
+			{
+				await ProcessSolutionChanged(hotReload, files, CancellationToken.None);
+			}
+			catch (Exception e)
+			{
+				_reporter.Warn($"Internal error while processing hot-reload ({e.Message}).");
 
-					await hotReload.CompleteUsingIntermediates();
-				}
-				catch (Exception e)
-				{
-					_reporter.Warn($"Internal error while processing hot-reload ({e.Message}).");
-
-					await hotReload.CompleteUsingIntermediates(e);
-				}
+				await hotReload.Complete(HotReloadServerResult.InternalError, e);
 			}
 		}
 
-		private async Task<bool> ProcessSolutionChanged(HotReloadServerOperation hotReload, string file, CancellationToken cancellationToken)
+		private async ValueTask ProcessSolutionChanged(HotReloadServerOperation hotReload, ImmutableHashSet<string> files, CancellationToken ct)
 		{
 			if (!await EnsureSolutionInitializedAsync() || _currentSolution is null || _hotReloadService is null)
 			{
-				hotReload.NotifyIntermediate(file, HotReloadServerResult.NoChanges);
-				return false;
+				await hotReload.Complete(HotReloadServerResult.Failed); // Failed to init the workspace
+				return;
 			}
 
 			var sw = Stopwatch.StartNew();
 
-			Solution? updatedSolution = null;
-			ProjectId updatedProjectId;
-
-			if (_currentSolution.Projects.SelectMany(p => p.Documents).FirstOrDefault(d => string.Equals(d.FilePath, file, StringComparison.OrdinalIgnoreCase)) is Document documentToUpdate)
+			// Edit the files in the workspace.
+			var solution = _currentSolution;
+			foreach (var file in files)
 			{
-				var sourceText = await GetSourceTextAsync(file);
-				updatedSolution = documentToUpdate.WithText(sourceText).Project.Solution;
-				updatedProjectId = documentToUpdate.Project.Id;
-			}
-			else if (_currentSolution.Projects.SelectMany(p => p.AdditionalDocuments).FirstOrDefault(d => string.Equals(d.FilePath, file, StringComparison.OrdinalIgnoreCase)) is AdditionalDocument additionalDocument)
-			{
-				var sourceText = await GetSourceTextAsync(file);
-				updatedSolution = _currentSolution.WithAdditionalDocumentText(additionalDocument.Id, sourceText, PreservationMode.PreserveValue);
-				updatedProjectId = additionalDocument.Project.Id;
-
-				// Generate an empty document to force the generators to run
-				// in a separate project of the same solution. This is not needed
-				// for the head project, but it's no causing issues either.
-				var docName = Guid.NewGuid().ToString();
-				updatedSolution = updatedSolution.AddAdditionalDocument(
-					DocumentId.CreateNewId(updatedProjectId),
-					docName,
-					SourceText.From("")
-				);
-			}
-			else
-			{
-				_reporter.Verbose($"Could not find document with path {file} in the workspace.");
-				// HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
-				hotReload.NotifyIntermediate(file, HotReloadServerResult.NoChanges);
-				return false;
-			}
-
-
-			var (updates, hotReloadDiagnostics) = await _hotReloadService.EmitSolutionUpdateAsync(updatedSolution, cancellationToken);
-			var hasErrorDiagnostics = hotReloadDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error);
-
-			_reporter.Output($"Found {updates.Length} metadata updates after {sw.Elapsed}");
-
-			if (hasErrorDiagnostics && updates.IsDefaultOrEmpty)
-			{
-				// It's possible that there are compilation errors which prevented the solution update
-				// from being updated. Let's look to see if there are compilation errors.
-				var diagnostics = GetErrorDiagnostics(updatedSolution, cancellationToken);
-				if (diagnostics.IsDefaultOrEmpty)
+				if (solution.Projects.SelectMany(p => p.Documents).FirstOrDefault(d => string.Equals(d.FilePath, file, StringComparison.OrdinalIgnoreCase)) is Document documentToUpdate)
 				{
-					await UpdateMetadata(file, updates);
-					hotReload.NotifyIntermediate(file, HotReloadServerResult.NoChanges);
+					var sourceText = await GetSourceTextAsync(file);
+					solution = documentToUpdate.WithText(sourceText).Project.Solution;
+				}
+				else if (solution.Projects.SelectMany(p => p.AdditionalDocuments).FirstOrDefault(d => string.Equals(d.FilePath, file, StringComparison.OrdinalIgnoreCase)) is AdditionalDocument additionalDocument)
+				{
+					var sourceText = await GetSourceTextAsync(file);
+					solution = solution.WithAdditionalDocumentText(additionalDocument.Id, sourceText, PreservationMode.PreserveValue);
+
+					// Generate an empty document to force the generators to run
+					// in a separate project of the same solution. This is not needed
+					// for the head project, but it's no causing issues either.
+					var docName = Guid.NewGuid().ToString();
+					solution = solution.AddAdditionalDocument(
+						DocumentId.CreateNewId(additionalDocument.Project.Id),
+						docName,
+						SourceText.From("")
+					);
 				}
 				else
 				{
-					_reporter.Output($"Got {diagnostics.Length} errors");
-					hotReload.NotifyIntermediate(file, HotReloadServerResult.Failed);
+					_reporter.Verbose($"Could not find document with path {file} in the workspace.");
 				}
-
-				// HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
-				// Even if there were diagnostics, continue treating this as a success
-				return true;
 			}
 
-			if (hasErrorDiagnostics)
+			// Not mater if the build will succeed or not, we update the _currentSolution.
+			// Files needs to be updated again to fix the compilation errors.
+			if (solution == _currentSolution)
+			{
+				_reporter.Output($"No changes found in {string.Join(",", files.Select(Path.GetFileName))}");
+
+				await hotReload.Complete(HotReloadServerResult.NoChanges);
+				return;
+			}
+
+			_currentSolution = solution;
+
+			// Compile the solution and get deltas
+			var (updates, hotReloadDiagnostics) = await _hotReloadService.EmitSolutionUpdateAsync(solution, ct);
+			// hotReloadDiagnostics currently includes semantic Warnings and Errors for types being updated. We want to limit rude edits to the class
+			// of unrecoverable errors that a user cannot fix and requires an app rebuild.
+			var rudeEdits = hotReloadDiagnostics.RemoveAll(d => d.Severity == DiagnosticSeverity.Warning || !d.Descriptor.Id.StartsWith("ENC", StringComparison.Ordinal));
+
+			_reporter.Output($"Found {updates.Length} metadata updates after {sw.Elapsed}");
+			sw.Stop();
+
+
+			if (rudeEdits.IsEmpty && updates.IsEmpty)
+			{
+				var compilationErrors = GetCompilationErrors(solution, ct);
+				if (compilationErrors.IsEmpty)
+				{
+					_reporter.Output("No hot reload changes to apply.");
+					await hotReload.Complete(HotReloadServerResult.NoChanges);
+				}
+				else
+				{
+					await hotReload.Complete(HotReloadServerResult.Failed);
+				}
+
+				return;
+			}
+
+			if (!rudeEdits.IsEmpty)
 			{
 				// Rude edit.
-				_reporter.Output("Unable to apply hot reload because of a rude edit. Rebuilding the app...");
+				_reporter.Output("Unable to apply hot reload because of a rude edit.");
 				foreach (var diagnostic in hotReloadDiagnostics)
 				{
 					_reporter.Verbose(CSharpDiagnosticFormatter.Instance.Format(diagnostic, CultureInfo.InvariantCulture));
 				}
 
-				hotReload.NotifyIntermediate(file, HotReloadServerResult.RudeEdit);
-
-				// HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
-				return false;
+				await hotReload.Complete(HotReloadServerResult.RudeEdit);
+				return;
 			}
 
-			_currentSolution = updatedSolution;
+			await SendUpdates(updates);
 
-			sw.Stop();
+			await hotReload.Complete(HotReloadServerResult.Success);
 
-			await UpdateMetadata(file, updates);
-			hotReload.NotifyIntermediate(file, HotReloadServerResult.Success);
-
-			// HotReloadEventSource.Log.HotReloadEnd(HotReloadEventSource.StartType.CompilationHandler);
-			return true;
-
-			async Task UpdateMetadata(string file, ImmutableArray<WatchHotReloadService.Update> updates)
+			async Task SendUpdates(ImmutableArray<WatchHotReloadService.Update> updates)
 			{
 #if DEBUG
-				_reporter.Output($"Sending {updates.Length} metadata updates for {file}");
+				_reporter.Output($"Sending {updates.Length} metadata updates for {string.Join(",", files.Select(Path.GetFileName))}");
 #endif
 
-				for (int i = 0; i < updates.Length; i++)
+				for (var i = 0; i < updates.Length; i++)
 				{
 					var updateTypesWriterStream = new MemoryStream();
 					var updateTypesWriter = new BinaryWriter(updateTypesWriterStream);
 					WriteIntArray(updateTypesWriter, updates[i].UpdatedTypes.ToArray());
 
 					await _remoteControlServer.SendFrame(
-						new AssemblyDeltaReload()
+						new AssemblyDeltaReload
 						{
-							FilePath = file,
+							FilePaths = files,
 							ModuleId = updates[i].ModuleId.ToString(),
 							PdbDelta = Convert.ToBase64String(updates[i].PdbDelta.ToArray()),
 							ILDelta = Convert.ToBase64String(updates[i].ILDelta.ToArray()),
@@ -319,7 +304,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			return null;
 		}
 
-		private ImmutableArray<string> GetErrorDiagnostics(Solution solution, CancellationToken cancellationToken)
+		private ImmutableArray<string> GetCompilationErrors(Solution solution, CancellationToken cancellationToken)
 		{
 			var @lock = new object();
 			var builder = ImmutableArray<string>.Empty;
@@ -331,7 +316,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				}
 
 				var compilationDiagnostics = compilation.GetDiagnostics(cancellationToken);
-				if (compilationDiagnostics.IsDefaultOrEmpty)
+				if (compilationDiagnostics.IsEmpty)
 				{
 					return;
 				}
@@ -342,7 +327,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					if (item.Severity == DiagnosticSeverity.Error)
 					{
 						var diagnostic = CSharpDiagnosticFormatter.Instance.Format(item, CultureInfo.InvariantCulture);
-						_reporter.Output(diagnostic);
+						_reporter.Output("\x1B[40m\x1B[31m" + diagnostic);
 						projectDiagnostics = projectDiagnostics.Add(diagnostic);
 					}
 				}
@@ -355,7 +340,6 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 			return builder;
 		}
-
 
 		[MemberNotNullWhen(true, nameof(_currentSolution), nameof(_hotReloadService))]
 		private async ValueTask<bool> EnsureSolutionInitializedAsync()

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
@@ -149,8 +149,9 @@ namespace Uno.UI.RemoteControl.HotReload
 				{
 					if (this.Log().IsEnabled(LogLevel.Error))
 					{
-						this.Log().Error($"Hot Reload is not supported when the debugger is attached.");
+						this.Log().Error("Hot Reload is not supported when the debugger is attached.");
 					}
+					_status.ReportLocalStarting([]).ReportIgnored("Hot Reload is not supported when the debugger is attached");
 
 					return;
 				}
@@ -159,13 +160,13 @@ namespace Uno.UI.RemoteControl.HotReload
 				{
 					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
-						this.Log().Trace($"Applying IL Delta after {assemblyDeltaReload.FilePath}, Guid:{assemblyDeltaReload.ModuleId}");
+						this.Log().Trace($"Applying IL Delta after {string.Join(",", assemblyDeltaReload.FilePaths)}, Guid:{assemblyDeltaReload.ModuleId}");
 					}
 
 					var changedTypesStreams = new MemoryStream(Convert.FromBase64String(assemblyDeltaReload.UpdatedTypes));
 					var changedTypesReader = new BinaryReader(changedTypesStreams);
 
-					var delta = new UpdateDelta()
+					var delta = new UpdateDelta
 					{
 						MetadataDelta = Convert.FromBase64String(assemblyDeltaReload.MetadataDelta),
 						ILDelta = Convert.FromBase64String(assemblyDeltaReload.ILDelta),
@@ -179,14 +180,14 @@ namespace Uno.UI.RemoteControl.HotReload
 
 					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
-						this.Log().Trace($"Done applying IL Delta for {assemblyDeltaReload.FilePath}, Guid:{assemblyDeltaReload.ModuleId}");
+						this.Log().Trace($"Done applying IL Delta for {string.Join(",", assemblyDeltaReload.FilePaths)}, Guid:{assemblyDeltaReload.ModuleId}");
 					}
 				}
 				else
 				{
 					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
-						this.Log().Trace($"Failed to apply IL Delta for {assemblyDeltaReload.FilePath} ({assemblyDeltaReload})");
+						this.Log().Trace($"Failed to apply IL Delta for {string.Join(",", assemblyDeltaReload.FilePaths)} ({assemblyDeltaReload})");
 					}
 				}
 			}
@@ -194,7 +195,7 @@ namespace Uno.UI.RemoteControl.HotReload
 			{
 				if (this.Log().IsEnabled(LogLevel.Error))
 				{
-					this.Log().Error($"An exception occurred when applying IL Delta for {assemblyDeltaReload.FilePath} ({assemblyDeltaReload.ModuleId})", e);
+					this.Log().Error($"An exception occurred when applying IL Delta for {string.Join(",", assemblyDeltaReload.FilePaths)} ({assemblyDeltaReload.ModuleId})", e);
 				}
 			}
 			finally

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -196,7 +196,7 @@ public partial class ClientHotReloadProcessor
 
 		internal void ReportCompleted()
 		{
-			var result = (_exceptions, AbortReason: IgnoreReason) switch
+			var result = (_exceptions, IgnoreReason) switch
 			{
 				({ Count: > 0 }, _) => HotReloadClientResult.Failed,
 				(_, not null) => HotReloadClientResult.Ignored,

--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.xaml
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.xaml
@@ -199,16 +199,16 @@
 									</Flyout.FlyoutPresenterStyle>
 
 									<StackPanel CornerRadius="8" Spacing="10" >
-										<StackPanel Orientation="Horizontal" Spacing="10">
+										<StackPanel Orientation="Horizontal" Spacing="10" Visibility="{Binding ElementName=PART_DevServerStatus, Path=Status.IsProblematic}">
 											<devServer:RemoteControlStatusView
 												x:Name="PART_DevServerStatus"
 												VerticalAlignment="Center" />
 											<TextBlock
 												MaxWidth="380"
-												Text="{Binding ElementName=PART_DevServerStatus, Path=HeadLine}" 
+												Text="{Binding ElementName=PART_DevServerStatus, Path=HeadLine}"
 												FontSize="14"
 												FontWeight="SemiLight"
-												TextWrapping="WrapWholeWords" 
+												TextWrapping="WrapWholeWords"
 												VerticalAlignment="Center" />
 										</StackPanel>
 

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/AssemblyDeltaReload.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/AssemblyDeltaReload.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace Uno.UI.RemoteControl.HotReload.Messages
@@ -8,7 +9,7 @@ namespace Uno.UI.RemoteControl.HotReload.Messages
 		public const string Name = nameof(AssemblyDeltaReload);
 
 		[JsonProperty]
-		public string? FilePath { get; set; }
+		public ImmutableHashSet<string> FilePaths { get; set; } = [];
 
 		[JsonProperty]
 		public string? ModuleId { get; set; }
@@ -34,7 +35,7 @@ namespace Uno.UI.RemoteControl.HotReload.Messages
 		[MemberNotNullWhen(true, nameof(UpdatedTypes), nameof(MetadataDelta), nameof(ILDelta), nameof(PdbDelta), nameof(ModuleId))]
 		public bool IsValid()
 		{
-			return FilePath is not null
+			return FilePaths is { IsEmpty: false }
 				&& UpdatedTypes is not null
 				&& MetadataDelta is not null
 				&& ILDelta is not null

--- a/src/Uno.UI.RemoteControl/RemoteControlStatus.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlStatus.cs
@@ -12,25 +12,29 @@ internal record RemoteControlStatus(
 	ImmutableHashSet<RemoteControlStatus.MissingProcessor> MissingRequiredProcessors,
 	(long Count, ImmutableHashSet<Type> Types) InvalidFrames)
 {
+	public bool IsAllGood => State == ConnectionState.Connected && IsVersionValid == true && MissingRequiredProcessors.IsEmpty && KeepAlive.State == KeepAliveState.Ok && InvalidFrames.Count == 0;
+
+	public bool IsProblematic => !IsAllGood;
+
 	public (Classification kind, string message) GetSummary()
 	{
 		var (kind, message) = State switch
 		{
 			ConnectionState.Idle => (Classification.Info, "Initializing..."),
 			ConnectionState.NoServer => (Classification.Error, "No server configured, cannot initialize connection."),
-			ConnectionState.Connecting => (Classification.Info, "Connecting to dev-server."),
-			ConnectionState.ConnectionTimeout => (Classification.Error, "Failed to connect to dev-server (timeout)."),
-			ConnectionState.ConnectionFailed => (Classification.Error, "Failed to connect to dev-server (error)."),
-			ConnectionState.Reconnecting => (Classification.Info, "Connection to dev-server has been lost, reconnecting."),
-			ConnectionState.Disconnected => (Classification.Error, "Connection to dev-server has been lost, will retry later."),
+			ConnectionState.Connecting => (Classification.Info, "Connecting to IDE."),
+			ConnectionState.ConnectionTimeout => (Classification.Error, "Failed to connect to IDE (timeout)."),
+			ConnectionState.ConnectionFailed => (Classification.Error, "Failed to connect to IDE (error)."),
+			ConnectionState.Reconnecting => (Classification.Info, "Connection to IDE has been lost, reconnecting."),
+			ConnectionState.Disconnected => (Classification.Error, "Connection to IDE has been lost, will retry later."),
 
-			ConnectionState.Connected when IsVersionValid is false => (Classification.Warning, "Connected to dev-server, but version mis-match with client."),
-			ConnectionState.Connected when InvalidFrames.Count is not 0 => (Classification.Warning, $"Connected to dev-server, but received {InvalidFrames.Count} invalid frames from the server."),
-			ConnectionState.Connected when MissingRequiredProcessors is { IsEmpty: false } => (Classification.Warning, "Connected to dev-server, but some required processors are missing on server."),
-			ConnectionState.Connected when KeepAlive.State is KeepAliveState.Late => (Classification.Info, "Connected to dev-server, but keep-alive messages are taking longer than expected."),
-			ConnectionState.Connected when KeepAlive.State is KeepAliveState.Lost => (Classification.Warning, "Connected to dev-server, but last keep-alive messages have been lost."),
-			ConnectionState.Connected when KeepAlive.State is KeepAliveState.Aborted => (Classification.Warning, "Connected to dev-server, but keep-alive has been aborted."),
-			ConnectionState.Connected => (Classification.Ok, "Connected to dev-server."),
+			ConnectionState.Connected when IsVersionValid is false => (Classification.Warning, "Connected to IDE, but version mis-match with client."),
+			ConnectionState.Connected when InvalidFrames.Count is not 0 => (Classification.Warning, $"Connected to IDE, but received {InvalidFrames.Count} invalid frames."),
+			ConnectionState.Connected when MissingRequiredProcessors is { IsEmpty: false } => (Classification.Warning, "Connected to IDE, but some required processors are missing on it."),
+			ConnectionState.Connected when KeepAlive.State is KeepAliveState.Late => (Classification.Info, "Connected to IDE, but keep-alive messages are taking longer than expected."),
+			ConnectionState.Connected when KeepAlive.State is KeepAliveState.Lost => (Classification.Warning, "Connected to IDE, but last keep-alive messages has been lost."),
+			ConnectionState.Connected when KeepAlive.State is KeepAliveState.Aborted => (Classification.Warning, "Connected to IDE, but keep-alive has been aborted."),
+			ConnectionState.Connected => (Classification.Ok, "Connected to IDE."),
 
 			_ => (Classification.Warning, State.ToString()),
 		};
@@ -51,7 +55,7 @@ internal record RemoteControlStatus(
 		{
 			details.AppendLine();
 			details.AppendLine();
-			details.AppendLine("Some processor(s) requested by the client are missing on the server:");
+			details.AppendLine("Some processor(s) requested by the client are missing on the IDE:");
 
 			foreach (var m in missing)
 			{
@@ -67,11 +71,11 @@ internal record RemoteControlStatus(
 		{
 			details.AppendLine();
 			details.AppendLine();
-			details.AppendLine($"Received {InvalidFrames.Count} invalid frames from the server. Failing frame types ({invalidFrameTypes.Count}):");
+			details.AppendLine($"Received {InvalidFrames.Count} invalid frames from the IDE. Failing frame types ({invalidFrameTypes.Count}):");
 
 			foreach (var type in invalidFrameTypes)
 			{
-				details.AppendLine($"- {type.FullName}");
+				details.AppendLine($"- {type.Name}");
 			}
 		}
 


### PR DESCRIPTION
## Bugfix & Feature
* Fix file change detection
* Process all changed files in a single update

## What is the current behavior?
* An empty buffer of file is sent every 250 ms causing lot of messages for nothing
* Once we detect changes, we process each file individually instead of compiling only once with all update files

## What is the new behavior?
* No more empty file lists processed
* We wait effectively for 250ms without any file change (instead of processing a buffer of changed file during a random 250ms window)
* Once detected all changed files are processed in a single compilation

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
