### PR TITLE
fix: Use ios17.5 and maccatalyst17.5 for SamplesApp

### DIFF
--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -149,7 +149,7 @@ jobs:
   - bash: |
       cd $(BUILD.SOURCESDIRECTORY)/src/SamplesApp/SamplesApp.netcoremobile
       dotnet publish \
-        -f net8.0-ios17.0 \
+        -f net8.0-ios17.5 \
         -c Release \
         -p:BuildForTestFlight=true \
         -p:UnoTargetFrameworkOverride=net8.0-ios17.0 \

--- a/build/ci/.azure-devops-ios-tests.yml
+++ b/build/ci/.azure-devops-ios-tests.yml
@@ -149,7 +149,7 @@ jobs:
   - bash: |
       cd $(BUILD.SOURCESDIRECTORY)/src/SamplesApp/SamplesApp.netcoremobile
       dotnet publish \
-        -f net8.0-ios17.5 \
+        -f net8.0-ios \
         -c Release \
         -p:BuildForTestFlight=true \
         -p:UnoTargetFrameworkOverride=net8.0-ios17.0 \

--- a/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>$(NetMobilePreviousAndCurrent)</TargetFrameworks>
+		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 
 	<Import Project="../../targetframework-override.props" />
@@ -8,7 +9,6 @@
 	<PropertyGroup>
 		<SingleProject>true</SingleProject>
 
-		<OutputType>Exe</OutputType>
 		<AssemblyName>SamplesApp</AssemblyName>
 		<DefineConstants>$(DefineConstants);XAMARIN;HAS_UNO</DefineConstants>
 		<IsUnoHead>true</IsUnoHead>

--- a/src/targetframework-override-netprevious.props
+++ b/src/targetframework-override-netprevious.props
@@ -4,8 +4,8 @@
 	<TargetFrameworks>$(UnoTargetFrameworkOverride.Replace('$(NetCurrent)', '$(NetPrevious)'))</TargetFrameworks>
 
 	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-macos'">net8.0-macos14.0</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-ios'">net8.0-ios17.5</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-maccatalyst'">net8.0-maccatalyst17.5</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-ios' and '$(OutputType)'!='Exe'">net8.0-ios17.0</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-maccatalyst' and '$(OutputType)'!='Exe'">net8.0-maccatalyst17.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/targetframework-override-netprevious.props
+++ b/src/targetframework-override-netprevious.props
@@ -4,8 +4,8 @@
 	<TargetFrameworks>$(UnoTargetFrameworkOverride.Replace('$(NetCurrent)', '$(NetPrevious)'))</TargetFrameworks>
 
 	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-macos'">net8.0-macos14.0</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-ios'">net8.0-ios17.0</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-maccatalyst'">net8.0-maccatalyst17.0</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-ios'">net8.0-ios17.5</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-maccatalyst'">net8.0-maccatalyst17.5</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/targetframework-override.props
+++ b/src/targetframework-override.props
@@ -2,10 +2,10 @@
 
   <PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
 	<TargetFrameworks>$(UnoTargetFrameworkOverride)</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-ios'">net8.0-ios17.5</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-ios'">net9.0-ios17.5</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-maccatalyst'">net8.0-maccatalyst17.5</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-maccatalyst'">net9.0-maccatalyst17.5</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-ios' and '$(OutputType)'!='Exe'">net8.0-ios17.0</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-ios' and '$(OutputType)'!='Exe'">net9.0-ios17.2</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-maccatalyst' and '$(OutputType)'!='Exe'">net8.0-maccatalyst17.0</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-maccatalyst' and '$(OutputType)'!='Exe'">net9.0-maccatalyst17.2</TargetFrameworks>
 	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-macos'">net8.0-macos14.0</TargetFrameworks>
 	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-macos'">net9.0-macos14.2</TargetFrameworks>
   </PropertyGroup>

--- a/src/targetframework-override.props
+++ b/src/targetframework-override.props
@@ -2,10 +2,10 @@
 
   <PropertyGroup Condition="'$(UnoTargetFrameworkOverride)'!=''">
 	<TargetFrameworks>$(UnoTargetFrameworkOverride)</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-ios'">net8.0-ios17.0</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-ios'">net9.0-ios17.2</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-maccatalyst'">net8.0-maccatalyst17.0</TargetFrameworks>
-	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-maccatalyst'">net9.0-maccatalyst17.2</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-ios'">net8.0-ios17.5</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-ios'">net9.0-ios17.5</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-maccatalyst'">net8.0-maccatalyst17.5</TargetFrameworks>
+	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-maccatalyst'">net9.0-maccatalyst17.5</TargetFrameworks>
 	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net8.0-macos'">net8.0-macos14.0</TargetFrameworks>
 	<TargetFrameworks Condition="'$(TargetFrameworks)'=='net9.0-macos'">net9.0-macos14.2</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Trying to build and deploy Samples app via remote connected Mac ends with https://github.com/xamarin/xamarin-macios/issues/21093

## What is the new behavior?

- Using iOS 17.5 and Mac Catalyst 17.5.
- .NET iOS 17.5 includes the fix for https://github.com/xamarin/xamarin-macios/issues/21093

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.