### PR TITLE
feat(hr): Add UpdateFile API

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -458,7 +458,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				{
 					if (this.Log().IsEnabled(LogLevel.Debug))
 					{
-						this.Log().LogDebug($"Got an invalid update file frame ({message})");
+						this.Log().LogDebug($"Got an invalid update file frame ({message}) [{message?.RequestId}].");
 					}
 
 					return (FileUpdateResult.BadRequest, "Invalid request");
@@ -468,7 +468,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				{
 					if (this.Log().IsEnabled(LogLevel.Debug))
 					{
-						this.Log().LogDebug($"Requested file '{message.FilePath}' does not exists.");
+						this.Log().LogDebug($"Requested file '{message.FilePath}' does not exists [{message.RequestId}].");
 					}
 
 					return (FileUpdateResult.FileNotFound, $"Requested file '{message.FilePath}' does not exists.");
@@ -476,26 +476,26 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 				if (this.Log().IsEnabled(LogLevel.Debug))
 				{
-					this.Log().LogDebug($"Apply Changes to {message.FilePath}");
+					this.Log().LogDebug($"Apply Changes to {message.FilePath} [{message.RequestId}].");
 				}
 
 				var originalContent = File.ReadAllText(message.FilePath);
 				if (this.Log().IsEnabled(LogLevel.Trace))
 				{
-					this.Log().LogTrace($"Original content: {message.FilePath}");
+					this.Log().LogTrace($"Original content: {message.FilePath} [{message.RequestId}].");
 				}
 
 				var updatedContent = originalContent.Replace(message.OldText, message.NewText);
 				if (this.Log().IsEnabled(LogLevel.Trace))
 				{
-					this.Log().LogTrace($"Updated content: {message.FilePath}");
+					this.Log().LogTrace($"Updated content: {message.FilePath} [{message.RequestId}].");
 				}
 
 				if (updatedContent == originalContent)
 				{
 					if (this.Log().IsEnabled(LogLevel.Debug))
 					{
-						this.Log().LogDebug($"No changes detected in {message.FilePath}");
+						this.Log().LogDebug($"No changes detected in {message.FilePath} [{message.RequestId}].");
 					}
 
 					return (FileUpdateResult.NoChanges, null);

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -1,4 +1,4 @@
-﻿#if __SKIA__
+﻿#if HAS_UNO_WINUI && __SKIA__
 
 using System;
 using System.IO;

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -160,7 +160,7 @@ public partial class ClientHotReloadProcessor
 		}
 	}
 
-	private partial void ProcessUpdateFileResponse(UpdateFileResponse response)
+	partial void ProcessUpdateFileResponse(UpdateFileResponse response)
 		=> _updateResponse?.Invoke(this, response);
 	#endregion
 

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -3,11 +3,13 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI.RemoteControl.HotReload.Messages;
+using Windows.UI.Notifications;
 
 namespace Uno.UI.RemoteControl.HotReload;
 
@@ -15,81 +17,118 @@ public partial class ClientHotReloadProcessor
 {
 	private static int _reqId;
 
+	/// <summary>
+	/// Result details of a file update
+	/// </summary>
+	/// <param name="FileUpdated">Indicates if is known to have been updated on server-side.</param>
+	/// <param name="ApplicationUpdated">Indicates if the change had an impact on the compilation of the application (might be a success-full build or an error).</param>
+	/// <param name="Error">Gets the error if any happened during the update.</param>
+	public record struct UpdateResult(
+		bool FileUpdated,
+		bool? ApplicationUpdated,
+		Exception? Error = null);
+
 	public async Task UpdateFileAsync(string filePath, string oldText, string newText, bool waitForHotReload, CancellationToken ct)
 	{
-		if (string.IsNullOrWhiteSpace(filePath))
+		if (await TryUpdateFileAsync(filePath, oldText, newText, waitForHotReload, ct) is { Error: { } error })
 		{
-			throw new ArgumentOutOfRangeException(nameof(filePath), "File path is invalid (null or empty).");
+			ExceptionDispatchInfo.Throw(error);
 		}
+	}
 
-		var log = this.Log();
-		var trace = log.IsTraceEnabled(LogLevel.Trace) ? log : default;
-		var debug = log.IsDebugEnabled(LogLevel.Debug) ? log : default;
-		var tag = $"[{Interlocked.Increment(ref _reqId):D2}-{Path.GetFileName(filePath)}]";
-
-		debug?.Debug($"{tag} Updating file {filePath} (from: {oldText[..100]} | to: {newText[..100]}.");
-
-		var request = new UpdateFile { FilePath = filePath, OldText = oldText, NewText = newText };
-		var response = await UpdateFileAsync(request, ct);
-
-		if (response.Result is FileUpdateResult.NoChanges)
+	public async Task<UpdateResult> TryUpdateFileAsync(string filePath, string oldText, string newText, bool waitForHotReload, CancellationToken ct)
+	{
+		var result = default(UpdateResult);
+		try
 		{
-			debug?.Debug($"{tag} Changes requested has no effect on server, completing.");
-			return;
-		}
+			if (string.IsNullOrWhiteSpace(filePath))
+			{
+				return result with { Error = new ArgumentOutOfRangeException(nameof(filePath), "File path is invalid (null or empty).") };
+			}
 
-		if (response.Result is not FileUpdateResult.Success)
+			var log = this.Log();
+			var trace = log.IsTraceEnabled(LogLevel.Trace) ? log : default;
+			var debug = log.IsDebugEnabled(LogLevel.Debug) ? log : default;
+			var tag = $"[{Interlocked.Increment(ref _reqId):D2}-{Path.GetFileName(filePath)}]";
+
+			debug?.Debug($"{tag} Updating file {filePath} (from: {oldText[..100]} | to: {newText[..100]}.");
+
+			var request = new UpdateFile { FilePath = filePath, OldText = oldText, NewText = newText };
+			var response = await UpdateFileCoreAsync(request, ct);
+
+			if (response.Result is FileUpdateResult.NoChanges)
+			{
+				debug?.Debug($"{tag} Changes requested has no effect on server, completing.");
+				return result;
+			}
+
+			if (response.Result is not FileUpdateResult.Success)
+			{
+				debug?.Debug($"{tag} Server failed to update file: {response.Result} (srv error: {response.Error}).");
+				return result with { Error = new InvalidOperationException($"Failed to update file {filePath}: {response.Result} (see inner exception for more details)", new InvalidOperationException(response.Error)) };
+			}
+
+			result.FileUpdated = true;
+
+			if (!waitForHotReload)
+			{
+				trace?.Trace($"{tag} File updated successfully and do not wait for HR, completing.");
+				return result;
+			}
+
+			if (response.HotReloadCorrelationId is null)
+			{
+				debug?.Debug($"{tag} File updated successfully, but didn't get any HR id from server to wait for.");
+				return result with { Error = new InvalidOperationException("Cannot wait for Hot reload for this file.") };
+			}
+
+			trace?.Trace($"{tag} Successfully updated file on server ({response.Result}), waiting for server HR id {response.HotReloadCorrelationId}.");
+
+			var localHrTask = WaitForNextLocalHotReload(ct);
+			var serverHr = await WaitForServerHotReloadAsync(response.HotReloadCorrelationId.Value, ct);
+			if (serverHr.Result is HotReloadServerResult.NoChanges)
+			{
+				trace?.Trace($"{tag} Server didn't detected any changes in code, do not wait for local HR.");
+				return result with { ApplicationUpdated = false };
+			}
+
+			result.ApplicationUpdated = true;
+
+			if (serverHr.Result is not HotReloadServerResult.Success)
+			{
+				debug?.Debug($"{tag} Server failed to applied changes in code: {serverHr.Result}.");
+				return result with { Error = new InvalidOperationException($"Failed to update file {filePath}, hot-reload failed on server: {serverHr.Result}.") };
+			}
+
+			trace?.Trace($"{tag} Successfully got HR from server ({serverHr.Result}), waiting for local HR to complete.");
+
+			var localHr = await localHrTask;
+			if (localHr.Result is HotReloadClientResult.Failed)
+			{
+				debug?.Debug($"{tag} Failed to apply HR locally: {localHr.Result}.");
+				return result with { Error = new InvalidOperationException($"Failed to update file {filePath}, hot-reload failed locally: {localHr.Result}.") };
+			}
+
+			await Task.Delay(100, ct); // Wait a bit to make sure to let the dispatcher to resume, this is just for safety.
+
+			trace?.Trace($"{tag} Successfully updated file and completed HR.");
+
+			return result;
+		}
+		catch (OperationCanceledException) when (ct.IsCancellationRequested)
 		{
-			debug?.Debug($"{tag} Server failed to update file: {response.Result} (srv error: {response.Error}).");
-			throw new InvalidOperationException($"Failed to update file {filePath}: {response.Result}. Server replied: {response.Error}");
+			return result with { Error = new OperationCanceledException("Update file operation has been cancelled.") };
 		}
-
-		if (!waitForHotReload)
+		catch (Exception error)
 		{
-			trace?.Trace($"{tag} File updated successfully and do not wait for HR, completing.");
-			return;
+			return result with { Error = error };
 		}
-
-		if (response.HotReloadCorrelationId is null)
-		{
-			debug?.Debug($"{tag} File updated successfully, but didn't get any HR id from server to wait for.");
-			throw new InvalidOperationException("Cannot wait for Hot reload for this file.");
-		}
-
-		trace?.Trace($"{tag} Successfully updated file on server ({response.Result}), waiting for server HR id {response.HotReloadCorrelationId}.");
-
-		var localHrTask = WaitForNextLocalHotReload(ct);
-		var serverHr = await WaitForServerHotReloadAsync(response.HotReloadCorrelationId.Value, ct);
-		if (serverHr.Result is HotReloadServerResult.NoChanges)
-		{
-			trace?.Trace($"{tag} Server didn't detected any changes in code, do not wait for local HR.");
-			return;
-		}
-
-		if (serverHr.Result is not HotReloadServerResult.Success)
-		{
-			debug?.Debug($"{tag} Server failed to applied changes in code: {serverHr.Result}.");
-			throw new InvalidOperationException($"Failed to update file {filePath}, hot-reload failed on server: {serverHr.Result}.");
-		}
-
-		trace?.Trace($"{tag} Successfully got HR from server ({serverHr.Result}), waiting for local HR to complete.");
-
-		var localHr = await localHrTask;
-		if (localHr.Result is HotReloadClientResult.Failed)
-		{
-			debug?.Debug($"{tag} Failed to apply HR locally: {localHr.Result}.");
-			throw new InvalidOperationException($"Failed to update file {filePath}, hot-reload failed locally: {localHr.Result}.");
-		}
-
-		await Task.Delay(100, ct); // Wait a bit to make sure to let the dispatcher to resume, this is just for safety.
-
-		trace?.Trace($"{tag} Successfully updated file and completed HR.");
 	}
 
 	#region File updates messaging
 	private EventHandler<UpdateFileResponse>? _updateResponse;
 
-	private async ValueTask<UpdateFileResponse> UpdateFileAsync(UpdateFile request, CancellationToken ct)
+	private async ValueTask<UpdateFileResponse> UpdateFileCoreAsync(UpdateFile request, CancellationToken ct)
 	{
 		var timeout = Task.Delay(10_000, ct);
 		var responseAsync = new TaskCompletionSource<UpdateFileResponse>();
@@ -122,7 +161,7 @@ public partial class ClientHotReloadProcessor
 	}
 
 	private partial void ProcessUpdateFileResponse(UpdateFileResponse response)
-		=> _updateResponse?.Invoke(this, response); 
+		=> _updateResponse?.Invoke(this, response);
 	#endregion
 
 	private async ValueTask<HotReloadServerOperationData> WaitForServerHotReloadAsync(long hotReloadId, CancellationToken ct)

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -65,7 +65,7 @@ public partial class ClientHotReloadProcessor
 
 		public UpdateRequest WithExtendedTimeouts(float? factor = null)
 		{
-			factor ??= Debugger.IsAttached ? 30 : 10;
+			factor ??= Debugger.IsAttached ? 10 : 30;
 
 			return this with
 			{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -1,0 +1,198 @@
+﻿#if __SKIA__
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions;
+using Uno.Foundation.Logging;
+using Uno.UI.RemoteControl.HotReload.Messages;
+
+namespace Uno.UI.RemoteControl.HotReload;
+
+public partial class ClientHotReloadProcessor
+{
+	private static int _reqId;
+
+	public async Task UpdateFileAsync(string filePath, string oldText, string newText, bool waitForHotReload, CancellationToken ct)
+	{
+		if (string.IsNullOrWhiteSpace(filePath))
+		{
+			throw new ArgumentOutOfRangeException(nameof(filePath), "File path is invalid (null or empty).");
+		}
+
+		var log = this.Log();
+		var trace = log.IsTraceEnabled(LogLevel.Trace) ? log : default;
+		var debug = log.IsDebugEnabled(LogLevel.Debug) ? log : default;
+		var tag = $"[{Interlocked.Increment(ref _reqId):D2}-{Path.GetFileName(filePath)}]";
+
+		debug?.Debug($"{tag} Updating file {filePath} (from: {oldText[..100]} | to: {newText[..100]}.");
+
+		var request = new UpdateFile { FilePath = filePath, OldText = oldText, NewText = newText };
+		var response = await UpdateFileAsync(request, ct);
+
+		if (response.Result is FileUpdateResult.NoChanges)
+		{
+			debug?.Debug($"{tag} Changes requested has no effect on server, completing.");
+			return;
+		}
+
+		if (response.Result is not FileUpdateResult.Success)
+		{
+			debug?.Debug($"{tag} Server failed to update file: {response.Result} (srv error: {response.Error}).");
+			throw new InvalidOperationException($"Failed to update file {filePath}: {response.Result}. Server replied: {response.Error}");
+		}
+
+		if (!waitForHotReload)
+		{
+			trace?.Trace($"{tag} File updated successfully and do not wait for HR, completing.");
+			return;
+		}
+
+		if (response.HotReloadCorrelationId is null)
+		{
+			debug?.Debug($"{tag} File updated successfully, but didn't get any HR id from server to wait for.");
+			throw new InvalidOperationException("Cannot wait for Hot reload for this file.");
+		}
+
+		trace?.Trace($"{tag} Successfully updated file on server ({response.Result}), waiting for server HR id {response.HotReloadCorrelationId}.");
+
+		var localHrTask = WaitForNextLocalHotReload(ct);
+		var serverHr = await WaitForServerHotReloadAsync(response.HotReloadCorrelationId.Value, ct);
+		if (serverHr.Result is HotReloadServerResult.NoChanges)
+		{
+			trace?.Trace($"{tag} Server didn't detected any changes in code, do not wait for local HR.");
+			return;
+		}
+
+		if (serverHr.Result is not HotReloadServerResult.Success)
+		{
+			debug?.Debug($"{tag} Server failed to applied changes in code: {serverHr.Result}.");
+			throw new InvalidOperationException($"Failed to update file {filePath}, hot-reload failed on server: {serverHr.Result}.");
+		}
+
+		trace?.Trace($"{tag} Successfully got HR from server ({serverHr.Result}), waiting for local HR to complete.");
+
+		var localHr = await localHrTask;
+		if (localHr.Result is HotReloadClientResult.Failed)
+		{
+			debug?.Debug($"{tag} Failed to apply HR locally: {localHr.Result}.");
+			throw new InvalidOperationException($"Failed to update file {filePath}, hot-reload failed locally: {localHr.Result}.");
+		}
+
+		await Task.Delay(100, ct); // Wait a bit to make sure to let the dispatcher to resume, this is just for safety.
+
+		trace?.Trace($"{tag} Successfully updated file and completed HR.");
+	}
+
+	#region File updates messaging
+	private EventHandler<UpdateFileResponse>? _updateResponse;
+
+	private async ValueTask<UpdateFileResponse> UpdateFileAsync(UpdateFile request, CancellationToken ct)
+	{
+		var timeout = Task.Delay(10_000, ct);
+		var responseAsync = new TaskCompletionSource<UpdateFileResponse>();
+
+		try
+		{
+			_updateResponse += OnFileUpdated;
+
+			await _rcClient.SendMessage(request);
+
+			if (await Task.WhenAny(responseAsync.Task, timeout) == timeout)
+			{
+				throw new TimeoutException("Failed to get response from the server in the given delay.");
+			}
+
+			return await responseAsync.Task;
+		}
+		finally
+		{
+			_updateResponse -= OnFileUpdated;
+		}
+
+		void OnFileUpdated(object? _, UpdateFileResponse response)
+		{
+			if (response.RequestId == request.RequestId)
+			{
+				responseAsync.TrySetResult(response);
+			}
+		}
+	}
+
+	private partial void ProcessUpdateFileResponse(UpdateFileResponse response)
+		=> _updateResponse?.Invoke(this, response); 
+	#endregion
+
+	private async ValueTask<HotReloadServerOperationData> WaitForServerHotReloadAsync(long hotReloadId, CancellationToken ct)
+	{
+		var timeout = Task.Delay(10_000, ct);
+		var operationAsync = new TaskCompletionSource<HotReloadServerOperationData>();
+
+		try
+		{
+			StatusChanged += OnStatusChanged;
+			CheckIfCompleted(CurrentStatus);
+
+			if (await Task.WhenAny(operationAsync.Task, timeout) == timeout)
+			{
+				throw new TimeoutException($"Failed to get hot-reload (id: {hotReloadId}) from the server in the given delay.");
+			}
+
+			return await operationAsync.Task;
+		}
+		finally
+		{
+			StatusChanged -= OnStatusChanged;
+		}
+
+		void OnStatusChanged(object? _, Status status)
+			=> CheckIfCompleted(status);
+
+		void CheckIfCompleted(Status status)
+		{
+			var operation = status.Server.Operations.FirstOrDefault(op => op.Id >= hotReloadId && op.Result is not (null or HotReloadServerResult.Aborted));
+			if (operation is not null)
+			{
+				operationAsync.TrySetResult(operation);
+			}
+		}
+	}
+
+	private async ValueTask<HotReloadClientOperation> WaitForNextLocalHotReload(CancellationToken ct)
+	{
+		var timeout = Task.Delay(10_000, ct);
+		var operationAsync = new TaskCompletionSource<HotReloadClientOperation>();
+		var previousId = CurrentStatus.Local.Operations is { Count: > 0 } ops ? ops.Max(op => op.Id) : -1;
+
+		try
+		{
+			StatusChanged += OnStatusChanged;
+
+			if (await Task.WhenAny(operationAsync.Task, timeout) == timeout)
+			{
+				throw new TimeoutException($"Failed to get a local hot-reload (id: {previousId}+) in the given delay.");
+			}
+
+			return await operationAsync.Task;
+		}
+		finally
+		{
+			StatusChanged -= OnStatusChanged;
+		}
+
+		void OnStatusChanged(object? _, Status status)
+			=> CheckIfCompleted(status);
+
+		void CheckIfCompleted(Status status)
+		{
+			var operation = status.Local.Operations.FirstOrDefault(op => op.Id > previousId && op.Result is not null);
+			if (operation is not null)
+			{
+				operationAsync.TrySetResult(operation);
+			}
+		}
+	}
+}
+#endif

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -25,6 +25,11 @@ public partial class ClientHotReloadProcessor
 	/// </summary>
 	internal EventHandler<Status>? StatusChanged;
 
+	/// <summary>
+	/// The current status of the hot-reload engine.
+	/// </summary>
+	internal Status CurrentStatus => _status.Current;
+
 	private readonly StatusSink _status;
 
 	internal enum HotReloadSource
@@ -74,6 +79,8 @@ public partial class ClientHotReloadProcessor
 		private ImmutableDictionary<long, HotReloadServerOperationData> _serverOperations = ImmutableDictionary<long, HotReloadServerOperationData>.Empty;
 		private ImmutableList<HotReloadClientOperation> _localOperations = ImmutableList<HotReloadClientOperation>.Empty;
 		private HotReloadSource _source;
+
+		public Status Current { get; private set; } = null!;
 
 		public void ReportInvalidRuntime()
 		{
@@ -133,6 +140,8 @@ public partial class ClientHotReloadProcessor
 		private void NotifyStatusChanged()
 		{
 			var status = BuildStatus();
+
+			Current = status;
 #if HAS_UNO_WINUI
 			_view.Update(status);
 #endif

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -70,7 +70,7 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 		}
 	}
 
-	private partial void ProcessUpdateFileResponse(UpdateFileResponse response);
+	partial void ProcessUpdateFileResponse(UpdateFileResponse response);
 
 	private async Task ProcessFileReload(HotReload.Messages.FileReload fileReload)
 	{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -45,6 +45,10 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 				ProcessAssemblyReload(frame.GetContent<AssemblyDeltaReload>());
 				break;
 
+			case UpdateFileResponse.Name:
+				ProcessUpdateFileResponse(frame.GetContent<UpdateFileResponse>());
+				break;
+
 			case FileReload.Name:
 				await ProcessFileReload(frame.GetContent<FileReload>());
 				break;
@@ -65,6 +69,8 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 				break;
 		}
 	}
+
+	private partial void ProcessUpdateFileResponse(UpdateFileResponse response);
 
 	private async Task ProcessFileReload(HotReload.Messages.FileReload fileReload)
 	{

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
@@ -14,7 +14,7 @@ public class UpdateFile : IMessage
 	/// ID of this file update request.
 	/// </summary>
 	[JsonProperty]
-	public string RequestId { get; } = Guid.NewGuid().ToString();
+	public string RequestId { get; set; } = Guid.NewGuid().ToString();
 
 	[JsonProperty]
 	public string FilePath { get; set; } = string.Empty;

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/FrameworkElementExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/FrameworkElementExtensions.cs
@@ -8,7 +8,7 @@ namespace Uno.UI.RuntimeTests.Tests.HotReload
 {
 	internal static class FrameworkElementExtensions
 	{
-		private static (string FileName, int FileLine, int LinePosition) GetDebugParseContext(this FrameworkElement element)
+		public static (string FileName, int FileLine, int LinePosition) GetDebugParseContext(this FrameworkElement element)
 		{
 			var dpcProp = typeof(FrameworkElement).GetProperty("DebugParseContext", BindingFlags.Instance | BindingFlags.NonPublic);
 

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBlock.cs
@@ -75,25 +75,21 @@ public class Given_TextBlock : BaseTestClass
 
 		var hr = Uno.UI.RemoteControl.RemoteControlClient.Instance?.Processors.OfType<Uno.UI.RemoteControl.HotReload.ClientHotReloadProcessor>().Single();
 		var ctx = Uno.UI.RuntimeTests.Tests.HotReload.FrameworkElementExtensions.GetDebugParseContext(new HR_Frame_Pages_Page1());
+		var req = new Uno.UI.RemoteControl.HotReload.ClientHotReloadProcessor.UpdateRequest(
+			ctx.FileName,
+			FirstPageTextBlockOriginalText,
+			FirstPageTextBlockChangedText,
+			true)
+			.WithExtendedTimeouts(); // Required for CI
 		try
 		{
-			await hr.UpdateFileAsync(
-				ctx.FileName,
-				FirstPageTextBlockOriginalText,
-				FirstPageTextBlockChangedText,
-				true,
-				ct);
+			await hr.UpdateFileAsync(req, ct);
 
 			await UnitTestsUIContentHelper.Content.ValidateTextOnChildTextBlock(FirstPageTextBlockChangedText);
 		}
 		finally
 		{
-			await hr.UpdateFileAsync(
-				ctx.FileName,
-				FirstPageTextBlockChangedText,
-				FirstPageTextBlockOriginalText,
-				false,
-				CancellationToken.None);
+			await hr.UpdateFileAsync(req.Undo(waitForHotReload: false), CancellationToken.None);
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_TextBlock.cs
@@ -57,6 +57,7 @@ public class Given_TextBlock : BaseTestClass
 			ct);
 	}
 
+#if HAS_UNO_WINUI
 	/// <summary>
 	/// Checks that a simple change to a XAML element (change Text on TextBlock) will be applied to
 	/// the currently visible page:
@@ -92,4 +93,5 @@ public class Given_TextBlock : BaseTestClass
 			await hr.UpdateFileAsync(req.Undo(waitForHotReload: false), CancellationToken.None);
 		}
 	}
+#endif
 }

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.Gtk.csproj
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Uno.UI.RuntimeTests.HRApp.Skia.Gtk.csproj
@@ -16,7 +16,7 @@
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
 		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-		<NoWarn>$(NoWarn);CS1998;IDE0051;IDE0055</NoWarn>
+		<NoWarn>$(NoWarn);CS1998;IDE0051;IDE0055;NU1903;MSB3277</NoWarn>
 	</PropertyGroup>
 
 	<Target Name="DisplayBasePath" BeforeTargets="BeforeBuild">


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/611

## Feature
Add UpdateFile API

## What is the current behavior?
No easy / reliable way to update a file on the server and wait for HR

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
