### PR TITLE
Dev/dr/hr UI update

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -83,7 +83,10 @@ public partial class ClientHotReloadProcessor
 #if HAS_UNO_WINUI
 		public void ReportServerStatus(HotReloadStatusMessage status)
 		{
-			_serverState ??= status.State; // Do not override the state if it has already been set (debugger attached with dev-server)
+			if (_serverState is not HotReloadState.Disabled)
+			{
+				_serverState = status.State; // Do not override the state if it has already been set (debugger attached with dev-server)
+			}
 			ImmutableInterlocked.Update(ref _serverOperations, UpdateOperations, status.Operations);
 			NotifyStatusChanged();
 

--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.Entries.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.Entries.cs
@@ -67,11 +67,17 @@ internal record ServerEntry : HotReloadLogEntry
 		Update(srvOp);
 	}
 
+	/// <summary>
+	/// Indicates if this notification is the final one for the operation, INCLUDING application wide.
+	/// </summary>
+	public bool IsFinal { get; private set; }
+
 	public void Update(HotReloadServerOperationData srvOp)
 	{
+		IsFinal = srvOp.Result is not HotReloadServerResult.Success;
 		(IsSuccess, Icon) = srvOp.Result switch
 		{
-			null => (default(bool?), EntryIcon.HotReload | EntryIcon.Loading),
+			null => (default, EntryIcon.HotReload | EntryIcon.Loading),
 			HotReloadServerResult.Success or HotReloadServerResult.NoChanges => (true, EntryIcon.HotReload | EntryIcon.Success),
 			_ => (false, EntryIcon.HotReload | EntryIcon.Error)
 		};

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.xaml
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.xaml
@@ -36,7 +36,8 @@
 						x:Name="Root"
 						CornerRadius="{TemplateBinding CornerRadius}"
 						Height="{TemplateBinding Height}"
-						Orientation="Horizontal">
+						Orientation="Horizontal"
+						Spacing="4">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="DisplayMode">
 								<VisualState x:Name="Compact">
@@ -51,16 +52,36 @@
 								</VisualState>
 							</VisualStateGroup>
 							<VisualStateGroup x:Name="Notification">
+								<VisualStateGroup.Transitions>
+									<VisualTransition To="Collapsed">
+										<Storyboard>
+											<DoubleAnimation
+												Storyboard.TargetName="PART_Notification"
+												Storyboard.TargetProperty="Opacity"
+												To="0"
+												Duration="0:0:1" />
+										</Storyboard>
+									</VisualTransition>
+									<VisualTransition To="Visible">
+										<Storyboard>
+											<DoubleAnimation
+												Storyboard.TargetName="PART_Notification"
+												Storyboard.TargetProperty="Opacity"
+												From="0.5"
+												To="1"
+												Duration="0:0:0.2" />
+										</Storyboard>
+									</VisualTransition>
+								</VisualStateGroup.Transitions>
 								<VisualState x:Name="Collapsed">
 									<VisualState.Setters>
 										<Setter Target="PART_Notification.MaxWidth" Value="0" />
-										<Setter Target="PART_Notification.Margin" Value="0" />
 									</VisualState.Setters>
 								</VisualState>
 								<VisualState x:Name="Visible">
 									<VisualState.Setters>
 										<Setter Target="PART_Notification.MaxWidth" Value="512" />
-										<Setter Target="PART_Notification.Margin" Value="4,0" />
+										<Setter Target="PART_Notification.Opacity" Value="1" />
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
@@ -100,6 +121,7 @@
 
 						<ContentPresenter
 							x:Name="PART_Notification"
+							Opacity="0.5"
 							VerticalAlignment="Center" />
 					</StackPanel>
 				</ControlTemplate>

--- a/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
@@ -459,30 +459,31 @@ namespace Microsoft.UI.Xaml
 			// The most specific transition wins (i.e. with matching From and To),
 			// then we validate for transitions that have only From or To defined which match.
 
+			var transitions = Transitions;
 			var hasOld = !oldStateName.IsNullOrEmpty();
 			var hasNew = !newStateName.IsNullOrEmpty();
 
-			if (hasOld && hasNew && GetFirstMatch(oldStateName, newStateName) is { } perfectMatch)
+			if (hasOld && hasNew && GetFirstMatch(transitions, oldStateName, newStateName) is { } perfectMatch)
 			{
 				return perfectMatch;
 			}
 
-			if (hasOld && GetFirstMatch(oldStateName, null) is { } fromMatch)
+			if (hasOld && GetFirstMatch(transitions, oldStateName, null) is { } fromMatch)
 			{
 				return fromMatch;
 			}
 
-			if (hasNew && GetFirstMatch(null, newStateName) is { } newMatch)
+			if (hasNew && GetFirstMatch(transitions, null, newStateName) is { } newMatch)
 			{
 				return newMatch;
 			}
 
 			return default;
 
-			VisualTransition GetFirstMatch(string from, string to)
+			static VisualTransition GetFirstMatch(IList<VisualTransition> transitions, string from, string to)
 			{
 				// Avoid using Transitions.FirstOrDefault as it incurs unnecessary Func<VisualTransition, bool> allocations.
-				foreach (var transition in Transitions)
+				foreach (var transition in transitions)
 				{
 					if (Match(transition, from, to))
 					{
@@ -493,8 +494,8 @@ namespace Microsoft.UI.Xaml
 				return null;
 			}
 
-			bool Match(VisualTransition transition, string from, string to)
-				=> string.Equals(transition.From, oldStateName) && string.Equals(transition.To, newStateName);
+			static bool Match(VisualTransition transition, string from, string to)
+				=> string.Equals(transition.From, from) && string.Equals(transition.To, to);
 		}
 
 		internal void RefreshStateTriggers(bool force = false)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/507

Note: This is based on https://github.com/unoplatform/uno/pull/17425, and includes https://github.com/unoplatform/uno/pull/17436. This current PR is expected to be merged only once those both PR has been merged.

Only this commit https://github.com/unoplatform/uno/commit/b49756b0d1d3c9e047b68d1465c86e4a0c01a868 is relevent

## Feature
Animate entrance and exit of notification from HR UI

## What is the current behavior?
No anim

## What is the new behavior?
Animated

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
