### PR TITLE
Typo in implicit packages remove item

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.targets
@@ -80,7 +80,7 @@
 		</ImplicitPackagesResolver_v0>
 
 		<ItemGroup>
-			<_UnoProjectSystemPackageReference Remove="@(_UnoProjectSystemPackageReference" />
+			<_UnoProjectSystemPackageReference Remove="@(_UnoProjectSystemPackageReference)" />
 			<PackageVersion Remove="@(_UnoRemovePackageVersions)" />
 			<PackageReference Include="@(_UnoImplicitPackageReference)" />
 			<_UnoImplicitPackageReference Remove="@(_UnoImplicitPackageReference)" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #17865

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

There is a typo when we remove the temporary Implicit Package group

## What is the new behavior?

This is fixed