### PR TITLE
fix: Fix ListView dragging not reverting back to NotDragging state

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -16,7 +16,6 @@ using _DragEventArgs = global::Microsoft.UI.Xaml.DragEventArgs;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media.Imaging;
-using Microsoft.UI.Dispatching;
 
 namespace Microsoft.UI.Xaml.Controls
 {
@@ -266,7 +265,11 @@ namespace Microsoft.UI.Xaml.Controls
 			// CompleteReordering will remove the children and add them back on next measure.
 			// We defer ChangeSelectorItemsVisualState to the next measure so that the children are there and updated.
 			// An alternative could be to retrieve the children before CompleteReordering and then update the visual state here.
-			that.DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () => that.ChangeSelectorItemsVisualState(true));
+#if HAS_UNO_WINUI
+			that.DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () => that.ChangeSelectorItemsVisualState(true));
+#else
+			_ = that.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Low, () => that.ChangeSelectorItemsVisualState(true));
+#endif
 
 			if (that.IsGrouping
 				|| !updatedIndex.HasValue

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.DragDrop.cs
@@ -16,6 +16,7 @@ using _DragEventArgs = global::Microsoft.UI.Xaml.DragEventArgs;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Dispatching;
 
 namespace Microsoft.UI.Xaml.Controls
 {
@@ -262,7 +263,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 			that.m_tpPrimaryDraggedContainer = null;
 
-			that.ChangeSelectorItemsVisualState(true);
+			// CompleteReordering will remove the children and add them back on next measure.
+			// We defer ChangeSelectorItemsVisualState to the next measure so that the children are there and updated.
+			// An alternative could be to retrieve the children before CompleteReordering and then update the visual state here.
+			that.DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () => that.ChangeSelectorItemsVisualState(true));
 
 			if (that.IsGrouping
 				|| !updatedIndex.HasValue


### PR DESCRIPTION
GitHub Issue (If applicable): closes #17464

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
