### PR TITLE
feat(hrui): Add ability to show details from notification

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -66,7 +66,7 @@ public partial class ClientHotReloadProcessor
 	private class StatusSink(ClientHotReloadProcessor owner)
 	{
 #if HAS_UNO_WINUI
-		private readonly DiagnosticView<HotReloadStatusView, Status> _view = DiagnosticView.Register<HotReloadStatusView, Status>("Hot reload", ctx => new HotReloadStatusView(ctx), static (view, status) => view.OnHotReloadStatusChanged(status));
+		private readonly DiagnosticView<HotReloadStatusView, Status> _view = DiagnosticView.Register<HotReloadStatusView, Status>("Hot reload", ctx => new HotReloadStatusView(ctx));
 #endif
 
 		private HotReloadState? _serverState;

--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.cs
@@ -172,6 +172,7 @@ internal sealed partial class HotReloadStatusView : Control, IDiagnosticViewElem
 	/// <inheritdoc />
 	void IDiagnosticViewElement<Status>.Update(Status status)
 		=> OnHotReloadStatusChanged(status);
+
 	private void OnHotReloadStatusChanged(Status status)
 	{
 		var oldStatus = _hotReloadStatus;

--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.xaml
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.xaml
@@ -309,7 +309,8 @@
 								</Style>
 							</Button.Resources>
 							<Button.Flyout>
-								<Flyout Placement="BottomEdgeAlignedLeft"
+								<Flyout x:Name="PART_Details"
+										Placement="BottomEdgeAlignedLeft"
 										FlyoutPresenterStyle="{StaticResource HotReloadFlyoutPresenterStyle}">
 									<Grid>
 										<Grid.Resources>

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame_DataContext.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame_DataContext.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 #pragma warning disable IDE0051 // Members used for testing by reflection
+#pragma warning disable CS1998
 
 using System;
 using System.Formats.Asn1;
@@ -191,5 +192,41 @@ public class Given_Frame_DataContext : BaseTestClass
 
 		// Check that the text is still the original value
 		await frame.ValidateTextOnChildTextBlock(vm.TitleText, 1);
+	}
+
+	[TestMethod]
+	public async Task Check_Preserved_IfNotChanged()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+
+		var frame = new Microsoft.UI.Xaml.Controls.Frame();
+		UnitTestsUIContentHelper.Content = frame;
+
+		frame.Navigate(typeof(HR_Frame_Pages_DataContext));
+
+		var vm = (frame.Content as Page).DataContext;
+
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_Page1>(
+			"** HR_Frame_Pages_DataContext Original **",
+			"** HR_Frame_Pages_DataContext Updated **",
+			async () => Assert.AreSame(vm, (frame.Content as Page)?.DataContext),
+			ct);
+	}
+
+	[TestMethod]
+	public async Task Check_Replaced_IfUpdated()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+
+		var frame = new Microsoft.UI.Xaml.Controls.Frame();
+		UnitTestsUIContentHelper.Content = frame;
+
+		frame.Navigate(typeof(HR_Frame_Pages_DataContext));
+
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_Page1>(
+			"<local:HR_Frame_Pages_DataContext_VM />",
+			"<local:HR_Frame_Pages_DataContext_VM_2 />",
+			async () => Assert.IsTrue(frame.Content is Page { IsLoaded: true, DataContext: HR_Frame_Pages_DataContext_VM_2 }),
+			ct);
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataContext.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataContext.xaml
@@ -1,0 +1,19 @@
+<Page 
+	x:Class="Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages.HR_Frame_Pages_DataContext"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests.Pages"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.DataContext>
+		<local:HR_Frame_Pages_DataContext_VM />
+	</Page.DataContext>
+
+	<StackPanel>
+		<TextBlock Text="** HR_Frame_Pages_DataContext Original **" />
+		<TextBlock Text="{Binding Value}" />
+	</StackPanel>
+</Page>
+

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataContext.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataContext.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
+
+public sealed partial class HR_Frame_Pages_DataContext : Page
+{
+	public HR_Frame_Pages_DataContext()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataContext_VM.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Pages/HR_Frame_Pages_DataContext_VM.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests.Pages;
+
+public record HR_Frame_Pages_DataContext_VM
+{
+	private static int _counter = 0;
+
+	private string Value { get; } = $"DataContext #{Interlocked.Increment(ref _counter)}";
+}
+
+public record HR_Frame_Pages_DataContext_VM_2 : HR_Frame_Pages_DataContext_VM;

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Notification.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Notification.cs
@@ -18,6 +18,7 @@ public sealed partial class DiagnosticsOverlay
 		{
 			element.ShowDetails();
 		}
+		HideNotification();
 	}
 
 #pragma warning disable IDE0051 // Not used on windows UWP

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Notification.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Notification.cs
@@ -14,7 +14,10 @@ public sealed partial class DiagnosticsOverlay
 
 	private void OnNotificationTapped(object sender, TappedRoutedEventArgs e)
 	{
-		HideNotification();
+		if (sender is FrameworkElement { Tag: DiagnosticElement element })
+		{
+			element.ShowDetails();
+		}
 	}
 
 #pragma warning disable IDE0051 // Not used on windows UWP
@@ -45,6 +48,7 @@ public sealed partial class DiagnosticsOverlay
 				return;
 			}
 
+			presenter.Tag = context.Element;
 			presenter.Content = notif.Content;
 			presenter.ContentTemplate = notif.ContentTemplate as DataTemplate;
 			VisualStateManager.GoToState(this, NotificationVisibleStateName, true);

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Windows.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Windows.csproj
@@ -61,6 +61,7 @@
 		<Compile Include="..\Uno.UI\Diagnostics\DiagnosticViewHelper.cs" Link="Uno.UI\Diagnostics\DiagnosticViewHelper.cs" />
 		<Compile Include="..\Uno.UI\Diagnostics\DiagnosticViewManager.TView.cs" Link="Uno.UI\Diagnostics\DiagnosticViewManager.TView.cs" />
 		<Compile Include="..\Uno.UI\Diagnostics\DiagnosticViewManager.TView.TState.cs" Link="Uno.UI\Diagnostics\DiagnosticViewManager.TView.TState.cs" />
+		<Compile Include="..\Uno.UI\Diagnostics\IDiagnosticViewElement.cs" Link="Uno.UI\Diagnostics\IDiagnosticViewElement.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI/Diagnostics/DiagnosticView.Factories.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticView.Factories.cs
@@ -101,18 +101,19 @@ internal partial class DiagnosticView
 	}
 
 	/// <summary>
-	/// Registers a generic FrameworkElement as diagnostic view.
+	/// Registers a generic FrameworkElement as a diagnostic view.
 	/// </summary>
 	/// <remarks>
-	/// This only registers the diagnostic, it does not open the overlay.
+	/// This method only registers the diagnostic view; it does not open the overlay.
 	/// </remarks>
-	/// <typeparam name="TView">Type if the generic FrameworkElement to use.</typeparam>
-	/// <typeparam name="TState">Type of the state used to update the <typeparamref name="TView"/>.</typeparam>
-	/// <param name="friendlyName">The user-friendly name of the diagnostics view.</param>
-	/// <param name="factory">Factory to create an instance of the generic element.</param>
-	/// <param name="update">Delegate to use to update the <typeparamref name="TView"/> when the <typeparamref name="TState"/> is being updated.</param>
-	/// <param name="details">Optional delegate used to show more details about the diagnostic info when user taps on the view.</param>
-	/// <returns>A diagnostic view helper class which can be used to push updates of the state (cf. <see cref="DiagnosticView{TView,TState}.Update"/>).</returns>
+	/// <typeparam name="TView">The type of the generic FrameworkElement to use.</typeparam>
+	/// <typeparam name="TState">The type of the state used to update the <typeparamref name="TView"/>.</typeparam>
+	/// <param name="friendlyName">The user-friendly name of the diagnostic view.</param>
+	/// <param name="factory">A factory function to create an instance of the generic element.</param>
+	/// <param name="update">A delegate used to update the <typeparamref name="TView"/> when the <typeparamref name="TState"/> is updated.</param>
+	/// <param name="details">An optional delegate used to show more details about the diagnostic info when the user taps on the view.</param>
+	/// <returns>A diagnostic view helper class which can be used to push updates to the state (see <see cref="DiagnosticView{TView,TState}.Update"/>).</returns>
+
 	public static DiagnosticView<TView, TState> Register<TView, TState>(
 		string friendlyName,
 		Func<IDiagnosticViewContext, TView> factory)

--- a/src/Uno.UI/Diagnostics/DiagnosticView.TView.TState.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticView.TView.TState.cs
@@ -15,7 +15,7 @@ internal class DiagnosticView<TView, TState>(
 	string name,
 	Func<IDiagnosticViewContext, TView> factory,
 	Action<TView, TState> update,
-	Func<IDiagnosticViewContext, TState, CancellationToken, ValueTask<object?>>? details = null)
+	Func<IDiagnosticViewContext, TView, TState, CancellationToken, ValueTask<object?>>? details = null)
 	: IDiagnosticView
 	where TView : FrameworkElement
 {
@@ -43,5 +43,5 @@ internal class DiagnosticView<TView, TState>(
 
 	/// <inheritdoc />
 	async ValueTask<object?> IDiagnosticView.GetDetailsAsync(IDiagnosticViewContext context, CancellationToken ct)
-		=> _hasState && details is not null ? await details(context, _state!, ct) : null;
+		=> _hasState && details is not null ? await details(context, _elementsManager.GetView(context), _state!, ct) : null;
 }

--- a/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.TState.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.TState.cs
@@ -3,7 +3,6 @@ using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml;
-using Uno.Collections;
 
 namespace Uno.Diagnostics.UI;
 

--- a/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.TState.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.TState.cs
@@ -16,7 +16,7 @@ namespace Uno.Diagnostics.UI;
 internal class DiagnosticViewManager<TView, TState>(Func<IDiagnosticViewContext, TView> factory, Action<IDiagnosticViewContext, TView, TState> update)
 	where TView : FrameworkElement
 {
-	private ConditionalWeakTable<IDiagnosticViewContext, TView> _views = new();
+	private readonly ConditionalWeakTable<IDiagnosticViewContext, TView> _views = new();
 	private event EventHandler<TState>? _changed;
 	private bool _hasState;
 	private TState? _state;

--- a/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml;
 
 namespace Uno.Diagnostics.UI;
@@ -16,6 +17,7 @@ namespace Uno.Diagnostics.UI;
 internal class DiagnosticViewManager<TView>(Func<IDiagnosticViewContext, TView> factory, Action<IDiagnosticViewContext, TView> update)
 	where TView : FrameworkElement
 {
+	private ConditionalWeakTable<IDiagnosticViewContext, TView> _views = new();
 	private event EventHandler? _changed;
 
 	public DiagnosticViewManager(Func<TView> factory, Action<TView> update)
@@ -30,7 +32,7 @@ internal class DiagnosticViewManager<TView>(Func<IDiagnosticViewContext, TView> 
 
 	public UIElement GetView(IDiagnosticViewContext context)
 	{
-		var view = factory(context);
+		var view = _views.GetValue(context, ctx => factory(ctx));
 		EventHandler requestUpdate = (_, __) => context.Schedule(() => update(context, view));
 
 		view.Loaded += (snd, e) =>

--- a/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticViewManager.TView.cs
@@ -17,7 +17,7 @@ namespace Uno.Diagnostics.UI;
 internal class DiagnosticViewManager<TView>(Func<IDiagnosticViewContext, TView> factory, Action<IDiagnosticViewContext, TView> update)
 	where TView : FrameworkElement
 {
-	private ConditionalWeakTable<IDiagnosticViewContext, TView> _views = new();
+	private readonly ConditionalWeakTable<IDiagnosticViewContext, TView> _views = new();
 	private event EventHandler? _changed;
 
 	public DiagnosticViewManager(Func<TView> factory, Action<TView> update)

--- a/src/Uno.UI/Diagnostics/IDiagnosticViewElement.cs
+++ b/src/Uno.UI/Diagnostics/IDiagnosticViewElement.cs
@@ -1,0 +1,28 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uno.Diagnostics.UI;
+
+/// <summary>
+/// Interface that a diagnostic element can implement to enhance support for the diagnostic overlay.
+/// </summary>
+/// <remarks>Type that implements this interface expected to inherit from Control</remarks>
+/// <typeparam name="TState">Type of the state exposed by this element.</typeparam>
+public interface IDiagnosticViewElement<in TState>
+{
+	/// <summary>
+	/// Update the state of the diagnostic element.
+	/// </summary>
+	/// <param name="state"></param>
+	public void Update(TState state);
+
+	/// <summary>
+	/// Request to the element to show its details.
+	/// </summary>
+	/// <param name="ct">Cancellation token which is cancelled once the details should no longer be visible.</param>
+	/// <returns></returns>
+	public ValueTask ShowDetails(CancellationToken ct);
+}

--- a/src/Uno.UI/Diagnostics/IDiagnosticViewElement.cs
+++ b/src/Uno.UI/Diagnostics/IDiagnosticViewElement.cs
@@ -21,10 +21,10 @@ public interface IDiagnosticViewElement<in TState>
 	/// <param name="state">The new state to be applied to the element.</param>
 	public void Update(TState state);
 
-    /// <summary>
-    /// Requests the element to display its details.
-    /// </summary>
-    /// <param name="ct">A cancellation token that is canceled when the details should no longer be visible.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
+	/// <summary>
+	/// Requests the element to display its details.
+	/// </summary>
+	/// <param name="ct">A cancellation token that is canceled when the details should no longer be visible.</param>
+	/// <returns>A task that represents the asynchronous operation.</returns>
 	public ValueTask ShowDetails(CancellationToken ct);
 }

--- a/src/Uno.UI/Diagnostics/IDiagnosticViewElement.cs
+++ b/src/Uno.UI/Diagnostics/IDiagnosticViewElement.cs
@@ -7,22 +7,24 @@ using System.Threading.Tasks;
 namespace Uno.Diagnostics.UI;
 
 /// <summary>
-/// Interface that a diagnostic element can implement to enhance support for the diagnostic overlay.
+/// Defines an interface for diagnostic elements to enhance support for the diagnostic overlay.
 /// </summary>
-/// <remarks>Type that implements this interface expected to inherit from Control</remarks>
-/// <typeparam name="TState">Type of the state exposed by this element.</typeparam>
+/// <remarks>
+/// Implementing types are expected to inherit from the <see cref="Control"/> class.
+/// </remarks>
+/// <typeparam name="TState">The type of state exposed by this element.</typeparam>
 public interface IDiagnosticViewElement<in TState>
 {
 	/// <summary>
 	/// Update the state of the diagnostic element.
 	/// </summary>
-	/// <param name="state"></param>
+	/// <param name="state">The new state to be applied to the element.</param>
 	public void Update(TState state);
 
-	/// <summary>
-	/// Request to the element to show its details.
-	/// </summary>
-	/// <param name="ct">Cancellation token which is cancelled once the details should no longer be visible.</param>
-	/// <returns></returns>
+    /// <summary>
+    /// Requests the element to display its details.
+    /// </summary>
+    /// <param name="ct">A cancellation token that is canceled when the details should no longer be visible.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
 	public ValueTask ShowDetails(CancellationToken ct);
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## Feature
Add ability to show details from notification

## What is the current behavior?
Tapping a notification only dismiss it

## What is the new behavior?
Tapping a notification from HR indicator will show the HR log

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
