### PR TITLE
fix: Use `FallbackColor` for unsupported brushes on iOS

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Rectangle.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Rectangle.cs
@@ -193,13 +193,15 @@ public class Given_Rectangle
 			};
 			var root = new Grid
 			{
+				HorizontalAlignment = HorizontalAlignment.Left,
+				VerticalAlignment = VerticalAlignment.Top,
 				Children =
 				{
 					rectangle,
 				},
 			};
 			await UITestHelper.Load(root);
-			var screenshot = await UITestHelper.ScreenShot(root);
+			var screenshot = await UITestHelper.ScreenShot(rectangle);
 			ImageAssert.HasColorAt(screenshot, new(50, 50), Microsoft.UI.Colors.Green, tolerance: 0);
 			unhandledExceptionFired.Should().BeFalse();
 		}

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.iOSmacOS.cs
@@ -102,8 +102,15 @@ namespace Microsoft.UI.Xaml.Shapes
 					fillColor = Colors.Transparent;
 					break;
 
+				case XamlCompositionBrushBase compositionBrush: // Use Fallback for unsupported brushes
+					fillColor = compositionBrush.FallbackColorWithOpacity;
+					break;
+
 				default:
-					Application.Current.RaiseRecoverableUnhandledException(new NotSupportedException($"The brush {Fill} is not supported as Fill for a {this} on this platform."));
+					if (this.Log().IsEnabled(LogLevel.Warning))
+					{
+						this.Log().LogWarning($"The brush {Fill} is not supported as Fill for a {this} on this platform.");
+					}
 					fillColor = Colors.Transparent;
 					break;
 			}


### PR DESCRIPTION
Previously we have thrown Application.UnhandledException when an unsupported brush was used, even though we still had FallbackColorWithOpacity available

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`UnhandledException` is thrown when acrylic brush is used as `Fill` of a `Shape` on iOS

## What is the new behavior?

No exception

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.