### PR TITLE
fix: `ScrollViewer` focus behavior on pointer release

### DIFF
--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
@@ -10,8 +10,6 @@ using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 using System.Threading;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.RuntimeTests.Helpers;
-using static Microsoft.UI.Xaml.Controls.CollectionChangedOperation;
-
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.InputHelper.cs
@@ -10,6 +10,8 @@ using Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
 using System.Threading;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.RuntimeTests.Helpers;
+using static Microsoft.UI.Xaml.Controls.CollectionChangedOperation;
+
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;
@@ -78,7 +80,21 @@ namespace Private.Infrastructure
 			}
 			public static void Tap(Point point)
 			{
+#if WINAPPSDK || __SKIA__
+				Finger finger = null;
+				MUXControlsTestApp.Utilities.RunOnUIThread.Execute(() =>
+				{
+					finger = InputInjector.TryCreate()?.GetFinger() ?? throw new InvalidOperationException("Failed to create finger");
+					finger.Press(point);
+				});
+
+				MUXControlsTestApp.Utilities.RunOnUIThread.Execute(() =>
+				{
+					finger.Release();
+				});
+#else
 				throw new System.NotImplementedException();
+#endif
 			}
 
 			public static void ScrollMouseWheel(CalendarView cv, int i)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -18,7 +18,9 @@ using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI;
 using Windows.UI.Input.Preview.Injection;
+using Windows.UI.ViewManagement;
 using static Private.Infrastructure.TestServices;
+using Disposable = Uno.Disposables.Disposable;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -781,7 +781,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				}
 			};
 
-			await UITestHelper.Load(SUT);
+			await UITestHelper.Load(outer);
 
 			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 			using var mouse = injector.GetMouse();

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -5,23 +5,20 @@ using System.Numerics;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+using MUXControlsTestApp.Utilities;
+using Uno.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
 using Windows.UI;
 using Windows.UI.Input.Preview.Injection;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Shapes;
-using Windows.UI.ViewManagement;
-using Microsoft.UI.Xaml.Input;
-using MUXControlsTestApp.Utilities;
 using static Private.Infrastructure.TestServices;
-using Uno.Disposables;
-using Uno.Extensions;
-using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.Toolkit.Extensions;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -90,6 +87,34 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				.Count();
 
 			Assert.IsTrue(buttons == 0);
+		}
+
+		[TestMethod]
+		public async Task When_ScrollViewer_Pointer_Released_Should_Not_Focus()
+		{
+			var scrollViewer = new ScrollViewer();
+			var stackPanel = new StackPanel();
+			stackPanel.Children.Add(new Button() { Content = "First button" });
+			stackPanel.Children.Add(new Button() { Content = "Second button" });
+			stackPanel.Children.Add(new Rectangle() { Fill = new SolidColorBrush() { Color = Colors.Red }, Width = 100, Height = 100 });
+
+			scrollViewer.Content = stackPanel;
+
+			WindowHelper.WindowContent = scrollViewer;
+			await WindowHelper.WaitForLoaded(scrollViewer);
+
+			// Focus second button
+			var secondButton = stackPanel.Children[1] as Button;
+			secondButton.Focus(FocusState.Programmatic);
+
+			// Tap the rectangle center
+			var rectangle = stackPanel.Children[2] as Rectangle;
+			InputHelper.Tap(rectangle);
+
+			await WindowHelper.WaitForIdle();
+
+			// Second button should still be focused
+			Assert.AreEqual(secondButton, FocusManager.GetFocusedElement(WindowHelper.WindowContent.XamlRoot));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -19,6 +19,7 @@ using Windows.Foundation.Metadata;
 using Windows.UI;
 using Windows.UI.Input.Preview.Injection;
 using Windows.UI.ViewManagement;
+using Uno.UI.Toolkit.Extensions;
 using static Private.Infrastructure.TestServices;
 using Disposable = Uno.Disposables.Disposable;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.MuxInternal.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.MuxInternal.cs
@@ -112,18 +112,67 @@ namespace Microsoft.UI.Xaml.Controls
 
 		protected override void OnPointerReleased(PointerRoutedEventArgs args)
 		{
+			base.OnPointerReleased(args);
+			var handled = args.Handled;
+			if (handled)
+			{
+				return;
+			}
+
 			if (m_isPointerLeftButtonPressed)
 			{
+				//GestureModes gestureFollowing = GestureModes.None;
+
+				// Reset the pointer left button pressed state
 				m_isPointerLeftButtonPressed = false;
 
-				var isFocusedOnLightDismissPopupOfFlyout = ScrollContentControl_SetFocusOnFlyoutLightDismissPopupByPointer(this);
-				if (isFocusedOnLightDismissPopupOfFlyout)
+				//var gestureFollowing = args.GestureFollowing;
+
+				//if (gestureFollowing == GestureModes.RightTapped)
+				//{
+				//	// Schedule the focus change for OnRightTappedUnhandled.
+				//	m_shouldFocusOnRightTapUnhandled = true;
+				//}
+				//else
 				{
-					args.Handled = true;
-				}
-				else
-				{
-					args.Handled = Focus(FocusState.Pointer);
+					// Set focus on the Flyout inner ScrollViewer to dismiss IHM.
+					//if (m_isFocusableOnFlyoutScrollViewer)
+					//{
+					var isFocusedOnLightDismissPopupOfFlyout = ScrollContentControl_SetFocusOnFlyoutLightDismissPopupByPointer(this);
+					//}
+					if (isFocusedOnLightDismissPopupOfFlyout)
+					{
+						args.Handled = true;
+					}
+					else
+					{
+						bool scrollViewerIsFocusAncestor = false;
+						var scrollViewerIsTabStop = IsTabStop;
+
+						if (VisualTree.GetFocusManagerForElement(this) is FocusManager focusManager)
+						{
+							if (focusManager.FocusedElement is DependencyObject currentFocusedElement)
+							{
+								scrollViewerIsFocusAncestor = this.IsAncestorOf(currentFocusedElement);
+							}
+						}
+
+						if (!scrollViewerIsTabStop && scrollViewerIsFocusAncestor)
+						{
+							// Do not take focus when:
+							// - ScrollViewer.IsTabStop is False and
+							// - Currently focused element is within this ScrollViewer.
+							// In that case, leave the focus as is by marking this event handled.
+							args.Handled = true;
+						}
+						else
+						{
+							// Focus now.
+							// Set focus to the ScrollViewer to capture key input for scrolling
+							var focused = Focus(FocusState.Pointer);
+							args.Handled = focused;
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/17384

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Currently the first focusable element gets focused on pointer release on `ScrollViewer`.


## What is the new behavior?

Ported fix from WinUI 3 1.6

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
