### PR TITLE
fix: Refresh theme resources on `Loading`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ThemeResource_Refresh_On_Loading.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ThemeResource_Refresh_On_Loading.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.ThemeResource_Refresh_On_Loading"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<Grid>
+		<Grid.Resources>
+			<ResourceDictionary>
+				<Thickness x:Key="DatePickerHostPadding">40,40,40,40</Thickness>
+			</ResourceDictionary>
+		</Grid.Resources>
+
+		<Border Background="Red" Width="150" Height="150">
+			<ContentControl x:Name="ContentOwner" />
+		</Border>
+	</Grid>
+</UserControl>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ThemeResource_Refresh_On_Loading.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/ThemeResource_Refresh_On_Loading.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+
+public sealed partial class ThemeResource_Refresh_On_Loading : UserControl
+{
+	public ThemeResource_Refresh_On_Loading()
+	{
+		this.InitializeComponent();
+	}
+
+	public void SetContent(UIElement content)
+	{
+		ContentOwner.Content = content;
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_ThemeResource.cs
@@ -1,19 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
-using Uno.UI.RuntimeTests.Helpers;
-using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
-using Windows.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
+using MUXControlsTestApp.Utilities;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+using Windows.UI;
 using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
@@ -193,6 +188,28 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 				Assert.AreEqual(Colors.DarkGreen, (control.button03_override.Background as SolidColorBrush)?.Color);
 				Assert.AreEqual(Colors.DarkGreen, (control.button04_override.Background as SolidColorBrush)?.Color);
 			}
+		}
+
+		[TestMethod]
+		public async Task When_Refresh_On_Loading()
+		{
+			using var _ = StyleHelper.UseFluentStyles();
+			var userControl = new ThemeResource_Refresh_On_Loading();
+			WindowHelper.WindowContent = userControl;
+			await WindowHelper.WaitForLoaded(userControl);
+
+			var expected = new Thickness(40);
+
+			var loaded = false;
+			var datePicker = new DatePicker();
+			datePicker.Loaded += (s, e) => loaded = true;
+			userControl.SetContent(datePicker);
+
+			await WindowHelper.WaitFor(() => loaded);
+
+			var datePart = (TextBlock)datePicker.FindVisualChildByName("DayTextBlock");
+
+			Assert.AreEqual(expected, datePart.Padding);
 		}
 
 		private async Task When_DefaultForeground(Color lightThemeColor, Color darkThemeColor)

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_xLoad.cs
@@ -182,8 +182,8 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 			Assert.AreEqual("[SolidColorBrush #FFFF0000]", tb02.Foreground?.ToString());
 
 			var tb01 = SUT.FindName("tb01") as TextBlock;
-			// This assertion is incorrect because of https://github.com/unoplatform/uno/issues/6700
-			Assert.AreEqual("[SolidColorBrush #FF000000]", tb01.Foreground?.ToString());
+
+			Assert.AreEqual("[SolidColorBrush #FFFF0000]", tb01.Foreground?.ToString());
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -385,8 +385,7 @@ namespace Microsoft.UI.Xaml.Controls
 				m_tpMonthTextBlock = null;
 				m_tpDayTextBlock = null;
 
-				// UNO TODO
-				// DatePickerGenerated.OnApplyTemplate();
+				base.OnApplyTemplate();
 
 				// Get selectors for day/month/year pickers
 				GetTemplatePart<Selector>("DayPicker", out spDayPicker);
@@ -518,7 +517,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 				RefreshSetup();
 
-				// UpdateVisualState(false);
+				UpdateVisualState(false);
 
 			}
 			finally

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -417,6 +417,10 @@ namespace Microsoft.UI.Xaml
 
 			// Apply active style and default style when we enter the visual tree, if they haven't been applied already.
 			ApplyStyles();
+
+			// This is replicating the UpdateAllThemeReferences call in Enter in WinUI.
+			// Updates theme references to account for new ancestor theme dictionaries.
+			this.UpdateResourceBindings();
 		}
 
 		partial void OnUnloadedPartial()


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/17637, closes https://github.com/unoplatform/uno/issues/6700

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In WinUI `ThemeResources` are refreshed when the element is loading, as that's the time when the parent tree is valid and it is possible to properly gather the applicable resource dictionaries.


## What is the new behavior?

Refresh explicitly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
