### PR TITLE
fix: ActionAppNotificationSettings `Launcher` missing package reference

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_System/LauncherTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_System/LauncherTests.xaml
@@ -20,5 +20,7 @@
 		<TextBlock Foreground="Red" Text="{Binding Error}" />
         <Button Command="{Binding OpenFolderCommand}">Open sample folder</Button>
         <Button Command="{Binding OpenFileCommand}">Open sample file</Button>
+		<TextBlock>Special Uris (Windows/Android only)</TextBlock>
+		<Button Command="{Binding OpenAppNotificationSettingsCommand}">Open System Notification Settings</Button>
 	</StackPanel>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_System/LauncherTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_System/LauncherTests.xaml.cs
@@ -11,11 +11,12 @@ using EventHandler = System.EventHandler;
 using Windows.ApplicationModel;
 using System.IO;
 using Windows.Storage;
+using BenchmarkDotNet.Code;
 
 namespace UITests.Shared.Windows_System
 {
 	[SampleControlInfo("Windows.System", "Launcher",
-		description: "Tests the Launcher. Some special URIs are supported on some platforms (Android, iOS - ms-settings:)",
+		description: "Tests the Launcher. Some special URIs are supported on certain platforms (Windows, Android, iOS—such as ms-settings:). On Android, the 'Open System Notification Settings' option should take you directly to the 'App Notifications' section in the system settings.",
 		viewModelType: typeof(LauncherTestsViewModel))]
 	public sealed partial class LauncherTests : UserControl
 	{
@@ -67,7 +68,7 @@ namespace UITests.Shared.Windows_System
 
 		public ICommand QuerySupportCommand => GetOrCreateCommand(QuerySupport);
 
-		public ICommand LaunchCommand => GetOrCreateCommand(Launch);
+		public ICommand LaunchCommand => GetOrCreateCommand(() => Launch());
 
 		public ICommand OpenFileCommand => GetOrCreateCommand(OpenFile);
 
@@ -87,12 +88,12 @@ namespace UITests.Shared.Windows_System
 			await Launcher.LaunchFolderPathAsync(path);
 		}
 
-		private async void Launch()
+		private async void Launch(string uriParam = null)
 		{
 			Error = "";
 			try
 			{
-				if (System.Uri.TryCreate(Uri, UriKind.Absolute, out var parsedUri))
+				if (System.Uri.TryCreate(uriParam ?? Uri, UriKind.Absolute, out var parsedUri))
 				{
 					await Launcher.LaunchUriAsync(parsedUri);
 				}
@@ -126,5 +127,9 @@ namespace UITests.Shared.Windows_System
 				Error = ex.ToString();
 			}
 		}
+
+		public ICommand OpenAppNotificationSettingsCommand => GetOrCreateCommand(OpenAppNotificationSettings);
+
+		private void OpenAppNotificationSettings() => Launch("ms-settings:notifications");
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_System/LauncherTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_System/LauncherTests.xaml.cs
@@ -1,17 +1,11 @@
 ﻿using System;
-using System.Windows.Input;
+using System.IO;
+using Microsoft.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
 using Uno.UI.Samples.UITests.Helpers;
-using Windows.System;
-using Windows.UI.Core;
-using Microsoft.UI.Xaml.Controls;
-
-using ICommand = System.Windows.Input.ICommand;
-using EventHandler = System.EventHandler;
-using Windows.ApplicationModel;
-using System.IO;
 using Windows.Storage;
-using BenchmarkDotNet.Code;
+using Windows.System;
+using ICommand = System.Windows.Input.ICommand;
 
 namespace UITests.Shared.Windows_System
 {

--- a/src/Uno.UWP/System/Launcher.Android.SpecialUris.cs
+++ b/src/Uno.UWP/System/Launcher.Android.SpecialUris.cs
@@ -1,11 +1,11 @@
 ﻿#if __ANDROID__
-using System.Linq;
-using System.Threading.Tasks;
-using Android.Content;
 using System;
-using Android.Provider;
 using System.Collections.Generic;
+using System.Linq;
+using Android.App;
+using Android.Content;
 using Android.OS;
+using Android.Provider;
 
 namespace Windows.System
 {
@@ -96,6 +96,11 @@ namespace Windows.System
 			}
 
 			var intent = new Intent(launchAction ?? Settings.ActionSettings);
+			if (launchAction == Settings.ActionAppNotificationSettings)
+			{
+				intent.PutExtra(Settings.ExtraAppPackage, Application.Context.PackageName);
+			}
+
 			StartActivity(intent);
 			return true;
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #18080

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The special Uri never launches correctly:

![image](https://github.com/user-attachments/assets/1470cbee-bf33-4927-bd42-4e38b57bad86)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

The intended Settings page is launched as the package name is provided:

![image](https://github.com/user-attachments/assets/32bb1072-ed01-4fd5-b388-b5395e366654)

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.