### PR TITLE
Project capabilities should always be present for SingleProject

### DIFF
--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.SingleProject.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.SingleProject.targets
@@ -14,11 +14,6 @@
 		<!-- Otherwise define LaunchProfilesGroupByPlatformFilters by default -->
 		<ProjectCapability Include="LaunchProfilesGroupByPlatformFilters" Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &gt;= '17.0' " Exclude="@(ProjectCapability)" />
 		<ProjectCapability Include="SingleTargetBuildForStartupProjects" Condition=" '$(EnableSingleTargetBuildForStartupProjects)' != 'false' " Exclude="@(ProjectCapability)" />
-
-		<!-- Required since VS 2022 17.4 Preview 1 -->
-		<ProjectCapability Include="MauiCore" Exclude="@(ProjectCapability)" />
-		<ProjectCapability Include="Maui" Exclude="@(ProjectCapability)" />
-		<ProjectCapability Include="UseMauiCore" Exclude="@(ProjectCapability)" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="$(IsWinAppSdk)">

--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
@@ -29,6 +29,14 @@
 		<ProjectCapability Include="WindowsUniversalMultiViews"/>
 	</ItemGroup>
 
+	<ItemGroup>
+		<!-- Required since VS 2022 17.4 Preview 1 -->
+		<!-- Moved to root capabilities as Visual Studio doesn't like it in the SingleProject specific capabilities -->
+		<ProjectCapability Include="MauiCore" Exclude="@(ProjectCapability)" />
+		<ProjectCapability Include="Maui" Exclude="@(ProjectCapability)" />
+		<ProjectCapability Include="UseMauiCore" Exclude="@(ProjectCapability)" />
+	</ItemGroup>
+
 	<Import Project="Uno.ProjectCapabilities.WinAppSdk.targets" Condition="$(IsWinAppSdk)" />
 
 	<Import Project="Uno.ProjectCapabilities.Wasm.targets" Condition="$(IsBrowserWasm)" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- fixes #16490

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When selecting the project properties in Visual Studio an exception is encountered

## What is the new behavior?

We now always provide the required MAUI capability which seems to resolve the problem in Visual Studio without adjustments to the csproj.