### PR TITLE
fix: Scrolling on WebKit randomly produces blank content temporarily

### DIFF
--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -194,6 +194,12 @@ embed.uno-frameworkelement.uno-unarranged {
   -webkit-overflow-scrolling: touch;
 }
 
+  .uno-scrollcontentpresenter > * {
+    /* Force hardware acceleration as per https://stackoverflow.com/q/9807620 */
+    /* Fixes https://github.com/unoplatform/uno/issues/17640 */
+    -webkit-transform: translate3d(0, 0, 0);
+  }
+
   .uno-scrollcontentpresenter.scroll-x-auto {
     overflow-x: auto;
   }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #17640

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Safari sometimes causes blank content to show up temporarily until a user action when scrolling, especially when the window is not active. See https://stackoverflow.com/q/9807620 for detailed discussion.

The issue is not Uno side - I have exported raw HTML of the state with blanked out content and after it appeared again and there was not actual difference, so it is all on the rendering side of the browser.

## What is the new behavior?

Applying `-webkit-transform3d` to the direct child of `ScrollContentPresenter` seems to resolve this issue, pending further testing. Setting this should not collide with `transform` set from managed code, where we set it directly on the individual elements.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
