### PR TITLE
fix: Adjust error message for global.json sdk version change

### DIFF
--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -35,7 +35,7 @@ Follow this guide in order to [update the Uno Platform packages](xref:Uno.Develo
 
 ### UNOB0005: The Version of Uno.WinUI must match the version of the Uno.Sdk found in global.json
 
-The build process has determined that the version of the Uno.WinUI NuGet package does not match the Uno.Sdk package version. This generally happens when the Uno.WinUI.* packages are updated through Visual Studio's NuGet Package manager.
+The build process has determined that the version of the Uno.WinUI NuGet package does not match the Uno.Sdk version. In general, restarting your IDE and compiling again will fix this issue.
 
 Follow this guide in order to [update the Uno Platform packages](xref:Uno.Development.UpgradeUnoNuget).
 

--- a/src/Uno.Sdk/targets/Uno.Build.targets
+++ b/src/Uno.Sdk/targets/Uno.Build.targets
@@ -16,7 +16,7 @@
 
 		<Error Code="UNOB0005"
 			HelpLink="https://aka.platform.uno/UNOB0005"
-			Text="The version of Uno.WinUI must match the version of the Uno.Sdk found in global.json (found $(_UnoSdkVersionCheck_Resolved_UnoWinUI) and expected DefaultUnoVersion). For more information about updating Uno Platform packages, visit https://aka.platform.uno/upgrade-uno-packages"
+			Text="The version of Uno.WinUI must match the version of the Uno.Sdk found in global.json (found $(_UnoSdkVersionCheck_Resolved_UnoWinUI) and expected DefaultUnoVersion). If the version was recently changed in global.json, make sure to restart your IDE. For more information about updating Uno Platform packages, visit https://aka.platform.uno/upgrade-uno-packages"
 			Condition="$(_UnoSdkVersionCheck_Resolved_UnoWinUI) != 'DefaultUnoVersion'" />
 	</Target>
 


### PR DESCRIPTION
Adjusts error message for global.json sdk version change, when visual studio or other enfironments may not have properly reloaded the solution.