### PR TITLE
fix(hrui): Add notification for XAML reader based HR

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -180,7 +180,7 @@ public partial class ClientHotReloadProcessor
 
 		public HotReloadSource Source { get; }
 
-		public Type[] Types { get; }
+		public Type[] Types { get; private set; }
 
 		internal string[] CuratedTypes => _curatedTypes ??= GetCuratedTypes();
 
@@ -225,6 +225,18 @@ public partial class ClientHotReloadProcessor
 		public ImmutableList<Exception> Exceptions => _exceptions;
 
 		public string? IgnoreReason { get; private set; }
+
+		internal void AddType(Type type)
+		{
+			if (Types.Contains(type))
+			{
+				return;
+			}
+
+			_curatedTypes = null;
+			Types = Types.Append(type).ToArray();
+			_onUpdated();
+		}
 
 		internal void ReportError(MethodInfo source, Exception error)
 			=> ReportError(error); // For now we just ignore the source

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Xaml.cs
@@ -39,7 +39,6 @@ namespace Uno.UI.RemoteControl.HotReload
 {
 	partial class ClientHotReloadProcessor
 	{
-		private string? _lastUpdatedFilePath;
 		private bool _supportsXamlReader;
 
 #if __IOS__ || __CATALYST__ || __ANDROID__
@@ -146,19 +145,19 @@ namespace Uno.UI.RemoteControl.HotReload
 				return;
 			}
 
-			_lastUpdatedFilePath = fileReload.FilePath;
+			var op = _status.ReportLocalStarting([]);
 
 			_ = Windows.ApplicationModel.Core.CoreApplication.MainView.Dispatcher.RunAsync(
 				Windows.UI.Core.CoreDispatcherPriority.Normal,
 				async () =>
 				{
-					await ReloadWithFileAndContent(fileReload.FilePath, fileReload.Content);
+					await ReloadWithFileAndContent(op, fileReload.FilePath, fileReload.Content);
 
 					RemoteControlClient.Instance?.NotifyOfEvent(nameof(FileReload), fileReload.FilePath);
 				});
 		}
 
-		private async Task ReloadWithFileAndContent(string filePath, string fileContent)
+		private async Task ReloadWithFileAndContent(HotReloadClientOperation op, string filePath, string fileContent)
 		{
 			try
 			{
@@ -192,6 +191,7 @@ namespace Uno.UI.RemoteControl.HotReload
 						if (XamlReader.LoadUsingXClass(fileContent, uri.ToString()) is FrameworkElement newContent)
 						{
 							SwapViews(instance, newContent);
+							op.AddType(newContent.GetType());
 						}
 					}
 				}
@@ -201,6 +201,15 @@ namespace Uno.UI.RemoteControl.HotReload
 					var replacementDictionary = (ResourceDictionary)XamlReader.Load(fileContent);
 					targetDictionary.CopyFrom(replacementDictionary);
 					Application.Current.UpdateResourceBindingsForHotReload();
+				}
+
+				if (op.Types.Length is 0)
+				{
+					op.ReportIgnored("No instances found");
+				}
+				else
+				{
+					op.ReportCompleted();
 				}
 			}
 			catch (Exception e)
@@ -221,6 +230,8 @@ namespace Uno.UI.RemoteControl.HotReload
 						exceptionType: e.GetType().ToString(),
 						message: e.Message,
 						stackTrace: e.StackTrace));
+
+				op.ReportError(e);
 			}
 		}
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/574#top

## Bugfix
Add notification for XAML reader based HR

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Note: This only fixes the missing notifications, but the HR on save is by design and will remain as is