### PR TITLE
fix: Fix support of ISelectionInfo in ListViewBase

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Private.Infrastructure;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.Foundation;
+using Windows.UI.Input.Preview.Injection;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
+
+namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
+{
+	[TestClass]
+	public class Given_ListView
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+#if !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is only supported on Skia #14948")]
+#endif
+		public async Task When_ItemClicked_SelectsCorrectIndex()
+		{
+			var loggingSelectionInfo = new LoggingSelectionInfo();
+			var listViewBase = new ListViewBase
+			{
+				ItemsSource = loggingSelectionInfo
+			};
+
+			TestServices.WindowHelper.WindowContent = listViewBase;
+			await TestServices.WindowHelper.WaitForLoaded(listViewBase);
+
+			// We don't use ActualWidth because of https://github.com/unoplatform/uno/issues/15982
+			var tapTarget = listViewBase.TransformToVisual(null).TransformPoint(new Point(112 * 0.9, listViewBase.ActualHeight / 2));
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(tapTarget);
+			finger.Release();
+
+			var selectionInfo = (MockSelectionInfo)listViewBase.ItemsSource;
+			Assert.AreEqual(0, selectionInfo.SelectedIndex);
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -37,9 +37,12 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			finger.Press(tapTarget);
 			finger.Release();
 
-			Assert.AreEqual(loggingSelectionInfo.IsSelected(0), true, "Item 0 should remain unselected.");
-			Assert.AreEqual(loggingSelectionInfo.CurrentPosition, 0, "CurrentPosition should be 0 after the tap.");
-			Assert.AreEqual(loggingSelectionInfo.CurrentItem, items[0], "CurrentItem should be 'Item 1' after the tap.");
+			// Confirm that selection has been pushed to the source using the ISelectionInfo
+			Assert.AreEqual(loggingSelectionInfo.IsSelected(0), true, "Item 0 should be selected now.");
+
+			// Confirm that the selection HAS NOT been pushed using the `ICollectionView`
+			Assert.AreEqual(loggingSelectionInfo.CurrentPosition, -1, "CurrentPosition should not have been updated.");
+			Assert.AreEqual(loggingSelectionInfo.CurrentItem, null, "CurrentItem should be not have been updated.");
 		}
 	}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -30,18 +30,16 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 
 			TestServices.WindowHelper.WindowContent = listViewBase;
 			await TestServices.WindowHelper.WaitForIdle();
-
-			// We don't use ActualWidth because of https://github.com/unoplatform/uno/issues/15982
-			var tapTarget = listViewBase.TransformToVisual(null).TransformPoint(new Point(112 * 0.9, listViewBase.ActualHeight / 2));
+			var tapTarget = listViewBase.TransformToVisual(null).TransformPoint(new Point(listViewBase.ActualWidth / 2, listViewBase.ActualHeight / 6));
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 			using var finger = injector.GetFinger();
 
 			finger.Press(tapTarget);
 			finger.Release();
 
-			Assert.AreEqual(loggingSelectionInfo.IsSelected(0), false, "Items at any index should not be selected by default.");
-			Assert.AreEqual(loggingSelectionInfo.CurrentPosition, -1, "CurrentPosition should not have been updated by the ListView.");
-			Assert.AreEqual(loggingSelectionInfo.CurrentItem, null, "CurrentItem should not have been updated by the ListView.");
+			Assert.AreEqual(loggingSelectionInfo.IsSelected(0), true, "Item 0 should remain unselected.");
+			Assert.AreEqual(loggingSelectionInfo.CurrentPosition, 0, "CurrentPosition should be 0 after the tap.");
+			Assert.AreEqual(loggingSelectionInfo.CurrentItem, items[0], "CurrentItem should be 'Item 1' after the tap.");
 		}
 	}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -7,7 +7,7 @@ using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Input;
+using System.Linq;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 {
@@ -21,10 +21,11 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 #endif
 		public async Task When_ItemClicked_SelectsCorrectIndex()
 		{
+			var items = new object[] { "Item 1", "Item 2", "Item 3" };
 			var loggingSelectionInfo = new LoggingSelectionInfo();
 			var listViewBase = new ListViewBase
 			{
-				ItemsSource = loggingSelectionInfo
+				ItemsSource = items,
 			};
 
 			TestServices.WindowHelper.WindowContent = listViewBase;
@@ -38,8 +39,8 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			finger.Press(tapTarget);
 			finger.Release();
 
-			var selectionInfo = (MockSelectionInfo)listViewBase.ItemsSource;
-			Assert.AreEqual(0, selectionInfo.SelectedIndex);
+			Assert.AreEqual(0, listViewBase.SelectedIndex);
+			Assert.IsTrue(loggingSelectionInfo.MethodLog.All(m => !m.Contains("MoveCurrent", StringComparison.OrdinalIgnoreCase)));
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -39,10 +39,9 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			finger.Press(tapTarget);
 			finger.Release();
 
-			Assert.AreEqual(0, listViewBase.SelectedIndex);
 			Assert.AreEqual(loggingSelectionInfo.IsSelected(0), false, "Items at any index should not be selected by default.");
-			Assert.AreEqual(loggingSelectionInfo.CurrentPosition, 0, "CurrentPosition should be 0 after the tap.");
-			Assert.AreEqual(loggingSelectionInfo.CurrentItem, items[0], "CurrentItem should be 'Item 1' after the tap.");
+			Assert.AreEqual(loggingSelectionInfo.CurrentPosition, -1, "CurrentPosition should not have been updated by the ListView.");
+			Assert.AreEqual(loggingSelectionInfo.CurrentItem, null, "CurrentItem should not have been updated by the ListView.");
 		}
 	}
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -31,6 +31,8 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			TestServices.WindowHelper.WindowContent = listViewBase;
 			await TestServices.WindowHelper.WaitForLoaded(listViewBase);
 
+			loggingSelectionInfo.SafeMoveCurrentToPosition(0);
+
 			// We don't use ActualWidth because of https://github.com/unoplatform/uno/issues/15982
 			var tapTarget = listViewBase.TransformToVisual(null).TransformPoint(new Point(112 * 0.9, listViewBase.ActualHeight / 2));
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -6,7 +6,6 @@ using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using System.Linq;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
@@ -17,21 +16,19 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 		[TestMethod]
 		[RunsOnUIThread]
 #if !HAS_INPUT_INJECTOR
-		[Ignore("InputInjector is only supported on Skia #14948")]
+		[Ignore("InputInjector is not supported on this platform.")]
 #endif
 		public async Task When_ItemClicked_SelectsCorrectIndex()
 		{
 			var items = new object[] { "Item 1", "Item 2", "Item 3" };
-			var loggingSelectionInfo = new LoggingSelectionInfo(items, false, null);
+			var loggingSelectionInfo = new LoggingSelectionInfo(items);
 			var listViewBase = new ListView
 			{
-				ItemsSource = items,
+				ItemsSource = loggingSelectionInfo,
 			};
 
 			TestServices.WindowHelper.WindowContent = listViewBase;
 			await TestServices.WindowHelper.WaitForLoaded(listViewBase);
-
-			loggingSelectionInfo.SafeMoveCurrentToPosition(0);
 
 			// We don't use ActualWidth because of https://github.com/unoplatform/uno/issues/15982
 			var tapTarget = listViewBase.TransformToVisual(null).TransformPoint(new Point(112 * 0.9, listViewBase.ActualHeight / 2));
@@ -42,6 +39,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			finger.Release();
 
 			Assert.AreEqual(0, listViewBase.SelectedIndex);
+			Assert.IsTrue(loggingSelectionInfo.IsSelected(0), "The item at index 0 should be selected.");
 			Assert.IsTrue(loggingSelectionInfo.MethodLog.All(m => !m.Contains("MoveCurrent", StringComparison.OrdinalIgnoreCase)));
 		}
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -28,7 +28,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			};
 
 			TestServices.WindowHelper.WindowContent = listViewBase;
-			await TestServices.WindowHelper.WaitForLoaded(listViewBase);
+			await TestServices.WindowHelper.WaitForIdle();
 
 			// We don't use ActualWidth because of https://github.com/unoplatform/uno/issues/15982
 			var tapTarget = listViewBase.TransformToVisual(null).TransformPoint(new Point(112 * 0.9, listViewBase.ActualHeight / 2));
@@ -39,8 +39,9 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			finger.Release();
 
 			Assert.AreEqual(0, listViewBase.SelectedIndex);
-			Assert.IsTrue(loggingSelectionInfo.IsSelected(0), "The item at index 0 should be selected.");
-			Assert.IsTrue(loggingSelectionInfo.MethodLog.All(m => !m.Contains("MoveCurrent", StringComparison.OrdinalIgnoreCase)));
+			Assert.AreEqual(loggingSelectionInfo.IsSelected(0), false, "Items at any index should not be selected by default.");
+			Assert.AreEqual(loggingSelectionInfo.CurrentPosition, 0, "CurrentPosition should be 0 after the tap.");
+			Assert.AreEqual(loggingSelectionInfo.CurrentItem, items[0], "CurrentItem should be 'Item 1' after the tap.");
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -10,6 +10,7 @@ using System.Linq;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 {
+#if HAS_UNO
 	[TestClass]
 	public class Given_ListView
 	{
@@ -44,4 +45,5 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			Assert.AreEqual(loggingSelectionInfo.CurrentItem, items[0], "CurrentItem should be 'Item 1' after the tap.");
 		}
 	}
+#endif
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListView.cs
@@ -22,8 +22,8 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 		public async Task When_ItemClicked_SelectsCorrectIndex()
 		{
 			var items = new object[] { "Item 1", "Item 2", "Item 3" };
-			var loggingSelectionInfo = new LoggingSelectionInfo();
-			var listViewBase = new ListViewBase
+			var loggingSelectionInfo = new LoggingSelectionInfo(items, false, null);
+			var listViewBase = new ListView
 			{
 				ItemsSource = items,
 			};

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Microsoft.UI.Xaml.Data;
+
+public class LoggingSelectionInfo : ISelectionInfo
+{
+	public List<string> MethodLog { get; } = new List<string>();
+
+	public void SelectRange(ItemIndexRange itemIndexRange)
+	{
+		MethodLog.Add($"SelectRange({itemIndexRange.FirstIndex}, {itemIndexRange.Length})");
+	}
+
+	public void DeselectRange(ItemIndexRange itemIndexRange)
+	{
+		MethodLog.Add($"DeselectRange({itemIndexRange.FirstIndex}, {itemIndexRange.Length})");
+	}
+
+	public bool IsSelected(int index)
+	{
+		MethodLog.Add($"IsSelected({index})");
+		return false;
+	}
+
+	public IReadOnlyList<ItemIndexRange> GetSelectedRanges()
+	{
+		MethodLog.Add("GetSelectedRanges()");
+		return new List<ItemIndexRange>();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -9,7 +9,7 @@ using Windows.Foundation;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<object>, INotifyCollectionChanged, INotifyPropertyChanged, IObservableVector<object>
+internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<object>, INotifyCollectionChanged, INotifyPropertyChanged
 {
 	private readonly List<object> _collection = new List<object>();
 	private readonly HashSet<int> _selectedIndices = new HashSet<int>();
@@ -79,7 +79,7 @@ internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<obj
 
 	public bool CanSort => SortDescriptions != null;
 
-	public IObservableVector<object> CollectionGroups { get; } = new ObservableVector<object>();
+	public IObservableVector<object> CollectionGroups { get; } = null;
 
 	public bool CanGroup => false;
 
@@ -196,14 +196,12 @@ internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<obj
 	{
 		_collection.Add(item);
 		OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
-		OnVectorChanged(CollectionChange.ItemInserted, _collection.Count - 1);
 	}
 
 	public void Insert(int index, object item)
 	{
 		_collection.Insert(index, item);
 		OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
-		OnVectorChanged(CollectionChange.ItemInserted, index);
 	}
 
 	public void RemoveAt(int index)
@@ -211,14 +209,12 @@ internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<obj
 		var removedItem = _collection[index];
 		_collection.RemoveAt(index);
 		OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removedItem, index));
-		OnVectorChanged(CollectionChange.ItemRemoved, index);
 	}
 
 	public void Clear()
 	{
 		_collection.Clear();
 		OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
-		OnVectorChanged(CollectionChange.Reset, 0);
 	}
 
 	public void CopyTo(object[] array, int arrayIndex)
@@ -233,7 +229,6 @@ internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<obj
 		{
 			_collection.RemoveAt(index);
 			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
-			OnVectorChanged(CollectionChange.ItemRemoved, index);
 			return true;
 		}
 		return false;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -11,6 +11,11 @@ internal class LoggingSelectionInfo : CollectionView, ISelectionInfo
 {
 	public List<string> MethodLog { get; } = new List<string>();
 
+	public LoggingSelectionInfo(IEnumerable collection, bool isGrouped, PropertyPath itemsPath)
+		: base(collection, isGrouped, itemsPath)
+	{
+	}
+
 	public void SelectRange(ItemIndexRange itemIndexRange)
 	{
 		MethodLog.Add($"SelectRange({itemIndexRange.FirstIndex}, {itemIndexRange.Length})");
@@ -33,13 +38,114 @@ internal class LoggingSelectionInfo : CollectionView, ISelectionInfo
 		return new List<ItemIndexRange>();
 	}
 
-	private object _currentItem;
-
-	private int _currentPosition;
-
-	public LoggingSelectionInfo(IEnumerable collection, bool isGrouped, PropertyPath itemsPath) : base(collection, isGrouped, itemsPath)
+	public void LogAndMoveCurrentToPosition(int index)
 	{
+		MethodLog.Add($"MoveCurrentToPosition({index})");
+		base.MoveCurrentToPosition(index);
 	}
 
+	public void LogAndMoveCurrentTo(object item)
+	{
+		MethodLog.Add($"MoveCurrentTo({item})");
+		base.MoveCurrentTo(item);
+	}
+
+	public void LogAndMoveCurrentToFirst()
+	{
+		MethodLog.Add("MoveCurrentToFirst()");
+		base.MoveCurrentToFirst();
+	}
+
+	public void LogAndMoveCurrentToLast()
+	{
+		MethodLog.Add("MoveCurrentToLast()");
+		base.MoveCurrentToLast();
+	}
+
+	public void LogAndMoveCurrentToNext()
+	{
+		MethodLog.Add("MoveCurrentToNext()");
+		base.MoveCurrentToNext();
+	}
+
+	public void LogAndMoveCurrentToPrevious()
+	{
+		MethodLog.Add("MoveCurrentToPrevious()");
+		base.MoveCurrentToPrevious();
+	}
+
+	private bool IsUsingISelectionInfo => true;
+
+	public void SafeMoveCurrentTo(object item)
+	{
+		if (IsUsingISelectionInfo)
+		{
+			MethodLog.Add("MoveCurrentTo() - Skipped due to ISelectionInfo usage");
+		}
+		else
+		{
+			LogAndMoveCurrentTo(item);
+		}
+	}
+
+	public void SafeMoveCurrentToPosition(int index)
+	{
+		if (IsUsingISelectionInfo)
+		{
+			MethodLog.Add("MoveCurrentToPosition() - Skipped due to ISelectionInfo usage");
+		}
+		else
+		{
+			LogAndMoveCurrentToPosition(index);
+		}
+	}
+
+	public void SafeMoveCurrentToFirst()
+	{
+		if (IsUsingISelectionInfo)
+		{
+			MethodLog.Add("MoveCurrentToFirst() - Skipped due to ISelectionInfo usage");
+		}
+		else
+		{
+			LogAndMoveCurrentToFirst();
+		}
+	}
+
+	public void SafeMoveCurrentToLast()
+	{
+		if (IsUsingISelectionInfo)
+		{
+			MethodLog.Add("MoveCurrentToLast() - Skipped due to ISelectionInfo usage");
+		}
+		else
+		{
+			LogAndMoveCurrentToLast();
+		}
+	}
+
+	public void SafeMoveCurrentToNext()
+	{
+		if (IsUsingISelectionInfo)
+		{
+			MethodLog.Add("MoveCurrentToNext() - Skipped due to ISelectionInfo usage");
+		}
+		else
+		{
+			LogAndMoveCurrentToNext();
+		}
+	}
+
+	public void SafeMoveCurrentToPrevious()
+	{
+		if (IsUsingISelectionInfo)
+		{
+			MethodLog.Add("MoveCurrentToPrevious() - Skipped due to ISelectionInfo usage");
+		}
+		else
+		{
+			LogAndMoveCurrentToPrevious();
+		}
+	}
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -20,11 +20,6 @@ internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<obj
 	public LoggingSelectionInfo(IEnumerable<object> items)
 	{
 		_collection.AddRange(items);
-		if (_collection.Count > 0)
-		{
-			_currentItem = _collection[0];
-			_currentPosition = 0;
-		}
 	}
 
 	#region ICollectionView Implementation

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -1,3 +1,4 @@
+#if HAS_UNO
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -277,3 +278,4 @@ internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<obj
 
 	#endregion
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -1,7 +1,9 @@
+#if HAS_UNO
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Data;
 using Windows.Foundation;
 using System.Threading.Tasks;
+using System;
 
 public class LoggingSelectionInfo : ISelectionInfo, ICollectionView
 {
@@ -30,7 +32,7 @@ public class LoggingSelectionInfo : ISelectionInfo, ICollectionView
 	}
 
 	public event CurrentChangingEventHandler CurrentChanging;
-	public event CurrentChangedEventHandler CurrentChanged;
+	public event EventHandler<object> CurrentChanged;
 
 	private object _currentItem;
 	public object CurrentItem
@@ -151,3 +153,4 @@ public class LoggingSelectionInfo : ISelectionInfo, ICollectionView
 		return true;
 	}
 }
+#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -4,8 +4,10 @@ using Microsoft.UI.Xaml.Data;
 using Windows.Foundation;
 using System.Threading.Tasks;
 using System;
+using System.Collections;
+using Microsoft.UI.Xaml;
 
-public class LoggingSelectionInfo : ISelectionInfo, ICollectionView
+internal class LoggingSelectionInfo : CollectionView, ISelectionInfo
 {
 	public List<string> MethodLog { get; } = new List<string>();
 
@@ -31,126 +33,13 @@ public class LoggingSelectionInfo : ISelectionInfo, ICollectionView
 		return new List<ItemIndexRange>();
 	}
 
-	public event CurrentChangingEventHandler CurrentChanging;
-	public event EventHandler<object> CurrentChanged;
-
 	private object _currentItem;
-	public object CurrentItem
-	{
-		get
-		{
-			MethodLog.Add("get_CurrentItem()");
-			return _currentItem;
-		}
-		set
-		{
-			if (_currentItem != value)
-			{
-				if (CurrentChanging != null)
-				{
-					var args = new CurrentChangingEventArgs();
-					CurrentChanging(this, args);
-					if (args.Cancel)
-					{
-						MethodLog.Add("set_CurrentItem() - Cancelled");
-						return;
-					}
-				}
-
-				_currentItem = value;
-				MethodLog.Add($"set_CurrentItem({value})");
-
-				CurrentChanged?.Invoke(this, null);
-			}
-		}
-	}
 
 	private int _currentPosition;
-	public int CurrentPosition
+
+	public LoggingSelectionInfo(IEnumerable collection, bool isGrouped, PropertyPath itemsPath) : base(collection, isGrouped, itemsPath)
 	{
-		get
-		{
-			MethodLog.Add("get_CurrentPosition()");
-			return _currentPosition;
-		}
-		set
-		{
-			if (_currentPosition != value)
-			{
-				_currentPosition = value;
-				MethodLog.Add($"set_CurrentPosition({value})");
-			}
-		}
 	}
 
-	public bool HasMoreItems
-	{
-		get
-		{
-			MethodLog.Add("get_HasMoreItems()");
-			return false;
-		}
-	}
-
-	public bool IsCurrentAfterLast
-	{
-		get
-		{
-			MethodLog.Add("get_IsCurrentAfterLast()");
-			return false;
-		}
-	}
-
-	public bool IsCurrentBeforeFirst
-	{
-		get
-		{
-			MethodLog.Add("get_IsCurrentBeforeFirst()");
-			return false;
-		}
-	}
-
-	public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
-	{
-		MethodLog.Add($"LoadMoreItemsAsync({count})");
-		return Task.FromResult(new LoadMoreItemsResult { Count = 0 }).AsAsyncOperation();
-	}
-
-	public void MoveCurrentToPosition(int index)
-	{
-		MethodLog.Add($"MoveCurrentToPosition({index})");
-		CurrentPosition = index;
-	}
-
-	public bool MoveCurrentTo(object item)
-	{
-		MethodLog.Add($"MoveCurrentTo({item})");
-		CurrentItem = item;
-		return true;
-	}
-
-	public bool MoveCurrentToFirst()
-	{
-		MethodLog.Add("MoveCurrentToFirst()");
-		return true;
-	}
-
-	public bool MoveCurrentToLast()
-	{
-		MethodLog.Add("MoveCurrentToLast()");
-		return true;
-	}
-
-	public bool MoveCurrentToNext()
-	{
-		MethodLog.Add("MoveCurrentToNext()");
-		return true;
-	}
-
-	public bool MoveCurrentToPrevious()
-	{
-		MethodLog.Add("MoveCurrentToPrevious()");
-		return true;
-	}
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -1,4 +1,3 @@
-#if HAS_UNO
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -283,4 +282,3 @@ internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<obj
 
 	#endregion
 }
-#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using Microsoft.UI.Xaml.Data;
+using Windows.Foundation;
+using System.Threading.Tasks;
 
-public class LoggingSelectionInfo : ISelectionInfo
+public class LoggingSelectionInfo : ISelectionInfo, ICollectionView
 {
 	public List<string> MethodLog { get; } = new List<string>();
 
@@ -25,5 +27,127 @@ public class LoggingSelectionInfo : ISelectionInfo
 	{
 		MethodLog.Add("GetSelectedRanges()");
 		return new List<ItemIndexRange>();
+	}
+
+	public event CurrentChangingEventHandler CurrentChanging;
+	public event CurrentChangedEventHandler CurrentChanged;
+
+	private object _currentItem;
+	public object CurrentItem
+	{
+		get
+		{
+			MethodLog.Add("get_CurrentItem()");
+			return _currentItem;
+		}
+		set
+		{
+			if (_currentItem != value)
+			{
+				if (CurrentChanging != null)
+				{
+					var args = new CurrentChangingEventArgs();
+					CurrentChanging(this, args);
+					if (args.Cancel)
+					{
+						MethodLog.Add("set_CurrentItem() - Cancelled");
+						return;
+					}
+				}
+
+				_currentItem = value;
+				MethodLog.Add($"set_CurrentItem({value})");
+
+				CurrentChanged?.Invoke(this, null);
+			}
+		}
+	}
+
+	private int _currentPosition;
+	public int CurrentPosition
+	{
+		get
+		{
+			MethodLog.Add("get_CurrentPosition()");
+			return _currentPosition;
+		}
+		set
+		{
+			if (_currentPosition != value)
+			{
+				_currentPosition = value;
+				MethodLog.Add($"set_CurrentPosition({value})");
+			}
+		}
+	}
+
+	public bool HasMoreItems
+	{
+		get
+		{
+			MethodLog.Add("get_HasMoreItems()");
+			return false;
+		}
+	}
+
+	public bool IsCurrentAfterLast
+	{
+		get
+		{
+			MethodLog.Add("get_IsCurrentAfterLast()");
+			return false;
+		}
+	}
+
+	public bool IsCurrentBeforeFirst
+	{
+		get
+		{
+			MethodLog.Add("get_IsCurrentBeforeFirst()");
+			return false;
+		}
+	}
+
+	public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
+	{
+		MethodLog.Add($"LoadMoreItemsAsync({count})");
+		return Task.FromResult(new LoadMoreItemsResult { Count = 0 }).AsAsyncOperation();
+	}
+
+	public void MoveCurrentToPosition(int index)
+	{
+		MethodLog.Add($"MoveCurrentToPosition({index})");
+		CurrentPosition = index;
+	}
+
+	public bool MoveCurrentTo(object item)
+	{
+		MethodLog.Add($"MoveCurrentTo({item})");
+		CurrentItem = item;
+		return true;
+	}
+
+	public bool MoveCurrentToFirst()
+	{
+		MethodLog.Add("MoveCurrentToFirst()");
+		return true;
+	}
+
+	public bool MoveCurrentToLast()
+	{
+		MethodLog.Add("MoveCurrentToLast()");
+		return true;
+	}
+
+	public bool MoveCurrentToNext()
+	{
+		MethodLog.Add("MoveCurrentToNext()");
+		return true;
+	}
+
+	public bool MoveCurrentToPrevious()
+	{
+		MethodLog.Add("MoveCurrentToPrevious()");
+		return true;
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -90,6 +90,11 @@ internal class LoggingSelectionInfo : CollectionView, ISelectionInfo
 
 	public void SafeMoveCurrentToPosition(int index)
 	{
+		if (index == -1)
+		{
+			MethodLog.Add("MoveCurrentToPosition() - Skipped due to invalid index (-1)");
+			return;
+		}
 		if (IsUsingISelectionInfo)
 		{
 			MethodLog.Add("MoveCurrentToPosition() - Skipped due to ISelectionInfo usage");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -1,156 +1,286 @@
 #if HAS_UNO
-using System.Collections.Generic;
-using Microsoft.UI.Xaml.Data;
-using Windows.Foundation;
-using System.Threading.Tasks;
 using System;
 using System.Collections;
-using Microsoft.UI.Xaml;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Microsoft.UI.Xaml.Data;
+using Windows.Foundation.Collections;
+using Windows.Foundation;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
-internal class LoggingSelectionInfo : CollectionView, ISelectionInfo
+internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<object>, INotifyCollectionChanged, INotifyPropertyChanged, IObservableVector<object>
 {
-	public List<string> MethodLog { get; } = new List<string>();
+	private readonly List<object> _collection = new List<object>();
+	private readonly HashSet<int> _selectedIndices = new HashSet<int>();
+	private object _currentItem;
+	private int _currentPosition = -1;
 
-	public LoggingSelectionInfo(IEnumerable collection, bool isGrouped, PropertyPath itemsPath)
-		: base(collection, isGrouped, itemsPath)
+	public LoggingSelectionInfo(IEnumerable<object> items)
 	{
+		_collection.AddRange(items);
+		if (_collection.Count > 0)
+		{
+			_currentItem = _collection[0];
+			_currentPosition = 0;
+		}
 	}
+
+	#region ICollectionView Implementation
+
+	public event CurrentChangingEventHandler CurrentChanging;
+	public event EventHandler<object> CurrentChanged;
+
+	public object CurrentItem => _currentItem;
+
+	public int CurrentPosition => _currentPosition;
+
+	public bool IsCurrentAfterLast => _currentPosition >= _collection.Count;
+
+	public bool IsCurrentBeforeFirst => _currentPosition < 0;
+
+	public bool MoveCurrentTo(object item)
+	{
+		int index = _collection.IndexOf(item);
+		return MoveCurrentToPosition(index);
+	}
+
+	public bool MoveCurrentToPosition(int index)
+	{
+		if (index >= 0 && index < _collection.Count)
+		{
+			if (_currentPosition != index)
+			{
+				OnCurrentChanging();
+				_currentItem = _collection[index];
+				_currentPosition = index;
+				OnCurrentChanged();
+			}
+			return true;
+		}
+		return false;
+	}
+
+	public bool MoveCurrentToFirst() => MoveCurrentToPosition(0);
+
+	public bool MoveCurrentToLast() => MoveCurrentToPosition(_collection.Count - 1);
+
+	public bool MoveCurrentToNext() => MoveCurrentToPosition(_currentPosition + 1);
+
+	public bool MoveCurrentToPrevious() => MoveCurrentToPosition(_currentPosition - 1);
+
+	public Predicate<object> Filter { get; set; }
+
+	public bool CanFilter => Filter != null;
+
+	public bool Contains(object item) => _collection.Contains(item);
+
+	public IComparer<object> SortDescriptions { get; set; }
+
+	public bool CanSort => SortDescriptions != null;
+
+	public IObservableVector<object> CollectionGroups { get; } = new ObservableVector<object>();
+
+	public bool CanGroup => false;
+
+	public object GetItemAt(int index) => _collection[index];
+
+	public int IndexOf(object item) => _collection.IndexOf(item);
+
+	public bool HasMoreItems => false;
+
+	public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
+	{
+		throw new NotImplementedException("LoadMoreItemsAsync is not implemented.");
+	}
+
+	protected virtual void OnCurrentChanged()
+	{
+		CurrentChanged?.Invoke(this, EventArgs.Empty);
+	}
+
+	protected virtual void OnCurrentChanging()
+	{
+		CurrentChanging?.Invoke(this, new CurrentChangingEventArgs(false));
+	}
+
+	#endregion
+
+	#region ISelectionInfo Implementation
 
 	public void SelectRange(ItemIndexRange itemIndexRange)
 	{
-		MethodLog.Add($"SelectRange({itemIndexRange.FirstIndex}, {itemIndexRange.Length})");
+		for (int i = itemIndexRange.FirstIndex; i < itemIndexRange.FirstIndex + itemIndexRange.Length; i++)
+		{
+			if (i >= 0 && i < _collection.Count)
+			{
+				_selectedIndices.Add(i);
+			}
+		}
+		OnSelectionChanged();
 	}
 
 	public void DeselectRange(ItemIndexRange itemIndexRange)
 	{
-		MethodLog.Add($"DeselectRange({itemIndexRange.FirstIndex}, {itemIndexRange.Length})");
+		for (int i = itemIndexRange.FirstIndex; i < itemIndexRange.FirstIndex + itemIndexRange.Length; i++)
+		{
+			_selectedIndices.Remove(i);
+		}
+		OnSelectionChanged();
 	}
 
 	public bool IsSelected(int index)
 	{
-		MethodLog.Add($"IsSelected({index})");
-		return false;
+		return _selectedIndices.Contains(index);
 	}
 
 	public IReadOnlyList<ItemIndexRange> GetSelectedRanges()
 	{
-		MethodLog.Add("GetSelectedRanges()");
-		return new List<ItemIndexRange>();
+		if (_selectedIndices.Count == 0)
+		{
+			return new List<ItemIndexRange>();
+		}
+
+		List<ItemIndexRange> ranges = new List<ItemIndexRange>();
+		List<int> sortedIndices = new List<int>(_selectedIndices);
+		sortedIndices.Sort();
+
+		int rangeStart = sortedIndices[0];
+		int rangeLength = 1;
+
+		for (int i = 1; i < sortedIndices.Count; i++)
+		{
+			if (sortedIndices[i] == sortedIndices[i - 1] + 1)
+			{
+				rangeLength++;
+			}
+			else
+			{
+				ranges.Add(new ItemIndexRange(rangeStart, (uint)rangeLength));
+				rangeStart = sortedIndices[i];
+				rangeLength = 1;
+			}
+		}
+
+		ranges.Add(new ItemIndexRange(rangeStart, (uint)rangeLength));
+		return ranges;
 	}
 
-	public void LogAndMoveCurrentToPosition(int index)
+	protected virtual void OnSelectionChanged()
 	{
-		MethodLog.Add($"MoveCurrentToPosition({index})");
-		base.MoveCurrentToPosition(index);
+		OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 	}
 
-	public void LogAndMoveCurrentTo(object item)
+	#endregion
+
+	#region IList<object> and ICollection<object> Implementation
+
+	public int Count => _collection.Count;
+
+	public bool IsReadOnly => false;
+
+	public object this[int index]
 	{
-		MethodLog.Add($"MoveCurrentTo({item})");
-		base.MoveCurrentTo(item);
+		get => _collection[index];
+		set
+		{
+			if (_collection[index] != value)
+			{
+				_collection[index] = value;
+				OnPropertyChanged($"Item[{index}]");
+			}
+		}
 	}
 
-	public void LogAndMoveCurrentToFirst()
+	public void Add(object item)
 	{
-		MethodLog.Add("MoveCurrentToFirst()");
-		base.MoveCurrentToFirst();
+		_collection.Add(item);
+		OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
+		OnVectorChanged(CollectionChange.ItemInserted, _collection.Count - 1);
 	}
 
-	public void LogAndMoveCurrentToLast()
+	public void Insert(int index, object item)
 	{
-		MethodLog.Add("MoveCurrentToLast()");
-		base.MoveCurrentToLast();
+		_collection.Insert(index, item);
+		OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
+		OnVectorChanged(CollectionChange.ItemInserted, index);
 	}
 
-	public void LogAndMoveCurrentToNext()
+	public void RemoveAt(int index)
 	{
-		MethodLog.Add("MoveCurrentToNext()");
-		base.MoveCurrentToNext();
+		var removedItem = _collection[index];
+		_collection.RemoveAt(index);
+		OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removedItem, index));
+		OnVectorChanged(CollectionChange.ItemRemoved, index);
 	}
 
-	public void LogAndMoveCurrentToPrevious()
+	public void Clear()
 	{
-		MethodLog.Add("MoveCurrentToPrevious()");
-		base.MoveCurrentToPrevious();
+		_collection.Clear();
+		OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+		OnVectorChanged(CollectionChange.Reset, 0);
 	}
 
-	private bool IsUsingISelectionInfo => true;
-
-	public void SafeMoveCurrentTo(object item)
+	public void CopyTo(object[] array, int arrayIndex)
 	{
-		if (IsUsingISelectionInfo)
-		{
-			MethodLog.Add("MoveCurrentTo() - Skipped due to ISelectionInfo usage");
-		}
-		else
-		{
-			LogAndMoveCurrentTo(item);
-		}
+		_collection.CopyTo(array, arrayIndex);
 	}
 
-	public void SafeMoveCurrentToPosition(int index)
+	public bool Remove(object item)
 	{
-		if (index == -1)
+		var index = _collection.IndexOf(item);
+		if (index >= 0)
 		{
-			MethodLog.Add("MoveCurrentToPosition() - Skipped due to invalid index (-1)");
-			return;
+			_collection.RemoveAt(index);
+			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
+			OnVectorChanged(CollectionChange.ItemRemoved, index);
+			return true;
 		}
-		if (IsUsingISelectionInfo)
-		{
-			MethodLog.Add("MoveCurrentToPosition() - Skipped due to ISelectionInfo usage");
-		}
-		else
-		{
-			LogAndMoveCurrentToPosition(index);
-		}
+		return false;
 	}
 
-	public void SafeMoveCurrentToFirst()
+	#endregion
+
+	#region IEnumerable Implementation
+
+	public IEnumerator<object> GetEnumerator() => _collection.GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator() => _collection.GetEnumerator();
+
+	#endregion
+
+	#region INotifyCollectionChanged Implementation
+
+	public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+	protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
 	{
-		if (IsUsingISelectionInfo)
-		{
-			MethodLog.Add("MoveCurrentToFirst() - Skipped due to ISelectionInfo usage");
-		}
-		else
-		{
-			LogAndMoveCurrentToFirst();
-		}
+		CollectionChanged?.Invoke(this, e);
 	}
 
-	public void SafeMoveCurrentToLast()
+	#endregion
+
+	#region INotifyPropertyChanged Implementation
+
+	public event PropertyChangedEventHandler PropertyChanged;
+
+	protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
 	{
-		if (IsUsingISelectionInfo)
-		{
-			MethodLog.Add("MoveCurrentToLast() - Skipped due to ISelectionInfo usage");
-		}
-		else
-		{
-			LogAndMoveCurrentToLast();
-		}
+		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 	}
 
-	public void SafeMoveCurrentToNext()
+	#endregion
+
+	#region IObservableVector<object> Implementation
+
+	public event VectorChangedEventHandler<object> VectorChanged;
+
+	protected virtual void OnVectorChanged(CollectionChange change, int index)
 	{
-		if (IsUsingISelectionInfo)
-		{
-			MethodLog.Add("MoveCurrentToNext() - Skipped due to ISelectionInfo usage");
-		}
-		else
-		{
-			LogAndMoveCurrentToNext();
-		}
+		VectorChanged?.Invoke(this, new VectorChangedEventArgs(change, (uint)index));
 	}
 
-	public void SafeMoveCurrentToPrevious()
-	{
-		if (IsUsingISelectionInfo)
-		{
-			MethodLog.Add("MoveCurrentToPrevious() - Skipped due to ISelectionInfo usage");
-		}
-		else
-		{
-			LogAndMoveCurrentToPrevious();
-		}
-	}
+	#endregion
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/LoggingSelectionInfo.cs
@@ -9,7 +9,7 @@ using Windows.Foundation;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<object>, INotifyCollectionChanged, INotifyPropertyChanged
+internal class LoggingSelectionInfo : ICollectionView, ISelectionInfo, IList<object>, INotifyCollectionChanged, INotifyPropertyChanged, IObservableVector<object>
 {
 	private readonly List<object> _collection = new List<object>();
 	private readonly HashSet<int> _selectedIndices = new HashSet<int>();

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -609,7 +609,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			void SingleSelectionCase()
 			{
-				//Verifying if the ItemsSource is a CollectionView and not ISelectionInfo
+				//Making sure that the ItemsSource is a CollectionView and not ISelectionInfo as it breaks the selection logic
 				if (ItemsSource is ICollectionView collectionView and not ISelectionInfo)
 				{
 					//NOTE: Windows seems to call MoveCurrentTo(item); we set position instead to have expected behavior when you have duplicate items in the list.

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -609,7 +609,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			void SingleSelectionCase()
 			{
-
+				//Verifying if the ItemsSource is a CollectionView and not ISelectionInfo
 				if (ItemsSource is ICollectionView collectionView and not ISelectionInfo)
 				{
 					//NOTE: Windows seems to call MoveCurrentTo(item); we set position instead to have expected behavior when you have duplicate items in the list.

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -611,7 +611,16 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				//The `ISelectionInfo` handled directly by the `ItemsSource` has precedence over the `ICollectionView`.
 				//If an object implements both interfaces, as WinUI, we make sure to use only the `ISelectionInfo` to avoid conflicting interaction.
-				if (ItemsSource is ICollectionView collectionView and not ISelectionInfo)
+
+				// Ensure that we do not alter the selection if ISelectionInfo is in use
+				if (ItemsSource is ISelectionInfo)
+				{
+					// The selection will be managed by ISelectionInfo, so we do nothing here.
+					// This prevents ICollectionView from interfering with the selection logic.
+					return;
+				}
+
+				if (ItemsSource is ICollectionView collectionView && !(ItemsSource is ISelectionInfo))
 				{
 					//NOTE: Windows seems to call MoveCurrentTo(item); we set position instead to have expected behavior when you have duplicate items in the list.
 					collectionView.MoveCurrentToPosition(clickedIndex);

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -609,7 +609,8 @@ namespace Microsoft.UI.Xaml.Controls
 
 			void SingleSelectionCase()
 			{
-				//Making sure that the ItemsSource is a CollectionView and not ISelectionInfo as it breaks the selection logic
+				//The `ISelectionInfo` handled directly by the `ItemsSource` has precedence over the `ICollectionView`.
+				//If an object implements both interfaces, as WinUI, we make sure to use only the `ISelectionInfo` to avoid conflicting interaction.
 				if (ItemsSource is ICollectionView collectionView and not ISelectionInfo)
 				{
 					//NOTE: Windows seems to call MoveCurrentTo(item); we set position instead to have expected behavior when you have duplicate items in the list.

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -610,7 +610,7 @@ namespace Microsoft.UI.Xaml.Controls
 			void SingleSelectionCase()
 			{
 
-				if (ItemsSource is ICollectionView collectionView)
+				if (ItemsSource is ICollectionView collectionView and not ISelectionInfo)
 				{
 					//NOTE: Windows seems to call MoveCurrentTo(item); we set position instead to have expected behavior when you have duplicate items in the list.
 					collectionView.MoveCurrentToPosition(clickedIndex);


### PR DESCRIPTION
closes: https://github.com/unoplatform/uno.extensions/issues/2393

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

If the provided `ItemsSource` implements both `ISelectionInfo` and `ICollectionView`, the `ListView` will attempt to push selection using the 2 interfaces.

## What is the new behavior?
`ListView` will only use the `ISelectionInfo` API.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
