### PR TITLE
fix: Ensure `Border.Child` is measured/arranged when reset

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -626,20 +626,22 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			var child = new MeasureArrangeCounterButton();
 			SUT.Child = child;
 
-			await WindowHelper.WaitFor(() => child.ArrangeCount > 0);
+			await WindowHelper.WaitForLoaded(child);
 
-			Assert.IsTrue(child.MeasureCount > 0);
-			Assert.IsTrue(child.ArrangeCount > 0);
-
-			var oldMeasureCount = child.MeasureCount;
-			var oldArrangeCount = child.ArrangeCount;
+#if HAS_UNO // Uno specific: The initial layout count here is incorrect - should be 1 as in WinUI
+			var initialCount = 2;
+#else
+			var initialCount = 1;
+#endif
+			Assert.AreEqual(initialCount, child.MeasureCount);
+			Assert.AreEqual(initialCount, child.ArrangeCount);
 
 			SUT.Child = child;
 
-			await WindowHelper.WaitFor(() => child.MeasureCount > oldMeasureCount);
+			await WindowHelper.WaitFor(() => child.MeasureCount > initialCount);
 
-			Assert.IsTrue(child.MeasureCount > oldMeasureCount);
-			Assert.IsTrue(child.ArrangeCount > oldArrangeCount);
+			Assert.AreEqual(3, child.MeasureCount);
+			Assert.AreEqual(3, child.ArrangeCount);
 		}
 
 		internal partial class MeasureArrangeCounterButton : Button

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -588,7 +588,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitForLoaded(child);
 
-#if __SKIA__ || __WASM__ // Uno specific: The initial layout count here is incorrect - should be 1 as in WinUI
+#if __SKIA__ || __WASM__ || __IOS__// Uno specific: The initial layout count here is incorrect - should be 1 as in WinUI
 			var initialCount = 2;
 #else
 			var initialCount = 1;
@@ -600,7 +600,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitFor(() => child.MeasureCount > initialCount);
 
-#if __SKIA__ || __WASM__ // Uno specific: The layout count here is incorrect - should be 2 as in WinUI
+#if __SKIA__ || __WASM__ || __IOS__ // Uno specific: The layout count here is incorrect - should be 2 as in WinUI
 			var newCount = 4;
 #else
 			var newCount = 2;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -588,7 +588,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitForLoaded(child);
 
-#if HAS_UNO // Uno specific: The initial layout count here is incorrect - should be 1 as in WinUI
+#if __SKIA__ || __WASM__ // Uno specific: The initial layout count here is incorrect - should be 1 as in WinUI
 			var initialCount = 2;
 #else
 			var initialCount = 1;
@@ -600,7 +600,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitFor(() => child.MeasureCount > initialCount);
 
-#if HAS_UNO // Uno specific: The layout count here is incorrect - should be 2 as in WinUI
+#if __SKIA__ || __WASM__ // Uno specific: The layout count here is incorrect - should be 2 as in WinUI
 			var newCount = 4;
 #else
 			var newCount = 2;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -640,8 +640,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitFor(() => child.MeasureCount > initialCount);
 
-			Assert.AreEqual(3, child.MeasureCount);
-			Assert.AreEqual(3, child.ArrangeCount);
+#if HAS_UNO // Uno specific: The layout count here is incorrect - should be 2 as in WinUI
+			var newCount = 4;
+#else
+			var newCount = 2;
+#endif
+
+			Assert.AreEqual(newCount, child.MeasureCount);
+			Assert.AreEqual(newCount, child.ArrangeCount);
 		}
 
 		internal partial class MeasureArrangeCounterButton : Button

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -575,46 +575,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			ImageAssert.HasColorAt(screenshot, textBoxRect.CenterX - (float)(0.45 * textBoxRect.Width), textBoxRect.Y, "#FF0000", tolerance: 20);
 		}
 
-#if HAS_UNO
-#if !HAS_INPUT_INJECTOR
-		[Ignore("InputInjector is not supported on this platform.")]
-#else
-		[TestMethod]
-		[RunsOnUIThread]
-#endif
-		public async Task Nested_Element_Tapped()
-		{
-			var SUT = new Border()
-			{
-				Child = new Button()
-			};
-
-			var outerBorderTaps = 0;
-			var outerBorderRightTaps = 0;
-
-			SUT.Tapped += (_, _) => outerBorderTaps++;
-			SUT.RightTapped += (_, _) => outerBorderRightTaps++;
-			SUT.Child.RightTapped += (_, _) => { };
-
-			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
-			using var mouse = injector.GetMouse();
-
-			WindowHelper.WindowContent = SUT;
-			await WindowHelper.WaitForIdle();
-
-			mouse.Press(SUT.GetAbsoluteBounds().GetCenter());
-			mouse.Release();
-
-			Assert.AreEqual(1, outerBorderTaps);
-			Assert.AreEqual(0, outerBorderRightTaps);
-
-			mouse.PressRight(SUT.GetAbsoluteBounds().GetCenter());
-			mouse.ReleaseRight();
-
-			Assert.AreEqual(1, outerBorderTaps);
-			Assert.AreEqual(1, outerBorderRightTaps);
-		}
-
 		[TestMethod]
 		[RunsOnUIThread]
 		public async Task When_Child_Set_Same_Reference()
@@ -667,6 +627,46 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				ArrangeCount++;
 				return base.ArrangeOverride(finalSize);
 			}
+		}
+
+#if HAS_UNO
+#if !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#else
+		[TestMethod]
+		[RunsOnUIThread]
+#endif
+		public async Task Nested_Element_Tapped()
+		{
+			var SUT = new Border()
+			{
+				Child = new Button()
+			};
+
+			var outerBorderTaps = 0;
+			var outerBorderRightTaps = 0;
+
+			SUT.Tapped += (_, _) => outerBorderTaps++;
+			SUT.RightTapped += (_, _) => outerBorderRightTaps++;
+			SUT.Child.RightTapped += (_, _) => { };
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var mouse = injector.GetMouse();
+
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForIdle();
+
+			mouse.Press(SUT.GetAbsoluteBounds().GetCenter());
+			mouse.Release();
+
+			Assert.AreEqual(1, outerBorderTaps);
+			Assert.AreEqual(0, outerBorderRightTaps);
+
+			mouse.PressRight(SUT.GetAbsoluteBounds().GetCenter());
+			mouse.ReleaseRight();
+
+			Assert.AreEqual(1, outerBorderTaps);
+			Assert.AreEqual(1, outerBorderRightTaps);
 		}
 
 #if !HAS_INPUT_INJECTOR

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -615,6 +615,52 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(1, outerBorderRightTaps);
 		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Child_Set_Same_Reference()
+		{
+			var SUT = new Border() { Width = 100, Height = 100 };
+			WindowHelper.WindowContent = SUT;
+			await WindowHelper.WaitForLoaded(SUT);
+
+			var child = new MeasureArrangeCounterButton();
+			SUT.Child = child;
+
+			await WindowHelper.WaitFor(() => child.ArrangeCount > 0);
+
+			Assert.IsTrue(child.MeasureCount > 0);
+			Assert.IsTrue(child.ArrangeCount > 0);
+
+			var oldMeasureCount = child.MeasureCount;
+			var oldArrangeCount = child.ArrangeCount;
+
+			SUT.Child = child;
+
+			await WindowHelper.WaitFor(() => child.MeasureCount > oldMeasureCount);
+
+			Assert.IsTrue(child.MeasureCount > oldMeasureCount);
+			Assert.IsTrue(child.ArrangeCount > oldArrangeCount);
+		}
+
+		internal partial class MeasureArrangeCounterButton : Button
+		{
+			internal int MeasureCount { get; private set; }
+
+			internal int ArrangeCount { get; private set; }
+
+			protected override Size MeasureOverride(Size availableSize)
+			{
+				MeasureCount++;
+				return base.MeasureOverride(availableSize);
+			}
+
+			protected override Size ArrangeOverride(Size finalSize)
+			{
+				ArrangeCount++;
+				return base.ArrangeOverride(finalSize);
+			}
+		}
+
 #if !HAS_INPUT_INJECTOR
 		[Ignore("InputInjector is not supported on this platform.")]
 #else

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -588,26 +588,24 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await WindowHelper.WaitForLoaded(child);
 
-#if __SKIA__ || __WASM__ || __IOS__// Uno specific: The initial layout count here is incorrect - should be 1 as in WinUI
-			var initialCount = 2;
-#else
-			var initialCount = 1;
+#if !HAS_UNO // Uno specific: The initial layout count here is incorrect - should be 1 as in WinUI
+			Assert.AreEqual(1, child.MeasureCount);
+			Assert.AreEqual(1, child.ArrangeCount);
 #endif
-			Assert.AreEqual(initialCount, child.MeasureCount);
-			Assert.AreEqual(initialCount, child.ArrangeCount);
+
+			var initialMeasureCount = child.MeasureCount;
+			var initialArrangeCount = child.ArrangeCount;
 
 			SUT.Child = child;
 
-			await WindowHelper.WaitFor(() => child.MeasureCount > initialCount);
+			// Both measure and arrange count must increase
+			await WindowHelper.WaitFor(() => child.MeasureCount > initialMeasureCount);
+			await WindowHelper.WaitFor(() => child.ArrangeCount > initialArrangeCount);
 
-#if __SKIA__ || __WASM__ || __IOS__ // Uno specific: The layout count here is incorrect - should be 2 as in WinUI
-			var newCount = 4;
-#else
-			var newCount = 2;
+#if !HAS_UNO // Uno specific: The initial layout count here is incorrect - should be 1 as in WinUI
+			Assert.AreEqual(2, child.MeasureCount);
+			Assert.AreEqual(2, child.ArrangeCount);
 #endif
-
-			Assert.AreEqual(newCount, child.MeasureCount);
-			Assert.AreEqual(newCount, child.ArrangeCount);
 		}
 
 		internal partial class MeasureArrangeCounterButton : Button

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.cs
@@ -85,19 +85,19 @@ public partial class Border : FrameworkElement
 
 	public UIElement Child
 	{
-		get => (UIElement)this.GetValue(ChildProperty);
+		get => (UIElement)GetValue(ChildProperty);
 		set
 		{
 			// This means that setting Child to the same reference does not trigger PropertyChanged, 
 			// which is a problem, as WinUI always removes the current child and adds it again,
 			// even when dealing with the exact same reference. This also triggers measure/arrange
 			// on the child. To work around this, we force the update here.
-			if (value == this.Child)
+			if (value == Child)
 			{
-				SetChild(value);
+				SetChild(value, value);
 			}
 
-			this.SetValue(ChildProperty, value);
+			SetValue(ChildProperty, value);
 		}
 	}
 
@@ -112,23 +112,25 @@ public partial class Border : FrameworkElement
 				// disable the property-based propagation here to support the case where the Parent property is overridden to simulate
 				// a different inheritance hierarchy, as is done for some controls with native styles.
 				FrameworkPropertyMetadataOptions.ValueDoesNotInheritDataContext,
-				(DependencyObject s, DependencyPropertyChangedEventArgs e) => ((Border)s)?.SetChild((UIElement)e.NewValue)
+				(DependencyObject s, DependencyPropertyChangedEventArgs e) => ((Border)s)?.SetChild((UIElement)e.OldValue, (UIElement)e.NewValue)
 			)
 		);
 
-	private void SetChild(UIElement child)
+	private void SetChild(UIElement previousChild, UIElement newChild)
 	{
-		var existingChild = Child;
-		ReAttachChildTransitions(existingChild, child);
-
-		if (existingChild is not null)
+		if (previousChild != newChild)
 		{
-			RemoveChild(existingChild);
+			ReAttachChildTransitions(previousChild, newChild);
 		}
 
-		if (child is not null)
+		if (previousChild is not null)
 		{
-			AddChild(child);
+			RemoveChild(previousChild);
+		}
+
+		if (newChild is not null)
+		{
+			AddChild(newChild);
 		}
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1046

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Re-setting `Border.Child` to the same reference does not do anything.

## What is the new behavior?

Measure/Arrange are triggered on the `Child` as it is temporarily removed and re-added

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.