### PR TITLE
fix(hr): Fix indicator not showing in rider

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -118,6 +118,13 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 				InitializePartialReload();
 				InitializeXamlReader();
 
+				if (!_serverMetadataUpdatesEnabled
+					&& !_supportsLightweightHotReload
+					&& !_supportsXamlReader)
+				{
+					_status.ReportInvalidRuntime();
+				}
+
 				ConfigureServer message = new(_projectPath, _xamlPaths, GetMetadataUpdateCapabilities(), _serverMetadataUpdatesEnabled, config.MSBuildProperties);
 
 				await _rcClient.SendMessage(message);

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -139,6 +139,11 @@ public partial class RemoteControlClient : IRemoteControlClient
 				.ToArray();
 		}
 
+		// Enable hot-reload
+		// Note: We register the HR processor even if we _serverAddresses is empty. This is to make sure to create the HR indicator.
+		RegisterProcessor(new HotReload.ClientHotReloadProcessor(this));
+		_status.RegisterRequiredServerProcessor("Uno.UI.RemoteControl.Host.HotReload.ServerHotReloadProcessor", VersionHelper.GetVersion(typeof(ClientHotReloadProcessor)));
+
 		if (_serverAddresses is null or { Length: 0 })
 		{
 			this.Log().LogError("Failed to get any remote control server endpoint from the IDE.");
@@ -147,10 +152,6 @@ public partial class RemoteControlClient : IRemoteControlClient
 			_status.Report(ConnectionState.NoServer);
 			return;
 		}
-
-		// Enable hot-reload
-		RegisterProcessor(new HotReload.ClientHotReloadProcessor(this));
-		_status.RegisterRequiredServerProcessor("Uno.UI.RemoteControl.Host.HotReload.ServerHotReloadProcessor", VersionHelper.GetVersion(typeof(ClientHotReloadProcessor)));
 
 		_connection = StartConnection();
 	}

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Context.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Context.cs
@@ -24,7 +24,7 @@ public sealed partial class DiagnosticsOverlay
 
 		public static ViewContext? TryCreate(DiagnosticsOverlay owner)
 		{
-			if (owner._root.Content?.DispatcherQueue is { } dispatcher 
+			if (owner._root.Content?.DispatcherQueue is { } dispatcher
 				&& owner._context?._dispatcher != dispatcher)
 			{
 				return new ViewContext(owner, dispatcher);

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Context.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Context.cs
@@ -24,7 +24,8 @@ public sealed partial class DiagnosticsOverlay
 
 		public static ViewContext? TryCreate(DiagnosticsOverlay owner)
 		{
-			if (owner._root.Content?.DispatcherQueue is { } dispatcher)
+			if (owner._root.Content?.DispatcherQueue is { } dispatcher 
+				&& owner._context?._dispatcher != dispatcher)
 			{
 				return new ViewContext(owner, dispatcher);
 			}

--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -89,8 +89,8 @@ public sealed partial class DiagnosticsOverlay : Control
 		root.Changed += static (snd, e) =>
 		{
 			var overlay = Get(snd);
-			var context = ViewContext.TryCreate(overlay);
-			if (context != overlay._context) // I.e. dispatcher changed ... is this even possible ???
+
+			if (ViewContext.TryCreate(overlay) is { } context) // I.e. dispatcher changed ... is this even possible ???
 			{
 				lock (overlay._updateGate)
 				{
@@ -103,9 +103,11 @@ public sealed partial class DiagnosticsOverlay : Control
 					{
 						element.Dispose();
 					}
+
 					overlay._elements.Clear();
 				}
 			}
+
 			overlay.UpdatePlacement();
 			overlay.EnqueueUpdate();
 		};


### PR DESCRIPTION
linked https://github.com/unoplatform/uno.rider/issues/101
closes https://github.com/unoplatform/uno/issues/17836

## Bugfix
Fix indicator not showing in rider

## What is the current behavior?
When we create a new project using latest version of rider's plugin the dev-server is not started and port is not published to app. This drives the app to not even try to connect, causing the HR indicator to be stuck in an invalid state.

## What is the new behavior?
The indicator is read (until https://github.com/unoplatform/uno.rider/issues/101 is being fixed)

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
