### PR TITLE
fix: Adjust ScrollContentPresenter measure to prevent infinite available size when necessary

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ItemsPresenter.cs
@@ -1180,5 +1180,23 @@ public class Given_ItemsPresenter
 		Assert.AreEqual(SUT.FindVisualChildByType<TextBlock>().Text, "updated footer value");
 	}
 
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_Inside_ScrollContentPresenter()
+	{
+		var lv = new ListView();
+		ScrollViewer.SetHorizontalScrollBarVisibility(lv, ScrollBarVisibility.Visible);
+		ScrollViewer.SetHorizontalScrollMode(lv, ScrollMode.Enabled);
+		lv.Items.Add("1");
+
+		await UITestHelper.Load(lv);
+
+		var sv = (ScrollViewer)((Border)VisualTreeHelper.GetChild(lv, 0)).Child;
+		var itemsPresenter = (ItemsPresenter)sv.Content;
+
+		var availableSize = LayoutInformation.GetAvailableSize(itemsPresenter);
+		Assert.AreNotEqual(double.PositiveInfinity, availableSize.Width);
+	}
+
 	public record MyTextModel(string MyText);
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -348,6 +348,17 @@ namespace Microsoft.UI.Xaml.Controls
 #endif
 		}
 
+		internal override bool WantsScrollViewerToObscureAvailableSizeBasedOnScrollBarVisibility(Orientation orientation)
+		{
+			return WantsScrollViewerToObscureAvailableSizeBasedOnScrollBarVisibility(orientation, Panel);
+		}
+
+		private bool WantsScrollViewerToObscureAvailableSizeBasedOnScrollBarVisibility(Orientation orientation, _ViewGroup spPanel)
+		{
+			return (spPanel as FrameworkElement)?.WantsScrollViewerToObscureAvailableSizeBasedOnScrollBarVisibility(orientation) ?? true;
+		}
+
+
 		protected override Size ArrangeOverride(Size finalSize)
 		{
 			// Most of this is inspired by StackPanel's ArrangeOverride

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanel.cs
@@ -102,6 +102,12 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 			}
 		}
+
+		// In WinUI, this is actually for ModernCollectionBasePanel
+		internal override bool WantsScrollViewerToObscureAvailableSizeBasedOnScrollBarVisibility(Orientation orientation)
+		{
+			return Orientation == orientation;
+		}
 	}
 }
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGrid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsWrapGrid/ItemsWrapGrid.cs
@@ -56,6 +56,12 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			return _layout;
 		}
+
+		// In WinUI, this is actually for ModernCollectionBasePanel
+		internal override bool WantsScrollViewerToObscureAvailableSizeBasedOnScrollBarVisibility(Orientation orientation)
+		{
+			return Orientation == orientation;
+		}
 	}
 }
 

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.cs
@@ -189,14 +189,16 @@ namespace Microsoft.UI.Xaml.Controls
 
 				if (CanVerticallyScroll)
 				{
-					if (!sizesContentToTemplatedParent)
+					var childPreventsInfiniteAvailableHeight = !child.WantsScrollViewerToObscureAvailableSizeBasedOnScrollBarVisibility(Orientation.Vertical);
+					if (!sizesContentToTemplatedParent && !childPreventsInfiniteAvailableHeight)
 					{
 						slotSize.Height = double.PositiveInfinity;
 					}
 				}
 				if (CanHorizontallyScroll)
 				{
-					if (!sizesContentToTemplatedParent)
+					var childPreventsInfiniteAvailableWidth = !child.WantsScrollViewerToObscureAvailableSizeBasedOnScrollBarVisibility(Orientation.Horizontal);
+					if (!sizesContentToTemplatedParent && !childPreventsInfiniteAvailableWidth)
 					{
 						slotSize.Width = double.PositiveInfinity;
 					}

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -1929,5 +1929,8 @@ namespace Microsoft.UI.Xaml
 
 		}
 #endif
+
+		internal virtual bool WantsScrollViewerToObscureAvailableSizeBasedOnScrollBarVisibility(Orientation horizontal)
+			=> true;
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/kahua-private/issues/176
