### PR TITLE
feat(hrui): Improve HR indicator placement strategies

### DIFF
--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Notification.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Notification.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 #if WINUI || HAS_UNO_WINUI
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
@@ -10,6 +10,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI;
+using Uno.UI.Toolkit.Extensions;
 
 namespace Uno.Diagnostics.UI;
 
@@ -43,7 +44,9 @@ public sealed partial class DiagnosticsOverlay
 
 	private PlacementOrigin _origin;
 	private Point _location; // The location, relative to the _origin
+#if HAS_UNO_WINUI
 	private StatusBar? _statusBar;
+#endif
 	private bool _isPlacementInit;
 
 	private void InitPlacement()
@@ -51,6 +54,7 @@ public sealed partial class DiagnosticsOverlay
 		CleanPlacement();
 		RestoreLocation();
 
+#if HAS_UNO_WINUI
 		if (ApiInformation.IsMethodPresent(typeof(StatusBar), nameof(StatusBar.GetForCurrentView))
 			&& StatusBar.GetForCurrentView() is { } statusBar)
 		{
@@ -59,6 +63,7 @@ public sealed partial class DiagnosticsOverlay
 			statusBar.Hiding += OnStatusBarChanged;
 			statusBar.Showing += OnStatusBarChanged;
 		}
+#endif
 
 		_isPlacementInit = true;
 	}
@@ -67,11 +72,13 @@ public sealed partial class DiagnosticsOverlay
 	{
 		_isPlacementInit = false;
 
+#if HAS_UNO_WINUI
 		if (_statusBar is { } statusBar)
 		{
 			statusBar.Hiding -= OnStatusBarChanged;
 			statusBar.Showing -= OnStatusBarChanged;
 		}
+#endif
 	}
 
 	/// <summary>
@@ -80,6 +87,7 @@ public sealed partial class DiagnosticsOverlay
 	/// <returns></returns>
 	public Rect GetSafeArea()
 	{
+#if HAS_UNO_WINUI
 		var bounds = _root.Bounds;
 		if (
 			_statusBar?.OccludedRect is { Height: > 0 } occludedRect
@@ -91,6 +99,9 @@ public sealed partial class DiagnosticsOverlay
 			bounds.Y += occludedRect.Height;
 			bounds.Height -= occludedRect.Height;
 		}
+#else
+		var bounds = new Rect(default, _root.Size);
+#endif
 
 		bounds.Width -= _toolbar?.ActualWidth ?? ActualWidth;
 		bounds.Height -= ActualHeight;
@@ -126,8 +137,10 @@ public sealed partial class DiagnosticsOverlay
 	private void OnAnchorManipulatedCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
 		=> UpdatePlacement();
 
+#if HAS_UNO_WINUI
 	private void OnStatusBarChanged(StatusBar sender, object args)
 		=> UpdatePlacement();
+#endif
 
 	private void UpdatePlacement()
 	{

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
@@ -81,7 +81,12 @@ public sealed partial class DiagnosticsOverlay
 	public Rect GetSafeArea()
 	{
 		var bounds = _root.Bounds;
-		if (_statusBar?.OccludedRect is { Height: > 0 } occludedRect)
+		if (
+			_statusBar?.OccludedRect is { Height: > 0 } occludedRect
+#if __ANDROID__
+			&& (Window.Current?.IsStatusBarTranslucent() ?? true)
+#endif
+			)
 		{
 			bounds.Y += occludedRect.Height;
 			bounds.Height -= occludedRect.Height;
@@ -168,7 +173,9 @@ public sealed partial class DiagnosticsOverlay
 		}
 
 		// Update direction
-		var direction = distanceToRight < _rightDirectionDistance ? HorizontalDirectionLeftVisualState : HorizontalDirectionRightVisualState;
+		var direction = distanceToRight < Math.Min(_rightDirectionDistance, area.Width / 2.0)
+			? HorizontalDirectionLeftVisualState
+			: HorizontalDirectionRightVisualState;
 		VisualStateManager.GoToState(this, direction, true);
 
 		PersistLocation();

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
@@ -1,0 +1,216 @@
+﻿#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.Foundation.Metadata;
+using Windows.Storage;
+using Windows.UI.ViewManagement;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI;
+
+namespace Uno.Diagnostics.UI;
+
+public sealed partial class DiagnosticsOverlay
+{
+	private const string _originSettingsKey = "__UNO__" + nameof(DiagnosticsOverlay) + "__placement" + nameof(_origin);
+	private const string _locationXSettingsKey = "__UNO__" + nameof(DiagnosticsOverlay) + "__placement" + nameof(_location) + "_X";
+	private const string _locationYSettingsKey = "__UNO__" + nameof(DiagnosticsOverlay) + "__placement" + nameof(_location) + "_Y";
+
+	private const int _horizontalSnappingDistance = 25;
+	private const int _verticalSnappingDistance = 25;
+	private const int _rightDirectionDistance = 250;
+
+	[Flags]
+	private enum PlacementOrigin
+	{
+		Left = 0, // 0 << 1,
+		Right = 1 << 1,
+
+		Top = 0, // 0 << 2,
+		Bottom = 1 << 2,
+
+		TopLeft = Top | Left,
+		TopRight = Top | Right,
+		BottomLeft = Bottom | Left,
+		BottomRight = Bottom | Right,
+	}
+
+	private readonly bool _magnetic = true;
+	private readonly Thickness _edgePadding = new(4);
+
+	private PlacementOrigin _origin;
+	private Point _location; // The location, relative to the _origin
+	private StatusBar? _statusBar;
+	private bool _isPlacementInit;
+
+	private void InitPlacement()
+	{
+		CleanPlacement();
+		RestoreLocation();
+
+		if (ApiInformation.IsMethodPresent(typeof(StatusBar), nameof(StatusBar.GetForCurrentView))
+			&& StatusBar.GetForCurrentView() is { } statusBar)
+		{
+			_statusBar = statusBar;
+
+			statusBar.Hiding += OnStatusBarChanged;
+			statusBar.Showing += OnStatusBarChanged;
+		}
+
+		_isPlacementInit = true;
+	}
+
+	private void CleanPlacement()
+	{
+		_isPlacementInit = false;
+
+		if (_statusBar is { } statusBar)
+		{
+			statusBar.Hiding -= OnStatusBarChanged;
+			statusBar.Showing -= OnStatusBarChanged;
+		}
+	}
+
+	/// <summary>
+	/// Gets the area where the top-left corner of the overlay can be placed (i.e. already excludes the overlay size).
+	/// </summary>
+	/// <returns></returns>
+	public Rect GetSafeArea()
+	{
+		var bounds = _root.Bounds;
+		if (_statusBar?.OccludedRect is { Height: > 0 } occludedRect)
+		{
+			bounds.Y += occludedRect.Height;
+			bounds.Height -= occludedRect.Height;
+		}
+
+		bounds.Width -= _toolbar?.ActualWidth ?? ActualWidth;
+		bounds.Height -= ActualHeight;
+
+		bounds = bounds.DeflateBy(_edgePadding);
+
+		return bounds;
+	}
+
+	public Point GetAbsoluteLocation()
+	{
+		var area = GetSafeArea();
+
+		var x = _origin.HasFlag(PlacementOrigin.Right)
+			? area.Right - _location.X
+			: area.Left + _location.X;
+
+		var y = _origin.HasFlag(PlacementOrigin.Bottom)
+			? area.Bottom - _location.Y
+			: area.Top + _location.Y;
+
+		return new Point(x, y);
+	}
+
+	private void OnAnchorManipulated(object sender, ManipulationDeltaRoutedEventArgs e)
+	{
+		_location.X += _origin.HasFlag(PlacementOrigin.Right) ? -e.Delta.Translation.X : e.Delta.Translation.X;
+		_location.Y += _origin.HasFlag(PlacementOrigin.Bottom) ? -e.Delta.Translation.Y : e.Delta.Translation.Y;
+
+		ApplyLocation();
+	}
+
+	private void OnAnchorManipulatedCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
+		=> UpdatePlacement();
+
+	private void OnStatusBarChanged(StatusBar sender, object args)
+		=> UpdatePlacement();
+
+	private void UpdatePlacement()
+	{
+		if (!_isPlacementInit)
+		{
+			return;
+		}
+
+		var area = GetSafeArea();
+
+		// First constraints in the area, no matter the anchor type here
+		_location.X = Math.Max(0, Math.Min(area.Width, _location.X));
+		_location.Y = Math.Max(0, Math.Min(area.Height, _location.Y));
+
+		// Snap to the edges of the area
+		var location = GetAbsoluteLocation();
+		var distanceToRight = Math.Max(0, area.Right - location.X);
+		if (distanceToRight < _horizontalSnappingDistance && !_origin.HasFlag(PlacementOrigin.Right))
+		{
+			_origin |= PlacementOrigin.Right;
+			_location.X = _magnetic ? 0 : distanceToRight;
+		}
+
+		var distanceToLeft = Math.Max(0, location.X - area.Left);
+		if (distanceToLeft < _horizontalSnappingDistance && _origin.HasFlag(PlacementOrigin.Right))
+		{
+			_origin &= ~PlacementOrigin.Right;
+			_location.X = _magnetic ? 0 : distanceToLeft;
+		}
+
+		var distanceToBottom = Math.Max(0, area.Bottom - location.Y);
+		if (distanceToBottom < _verticalSnappingDistance && !_origin.HasFlag(PlacementOrigin.Bottom))
+		{
+			_origin |= PlacementOrigin.Bottom;
+			_location.Y = _magnetic ? 0 : distanceToBottom;
+		}
+
+		var distanceToTop = Math.Max(0, location.Y - area.Top);
+		if (distanceToTop < _verticalSnappingDistance && _origin.HasFlag(PlacementOrigin.Bottom))
+		{
+			_origin &= ~PlacementOrigin.Bottom;
+			_location.Y = _magnetic ? 0 : distanceToTop;
+		}
+
+		// Update direction
+		var direction = distanceToRight < _rightDirectionDistance ? HorizontalDirectionLeftVisualState : HorizontalDirectionRightVisualState;
+		VisualStateManager.GoToState(this, direction, true);
+
+		PersistLocation();
+		ApplyLocation();
+	}
+
+	private void ApplyLocation()
+	{
+		if (RenderTransform is not TranslateTransform transform)
+		{
+			RenderTransform = transform = new TranslateTransform();
+		}
+
+		var location = GetAbsoluteLocation();
+		transform.X = location.X;
+		transform.Y = location.Y;
+	}
+
+	private void RestoreLocation()
+	{
+		try
+		{
+			if (ApplicationData.Current.LocalSettings.Values.TryGetValue(_locationXSettingsKey, out var storedX)
+				&& ApplicationData.Current.LocalSettings.Values.TryGetValue(_locationYSettingsKey, out var storedY)
+				&& storedX is double x
+				&& storedY is double y)
+			{
+				_location = new Point(x, y);
+			}
+			if (ApplicationData.Current.LocalSettings.Values.TryGetValue(_originSettingsKey, out var storedOrigin)
+				&& storedOrigin is int origin)
+			{
+				_origin = (PlacementOrigin)origin;
+			}
+		}
+		catch { }
+	}
+
+	private void PersistLocation()
+	{
+		ApplicationData.Current.LocalSettings.Values[_locationXSettingsKey] = _location.X;
+		ApplicationData.Current.LocalSettings.Values[_locationYSettingsKey] = _location.Y;
+		ApplicationData.Current.LocalSettings.Values[_originSettingsKey] = (int)_origin;
+	}
+}

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
@@ -1,5 +1,5 @@
 ﻿#nullable enable
-
+#if WINUI || HAS_UNO_WINUI
 using System;
 using System.Threading.Tasks;
 using Windows.Foundation;
@@ -221,3 +221,4 @@ public sealed partial class DiagnosticsOverlay
 		ApplicationData.Current.LocalSettings.Values[_originSettingsKey] = (int)_origin;
 	}
 }
+#endif

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -18,6 +18,7 @@ namespace Uno.Diagnostics.UI;
 /// <summary>
 /// An overlay layer used to inject analytics and diagnostics indicators into the UI.
 /// </summary>
+[TemplatePart(Name = ToolbarPartName, Type = typeof(FrameworkElement))]
 [TemplatePart(Name = ElementsPanelPartName, Type = typeof(Panel))]
 [TemplatePart(Name = AnchorPartName, Type = typeof(UIElement))]
 [TemplatePart(Name = NotificationPartName, Type = typeof(ContentPresenter))]
@@ -25,8 +26,11 @@ namespace Uno.Diagnostics.UI;
 [TemplateVisualState(GroupName = "DisplayMode", Name = DisplayModeExpandedStateName)]
 [TemplateVisualState(GroupName = "Notification", Name = NotificationCollapsedStateName)]
 [TemplateVisualState(GroupName = "Notification", Name = NotificationVisibleStateName)]
+[TemplateVisualState(GroupName = "HorizontalDirection", Name = HorizontalDirectionLeftVisualState)]
+[TemplateVisualState(GroupName = "HorizontalDirection", Name = HorizontalDirectionRightVisualState)]
 public sealed partial class DiagnosticsOverlay : Control
 {
+	private const string ToolbarPartName = "PART_Toolbar";
 	private const string ElementsPanelPartName = "PART_Elements";
 	private const string AnchorPartName = "PART_Anchor";
 	private const string NotificationPartName = "PART_Notification";
@@ -36,6 +40,9 @@ public sealed partial class DiagnosticsOverlay : Control
 
 	private const string NotificationCollapsedStateName = "Collapsed";
 	private const string NotificationVisibleStateName = "Visible";
+
+	private const string HorizontalDirectionLeftVisualState = "Left";
+	private const string HorizontalDirectionRightVisualState = "Left";
 
 	private static readonly ConditionalWeakTable<XamlRoot, DiagnosticsOverlay> _overlays = new();
 
@@ -58,6 +65,7 @@ public sealed partial class DiagnosticsOverlay : Control
 	private bool _isVisible;
 	private bool _isExpanded = true;
 	private int _updateEnqueued;
+	private FrameworkElement? _toolbar;
 	private Panel? _elementsPanel;
 	private UIElement? _anchor;
 	private ContentPresenter? _notificationPresenter;
@@ -98,6 +106,7 @@ public sealed partial class DiagnosticsOverlay : Control
 					overlay._elements.Clear();
 				}
 			}
+			overlay.UpdatePlacement();
 			overlay.EnqueueUpdate();
 		};
 
@@ -198,6 +207,7 @@ public sealed partial class DiagnosticsOverlay : Control
 		{
 			//_anchor.Tapped -= OnAnchorTapped;
 			_anchor.ManipulationDelta -= OnAnchorManipulated;
+			_anchor.ManipulationCompleted -= OnAnchorManipulatedCompleted;
 		}
 		if (_notificationPresenter is not null)
 		{
@@ -206,6 +216,7 @@ public sealed partial class DiagnosticsOverlay : Control
 
 		base.OnApplyTemplate();
 
+		_toolbar = GetTemplateChild(ToolbarPartName) as FrameworkElement;
 		_elementsPanel = GetTemplateChild(ElementsPanelPartName) as Panel;
 		_anchor = GetTemplateChild(AnchorPartName) as UIElement;
 		_notificationPresenter = GetTemplateChild(NotificationPartName) as ContentPresenter;
@@ -214,11 +225,13 @@ public sealed partial class DiagnosticsOverlay : Control
 		{
 			//_anchor.Tapped += OnAnchorTapped;
 			_anchor.ManipulationDelta += OnAnchorManipulated;
+			_anchor.ManipulationCompleted += OnAnchorManipulatedCompleted;
 			_anchor.ManipulationMode = ManipulationModes.TranslateX | ManipulationModes.TranslateY | ManipulationModes.TranslateInertia;
-			RenderTransform = new TranslateTransform { X = 15, Y = 15 };
+			RenderTransform = new TranslateTransform();
 		}
 		if (_notificationPresenter is not null)
 		{
+			RelativePlacement.SetAnchor(_notificationPresenter, _toolbar);
 			_notificationPresenter.Tapped += OnNotificationTapped;
 		}
 
@@ -233,18 +246,6 @@ public sealed partial class DiagnosticsOverlay : Control
 	//	VisualStateManager.GoToState(this, _isExpanded ? DisplayModeExpandedStateName : DisplayModeCompactStateName, true);
 	//	args.Handled = true;
 	//}
-
-	private void OnAnchorManipulated(object sender, ManipulationDeltaRoutedEventArgs e)
-	{
-		var transform = RenderTransform as TranslateTransform;
-		if (transform is null)
-		{
-			RenderTransform = transform = new TranslateTransform();
-		}
-
-		transform.X += e.Delta.Translation.X;
-		transform.Y += e.Delta.Translation.Y;
-	}
 
 	private void EnqueueUpdate(bool forceUpdate = false)
 	{
@@ -331,17 +332,25 @@ public sealed partial class DiagnosticsOverlay : Control
 			}
 
 			ShowHost(host, isVisible: visibleViews is not 0);
+			UpdatePlacement();
 		});
 	}
 
 	private static Popup CreateHost(XamlRoot root, DiagnosticsOverlay overlay)
-		=> new()
+	{
+		var host = new Popup
 		{
 			XamlRoot = root,
 			Child = overlay,
 			IsLightDismissEnabled = false,
-			LightDismissOverlayMode = LightDismissOverlayMode.Off,
+			LightDismissOverlayMode = LightDismissOverlayMode.Off
 		};
+
+		host.Opened += static (snd, e) => ((snd as Popup)?.Child as DiagnosticsOverlay)?.InitPlacement();
+		host.Closed += static (snd, e) => ((snd as Popup)?.Child as DiagnosticsOverlay)?.CleanPlacement();
+
+		return host;
+	}
 
 	private static void ShowHost(Popup host, bool isVisible)
 		=> host.IsOpen = isVisible;

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -214,7 +214,7 @@ public sealed partial class DiagnosticsOverlay : Control
 			_notificationPresenter.Tapped -= OnNotificationTapped;
 		}
 
-#if __ANDROID__
+#if __ANDROID__ || __IOS__
 		if (_toolbar is not null)
 		{
 			_toolbar.SizeChanged += OnToolBarSizeChanged;
@@ -241,7 +241,7 @@ public sealed partial class DiagnosticsOverlay : Control
 			RelativePlacement.SetAnchor(_notificationPresenter, _toolbar);
 			_notificationPresenter.Tapped += OnNotificationTapped;
 		}
-#if __ANDROID__
+#if __ANDROID__ || __IOS__
 		if (_toolbar is not null)
 		{
 			_toolbar.SizeChanged += OnToolBarSizeChanged;
@@ -250,7 +250,7 @@ public sealed partial class DiagnosticsOverlay : Control
 		static void OnToolBarSizeChanged(object sender, SizeChangedEventArgs args)
 		{
 			// Patches pointer event dispatch on a 0x0 Canvas
-			if (sender is UIElement { TemplatedParent: DiagnosticsOverlay {TemplatedRoot: Canvas canvas } })
+			if (sender is UIElement { TemplatedParent: DiagnosticsOverlay { TemplatedRoot: Canvas canvas } })
 			{
 				canvas.Width = args.NewSize.Width;
 			}

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -42,7 +42,7 @@ public sealed partial class DiagnosticsOverlay : Control
 	private const string NotificationVisibleStateName = "Visible";
 
 	private const string HorizontalDirectionLeftVisualState = "Left";
-	private const string HorizontalDirectionRightVisualState = "Left";
+	private const string HorizontalDirectionRightVisualState = "Right";
 
 	private static readonly ConditionalWeakTable<XamlRoot, DiagnosticsOverlay> _overlays = new();
 
@@ -214,6 +214,13 @@ public sealed partial class DiagnosticsOverlay : Control
 			_notificationPresenter.Tapped -= OnNotificationTapped;
 		}
 
+#if __ANDROID__
+		if (_toolbar is not null)
+		{
+			_toolbar.SizeChanged += OnToolBarSizeChanged;
+		}
+#endif
+
 		base.OnApplyTemplate();
 
 		_toolbar = GetTemplateChild(ToolbarPartName) as FrameworkElement;
@@ -234,6 +241,21 @@ public sealed partial class DiagnosticsOverlay : Control
 			RelativePlacement.SetAnchor(_notificationPresenter, _toolbar);
 			_notificationPresenter.Tapped += OnNotificationTapped;
 		}
+#if __ANDROID__
+		if (_toolbar is not null)
+		{
+			_toolbar.SizeChanged += OnToolBarSizeChanged;
+		}
+
+		static void OnToolBarSizeChanged(object sender, SizeChangedEventArgs args)
+		{
+			// Patches pointer event dispatch on a 0x0 Canvas
+			if (sender is UIElement { TemplatedParent: DiagnosticsOverlay {TemplatedRoot: Canvas canvas } })
+			{
+				canvas.Width = args.NewSize.Width;
+			}
+		}
+#endif
 
 		VisualStateManager.GoToState(this, _isExpanded ? DisplayModeExpandedStateName : DisplayModeCompactStateName, false);
 		VisualStateManager.GoToState(this, NotificationCollapsedStateName, false);

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.xaml
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.xaml
@@ -32,12 +32,9 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="local:DiagnosticsOverlay">
-					<StackPanel
-						x:Name="Root"
+					<Canvas
 						CornerRadius="{TemplateBinding CornerRadius}"
-						Height="{TemplateBinding Height}"
-						Orientation="Horizontal"
-						Spacing="4">
+						Height="{TemplateBinding Height}">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="DisplayMode">
 								<VisualState x:Name="Compact">
@@ -85,22 +82,37 @@
 									</VisualState.Setters>
 								</VisualState>
 							</VisualStateGroup>
+							<VisualStateGroup x:Name="HorizontalDirection">
+								<VisualState x:Name="Right" />
+								<VisualState x:Name="Left">
+									<VisualState.Setters>
+										<Setter Target="PART_Anchor.(Grid.Column)" Value="1" />
+										<Setter Target="PART_Elements.(Grid.Column)" Value="0" />
+										<Setter Target="PART_Notification.(local:RelativePlacement.Mode)" Value="Left" />
+									</VisualState.Setters>
+								</VisualState>
+							</VisualStateGroup>
 						</VisualStateManager.VisualStateGroups>
 
-						<StackPanel
+						<Grid
+							x:Name="PART_Toolbar"
 							BorderThickness="{TemplateBinding BorderThickness}"
 							BorderBrush="{ThemeResource DiagnosticsOverlayBorderBrush}"
 							CornerRadius="{TemplateBinding CornerRadius}"
 							Height="{TemplateBinding Height}"
-							Background="{ThemeResource DiagnosticsOverlayBackgroundBrush}"
-							Orientation="Horizontal">
+							Background="{ThemeResource DiagnosticsOverlayBackgroundBrush}">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
 
-							<Grid 
+							<Border
 								x:Name="PART_Anchor"
+								Grid.Column="0"
 								BorderThickness="0,0,1,0"
 								BorderBrush="{ThemeResource DiagnosticsOverlayBorderBrush}"
 								Background="{ThemeResource DiagnosticsOverlayBackgroundBrush}">
-								<Path 
+								<Path
 									Stretch="Uniform"
 									Width="12"
 									Height="16"
@@ -108,22 +120,24 @@
 									HorizontalAlignment="Center"
 									Data="{StaticResource AnchorIcon}"
 									Fill="{ThemeResource DiagnosticsAnchorFillBrush}" />
-							</Grid>
+							</Border>
 
 							<StackPanel
 								x:Name="PART_Elements"
+								Grid.Column="1"
 								MaxWidth="0"
 								Spacing="4"
 								Padding="4,0"
 								Orientation="Horizontal"
-								VerticalAlignment="Center" />
-						</StackPanel>
+								VerticalAlignment="Center"/>
+						</Grid>
 
 						<ContentPresenter
 							x:Name="PART_Notification"
+							local:RelativePlacement.Mode="Right"
 							Opacity="0.5"
 							VerticalAlignment="Center" />
-					</StackPanel>
+					</Canvas>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.xaml
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.xaml
@@ -32,9 +32,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="local:DiagnosticsOverlay">
-					<Canvas
-						CornerRadius="{TemplateBinding CornerRadius}"
-						Height="{TemplateBinding Height}">
+					<Canvas Height="{TemplateBinding Height}">
 						<VisualStateManager.VisualStateGroups>
 							<VisualStateGroup x:Name="DisplayMode">
 								<VisualState x:Name="Compact">

--- a/src/Uno.UI.Toolkit/Diagnostics/RelativePlacement.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/RelativePlacement.cs
@@ -1,0 +1,130 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Windows.Foundation;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
+
+namespace Uno.Diagnostics.UI;
+
+internal static class RelativePlacement
+{
+	private static readonly ConditionalWeakTable<FrameworkElement, List<FrameworkElement>> _targets = new();
+
+	#region Anchor (Attached DP)
+	public static DependencyProperty AnchorProperty { get; } = DependencyProperty.RegisterAttached(
+		"Anchor",
+		typeof(FrameworkElement),
+		typeof(RelativePlacement),
+		new PropertyMetadata(default(FrameworkElement), OnAnchorChanged));
+
+	public static FrameworkElement? GetAnchor(UIElement elt)
+		=> (FrameworkElement)elt.GetValue(AnchorProperty);
+
+	public static void SetAnchor(UIElement elt, FrameworkElement? target)
+		=> elt.SetValue(AnchorProperty, target);
+
+	private static void OnAnchorChanged(DependencyObject elt, DependencyPropertyChangedEventArgs args)
+	{
+		if (elt is not FrameworkElement target)
+		{
+			return;
+		}
+
+		target.SizeChanged -= OnTargetSizeChanged;
+		if (args.OldValue is FrameworkElement oldAnchor)
+		{
+			oldAnchor.SizeChanged -= OnAnchorSizeChanged;
+		}
+
+		if (args.NewValue is FrameworkElement newAnchor)
+		{
+			target.SizeChanged += OnTargetSizeChanged;
+			newAnchor.SizeChanged += OnAnchorSizeChanged;
+		}
+		else
+		{
+			target.RenderTransform = null;
+		}
+	}
+	#endregion
+
+	#region Mode (Attached DP)
+	public static DependencyProperty ModeProperty { get; } = DependencyProperty.RegisterAttached(
+		"Mode",
+		typeof(FlyoutPlacementMode),
+		typeof(RelativePlacement),
+		new PropertyMetadata(FlyoutPlacementMode.Right, OnModeChanged));
+
+	public static FlyoutPlacementMode GetMode(UIElement elt)
+		=> (FlyoutPlacementMode)elt.GetValue(ModeProperty);
+
+	public static void SetMode(UIElement elt, FlyoutPlacementMode mode)
+		=> elt.SetValue(ModeProperty, mode);
+
+	private static void OnModeChanged(DependencyObject elt, DependencyPropertyChangedEventArgs args)
+	{
+		if (elt is not FrameworkElement element)
+		{
+			return;
+		}
+
+		if (GetAnchor(element) is { } anchor)
+		{
+			RefreshPlacement(anchor, element);
+		}
+	}
+	#endregion
+
+	private static void OnTargetSizeChanged(object sender, SizeChangedEventArgs args)
+	{
+		if (sender is FrameworkElement target && GetAnchor(target) is { } anchor)
+		{
+			RefreshPlacement(anchor, target);
+		}
+	}
+
+	private static void OnAnchorSizeChanged(object sender, SizeChangedEventArgs args)
+	{
+		if (sender is FrameworkElement anchor)
+		{
+			RefreshPlacement(anchor);
+		}
+	}
+
+	private static void RefreshPlacement(FrameworkElement anchor)
+	{
+		if (!_targets.TryGetValue(anchor, out var targets) || targets is null or { Count: 0 })
+		{
+			return;
+		}
+
+		foreach (var target in targets)
+		{
+			RefreshPlacement(anchor, target);
+		}
+	}
+
+	private static void RefreshPlacement(FrameworkElement anchor, FrameworkElement target)
+	{
+		var mode = GetMode(target);
+		var targetLocation = mode switch
+		{
+			FlyoutPlacementMode.Left => new Point(-target.ActualWidth, 0),
+			FlyoutPlacementMode.Right => new Point(anchor.ActualWidth, 0),
+			_ => throw new NotImplementedException("Only Left and Right mode are currently supported"),
+		};
+
+		if (target.RenderTransform is not TranslateTransform transform)
+		{
+			target.RenderTransform = transform = new();
+		}
+
+		// TODO: This assumes that target is at same origin that the anchor, we need to TransformToVisual to get the correct position
+		transform.X = targetLocation.X;
+		transform.Y = targetLocation.Y;
+	}
+}

--- a/src/Uno.UI.Toolkit/RectExtensions.cs
+++ b/src/Uno.UI.Toolkit/RectExtensions.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Graphics.Display;
+using Microsoft.UI.Xaml;
 
 namespace Uno.UI.Toolkit.Extensions
 {
@@ -47,6 +48,21 @@ namespace Uno.UI.Toolkit.Extensions
 				return DisplayOrientations.None;
 			}
 		}
+
+		internal static Rect InflateBy(this Rect left, Thickness right)
+		{
+			var newWidth = right.Left + left.Width + right.Right;
+			var newHeight = right.Top + left.Height + right.Bottom;
+
+			// The origin is always following the left/top
+			var newX = left.X - right.Left;
+			var newY = left.Y - right.Top;
+
+			return new Rect(newX, newY, Math.Max(newWidth, 0d), Math.Max(newHeight, 0d));
+		}
+
+		internal static Rect DeflateBy(this Rect left, Thickness right)
+			=> left.InflateBy(new Thickness(-right.Left, -right.Top, -right.Right, -right.Bottom));
 #endif
 	}
 }


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/511
closes https://github.com/unoplatform/uno-private/issues/512
closes https://github.com/unoplatform/uno-private/issues/513

## Feature
Improve placement strategies of the HR indicator 

## What is the current behavior?
Basic drag and drop of the indicator

## What is the new behavior?
* Enforce window edges + safe area
* Persist location and restore on app restart
* Move the anchor at the right and display notification on the left when to close for the right edge of the window

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
