### PR TITLE
chore: Remove reference to IMessage (and some other messages) from toolkit (windows)

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Uno.Disposables;
 using Uno.Extensions;
+using Uno.UI.RemoteControl.HotReload;
 using Uno.UI.RemoteControl.HotReload.Messages;
 using Uno.UI.RemoteControl.Messaging.HotReload;
 using Uno.UI.RemoteControl.Messaging.IdeChannel;

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -8,7 +8,13 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using Uno.Diagnostics.UI;
+
+#if HAS_UNO_WINUI
 using Uno.UI.RemoteControl.HotReload.Messages;
+#else
+using HotReloadServerOperationData = object;
+#pragma warning disable CS0649 // Field _serverState is not used on windows, we need to keep it to default
+#endif
 
 namespace Uno.UI.RemoteControl.HotReload;
 
@@ -68,6 +74,7 @@ public partial class ClientHotReloadProcessor
 		private ImmutableList<HotReloadClientOperation> _localOperations = ImmutableList<HotReloadClientOperation>.Empty;
 		private HotReloadSource _source;
 
+#if HAS_UNO_WINUI
 		public void ReportServerStatus(HotReloadStatusMessage status)
 		{
 			_serverState = status.State;
@@ -85,6 +92,7 @@ public partial class ClientHotReloadProcessor
 				return updatedHistory.ToImmutable();
 			}
 		}
+#endif
 
 		public void ConfigureSourceForNextOperation(HotReloadSource source)
 			=> _source = source;

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -163,6 +163,8 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 
 	private async Task ProcessServerStatus(HotReloadStatusMessage status)
 	{
+#if HAS_UNO_WINUI
 		_status.ReportServerStatus(status);
+#endif
 	}
 }

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/HotReloadState.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/HotReloadState.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace Uno.UI.RemoteControl.HotReload.Messages;
+namespace Uno.UI.RemoteControl.HotReload;
 
 internal enum HotReloadState
 {

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Windows.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Windows.csproj
@@ -44,11 +44,7 @@
 		<Compile Include="..\Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.Common.Status.cs" Link="Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.Common.Status.cs" />
 		<Compile Include="..\Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.MetadataUpdate.cs" Link="Uno.UI.RemoteControl\HotReload\ClientHotReloadProcessor.MetadataUpdate.cs" />
 		<Compile Include="..\Uno.UI.RemoteControl\HotReload\MetadataUpdater\ElementUpdaterAgent.cs" Link="Uno.UI.RemoteControl\HotReload\MetadataUpdater\ElementUpdaterAgent.cs" />
-		<Compile Include="..\Uno.UI.RemoteControl\HotReload\Messages\HotReloadStatusMessage.cs" Link="Uno.UI.RemoteControl\HotReload\Messages\HotReloadStatusMessage.cs" />
-		<Compile Include="..\Uno.UI.RemoteControl\HotReload\Messages\HotReloadServerResult.cs" Link="Uno.UI.RemoteControl\HotReload\Messages\HotReloadServerResult.cs" />
 		<Compile Include="..\Uno.UI.RemoteControl\HotReload\Messages\HotReloadState.cs" Link="Uno.UI.RemoteControl\HotReload\Messages\HotReloadState.cs" />
-		<Compile Include="..\Uno.UI.RemoteControl.Messaging\WellKnownScopes.cs" Link="Uno.UI.RemoteControl.Messaging\WellKnownScopes.cs" />
-		<Compile Include="..\Uno.UI.RemoteControl.Messaging\Messages\IMessage.cs" Link="Uno.UI.RemoteControl.Messaging\Messages\IMessage.cs" />
 		<Compile Include="..\Uno.UI\UI\Xaml\**\*.HotReload.cs" Link="Uno.UI.RemoteControl\HotReload\MetadataUpdater\%(FileName)%(Extension)" />
 
 		<!--<Compile Include="..\Uno.UI\UI\Xaml\Media\VisualTreeHelper.crossruntime.cs" Link="Uno.UI\UI\Xaml\Media\VisualTreeHelper.crossruntime.cs" />-->
@@ -58,7 +54,7 @@
 		<Compile Include="..\Uno.Foundation\Diagnostics\DiagnosticViewRegistry.cs" Link="Uno.Foundation\Diagnostics\DiagnosticViewRegistry.cs" />
 		<Compile Include="..\Uno.Foundation\Diagnostics\IDiagnosticView.cs" Link="Uno.Foundation\Diagnostics\IDiagnosticView.cs" />
 		<Compile Include="..\Uno.Foundation\Diagnostics\IDiagnosticViewContext.cs" Link="Uno.Foundation\Diagnostics\IDiagnosticViewContext.cs" />
-		<Compile Include="..\Uno.UI\Diagnostics\DiagnosticView.cs" Link="Uno.UI\Diagnostics\DiagnosticView.cs" />
+		<Compile Include="..\Uno.UI\Diagnostics\DiagnosticView.cs" Link="Uno.UI\Diagnostics\DiagnosticView.cs" /> 
 		<Compile Include="..\Uno.UI\Diagnostics\DiagnosticView.Factories.cs" Link="Uno.UI\Diagnostics\DiagnosticView.Factories.cs" />
 		<Compile Include="..\Uno.UI\Diagnostics\DiagnosticView.TView.cs" Link="Uno.UI\Diagnostics\DiagnosticView.TView.cs" />
 		<Compile Include="..\Uno.UI\Diagnostics\DiagnosticView.TView.TState.cs" Link="Uno.UI\Diagnostics\DiagnosticView.TView.TState.cs" />


### PR DESCRIPTION
## Chore / Bugfix
Remove reference to IMessage (and some other messages) from toolkit (windows)

## What is the current behavior?
Some types from `Uno.RemoteControl.Messaging` assembly are referenced in the toolkit on windows, noticeably `IMessage`. This prevent app to reference both assemblies.

## What is the new behavior?
Only required internal types are referenced in the toolkit.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
