### PR TITLE
fix: Use XAML reader hot reload for android

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -84,10 +84,10 @@ namespace Uno.UI.RemoteControl.HotReload
 
 				if (assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>() is AssemblyInformationalVersionAttribute aiva)
 				{
-#if __IOS__ || __CATALYST__
+#if __IOS__ || __CATALYST__ || __ANDROID__
 					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
-						this.Log().Trace($"iOS/Catalyst do not support C# based XAML hot reload: https://github.com/unoplatform/uno/issues/15918");
+						this.Log().Trace($"iOS/Catalyst/Android do not support C# based XAML hot reload: https://github.com/unoplatform/uno/issues/15918");
 					}
 
 					_isIssue93860Fixed = false;


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/15918, closes https://github.com/unoplatform/uno-private/issues/525

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restore XAML hot reload for android until lambda adjustments can be used.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
