### PR TITLE
fix: Replace deprecated DOMNodeInserted with MutationObserver for Algolia DocSearch initialization

### DIFF
--- a/doc/templates/uno/partials/scripts.tmpl.partial
+++ b/doc/templates/uno/partials/scripts.tmpl.partial
@@ -16,30 +16,120 @@ startOnLoad: false
 });
 mermaid.init(undefined, ".lang-mermaid");
 </script>
+
 <!-- Algolia DocSearch -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 <script>
-    function handleCreateSearchBox(){
-      if (document.getElementById("docsearch")){
-        if (document.getElementById("docsearch").children.length>0)
-        {
-          document.removeEventListener('DOMNodeInserted', handleCreateSearchBox);
+    /**
+     * Initialize Algolia DocSearch
+     * This function initializes DocSearch for the element with id 'docsearch'.
+     */
+    function initializeDocSearch() {
+        console.log("initializeDocSearch called");
+        try {
+            const searchBox = document.getElementById("docsearch");
+
+            if (searchBox) {
+                console.log("Found 'docsearch' element");
+                // Check if the search box is already initialized
+                if (searchBox.children.length > 0) {
+                    console.log("Search box already initialized.");
+                    // Disconnect the observer if search box is already initialized
+                    if (observer) {
+                        observer.disconnect();
+                        console.log("MutationObserver disconnected.");
+                    }
+                } else {
+                    // Initialize DocSearch if not already initialized
+                    console.log("Initializing DocSearch...");
+                    docsearch({
+                        container: '#docsearch',
+                        appId: 'PHB9D8WS99',
+                        indexName: 'platform',
+                        apiKey: '7877394996f96cde1a9b795dce3f7787',
+                        placeholder: 'Search Docs...'
+                    });
+                    console.log("DocSearch initialized.");
+                    // Disconnect the observer after initialization
+                    if (observer) {
+                        observer.disconnect();
+                        console.log("MutationObserver disconnected.");
+                    }
+                }
+            } else {
+                console.warn("'docsearch' element not found.");
+            }
+        } catch (error) {
+            console.error("Error initializing DocSearch:", error);
         }
-        else {
-          docsearch({
-            container: '#docsearch',
-            appId: 'PHB9D8WS99',
-            indexName: 'platform',
-            apiKey: '7877394996f96cde1a9b795dce3f7787',
-            placeholder: 'Search Docs...'
-          });
-          console.log(docsearch);
-        }
-      }
     }
-    window.addEventListener('DOMNodeInserted', handleCreateSearchBox);
+
+    /**
+     * Set up MutationObserver to watch for additions to the DOM
+     * This function sets up a MutationObserver to monitor the entire document for added nodes.
+     * If the 'docsearch' element is added, it will call initializeDocSearch().
+     */
+    let observer;
+    function observeDocSearch() {
+        observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.addedNodes.length) {
+                    mutation.addedNodes.forEach((node) => {
+                        // Check if the added node is the 'docsearch' element
+                        if (node.id === 'docsearch') {
+                            console.log("'docsearch' element added to DOM");
+                            initializeDocSearch();
+                        }
+                    });
+                }
+            });
+        });
+
+        // Observe the entire document for child additions
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+
+        console.log("MutationObserver set up to observe 'docsearch' element");
+    }
+
+    /**
+     * Retry initialization using requestAnimationFrame
+     * This function tries to initialize DocSearch using requestAnimationFrame for better timing handling for some browsers like Firefox.
+     */
+    function retryInitialization() {
+        if (!document.getElementById('docsearch')) {
+            console.log("Retrying DocSearch initialization using requestAnimationFrame");
+            requestAnimationFrame(retryInitialization);
+        } else {
+            initializeDocSearch();
+        }
+    }
+
+    /**
+     * Load event handler
+     * This function handles the load event to ensure the entire page is fully loaded.
+     * It then checks if the 'docsearch' element is present and initializes DocSearch.
+     * If the element is not present, it sets up the MutationObserver and starts the retry mechanism.
+     */
+    window.addEventListener('load', () => {
+        console.log("Load event fired");
+
+        // Check if the 'docsearch' element already exists in the DOM
+        if (document.getElementById('docsearch')) {
+            console.log("'docsearch' element already present in DOM");
+            initializeDocSearch();
+        } else {
+            console.log("'docsearch' element not present in DOM, setting up MutationObserver");
+            observeDocSearch();
+            // Start retrying using requestAnimationFrame
+            retryInitialization();
+        }
+    });
 </script>
+
 <!-- Easy-copy-code -->
 <script>
 $(function() {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Bugfix 

## What is the current behavior?

The Algolia search box for the documentation is no longer visible in canary browsers, and a similar behavior is expected in upcoming stable browser versions when using the deprecated `DOMNodeInserted`.

![image](https://github.com/unoplatform/uno/assets/16295702/c89d7a80-6d2b-4748-a1ea-45a5d97b2849)


## What is the new behavior?

The Algolia search box for the documentation is visible for all browser versions using `MutationObserver` as a replacement for the deprecated `DOMNodeInserted`.

![image](https://github.com/unoplatform/uno/assets/16295702/d422f037-b382-4148-913f-cb9c6b012d07)

## Changes Summary

> [!IMPORTANT]
> Currently, `DOMNodeInserted` is deprecated and triggers a warning in stable browser versions (126.0.x.x) but has already been disabled and throws an error in the latest canary versions (127.0.x.x and above). 
> Mutation event support will be disabled by default starting in Chrome 127, around **July 30, 2024**.
> For more information: [Chrome Status](https://chromestatus.com/feature/5083947249172480).

Replaced deprecated `DOMNodeInserted` with `MutationObserver` for Algolia DocSearch initialization:

- Removed deprecated `DOMNodeInserted` event listener.
- Implemented `MutationObserver` to monitor changes in the DOM and initialize DocSearch when the `#docsearch` element is added.
- Added error handling for better debugging.
- Ensured observation starts only after the DOM is fully loaded.
- Included comments for better code understanding and future updates.

### Changes tested with latest versions of:
- [x] Chrome (Stable, Dev, Canary)
- [x] Edge (Stable, Dev, Canary)
- [x] Firefox (Stable, Dev, Nightly)
- [x] Safari (Stable)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
