### PR TITLE
feat: Notify for VS restore on uno.sdk change

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -51,6 +51,7 @@ public partial class EntryPoint : IDisposable
 	private bool _isDisposed;
 	private IdeChannelClient? _ideChannelClient;
 	private ProfilesObserver _debuggerObserver;
+	private GlobalJsonObserver _globalJsonObserver;
 	private readonly Func<Task> _globalPropertiesChanged;
 	private readonly _dispSolutionEvents_BeforeClosingEventHandler _closeHandler;
 	private readonly _dispBuildEvents_OnBuildDoneEventHandler _onBuildDoneHandler;
@@ -94,6 +95,8 @@ public partial class EntryPoint : IDisposable
 			, OnDebugProfileChangedAsync
 			, OnStartupProjectChangedAsync
 			, _debugAction);
+
+		_globalJsonObserver = new GlobalJsonObserver(asyncPackage, _dte, _debugAction, _infoAction, _warningAction, _errorAction);
 
 		_ = _debuggerObserver.ObserveProfilesAsync();
 
@@ -431,6 +434,7 @@ public partial class EntryPoint : IDisposable
 			_ct.Cancel(false);
 			_dte.Events.BuildEvents.OnBuildDone -= _onBuildDoneHandler;
 			_dte.Events.BuildEvents.OnBuildProjConfigBegin -= _onBuildProjConfigBeginHandler;
+			_globalJsonObserver.Dispose();
 		}
 		catch (Exception e)
 		{

--- a/src/Uno.UI.RemoteControl.VS/GlobalJsonObserver.cs
+++ b/src/Uno.UI.RemoteControl.VS/GlobalJsonObserver.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.IO;
+using System.Text.Json;
+using System.Linq;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell.Interop;
+using Uno.UI.RemoteControl.VS.Helpers;
+using Microsoft.VisualStudio.PlatformUI;
+using Uno.UI.RemoteControl.VS.Notifications;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio;
+using System.Threading.Tasks;
+
+namespace Uno.UI.RemoteControl.VS;
+
+internal class GlobalJsonObserver
+{
+	private AsyncPackage _asyncPackage;
+	private DTE _dte;
+	private Action<string> _debugAction;
+	private readonly Action<string> _infoAction;
+	private readonly Action<string> _warningAction;
+	private readonly Action<string> _errorAction;
+	private FileSystemWatcher? _fileWatcher;
+	private readonly JsonSerializerOptions _readerOptions = new() { ReadCommentHandling = JsonCommentHandling.Skip };
+
+	public GlobalJsonObserver(
+		AsyncPackage asyncPackage
+		, DTE dte
+		, Action<string> debugAction
+		, Action<string> infoAction
+		, Action<string> warningAction
+		, Action<string> errorAction)
+	{
+		_asyncPackage = asyncPackage;
+		_dte = dte;
+		_debugAction = debugAction;
+		_infoAction = infoAction;
+		_warningAction = warningAction;
+		_errorAction = errorAction;
+
+		_debugAction($"GlobalJsonObserver: Starting");
+
+		try
+		{
+			Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
+
+			var globalJsonPath = GetGlobalJsonPath();
+
+			ObserveChanges(globalJsonPath);
+		}
+		catch (Exception e)
+		{
+			_debugAction($"GlobalJsonObserver: Failed to start " + e);
+		}
+	}
+
+	private void ObserveChanges(string? globalJsonPath)
+	{
+		// Observe file changes to globalJsonPath, and only reload when "msbuild-sdks.Uno.Sdk" changes value
+		if (globalJsonPath != null)
+		{
+			var unoSdkVersion = ReadUnoSdkVersion(globalJsonPath);
+
+			_debugAction($"GlobalJsonObserver: Observing {globalJsonPath}");
+
+			_fileWatcher = new FileSystemWatcher(Path.GetDirectoryName(globalJsonPath), Path.GetFileName(globalJsonPath));
+
+			_fileWatcher.Changed += (sender, e) =>
+			{
+				_debugAction($"GlobalJsonObserver: File changed: {e.FullPath}");
+
+				try
+				{
+					var newVersion = ReadUnoSdkVersion(globalJsonPath);
+
+					if (newVersion != unoSdkVersion)
+					{
+						unoSdkVersion = newVersion;
+
+						// Reload all projects that use the Uno.SDK
+						_debugAction($"GlobalJsonObserver: Uno.Sdk version changed to {unoSdkVersion}.");
+
+						_asyncPackage.JoinableTaskFactory.Run(async () =>
+						{
+							await NotifyRestartAsync(unoSdkVersion);
+						});
+
+					}
+				}
+				catch (Exception ex)
+				{
+					_debugAction($"GlobalJsonObserver: Error reading global.json: {ex.Message}");
+				}
+			};
+
+			_fileWatcher.NotifyFilter = NotifyFilters.LastWrite |
+						NotifyFilters.Attributes |
+						NotifyFilters.Size |
+						NotifyFilters.CreationTime |
+						NotifyFilters.FileName;
+			_fileWatcher.EnableRaisingEvents = true;
+		}
+		else
+		{
+			_debugAction("GlobalJsonObserver: No global.json file found");
+		}
+	}
+
+	private async Task NotifyRestartAsync(string? unoSdkVersion)
+	{
+		await _asyncPackage.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+		if (
+			await _asyncPackage.GetServiceAsync(typeof(SVsShell)) is IVsShell shell
+			&& await _asyncPackage.GetServiceAsync(typeof(SVsInfoBarUIFactory)) is IVsInfoBarUIFactory infoBarFactory)
+		{
+			var factory = new InfoBarFactory(infoBarFactory, shell);
+			var restartVSItem = new ActionBarItem { Text = "Restart Visual Studio" };
+			var moreInformationVSItem = new ActionBarItem { Text = "More information" };
+
+			var infoBar = await factory.CreateAsync(
+				new InfoBarModel(
+					$"The Uno.Sdk version changed to {unoSdkVersion} and requires restarting Visual Studio."
+					, [
+						restartVSItem,
+						moreInformationVSItem
+					]
+					, KnownMonikers.StatusError
+					, true));
+
+			if (infoBar is not null)
+			{
+				infoBar.ActionItemClicked += (s, e) =>
+				{
+					_asyncPackage.JoinableTaskFactory.Run(async () =>
+					{
+						if (e.ActionItem == restartVSItem)
+						{
+							await _asyncPackage.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+							if (shell is IVsShell4 shell4)
+							{
+								((IVsShell3)shell).IsRunningElevated(out var elevated);
+								var type = elevated ? __VSRESTARTTYPE.RESTART_Elevated : __VSRESTARTTYPE.RESTART_Normal;
+								var hr = shell4.Restart((uint)type);
+							}
+						}
+						else if (e.ActionItem == moreInformationVSItem)
+						{
+							System.Diagnostics.Process.Start("https://aka.platform.uno/upgrade-uno-packages");
+						}
+					});
+				};
+
+				await infoBar.TryShowInfoBarUIAsync();
+			}
+		}
+	}
+
+	private string? ReadUnoSdkVersion(string globalJsonPath)
+	{
+		var document = JsonSerializer.Deserialize<JsonElement>(
+			File.ReadAllText(globalJsonPath)
+			, _readerOptions);
+
+		if (document.TryGetProperty("msbuild-sdks", out var msbuildSdksElement))
+		{
+			if (msbuildSdksElement.TryGetProperty("Uno.Sdk", out var unoSdkElement))
+			{
+				return unoSdkElement.ToString();
+			}
+		}
+
+		return null;
+	}
+
+	private string? GetGlobalJsonPath()
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+
+		// Get the solution directory
+		string solutionDir = Path.GetDirectoryName(_dte.Solution.FullName);
+
+		// Traverse the directory tree upwards to find global.json
+		string? currentDir = solutionDir;
+		while (!string.IsNullOrEmpty(currentDir))
+		{
+			string globalJsonPath = Path.Combine(currentDir, "global.json");
+
+			if (File.Exists(globalJsonPath))
+			{
+				return globalJsonPath;
+			}
+
+			currentDir = Directory.GetParent(currentDir)?.FullName;
+		}
+
+		// If no global.json file is found
+		return null;
+	}
+
+	internal void Dispose()
+	{
+		_fileWatcher?.Dispose();
+	}
+}

--- a/src/Uno.UI.RemoteControl.VS/GlobalJsonObserver.cs
+++ b/src/Uno.UI.RemoteControl.VS/GlobalJsonObserver.cs
@@ -41,7 +41,7 @@ internal class GlobalJsonObserver
 		_warningAction = warningAction;
 		_errorAction = errorAction;
 
-		_debugAction($"GlobalJsonObserver: Starting");
+		_debugAction("GlobalJsonObserver: Starting");
 
 		try
 		{
@@ -81,7 +81,7 @@ internal class GlobalJsonObserver
 						unoSdkVersion = newVersion;
 
 						// Reload all projects that use the Uno.SDK
-						_debugAction($"GlobalJsonObserver: Uno.Sdk version changed to {unoSdkVersion}.");
+						_debugAction($"GlobalJsonObserver: Uno.Sdk version changed to {unoSdkVersion}");
 
 						_asyncPackage.JoinableTaskFactory.Run(async () =>
 						{
@@ -123,13 +123,14 @@ internal class GlobalJsonObserver
 
 			var infoBar = await factory.CreateAsync(
 				new InfoBarModel(
-					$"The Uno.Sdk version changed to {unoSdkVersion} and requires restarting Visual Studio."
-					, [
+					$"The Uno.Sdk version has changed to {unoSdkVersion}, and a restart of Visual Studio is required.",
+					new[]
+					{
 						restartVSItem,
 						moreInformationVSItem
-					]
-					, KnownMonikers.StatusError
-					, true));
+					},
+					KnownMonikers.StatusError,
+					true));
 
 			if (infoBar is not null)
 			{

--- a/src/Uno.UI.RemoteControl.VS/Notifications/InfoBar.cs
+++ b/src/Uno.UI.RemoteControl.VS/Notifications/InfoBar.cs
@@ -1,0 +1,132 @@
+﻿// Imported from https://github.com/VsixCommunity/Community.VisualStudio.Toolkit
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Uno.UI.RemoteControl.VS.Notifications;
+
+/// <summary>
+/// Creates InfoBar controls for use on documents and tool windows.
+/// </summary>
+public class InfoBarFactory
+{
+	private IVsInfoBarUIFactory _infoBarUIFactory;
+	private readonly IVsShell _shell;
+
+	public InfoBarFactory(IVsInfoBarUIFactory infoBarUIFactory, IVsShell shell)
+	{
+		_infoBarUIFactory = infoBarUIFactory;
+		_shell = shell;
+	}
+
+	/// <summary>
+	/// Creates a new InfoBar in the main window.
+	/// </summary>
+	/// <param name="model">A model representing the text, icon, and actions of the InfoBar.</param>
+	public async Task<InfoBar?> CreateAsync(InfoBarModel model)
+	{
+		await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+		_shell.GetProperty((int)__VSSPROPID7.VSSPROPID_MainWindowInfoBarHost, out var value);
+
+		if (value is IVsInfoBarHost host)
+		{
+			return new InfoBar(host, _infoBarUIFactory, model);
+		}
+
+		return null;
+	}
+}
+
+/// <summary>
+/// An instance of an InfoBar (also known as Yellow- or Gold bar).
+/// </summary>
+public class InfoBar : IVsInfoBarUIEvents
+{
+	private readonly IVsInfoBarHost _host;
+	private readonly IVsInfoBarUIFactory _infoBarUIFactory;
+	private readonly InfoBarModel _model;
+	private IVsInfoBarUIElement? _uiElement;
+	private uint _listenerCookie;
+
+	/// <summary>
+	/// Creates a new instance of the InfoBar in a specific window frame or document window.
+	/// </summary>
+	internal InfoBar(IVsInfoBarHost host, IVsInfoBarUIFactory infoBarUIFactory, InfoBarModel model)
+	{
+		_host = host;
+		_infoBarUIFactory = infoBarUIFactory;
+		_model = model;
+	}
+
+	/// <summary>
+	/// Indicates if the InfoBar is visible in the UI or not.
+	/// </summary>
+	public bool IsVisible { get; set; }
+
+	/// <summary>
+	/// Displays the InfoBar in the tool window or document previously specified.
+	/// </summary>
+	/// <returns><see langword="true" /> if the InfoBar was shown; otherwise <see langword="false" />.</returns>
+	public async Task<bool> TryShowInfoBarUIAsync()
+	{
+		await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+		_uiElement = _infoBarUIFactory.CreateInfoBar(_model);
+		_uiElement.Advise(this, out _listenerCookie);
+
+		if (_host != null)
+		{
+			_host.AddInfoBar(_uiElement);
+			IsVisible = true;
+		}
+
+		return IsVisible;
+	}
+
+	/// <summary>
+	/// Closes the InfoBar without the user manually had to do it.
+	/// </summary>
+	public void Close()
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+
+		if (IsVisible && _uiElement != null)
+		{
+			_uiElement.Close();
+		}
+	}
+
+	/// <summary>
+	/// An event triggered when an action item in the InfoBar is clicked.
+	/// </summary>
+	public event EventHandler<InfoBarActionItemEventArgs>? ActionItemClicked;
+
+	void IVsInfoBarUIEvents.OnClosed(IVsInfoBarUIElement infoBarUIElement)
+	{
+		IsVisible = false;
+		ThreadHelper.ThrowIfNotOnUIThread();
+		_uiElement?.Unadvise(_listenerCookie);
+	}
+
+	void IVsInfoBarUIEvents.OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)
+	{
+		ActionItemClicked?.Invoke(this, new InfoBarActionItemEventArgs(infoBarUIElement, _model, actionItem));
+	}
+}
+
+class ActionBarItem : IVsInfoBarActionItem
+{
+	public string? Text { get; set; }
+
+	public bool Bold { get; set; }
+
+	public bool Italic { get; set; }
+
+	public bool Underline { get; set; }
+
+	public object? ActionContext { get; set; }
+
+	public bool IsButton { get; set; }
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/17495

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Provide a banner to restart VS in place when the uno.sdk has changed.