### PR TITLE
feat: Transparent icon background on non-mobile

### DIFF
--- a/src/Uno.Sdk/targets/Uno.DefaultItems.Resizetizer.targets
+++ b/src/Uno.Sdk/targets/Uno.DefaultItems.Resizetizer.targets
@@ -13,8 +13,8 @@
 		<UnoSplashScreenBaseSize Condition="$(UnoSplashScreenBaseSize) == ''">300,300</UnoSplashScreenBaseSize>
 		<UnoSplashScreenColor Condition="$(UnoSplashScreenColor) == ''">#FFFFFF</UnoSplashScreenColor>
 
-		<UnoUseIconBackground Condition="$(UnoUseIconBackground) == '' and ($(IsWinAppSdk) or $(IsDesktop) or $(IsBrowserWasm))">false</UnoUseIconBackground>
-		<UnoUseIconBackground Condition="$(UnoUseIconBackground) == ''">true</UnoUseIconBackground>
+		<UnoUseIconBackgroundFile Condition="$(UnoUseIconBackgroundFile) == '' and ($(IsWinAppSdk) or $(IsDesktop) or $(IsBrowserWasm))">false</UnoUseIconBackgroundFile>
+		<UnoUseIconBackgroundFile Condition="$(UnoUseIconBackgroundFile) == ''">true</UnoUseIconBackgroundFile>
 
 		<!-- Support net8.0, without a platform identifier -->
 		<_UnoResizetizerIsCompatibleApp Condition=" 
@@ -28,7 +28,7 @@
 			ForegroundFile="$(UnoIconForegroundFile)"
 			ForegroundScale="$(UnoIconForegroundScale)"
 			Color="$(UnoIconBackgroundColor)"
-			UseIconBackground="$(UnoUseIconBackground)"
+			UseBackgroundFile="$(UnoUseIconBackgroundFile)"
 			IsDefaultItem="true"
 			Exclude="@(UnoIcon)"
 			Condition="Exists('$(UnoIconBackgroundFile)') and Exists('$(UnoIconForegroundFile)')" />

--- a/src/Uno.Sdk/targets/Uno.DefaultItems.Resizetizer.targets
+++ b/src/Uno.Sdk/targets/Uno.DefaultItems.Resizetizer.targets
@@ -13,6 +13,9 @@
 		<UnoSplashScreenBaseSize Condition="$(UnoSplashScreenBaseSize) == ''">300,300</UnoSplashScreenBaseSize>
 		<UnoSplashScreenColor Condition="$(UnoSplashScreenColor) == ''">#FFFFFF</UnoSplashScreenColor>
 
+		<UnoUseIconBackground Condition="$(UnoUseIconBackground) == '' and ($(IsWinAppSdk) or $(IsDesktop) or $(IsBrowserWasm))">false</UnoUseIconBackground>
+		<UnoUseIconBackground Condition="$(UnoUseIconBackground) == ''">true</UnoUseIconBackground>
+
 		<!-- Support net8.0, without a platform identifier -->
 		<_UnoResizetizerIsCompatibleApp Condition=" 
 			$(_IsUnoSingleProjectAndLegacy) == 'true' 
@@ -25,6 +28,7 @@
 			ForegroundFile="$(UnoIconForegroundFile)"
 			ForegroundScale="$(UnoIconForegroundScale)"
 			Color="$(UnoIconBackgroundColor)"
+			UseIconBackground="$(UnoUseIconBackground)"
 			IsDefaultItem="true"
 			Exclude="@(UnoIcon)"
 			Condition="Exists('$(UnoIconBackgroundFile)') and Exists('$(UnoIconForegroundFile)')" />


### PR DESCRIPTION
# Requires https://github.com/unoplatform/uno.resizetizer/pull/310

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Icon background file is used by default on WinUI, Desktop and WASM

## What is the new behavior?

Not used by default

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
