### PR TITLE
Adjust devserver inclusion when WinExe is selected

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -8,7 +8,7 @@
 		<_IsUnoSingleProjectAndLegacy Condition=" $(SingleProject) == 'true' OR $(UnoSingleProject) == 'true' ">true</_IsUnoSingleProjectAndLegacy>
 
 		<_ImplicitRestoreOutputType>$([MSBuild]::ValueOrDefault('$(OutputType)', 'Library'))</_ImplicitRestoreOutputType>
-		<IsUnoHead Condition="$(_ImplicitRestoreOutputType) == 'Exe'">true</IsUnoHead>
+		<IsUnoHead Condition=" '$(_InitialOutputType)' == 'WinExe' OR '$(_InitialOutputType)' == 'Exe' ">true</IsUnoHead>
 		<_InitialOutputType>$([MSBuild]::ValueOrDefault('$(OutputType)', 'Library'))</_InitialOutputType>
 		<_InitialOutputType Condition="$(TargetFramework) == '' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == '' ">Library</_InitialOutputType>
 		<_IsStandaloneWasmHead>false</_IsStandaloneWasmHead>

--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -8,7 +8,7 @@
 		<_IsUnoSingleProjectAndLegacy Condition=" $(SingleProject) == 'true' OR $(UnoSingleProject) == 'true' ">true</_IsUnoSingleProjectAndLegacy>
 
 		<_ImplicitRestoreOutputType>$([MSBuild]::ValueOrDefault('$(OutputType)', 'Library'))</_ImplicitRestoreOutputType>
-		<IsUnoHead Condition=" '$(_InitialOutputType)' == 'WinExe' OR '$(_InitialOutputType)' == 'Exe' ">true</IsUnoHead>
+		<IsUnoHead Condition=" '$(_ImplicitRestoreOutputType)' == 'WinExe' OR '$(_ImplicitRestoreOutputType)' == 'Exe' ">true</IsUnoHead>
 		<_InitialOutputType>$([MSBuild]::ValueOrDefault('$(OutputType)', 'Library'))</_InitialOutputType>
 		<_InitialOutputType Condition="$(TargetFramework) == '' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == '' ">Library</_InitialOutputType>
 		<_IsStandaloneWasmHead>false</_IsStandaloneWasmHead>

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
@@ -9,7 +9,7 @@
 		<_UnoProjectSystemPackageReference Include="Uno.Resizetizer" ProjectSystem="true" PrivateAssets="all" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(_InitialOutputType)' == 'WinExe' OR '$(_InitialOutputType)' == 'Exe' ">
+	<ItemGroup Condition=" '$(_ImplicitRestoreOutputType)' == 'WinExe' OR '$(_ImplicitRestoreOutputType)' == 'Exe' ">
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.DevServer" ProjectSystem="true" Condition="$(Optimize) != 'true'" />
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.DevServer" ProjectSystem="true" Exclude="all" Condition="$(Optimize) == 'true'" />
 	</ItemGroup>

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.targets
@@ -9,7 +9,7 @@
 		<_UnoProjectSystemPackageReference Include="Uno.Resizetizer" ProjectSystem="true" PrivateAssets="all" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(_ImplicitRestoreOutputType) == 'Exe'">
+	<ItemGroup Condition=" '$(_InitialOutputType)' == 'WinExe' OR '$(_InitialOutputType)' == 'Exe' ">
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.DevServer" ProjectSystem="true" Condition="$(Optimize) != 'true'" />
 		<_UnoProjectSystemPackageReference Include="Uno.WinUI.DevServer" ProjectSystem="true" Exclude="all" Condition="$(Optimize) == 'true'" />
 	</ItemGroup>

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -10,7 +10,7 @@
 		<ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition=" '$(IsUnoHead)' == 'true' ">
+	<PropertyGroup Condition=" '$(IsUnoHead)' == 'true' AND $(Optimize) == 'true' ">
 		<OutputType>WinExe</OutputType>
 	</PropertyGroup>
 

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -10,7 +10,7 @@
 		<ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
 	</PropertyGroup>
 	
-	<PropertyGroup Condition=" '$(IsUnoHead)' == 'true' AND $(Optimize) == 'true' ">
+	<PropertyGroup Condition=" '$(IsUnoHead)' == 'true' ">
 		<OutputType>WinExe</OutputType>
 	</PropertyGroup>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

- closes #17719

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

We limit the WinEXE Output Type to when we are building a release

## What is the new behavior?

We always use WinEXE for the Output Type of the Desktop Target for an Uno Head project.
cc: @jeromelaban 