### PR TITLE
fix: Avoid TFM error on SamplesApp.UITests

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
+++ b/src/SamplesApp/SamplesApp.UITests/SamplesApp.UITests.csproj
@@ -11,6 +11,10 @@
 		<NoWarn>$(NoWarn);SYSLIB1045;CS1998</NoWarn>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(Configuration)' == 'Debug'">
+		<Import Project="../../targetframework-override-noplatform.props" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When targeting .NET 8 tfm override VS complains that the project targets .NET 9

## What is the new behavior?

Adjusted.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.