### PR TITLE
fix: Fix Visual transition not applied properly

### DIFF
--- a/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
@@ -459,30 +459,31 @@ namespace Microsoft.UI.Xaml
 			// The most specific transition wins (i.e. with matching From and To),
 			// then we validate for transitions that have only From or To defined which match.
 
+			var transitions = Transitions;
 			var hasOld = !oldStateName.IsNullOrEmpty();
 			var hasNew = !newStateName.IsNullOrEmpty();
 
-			if (hasOld && hasNew && GetFirstMatch(oldStateName, newStateName) is { } perfectMatch)
+			if (hasOld && hasNew && GetFirstMatch(transitions, oldStateName, newStateName) is { } perfectMatch)
 			{
 				return perfectMatch;
 			}
 
-			if (hasOld && GetFirstMatch(oldStateName, null) is { } fromMatch)
+			if (hasOld && GetFirstMatch(transitions, oldStateName, null) is { } fromMatch)
 			{
 				return fromMatch;
 			}
 
-			if (hasNew && GetFirstMatch(null, newStateName) is { } newMatch)
+			if (hasNew && GetFirstMatch(transitions, null, newStateName) is { } newMatch)
 			{
 				return newMatch;
 			}
 
 			return default;
 
-			VisualTransition GetFirstMatch(string from, string to)
+			static VisualTransition GetFirstMatch(IList<VisualTransition> transitions, string from, string to)
 			{
 				// Avoid using Transitions.FirstOrDefault as it incurs unnecessary Func<VisualTransition, bool> allocations.
-				foreach (var transition in Transitions)
+				foreach (var transition in transitions)
 				{
 					if (Match(transition, from, to))
 					{
@@ -493,8 +494,8 @@ namespace Microsoft.UI.Xaml
 				return null;
 			}
 
-			bool Match(VisualTransition transition, string from, string to)
-				=> string.Equals(transition.From, oldStateName) && string.Equals(transition.To, newStateName);
+			static bool Match(VisualTransition transition, string from, string to)
+				=> string.Equals(transition.From, from) && string.Equals(transition.To, to);
 		}
 
 		internal void RefreshStateTriggers(bool force = false)


### PR DESCRIPTION
## Bugfix
Fix Visual transition not applied properly

## What is the current behavior?
We are ignoring transitions that does not have both `From` and `To` set

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
