### PR TITLE
fix: Ensure compatibility with SkiaSharp 3 targeting net7.0

### DIFF
--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -55,6 +55,9 @@ $projects =
     # 5.2 Blank
     @("5.2/uno52blank/uno52blank/uno52blank.csproj", ""),
 
+    # 5.2 Blank SkiaSharp 3
+    @("5.2/uno52blank/uno52blank/uno52blank.csproj", "-p:SkiaSharpVersion=3.0.0-preview.3.1"),
+
     # 5.2 Uno Lib
     @("5.2/uno52Lib/uno52Lib.csproj", ""),
 

--- a/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
+++ b/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
@@ -58,7 +58,14 @@
   <!-- Validate SkiaSharp 3 -->
   <Target Name="ValiateSkiaSharp3"
           AfterTargets="AfterBuild"
-          Condition=" '$(SkiaSharpVersion)' != '' AND $(SkiaSharpVersion.StartsWith('3'))">
+          Condition="
+            '$(SkiaSharpVersion)' != '' 
+            AND $(SkiaSharpVersion.StartsWith('3'))
+            AND (
+              '$(TargetFramework)' == 'net8.0-desktop'
+              OR '$(TargetFramework)' == 'net8.0-browserwasm'
+            )
+          ">
 
     <!-- Validates that SkiaShap uno-runtime file is copied to the output folder -->
     <Error Text="Missing asset $(OutputPath)SkiaSharp.Views.Windows.dll"

--- a/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
+++ b/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
@@ -54,5 +54,15 @@
       Condition="'%(BundleResource.LogicalName)' != '' And $([System.IO.Path]::IsPathRooted('%(BundleResource.LogicalName)'))" 
       Text="BundleResource.LogicalName must not contain a rooted path" />
   </Target>
+  
+  <!-- Validate SkiaSharp 3 -->
+  <Target Name="ValiateSkiaSharp3"
+          AfterTargets="AfterBuild"
+          Condition=" '$(SkiaSharpVersion)' != '' AND $(SkiaSharpVersion.StartsWith('3'))">
+
+    <!-- Validates that SkiaShap uno-runtime file is copied to the output folder -->
+    <Error Text="Missing asset $(OutputPath)\SkiaSharp.Views.Windows.dll"
+          Condition="!exists('$(OutputPath)\SkiaSharp.Views.Windows.dll')" />
+  </Target>
 
 </Project>

--- a/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
+++ b/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
@@ -61,8 +61,8 @@
           Condition=" '$(SkiaSharpVersion)' != '' AND $(SkiaSharpVersion.StartsWith('3'))">
 
     <!-- Validates that SkiaShap uno-runtime file is copied to the output folder -->
-    <Error Text="Missing asset $(OutputPath)\SkiaSharp.Views.Windows.dll"
-          Condition="!exists('$(OutputPath)\SkiaSharp.Views.Windows.dll')" />
+    <Error Text="Missing asset $(OutputPath)SkiaSharp.Views.Windows.dll"
+          Condition="!exists('$(OutputPath)SkiaSharp.Views.Windows.dll')" />
   </Target>
 
 </Project>

--- a/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
+++ b/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
@@ -61,10 +61,7 @@
           Condition="
             '$(SkiaSharpVersion)' != '' 
             AND $(SkiaSharpVersion.StartsWith('3'))
-            AND (
-              '$(TargetFramework)' == 'net8.0-desktop'
-              OR '$(TargetFramework)' == 'net8.0-browserwasm'
-            )
+            AND '$(TargetFramework)' == 'net8.0-desktop'
           ">
 
     <!-- Validates that SkiaShap uno-runtime file is copied to the output folder -->

--- a/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
+++ b/src/SolutionTemplate/5.2/uno52blank/uno52blank/uno52blank.csproj
@@ -64,7 +64,7 @@
             AND '$(TargetFramework)' == 'net8.0-desktop'
           ">
 
-    <!-- Validates that SkiaShap uno-runtime file is copied to the output folder -->
+    <!-- Validates that SkiaSharp uno-runtime file is copied to the output folder -->
     <Error Text="Missing asset $(OutputPath)SkiaSharp.Views.Windows.dll"
           Condition="!exists('$(OutputPath)SkiaSharp.Views.Windows.dll')" />
   </Target>

--- a/src/SourceGenerators/Uno.UI.Tasks/RuntimeAssetsSelector/RuntimeAssetsSelectorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/RuntimeAssetsSelector/RuntimeAssetsSelectorTask.cs
@@ -72,6 +72,14 @@ namespace Uno.UI.Tasks.RuntimeAssetsSelector
 						searchPaths.Add(Path.Combine(packageBasePath, "..", "uno-runtime", "net8.0", UnoRuntimeIdentifier));
 					}
 
+					if (targetFrameworkVersion >= new Version(7, 0))
+					{
+						// Even if Uno does not support nte7.0 explicitly anymore, dependencies
+						// may still be providing net7.0 runtime support files (e.g. SkiaSharp)
+						searchPaths.Add(Path.Combine(packageBasePath, "uno-runtime", "net7.0", UnoRuntimeIdentifier));
+						searchPaths.Add(Path.Combine(packageBasePath, "..", "uno-runtime", "net7.0", UnoRuntimeIdentifier));
+					}
+
 					if (targetFrameworkVersion >= new Version(2, 0))
 					{
 						searchPaths.Add(Path.Combine(packageBasePath, "uno-runtime", "netstandard2.0", UnoRuntimeIdentifier));


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that net7.0 cross-runtime libraries can still be referenced.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
