### PR TITLE
docs: Update external documentation to latest

### DIFF
--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -7,17 +7,17 @@ Set-PSDebug -Trace 1
 
 $external_docs = @{
     # use either commit, or branch name to use its latest commit
-    "uno.wasm.bootstrap" = "9c669e555a05d05465a6c9c894bc0c5b86b76577" #latest main commit
-    "uno.themes"         = "7ce3b5215bf5802927d2c65f0e2044cacae8c311" #latest release branch commit
-    "uno.toolkit.ui"     = "a8a382ded333547580b7a4086dc1415d9e8cab04" #latest release branch commit
-    "uno.check"          = "73c3b7960601d16e81e425412755385298edad0d" #latest main commit
+    "uno.wasm.bootstrap" = "6a034bdd23a8be6882b0d05e8b017e49f655e89d" #latest main commit
+    "uno.themes"         = "38d6bf005a2637f77bb052d92be88ac567479811" #latest release branch commit
+    "uno.toolkit.ui"     = "27c6e65094a8e9a53e6a4f33b846f4d98c118fc4" #latest release branch commit
+    "uno.check"          = "27a06fd34c4744d07d48249daae1bcdf21a8a005" #latest main commit
     "uno.xamlmerge.task" = "21f02c98702b875a9942047ca042e41810b6fe56" #latest main commit
     "figma-docs"         = "842a2792282b88586a337381b2b3786e779973b4" #latest main commit
-    "uno.resizetizer"    = "ab50fa33bc8a9f8aeed68517ad59e111b1acbb5a" #latest main commit
+    "uno.resizetizer"    = "dce3eabef076e37b38fe058b427eb84f1d19b881" #latest main commit
     "uno.uitest"         = "9669fd2783187d06c36dd6a717c1b9f08d1fa29c" #latest master commit
-    "uno.extensions"     = "502d6a3d7e4aeab66d1c943bc5f39227c4022de5" #latest release branch commit
-    "workshops"          = "3b5bd04b4833305df698ceec51056b6ef6db3190" #latest master commit
-    "uno.samples"        = "d82132390ce1e59f9ab7d66a16fc5ac95651f455" #latest master commit
+    "uno.extensions"     = "bf12644ee945bf1cf1020ddbdc0622cccb8fed5b" #latest release branch commit
+    "workshops"          = "df05737f9e3088a4e60179f6fa2cd2fc6866d2c7" #latest master commit
+    "uno.samples"        = "d30313f954c312563a118196b734a534718eceb9" #latest master commit
 }
 
 $uno_git_url = "https://github.com/unoplatform/"


### PR DESCRIPTION
GitHub Issue (If applicable): partially related to https://github.com/unoplatform/private/issues/504 (with additional latest docs fixes)

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## Description

Update external documentation to the latest to fix broken links and add latest other doc fixes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

