### PR TITLE
feat: Make breaking on unhandled exceptions opt-in

### DIFF
--- a/doc/articles/features/unhandled-exceptions.md
+++ b/doc/articles/features/unhandled-exceptions.md
@@ -4,10 +4,18 @@ uid: xref:Uno.Development.UnhandledExceptions
 
 # Generic Unhandled Exceptions handler
 
-Starting Uno Platform 5.4, we are generating a generic handler for `Application.UnhandledException`, in line with WinUI approach. When debugger is attached, unhandled framework exceptions will be logged in the debugger output by default and the debugger will automatically break. To avoid debugger breaking behavior, you can add the following into any `PropertyGroup` of your `.csproj`:
+Starting Uno Platform 5.4, we are generating a generic handler for `Application.UnhandledException`, in line with WinUI approach. When debugger is attached, unhandled framework exceptions will be logged in the debugger output by default. If you also want the debugger to break on unhandled exceptions, set the `BreakOnUnhandledExceptions` property to `true` in the `.csproj`:
 
 ```xml
 <PropertyGroup>
-  <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
+  <BreakOnUnhandledExceptions>true</DefineConstants>
+</PropertyGroup>
+```
+
+If you want to disable the generated `Application.UnhandledException` handler altogether, define the `DISABLE_GENERATED_UNHANDLED_EXCEPTION_HANDLER` constant in `.csproj` instead:
+
+```xml
+<PropertyGroup>
+  <DefineConstants>$(DefineConstants);DISABLE_GENERATED_UNHANDLED_EXCEPTION_HANDLER</DefineConstants>
 </PropertyGroup>
 ```

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -568,7 +568,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			void AttachUnhandledExceptionHandler()
 			{
-				writer.Append($"#if DEBUG");
+				writer.Append($"#if DEBUG && !DISABLE_GENERATED_UNHANDLED_EXCEPTION_HANDLER");
 				writer.AppendLine();
 				writer.AppendLineIndented($"UnhandledException += (s, e) =>");
 				writer.AppendLineIndented("{");

--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -122,6 +122,11 @@
 		<None Include="@(_IgnorePlatformFiles)" Sdk="Uno" />
 	</ItemGroup>
 
+	<PropertyGroup>
+		<!-- Make breaking on Application.UnhandledException opt-in only -->
+		<DefineConstants Condition="!$(DefineConstants.Contains(DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION)) and '$(BreakOnUnhandledExceptions)' != 'true' and $(IsWinAppSdk) != 'true' ">$(DefineConstants);DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>		
+	</PropertyGroup>
+
 	<ItemGroup Condition="$(UnoFeatures.Contains(';dsp;'))">
 		<!-- New Material Theme Builder export format (Uno.Dsp 1.3+) -->
 		<UnoDspImportColors Include="Styles\*.json" Generator="Xaml" Condition="!$(UnoFeatures.Contains(';csharpmarkup;'))" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Previously the debugger break happened on `UnhandledException` by default.

## What is the new behavior?

The behavior is now opt-in, part of the Uno.Sdk

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.