### PR TITLE
fix: Fix dev-server connection wrongly reported as failed

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -70,7 +70,7 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 	{
 		if ((
 				_forcedHotReloadMode is null
-				&& !_supportsLightweightHotReload
+				&& !_supportsPartialHotReload
 				&& !_serverMetadataUpdatesEnabled
 				&& _supportsXamlReader)
 			|| _forcedHotReloadMode == HotReloadMode.XamlReader)
@@ -118,8 +118,8 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 				InitializePartialReload();
 				InitializeXamlReader();
 
-				if (!_serverMetadataUpdatesEnabled
-					&& !_supportsLightweightHotReload
+				if (!_supportsMetadataUpdates
+					&& !_supportsPartialHotReload
 					&& !_supportsXamlReader)
 				{
 					_status.ReportInvalidRuntime();


### PR DESCRIPTION
fixes https://github.com/unoplatform/uno/issues/18037

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
