### PR TITLE
fix: `MinWidth` and `MinHeight` should not be applied by default on `TextBox`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -1023,5 +1023,69 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(VerticalAlignment.Stretch, placeHolder.VerticalAlignment);
 			Assert.AreEqual(VerticalAlignment.Stretch, contentElement.VerticalAlignment);
 		}
+
+		[TestMethod]
+		public async Task When_Size_Zero_Fluent_Default()
+		{
+			var loaded = false;
+			using var styles = StyleHelper.UseFluentStyles();
+			var textBox = new TextBox
+			{
+				Text = "",
+				Width = 0,
+				Height = 0
+			};
+			textBox.Loaded += (s, e) => loaded = true;
+
+			WindowHelper.WindowContent = textBox;
+			await WindowHelper.WaitFor(() => loaded);
+
+			Assert.AreEqual(textBox.ActualWidth, textBox.MinWidth, 0.1);
+			Assert.AreEqual(textBox.ActualHeight, textBox.MinHeight, 0.1);
+		}
+
+		[TestMethod]
+		public async Task When_Size_Zero_Default()
+		{
+			var loaded = false;
+			var textBox = new TextBox
+			{
+				Text = "",
+				Width = 0,
+				Height = 0
+			};
+			textBox.Loaded += (s, e) => loaded = true;
+
+			WindowHelper.WindowContent = textBox;
+			await WindowHelper.WaitFor(() => loaded);
+
+			Assert.AreEqual(textBox.ActualWidth, 0);
+			Assert.AreEqual(textBox.ActualHeight, 0);
+		}
+
+		[TestMethod]
+		public async Task When_Size_Zero_Fluent_ComboBoxTextBoxStyle()
+		{
+			using var styles = StyleHelper.UseFluentStyles();
+			var loaded = false;
+			var style = Application.Current.Resources["ComboBoxTextBoxStyle"] as Style;
+
+			Assert.IsNotNull(style);
+
+			var textBox = new TextBox
+			{
+				Text = "",
+				Width = 0,
+				Height = 0,
+				Style = style
+			};
+			textBox.Loaded += (s, e) => loaded = true;
+
+			WindowHelper.WindowContent = textBox;
+			await WindowHelper.WaitFor(() => loaded);
+
+			Assert.AreEqual(textBox.ActualWidth, 0);
+			Assert.AreEqual(textBox.ActualHeight, 0);
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -1025,8 +1025,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var textBox = await LoadZeroSizeTextBoxAsync(null);
 
-			Assert.AreEqual(textBox.ActualWidth, textBox.MinWidth, 0.1);
-			Assert.AreEqual(textBox.ActualHeight, textBox.MinHeight, 0.1);
+			textBox.ActualWidth.Should().BeApproximately(textBox.MinWidth, 0.1);
+			textBox.ActualHeight.Should().BeApproximately(textBox.MinHeight, 0.1);
 		}
 
 		[TestMethod]
@@ -1034,8 +1034,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		{
 			var textBox = await LoadZeroSizeTextBoxAsync(null);
 
-			Assert.AreEqual(textBox.ActualWidth, 0);
-			Assert.AreEqual(textBox.ActualHeight, 0);
+			textBox.ActualWidth.Should().Be(0);
+			textBox.ActualHeight.Should().Be(0);
 		}
 
 		[TestMethod]
@@ -1046,8 +1046,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var textBox = await LoadZeroSizeTextBoxAsync(style);
 
-			Assert.AreEqual(textBox.ActualWidth, 0);
-			Assert.AreEqual(textBox.ActualHeight, 0);
+			textBox.ActualWidth.Should().Be(0);
+			textBox.ActualHeight.Should().Be(0);
 		}
 
 		private static async Task<TextBox> LoadZeroSizeTextBoxAsync(Style style)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -1,14 +1,19 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MUXControlsTestApp.Utilities;
 using Uno.UI.Helpers;
 using Uno.UI.RuntimeTests.Helpers;
 using Windows.ApplicationModel.DataTransfer;
+using Color = Windows.UI.Color;
 
 #if HAS_UNO_WINUI || WINAPPSDK || WINUI
 using Colors = Microsoft.UI.Colors;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -764,7 +764,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var SUT = new TextBox
 			{
-				Width = 40,
+				Width = 64, // == TextControlThemeMinWidth for UWP styles
 				Text = "This should be a lot longer than the width of the TextBox."
 			};
 

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -221,10 +221,6 @@
 
 	<Style x:Key="XamlDefaultTextBox"
 		   TargetType="TextBox">
-		<Setter Property="MinWidth"
-				Value="{ThemeResource TextControlThemeMinWidth}" />
-		<Setter Property="MinHeight"
-				Value="{ThemeResource TextControlThemeMinHeight}" />
 		<Setter Property="Foreground"
 				Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
 		<Setter Property="Background"


### PR DESCRIPTION
GitHub Issue (If applicable): part of https://github.com/unoplatform/uno/issues/9063

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Our generic.xaml applies `MinWidth` and `MinHeight` in the default style

## What is the new behavior?

As per WinUI sources, `MinWidth` and `MinHeight` should only be applied to the border inside of the control, not as properties on the control directly. This way, setting 0 width and height should make the `TextBox` invisible. On the other hand, the default fluent text box style should apply these properties directly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
