### PR TITLE
docs: Update migrating-from-previous-releases.md for 4.1 migration notes by removing a non-working link

### DIFF
--- a/doc/articles/migrating-from-previous-releases.md
+++ b/doc/articles/migrating-from-previous-releases.md
@@ -136,7 +136,7 @@ Additionally, here are some specific hints about the migration to Android 12:
     displayName: Select JDK 11
     ```
 
-  - You may need to [add the following property](https://github.com/tdevere/AppCenterSupportDocs/blob/main/Build/Could_not_determine_API_level_for_$TargetFrameworkVersion_of_v12.0.md) to your Android csproj:
+  - You may need to add the following property to your Android csproj:
 
     ```xml
     <PropertyGroup>


### PR DESCRIPTION
GitHub Issue: https://github.com/unoplatform/private/issues/504

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## Description

Update migrating-from-previous-releases.md for older 4.1 migration notes to remove a link that does not exist anymore

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

