### PR TITLE
docs: Add Tip for Toolkit StatusBar Extensions

### DIFF
--- a/doc/articles/guides/status-bar-theme-color.md
+++ b/doc/articles/guides/status-bar-theme-color.md
@@ -6,6 +6,9 @@ uid: Uno.Tutorials.StatusBarThemeColor
 
 The [`UISettings.ColorValuesChanged` event](https://learn.microsoft.com/uwp/api/windows.ui.viewmanagement.uisettings.colorvalueschanged) can be used to listen for notifications when dark mode is enabled or disabled at the system level.
 
+> TIP
+> For easier customization of the StatusBar, consider using the [StatusBar Extensions](xref:Toolkit.Helpers.StatusBarExtensions) from Uno.Toolkit, as it simplifies the process of updating the StatusBar.
+
 ## Example
 
 The complete sample code can be found in the [StatusBarThemeColor sample in Uno.Samples GitHub repository](https://github.com/unoplatform/Uno.Samples/tree/master/UI/StatusBarThemeColor).


### PR DESCRIPTION
GitHub Issue (If applicable): internal discussion

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the new behavior?

Prompt users to use the StatusBar extension from Toolkit

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
