### PR TITLE
fix: Ensure Renderer is initialized when HWND is already available

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Wpf/Rendering/OpenGLWpfRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Rendering/OpenGLWpfRenderer.cs
@@ -54,6 +54,12 @@ internal partial class OpenGLWpfRenderer : IWpfRenderer
 
 			return true;
 		}
+#if DEBUG
+		else if (hwnd == IntPtr.Zero)
+		{
+			throw new InvalidOperationException("Window handle was not available while attempting to initialize OpenGL renderer.");
+		}
+#endif
 		else
 		{
 			Release();

--- a/src/Uno.UI.Runtime.Skia.Wpf/Rendering/OpenGLWpfRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Rendering/OpenGLWpfRenderer.cs
@@ -43,7 +43,19 @@ internal partial class OpenGLWpfRenderer : IWpfRenderer
 	public bool TryInitialize()
 	{
 		// Get the window from the wpf control
-		var hwnd = new WindowInteropHelper(Window.GetWindow(_hostControl)).Handle;
+		var window = Window.GetWindow(_hostControl);
+		if (window is null)
+		{
+			throw new InvalidOperationException("The host control is not associated with any Window");
+		}
+
+		var windowInteropHelper = new WindowInteropHelper(window);
+		var hwnd = windowInteropHelper.Handle;
+		if (hwnd == IntPtr.Zero)
+		{
+			windowInteropHelper.EnsureHandle();
+			hwnd = windowInteropHelper.Handle;
+		}
 
 		if (hwnd != IntPtr.Zero && hwnd == _hwnd)
 		{
@@ -54,12 +66,6 @@ internal partial class OpenGLWpfRenderer : IWpfRenderer
 
 			return true;
 		}
-#if DEBUG
-		else if (hwnd == IntPtr.Zero)
-		{
-			throw new InvalidOperationException("Window handle was not available while attempting to initialize OpenGL renderer.");
-		}
-#endif
 		else
 		{
 			Release();

--- a/src/Uno.UI.Runtime.Skia.Wpf/Rendering/OpenGLWpfRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Rendering/OpenGLWpfRenderer.cs
@@ -49,15 +49,13 @@ internal partial class OpenGLWpfRenderer : IWpfRenderer
 			throw new InvalidOperationException("The host control is not associated with any Window");
 		}
 
-		var windowInteropHelper = new WindowInteropHelper(window);
-		var hwnd = windowInteropHelper.Handle;
+		var hwnd = new WindowInteropHelper(window).EnsureHandle();
 		if (hwnd == IntPtr.Zero)
 		{
-			windowInteropHelper.EnsureHandle();
-			hwnd = windowInteropHelper.Handle;
+			throw new InvalidOperationException("HWND should be initialized");
 		}
 
-		if (hwnd != IntPtr.Zero && hwnd == _hwnd)
+		if (hwnd == _hwnd)
 		{
 			if (this.Log().IsEnabled(LogLevel.Trace))
 			{

--- a/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoCompositeWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoCompositeWindowHost.cs
@@ -12,6 +12,7 @@ using Uno.UI.Runtime.Skia.Wpf.Rendering;
 using WpfCanvas = System.Windows.Controls.Canvas;
 using WpfContentPresenter = System.Windows.Controls.ContentPresenter;
 using WpfControl = System.Windows.Controls.Control;
+using WpfWindow = System.Windows.Window;
 using WpfFrameworkPropertyMetadata = System.Windows.FrameworkPropertyMetadata;
 using MUX = Microsoft.UI.Xaml;
 
@@ -55,7 +56,7 @@ internal class UnoWpfWindowHost : WpfControl, IWpfWindowHost
 	private readonly MUX.Window _winUIWindow;
 
 	private readonly WpfCanvas _nativeOverlayLayer;
-	private readonly RenderingLayerHost _renderLayer;
+	private RenderingLayerHost _renderLayer;
 
 	private readonly SerialDisposable _backgroundDisposable = new();
 
@@ -73,20 +74,25 @@ internal class UnoWpfWindowHost : WpfControl, IWpfWindowHost
 
 		_nativeOverlayLayer = new WpfCanvas();
 		// Transparency doesn't work with the OpenGL renderer, so we have to use the software renderer for the top layer
-		_renderLayer = new RenderingLayerHost(WpfRendererProvider.CreateForHost(this));
+		_renderLayer = new RenderingLayerHost();
 
 		Loaded += WpfHost_Loaded;
 		Unloaded += (_, _) => _backgroundDisposable.Dispose();
 
-		UpdateRendererBackground();
 		_backgroundDisposable.Disposable = _winUIWindow.RegisterBackgroundChangedEvent((_, _) => UpdateRendererBackground());
 	}
+
+	public WpfWindow Window => _wpfWindow;
 
 	public WpfControl RenderLayer => _renderLayer;
 	public WpfControl BottomLayer => _renderLayer;
 
 	private void WpfHost_Loaded(object _, System.Windows.RoutedEventArgs __)
 	{
+		_renderLayer.Renderer = WpfRendererProvider.CreateForHost(this);
+		UpdateRendererBackground();
+		_renderLayer.InvalidateVisual();
+
 		// Avoid dotted border on focus.
 		if (Parent is WpfControl control)
 		{
@@ -97,6 +103,11 @@ internal class UnoWpfWindowHost : WpfControl, IWpfWindowHost
 
 	void UpdateRendererBackground()
 	{
+		if (_renderLayer.Renderer is null)
+		{
+			return;
+		}
+
 		// the flyout layer always has a transparent background so that elements underneath can be seen.
 		_renderLayer.Renderer.BackgroundColor = SKColors.Transparent;
 
@@ -142,14 +153,14 @@ internal class UnoWpfWindowHost : WpfControl, IWpfWindowHost
 
 	RenderSurfaceType? IWpfXamlRootHost.RenderSurfaceType => WpfHost.Current?.RenderSurfaceType ?? null;
 
-	private class RenderingLayerHost(IWpfRenderer renderer) : WpfControl
+	private class RenderingLayerHost : WpfControl
 	{
-		public IWpfRenderer Renderer { get; } = renderer;
+		public IWpfRenderer? Renderer { get; set; }
 
 		protected override void OnRender(System.Windows.Media.DrawingContext drawingContext)
 		{
 			base.OnRender(drawingContext);
-			Renderer.Render(drawingContext);
+			Renderer?.Render(drawingContext);
 		}
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoCompositeWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoCompositeWindowHost.cs
@@ -87,12 +87,14 @@ internal class UnoWpfWindowHost : WpfControl, IWpfWindowHost
 	public WpfControl RenderLayer => _renderLayer;
 	public WpfControl BottomLayer => _renderLayer;
 
-	private void WpfHost_Loaded(object _, System.Windows.RoutedEventArgs __)
+	internal void InitializeRenderer()
 	{
 		_renderLayer.Renderer = WpfRendererProvider.CreateForHost(this);
 		UpdateRendererBackground();
-		_renderLayer.InvalidateVisual();
+	}
 
+	private void WpfHost_Loaded(object _, System.Windows.RoutedEventArgs __)
+	{
 		// Avoid dotted border on focus.
 		if (Parent is WpfControl control)
 		{

--- a/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoWpfWindow.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/UnoWpfWindow.cs
@@ -42,7 +42,8 @@ internal class UnoWpfWindow : WpfWindow
 		Width = (int)preferredWindowSize.Width;
 		Height = (int)preferredWindowSize.Height;
 
-		Host = new UnoWpfWindowHost(this, winUIWindow);
+		var windowHost = new UnoWpfWindowHost(this, winUIWindow);
+		Host = windowHost;
 		WpfManager.XamlRootMap.Register(xamlRoot, (IWpfXamlRootHost)Host);
 
 		_applicationView = ApplicationView.GetForWindowId(winUIWindow.AppWindow.Id);
@@ -56,6 +57,8 @@ internal class UnoWpfWindow : WpfWindow
 		UpdateWindowPropertiesFromPackage();
 		UpdateWindowPropertiesFromApplicationView();
 		UpdateWindowPropertiesFromCoreApplication();
+
+		this.SourceInitialized += (s, e) => windowHost.InitializeRenderer();
 	}
 
 	public static WpfWindow? GetFromWinUIWindow(WinUI.Window window)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/18000

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

WPF always chooses software renderer


## What is the new behavior?

Adjusted so that the OpenGL renderer initializes properly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
