### PR TITLE
fix(devSrv): Improve dev-server reliability

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -70,6 +70,7 @@
 		<CompilerVisibleProperty Include="UnoRemoteControlPort" />
 		<CompilerVisibleProperty Include="UnoRemoteControlHost" />
 		<CompilerVisibleProperty Include="UnoRemoteControlProcessorsPath" />
+		<CompilerVisibleProperty Include="UnoRemoteControlConfigCookie" />
 		<CompilerVisibleProperty Include="UnoEnCLogPath" />
 		<CompilerVisibleProperty Include="UnoDisableBindableTypeProvidersGeneration" />
 		<CompilerVisibleProperty Include="ShouldWriteErrorOnInvalidXaml" />

--- a/src/Uno.Foundation/Diagnostics/DiagnosticViewRegistry.cs
+++ b/src/Uno.Foundation/Diagnostics/DiagnosticViewRegistry.cs
@@ -23,12 +23,13 @@ internal static class DiagnosticViewRegistry
 	/// Register a global diagnostic view that can be displayed on any window.
 	/// </summary>
 	/// <param name="view">A diagnostic view to display.</param>
-	public static void Register(IDiagnosticView view)
+	/// <param name="mode">Defines when the registered diagnostic view should be displayed.</param>
+	public static void Register(IDiagnosticView view, DiagnosticViewRegistrationMode mode = default)
 	{
 		ImmutableInterlocked.Update(
 			ref _registrations,
 			static (providers, provider) => providers.Add(provider),
-			new DiagnosticViewRegistration(DiagnosticViewRegistrationMode.One, view));
+			new DiagnosticViewRegistration(mode, view));
 
 		Added?.Invoke(null, _registrations);
 	}
@@ -39,15 +40,15 @@ internal record DiagnosticViewRegistration(DiagnosticViewRegistrationMode Mode, 
 internal enum DiagnosticViewRegistrationMode
 {
 	/// <summary>
-	/// Diagnostic is being rendered as overlay on each window.
-	/// </summary>
-	All,
-
-	/// <summary>
 	/// Diagnostic is being display on at least one window.
 	/// I.e. only the main/first opened but move to the next one if the current window is closed.
 	/// </summary>
 	One,
+
+	/// <summary>
+	/// Diagnostic is being rendered as overlay on each window.
+	/// </summary>
+	All,
 
 	/// <summary>
 	/// Only registers the diagnostic provider but does not display it.

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -215,7 +215,7 @@ public partial class EntryPoint : IDisposable
 			return "Unknown";
 		}
 	}
-	
+
 	private async Task UpdateProjectsAsync()
 	{
 		try

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -107,12 +107,10 @@ public partial class EntryPoint : IDisposable
 
 		_ = _debuggerObserver.ObserveProfilesAsync();
 
-		_ = _globalPropertiesChanged();
-
 		TelemetryHelper.DataModelTelemetrySession.AddSessionChannel(new TelemetryEventListener(this));
 	}
 
-	private async Task<Dictionary<string, string>> OnProvideGlobalPropertiesAsync()
+	private Task<Dictionary<string, string>> OnProvideGlobalPropertiesAsync()
 	{
 		Dictionary<string, string> properties = new()
 		{
@@ -129,9 +127,7 @@ public partial class EntryPoint : IDisposable
 			properties.Add(UnoRemoteControlConfigCookieProperty, _remoteControlConfigCookie);
 		}
 
-		await Task.Yield();
-
-		return properties;
+		return Task.FromResult(properties);
 	}
 
 	[MemberNotNull(
@@ -285,8 +281,8 @@ public partial class EntryPoint : IDisposable
 
 		if (_process is { HasExited: false })
 		{
-			_debugAction?.Invoke($"Server already running");
-			return; // Dev-server is already running.
+			_debugAction?.Invoke("Server already running");
+			return;
 		}
 
 		await _processGate.WaitAsync();
@@ -346,6 +342,8 @@ public partial class EntryPoint : IDisposable
 				_ideChannelClient.ForceHotReloadRequested += OnForceHotReloadRequestedAsync;
 				_ideChannelClient.ConnectToHost();
 
+				// Set the port to the projects
+				// This LEGACY as port should be set through the global properties (cf. OnProvideGlobalPropertiesAsync)
 				var portString = _remoteControlServerPort.ToString(CultureInfo.InvariantCulture);
 				foreach (var p in await _dte.GetProjectsAsync())
 				{
@@ -386,10 +384,30 @@ public partial class EntryPoint : IDisposable
 		{
 			if (_closing || _ct.IsCancellationRequested)
 			{
+				if (_remoteControlConfigCookie is not null)
+				{
+					File.WriteAllText(_remoteControlConfigCookie, "--closed--"); // Make sure VS will re-build on next start
+				}
+
+				_debugAction?.Invoke($"Remote Control server exited ({_process?.ExitCode}) and won't be restarted as solution is closing.");
 				return;
 			}
 
+			_debugAction?.Invoke($"Remote Control server exited ({_process?.ExitCode}). It will restart in 5sec.");
+
 			await Task.Delay(5000, _ct.Token);
+
+			if (_closing || _ct.IsCancellationRequested)
+			{
+				if (_remoteControlConfigCookie is not null)
+				{
+					File.WriteAllText(_remoteControlConfigCookie, "--closed--"); // Make sure VS will re-build on next start
+				}
+
+				_debugAction?.Invoke($"Remote Control server will not be restarted as solution is closing.");
+				return;
+			}
+
 			await EnsureServerAsync();
 		}
 	}

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
@@ -33,7 +33,7 @@ namespace Uno.UI.RemoteControl.HotReload
 			// This mean that HR won't work with the debugger attached.
 			if (Debugger.IsAttached)
 			{
-				_status.ReportServerState(HotReloadState.Disabled);
+				_status.ReportInvalidRuntime();
 			}
 			_hotReloadWorkloadSpaceLoaded.SetResult(hotReloadWorkspaceLoadResult.WorkspaceInitialized);
 		}

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -87,40 +87,51 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 	private async Task ConfigureServer()
 	{
 		var assembly = _rcClient.AppType.Assembly;
-
 		if (assembly.GetCustomAttributes(typeof(ProjectConfigurationAttribute), false) is ProjectConfigurationAttribute[] configs)
 		{
-			var config = configs.First();
+			_status.ReportServerState(HotReloadState.Initializing);
 
-			_projectPath = config.ProjectPath;
-			_xamlPaths = config.XamlPaths;
-
-			if (this.Log().IsEnabled(LogLevel.Debug))
+			try
 			{
-				this.Log().LogDebug($"ProjectConfigurationAttribute={config.ProjectPath}, Paths={_xamlPaths.Length}");
-			}
+				var config = configs.First();
 
-			if (this.Log().IsEnabled(LogLevel.Trace))
-			{
-				foreach (var path in _xamlPaths)
+				_projectPath = config.ProjectPath;
+				_xamlPaths = config.XamlPaths;
+
+				if (this.Log().IsEnabled(LogLevel.Debug))
 				{
-					this.Log().Trace($"\t- {path}");
+					this.Log().LogDebug($"ProjectConfigurationAttribute={config.ProjectPath}, Paths={_xamlPaths.Length}");
 				}
+
+				if (this.Log().IsEnabled(LogLevel.Trace))
+				{
+					foreach (var path in _xamlPaths)
+					{
+						this.Log().Trace($"\t- {path}");
+					}
+				}
+
+				_msbuildProperties = Messages.ConfigureServer.BuildMSBuildProperties(config.MSBuildProperties);
+
+				ConfigureHotReloadMode();
+				InitializeMetadataUpdater();
+				InitializePartialReload();
+				InitializeXamlReader();
+
+				ConfigureServer message = new(_projectPath, _xamlPaths, GetMetadataUpdateCapabilities(), _serverMetadataUpdatesEnabled, config.MSBuildProperties);
+
+				await _rcClient.SendMessage(message);
 			}
-
-			_msbuildProperties = Messages.ConfigureServer.BuildMSBuildProperties(config.MSBuildProperties);
-
-			ConfigureHotReloadMode();
-			InitializeMetadataUpdater();
-			InitializePartialReload();
-			InitializeXamlReader();
-
-			ConfigureServer message = new(_projectPath, _xamlPaths, GetMetadataUpdateCapabilities(), _serverMetadataUpdatesEnabled, config.MSBuildProperties);
-
-			await _rcClient.SendMessage(message);
+			catch
+			{
+				_status.ReportServerState(HotReloadState.Disabled);
+				throw;
+			}
 		}
 		else
 		{
+			_status.ReportServerState(HotReloadState.Disabled);
+
 			if (this.Log().IsEnabled(LogLevel.Error))
 			{
 				this.Log().LogError("Unable to find ProjectConfigurationAttribute");

--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.Entries.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.Entries.cs
@@ -24,13 +24,13 @@ internal record DevServerEntry() : HotReloadLogEntry(EntrySource.DevServer, -1, 
 		var (iconState, desc) = (oldStatus, newStatus) switch
 		{
 			(_, { State: ConnectionState.NoServer }) => (EntryIcon.Error, "No endpoint found"),
-			(_, { State: ConnectionState.Connecting }) => (EntryIcon.Loading, "Connecting..."),
-			({ State: not ConnectionState.ConnectionTimeout }, { State: ConnectionState.ConnectionTimeout }) => (EntryIcon.Error, "Timeout"),
-			({ State: not ConnectionState.ConnectionFailed }, { State: ConnectionState.ConnectionFailed }) => (EntryIcon.Error, "Connection error"),
+			(not null, { State: ConnectionState.Connecting }) => (EntryIcon.Loading, "Connecting..."),
+			(null or { State: not ConnectionState.ConnectionTimeout }, { State: ConnectionState.ConnectionTimeout }) => (EntryIcon.Error, "Timeout"),
+			(null or { State: not ConnectionState.ConnectionFailed }, { State: ConnectionState.ConnectionFailed }) => (EntryIcon.Error, "Connection error"),
 
-			({ IsVersionValid: not false }, { IsVersionValid: false }) => (EntryIcon.Warning, "Version mismatch"),
-			({ InvalidFrames.Count: 0 }, { InvalidFrames.Count: > 0 }) => (EntryIcon.Warning, "Unknown messages"),
-			({ MissingRequiredProcessors.IsEmpty: true }, { MissingRequiredProcessors.IsEmpty: false }) => (EntryIcon.Warning, "Processors missing"),
+			(null or { IsVersionValid: not false }, { IsVersionValid: false }) => (EntryIcon.Warning, "Version mismatch"),
+			(null or { InvalidFrames.Count: 0 }, { InvalidFrames.Count: > 0 }) => (EntryIcon.Warning, "Unknown messages"),
+			(null or { MissingRequiredProcessors.IsEmpty: true }, { MissingRequiredProcessors.IsEmpty: false }) => (EntryIcon.Warning, "Processors missing"),
 
 			({ KeepAlive.State: KeepAliveState.Idle or KeepAliveState.Ok }, { KeepAlive.State: KeepAliveState.Late }) => (EntryIcon.Error, "Connection lost (>1000ms)"),
 			({ KeepAlive.State: KeepAliveState.Idle or KeepAliveState.Ok }, { KeepAlive.State: KeepAliveState.Lost }) => (EntryIcon.Error, "Connection lost (>1s)"),
@@ -139,14 +139,14 @@ public enum EntrySource
 public enum EntryIcon
 {
 	// Kind
-	Loading = 0x1,
-	Success = 0x2,
-	Warning = 0x3,
-	Error = 0x4,
+	Loading = 1 << 0,
+	Success = 1 << 1,
+	Warning = 1 << 2,
+	Error = 1 << 3,
 
 	// Source
-	Connection = 0x1 << 8,
-	HotReload = 0x2 << 8,
+	Connection = 1 << 8,
+	HotReload = 2 << 8,
 }
 
 

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.Status.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.Status.cs
@@ -26,7 +26,7 @@ public partial class RemoteControlClient
 		{
 			_owner = owner;
 #if HAS_UNO_WINUI
-			DiagnosticView.Register("Dev-server", () => new RemoteControlStatusView(owner));
+			DiagnosticView.Register("Dev-server", () => new RemoteControlStatusView(owner), DiagnosticViewRegistrationMode.OnDemand);
 #endif
 		}
 

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.UI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.UI.DevServer.targets
@@ -6,6 +6,10 @@
 		<UnoRuntimeEnabledPackage Include="Uno.WinUI.DevServer"  PackageBasePath="$(MSBuildThisFileDirectory)" Condition="'$(MSBuildThisFile)'=='uno.winui.devserver.targets'"  />
 	</ItemGroup>
 
+	<ItemGroup Condition="$(UnoRemoteControlConfigCookie) != ''">
+		<UpToDateCheckInput Include="$(UnoRemoteControlConfigCookie)" />
+	</ItemGroup>
+
 	<PropertyGroup>
 		<!-- Keep the inner path with '/' separator -->
 		<UnoRemoteControlProcessorsPath Condition="'$(SolutionFileName)'!='Uno.UI.sln'">$(MSBuildThisFileDirectory)../tools/rc/processors</UnoRemoteControlProcessorsPath>

--- a/src/Uno.UI/Diagnostics/DiagnosticView.Factories.cs
+++ b/src/Uno.UI/Diagnostics/DiagnosticView.Factories.cs
@@ -42,11 +42,12 @@ internal partial class DiagnosticView
 	/// <typeparam name="TView">Type of the control.</typeparam>
 	/// <param name="friendlyName">The user-friendly name of the diagnostics view.</param>
 	/// <param name="factory">Factory to create an instance of the control.</param>
-	public static DiagnosticView<TView> Register<TView>(string friendlyName, Func<TView> factory)
+	/// <param name="mode">Defines when the registered diagnostic view should be displayed.</param>
+	public static DiagnosticView<TView> Register<TView>(string friendlyName, Func<TView> factory, DiagnosticViewRegistrationMode mode = default)
 		where TView : UIElement
 	{
 		var provider = new DiagnosticView<TView>(typeof(TView).Name, friendlyName, factory);
-		DiagnosticViewRegistry.Register(provider);
+		DiagnosticViewRegistry.Register(provider, mode);
 		return provider;
 	}
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/17753
closes https://github.com/unoplatform/uno/issues/17756
linked https://github.com/unoplatform/uno/issues/17757
closes https://github.com/unoplatform/uno/issues/17846

## Bugfix
Improve dev-server reliability

## What is the current behavior?
* Dev-Server is restarted only after build, driving the built app to not have the updated port to use
* When dev-server uses a new port, app needs to be manullay rebuilt
* Connection cannot be restore

## What is the new behavior?
* Dev-server is automatically restarted 5sec after it's being closed
* Dev-server attempts to re-use the same port when possible, allowing apps to restore connection automatically
* On re-connection, the client will make sure to re-configure the server (discover processors)

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
