### PR TITLE
perf: Avoid storing DefaultValue in DPDetails

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1874,8 +1874,6 @@
 		</Fields>
 
 		<Properties>
-			<Member fullName="Windows.UI.Xaml.DependencyProperty Windows.UI.Xaml.FrameworkElement::StretchAffectsMeasureProperty()" reason="Not in WinUI. Made a regular property" />
-			<Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.FrameworkElement::StretchAffectsMeasureProperty()" reason="Not in WinUI. Made a regular property" />
 		</Properties>
 
 		<Methods>
@@ -1891,9 +1889,6 @@
 			<!-- MarkupExtensions\XamlServiceProvider -->
 			<Member fullName="Microsoft.UI.Xaml.IXamlServiceProvider Uno.UI.Helpers.MarkupHelper.CreateParserContext(System.Object target, Microsoft.UI.Xaml.Markup.ProvideValueTargetProperty property)" reason="Not in WinUI; refactored out" />
 			<Member fullName="Windows.UI.Xaml.IXamlServiceProvider Uno.UI.Helpers.MarkupHelper.CreateParserContext(System.Object target, Windows.UI.Xaml.Markup.ProvideValueTargetProperty property)" reason="Not in WinUI; refactored out" />
-
-			<Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.FrameworkElement.get_StretchAffectsMeasureProperty()" reason="Not in WinUI. Made a regular property" />
-			<Member fullName="Windows.UI.Xaml.DependencyProperty Windows.UI.Xaml.FrameworkElement.get_StretchAffectsMeasureProperty()" reason="Not in WinUI. Made a regular property" />
 
 		</Methods>
 	</IgnoreSet>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1874,6 +1874,8 @@
 		</Fields>
 
 		<Properties>
+			<Member fullName="Windows.UI.Xaml.DependencyProperty Windows.UI.Xaml.FrameworkElement::StretchAffectsMeasureProperty()" reason="Not in WinUI. Made a regular property" />
+			<Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.FrameworkElement::StretchAffectsMeasureProperty()" reason="Not in WinUI. Made a regular property" />
 		</Properties>
 
 		<Methods>
@@ -1889,6 +1891,9 @@
 			<!-- MarkupExtensions\XamlServiceProvider -->
 			<Member fullName="Microsoft.UI.Xaml.IXamlServiceProvider Uno.UI.Helpers.MarkupHelper.CreateParserContext(System.Object target, Microsoft.UI.Xaml.Markup.ProvideValueTargetProperty property)" reason="Not in WinUI; refactored out" />
 			<Member fullName="Windows.UI.Xaml.IXamlServiceProvider Uno.UI.Helpers.MarkupHelper.CreateParserContext(System.Object target, Windows.UI.Xaml.Markup.ProvideValueTargetProperty property)" reason="Not in WinUI; refactored out" />
+
+			<Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.FrameworkElement.get_StretchAffectsMeasureProperty()" reason="Not in WinUI. Made a regular property" />
+			<Member fullName="Windows.UI.Xaml.DependencyProperty Windows.UI.Xaml.FrameworkElement.get_StretchAffectsMeasureProperty()" reason="Not in WinUI. Made a regular property" />
 
 		</Methods>
 	</IgnoreSet>

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControl.cs
@@ -56,16 +56,12 @@ namespace Uno.UI.Samples.Controls
 		}
 
 #if XAMARIN
-		internal override bool GetDefaultValue2(DependencyProperty property, out object defaultValue)
+		protected override void OnDataContextChanged()
 		{
-			if (property == ContentProperty)
-			{
-				// Workaround to #10396: The DataContext of ContentTemplate should be ContentControl.DataContext if ContentControl.Content is not set.
-				defaultValue = DataContext;
-				return true;
-			}
+			base.OnDataContextChanged();
 
-			return base.GetDefaultValue2(property, out defaultValue);
+			// Workaround to #10396: The DataContext of ContentTemplate should be ContentControl.DataContext if ContentControl.Content is not set.
+			this.SetValue(ContentProperty, DataContext, DependencyPropertyValuePrecedences.DefaultStyle);
 		}
 #endif
 	}

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControl.cs
@@ -54,16 +54,6 @@ namespace Uno.UI.Samples.Controls
 		{
 			(dependencyObject as SampleControl).ContentTemplate = args.NewValue as DataTemplate;
 		}
-
-#if XAMARIN
-		protected override void OnDataContextChanged()
-		{
-			base.OnDataContextChanged();
-
-			// Workaround to #10396: The DataContext of ContentTemplate should be ContentControl.DataContext if ContentControl.Content is not set.
-			this.SetValue(ContentProperty, DataContext, DependencyPropertyValuePrecedences.DefaultValue);
-		}
-#endif
 	}
 }
 #endif

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControl.cs
@@ -54,6 +54,20 @@ namespace Uno.UI.Samples.Controls
 		{
 			(dependencyObject as SampleControl).ContentTemplate = args.NewValue as DataTemplate;
 		}
+
+#if XAMARIN
+		internal override bool GetDefaultValue2(DependencyProperty property, out object defaultValue)
+		{
+			if (property == ContentProperty)
+			{
+				// Workaround to #10396: The DataContext of ContentTemplate should be ContentControl.DataContext if ContentControl.Content is not set.
+				defaultValue = DataContext;
+				return true;
+			}
+
+			return base.GetDefaultValue2(property, out defaultValue);
+		}
+#endif
 	}
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/StyleHelper.cs
@@ -93,27 +93,13 @@ namespace Uno.UI.RuntimeTests.Helpers
 
 			// Force default brushes to be reloaded
 			DefaultBrushes.ResetDefaultThemeBrushes();
-			ResetIslandRootForeground();
 
 			return new DisposableAction(() =>
 			{
 				resources.MergedDictionaries.Remove(xcr);
 				DefaultBrushes.ResetDefaultThemeBrushes();
-				ResetIslandRootForeground();
 			});
 #endif
 		}
-
-#if !WINAPPSDK
-		private static void ResetIslandRootForeground()
-		{
-			if (Uno.UI.Xaml.Core.CoreServices.Instance.InitializationType == Xaml.Core.InitializationType.IslandsOnly &&
-				VisualTreeUtils.FindVisualChildByType<Control>(TestServices.WindowHelper.XamlRoot.VisualTree.RootElement) is { } control)
-			{
-				// Ensure the root element's Foreground is set correctly
-				control.SetValue(Control.ForegroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
-			}
-		}
-#endif
 	}
 }

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DefaultValueProvider.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.DefaultValueProvider.cs
@@ -57,19 +57,7 @@ namespace Uno.UI.Tests.DependencyPropertyTests
 			var defaultValueTest = new DefaultValueTest();
 			Assert.AreEqual(expected, defaultValueTest.GetPrecedenceSpecificValue(DefaultValueTest.TestValueProperty, DependencyPropertyValuePrecedences.DefaultValue));
 			Assert.AreEqual(expected, defaultValueTest.GetValue(DefaultValueTest.TestValueProperty));
-			Assert.AreEqual(expected, (defaultValueTest as IDependencyObjectStoreProvider).Store.GetPropertyDetails(DefaultValueTest.TestValueProperty).GetDefaultValue());
-			Assert.AreEqual(expected, defaultValueTest.TestValue);
-		}
-
-		[TestMethod]
-		public void When_SetDefaultValue()
-		{
-			var expected = 24;
-			var defaultValueTest = new DefaultValueTest();
-			((IDependencyObjectStoreProvider)defaultValueTest).Store.GetPropertyDetails(DefaultValueTest.TestValueProperty).SetDefaultValue(expected);
-			Assert.AreEqual(expected, defaultValueTest.GetPrecedenceSpecificValue(DefaultValueTest.TestValueProperty, DependencyPropertyValuePrecedences.DefaultValue));
-			Assert.AreEqual(expected, defaultValueTest.GetValue(DefaultValueTest.TestValueProperty));
-			Assert.AreEqual(expected, ((IDependencyObjectStoreProvider)defaultValueTest).Store.GetPropertyDetails(DefaultValueTest.TestValueProperty).GetDefaultValue());
+			Assert.AreEqual(expected, (defaultValueTest as IDependencyObjectStoreProvider).Store.GetDefaultValue(DefaultValueTest.TestValueProperty));
 			Assert.AreEqual(expected, defaultValueTest.TestValue);
 		}
 

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
@@ -538,15 +538,9 @@ namespace Uno.UI.Tests.BinderTests.Propagation
 				var dc = new object();
 				SUT.DataContext = dc;
 
-				var originalBrush = SUT.Foreground as Brush;
-
 				SUT.SetValue(ContentControl.ForegroundProperty, null);
 
-				Assert.IsNull(originalBrush.DataContext);
-
 				SUT.ClearValue(ContentControl.ForegroundProperty);
-
-				Assert.AreEqual(dc, originalBrush.DataContext);
 
 				SUT.DataContext = null;
 

--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -370,7 +370,7 @@ namespace Microsoft.UI.Xaml.Data
 			else if (useTypeDefaultValue && TargetPropertyDetails != null)
 			{
 				var viewTarget = _view.Target;
-				SetTargetValue(TargetPropertyDetails.Property.GetDefaultValue(viewTarget as UIElement, viewTarget?.GetType()));
+				SetTargetValue(TargetPropertyDetails.Property.GetDefaultValue(viewTarget as DependencyObject, viewTarget?.GetType()));
 			}
 		}
 

--- a/src/Uno.UI/Helpers/Boxes.cs
+++ b/src/Uno.UI/Helpers/Boxes.cs
@@ -1,0 +1,58 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.Xaml;
+
+namespace Uno.UI.Helpers;
+
+
+internal static class Boxes
+{
+	public static class BooleanBoxes
+	{
+		public static readonly object BoxedTrue = true;
+		public static readonly object BoxedFalse = false;
+	}
+
+	public static class VerticalAlignmentBoxes
+	{
+		public static readonly VerticalAlignment Top = VerticalAlignment.Top;
+		public static readonly VerticalAlignment Bottom = VerticalAlignment.Bottom;
+		public static readonly VerticalAlignment Stretch = VerticalAlignment.Stretch;
+		public static readonly VerticalAlignment Center = VerticalAlignment.Center;
+	}
+
+	public static class NullableDoubleBoxes
+	{
+		public static readonly double? Zero = 0.0d;
+		public static readonly double? One = 1.0d;
+	}
+
+	public static class StretchBoxes
+	{
+		public static readonly Stretch None = Stretch.None;
+		public static readonly Stretch Fill = Stretch.Fill;
+		public static readonly Stretch Uniform = Stretch.Uniform;
+		public static readonly Stretch UniformToFill = Stretch.UniformToFill;
+	}
+
+	public static object Box(bool value) => value ? BooleanBoxes.BoxedTrue : BooleanBoxes.BoxedFalse;
+
+	public static object Box(VerticalAlignment value) => value switch
+	{
+		VerticalAlignment.Top => VerticalAlignmentBoxes.Top,
+		VerticalAlignment.Bottom => VerticalAlignmentBoxes.Bottom,
+		VerticalAlignment.Stretch => VerticalAlignmentBoxes.Stretch,
+		VerticalAlignment.Center => VerticalAlignmentBoxes.Center,
+		_ => value,
+	};
+
+	public static object Box(Stretch value) => value switch
+	{
+		Stretch.None => StretchBoxes.None,
+		Stretch.Fill => StretchBoxes.Fill,
+		Stretch.Uniform => StretchBoxes.Uniform,
+		Stretch.UniformToFill => StretchBoxes.UniformToFill,
+		_ => value,
+	};
+}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.Properties.cs
@@ -159,7 +159,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty TextReadingOrderProperty { get; } =
-			DependencyProperty.Register(nameof(TextReadingOrder), typeof(TextReadingOrder), typeof(NumberBox), new FrameworkPropertyMetadata(false));
+			DependencyProperty.Register(nameof(TextReadingOrder), typeof(TextReadingOrder), typeof(NumberBox), new FrameworkPropertyMetadata(TextReadingOrder.Default));
 
 		public bool PreventKeyboardDisplayOnProgrammaticFocus
 		{

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.Properties.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.Properties.cs
@@ -159,7 +159,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty TextReadingOrderProperty { get; } =
-			DependencyProperty.Register(nameof(TextReadingOrder), typeof(TextReadingOrder), typeof(NumberBox), new FrameworkPropertyMetadata(null));
+			DependencyProperty.Register(nameof(TextReadingOrder), typeof(TextReadingOrder), typeof(NumberBox), new FrameworkPropertyMetadata(false));
 
 		public bool PreventKeyboardDisplayOnProgrammaticFocus
 		{
@@ -168,7 +168,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		}
 
 		public static DependencyProperty PreventKeyboardDisplayOnProgrammaticFocusProperty { get; } =
-			DependencyProperty.Register(nameof(PreventKeyboardDisplayOnProgrammaticFocus), typeof(bool), typeof(NumberBox), new FrameworkPropertyMetadata(null));
+			DependencyProperty.Register(nameof(PreventKeyboardDisplayOnProgrammaticFocus), typeof(bool), typeof(NumberBox), new FrameworkPropertyMetadata(false));
 
 		public new object Description
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -77,7 +77,7 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 #if !UNO_HAS_BORDER_VISUAL
 		_borderRenderer = new BorderLayerRenderer(this);
 #endif
-		SetDefaultForeground(ForegroundProperty);
+		UpdateLastUsedTheme();
 
 		InitializePlatform();
 	}
@@ -1234,7 +1234,7 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 	internal override void UpdateThemeBindings(ResourceUpdateReason updateReason)
 	{
 		base.UpdateThemeBindings(updateReason);
-		SetDefaultForeground(ForegroundProperty);
+		UpdateLastUsedTheme();
 	}
 
 #if __ANDROID__

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -43,7 +43,6 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private void InitializeControl()
 		{
-			SetDefaultForeground(ForegroundProperty);
 			SubscribeToOverridenRoutedEvents();
 			OnIsFocusableChanged();
 
@@ -58,14 +57,6 @@ namespace Microsoft.UI.Xaml.Controls
 		protected override bool IsSimpleLayout => true;
 
 		internal override bool IsEnabledOverride() => IsEnabled && base.IsEnabledOverride();
-
-		internal override void UpdateThemeBindings(Data.ResourceUpdateReason updateReason)
-		{
-			base.UpdateThemeBindings(updateReason);
-
-			//override the default value from dependency property based on application theme
-			SetDefaultForeground(ForegroundProperty);
-		}
 
 		private protected override Type GetDefaultStyleKey() => DefaultStyleKey as Type;
 

--- a/src/Uno.UI/UI/Xaml/Controls/FocusVisual/SystemFocusVisual.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/FocusVisual/SystemFocusVisual.cs
@@ -66,7 +66,6 @@ internal partial class SystemFocusVisual : Control
 
 		if (args.NewValue is FrameworkElement element)
 		{
-			element.EnsureFocusVisualBrushDefaults();
 			element.SizeChanged += focusVisual.FocusedElementSizeChanged;
 #if !UNO_HAS_ENHANCED_LIFECYCLE
 			element.LayoutUpdated += focusVisual.FocusedElementLayoutUpdated;

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/BitmapIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/BitmapIcon.cs
@@ -8,7 +8,7 @@ namespace Microsoft.UI.Xaml.Controls;
 /// <summary>
 /// Represents an icon that uses a bitmap as its content.
 /// </summary>
-public partial class BitmapIcon : IconElement
+public partial class BitmapIcon : IconElement, IThemeChangeAware
 {
 	private readonly Image _image;
 
@@ -78,4 +78,8 @@ public partial class BitmapIcon : IconElement
 		}
 #endif
 	}
+
+	// The way this works in WinUI is by the MarkInheritedPropertyDirty call in CFrameworkElement::NotifyThemeChangedForInheritedProperties
+	// There is a special handling for Foreground specifically there.
+	void IThemeChangeAware.OnThemeChanged() => UpdateImageMonochromeColor();
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/FontIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/FontIcon.cs
@@ -12,7 +12,7 @@ namespace Microsoft.UI.Xaml.Controls;
 /// <summary>
 /// Represents an icon that uses a glyph from the specified font.
 /// </summary>
-public partial class FontIcon : IconElement
+public partial class FontIcon : IconElement, IThemeChangeAware
 {
 	private readonly TextBlock _textBlock;
 
@@ -218,6 +218,16 @@ public partial class FontIcon : IconElement
 		if (_textBlock is not null)
 		{
 			_textBlock.Foreground = (Brush)e.NewValue;
+		}
+	}
+
+	// The way this works in WinUI is by the MarkInheritedPropertyDirty call in CFrameworkElement::NotifyThemeChangedForInheritedProperties
+	// There is a special handling for Foreground specifically there.
+	void IThemeChangeAware.OnThemeChanged()
+	{
+		if (_textBlock is not null)
+		{
+			_textBlock.Foreground = Foreground;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/IconElement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/IconElement.cs
@@ -22,7 +22,7 @@ public partial class IconElement : FrameworkElement
 
 	public IconElement()
 	{
-		SetDefaultForeground(ForegroundProperty);
+		UpdateLastUsedTheme();
 	}
 
 	/// <summary>
@@ -95,7 +95,7 @@ public partial class IconElement : FrameworkElement
 	{
 		base.UpdateThemeBindings(updateReason);
 
-		SetDefaultForeground(ForegroundProperty);
+		UpdateLastUsedTheme();
 	}
 
 	[MemberNotNull(nameof(_rootGrid))]

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/PathIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/PathIcon.cs
@@ -6,7 +6,7 @@ namespace Microsoft.UI.Xaml.Controls;
 /// <summary>
 /// Represents an icon that uses a vector path as its content.
 /// </summary>
-public partial class PathIcon : IconElement
+public partial class PathIcon : IconElement, IThemeChangeAware
 {
 	private readonly Path _path;
 
@@ -58,6 +58,16 @@ public partial class PathIcon : IconElement
 		if (_path is not null)
 		{
 			_path.Fill = (Brush)e.NewValue;
+		}
+	}
+
+	// The way this works in WinUI is by the MarkInheritedPropertyDirty call in CFrameworkElement::NotifyThemeChangedForInheritedProperties
+	// There is a special handling for Foreground specifically there.
+	void IThemeChangeAware.OnThemeChanged()
+	{
+		if (_path is not null)
+		{
+			_path.Fill = Foreground;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Icons/SymbolIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Icons/SymbolIcon.cs
@@ -10,7 +10,7 @@ namespace Microsoft.UI.Xaml.Controls;
 /// <summary>
 /// Represents an icon that uses a glyph from the Segoe MDL2 Assets font as its content.
 /// </summary>
-public sealed partial class SymbolIcon : IconElement
+public sealed partial class SymbolIcon : IconElement, IThemeChangeAware
 {
 	private double _fontSize = 20.0;
 
@@ -101,6 +101,16 @@ public sealed partial class SymbolIcon : IconElement
 		if (_textBlock is not null)
 		{
 			_textBlock.Foreground = (Brush)e.NewValue;
+		}
+	}
+
+	// The way this works in WinUI is by the MarkInheritedPropertyDirty call in CFrameworkElement::NotifyThemeChangedForInheritedProperties
+	// There is a special handling for Foreground specifically there.
+	void IThemeChangeAware.OnThemeChanged()
+	{
+		if (_textBlock is not null)
+		{
+			_textBlock.Foreground = Foreground;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.cs
@@ -83,7 +83,7 @@ public partial class Popup
 	{
 		if (property == IsLightDismissEnabledProperty)
 		{
-			defaultValue = FeatureConfiguration.Popup.EnableLightDismissByDefault;
+			defaultValue = Uno.UI.Helpers.Boxes.Box(FeatureConfiguration.Popup.EnableLightDismissByDefault);
 			return true;
 		}
 		return base.GetDefaultValue2(property, out defaultValue);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -36,7 +36,7 @@ using UIKit;
 namespace Microsoft.UI.Xaml.Controls
 {
 	[ContentProperty(Name = nameof(Inlines))]
-	public partial class TextBlock : DependencyObject
+	public partial class TextBlock : DependencyObject, IThemeChangeAware
 	{
 		private InlineCollection _inlines;
 		private string _inlinesText; // Text derived from the content of Inlines
@@ -1265,5 +1265,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 		[SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Used only by some platforms")]
 		partial void UpdateIsTextTrimmed();
+
+		// The way this works in WinUI is by the MarkInheritedPropertyDirty call in CFrameworkElement::NotifyThemeChangedForInheritedProperties
+		// There is a special handling for Foreground specifically there.
+		void IThemeChangeAware.OnThemeChanged() => OnForegroundChanged();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -74,7 +74,7 @@ namespace Microsoft.UI.Xaml.Controls
 		public TextBlock()
 		{
 			IFrameworkElementHelper.Initialize(this);
-			SetDefaultForeground(ForegroundProperty);
+			UpdateLastUsedTheme();
 
 			_hyperlinks.CollectionChanged += HyperlinksOnCollectionChanged;
 
@@ -1230,7 +1230,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			base.UpdateThemeBindings(updateReason);
 
-			SetDefaultForeground(ForegroundProperty);
+			UpdateLastUsedTheme();
 
 			if (_inlines is not null)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -32,7 +32,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		public TextBlock()
 		{
-			SetDefaultForeground(ForegroundProperty);
+			UpdateLastUsedTheme();
 			_textVisual = new TextVisual(Visual.Compositor, this);
 
 			Visual.Children.InsertAtBottom(_textVisual);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -39,7 +39,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		public TextBlock() : base("p")
 		{
-			SetDefaultForeground(ForegroundProperty);
+			UpdateLastUsedTheme();
 
 			OnFontStyleChangedPartial();
 			OnFontWeightChangedPartial();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -51,18 +51,18 @@ namespace Microsoft.UI.Xaml.Controls
 			OnTextAlignmentChangedPartial();
 			OnTextWrappingChangedPartial();
 			OnIsTextSelectionEnabledChangedPartial();
-			InitializeDefaultValues();
 
 			_hyperlinks.CollectionChanged += HyperlinksOnCollectionChanged;
 		}
 
-		/// <summary>
-		/// Set default properties to vertical top.
-		/// In wasm, this behavior is closer to the default textblock property than stretch.
-		/// </summary>
-		private void InitializeDefaultValues()
+		internal override bool GetDefaultValue2(DependencyProperty property, out object defaultValue)
 		{
-			this.SetValue(VerticalAlignmentProperty, VerticalAlignment.Top, DependencyPropertyValuePrecedences.DefaultValue);
+			if (property == VerticalAlignmentProperty)
+			{
+				// In wasm, this behavior is closer to the default TextBlock property than stretch.
+				defaultValue = VerticalAlignment.Top;
+				return true;
+			}
 		}
 
 		private void ConditionalUpdate(ref bool condition, Action action)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -60,7 +60,7 @@ namespace Microsoft.UI.Xaml.Controls
 			if (property == VerticalAlignmentProperty)
 			{
 				// In wasm, this behavior is closer to the default TextBlock property than stretch.
-				defaultValue = VerticalAlignment.Top;
+				defaultValue = Uno.UI.Helpers.Boxes.VerticalAlignmentBoxes.Top;
 				return true;
 			}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -63,6 +63,9 @@ namespace Microsoft.UI.Xaml.Controls
 				defaultValue = VerticalAlignment.Top;
 				return true;
 			}
+
+			defaultValue = null;
+			return false;
 		}
 
 		private void ConditionalUpdate(ref bool condition, Action action)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -64,8 +64,7 @@ namespace Microsoft.UI.Xaml.Controls
 				return true;
 			}
 
-			defaultValue = null;
-			return false;
+			return base.GetDefaultValue2(property, out defaultValue);
 		}
 
 		private void ConditionalUpdate(ref bool condition, Action action)

--- a/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectExtensions.cs
@@ -265,10 +265,11 @@ namespace Microsoft.UI.Xaml
 		internal static (object value, DependencyPropertyValuePrecedences precedence)[] GetValueForEachPrecedences(
 			this DependencyObject instance, DependencyProperty property)
 		{
+			var store = GetStore(instance);
 			var propertyDetails = GetStore(instance).GetPropertyDetails(property).ToList();
 
 			return Enum.GetValues<DependencyPropertyValuePrecedences>()
-				.Select(precedence => (propertyDetails[(int)precedence], precedence))
+				.Select(precedence => (precedence == DependencyPropertyValuePrecedences.DefaultValue ? store.GetDefaultValue(property) : propertyDetails[(int)precedence], precedence))
 				.ToArray();
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1107,7 +1107,7 @@ namespace Microsoft.UI.Xaml
 		private object GetDefaultValue(DependencyProperty dp)
 		{
 			var actualInstance = ActualInstance;
-			var defaultValue = dp.GetDefaultValue(actualInstance as UIElement, actualInstance?.GetType());
+			var defaultValue = dp.GetDefaultValue(actualInstance, actualInstance?.GetType());
 			if (GetCurrentHighestValuePrecedence(dp) == DependencyPropertyValuePrecedences.DefaultValue &&
 				// This should be for OnDemand DPs in general which we don't yet support
 				dp == UIElement.KeyboardAcceleratorsProperty)

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -279,6 +279,12 @@ namespace Microsoft.UI.Xaml
 
 			ValidatePropertyOwner(property);
 
+			if (propertyDetails is null && (precedence is null || precedence == DependencyPropertyValuePrecedences.DefaultValue) && _properties.FindPropertyDetails(property) is null)
+			{
+				// Performance: Avoid force-creating DependencyPropertyDetails when not needed.
+				return GetDefaultValue(property);
+			}
+
 			propertyDetails ??= _properties.GetPropertyDetails(property);
 
 			return GetValue(propertyDetails, precedence, isPrecedenceSpecific);

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -17,6 +17,7 @@ using Uno.UI;
 using System.Collections;
 using System.Globalization;
 using Windows.ApplicationModel.Calls;
+using Microsoft.UI.Xaml.Controls;
 
 #if __ANDROID__
 using View = Android.Views.View;
@@ -1635,6 +1636,17 @@ namespace Microsoft.UI.Xaml
 						if (GetCurrentHighestValuePrecedence(prop) != DependencyPropertyValuePrecedences.DefaultValue)
 						{
 							store.OnParentPropertyChangedCallback(instanceRef, prop, GetValue(prop));
+						}
+						else
+						{
+							if (prop == _properties.DataContextPropertyDetails.Property || prop == _properties.TemplatedParentPropertyDetails.Property)
+							{
+								// Historically, the GetValue(prop) above was always called regardless of highest precedence.
+								// GetValue has a side effect of calling TryRegisterInheritedProperties.
+								// This tries to keep the original behavior, but it doesn't make sense that we need to do this.
+								// At least for TemplatedParent, this should be re-evaluated once we align TemplatedParent with WinUI.
+								TryRegisterInheritedProperties(force: true);
+							}
 						}
 					}
 				}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1107,7 +1107,15 @@ namespace Microsoft.UI.Xaml
 		private object GetDefaultValue(DependencyProperty dp)
 		{
 			var actualInstance = ActualInstance;
-			return dp.GetDefaultValue(actualInstance as UIElement, actualInstance?.GetType());
+			var defaultValue = dp.GetDefaultValue(actualInstance as UIElement, actualInstance?.GetType());
+			if (GetCurrentHighestValuePrecedence(dp) == DependencyPropertyValuePrecedences.DefaultValue &&
+				// This should be for OnDemand DPs in general which we don't yet support
+				dp == UIElement.KeyboardAcceleratorsProperty)
+			{
+				_properties.GetPropertyDetails(dp).SetValue(defaultValue, DependencyPropertyValuePrecedences.Local);
+			}
+
+			return defaultValue;
 		}
 
 		private object? GetPrecedenceSpecificValue(DependencyPropertyDetails details, DependencyPropertyValuePrecedences precedence)

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1104,7 +1104,8 @@ namespace Microsoft.UI.Xaml
 			return (value, resultPrecedence);
 		}
 
-		private object GetDefaultValue(DependencyProperty dp)
+		// Internal for unit testing
+		internal object GetDefaultValue(DependencyProperty dp)
 		{
 			var actualInstance = ActualInstance;
 			var defaultValue = dp.GetDefaultValue(actualInstance, actualInstance?.GetType());

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -2082,6 +2082,14 @@ namespace Microsoft.UI.Xaml
 				}
 			}
 
+			if (value == null && !propertyDetails.Property.IsTypeNullable)
+			{
+				// This probably shouldn't exist. We should fix cases that are broken.
+				// Most (if not all) broken cases appear to be related to TemplatedParent being null incorrectly when applying styles.
+				// This should be re-validated after https://github.com/unoplatform/uno/issues/1621 is fixed.
+				value = GetDefaultValue(propertyDetails.Property);
+			}
+
 			if (AreDifferent(value, GetPrecedenceSpecificValue(propertyDetails, precedence)))
 			{
 				propertyDetails.SetValue(value, precedence);

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1617,7 +1617,10 @@ namespace Microsoft.UI.Xaml
 					var prop = props[propertyIndex];
 					if (!IsTemplatedParentFrozen || prop != TemplatedParentProperty)
 					{
-						store.OnParentPropertyChangedCallback(instanceRef, prop, GetValue(prop));
+						if (GetCurrentHighestValuePrecedence(prop) != DependencyPropertyValuePrecedences.DefaultValue)
+						{
+							store.OnParentPropertyChangedCallback(instanceRef, prop, GetValue(prop));
+						}
 					}
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -16,6 +16,7 @@ using Uno;
 using Uno.Extensions;
 using Uno.UI;
 using Uno.UI.Dispatching;
+using Uno.UI.Helpers;
 using Uno.UI.Xaml.Media;
 
 #if __ANDROID__
@@ -39,6 +40,7 @@ namespace Microsoft.UI.Xaml
 
 		private readonly static TypeToPropertiesDictionary _getPropertiesForType = new TypeToPropertiesDictionary();
 		private readonly static NameToPropertyDictionary _getPropertyCache = new NameToPropertyDictionary();
+		private static object DefaultThemeAnimationDurationBox = new Duration(FeatureConfiguration.ThemeAnimation.DefaultThemeAnimationDuration);
 
 		/// <summary>
 		/// A static <see cref="PropertyCacheEntry"/> used for lookups and avoid creating new instances. This assumes that uses are non-reentrant.
@@ -529,7 +531,7 @@ namespace Microsoft.UI.Xaml
 			{
 				if (forType == typeof(Rectangle) || forType == typeof(Ellipse))
 				{
-					return Stretch.Fill;
+					return Boxes.StretchBoxes.Fill;
 				}
 			}
 
@@ -537,7 +539,16 @@ namespace Microsoft.UI.Xaml
 			{
 				if (referenceObject is FadeInThemeAnimation or FadeOutThemeAnimation)
 				{
-					return new Duration(FeatureConfiguration.ThemeAnimation.DefaultThemeAnimationDuration);
+					if (((Duration)DefaultThemeAnimationDurationBox).TimeSpan == FeatureConfiguration.ThemeAnimation.DefaultThemeAnimationDuration)
+					{
+						// Our box is valid, so we can re-use it.
+						return DefaultThemeAnimationDurationBox;
+					}
+
+					// Rare code path, it will be hit only once per change in the feature configuration.
+					// The cached box is not valid. So we create a new box update the cached box.
+					DefaultThemeAnimationDurationBox = new Duration(FeatureConfiguration.ThemeAnimation.DefaultThemeAnimationDuration);
+					return DefaultThemeAnimationDurationBox;
 				}
 			}
 
@@ -553,11 +564,11 @@ namespace Microsoft.UI.Xaml
 			{
 				if (referenceObject is FadeInThemeAnimation)
 				{
-					return (double?)1.0d;
+					return Uno.UI.Helpers.Boxes.NullableDoubleBoxes.One;
 				}
 				else if (referenceObject is FadeOutThemeAnimation)
 				{
-					return (double?)0.0d;
+					return Uno.UI.Helpers.Boxes.NullableDoubleBoxes.Zero;
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -10,6 +10,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Shapes;
 using Uno;
 using Uno.Extensions;
@@ -501,9 +502,9 @@ namespace Microsoft.UI.Xaml
 			return false;
 		}
 
-		internal object GetDefaultValue(UIElement referenceObject, Type forType)
+		internal object GetDefaultValue(DependencyObject referenceObject, Type forType)
 		{
-			if (referenceObject?.GetDefaultValue2(this, out var defaultValue) == true)
+			if ((referenceObject as UIElement)?.GetDefaultValue2(this, out var defaultValue) == true)
 			{
 				return defaultValue;
 			}
@@ -529,6 +530,34 @@ namespace Microsoft.UI.Xaml
 				if (forType == typeof(Rectangle) || forType == typeof(Ellipse))
 				{
 					return Stretch.Fill;
+				}
+			}
+
+			if (this == Timeline.DurationProperty)
+			{
+				if (referenceObject is FadeInThemeAnimation or FadeOutThemeAnimation)
+				{
+					return FeatureConfiguration.ThemeAnimation.DefaultThemeAnimationDuration;
+				}
+			}
+
+			if (this == Storyboard.TargetPropertyProperty)
+			{
+				if (referenceObject is FadeInThemeAnimation or FadeOutThemeAnimation)
+				{
+					return "Opacity";
+				}
+			}
+
+			if (this == DoubleAnimation.ToProperty)
+			{
+				if (referenceObject is FadeInThemeAnimation)
+				{
+					return (double?)1.0d;
+				}
+				else if (referenceObject is FadeOutThemeAnimation)
+				{
+					return (double?)0.0d;
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -537,7 +537,7 @@ namespace Microsoft.UI.Xaml
 			{
 				if (referenceObject is FadeInThemeAnimation or FadeOutThemeAnimation)
 				{
-					return FeatureConfiguration.ThemeAnimation.DefaultThemeAnimationDuration;
+					return new Duration(FeatureConfiguration.ThemeAnimation.DefaultThemeAnimationDuration);
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -8,12 +8,14 @@ using System.Threading;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using Uno;
 using Uno.Extensions;
 using Uno.UI;
 using Uno.UI.Dispatching;
+using Uno.UI.Xaml.Media;
 
 #if __ANDROID__
 using _View = Android.Views.View;
@@ -477,11 +479,44 @@ namespace Microsoft.UI.Xaml
 			return output.ToArray();
 		}
 
+		private bool TryGetDefaultInheritedPropertyValue(out object defaultValue)
+		{
+			if (this == TextElement.ForegroundProperty ||
+				this == TextBlock.ForegroundProperty ||
+				this == Control.ForegroundProperty ||
+				this == RichTextBlock.ForegroundProperty ||
+				this == ContentPresenter.ForegroundProperty ||
+				this == IconElement.ForegroundProperty)
+			{
+				defaultValue = DefaultBrushes.TextForegroundBrush;
+				return true;
+			}
+
+			defaultValue = null;
+			return false;
+		}
+
 		internal object GetDefaultValue(UIElement referenceObject, Type forType)
 		{
 			if (referenceObject?.GetDefaultValue2(this, out var defaultValue) == true)
 			{
 				return defaultValue;
+			}
+
+			if (IsInherited && TryGetDefaultInheritedPropertyValue(out var value))
+			{
+				return value;
+			}
+
+			if (this == FrameworkElement.FocusVisualPrimaryBrushProperty &&
+				ResourceResolver.TryStaticRetrieval("SystemControlFocusVisualPrimaryBrush", null, out var primaryBrush))
+			{
+				return primaryBrush;
+			}
+			else if (this == FrameworkElement.FocusVisualSecondaryBrushProperty &&
+				ResourceResolver.TryStaticRetrieval("SystemControlFocusVisualSecondaryBrush", null, out var secondaryBrush))
+			{
+				return secondaryBrush;
 			}
 
 			if (this == Shape.StretchProperty)

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -163,7 +163,8 @@ namespace Microsoft.UI.Xaml
 		{
 			if (metadata is null)
 			{
-				return new PropertyMetadata(defaultValue: RuntimeHelpers.GetUninitializedObject(propertyType));
+				var defaultValue = propertyType.IsNullable() ? null : RuntimeHelpers.GetUninitializedObject(propertyType);
+				return new PropertyMetadata(defaultValue);
 			}
 			else if (!propertyType.IsNullable() && metadata.DefaultValue is null)
 			{

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -138,6 +138,11 @@ namespace Microsoft.UI.Xaml
 		/// <exception cref="InvalidOperationException">A property with the same name has already been declared for the ownerType</exception>
 		public static DependencyProperty Register(string name, Type propertyType, Type ownerType, PropertyMetadata typeMetadata)
 		{
+			if (!propertyType.IsNullable() && typeMetadata.DefaultValue is null)
+			{
+				throw new Exception($"Cannot register property {ownerType}.{name} with non-nullable type {propertyType}");
+			}
+
 			var newProperty = new DependencyProperty(name, propertyType, ownerType, typeMetadata, attached: false);
 
 			try

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.Bindings.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.Bindings.cs
@@ -111,7 +111,15 @@ namespace Microsoft.UI.Xaml
 					bindings[i].ResumeBinding();
 				}
 
-				ApplyDataContext(DataContextPropertyDetails.GetValue());
+				var value = DataContextPropertyDetails.GetValue();
+				if (value == DependencyProperty.UnsetValue)
+				{
+					// If we get UnsetValue, it means this is DefaultValue precedence that's not stored in DependencyPropertyDetails.
+					// In this case, we know for sure that DataContext's default value is null.
+					value = null;
+				}
+
+				ApplyDataContext(value);
 			}
 		}
 
@@ -144,7 +152,15 @@ namespace Microsoft.UI.Xaml
 				{
 					_templateBindings = _templateBindings.Add(bindingExpression);
 
-					ApplyBinding(bindingExpression, TemplatedParentPropertyDetails.GetValue());
+					var templatedParent = TemplatedParentPropertyDetails.GetValue();
+					if (templatedParent == DependencyProperty.UnsetValue)
+					{
+						// If we get UnsetValue, it means this is DefaultValue precedence that's not stored in DependencyPropertyDetails.
+						// In this case, we know for sure that TemplatedParent's default value is null.
+						templatedParent = null;
+					}
+
+					ApplyBinding(bindingExpression, templatedParent);
 				}
 				else
 				{
@@ -156,7 +172,15 @@ namespace Microsoft.UI.Xaml
 					}
 					else
 					{
-						ApplyBinding(bindingExpression, DataContextPropertyDetails.GetValue());
+						var value = DataContextPropertyDetails.GetValue();
+						if (value == DependencyProperty.UnsetValue)
+						{
+							// If we get UnsetValue, it means this is DefaultValue precedence that's not stored in DependencyPropertyDetails.
+							// In this case, we know for sure that DataContext's default value is null.
+							value = null;
+						}
+
+						ApplyBinding(bindingExpression, value);
 					}
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.cs
@@ -193,20 +193,11 @@ namespace Microsoft.UI.Xaml
 					_entries = entries = newEntries;
 				}
 
-				// Avoid using ref here, as TryResolveDefaultValueFromProviders execution could execute code which
-				// could cause the entries array to be expanded by bucket size and to be reallocated, which would
-				// cause the reference to be invalidated. Example of this is a child property which calls child.SetParent(this).
-				// Even though the _entries size may change, the offset and bucketRemainder will still be valid.
-				var propertyEntry = entries[offset + bucketRemainder];
-				if (propertyEntry is null)
+				ref var propertyEntry = ref entries[offset + bucketRemainder];
+
+				if (propertyEntry == null)
 				{
 					propertyEntry = new DependencyPropertyDetails(property, _ownerType, property == _dataContextProperty || property == _templatedParentProperty);
-					_entries[offset + bucketRemainder] = propertyEntry;
-
-					if (TryResolveDefaultValueFromProviders(property, out var value))
-					{
-						propertyEntry.SetDefaultValue(value);
-					}
 				}
 
 				return propertyEntry;
@@ -228,18 +219,6 @@ namespace Microsoft.UI.Xaml
 
 				return null;
 			}
-		}
-
-		private bool TryResolveDefaultValueFromProviders(DependencyProperty property, out object? value)
-		{
-			// Replicate the WinUI behavior of DependencyObject::GetDefaultValue2 specifically for UIElement.
-			if (Owner is UIElement uiElement)
-			{
-				return uiElement.GetDefaultValue2(property, out value);
-			}
-
-			value = null;
-			return false;
 		}
 
 		private void ReturnEntriesAndOffsetsToPools()

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
@@ -167,7 +167,7 @@ namespace Microsoft.UI.Xaml.Documents
 
 		public Brush Foreground
 		{
-			get => GetForegroundValue();
+			get => (Brush)GetValue(ForegroundProperty);
 			set
 			{
 				if (value != null && !(value is SolidColorBrush))
@@ -175,14 +175,19 @@ namespace Microsoft.UI.Xaml.Documents
 					throw new InvalidOperationException("Specified brush is not a SolidColorBrush");
 				}
 
-				SetForegroundValue(value);
+				SetValue(ForegroundProperty, value);
 			}
 		}
 
-		[GeneratedDependencyProperty(Options = FrameworkPropertyMetadataOptions.Inherits, ChangedCallback = true, ChangedCallbackName = nameof(OnForegroundChanged))]
-		public static DependencyProperty ForegroundProperty { get; } = CreateForegroundProperty();
-
-		private static Brush GetForegroundDefaultValue() => SolidColorBrushHelper.Black;
+		public static DependencyProperty ForegroundProperty { get; } = DependencyProperty.Register(
+			nameof(Foreground),
+			typeof(Brush),
+			typeof(TextElement),
+			new FrameworkPropertyMetadata(
+				defaultValue: SolidColorBrushHelper.Black,
+				options: FrameworkPropertyMetadataOptions.Inherits,
+				propertyChangedCallback: (instance, args) => ((TextElement)instance).OnForegroundChanged()
+		));
 
 		protected virtual void OnForegroundChanged()
 		{
@@ -388,10 +393,6 @@ namespace Microsoft.UI.Xaml.Documents
 				// Hyperlink doesn't appear to inherit foreground from the parent.
 				// So, we set this with ImplicitStyle precedence which is a higher precedence than Inheritance.
 				this.SetValue(foregroundProperty, DefaultTextForegroundBrush, DependencyPropertyValuePrecedences.ImplicitStyle);
-			}
-			else
-			{
-				this.SetValue(foregroundProperty, DefaultTextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
 			}
 
 			((IDependencyObjectStoreProvider)this).Store.SetLastUsedTheme(Application.Current?.RequestedThemeForResources);

--- a/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextElement.cs
@@ -381,8 +381,8 @@ namespace Microsoft.UI.Xaml.Documents
 
 		private protected virtual Brush DefaultTextForegroundBrush => DefaultBrushes.TextForegroundBrush;
 
-#if __WASM__ // On Wasm, we inherit UIElement, and so we need to shadow UIElement.SetDefaultForeground.
-		private protected new
+#if __WASM__
+		private protected
 #else
 		private
 #endif

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
@@ -229,8 +229,7 @@ namespace Microsoft.UI.Xaml
 				return true;
 			}
 
-			defaultValue = null;
-			return false;
+			return base.GetDefaultValue2(property, out defaultValue);
 		}
 
 		#endregion

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
@@ -20,6 +20,8 @@ namespace Microsoft.UI.Xaml
 	{
 		private Size? _lastLayoutSize;
 		private bool _constraintsChanged;
+		private bool? _stretchAffectsMeasure;
+		private bool _stretchAffectsMeasureDefault;
 
 		/// <summary>
 		/// The parent of the <see cref="FrameworkElement"/> in the visual tree, which may differ from its <see cref="Parent"/> (ie if it's a child of a native view).
@@ -192,18 +194,12 @@ namespace Microsoft.UI.Xaml
 		partial void OnLoadedPartial()
 		{
 			// see StretchAffectsMeasure for details.
-			this.SetValue(
-				StretchAffectsMeasureProperty,
-				!(NativeVisualParent is DependencyObject),
-				DependencyPropertyValuePrecedences.DefaultValue
-			);
+			_stretchAffectsMeasureDefault = NativeVisualParent is not DependencyObject;
 
 			ReconfigureViewportPropagationPartial();
 		}
 
 		private partial void ReconfigureViewportPropagationPartial();
-
-		#region StretchAffectsMeasure DependencyProperty
 
 		/// <summary>
 		/// Indicates whether stretching (HorizontalAlignment.Stretch and VerticalAlignment.Stretch) should affect the measured size of the FrameworkElement.
@@ -211,20 +207,14 @@ namespace Microsoft.UI.Xaml
 		/// Note that this doesn't take Margins into account.
 		/// </summary>
 		/// <remarks>
-		/// The <see cref="DependencyPropertyValuePrecedences.DefaultValue"/> is updated at each <see cref="OnLoadedPartial"/> call, but may
-		/// be overridden by an external called as <see cref="DependencyPropertyValuePrecedences.Local"/>.
+		/// The <see cref="_stretchAffectsMeasureDefault"/> is updated at each <see cref="OnLoadedPartial"/> call, but may
+		/// be overridden by setting this property.
 		/// </remarks>
 		public bool StretchAffectsMeasure
 		{
-			get { return (bool)GetValue(StretchAffectsMeasureProperty); }
-			set { SetValue(StretchAffectsMeasureProperty, value); }
+			get => _stretchAffectsMeasure ?? _stretchAffectsMeasureDefault;
+			set => _stretchAffectsMeasure = value;
 		}
-
-		// Using a DependencyProperty as the backing store for StretchAffectsMeasure.  This enables animation, styling, binding, etc...
-		public static DependencyProperty StretchAffectsMeasureProperty { get; } =
-			DependencyProperty.Register("StretchAffectsMeasure", typeof(bool), typeof(FrameworkElement), new FrameworkPropertyMetadata(false));
-
-		#endregion
 
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
@@ -201,20 +201,39 @@ namespace Microsoft.UI.Xaml
 
 		private partial void ReconfigureViewportPropagationPartial();
 
+		#region StretchAffectsMeasure DependencyProperty
+
 		/// <summary>
 		/// Indicates whether stretching (HorizontalAlignment.Stretch and VerticalAlignment.Stretch) should affect the measured size of the FrameworkElement.
 		/// Only set on a FrameworkElement if the parent is a native view whose layouting relies on the values of MeasuredWidth and MeasuredHeight to account for stretching.
 		/// Note that this doesn't take Margins into account.
 		/// </summary>
 		/// <remarks>
-		/// The <see cref="_stretchAffectsMeasureDefault"/> is updated at each <see cref="OnLoadedPartial"/> call, but may
-		/// be overridden by setting this property.
+		/// The <see cref="DependencyPropertyValuePrecedences.DefaultValue"/> is updated at each <see cref="OnLoadedPartial"/> call, but may
+		/// be overridden by an external called as <see cref="DependencyPropertyValuePrecedences.Local"/>.
 		/// </remarks>
 		public bool StretchAffectsMeasure
 		{
-			get => _stretchAffectsMeasure ?? _stretchAffectsMeasureDefault;
-			set => _stretchAffectsMeasure = value;
+			get => (bool)GetValue(StretchAffectsMeasureProperty);
+			set => SetValue(StretchAffectsMeasureProperty, value);
 		}
+
+		public static DependencyProperty StretchAffectsMeasureProperty { get; } =
+			DependencyProperty.Register(nameof(StretchAffectsMeasure), typeof(bool), typeof(FrameworkElement), new FrameworkPropertyMetadata(false));
+
+		internal override bool GetDefaultValue2(DependencyProperty property, out object defaultValue)
+		{
+			if (property == StretchAffectsMeasureProperty)
+			{
+				defaultValue = _stretchAffectsMeasureDefault;
+				return true;
+			}
+
+			defaultValue = null;
+			return false;
+		}
+
+		#endregion
 
 		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -612,11 +612,7 @@ namespace Microsoft.UI.Xaml
 
 		public Brush FocusVisualSecondaryBrush
 		{
-			get
-			{
-				EnsureFocusVisualBrushDefaults();
-				return GetFocusVisualSecondaryBrushValue();
-			}
+			get => GetFocusVisualSecondaryBrushValue();
 			set => SetFocusVisualSecondaryBrushValue(value);
 		}
 
@@ -633,11 +629,7 @@ namespace Microsoft.UI.Xaml
 
 		public Brush FocusVisualPrimaryBrush
 		{
-			get
-			{
-				EnsureFocusVisualBrushDefaults();
-				return GetFocusVisualPrimaryBrushValue();
-			}
+			get => GetFocusVisualPrimaryBrushValue();
 			set => SetFocusVisualPrimaryBrushValue(value);
 		}
 
@@ -654,21 +646,6 @@ namespace Microsoft.UI.Xaml
 
 		[GeneratedDependencyProperty]
 		public static DependencyProperty FocusVisualMarginProperty { get; } = CreateFocusVisualMarginProperty();
-
-		private bool _focusVisualBrushesInitialized;
-
-		internal void EnsureFocusVisualBrushDefaults()
-		{
-			if (_focusVisualBrushesInitialized)
-			{
-				return;
-			}
-
-			ResourceResolver.ApplyResource(this, FocusVisualPrimaryBrushProperty, new SpecializedResourceDictionary.ResourceKey("SystemControlFocusVisualPrimaryBrush"), ResourceUpdateReason.ThemeResource, null, DependencyPropertyValuePrecedences.DefaultValue);
-			ResourceResolver.ApplyResource(this, FocusVisualSecondaryBrushProperty, new SpecializedResourceDictionary.ResourceKey("SystemControlFocusVisualSecondaryBrush"), ResourceUpdateReason.ThemeResource, null, DependencyPropertyValuePrecedences.DefaultValue);
-
-			_focusVisualBrushesInitialized = true;
-		}
 
 		/// <summary>
 		/// Gets or sets whether a disabled control can receive focus.
@@ -985,9 +962,6 @@ namespace Microsoft.UI.Xaml
 		{
 			Resources?.UpdateThemeBindings(updateReason);
 			(this as IDependencyObjectStoreProvider).Store.UpdateResourceBindings(updateReason);
-
-			// After theme change, the focus visual brushes may not reflect the correct settings
-			_focusVisualBrushesInitialized = false;
 
 			if (updateReason == ResourceUpdateReason.ThemeResource)
 			{

--- a/src/Uno.UI/UI/Xaml/Media/Animation/FadeInThemeAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/FadeInThemeAnimation.cs
@@ -7,24 +7,6 @@ namespace Microsoft.UI.Xaml.Media.Animation
 {
 	public partial class FadeInThemeAnimation : DoubleAnimation, ITimeline
 	{
-		public FadeInThemeAnimation()
-		{
-			this.SetValue(
-				DurationProperty,
-				new Duration(FeatureConfiguration.ThemeAnimation.DefaultThemeAnimationDuration),
-				DependencyPropertyValuePrecedences.DefaultValue);
-
-			this.SetValue(
-				Storyboard.TargetPropertyProperty,
-				"Opacity",
-				DependencyPropertyValuePrecedences.DefaultValue);
-
-			this.SetValue(
-				ToProperty,
-				(double?)1d,
-				DependencyPropertyValuePrecedences.DefaultValue);
-		}
-
 		public static DependencyProperty TargetNameProperty { get; } = DependencyProperty.Register(
 			"TargetName", typeof(string), typeof(FadeInThemeAnimation), new FrameworkPropertyMetadata(string.Empty));
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/FadeOutThemeAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/FadeOutThemeAnimation.cs
@@ -7,24 +7,6 @@ namespace Microsoft.UI.Xaml.Media.Animation
 {
 	public partial class FadeOutThemeAnimation : DoubleAnimation
 	{
-		public FadeOutThemeAnimation()
-		{
-			this.SetValue(
-				DurationProperty,
-				new Duration(FeatureConfiguration.ThemeAnimation.DefaultThemeAnimationDuration),
-				DependencyPropertyValuePrecedences.DefaultValue);
-
-			this.SetValue(
-				Storyboard.TargetPropertyProperty,
-				"Opacity",
-				DependencyPropertyValuePrecedences.DefaultValue);
-
-			this.SetValue(
-				ToProperty,
-				(double?)0d,
-				DependencyPropertyValuePrecedences.DefaultValue);
-		}
-
 		public static DependencyProperty TargetNameProperty { get; } = DependencyProperty.Register(
 			"TargetName", typeof(string), typeof(FadeOutThemeAnimation), new FrameworkPropertyMetadata(string.Empty));
 

--- a/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.cs
@@ -29,7 +29,7 @@ namespace Microsoft.UI.Xaml.Media
 				"Rect",
 				typeof(Rect), typeof(RectangleGeometry),
 				new FrameworkPropertyMetadata(
-					null,
+					default(Rect),
 					options: FrameworkPropertyMetadataOptions.AffectsMeasure,
 					propertyChangedCallback: OnRectChanged));
 

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -379,7 +379,7 @@ namespace Uno.UI
 		/// <summary>
 		/// Try to retrieve a resource statically (at parse time). This will check resources in 'xaml scope' first, then top-level resources.
 		/// </summary>
-		private static bool TryStaticRetrieval(in SpecializedResourceDictionary.ResourceKey resourceKey, object context, out object value)
+		internal static bool TryStaticRetrieval(in SpecializedResourceDictionary.ResourceKey resourceKey, object context, out object value)
 		{
 			// This block is a manual enumeration to avoid the foreach pattern
 			// See https://github.com/dotnet/runtime/issues/56309 for details

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -522,13 +522,8 @@ namespace Microsoft.UI.Xaml
 
 		partial void OnVisibilityChangedPartial(Visibility oldValue, Visibility newValue);
 
-		/// <summary>
-		/// Set correct default foreground for the current theme.
-		/// </summary>
-		/// <param name="foregroundProperty">The appropriate property for the calling instance.</param>
-		private protected void SetDefaultForeground(DependencyProperty foregroundProperty)
+		private protected void UpdateLastUsedTheme()
 		{
-			this.SetValue(foregroundProperty, DefaultBrushes.TextForegroundBrush, DependencyPropertyValuePrecedences.DefaultValue);
 			((IDependencyObjectStoreProvider)this).Store.SetLastUsedTheme(Application.Current?.RequestedThemeForResources);
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -217,7 +217,7 @@ namespace Microsoft.UI.Xaml
 			}
 			else if (property == IsTabStopProperty)
 			{
-				defaultValue = IsTabStopDefaultValue;
+				defaultValue = Uno.UI.Helpers.Boxes.Box(IsTabStopDefaultValue);
 				return true;
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- `DependencyPropertyDetails` object size is unnecessarily large, both directly by storing `_defaultValue` and indirectly through `DependencyPropertyDetails.Stack` size.
- On SamplesApp startup, `DependencyPropertyDetails.Stack` is responsible for 1.27MB of allocations (3.1% of all allocations)
- On SamplesApp startup, `DependencyPropertyDetails` is responsible for 2MB of allocations (4.9% of all allocations)

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- DependencyPropertyDetails size is reduced
- On SamplesApp startup, `DependencyPropertyDetails.Stack` is responsible for 644KB of allocations (1.7%)
- On SamplesApp startup, `DependencyPropertyDetails` is responsible for 1.2MB of allocations (3.3%)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
