### PR TITLE
Setting `BitmapImage.UriSource` to `null`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -278,6 +278,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 		[RunsOnUIThread]
 		public async Task When_Uri_Nullified()
 		{
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			{
+				Assert.Inconclusive("Taking screenshots is not possible on this target platform.");
+			}
+
 			var image = new Image();
 			var bitmapImage = new BitmapImage();
 			image.Source = bitmapImage;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -294,13 +294,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			var initialScreenshot = await UITestHelper.ScreenShot(border);
 
 			bitmapImage.UriSource = new Uri("ms-appx:///Assets/BlueSquare.png");
+			bool opened = false;
+			bitmapImage.ImageOpened += (s, e) => opened = true;
+
 			await WindowHelper.WaitForIdle();
+			await WindowHelper.WaitFor(() => opened);
+
 			var screenshotWithImage = await UITestHelper.ScreenShot(border);
 
 			await ImageAssert.AreNotEqualAsync(initialScreenshot, screenshotWithImage);
 
 			bitmapImage.UriSource = null;
 			await WindowHelper.WaitForIdle();
+
 			var screenshotWithoutImage = await UITestHelper.ScreenShot(border);
 
 			await ImageAssert.AreEqualAsync(screenshotWithoutImage, initialScreenshot);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -274,6 +274,38 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			await WindowHelper.WaitFor(() => imageOpened);
 		}
 
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Uri_Nullified()
+		{
+			var image = new Image();
+			var bitmapImage = new BitmapImage();
+			image.Source = bitmapImage;
+			var border = new Border()
+			{
+				Width = 100,
+				Height = 100,
+				Background = new SolidColorBrush(Colors.Red),
+			};
+			border.Child = image;
+			WindowHelper.WindowContent = border;
+			await WindowHelper.WaitForLoaded(border);
+
+			var initialScreenshot = await UITestHelper.ScreenShot(border);
+
+			bitmapImage.UriSource = new Uri("ms-appx:///Assets/BlueSquare.png");
+			await WindowHelper.WaitForIdle();
+			var screenshotWithImage = await UITestHelper.ScreenShot(border);
+
+			await ImageAssert.AreNotEqualAsync(initialScreenshot, screenshotWithImage);
+
+			bitmapImage.UriSource = null;
+			await WindowHelper.WaitForIdle();
+			var screenshotWithoutImage = await UITestHelper.ScreenShot(border);
+
+			await ImageAssert.AreEqualAsync(screenshotWithoutImage, initialScreenshot);
+		}
+
 		private class Given_BitmapSource_Exception : Exception
 		{
 			public string Caller { get; }

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.Linq;
 using System.Numerics;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
 using Uno.UI.Xaml.Media;
 using Windows.Foundation;
-using Microsoft.UI.Composition;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Media.Imaging;
-using Uno.UI;
 
 namespace Microsoft.UI.Xaml.Controls
 {
@@ -144,6 +142,12 @@ namespace Microsoft.UI.Xaml.Controls
 				_imageSprite.SetPaintColor(MonochromeColor);
 				_imageSprite.Brush = _surfaceBrush;
 				ImageOpened?.Invoke(this, new RoutedEventArgs(this));
+			}
+			else if (currentData is { Kind: ImageDataKind.Empty })
+			{
+				// Ensure the previous content is unloaded
+				_currentSurface = null;
+				_imageSprite.Brush = null;
 			}
 			else if (currentData is { Kind: ImageDataKind.Error })
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.skia.cs
@@ -17,7 +17,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private SkiaCompositionSurface _currentSurface;
 		private CompositionSurfaceBrush _surfaceBrush;
 		private readonly SpriteVisual _imageSprite;
-		private ImageData _pendingImageData;
+		private ImageData? _pendingImageData;
 
 		public Image()
 		{
@@ -33,7 +33,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_lastMeasuredSize = default;
 			_imageSprite.Brush = null;
 			_currentSurface = null;
-			_pendingImageData = new();
+			_pendingImageData = null;
 			InvalidateMeasure();
 
 			if (newValue is SvgImageSource svgImageSource)
@@ -133,27 +133,35 @@ namespace Microsoft.UI.Xaml.Controls
 		private void TryProcessPendingSource()
 		{
 			var currentData = _pendingImageData;
-			_pendingImageData = new();
-			if (currentData.HasData)
+			_pendingImageData = null;
+			if (currentData is null)
 			{
-				_currentSurface = currentData.CompositionSurface;
+				// No image data is pending
+				return;
+			}
+
+			var processedData = currentData.Value;
+
+			if (processedData.HasData)
+			{
+				_currentSurface = processedData.CompositionSurface;
 				_surfaceBrush = Visual.Compositor.CreateSurfaceBrush(_currentSurface);
 				_surfaceBrush.UsePaintColorToColorSurface = MonochromeColor is not null;
 				_imageSprite.SetPaintColor(MonochromeColor);
 				_imageSprite.Brush = _surfaceBrush;
 				ImageOpened?.Invoke(this, new RoutedEventArgs(this));
 			}
-			else if (currentData is { Kind: ImageDataKind.Empty })
+			else if (processedData is { Kind: ImageDataKind.Empty })
 			{
 				// Ensure the previous content is unloaded
 				_currentSurface = null;
 				_imageSprite.Brush = null;
 			}
-			else if (currentData is { Kind: ImageDataKind.Error })
+			else if (processedData is { Kind: ImageDataKind.Error })
 			{
 				ImageFailed?.Invoke(this, new(
 					this,
-					currentData.Error?.Message ?? "Unknown error"));
+					processedData.Error?.Message ?? "Unknown error"));
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/17540

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Setting `UriSource` to `null` previously kept the image displayed


## What is the new behavior?

Not showing the image anymore

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
