### PR TITLE
feat: Throw `ArgumentNullException` if `XamlRoot` is not provided

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
@@ -222,14 +222,28 @@ namespace Microsoft.UI.Xaml.Media
 			return Array.Empty<Popup>();
 		}
 
-		private static IReadOnlyList<Popup> GetOpenFlyoutPopups(XamlRoot xamlRoot) =>
-			GetOpenPopups(xamlRoot.VisualTree)
+		private static IReadOnlyList<Popup> GetOpenFlyoutPopups(XamlRoot xamlRoot)
+		{
+			if (xamlRoot is null)
+			{
+				throw new ArgumentNullException(nameof(xamlRoot));
+			}
+
+			return GetOpenPopups(xamlRoot.VisualTree)
 				.Where(p => p.IsForFlyout)
 				.ToList()
 				.AsReadOnly();
+		}
 
-		public static IReadOnlyList<Popup> GetOpenPopupsForXamlRoot(XamlRoot xamlRoot) =>
-			GetOpenPopups(xamlRoot.VisualTree);
+		public static IReadOnlyList<Popup> GetOpenPopupsForXamlRoot(XamlRoot xamlRoot)
+		{
+			if (xamlRoot is null)
+			{
+				throw new ArgumentNullException(nameof(xamlRoot));
+			}
+
+			return GetOpenPopups(xamlRoot.VisualTree);
+		}
 
 		private static IReadOnlyList<Popup> GetOpenPopups(VisualTree visualTree)
 		{
@@ -261,6 +275,11 @@ namespace Microsoft.UI.Xaml.Media
 
 		internal static void CloseAllPopups(XamlRoot xamlRoot)
 		{
+			if (xamlRoot is null)
+			{
+				throw new ArgumentNullException(nameof(xamlRoot));
+			}
+
 			foreach (var popup in GetOpenPopups(xamlRoot.VisualTree))
 			{
 				popup.IsOpen = false;
@@ -269,6 +288,11 @@ namespace Microsoft.UI.Xaml.Media
 
 		internal static void CloseLightDismissPopups(XamlRoot xamlRoot)
 		{
+			if (xamlRoot is null)
+			{
+				throw new ArgumentNullException(nameof(xamlRoot));
+			}
+
 			foreach (var popup in GetOpenPopups(xamlRoot.VisualTree).Where(p => p.IsLightDismissEnabled))
 			{
 				popup.IsOpen = false;


### PR DESCRIPTION
GitHub Issue (If applicable): related to internal issue

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Throws NRE trying to access `VisualTree`

## What is the new behavior?

Throws `ArgumentNullException` to provide clarity that `XamlRoot` is required

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
