### PR TITLE
docs: Fix missing image on Debugging WASM

### DIFF
--- a/doc/articles/debugging-wasm.md
+++ b/doc/articles/debugging-wasm.md
@@ -48,7 +48,7 @@ To debug your application:
   - Select **MyApp (WebAssembly IIS Express)** as the debugging target
   - Select **Chrome** or **Microsoft Edge** as the Web Browser
   - Make sure script debugging is disabled<br/>
-   ![IIS express settings](Assets/quick-start/![alt text](image.png))
+   ![IIS express settings](Assets/quick-start/wasm-debugging-iis-express.png)
 
 - Start the debugging session using <kbd>Ctrl</kbd><kbd>F5</kbd> or _Debug_ > _Start Without Debugging_ from the menu, (<kbd>F5</kbd> will work, but the debugging experience won't be in Visual Studio)
 - Once your application has started, press <kbd>Alt</kbd><kbd>Shift</kbd><kbd>D</kbd> (in Chrome, on your application's tab)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Documentation content changes

## What is the current behavior?

The image in the Debugging WASM was previously replaced by `![IIS express settings](Assets/quick-start/![alt text](image.png))`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.