### PR TITLE
Generate .app package for Desktop on MacOS

### DIFF
--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -361,3 +361,14 @@ for($i = 0; $i -lt $projects.Length; $i++)
         }
     }
 }
+
+CleanupTree
+
+# Publish Tests
+
+if ($IsMacOS)
+{
+    $projectPath = "5.2/uno52blank/uno52blank/uno52blank.csproj"
+    dotnet publish $projectPath -f net8.0-desktop -bl:binlogs/$projectPath/publish/msbuild.binlog
+    Assert-ExitCodeIsZero
+}

--- a/doc/articles/uno-publishing-desktop.md
+++ b/doc/articles/uno-publishing-desktop.md
@@ -11,22 +11,61 @@ uid: uno.publishing.desktop
 
 ## Publish your app
 
-### Using Visual Studio 2022
+The recommended way to publish your `netX.0-desktop` app is to use the Command Line with `dotnet publish`. This provides a familiar mechanism you may already be used to along with a few additional properties. While it is technically possible to publish from Visual Studio 2022, it is not recommended and this will only produce an app for Windows.
 
-To publish your app with Visual Studio 2022:
+When publishing your desktop application you should be using Uno.Sdk 5.4 or later. Publishing the application will only produce an application for the platform of the host OS. You cannot for instance publish a Mac app on Windows or a Windows app on Linux.
 
-- In the debugger toolbar drop-down, select the `net8.0-desktop` target framework
-- Once the project has reloaded, right-click on the project and select **Publish**
-- Select the appropriate target for your publication, this example will use the **Folder**, then click **Next**
-- Choose an output folder for the published output, then click **Close**.
-- In the opened editor, click the **Configuration** "pen" to edit the configuration
-- In the opened popup, ensure that **Target Framework** is set to `net8.0-desktop`, then click **Save**
-- On the top right, click the **Publish** button
-- Once the build is done, the output is located in the publish folder
+> [!NOTE]
+> For the purposes of the documented commands we are using `net8.0-desktop` if you are using a later version of .NET such as .NET 9.0 be sure to update to use the appropriate version such as `net9.0-desktop`.
 
-Once done, you can head over to the [publishing section](xref:uno.publishing.webassembly#publishing).
+# [**Windows**](#tab/windows)
 
-### Using the Command Line
+- [ClickOnce](https://learn.microsoft.com/visualstudio/deployment/quickstart-deploy-using-clickonce-folder?view=vs-2022) on Windows
+- Using a Zip file, then running the app using `dotnet [yourapp].dll`
+
+# [**MacOS**](#tab/macos)
+
+The Uno.Sdk supports publishing your app for MacOS in one of 3 ways.
+
+1) Generate an App Bundle (MyApp.app)
+2) Generate an Application Package Installer (MyApp.pkg)
+3) Generate an Apple Disk Image (MyApp.dmg)
+
+> [!NOTE]
+> At this time we do not support publishing an app that can install on either Intel or Apple Silicon. By default the published app will produce an artifact for the runtime of the host you publish on. You may optionally specify the the desired runtime to produce an artifact that can be installed on a different target runtime than the host operating system.
+
+> [!NOTE]
+> When publishing your app, the Uno.Sdk will enable a Self Contained publish. This will result in your app being ready to run on your users Mac without any additional steps like installing .NET.
+
+To get started with publishing you can simply run the following command to generate an App Bundle.
+
+```bash
+dotnet publish ./pathTo/Project.csproj -f net8.0-desktop
+```
+
+To specify the Runtime Identifier you must select one of the [available MacOS RID's](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog#macos-rids).
+
+```bash
+dotnet publish ./pathTo/Project.csproj -f net8.0-desktop -r osx-arm64
+```
+
+To generate an Application Package Installer or Apple Disk Image you optionally provide a package format argument as follows:
+
+```bash
+# Generates an Application Package Installer
+dotnet publish ./pathTo/Project.csproj -f net8.0-desktop /p:PackageFormat=pkg
+
+# Generates an Apple Disk Image
+dotnet publish ./pathTo/Project.csproj -f net8.0-desktop /p:PackageFormat=dmg
+```
+
+This is not needed to generate an App Bundle as this will always be provided and will be available in the publish folder.
+
+# [**Linux**](#tab/linux)
+
+Coming Soon
+
+---
 
 To build your app from the CLI, on Windows, Linux, or macOS:
 
@@ -38,14 +77,4 @@ To build your app from the CLI, on Windows, Linux, or macOS:
   dotnet publish -f net8.0-desktop -c Release -o ./publish
   ```
 
-- Once the build is done, the output is located in the `./publish` folder
 
-## Publishing
-
-> [!NOTE]
-> Work still in progress for publishing to some targets.
-
-Publishing your app can be done through different means:
-
-- [ClickOnce](https://learn.microsoft.com/visualstudio/deployment/quickstart-deploy-using-clickonce-folder?view=vs-2022) on Windows
-- Using a Zip file, then running the app using `dotnet [yourapp].dll`

--- a/doc/articles/uno-publishing-desktop.md
+++ b/doc/articles/uno-publishing-desktop.md
@@ -65,15 +65,3 @@ This is not needed to generate an App Bundle as this will always be provided and
 Coming Soon
 
 ---
-
-To build your app from the CLI, on Windows, Linux, or macOS:
-
-- Open a terminal, command line, or powershell
-- Navigate to your `csproj` folder
-- Publish the app using:
-
-  ```shell
-  dotnet publish -f net8.0-desktop -c Release -o ./publish
-  ```
-
-

--- a/doc/articles/uno-publishing-desktop.md
+++ b/doc/articles/uno-publishing-desktop.md
@@ -18,12 +18,12 @@ When publishing your desktop application you should be using Uno.Sdk 5.4 or late
 > [!NOTE]
 > For the purposes of the documented commands we are using `net8.0-desktop` if you are using a later version of .NET such as .NET 9.0 be sure to update to use the appropriate version such as `net9.0-desktop`.
 
-# [**Windows**](#tab/windows)
+### [**Windows**](#tab/windows)
 
 - [ClickOnce](https://learn.microsoft.com/visualstudio/deployment/quickstart-deploy-using-clickonce-folder?view=vs-2022) on Windows
 - Using a Zip file, then running the app using `dotnet [yourapp].dll`
 
-# [**MacOS**](#tab/macos)
+### [**MacOS**](#tab/macos)
 
 The Uno.Sdk supports publishing your app for MacOS in one of 3 ways.
 
@@ -33,7 +33,6 @@ The Uno.Sdk supports publishing your app for MacOS in one of 3 ways.
 
 > [!NOTE]
 > At this time we do not support publishing an app that can install on either Intel or Apple Silicon. By default the published app will produce an artifact for the runtime of the host you publish on. You may optionally specify the the desired runtime to produce an artifact that can be installed on a different target runtime than the host operating system.
-
 > [!NOTE]
 > When publishing your app, the Uno.Sdk will enable a Self Contained publish. This will result in your app being ready to run on your users Mac without any additional steps like installing .NET.
 
@@ -61,7 +60,7 @@ dotnet publish ./pathTo/Project.csproj -f net8.0-desktop /p:PackageFormat=dmg
 
 This is not needed to generate an App Bundle as this will always be provided and will be available in the publish folder.
 
-# [**Linux**](#tab/linux)
+### [**Linux**](#tab/linux)
 
 Coming Soon
 

--- a/src/Uno.Sdk/MacDev/IPValueObject.cs
+++ b/src/Uno.Sdk/MacDev/IPValueObject.cs
@@ -1,0 +1,11 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+
+namespace Uno.Sdk.MacDev;
+
+public interface IPValueObject
+{
+	object Value { get; set; }
+	bool TrySetValueFromString(string text, IFormatProvider formatProvider);
+}

--- a/src/Uno.Sdk/MacDev/PArray.cs
+++ b/src/Uno.Sdk/MacDev/PArray.cs
@@ -1,0 +1,169 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Uno.Sdk.MacDev;
+
+public class PArray : PObjectContainer, IEnumerable<PObject>
+{
+	private readonly List<PObject> _list;
+
+	public override int Count => _list.Count;
+
+	public PObject this[int i]
+	{
+		get => _list[i];
+		set
+		{
+			if (i < 0 || i >= Count)
+			{
+				throw new ArgumentOutOfRangeException(nameof(i));
+			}
+
+			var existing = _list[i];
+			_list[i] = value;
+
+			OnChildReplaced(null, existing, value);
+		}
+	}
+
+	public PArray()
+	{
+		_list = [];
+	}
+
+	public override PObject Clone()
+	{
+		var array = new PArray();
+		foreach (var item in this)
+		{
+			array.Add(item.Clone());
+		}
+
+		return array;
+	}
+
+	protected override bool Reload(PropertyListFormat.ReadWriteContext ctx)
+	{
+		SuppressChangeEvents = true;
+		var result = ctx.ReadArray(this);
+		SuppressChangeEvents = false;
+		if (result)
+		{
+			OnChanged(EventArgs.Empty);
+		}
+
+		return result;
+	}
+
+	public void Add(PObject obj)
+	{
+		_list.Add(obj);
+		OnChildAdded(null, obj);
+	}
+
+	public void Insert(int index, PObject obj)
+	{
+		_list.Insert(index, obj);
+		OnChildAdded(null, obj);
+	}
+
+	public void Replace(PObject oldObj, PObject newObject)
+	{
+		for (var i = 0; i < Count; i++)
+		{
+			if (_list[i] == oldObj)
+			{
+				_list[i] = newObject;
+				OnChildReplaced(null, oldObj, newObject);
+				break;
+			}
+		}
+	}
+
+	public void Remove(PObject obj)
+	{
+		if (_list.Remove(obj))
+		{
+			OnChildRemoved(null, obj);
+		}
+	}
+
+	public void RemoveAt(int index)
+	{
+		var obj = _list[index];
+		_list.RemoveAt(index);
+		OnChildRemoved(null, obj);
+	}
+
+	public void Sort(IComparer<PObject> comparer) => _list.Sort(comparer);
+
+	public void Clear()
+	{
+		_list.Clear();
+		OnCleared();
+	}
+
+	public override string ToString() => string.Format(CultureInfo.InvariantCulture, "[PArray: Items={0}]", Count);
+
+	public void AssignStringList(string strList)
+	{
+		SuppressChangeEvents = true;
+		try
+		{
+			Clear();
+			foreach (var item in strList.Split(',', ' '))
+			{
+				if (string.IsNullOrEmpty(item))
+				{
+					continue;
+				}
+
+				Add(new PString(item));
+			}
+		}
+		finally
+		{
+			SuppressChangeEvents = false;
+			OnChanged(EventArgs.Empty);
+		}
+	}
+
+	public string[] ToStringArray()
+	{
+		var strlist = new List<string>();
+
+		foreach (var str in _list.OfType<PString>())
+		{
+			strlist.Add(str.Value);
+		}
+
+		return [.. strlist];
+	}
+
+	public string ToStringList()
+	{
+		var sb = new StringBuilder();
+		foreach (var str in _list.OfType<PString>())
+		{
+			if (sb.Length > 0)
+			{
+				sb.Append(", ");
+			}
+
+			sb.Append(str);
+		}
+		return sb.ToString();
+	}
+
+	public IEnumerator<PObject> GetEnumerator() => _list.GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+
+	public override PObjectType Type => PObjectType.Array;
+}

--- a/src/Uno.Sdk/MacDev/PBoolean.cs
+++ b/src/Uno.Sdk/MacDev/PBoolean.cs
@@ -1,0 +1,31 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+
+namespace Uno.Sdk.MacDev;
+
+public class PBoolean(bool value) : PValueObject<bool>(value)
+{
+	public override PObject Clone() => new PBoolean(Value);
+
+	public override PObjectType Type => PObjectType.Boolean;
+
+	public override bool TrySetValueFromString(string text, IFormatProvider formatProvider)
+	{
+		const StringComparison ic = StringComparison.OrdinalIgnoreCase;
+
+		if ("true".Equals(text, ic) || "yes".Equals(text, ic))
+		{
+			Value = true;
+			return true;
+		}
+
+		if ("false".Equals(text, ic) || "no".Equals(text, ic))
+		{
+			Value = false;
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/Uno.Sdk/MacDev/PData.cs
+++ b/src/Uno.Sdk/MacDev/PData.cs
@@ -1,0 +1,16 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+
+namespace Uno.Sdk.MacDev;
+
+public class PData(byte[] value) : PValueObject<byte[]>(value ?? Empty)
+{
+	static readonly byte[] Empty = [];
+
+	public override PObject Clone() => new PData(Value);
+
+	public override PObjectType Type => PObjectType.Data;
+
+	public override bool TrySetValueFromString(string text, IFormatProvider formatProvider) => false;
+}

--- a/src/Uno.Sdk/MacDev/PDate.cs
+++ b/src/Uno.Sdk/MacDev/PDate.cs
@@ -1,0 +1,23 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+using System.Globalization;
+
+namespace Uno.Sdk.MacDev;
+
+public class PDate(DateTime value) : PValueObject<DateTime>(value)
+{
+	public override PObject Clone() => new PDate(Value);
+
+	public override PObjectType Type => PObjectType.Date;
+
+	public override bool TrySetValueFromString(string text, IFormatProvider formatProvider)
+	{
+		if (DateTime.TryParse(text, formatProvider, DateTimeStyles.None, out var result))
+		{
+			Value = result;
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/Uno.Sdk/MacDev/PDictionary.cs
+++ b/src/Uno.Sdk/MacDev/PDictionary.cs
@@ -1,0 +1,302 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Uno.Sdk.MacDev;
+
+public class PDictionary : PObjectContainer, IEnumerable<KeyValuePair<string?, PObject>>
+{
+	static readonly byte[] BeginMarkerBytes = Encoding.ASCII.GetBytes("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+	static readonly byte[] EndMarkerBytes = Encoding.ASCII.GetBytes("</plist>");
+
+	private readonly Dictionary<string, PObject> _dict;
+	private readonly List<string> _order;
+
+	public PObject? this[string key]
+	{
+		get
+		{
+			if (_dict.TryGetValue(key, out var value))
+			{
+				return value;
+			}
+
+			return null;
+		}
+		set
+		{
+			if (value is null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			var exists = _dict.TryGetValue(key, out var existing);
+			if (!exists)
+			{
+				_order.Add(key);
+			}
+
+			if (value is not null)
+			{
+				_dict[key] = value;
+			}
+
+			if (exists)
+			{
+				OnChildReplaced(key, existing!, value!);
+			}
+			else
+			{
+				OnChildAdded(key, value!);
+			}
+		}
+	}
+
+	public void Add(string key, PObject value)
+	{
+		_dict.Add(key, value);
+		_order.Add(key);
+
+		OnChildAdded(key, value);
+	}
+
+	public void InsertAfter(string keyBefore, string key, PObject value)
+	{
+		_dict.Add(key, value);
+		_order.Insert(_order.IndexOf(keyBefore) + 1, key);
+
+		OnChildAdded(key, value);
+	}
+
+	public override int Count => _dict.Count;
+
+	#region IEnumerable[KeyValuePair[System.String,PObject]] implementation
+	public IEnumerator<KeyValuePair<string?, PObject>> GetEnumerator()
+	{
+		foreach (var key in _order)
+		{
+			yield return new KeyValuePair<string?, PObject>(key, _dict[key]);
+		}
+	}
+	#endregion
+
+	#region IEnumerable implementation
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	#endregion
+
+	public PDictionary()
+	{
+		_dict = [];
+		_order = [];
+	}
+
+	public override PObject Clone()
+	{
+		var clone = new PDictionary();
+
+		foreach (var kv in this)
+		{
+			clone.Add(kv.Key!, kv.Value.Clone());
+		}
+
+		return clone;
+	}
+
+	public bool ContainsKey(string name) => _dict.ContainsKey(name);
+
+	public bool Remove(string key)
+	{
+		if (_dict.TryGetValue(key, out var obj))
+		{
+			_dict.Remove(key);
+			_order.Remove(key);
+			OnChildRemoved(key, obj);
+			return true;
+		}
+		return false;
+	}
+
+	public void Clear()
+	{
+		_dict.Clear();
+		_order.Clear();
+		OnCleared();
+	}
+
+	public bool ChangeKey(PObject obj, string newKey) => ChangeKey(obj, newKey, null);
+
+	public bool ChangeKey(PObject obj, string newKey, PObject? newValue)
+	{
+		var oldkey = GetKey(obj);
+		if (oldkey is null || _dict.ContainsKey(newKey))
+		{
+			return false;
+		}
+
+		_dict.Remove(oldkey);
+		_dict.Add(newKey, newValue ?? obj);
+		_order[_order.IndexOf(oldkey)] = newKey;
+		if (newValue is not null)
+		{
+			OnChildRemoved(oldkey, obj);
+			OnChildAdded(newKey, newValue);
+		}
+		else
+		{
+			OnChildRemoved(oldkey, obj);
+			OnChildAdded(newKey, obj);
+		}
+		return true;
+	}
+
+	public string? GetKey(PObject obj)
+	{
+		foreach (var pair in _dict)
+		{
+			if (pair.Value == obj)
+			{
+				return pair.Key;
+			}
+		}
+		return null;
+	}
+
+	public T? Get<T>(string key) where T : PObject
+	{
+		if (!_dict.TryGetValue(key, out var obj))
+		{
+			return null;
+		}
+
+		return obj as T;
+	}
+
+	public bool TryGetValue<T>(string key, [NotNullWhen(true)] out T? value) where T : PObject
+	{
+		if (_dict.TryGetValue(key, out var obj) && obj is T tobj)
+		{
+			value = tobj;
+			return true;
+		}
+
+		value = default;
+		return false;
+	}
+
+	static int IndexOf(byte[] haystack, int startIndex, byte[] needle)
+	{
+		var maxLength = haystack.Length - needle.Length;
+		int n;
+
+		for (var i = startIndex; i < maxLength; i++)
+		{
+			for (n = 0; n < needle.Length; n++)
+			{
+				if (haystack[i + n] != needle[n])
+				{
+					break;
+				}
+			}
+
+			if (n == needle.Length)
+			{
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
+	public static new PDictionary? FromByteArray(byte[] array, int startIndex, int length, out bool isBinary) => (PDictionary?)PObject.FromByteArray(array, startIndex, length, out isBinary);
+
+	public static new PDictionary? FromByteArray(byte[] array, out bool isBinary) => (PDictionary?)PObject.FromByteArray(array, out isBinary);
+
+	public static PDictionary? FromBinaryXml(byte[] array)
+	{
+		//find the raw plist within the .mobileprovision file
+		var start = IndexOf(array, 0, BeginMarkerBytes);
+		int length;
+
+		if (start < 0 || (length = (IndexOf(array, start, EndMarkerBytes) - start)) < 1)
+		{
+			throw new Exception("Did not find XML plist in buffer.");
+		}
+
+		length += EndMarkerBytes.Length;
+
+		return FromByteArray(array, start, length, out var _);
+	}
+
+	public new static PDictionary? FromFile(string fileName) => FromFile(fileName, out _);
+
+	public new static Task<PDictionary?> FromFileAsync(string fileName) => Task.Run(() =>
+	{
+		return FromFile(fileName, out _);
+	});
+
+	public new static PDictionary? FromFile(string fileName, out bool isBinary) => (PDictionary?)PObject.FromFile(fileName, out isBinary);
+
+	public static PDictionary? FromBinaryXml(string fileName) => FromBinaryXml(File.ReadAllBytes(fileName));
+
+	protected override bool Reload(PropertyListFormat.ReadWriteContext ctx)
+	{
+		SuppressChangeEvents = true;
+		var result = ctx.ReadDict(this);
+		SuppressChangeEvents = false;
+		if (result)
+		{
+			OnChanged(EventArgs.Empty);
+		}
+
+		return result;
+	}
+
+	public override string ToString() => string.Format(CultureInfo.InvariantCulture, "[PDictionary: Items={0}]", _dict.Count);
+
+	public void SetString(string key, string value)
+	{
+		var result = Get<PString>(key);
+
+		if (result is null)
+		{
+			this[key] = new PString(value);
+		}
+		else
+		{
+			result.Value = value;
+		}
+	}
+
+	public PString GetString(string key)
+	{
+		var result = Get<PString>(key);
+
+		if (result is null)
+		{
+			this[key] = result = new PString("");
+		}
+
+		return result;
+	}
+
+	public PArray GetArray(string key)
+	{
+		var result = Get<PArray>(key);
+
+		if (result is null)
+		{
+			this[key] = result = [];
+		}
+
+		return result;
+	}
+
+	public override PObjectType Type => PObjectType.Dictionary;
+}

--- a/src/Uno.Sdk/MacDev/PNumber.cs
+++ b/src/Uno.Sdk/MacDev/PNumber.cs
@@ -1,0 +1,23 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+using System.Globalization;
+
+namespace Uno.Sdk.MacDev;
+
+public class PNumber(long value) : PValueObject<long>(value)
+{
+	public override PObject Clone() => new PNumber(Value);
+
+	public override PObjectType Type => PObjectType.Number;
+
+	public override bool TrySetValueFromString(string text, IFormatProvider formatProvider)
+	{
+		if (long.TryParse(text, NumberStyles.Integer, formatProvider, out var result))
+		{
+			Value = result;
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/Uno.Sdk/MacDev/PObject.cs
+++ b/src/Uno.Sdk/MacDev/PObject.cs
@@ -1,0 +1,297 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Uno.Sdk.MacDev;
+
+public abstract class PObject
+{
+	public static PObject Create(PObjectType type) => type switch
+	{
+		PObjectType.Dictionary => new PDictionary(),
+		PObjectType.Array => new PArray(),
+		PObjectType.Number => new PNumber(0),
+		PObjectType.Real => new PReal(0),
+		PObjectType.Boolean => new PBoolean(true),
+		PObjectType.Data => new PData([]),
+		PObjectType.String => new PString(""),
+		PObjectType.Date => new PDate(DateTime.Now),
+		_ => throw new ArgumentOutOfRangeException(nameof(type)),
+	};
+
+	public static IEnumerable<KeyValuePair<string?, PObject>> ToEnumerable(PObject obj)
+	{
+		if (obj is PDictionary dictionary)
+		{
+			return dictionary;
+		}
+
+		if (obj is PArray array)
+		{
+			return array.Select(k => new KeyValuePair<string?, PObject>(k is IPValueObject valueObject ? valueObject.Value.ToString() : null, k));
+		}
+
+		return [];
+	}
+
+	private PObjectContainer? _parent;
+	public PObjectContainer? Parent
+	{
+		get => _parent;
+		set
+		{
+			if (_parent is not null && value is not null)
+			{
+				throw new NotSupportedException("Already parented.");
+			}
+
+			_parent = value;
+		}
+	}
+
+	public abstract PObject Clone();
+
+	public void Replace(PObject newObject)
+	{
+		var p = Parent;
+		if (p is PDictionary dict)
+		{
+			var key = dict.GetKey(this);
+			if (key is null)
+			{
+				return;
+			}
+
+			Remove();
+			dict[key] = newObject;
+		}
+		else if (p is PArray arr)
+		{
+			arr.Replace(this, newObject);
+		}
+	}
+
+	public string? Key
+	{
+		get
+		{
+			if (Parent is PDictionary dict)
+			{
+				return dict.GetKey(this);
+			}
+			return null;
+		}
+	}
+
+	public void Remove()
+	{
+		if (Parent is PDictionary dict)
+		{
+			dict.Remove(Key!);
+		}
+		else if (Parent is PArray arr)
+		{
+			arr.Remove(this);
+		}
+		else
+		{
+			if (Parent is null)
+			{
+				throw new InvalidOperationException("Can't remove from null parent");
+			}
+
+			throw new InvalidOperationException("Can't remove from parent " + Parent);
+		}
+	}
+
+	public abstract PObjectType Type { get; }
+
+	public static implicit operator PObject(string value) => new PString(value);
+
+	public static implicit operator PObject(long value) => new PNumber(value);
+
+	public static implicit operator PObject(double value) => new PReal(value);
+
+	public static implicit operator PObject(bool value) => new PBoolean(value);
+
+	public static implicit operator PObject(DateTime value) => new PDate(value);
+
+	public static implicit operator PObject(byte[] value) => new PData(value);
+
+	protected virtual void OnChanged(EventArgs e)
+	{
+		if (SuppressChangeEvents)
+		{
+			return;
+		}
+
+		var handler = Changed;
+		if (handler is not null)
+		{
+			handler(this, e);
+		}
+
+		Parent?.OnCollectionChanged(Key!, this);
+	}
+
+	protected bool SuppressChangeEvents { get; set; }
+
+	public event EventHandler? Changed;
+
+	public byte[] ToByteArray(PropertyListFormat format)
+	{
+		using var stream = new MemoryStream();
+		using (var context = format.StartWriting(stream))
+		{
+			context.WriteObject(this);
+		}
+
+		return stream.ToArray();
+	}
+
+	public byte[] ToByteArray(bool binary)
+	{
+		var format = binary ? PropertyListFormat.Binary : PropertyListFormat.Xml;
+
+		return ToByteArray(format);
+	}
+
+	public string ToJson() => Encoding.UTF8.GetString(ToByteArray(PropertyListFormat.Json));
+
+	public string ToXml() => Encoding.UTF8.GetString(ToByteArray(PropertyListFormat.Xml));
+
+	public static PObject? FromByteArray(byte[] array, int startIndex, int length, out bool isBinary)
+	{
+		var ctx = PropertyListFormat.Binary.StartReading(array, startIndex, length);
+
+		isBinary = true;
+
+		try
+		{
+			if (ctx is null)
+			{
+				isBinary = false;
+				ctx = PropertyListFormat.CreateReadContext(array, startIndex, length);
+				if (ctx is null)
+				{
+					return null;
+				}
+			}
+
+			return ctx.ReadObject();
+		}
+		finally
+		{
+			ctx?.Dispose();
+		}
+	}
+
+	public static PObject? FromByteArray(byte[] array, out bool isBinary) => FromByteArray(array, 0, array.Length, out isBinary);
+
+	public static PObject? FromString(string str)
+	{
+		var ctx = PropertyListFormat.CreateReadContext(Encoding.UTF8.GetBytes(str));
+		return ctx?.ReadObject();
+	}
+
+	public static PObject? FromStream(Stream stream)
+	{
+		var ctx = PropertyListFormat.CreateReadContext(stream);
+		return ctx?.ReadObject();
+	}
+
+	public static PObject? FromFile(string fileName) => FromFile(fileName, out var _);
+
+	public static Task<PObject?> FromFileAsync(string fileName) => Task.Run(() =>
+	{
+		return FromFile(fileName, out var _);
+	});
+
+	public static PObject? FromFile(string fileName, out bool isBinary)
+	{
+		using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+		var ctx = PropertyListFormat.Binary.StartReading(stream);
+
+		isBinary = true;
+
+		try
+		{
+			if (ctx is null)
+			{
+				ctx = PropertyListFormat.CreateReadContext(stream);
+				isBinary = false;
+
+				if (ctx is null)
+				{
+					throw new FormatException("Unrecognized property list format.");
+				}
+			}
+
+			return ctx.ReadObject();
+		}
+		finally
+		{
+			ctx?.Dispose();
+		}
+	}
+
+	public Task SaveAsync(string filename, bool atomic = false, bool binary = false) => Task.Run(() => Save(filename, atomic, binary));
+
+	public void Save(string filename, bool atomic = false, bool binary = false)
+	{
+		var tempFile = atomic ? GetTempFileName(filename) : filename;
+
+		try
+		{
+			var dir = Path.GetDirectoryName(tempFile);
+
+			if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+			{
+				Directory.CreateDirectory(dir);
+			}
+
+			using (var stream = new FileStream(tempFile, FileMode.Create, FileAccess.Write))
+			{
+				using var ctx = binary ? PropertyListFormat.Binary.StartWriting(stream) : PropertyListFormat.Xml.StartWriting(stream);
+				ctx.WriteObject(this);
+			}
+
+			if (atomic)
+			{
+				if (File.Exists(filename))
+				{
+					File.Replace(tempFile, filename, null, true);
+				}
+				else
+				{
+					File.Move(tempFile, filename);
+				}
+			}
+		}
+		finally
+		{
+			if (atomic)
+			{
+				File.Delete(tempFile); // just in case- no exception is raised if file is not found
+			}
+		}
+	}
+
+	static string GetTempFileName(string filename)
+	{
+		var tempfile = filename + ".tmp";
+		var i = 1;
+
+		while (File.Exists(tempfile))
+		{
+			tempfile = filename + ".tmp." + (i++);
+		}
+
+		return tempfile;
+	}
+}

--- a/src/Uno.Sdk/MacDev/PObjectContainer.cs
+++ b/src/Uno.Sdk/MacDev/PObjectContainer.cs
@@ -1,0 +1,71 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+using System.IO;
+
+namespace Uno.Sdk.MacDev;
+
+public abstract class PObjectContainer : PObject
+{
+	public abstract int Count { get; }
+
+	public bool Reload(string fileName)
+	{
+		using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+		using var ctx = PropertyListFormat.CreateReadContext(stream);
+		if (ctx is null)
+		{
+			return false;
+		}
+
+		return Reload(ctx);
+	}
+
+	protected abstract bool Reload(PropertyListFormat.ReadWriteContext ctx);
+
+	protected void OnChildAdded(string? key, PObject child)
+	{
+		child.Parent = this;
+
+		OnCollectionChanged(PObjectContainerAction.Added, key, null, child);
+	}
+
+	internal void OnCollectionChanged(string key, PObject child) => OnCollectionChanged(PObjectContainerAction.Changed, key, null, child);
+
+	protected void OnChildRemoved(string? key, PObject child)
+	{
+		child.Parent = null;
+
+		OnCollectionChanged(PObjectContainerAction.Removed, key, child, null);
+	}
+
+	protected void OnChildReplaced(string? key, PObject oldChild, PObject newChild)
+	{
+		oldChild.Parent = null;
+		newChild.Parent = this;
+
+		OnCollectionChanged(PObjectContainerAction.Replaced, key, oldChild, newChild);
+	}
+
+	protected void OnCleared() => OnCollectionChanged(PObjectContainerAction.Cleared, null, null, null);
+
+	protected void OnCollectionChanged(PObjectContainerAction action, string? key, PObject? oldChild, PObject? newChild)
+	{
+		if (SuppressChangeEvents)
+		{
+			return;
+		}
+
+		var handler = CollectionChanged;
+		if (handler is not null)
+		{
+			handler(this, new PObjectContainerEventArgs(action, key, oldChild, newChild));
+		}
+
+		OnChanged(EventArgs.Empty);
+
+		Parent?.OnCollectionChanged(Key!, this);
+	}
+
+	public event EventHandler<PObjectContainerEventArgs>? CollectionChanged;
+}

--- a/src/Uno.Sdk/MacDev/PObjectContainerAction.cs
+++ b/src/Uno.Sdk/MacDev/PObjectContainerAction.cs
@@ -1,0 +1,12 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+namespace Uno.Sdk.MacDev;
+
+public enum PObjectContainerAction
+{
+	Added,
+	Changed,
+	Removed,
+	Replaced,
+	Cleared
+}

--- a/src/Uno.Sdk/MacDev/PObjectContainerEventArgs.cs
+++ b/src/Uno.Sdk/MacDev/PObjectContainerEventArgs.cs
@@ -1,0 +1,24 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+
+namespace Uno.Sdk.MacDev;
+
+public sealed class PObjectContainerEventArgs : EventArgs
+{
+	internal PObjectContainerEventArgs(PObjectContainerAction action, string? key, PObject? oldItem, PObject? newItem)
+	{
+		Action = action;
+		Key = key;
+		OldItem = oldItem;
+		NewItem = newItem;
+	}
+
+	public PObjectContainerAction Action { get; private set; }
+
+	public string? Key { get; private set; }
+
+	public PObject? OldItem { get; private set; }
+
+	public PObject? NewItem { get; private set; }
+}

--- a/src/Uno.Sdk/MacDev/PObjectType.cs
+++ b/src/Uno.Sdk/MacDev/PObjectType.cs
@@ -1,0 +1,15 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+namespace Uno.Sdk.MacDev;
+
+public enum PObjectType
+{
+	Dictionary,
+	Array,
+	Real,
+	Number,
+	Boolean,
+	Data,
+	String,
+	Date
+}

--- a/src/Uno.Sdk/MacDev/PReal.cs
+++ b/src/Uno.Sdk/MacDev/PReal.cs
@@ -1,0 +1,23 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+using System.Globalization;
+
+namespace Uno.Sdk.MacDev;
+
+public class PReal(double value) : PValueObject<double>(value)
+{
+	public override PObject Clone() => new PReal(Value);
+
+	public override PObjectType Type => PObjectType.Real;
+
+	public override bool TrySetValueFromString(string text, IFormatProvider formatProvider)
+	{
+		if (double.TryParse(text, NumberStyles.AllowDecimalPoint, formatProvider, out var result))
+		{
+			Value = result;
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/Uno.Sdk/MacDev/PString.cs
+++ b/src/Uno.Sdk/MacDev/PString.cs
@@ -1,0 +1,26 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+
+namespace Uno.Sdk.MacDev;
+
+public class PString : PValueObject<string>
+{
+	public PString(string value) : base(value)
+	{
+		if (value is null)
+		{
+			throw new ArgumentNullException(nameof(value));
+		}
+	}
+
+	public override PObject Clone() => new PString(Value);
+
+	public override PObjectType Type => PObjectType.String;
+
+	public override bool TrySetValueFromString(string text, IFormatProvider formatProvider)
+	{
+		Value = text;
+		return true;
+	}
+}

--- a/src/Uno.Sdk/MacDev/PValueObject.cs
+++ b/src/Uno.Sdk/MacDev/PValueObject.cs
@@ -1,0 +1,37 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+
+namespace Uno.Sdk.MacDev;
+
+public abstract class PValueObject<T> : PObject, IPValueObject
+{
+	T val;
+	public T Value
+	{
+		get => val;
+		set
+		{
+			val = value;
+			OnChanged(EventArgs.Empty);
+		}
+	}
+
+	object IPValueObject.Value
+	{
+		get => Value!;
+		set => Value = (T)value;
+	}
+
+	protected PValueObject(T value)
+	{
+		// Make sure the compiler understands that all fields have been assigned at the end of the constructor
+		val = value;
+		// This calls the OnChanged virtual method.
+		Value = value;
+	}
+
+	public static implicit operator T(PValueObject<T> pObj) => pObj is not null ? pObj.Value : default!;
+
+	public abstract bool TrySetValueFromString(string text, IFormatProvider formatProvider);
+}

--- a/src/Uno.Sdk/MacDev/PropertyListFormat.cs
+++ b/src/Uno.Sdk/MacDev/PropertyListFormat.cs
@@ -1,0 +1,1382 @@
+﻿// Original source: https://github.com/xamarin/Xamarin.MacDev
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Security;
+using System.Text;
+using System.Xml;
+
+namespace Uno.Sdk.MacDev;
+
+public abstract class PropertyListFormat
+{
+	public static readonly PropertyListFormat Xml = new XmlFormat();
+	public static readonly PropertyListFormat Binary = new BinaryFormat();
+	public static readonly PropertyListFormat Json = new JsonFormat();
+
+	// Stream must be seekable
+	public static ReadWriteContext? CreateReadContext(Stream input) => Binary.StartReading(input) ?? Xml.StartReading(input);
+
+	public static ReadWriteContext? CreateReadContext(byte[] array, int startIndex, int length) => CreateReadContext(new MemoryStream(array, startIndex, length));
+
+	public static ReadWriteContext? CreateReadContext(byte[] array) => CreateReadContext(new MemoryStream(array, 0, array.Length));
+
+	// returns null if the input is not of the correct format. Stream must be seekable
+	public abstract ReadWriteContext? StartReading(Stream input);
+	public abstract ReadWriteContext StartWriting(Stream output);
+
+	public ReadWriteContext? StartReading(byte[] array, int startIndex, int length) => StartReading(new MemoryStream(array, startIndex, length));
+
+	public ReadWriteContext? StartReading(byte[] array) => StartReading(new MemoryStream(array, 0, array.Length));
+
+	internal class BinaryFormat : PropertyListFormat
+	{
+		// magic is bplist + 2 byte version id
+		private static readonly byte[] BPLIST_MAGIC = [0x62, 0x70, 0x6C, 0x69, 0x73, 0x74];  // "bplist"
+		private static readonly byte[] BPLIST_VERSION = [0x30, 0x30]; // "00"
+
+		public override ReadWriteContext? StartReading(Stream input)
+		{
+			if (input.Length < BPLIST_MAGIC.Length + 2)
+			{
+				return null;
+			}
+
+			input.Seek(0, SeekOrigin.Begin);
+			for (var i = 0; i < BPLIST_MAGIC.Length; i++)
+			{
+				if ((byte)input.ReadByte() != BPLIST_MAGIC[i])
+				{
+					return null;
+				}
+			}
+
+			// skip past the 2 byte version id for now
+			//  we currently don't bother checking it because it seems different versions of OSX might write different values here?
+			input.Seek(2, SeekOrigin.Current);
+			return new Context(input, true);
+		}
+
+		public override ReadWriteContext StartWriting(Stream output)
+		{
+			output.Write(BPLIST_MAGIC, 0, BPLIST_MAGIC.Length);
+			output.Write(BPLIST_VERSION, 0, BPLIST_VERSION.Length);
+
+			return new Context(output, false);
+		}
+
+		class Context : ReadWriteContext
+		{
+			private static readonly DateTime AppleEpoch = new(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc); //see CFDateGetAbsoluteTime
+
+			//https://github.com/mono/referencesource/blob/mono/mscorlib/system/datetime.cs
+			private const long TicksPerMillisecond = 10000;
+			private const long TicksPerSecond = TicksPerMillisecond * 1000;
+			private readonly Stream _stream;
+			private int _currentLength;
+
+			private CFBinaryPlistTrailer trailer;
+
+			//for writing
+			private readonly List<object> _objectRefs;
+			private int _currentRef;
+			private long[]? _offsets;
+
+			public Context(Stream stream, bool reading)
+			{
+				_objectRefs = [];
+				_stream = stream;
+				if (reading)
+				{
+					trailer = CFBinaryPlistTrailer.Read(this);
+					ReadObjectHead();
+				}
+			}
+
+			#region Binary reading members
+			protected override bool ReadBool() => CurrentType == PlistType.@true;
+
+			protected override void ReadObjectHead()
+			{
+				var b = _stream.ReadByte();
+				var len = 0L;
+				var type = (PlistType)(b & 0xF0);
+				if (type == PlistType.@null)
+				{
+					type = (PlistType)b;
+				}
+				else
+				{
+					len = b & 0x0F;
+					if (len == 0xF)
+					{
+						ReadObjectHead();
+						len = ReadInteger();
+					}
+				}
+				CurrentType = type;
+				_currentLength = (int)len;
+			}
+
+			protected override long ReadInteger() => CurrentType switch
+			{
+				PlistType.integer => ReadBigEndianInteger((int)Math.Pow(2, _currentLength)),
+				_ => throw new NotSupportedException("Integer of type: " + CurrentType),
+			};
+
+			protected override double ReadReal()
+			{
+				var bytes = ReadBigEndianBytes((int)Math.Pow(2, _currentLength));
+				return CurrentType switch
+				{
+					PlistType.real => bytes.Length switch
+					{
+						4 => (double)BitConverter.ToSingle(bytes, 0),
+						8 => BitConverter.ToDouble(bytes, 0),
+						_ => throw new NotSupportedException(bytes.Length + "-byte real"),
+					},
+					_ => throw new NotSupportedException("Real of type: " + CurrentType),
+				};
+			}
+
+			protected override DateTime ReadDate()
+			{
+				var bytes = ReadBigEndianBytes(8);
+				var seconds = BitConverter.ToDouble(bytes, 0);
+				// We need to manually convert the seconds to ticks because
+				//  .NET DateTime/TimeSpan methods dealing with (milli)seconds
+				//  round to the nearest millisecond (bxc #29079)
+				return AppleEpoch.AddTicks((long)(seconds * TicksPerSecond));
+			}
+
+			protected override byte[] ReadData()
+			{
+				var bytes = new byte[_currentLength];
+#if NET7_0_OR_GREATER
+				_stream.ReadExactly(bytes, 0, _currentLength);
+#else
+				_stream.Read(bytes, 0, _currentLength);
+#endif
+				return bytes;
+			}
+
+			protected override string ReadString()
+			{
+				byte[] bytes;
+				switch (CurrentType)
+				{
+					case PlistType.@string: // ASCII
+						bytes = new byte[_currentLength];
+#if NET7_0_OR_GREATER
+						_stream.ReadExactly(bytes, 0, bytes.Length);
+#else
+						_stream.Read(bytes, 0, bytes.Length);
+#endif
+						return Encoding.ASCII.GetString(bytes);
+					case PlistType.wideString: //CFBinaryPList.c: Unicode string...big-endian 2-byte uint16_t
+						bytes = new byte[_currentLength * 2];
+#if NET7_0_OR_GREATER
+						_stream.ReadExactly(bytes, 0, bytes.Length);
+#else
+						_stream.Read(bytes, 0, bytes.Length);
+#endif
+						return Encoding.BigEndianUnicode.GetString(bytes);
+				}
+
+				throw new NotSupportedException("String of type: " + CurrentType);
+			}
+
+			public override bool ReadArray(PArray array)
+			{
+				if (CurrentType != PlistType.array)
+				{
+					return false;
+				}
+
+				array.Clear();
+
+				// save currentLength as it will be overwritten by next ReadObjectHead call
+				var len = _currentLength;
+				for (var i = 0; i < len; i++)
+				{
+					var obj = ReadObjectByRef();
+					if (obj is not null)
+					{
+						array.Add(obj);
+					}
+				}
+
+				return true;
+			}
+
+			public override bool ReadDict(PDictionary dict)
+			{
+				if (CurrentType != PlistType.dict)
+				{
+					return false;
+				}
+
+				dict.Clear();
+
+				// save currentLength as it will be overwritten by next ReadObjectHead call
+				var len = _currentLength;
+				var keys = new string[len];
+				for (var i = 0; i < len; i++)
+				{
+					keys[i] = ((PString)ReadObjectByRef()!).Value;
+				}
+
+				for (var i = 0; i < len; i++)
+				{
+					dict.Add(keys[i], ReadObjectByRef()!);
+				}
+
+				return true;
+			}
+
+			PObject? ReadObjectByRef()
+			{
+				// read index into offset table
+				var objRef = (long)ReadBigEndianUInteger(trailer.ObjectRefSize);
+
+				// read offset in file from table
+				var lastPos = _stream.Position;
+				_stream.Seek(trailer.OffsetTableOffset + objRef * trailer.OffsetEntrySize, SeekOrigin.Begin);
+				_stream.Seek((long)ReadBigEndianUInteger(trailer.OffsetEntrySize), SeekOrigin.Begin);
+
+				ReadObjectHead();
+				var obj = ReadObject();
+
+				// restore original position
+				_stream.Seek(lastPos, SeekOrigin.Begin);
+				return obj;
+			}
+
+			byte[] ReadBigEndianBytes(int count)
+			{
+				var bytes = new byte[count];
+#if NET7_0_OR_GREATER
+				_stream.ReadExactly(bytes, 0, count);
+#else
+				_stream.Read(bytes, 0, count);
+#endif
+				if (BitConverter.IsLittleEndian)
+				{
+					Array.Reverse(bytes);
+				}
+
+				return bytes;
+			}
+
+			long ReadBigEndianInteger(int numBytes)
+			{
+				var bytes = ReadBigEndianBytes(numBytes);
+				return numBytes switch
+				{
+					1 => bytes[0],
+					2 => BitConverter.ToUInt16(bytes, 0),
+					4 => BitConverter.ToUInt32(bytes, 0),
+					8 => BitConverter.ToInt64(bytes, 0),
+					_ => throw new NotSupportedException(bytes.Length + "-byte integer"),
+				};
+			}
+
+			ulong ReadBigEndianUInteger(int numBytes)
+			{
+				var bytes = ReadBigEndianBytes(numBytes);
+				return numBytes switch
+				{
+					1 => bytes[0],
+					2 => BitConverter.ToUInt16(bytes, 0),
+					4 => BitConverter.ToUInt32(bytes, 0),
+					8 => BitConverter.ToUInt64(bytes, 0),
+					_ => throw new NotSupportedException(bytes.Length + "-byte integer"),
+				};
+			}
+
+			ulong ReadBigEndianUInt64()
+			{
+				var bytes = ReadBigEndianBytes(8);
+				return BitConverter.ToUInt64(bytes, 0);
+			}
+			#endregion
+
+			#region Binary writing members
+			public override void WriteObject(PObject value)
+			{
+				if (_offsets is null)
+				{
+					InitOffsetTable(value);
+				}
+
+				base.WriteObject(value);
+			}
+
+			protected override void Write(PBoolean boolean) =>
+				WriteObjectHead(boolean, boolean ? PlistType.@true : PlistType.@false);
+
+			protected override void Write(PNumber number)
+			{
+				if (WriteObjectHead(number, PlistType.integer))
+				{
+					Write(number.Value);
+				}
+			}
+
+			protected override void Write(PReal real)
+			{
+				if (WriteObjectHead(real, PlistType.real))
+				{
+					Write(real.Value);
+				}
+			}
+
+			protected override void Write(PDate date)
+			{
+				if (WriteObjectHead(date, PlistType.date))
+				{
+					var bytes = MakeBigEndian(BitConverter.GetBytes(date.Value.Subtract(AppleEpoch).TotalSeconds));
+					_stream.Write(bytes, 0, bytes.Length);
+				}
+			}
+
+			protected override void Write(PData data)
+			{
+				var bytes = data.Value;
+				if (WriteObjectHead(data, PlistType.data, bytes.Length))
+				{
+					_stream.Write(bytes, 0, bytes.Length);
+				}
+			}
+
+			protected override void Write(PString str)
+			{
+				var type = PlistType.@string;
+				byte[] bytes;
+
+				if (str.Value.Any(c => c > 127))
+				{
+					type = PlistType.wideString;
+					bytes = Encoding.BigEndianUnicode.GetBytes(str.Value);
+				}
+				else
+				{
+					bytes = Encoding.ASCII.GetBytes(str.Value);
+				}
+
+				if (WriteObjectHead(str, type, str.Value.Length))
+				{
+					_stream.Write(bytes, 0, bytes.Length);
+				}
+			}
+
+			protected override void Write(PArray array)
+			{
+				if (!WriteObjectHead(array, PlistType.array, array.Count))
+				{
+					return;
+				}
+
+				var curRef = _currentRef;
+
+				foreach (var item in array)
+				{
+					Write(GetObjRef(item), trailer.ObjectRefSize);
+				}
+
+				_currentRef = curRef;
+
+				foreach (var item in array)
+				{
+					WriteObject(item);
+				}
+			}
+
+			protected override void Write(PDictionary dict)
+			{
+				if (!WriteObjectHead(dict, PlistType.dict, dict.Count))
+				{
+					return;
+				}
+
+				// it would be better not to loop so many times, but we have to do it
+				//  if we want to lay things out the same way apple does
+
+				var curRef = _currentRef;
+
+				//write key refs
+				foreach (var item in dict)
+				{
+					Write(GetObjRef(item.Key!), trailer.ObjectRefSize);
+				}
+
+				//write value refs
+				foreach (var item in dict)
+				{
+					Write(GetObjRef(item.Value), trailer.ObjectRefSize);
+				}
+
+				_currentRef = curRef;
+
+				//write keys and values
+				foreach (var item in dict)
+				{
+					WriteObject(item.Key!);
+				}
+
+				foreach (var item in dict)
+				{
+					WriteObject(item.Value);
+				}
+			}
+
+			bool WriteObjectHead(PObject obj, PlistType type, int size = 0)
+			{
+				var id = GetObjRef(obj);
+				if (_offsets![id] != 0) // if we've already been written, don't write us again
+				{
+					return false;
+				}
+
+				_offsets[id] = _stream.Position;
+				switch (type)
+				{
+					case PlistType.@null:
+					case PlistType.@false:
+					case PlistType.@true:
+					case PlistType.fill:
+						_stream.WriteByte((byte)type);
+						break;
+					case PlistType.date:
+						_stream.WriteByte(0x33);
+						break;
+					case PlistType.integer:
+					case PlistType.real:
+						break;
+					default:
+						if (size < 15)
+						{
+							_stream.WriteByte((byte)((byte)type | size));
+						}
+						else
+						{
+							_stream.WriteByte((byte)((byte)type | 0xF));
+							Write(size);
+						}
+						break;
+				}
+				return true;
+			}
+
+			void Write(double value)
+			{
+				if (value >= float.MinValue && value <= float.MaxValue)
+				{
+					_stream.WriteByte((byte)PlistType.real | 0x2);
+					var bytes = MakeBigEndian(BitConverter.GetBytes((float)value));
+					_stream.Write(bytes, 0, bytes.Length);
+				}
+				else
+				{
+					_stream.WriteByte((byte)PlistType.real | 0x3);
+					var bytes = MakeBigEndian(BitConverter.GetBytes(value));
+					_stream.Write(bytes, 0, bytes.Length);
+				}
+			}
+
+			void Write(long value)
+			{
+				if (value < 0 || value > uint.MaxValue)
+				{ //they always write negative numbers with 8 bytes
+					_stream.WriteByte((byte)PlistType.integer | 0x3);
+					var bytes = MakeBigEndian(BitConverter.GetBytes(value));
+					_stream.Write(bytes, 0, bytes.Length);
+				}
+				else if (value <= byte.MaxValue)
+				{
+					_stream.WriteByte((byte)PlistType.integer);
+					_stream.WriteByte((byte)value);
+				}
+				else if (value <= ushort.MaxValue)
+				{
+					_stream.WriteByte((byte)PlistType.integer | 0x1);
+					var bytes = MakeBigEndian(BitConverter.GetBytes((short)value));
+					_stream.Write(bytes, 0, bytes.Length);
+				}
+				else if (value <= uint.MaxValue)
+				{
+					_stream.WriteByte((byte)PlistType.integer | 0x2);
+					var bytes = MakeBigEndian(BitConverter.GetBytes((int)value));
+					_stream.Write(bytes, 0, bytes.Length);
+				}
+			}
+
+			void Write(long value, int byteCount)
+			{
+				byte[] bytes;
+				switch (byteCount)
+				{
+					case 1:
+						_stream.WriteByte((byte)value);
+						break;
+					case 2:
+						bytes = MakeBigEndian(BitConverter.GetBytes((short)value));
+						_stream.Write(bytes, 0, bytes.Length);
+						break;
+					case 4:
+						bytes = MakeBigEndian(BitConverter.GetBytes((int)value));
+						_stream.Write(bytes, 0, bytes.Length);
+						break;
+					case 8:
+						bytes = MakeBigEndian(BitConverter.GetBytes(value));
+						_stream.Write(bytes, 0, bytes.Length);
+						break;
+					default:
+						throw new NotSupportedException(byteCount + "-byte integer");
+				}
+			}
+
+			void InitOffsetTable(PObject topLevel)
+			{
+				var count = 0;
+				MakeObjectRefs(topLevel, ref count);
+				trailer.ObjectRefSize = GetMinByteLength(count);
+				_offsets = new long[count];
+			}
+
+			void MakeObjectRefs(object obj, ref int count)
+			{
+				if (obj is null)
+				{
+					return;
+				}
+
+				if (ShouldDuplicate(obj) || !_objectRefs.Any(val => PObjectEqualityComparer.Instance.Equals(val, obj)))
+				{
+					_objectRefs.Add(obj);
+					count++;
+				}
+
+				// for containers, also count their contents
+				var pobj = obj as PObject;
+				if (pobj is not null)
+				{
+					switch (pobj.Type)
+					{
+
+						case PObjectType.Array:
+							foreach (var child in (PArray)obj)
+							{
+								MakeObjectRefs(child, ref count);
+							}
+
+							break;
+						case PObjectType.Dictionary:
+							foreach (var child in (PDictionary)obj)
+							{
+								MakeObjectRefs(child.Key!, ref count);
+							}
+
+							foreach (var child in (PDictionary)obj)
+							{
+								MakeObjectRefs(child.Value, ref count);
+							}
+
+							break;
+					}
+				}
+			}
+
+			static bool ShouldDuplicate(object obj)
+			{
+				if (obj is not PObject pobj)
+				{
+					return false;
+				}
+
+				return pobj.Type == PObjectType.Boolean || pobj.Type == PObjectType.Array || pobj.Type == PObjectType.Dictionary ||
+					(pobj.Type == PObjectType.String && ((PString)pobj).Value.Any(c => c > 255)); //LAMESPEC: this is weird. Some things are duplicated
+			}
+
+			int GetObjRef(object obj)
+			{
+				if (_currentRef < _objectRefs.Count && PObjectEqualityComparer.Instance.Equals(_objectRefs[_currentRef], obj))
+				{
+					return _currentRef++;
+				}
+
+				return _objectRefs.FindIndex(val => PObjectEqualityComparer.Instance.Equals(val, obj));
+			}
+
+			static int GetMinByteLength(long value)
+			{
+				if (value >= 0 && value < byte.MaxValue)
+				{
+					return 1;
+				}
+
+				if (value >= short.MinValue && value < short.MaxValue)
+				{
+					return 2;
+				}
+
+				if (value >= int.MinValue && value < int.MaxValue)
+				{
+					return 4;
+				}
+
+				return 8;
+			}
+
+			static byte[] MakeBigEndian(byte[] bytes)
+			{
+				if (BitConverter.IsLittleEndian)
+				{
+					Array.Reverse(bytes);
+				}
+
+				return bytes;
+			}
+			#endregion
+
+			public override void Dispose()
+			{
+				if (_offsets is not null)
+				{
+					trailer.OffsetTableOffset = _stream.Position;
+					trailer.OffsetEntrySize = GetMinByteLength(trailer.OffsetTableOffset);
+					foreach (var offset in _offsets)
+					{
+						Write(offset, trailer.OffsetEntrySize);
+					}
+
+					//LAMESPEC: seems like they always add 6 extra bytes here. not sure why
+					for (var i = 0; i < 6; i++)
+					{
+						_stream.WriteByte(0);
+					}
+
+					trailer.Write(this);
+				}
+			}
+
+			class PObjectEqualityComparer : IEqualityComparer<object>
+			{
+				public static readonly PObjectEqualityComparer Instance = new();
+
+				PObjectEqualityComparer()
+				{
+				}
+
+				public new bool Equals(object? x, object? y)
+				{
+					var vx = x as IPValueObject;
+					var vy = y as IPValueObject;
+
+					if (vx is null && vy is null)
+					{
+						return EqualityComparer<object?>.Default.Equals(x, y);
+					}
+
+					if (vx is null && x is not null && vy?.Value is not null)
+					{
+						return vy.Value.Equals(x);
+					}
+
+					if (vy is null && y is not null && vx?.Value is not null)
+					{
+						return vx.Value.Equals(y);
+					}
+
+					if (vx is null || vy is null)
+					{
+						return false;
+					}
+
+					return vx.Value?.Equals(vy.Value) == true;
+				}
+
+				public int GetHashCode(object obj)
+				{
+					var valueObj = obj as IPValueObject;
+					if (valueObj is not null)
+					{
+						return valueObj.Value.GetHashCode();
+					}
+
+					return obj.GetHashCode();
+				}
+			}
+
+			struct CFBinaryPlistTrailer
+			{
+				const int TRAILER_SIZE = 26;
+
+				public int OffsetEntrySize;
+				public int ObjectRefSize;
+				public long ObjectCount;
+				public long TopLevelRef;
+				public long OffsetTableOffset;
+
+				public static CFBinaryPlistTrailer Read(Context ctx)
+				{
+					var pos = ctx._stream.Position;
+					ctx._stream.Seek(-TRAILER_SIZE, SeekOrigin.End);
+					var result = new CFBinaryPlistTrailer
+					{
+						OffsetEntrySize = ctx._stream.ReadByte(),
+						ObjectRefSize = ctx._stream.ReadByte(),
+						ObjectCount = (long)ctx.ReadBigEndianUInt64(),
+						TopLevelRef = (long)ctx.ReadBigEndianUInt64(),
+						OffsetTableOffset = (long)ctx.ReadBigEndianUInt64()
+					};
+					ctx._stream.Seek(pos, SeekOrigin.Begin);
+					return result;
+				}
+
+				public readonly void Write(Context ctx)
+				{
+					byte[] bytes;
+					ctx._stream.WriteByte((byte)OffsetEntrySize);
+					ctx._stream.WriteByte((byte)ObjectRefSize);
+					//LAMESPEC: apple's comments say this is the number of entries in the offset table, but this really *is* number of objects??!?!
+					bytes = MakeBigEndian(BitConverter.GetBytes((long)ctx._objectRefs!.Count));
+					ctx._stream.Write(bytes, 0, bytes.Length);
+					bytes = new byte[8]; //top level always at offset 0
+					ctx._stream.Write(bytes, 0, bytes.Length);
+					bytes = MakeBigEndian(BitConverter.GetBytes(OffsetTableOffset));
+					ctx._stream.Write(bytes, 0, bytes.Length);
+				}
+			}
+		}
+	}
+
+	// Adapted from:
+	//https://github.com/mono/monodevelop/blob/07d9e6c07e5be8fe1d8d6f4272d3969bb087a287/main/src/addins/MonoDevelop.MacDev/MonoDevelop.MacDev.Plist/PlistDocument.cs
+	internal class XmlFormat : PropertyListFormat
+	{
+		private const string PLIST_HEADER = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
+<plist version=""1.0"">
+";
+		private static readonly Encoding _outputEncoding = new UTF8Encoding(false, false);
+
+		public override ReadWriteContext? StartReading(Stream input)
+		{
+			//allow DTD but not try to resolve it from web
+			var settings = new XmlReaderSettings()
+			{
+				CloseInput = true,
+				DtdProcessing = DtdProcessing.Ignore,
+				XmlResolver = null,
+			};
+
+			XmlReader? reader = null;
+			input.Seek(0, SeekOrigin.Begin);
+			try
+			{
+				reader = XmlReader.Create(input, settings);
+				reader.ReadToDescendant("plist");
+				while (reader.Read() && reader.NodeType != XmlNodeType.Element)
+				{
+				}
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine("Exception: {0}", ex);
+			}
+
+			if (reader is null || reader.EOF)
+			{
+				return null;
+			}
+
+			return new Context(reader);
+		}
+
+		public override ReadWriteContext StartWriting(Stream output)
+		{
+			var writer = new StreamWriter(output, _outputEncoding);
+			writer.Write(PLIST_HEADER);
+
+			return new Context(writer);
+		}
+
+		class Context : ReadWriteContext
+		{
+			private const string DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssK";
+			private readonly XmlReader? _reader;
+			private readonly TextWriter? _writer;
+
+			private int _indentLevel;
+			private string _indentString = string.Empty;
+
+			public Context(XmlReader reader)
+			{
+				_reader = reader;
+				ReadObjectHead();
+			}
+
+			public Context(TextWriter writer)
+			{
+				_writer = writer;
+			}
+
+			#region XML reading members
+			protected override void ReadObjectHead()
+			{
+				try
+				{
+					CurrentType = (PlistType)Enum.Parse(typeof(PlistType), _reader!.LocalName);
+				}
+				catch (Exception ex)
+				{
+					throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Failed to parse PList data type: {0}", _reader?.LocalName), ex);
+				}
+			}
+
+			protected override bool ReadBool()
+			{
+				// Create the PBoolean object, then move to the xml reader to next node
+				// so we are ready to parse the next object. 'bool' types don't have
+				// content so we have to move the reader manually, unlike integers which
+				// implicitly move to the next node because we parse the content.
+				var result = CurrentType == PlistType.@true;
+				_reader!.Read();
+				return result;
+			}
+
+			protected override long ReadInteger() => _reader!.ReadElementContentAsLong();
+
+			protected override double ReadReal() => _reader!.ReadElementContentAsDouble();
+
+			protected override DateTime ReadDate() => DateTime.ParseExact(_reader!.ReadElementContentAsString(), DATETIME_FORMAT, CultureInfo.InvariantCulture).ToUniversalTime();
+
+			protected override byte[] ReadData() => Convert.FromBase64String(_reader!.ReadElementContentAsString());
+
+			protected override string ReadString() => _reader!.ReadElementContentAsString();
+
+			public override bool ReadArray(PArray array)
+			{
+				if (CurrentType != PlistType.array)
+				{
+					return false;
+				}
+
+				array.Clear();
+
+				if (_reader!.IsEmptyElement)
+				{
+					_reader.Read();
+					return true;
+				}
+
+				// advance to first node
+				_reader.ReadStartElement();
+				while (!_reader.EOF && _reader.NodeType != XmlNodeType.Element && _reader.NodeType != XmlNodeType.EndElement)
+				{
+					if (!_reader.Read())
+					{
+						break;
+					}
+				}
+
+				while (!_reader.EOF && _reader.NodeType != XmlNodeType.EndElement)
+				{
+					if (_reader.NodeType == XmlNodeType.Element)
+					{
+						ReadObjectHead();
+
+						var val = ReadObject();
+						if (val is not null)
+						{
+							array.Add(val);
+						}
+					}
+					else if (!_reader.Read())
+					{
+						break;
+					}
+				}
+
+				if (!_reader.EOF && _reader.NodeType == XmlNodeType.EndElement && _reader.Name == "array")
+				{
+					_reader.ReadEndElement();
+					return true;
+				}
+
+				return false;
+			}
+
+			public override bool ReadDict(PDictionary dict)
+			{
+				if (CurrentType != PlistType.dict)
+				{
+					return false;
+				}
+
+				dict.Clear();
+
+				if (_reader!.IsEmptyElement)
+				{
+					_reader.Read();
+					return true;
+				}
+
+				_reader.ReadToDescendant("key");
+
+				while (!_reader.EOF && _reader.NodeType == XmlNodeType.Element)
+				{
+					var key = _reader.ReadElementString();
+
+					while (!_reader.EOF && _reader.NodeType != XmlNodeType.Element && _reader.Read())
+					{
+						if (_reader.NodeType == XmlNodeType.EndElement)
+						{
+							throw new FormatException(string.Format(CultureInfo.InvariantCulture, "No value found for key {0}", key));
+						}
+					}
+
+					ReadObjectHead();
+					var result = ReadObject();
+					if (result is not null)
+					{
+						// Keys are not required to be unique. The last entry wins.
+						dict[key] = result;
+					}
+
+					do
+					{
+						if (_reader.NodeType == XmlNodeType.Element && _reader.Name == "key")
+						{
+							break;
+						}
+
+						if (_reader.NodeType == XmlNodeType.EndElement)
+						{
+							break;
+						}
+					} while (_reader.Read());
+				}
+
+				if (!_reader.EOF && _reader.NodeType == XmlNodeType.EndElement && _reader.Name == "dict")
+				{
+					_reader.ReadEndElement();
+					return true;
+				}
+
+				return false;
+			}
+			#endregion
+
+			#region XML writing members
+			protected override void Write(PBoolean boolean) => WriteLine(boolean.Value ? "<true/>" : "<false/>");
+
+			protected override void Write(PNumber number) => WriteLine("<integer>" + SecurityElement.Escape(number.Value.ToString(CultureInfo.InvariantCulture)) + "</integer>");
+
+			protected override void Write(PReal real) => WriteLine("<real>" + SecurityElement.Escape(real.Value.ToString(CultureInfo.InvariantCulture)) + "</real>");
+
+			protected override void Write(PDate date) => WriteLine("<date>" + SecurityElement.Escape(date.Value.ToString(DATETIME_FORMAT, CultureInfo.InvariantCulture)) + "</date>");
+
+			protected override void Write(PData data) => WriteLine("<data>" + SecurityElement.Escape(Convert.ToBase64String(data.Value)) + "</data>");
+
+			protected override void Write(PString str) => WriteLine("<string>" + SecurityElement.Escape(str.Value) + "</string>");
+
+			protected override void Write(PArray array)
+			{
+				if (array.Count == 0)
+				{
+					WriteLine("<array/>");
+					return;
+				}
+
+				WriteLine("<array>");
+				IncreaseIndent();
+
+				foreach (var item in array)
+				{
+					WriteObject(item);
+				}
+
+				DecreaseIndent();
+				WriteLine("</array>");
+			}
+
+			protected override void Write(PDictionary dict)
+			{
+				if (dict.Count == 0)
+				{
+					WriteLine("<dict/>");
+					return;
+				}
+
+				WriteLine("<dict>");
+				IncreaseIndent();
+
+				foreach (var kv in dict)
+				{
+					WriteLine("<key>" + SecurityElement.Escape(kv.Key) + "</key>");
+					WriteObject(kv.Value);
+				}
+
+				DecreaseIndent();
+				WriteLine("</dict>");
+			}
+
+			void WriteLine(string value)
+			{
+				_writer!.Write(_indentString);
+				_writer.Write(value);
+				_writer.Write('\n');
+			}
+
+			void IncreaseIndent()
+			{
+				_indentString = new string('\t', ++_indentLevel);
+			}
+
+			void DecreaseIndent()
+			{
+				_indentString = new string('\t', --_indentLevel);
+			}
+			#endregion
+
+			public override void Dispose()
+			{
+				if (_writer is not null)
+				{
+					_writer.Write("</plist>\n");
+					_writer.Flush();
+					_writer.Dispose();
+				}
+			}
+		}
+	}
+
+	internal class JsonFormat : PropertyListFormat
+	{
+		static readonly Encoding outputEncoding = new UTF8Encoding(false, false);
+
+		public override ReadWriteContext StartReading(Stream input)
+		{
+			throw new NotImplementedException();
+		}
+
+		public override ReadWriteContext StartWriting(Stream output)
+		{
+			var writer = new StreamWriter(output, outputEncoding);
+
+			return new Context(writer);
+		}
+
+		class Context(TextWriter writer) : ReadWriteContext
+		{
+			const string DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssK";
+
+			readonly TextWriter writer = writer;
+
+			string indentString = "";
+			int indentLevel;
+
+			#region XML reading members
+			protected override void ReadObjectHead()
+			{
+				throw new NotImplementedException();
+			}
+
+			protected override bool ReadBool()
+			{
+				throw new NotImplementedException();
+			}
+
+			protected override long ReadInteger()
+			{
+				throw new NotImplementedException();
+			}
+
+			protected override double ReadReal()
+			{
+				throw new NotImplementedException();
+			}
+
+			protected override DateTime ReadDate()
+			{
+				throw new NotImplementedException();
+			}
+
+			protected override byte[] ReadData()
+			{
+				throw new NotImplementedException();
+			}
+
+			protected override string ReadString()
+			{
+				throw new NotImplementedException();
+			}
+
+			public override bool ReadArray(PArray array)
+			{
+				throw new NotImplementedException();
+			}
+
+			public override bool ReadDict(PDictionary dict)
+			{
+				throw new NotImplementedException();
+			}
+			#endregion
+
+			#region XML writing members
+			void Quote(string text)
+			{
+				var quoted = new StringBuilder(text.Length + 2, (text.Length * 2) + 2);
+
+				quoted.Append('"');
+				for (int i = 0; i < text.Length; i++)
+				{
+					if (text[i] == '\\' || text[i] == '"')
+					{
+						quoted.Append('\\');
+					}
+
+					quoted.Append(text[i]);
+				}
+				quoted.Append('"');
+
+				writer.Write(quoted);
+			}
+
+			protected override void Write(PBoolean boolean)
+			{
+				writer.Write(boolean.Value ? "true" : "false");
+			}
+
+			protected override void Write(PNumber number)
+			{
+				writer.Write(number.Value.ToString(CultureInfo.InvariantCulture));
+			}
+
+			protected override void Write(PReal real)
+			{
+				writer.Write(real.Value.ToString(CultureInfo.InvariantCulture));
+			}
+
+			protected override void Write(PDate date)
+			{
+				writer.Write("\"" + date.Value.ToString(DATETIME_FORMAT, CultureInfo.InvariantCulture) + "\"");
+			}
+
+			protected override void Write(PData data)
+			{
+				Quote(Convert.ToBase64String(data.Value));
+			}
+
+			protected override void Write(PString str)
+			{
+				Quote(str.Value);
+			}
+
+			protected override void Write(PArray array)
+			{
+				if (array.Count == 0)
+				{
+					writer.Write("[]");
+					return;
+				}
+
+				writer.WriteLine("[");
+				IncreaseIndent();
+
+				int i = 0;
+				foreach (var item in array)
+				{
+					writer.Write(indentString);
+					WriteObject(item);
+					if (++i < array.Count)
+					{
+						writer.Write(',');
+					}
+
+					writer.WriteLine();
+				}
+
+				DecreaseIndent();
+				writer.Write(indentString);
+				writer.Write("]");
+			}
+
+			protected override void Write(PDictionary dict)
+			{
+				if (dict.Count == 0)
+				{
+					writer.Write("{}");
+					return;
+				}
+
+				writer.WriteLine("{");
+				IncreaseIndent();
+
+				int i = 0;
+				foreach (var kv in dict)
+				{
+					writer.Write(indentString);
+					Quote(kv.Key!);
+					writer.Write(": ");
+					WriteObject(kv.Value);
+					if (++i < dict.Count)
+					{
+						writer.Write(',');
+					}
+
+					writer.WriteLine();
+				}
+
+				DecreaseIndent();
+				writer.Write(indentString);
+				writer.Write("}");
+			}
+
+			void IncreaseIndent()
+			{
+				indentString = new string(' ', (++indentLevel) * 2);
+			}
+
+			void DecreaseIndent()
+			{
+				indentString = new string(' ', (--indentLevel) * 2);
+			}
+			#endregion
+
+			public override void Dispose()
+			{
+				if (writer is not null)
+				{
+					writer.WriteLine();
+					writer.Flush();
+					writer.Dispose();
+				}
+			}
+		}
+	}
+
+	public abstract class ReadWriteContext : IDisposable
+	{
+		// Binary: The type is encoded in the 4 high bits; the low bits are data (except: null, true, false)
+		// Xml: The enum value name == element tag name (this actually reads a superset of the format, since null, fill and wideString are not plist xml elements afaik)
+		protected enum PlistType : byte
+		{
+			@null = 0x00,
+			@false = 0x08,
+			@true = 0x09,
+			fill = 0x0F,
+			integer = 0x10,
+			real = 0x20,
+			date = 0x30,
+			data = 0x40,
+			@string = 0x50,
+			wideString = 0x60,
+			array = 0xA0,
+			dict = 0xD0,
+		}
+
+		#region Reading members
+		public PObject? ReadObject()
+		{
+			switch (CurrentType)
+			{
+				case PlistType.@true:
+				case PlistType.@false:
+					return new PBoolean(ReadBool());
+				case PlistType.fill:
+					ReadObjectHead();
+					return ReadObject();
+
+				case PlistType.integer:
+					return new PNumber(ReadInteger());
+				case PlistType.real:
+					return new PReal(ReadReal());    //FIXME: we should probably make PNumber take floating point as well as ints
+
+				case PlistType.date:
+					return new PDate(ReadDate());
+				case PlistType.data:
+					return new PData(ReadData());
+
+				case PlistType.@string:
+				case PlistType.wideString:
+					return new PString(ReadString());
+
+				case PlistType.array:
+					var array = new PArray();
+					ReadArray(array);
+					return array;
+
+				case PlistType.dict:
+					var dict = new PDictionary();
+					ReadDict(dict);
+					return dict;
+			}
+			return null;
+		}
+
+		protected abstract void ReadObjectHead();
+		protected PlistType CurrentType { get; set; }
+
+		protected abstract bool ReadBool();
+		protected abstract long ReadInteger();
+		protected abstract double ReadReal();
+		protected abstract DateTime ReadDate();
+		protected abstract byte[] ReadData();
+		protected abstract string ReadString();
+
+		public abstract bool ReadArray(PArray array);
+		public abstract bool ReadDict(PDictionary dict);
+		#endregion
+
+		#region Writing members
+		public virtual void WriteObject(PObject value)
+		{
+			switch (value.Type)
+			{
+				case PObjectType.Boolean:
+					Write((PBoolean)value);
+					return;
+				case PObjectType.Number:
+					Write((PNumber)value);
+					return;
+				case PObjectType.Real:
+					Write((PReal)value);
+					return;
+				case PObjectType.Date:
+					Write((PDate)value);
+					return;
+				case PObjectType.Data:
+					Write((PData)value);
+					return;
+				case PObjectType.String:
+					Write((PString)value);
+					return;
+				case PObjectType.Array:
+					Write((PArray)value);
+					return;
+				case PObjectType.Dictionary:
+					Write((PDictionary)value);
+					return;
+			}
+			throw new NotSupportedException(value.Type.ToString());
+		}
+
+		protected abstract void Write(PBoolean boolean);
+		protected abstract void Write(PNumber number);
+		protected abstract void Write(PReal real);
+		protected abstract void Write(PDate date);
+		protected abstract void Write(PData data);
+		protected abstract void Write(PString str);
+		protected abstract void Write(PArray array);
+		protected abstract void Write(PDictionary dict);
+		#endregion
+
+		public abstract void Dispose();
+	}
+}

--- a/src/Uno.Sdk/MacDev/PropertyListFormat.cs
+++ b/src/Uno.Sdk/MacDev/PropertyListFormat.cs
@@ -155,11 +155,9 @@ public abstract class PropertyListFormat
 			protected override byte[] ReadData()
 			{
 				var bytes = new byte[_currentLength];
-#if NET7_0_OR_GREATER
-				_stream.ReadExactly(bytes, 0, _currentLength);
-#else
+
 				_stream.Read(bytes, 0, _currentLength);
-#endif
+
 				return bytes;
 			}
 
@@ -170,19 +168,15 @@ public abstract class PropertyListFormat
 				{
 					case PlistType.@string: // ASCII
 						bytes = new byte[_currentLength];
-#if NET7_0_OR_GREATER
-						_stream.ReadExactly(bytes, 0, bytes.Length);
-#else
+
 						_stream.Read(bytes, 0, bytes.Length);
-#endif
+
 						return Encoding.ASCII.GetString(bytes);
 					case PlistType.wideString: //CFBinaryPList.c: Unicode string...big-endian 2-byte uint16_t
 						bytes = new byte[_currentLength * 2];
-#if NET7_0_OR_GREATER
-						_stream.ReadExactly(bytes, 0, bytes.Length);
-#else
+
 						_stream.Read(bytes, 0, bytes.Length);
-#endif
+
 						return Encoding.BigEndianUnicode.GetString(bytes);
 				}
 
@@ -258,11 +252,9 @@ public abstract class PropertyListFormat
 			byte[] ReadBigEndianBytes(int count)
 			{
 				var bytes = new byte[count];
-#if NET7_0_OR_GREATER
-				_stream.ReadExactly(bytes, 0, count);
-#else
+
 				_stream.Read(bytes, 0, count);
-#endif
+
 				if (BitConverter.IsLittleEndian)
 				{
 					Array.Reverse(bytes);

--- a/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
+++ b/src/Uno.Sdk/Sdk/Sdk.props.buildschema.json
@@ -380,6 +380,12 @@
 		},
 		"UnoImage": {
 			"description": "Provides an asset typically an SVG or PNG that will be resized for use across each target platform."
+		},
+		"SkiaInfoPlist": {
+			"description": "Provides an Info.plist file for Skia Desktop projects."
+		},
+		"SkiaEntitlementsPlist": {
+			"description": "Provides an Entitlements.plist file for Skia Desktop projects."
 		}
 	},
 	"types": {

--- a/src/Uno.Sdk/Services/AppxManifestReader.cs
+++ b/src/Uno.Sdk/Services/AppxManifestReader.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+using Uno.Sdk.Tasks;
+
+namespace Uno.Sdk.Services;
+internal class AppxManifestReader
+{
+	public AppxManifestReader(string path, ISdkTask task)
+	{
+		if (!File.Exists(path))
+		{
+			task.LogError($"The file '{path}' was not found.");
+			Name = string.Empty;
+			Version = string.Empty;
+			DisplayName = string.Empty;
+			PublisherDisplayName = string.Empty;
+			Logo = string.Empty;
+			return;
+		}
+
+		var appx = XDocument.Load(path);
+		var xmlns = appx.Root!.GetDefaultNamespace();
+
+		var xidentity = xmlns + "Identity";
+		var identity = appx.Root.Element(xidentity);
+
+		if (identity is null)
+		{
+			task.LogError("The Identity node was not found in the Package.appxmanifest.");
+			Name = string.Empty;
+			Version = string.Empty;
+			DisplayName = string.Empty;
+			PublisherDisplayName = string.Empty;
+			Logo = string.Empty;
+			return;
+		}
+
+		Name = identity.Attribute("Name")?.Value ?? string.Empty;
+		Version = identity.Attribute("Version")?.Value ?? string.Empty;
+
+		var xproperties = xmlns + "Properties";
+		var properties = appx.Root.Element(xproperties);
+
+		if (properties is null)
+		{
+			task.LogError("The Properties node could not be found in the Package.appxmanifest.");
+			DisplayName = string.Empty;
+			PublisherDisplayName = string.Empty;
+			Logo = string.Empty;
+			return;
+		}
+
+		var xdisplayname = xmlns + "DisplayName";
+		var displayName = properties.Element(xdisplayname);
+		DisplayName = displayName.Value;
+
+		var xpublisherDisplayName = xmlns + "PublisherDisplayName";
+		var publisherDisplayName = properties.Element(xpublisherDisplayName);
+		PublisherDisplayName = publisherDisplayName.Value;
+
+		var xLogo = xmlns + "Logo";
+		var logo = properties.Element(xLogo);
+		Logo = logo.Value;
+	}
+
+	public string Name { get; }
+
+	public string DisplayName { get; }
+
+	public string PublisherDisplayName { get; }
+
+	public string Version { get; }
+
+	public string Logo { get; }
+
+	public bool Loaded => !string.IsNullOrEmpty(Name) && !string.IsNullOrEmpty(DisplayName) &&
+			!string.IsNullOrEmpty(PublisherDisplayName) && !string.IsNullOrEmpty(Version) &&
+			!string.IsNullOrEmpty(Logo);
+}

--- a/src/Uno.Sdk/Tasks/GenerateSkiaDesktopMacOSBundle.cs
+++ b/src/Uno.Sdk/Tasks/GenerateSkiaDesktopMacOSBundle.cs
@@ -133,7 +133,14 @@ public class GenerateSkiaDesktopMacOSBundle_v0 : SdkTask
 				continue;
 			}
 
-			source[kvp.Key!] = kvp.Value;
+			if (kvp.Value is PObject pObject)
+			{
+				source[kvp.Key!] = pObject.Clone();
+			}
+			else
+			{
+				source[kvp.Key!] = kvp.Value;
+			}
 		}
 	}
 }

--- a/src/Uno.Sdk/Tasks/GenerateSkiaDesktopMacOSBundle.cs
+++ b/src/Uno.Sdk/Tasks/GenerateSkiaDesktopMacOSBundle.cs
@@ -1,0 +1,123 @@
+﻿using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Uno.Sdk.MacDev;
+using Uno.Sdk.Services;
+
+namespace Uno.Sdk.Tasks;
+public class GenerateSkiaDesktopMacOSBundle_v0 : SdkTask
+{
+	[Required]
+	public string AssemblyName { get; set; } = null!;
+
+	[Required]
+	public string BundledDotNetVersion { get; set; } = null!;
+
+	[Required]
+	public string UnoVersion { get; set; } = null!;
+	public string TargetCulture { get; set; } = null!;
+	public string ApplicationDisplayVersion { get; set; } = null!;
+	public string ApplicationVersion { get; set; } = null!;
+
+	[Required]
+	public string AppBundleDirectory { get; set; } = null!;
+
+	public ITaskItem[] PartialPlists { get; set; } = [];
+
+	public ITaskItem[] EntitlementPlists { get; set; } = [];
+
+	public ITaskItem[] AppIconSets { get; set; } = [];
+
+	[Required]
+	public ITaskItem[] EmbeddedResources { get; set; } = [];
+
+	protected override void ExecuteInternal()
+	{
+		var infoPlistPathInfo = new FileInfo(Path.Combine(AppBundleDirectory, "Info.plist"));
+
+		GetMergePlist(PartialPlists, CreateInfoPlist()).Save(infoPlistPathInfo.FullName);
+		var entitlements = GetMergePlist(EntitlementPlists);
+		if (entitlements.Any())
+		{
+			var entitlementsPlistPathInfo = new FileInfo(Path.Combine(AppBundleDirectory, "Extras", "Entitlements.plist"));
+			entitlementsPlistPathInfo.Directory.Create();
+			entitlements.Save(entitlementsPlistPathInfo.FullName);
+		}
+	}
+
+	private PDictionary CreateInfoPlist()
+	{
+		var packageAppxManifestItem = EmbeddedResources.Single(x => x.HasMetadata("LogicalName") && x.GetMetadata("LogicalName") == "Package.appxmanifest");
+		if (packageAppxManifestItem is null || !File.Exists(packageAppxManifestItem.ItemSpec))
+		{
+			throw new FileNotFoundException("Could not locate the Package.appxmanifest.");
+		}
+		var appxManifest = new AppxManifestReader(packageAppxManifestItem.ItemSpec, this);
+
+		var appIconSetItem = AppIconSets.SingleOrDefault() ?? throw new FileNotFoundException("Could not locate appiconst.");
+		var iconAppSet = new DirectoryInfo(appIconSetItem.ItemSpec);
+
+		return new PDictionary
+		{
+			{ "UnoVersion", UnoVersion },
+			{ "BundledNETCorePlatformsPackageVersion", BundledDotNetVersion },
+			{ "CFBundleDisplayName", appxManifest.DisplayName },
+			{ "CFBundleName", appxManifest.DisplayName },
+			{ "CFBundleExecutable", $"{AssemblyName}.exe" },
+			{ "CFBundleGetInfoString", appxManifest.Version },
+			{ "CFBundleLongVersionString", appxManifest.Version },
+			{ "CFBundleInfoDictionaryVersion", ApplicationDisplayVersion },
+			{ "CFBundleVersion", ApplicationDisplayVersion },
+			{ "CFBundleShortVersionString", ApplicationVersion },
+			{ "CFBundleIdentifier", appxManifest.Name },
+			{ "CFBundlePackageType", "APPL" },
+			{ "CFBundleSignature", "????" },
+			{ "CFBundleSupportedPlatforms", new PArray { "MacOSX" } },
+			{ "NSPrincipalClass", "NSApplication" },
+			{ "CFBundleDevelopmentRegion", TargetCulture },
+			{ "CFBundleIconFile", Path.GetFileNameWithoutExtension(iconAppSet.Name) }
+		};
+	}
+
+	public static PDictionary GetMergePlist(ITaskItem[] items, PDictionary? initialDictionary = null)
+	{
+		var defaultPlistPath = items.SingleOrDefault(x => x.HasMetadata("IsDefaultItem") && bool.TryParse(x.GetMetadata("IsDefaultItem"), out var isDefault) && isDefault);
+		var plist = initialDictionary?.Clone() as PDictionary ?? [];
+
+		if(!string.IsNullOrEmpty(defaultPlistPath?.ItemSpec))
+		{
+			Merge(plist, PDictionary.FromFile(defaultPlistPath!.ItemSpec)!);
+		}
+
+		foreach (var item in items)
+		{
+			if (item == defaultPlistPath)
+			{
+				continue;
+			}
+
+			var partial = PDictionary.FromFile(item.ItemSpec);
+			Merge(plist, partial);
+		}
+
+		return plist;
+	}
+
+	private static void Merge(PDictionary source, PDictionary? newSource)
+	{
+		if (newSource is null || newSource.Count == 0)
+		{
+			return;
+		}
+
+		foreach (var kvp in newSource)
+		{
+			if (string.IsNullOrEmpty(kvp.Key))
+			{
+				continue;
+			}
+
+			source[kvp.Key!] = kvp.Value;
+		}
+	}
+}

--- a/src/Uno.Sdk/Tasks/GenerateSkiaDesktopMacOSBundle.cs
+++ b/src/Uno.Sdk/Tasks/GenerateSkiaDesktopMacOSBundle.cs
@@ -62,11 +62,14 @@ public class GenerateSkiaDesktopMacOSBundle_v0 : SdkTask
 		var appxManifest = new AppxManifestReader(packageAppxManifestItem.ItemSpec, this);
 
 		var appIconSetItem = AppIconSets.SingleOrDefault(x => Path.GetFileName(x.ItemSpec) == "Contents.json") ?? throw new FileNotFoundException("Could not locate appiconst.");
-		var iconAppSet = new DirectoryInfo(appIconSetItem.ItemSpec);
+		var iconAppSet = new FileInfo(appIconSetItem.ItemSpec).Directory;
+		var resourcesDirectory = new DirectoryInfo(Path.Combine(AppBundleDirectory, "Resources", iconAppSet.Name));
+		LogMessage("Creating Directory -> {0}", resourcesDirectory.FullName);
+		resourcesDirectory.Create();
 
 		foreach (var fi in iconAppSet.EnumerateFiles())
 		{
-			fi.CopyTo(Path.Combine(AppBundleDirectory, "Resources", iconAppSet.Name, fi.Name), true);
+			fi.CopyTo(Path.Combine(resourcesDirectory.FullName, fi.Name), true);
 			LogMessage($"Copying Icon: {fi.Name}");
 		}
 

--- a/src/Uno.Sdk/Tasks/GenerateSkiaDesktopMacOSBundle.cs
+++ b/src/Uno.Sdk/Tasks/GenerateSkiaDesktopMacOSBundle.cs
@@ -84,7 +84,7 @@ public class GenerateSkiaDesktopMacOSBundle_v0 : SdkTask
 		var defaultPlistPath = items.SingleOrDefault(x => x.HasMetadata("IsDefaultItem") && bool.TryParse(x.GetMetadata("IsDefaultItem"), out var isDefault) && isDefault);
 		var plist = initialDictionary?.Clone() as PDictionary ?? [];
 
-		if(!string.IsNullOrEmpty(defaultPlistPath?.ItemSpec))
+		if (!string.IsNullOrEmpty(defaultPlistPath?.ItemSpec))
 		{
 			Merge(plist, PDictionary.FromFile(defaultPlistPath!.ItemSpec)!);
 		}

--- a/src/Uno.Sdk/Tasks/ISdkTask.cs
+++ b/src/Uno.Sdk/Tasks/ISdkTask.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Uno.Sdk.Tasks;
+
+internal interface ISdkTask
+{
+	void LogMessage(string message, params object[] arguments);
+
+	void LogError(Exception exception);
+
+	void LogError(string message, params object[] arguments);
+}

--- a/src/Uno.Sdk/Tasks/SdkTask.cs
+++ b/src/Uno.Sdk/Tasks/SdkTask.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Uno.Sdk.Tasks;
+
+public abstract class SdkTask : Task, ISdkTask
+{
+	public bool SdkDebugging { get; set; }
+
+	public sealed override bool Execute()
+	{
+		try
+		{
+			ExecuteInternal();
+		}
+		catch (Exception ex)
+		{
+			Log.LogErrorFromException(ex);
+
+			if (SdkDebugging)
+			{
+				Log.LogMessage(MessageImportance.High, ex.ToString());
+			}
+		}
+
+		return !Log.HasLoggedErrors;
+	}
+
+	protected abstract void ExecuteInternal();
+
+	private MessageImportance DefaultImportance => SdkDebugging ? MessageImportance.High : MessageImportance.Normal;
+
+	public void LogMessage(string message, params object[] arguments)
+	{
+		if (string.IsNullOrEmpty(message))
+		{
+			message = string.Empty;
+		}
+
+		Log.LogMessage(DefaultImportantance, message, arguments);
+	}
+
+	public void LogError(Exception exception)
+	{
+		Log.LogError(exception.Message);
+
+		if (SdkDebugging)
+		{
+			Log.LogError(exception.ToString());
+		}
+	}
+
+	public void LogError(string message, params object[] arguments)
+	{
+		if (string.IsNullOrEmpty(message))
+		{
+			return;
+		}
+
+		Log.LogError(message, arguments);
+	}
+}

--- a/src/Uno.Sdk/Tasks/SdkTask.cs
+++ b/src/Uno.Sdk/Tasks/SdkTask.cs
@@ -38,7 +38,7 @@ public abstract class SdkTask : Task, ISdkTask
 			message = string.Empty;
 		}
 
-		Log.LogMessage(DefaultImportantance, message, arguments);
+		Log.LogMessage(DefaultImportance, message, arguments);
 	}
 
 	public void LogError(Exception exception)

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -44,7 +44,7 @@
 	},
 	{
 		"group": "CoreLogging",
-		"version": "4.0.1",
+		"version": "4.1.1",
 		"packages": [
 			"Uno.Core.Extensions.Logging.Singleton"
 		]
@@ -58,14 +58,14 @@
 	},
 	{
 		"group": "Dsp",
-		"version": "1.3.2",
+		"version": "1.4.0-dev.12",
 		"packages": [
 			"Uno.Dsp.Tasks"
 		]
 	},
 	{
 		"group": "Resizetizer",
-		"version": "1.5.0-dev.87",
+		"version": "1.6.0-dev.18",
 		"packages": [
 			"Uno.Resizetizer"
 		]
@@ -91,7 +91,7 @@
 	},
 	{
 		"group": "WinAppSdk",
-		"version": "1.5.240428000",
+		"version": "1.5.240627000",
 		"packages": [
 			"Microsoft.WindowsAppSDK"
 		]
@@ -110,17 +110,17 @@
 			"Microsoft.Extensions.Logging.Console"
 		],
 		"versionOverride": {
-			"net9.0": "9.0.0-preview.4.24266.19"
+			"net9.0": "9.0.0-preview.6.24327.7"
 		}
 	},
 	{
 		"group": "WindowsCompatibility",
-		"version": "8.0.6",
+		"version": "8.0.7",
 		"packages": [
 			"Microsoft.Windows.Compatibility"
 		],
 		"versionOverride": {
-			"net9.0": "9.0.0-preview.4.24267.11"
+			"net9.0": "9.0.0-preview.6.24327.6"
 		}
 	},
 	{
@@ -149,7 +149,7 @@
 	},
 	{
 		"group": "UnoFonts",
-		"version": "2.4.0",
+		"version": "2.4.0-dev.16",
 		"packages": [
 			"Uno.Fonts.OpenSans",
 			"Uno.Fonts.Fluent",
@@ -225,14 +225,14 @@
 	},
 	{
 		"group": "Maui",
-		"version": "8.0.40",
+		"version": "8.0.70",
 		"packages": [
 			"Microsoft.Maui.Controls",
 			"Microsoft.Maui.Controls.Compatibility",
 			"Microsoft.Maui.Graphics"
 		],
 		"versionOverride": {
-			"net9.0": "9.0.0-preview.4.10690"
+			"net9.0": "9.0.0-preview.6.24327.7"
 		}
 	},
 	{

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.Linux.Publish.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.Linux.Publish.targets
@@ -1,0 +1,3 @@
+<Project>
+
+</Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
@@ -25,7 +25,7 @@
 	<Target Name="GenerateMacOSAppBundle"
 			AfterTargets="Publish">
 		<PropertyGroup>
-			<TargetCulture Condition="$(TargetCulture) == ''">en</TargetCulture>
+			<TargetCulture Condition="$(TargetCulture) == '' OR $(TargetCulture) == '*'">en</TargetCulture>
 			<PackageFormat Condition="$(PackageFormat) == ''">app</PackageFormat>
 		</PropertyGroup>
 		
@@ -36,7 +36,8 @@
 			<PublishExclude Include="$(PublishDir)/**/runtimes/unix*/**" />
 			<PublishExclude Include="$(PublishDir)/**/*.ico" />
 			<_UnoPublishedFiles Include="$(PublishDir)/**" Exclude="@(PublishExclude)" PublishDir="$(_UnoAppBundleTempMacOSDir)%(RecursiveDir)%(Filename)%(Extension)"/>
-			<_PublishedIcon Include="$(_UnoIntermediateImages)Assets.xcassets/*.appiconset/**" />
+			<_PublishedIcon Include="$(_UnoIntermediateImages)Assets.xcassets/*.appiconset/Contents.json" />
+			<_PackageAppxManifest Include="@(EmbeddedResource)" Condition="'%(Filename)%(Extension)' == 'Package.appxmanifest'" />
 		</ItemGroup>
 
 		<Copy SourceFiles="@(_UnoPublishedFiles)"
@@ -51,9 +52,23 @@
 			TargetCulture="$(TargetCulture)"
 			ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
 			ApplicationVersion="$(ApplicationVersion)"
-			AppBundleDirectory="@(_UnoAppBundleTempMacOSDir)"
+			AppBundleDirectory="$(UnoAppBundleTempDir)"
 			PartialPlists="@(SkiaInfoPlist)"
 			EntitlementPlists="@(SkiaEntitlementsPlist)"
-			AppIconSets="@(_PublishedIcon)" />
+			AppIconSets="@(_PublishedIcon)"
+			EmbeddedResources="@(_PackageAppxManifest)" />
+	</Target>
+
+	<Target Name="PublishMacOSAppBundle"
+			AfterTargets="GenerateMacOSAppBundle">
+		<ItemGroup>
+			<_UnoAppBundleFiles Include="$(_UnoPublishDir)$(ApplicationTitle).app/**" />
+		</ItemGroup>
+
+		<Copy SourceFiles="@(_UnoAppBundleFiles)"
+			DestinationFiles="@(_UnoAppBundleFiles->'$(UnoAppPackagePublishDir)$(ApplicationTitle).app/%(RecursiveDir)%(Filename)%(Extension)')"
+			SkipUnchangedFiles="true" />
+
+		<Message Text="$(AssemblyName) -&gt; $(_UnoPublishDir)$(ApplicationTitle).app" Importance="High" />
 	</Target>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
@@ -25,7 +25,7 @@
 	<Target Name="GenerateMacOSAppBundle"
 			AfterTargets="Publish">
 		<PropertyGroup>
-			<TargetCulture Condition="$(TargetCulture) == '' OR $(TargetCulture) == '*'">en</TargetCulture>
+			<TargetCulture Condition="$(TargetCulture) == '' OR $(TargetCulture) == '*'">en-US</TargetCulture>
 			<PackageFormat Condition="$(PackageFormat) == ''">app</PackageFormat>
 		</PropertyGroup>
 		
@@ -52,7 +52,7 @@
 			TargetCulture="$(TargetCulture)"
 			ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
 			ApplicationVersion="$(ApplicationVersion)"
-			AppBundleDirectory="$(UnoAppBundleTempDir)"
+			AppBundleDirectory="$(_UnoAppBundleTempDir)"
 			PartialPlists="@(SkiaInfoPlist)"
 			EntitlementPlists="@(SkiaEntitlementsPlist)"
 			AppIconSets="@(_PublishedIcon)"

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
@@ -62,9 +62,9 @@
 		</ItemGroup>
 
 		<Copy SourceFiles="@(_UnoAppBundleFiles)"
-			DestinationFiles="@(_UnoAppBundleFiles->'$(UnoAppPackagePublishDir)$(ApplicationTitle).app/%(RecursiveDir)%(Filename)%(Extension)')"
+			DestinationFiles="@(_UnoAppBundleFiles->'$(_UnoAppPackagePublishDir)$(ApplicationTitle).app/%(RecursiveDir)%(Filename)%(Extension)')"
 			SkipUnchangedFiles="true" />
 
-		<Message Text="$(AssemblyName) -&gt; $(_UnoPublishDir)$(ApplicationTitle).app" Importance="High" />
+		<Message Text="$(AssemblyName) -&gt; $(_UnoAppPackagePublishDir)$(ApplicationTitle).app" Importance="High" />
 	</Target>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
@@ -30,10 +30,6 @@
 		</PropertyGroup>
 		
 		<ItemGroup>
-			<!-- This shouldn't happen but we want to prevent non-MacOS runtimes from being included. -->
-			<PublishExclude Include="$(PublishDir)/**/runtimes/win*/**" />
-			<PublishExclude Include="$(PublishDir)/**/runtimes/linux*/**" />
-			<PublishExclude Include="$(PublishDir)/**/runtimes/unix*/**" />
 			<PublishExclude Include="$(PublishDir)/**/*.ico" />
 			<_UnoPublishedFiles Include="$(PublishDir)/**" Exclude="@(PublishExclude)" PublishDir="$(_UnoAppBundleTempMacOSDir)%(RecursiveDir)%(Filename)%(Extension)"/>
 			<_PublishedIcon Include="$(_UnoIntermediateImages)Assets.xcassets/*.appiconset/Contents.json" />

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
@@ -7,18 +7,18 @@
 	</PropertyGroup>
 
 	<Target Name="RedirectPublishDir"
-          BeforeTargets="PrepareForPublish">
+			BeforeTargets="PrepareForPublish">
 		<PropertyGroup>
-		  <UnoAppPackagePublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(PublishDir)))))</UnoAppPackagePublishDir>
-		  <_UnoPublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(IntermediateOutputPath), 'unopublish'))))</_UnoPublishDir>
-		  <PublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(_UnoPublishDir), 'raw'))))</PublishDir>
-		  <UnoAppBundleTempDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(_UnoPublishDir)', '$(ApplicationTitle).app'))))</UnoAppBundleTempDir>
-		  <UnoAppBundleTempContentsDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(UnoAppBundleTempDir), 'Contents'))))</UnoAppBundleTempContentsDir>
-		  <UnoAppBundleTempMacOSDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(UnoAppBundleTempContentsDir), 'MacOS'))))</UnoAppBundleTempMacOSDir>
-		  <UnoAppBundleTempResourcesDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(UnoAppBundleTempContentsDir), 'Resources'))))</UnoAppBundleTempResourcesDir>
+			<_UnoAppPackagePublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(PublishDir)))))</_UnoAppPackagePublishDir>
+			<_UnoPublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(IntermediateOutputPath), 'unopublish'))))</_UnoPublishDir>
+			<PublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(_UnoPublishDir), 'raw'))))</PublishDir>
+			<_UnoAppBundleTempDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(_UnoPublishDir)', '$(ApplicationTitle).app'))))</_UnoAppBundleTempDir>
+			<_UnoAppBundleTempContentsDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(_UnoAppBundleTempDir), 'Contents'))))</_UnoAppBundleTempContentsDir>
+			<_UnoAppBundleTempMacOSDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(_UnoAppBundleTempContentsDir), 'MacOS'))))</_UnoAppBundleTempMacOSDir>
+			<_UnoAppBundleTempResourcesDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(_UnoAppBundleTempContentsDir), 'Resources'))))</_UnoAppBundleTempResourcesDir>
 		</PropertyGroup>
 
-		<RemoveDir Directories="$(UnoAppPackagePublishDir)" />
+		<RemoveDir Directories="$(_UnoAppPackagePublishDir)" />
 		<RemoveDir Directories="$(_UnoPublishDir)" />
 	</Target>
 
@@ -35,25 +35,25 @@
 			<PublishExclude Include="$(PublishDir)/**/runtimes/linux*/**" />
 			<PublishExclude Include="$(PublishDir)/**/runtimes/unix*/**" />
 			<PublishExclude Include="$(PublishDir)/**/*.ico" />
-			<_UnoPublishedFiles Include="$(PublishDir)/**" Exclude="@(PublishExclude)" PublishDir="$(UnoAppBundleTempMacOSDir)%(RecursiveDir)%(Filename)%(Extension)"/>
+			<_UnoPublishedFiles Include="$(PublishDir)/**" Exclude="@(PublishExclude)" PublishDir="$(_UnoAppBundleTempMacOSDir)%(RecursiveDir)%(Filename)%(Extension)"/>
 			<_PublishedIcon Include="$(_UnoIntermediateImages)Assets.xcassets/*.appiconset/**" />
 		</ItemGroup>
 
 		<Copy SourceFiles="@(_UnoPublishedFiles)"
-			DestinationFiles="@(_UnoPublishedFiles->'$(UnoAppBundleTempMacOSDir)%(RecursiveDir)%(Filename)%(Extension)')"
+			DestinationFiles="@(_UnoPublishedFiles->'$(_UnoAppBundleTempMacOSDir)%(RecursiveDir)%(Filename)%(Extension)')"
 			SkipUnchangedFiles="true" />
 
-		<GenerateSkiaDesktopMacOSBundle_v0 
-				AssemblyName="$(AssemblyName)"
-				SdkDebugging="$(UnoSdkDebugging)"
-				BundledDotNetVersion="$(BundledNETCorePlatformsPackageVersion)"
-				UnoVersion="$(UnoVersion)"
-				TargetCulture="$(TargetCulture)"
-				ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
-				ApplicationVersion="$(ApplicationVersion)"
-				AppBundleDirectory="@(UnoAppBundleTempMacOSDir)"
-				PartialPlists="@(SkiaInfoPlist)"
-				EntitlementPlists="@(SkiaEntitlementsPlist)"
-				AppIconSets="@(_PublishedIcon)" />
+		<GenerateSkiaDesktopMacOSBundle_v0
+			AssemblyName="$(AssemblyName)"
+			SdkDebugging="$(UnoSdkDebugging)"
+			BundledDotNetVersion="$(BundledNETCorePlatformsPackageVersion)"
+			UnoVersion="$(UnoVersion)"
+			TargetCulture="$(TargetCulture)"
+			ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
+			ApplicationVersion="$(ApplicationVersion)"
+			AppBundleDirectory="@(_UnoAppBundleTempMacOSDir)"
+			PartialPlists="@(SkiaInfoPlist)"
+			EntitlementPlists="@(SkiaEntitlementsPlist)"
+			AppIconSets="@(_PublishedIcon)" />
 	</Target>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.MacOS.Publish.targets
@@ -1,0 +1,59 @@
+<Project>
+	<UsingTask TaskName="Uno.Sdk.Tasks.GenerateSkiaDesktopMacOSBundle_v0"
+		AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0\Uno.Sdk_v0.dll" />
+
+	<PropertyGroup Condition="$(_IsPublishing) == 'true'">
+		<SelfContained>true</SelfContained>
+	</PropertyGroup>
+
+	<Target Name="RedirectPublishDir"
+          BeforeTargets="PrepareForPublish">
+		<PropertyGroup>
+		  <UnoAppPackagePublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(PublishDir)))))</UnoAppPackagePublishDir>
+		  <_UnoPublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(IntermediateOutputPath), 'unopublish'))))</_UnoPublishDir>
+		  <PublishDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(_UnoPublishDir), 'raw'))))</PublishDir>
+		  <UnoAppBundleTempDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(_UnoPublishDir)', '$(ApplicationTitle).app'))))</UnoAppBundleTempDir>
+		  <UnoAppBundleTempContentsDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(UnoAppBundleTempDir), 'Contents'))))</UnoAppBundleTempContentsDir>
+		  <UnoAppBundleTempMacOSDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(UnoAppBundleTempContentsDir), 'MacOS'))))</UnoAppBundleTempMacOSDir>
+		  <UnoAppBundleTempResourcesDir>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath($(UnoAppBundleTempContentsDir), 'Resources'))))</UnoAppBundleTempResourcesDir>
+		</PropertyGroup>
+
+		<RemoveDir Directories="$(UnoAppPackagePublishDir)" />
+		<RemoveDir Directories="$(_UnoPublishDir)" />
+	</Target>
+
+	<Target Name="GenerateMacOSAppBundle"
+			AfterTargets="Publish">
+		<PropertyGroup>
+			<TargetCulture Condition="$(TargetCulture) == ''">en</TargetCulture>
+			<PackageFormat Condition="$(PackageFormat) == ''">app</PackageFormat>
+		</PropertyGroup>
+		
+		<ItemGroup>
+			<!-- This shouldn't happen but we want to prevent non-MacOS runtimes from being included. -->
+			<PublishExclude Include="$(PublishDir)/**/runtimes/win*/**" />
+			<PublishExclude Include="$(PublishDir)/**/runtimes/linux*/**" />
+			<PublishExclude Include="$(PublishDir)/**/runtimes/unix*/**" />
+			<PublishExclude Include="$(PublishDir)/**/*.ico" />
+			<_UnoPublishedFiles Include="$(PublishDir)/**" Exclude="@(PublishExclude)" PublishDir="$(UnoAppBundleTempMacOSDir)%(RecursiveDir)%(Filename)%(Extension)"/>
+			<_PublishedIcon Include="$(_UnoIntermediateImages)Assets.xcassets/*.appiconset/**" />
+		</ItemGroup>
+
+		<Copy SourceFiles="@(_UnoPublishedFiles)"
+			DestinationFiles="@(_UnoPublishedFiles->'$(UnoAppBundleTempMacOSDir)%(RecursiveDir)%(Filename)%(Extension)')"
+			SkipUnchangedFiles="true" />
+
+		<GenerateSkiaDesktopMacOSBundle_v0 
+				AssemblyName="$(AssemblyName)"
+				SdkDebugging="$(UnoSdkDebugging)"
+				BundledDotNetVersion="$(BundledNETCorePlatformsPackageVersion)"
+				UnoVersion="$(UnoVersion)"
+				TargetCulture="$(TargetCulture)"
+				ApplicationDisplayVersion="$(ApplicationDisplayVersion)"
+				ApplicationVersion="$(ApplicationVersion)"
+				AppBundleDirectory="@(UnoAppBundleTempMacOSDir)"
+				PartialPlists="@(SkiaInfoPlist)"
+				EntitlementPlists="@(SkiaEntitlementsPlist)"
+				AppIconSets="@(_PublishedIcon)" />
+	</Target>
+</Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.Windows.Publish.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.Windows.Publish.targets
@@ -1,0 +1,3 @@
+<Project>
+
+</Project>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -50,6 +50,8 @@
 			Condition="$(NETCoreSdkRuntimeIdentifier.Contains('linux')) AND '$(IsUnoHead)' == 'true'" />
 	<Import Project="Uno.SingleProject.Desktop.MacOS.Publish.targets"
 			Condition="$(NETCoreSdkRuntimeIdentifier.Contains('osx')) AND '$(IsUnoHead)' == 'true'" />
+	<Import Project="Uno.SingleProject.Desktop.Windows.Publish.targets"
+			Condition="$(NETCoreSdkRuntimeIdentifier.Contains('win')) AND '$(IsUnoHead)' == 'true'" />
 
 	<Target Name="_UnoRemoveTransitiveWPFDependency"
 			BeforeTargets="_CheckForTransitiveWindowsDesktopDependencies"

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<SkiaInfoPlist Include="$(_DefaultInfoPlist)" Condition="$(_DefaultInfoPlist) == ''" IsDefaultItem="true" />
+		<SkiaInfoPlist Include="$(_DefaultInfoPlist)" Condition="$(_DefaultInfoPlist) != ''" IsDefaultItem="true" />
 		<SkiaEntitlementsPlist Include="$(_DefaultEntitlementsPlist)" Condition="$(_DefaultEntitlementsPlist) != ''" IsDefaultItem="true" />
 	</ItemGroup>
 

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -2,6 +2,8 @@
 	<PropertyGroup>
 		<ApplicationManifest Condition="$(ApplicationManifest) == '' AND Exists('$(DesktopProjectFolder)app.manifest')">$(DesktopProjectFolder)app.manifest</ApplicationManifest>
 		<ApplicationManifest Condition="$(ApplicationManifest) == '' AND Exists('app.manifest')">app.manifest</ApplicationManifest>
+		<_DefaultInfoPlist Condition="Exists('$(DesktopProjectFolder)Info.plist')">$(DesktopProjectFolder)Info.plist</_DefaultInfoPlist>
+		<_DefaultEntitlementsPlist Condition="Exist('$(DesktopProjectFolder)Entitlements.plist')">$(DesktopProjectFolder)Entitlements.plist</_DefaultEntitlementsPlist>
 
 		<!-- Follow the Android, iOS, & MacCatalyst SDK's -->
 		<!-- Default to 1, if blank -->
@@ -13,6 +15,11 @@
 	<PropertyGroup Condition=" '$(IsUnoHead)' == 'true' AND $(Optimize) == 'true' ">
 		<OutputType>WinExe</OutputType>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<SkiaInfoPlist Include="$(_DefaultInfoPlist)" Condition="$(_DefaultInfoPlist) == ''" IsDefaultItem="true" />
+		<SkiaEntitlementsPlist Include="$(_DefaultEntitlementsPlist)" Condition="$(_DefaultEntitlementsPlist) != ''" IsDefaultItem="true" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<EmbeddedResource Include="$(DesktopProjectFolder)Package.appxmanifest"
@@ -38,6 +45,11 @@
 		<EmbeddedResource Remove="@(_IgnorePlatformFiles)" />
 		<Manifest Remove="@(_IgnorePlatformFiles)" />
 	</ItemGroup>
+
+	<Import Project="Uno.SingleProject.Desktop.Linux.Publish.targets"
+			Condition="$(NETCoreSdkRuntimeIdentifier.Contains('linux')) AND '$(IsUnoHead)' == 'true'" />
+	<Import Project="Uno.SingleProject.Desktop.MacOS.Publish.targets"
+			Condition="$(NETCoreSdkRuntimeIdentifier.Contains('osx')) AND '$(IsUnoHead)' == 'true'" />
 
 	<Target Name="_UnoRemoveTransitiveWPFDependency"
 			BeforeTargets="_CheckForTransitiveWindowsDesktopDependencies"

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -3,7 +3,7 @@
 		<ApplicationManifest Condition="$(ApplicationManifest) == '' AND Exists('$(DesktopProjectFolder)app.manifest')">$(DesktopProjectFolder)app.manifest</ApplicationManifest>
 		<ApplicationManifest Condition="$(ApplicationManifest) == '' AND Exists('app.manifest')">app.manifest</ApplicationManifest>
 		<_DefaultInfoPlist Condition="Exists('$(DesktopProjectFolder)Info.plist')">$(DesktopProjectFolder)Info.plist</_DefaultInfoPlist>
-		<_DefaultEntitlementsPlist Condition="Exist('$(DesktopProjectFolder)Entitlements.plist')">$(DesktopProjectFolder)Entitlements.plist</_DefaultEntitlementsPlist>
+		<_DefaultEntitlementsPlist Condition="Exists('$(DesktopProjectFolder)Entitlements.plist')">$(DesktopProjectFolder)Entitlements.plist</_DefaultEntitlementsPlist>
 
 		<!-- Follow the Android, iOS, & MacCatalyst SDK's -->
 		<!-- Default to 1, if blank -->


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #17427

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`dotnet publish -f net8.0-desktop` generates normal .NET application

## What is the new behavior?

`dotnet publish -f net8.0-desktop` will now generate a MacOS `.app` bundle when compiled on MacOS.