### PR TITLE
docs: Add Android platform specific for `RequestAccessAsync`

### DIFF
--- a/doc/articles/features/windows-devices-geolocation.md
+++ b/doc/articles/features/windows-devices-geolocation.md
@@ -23,6 +23,18 @@ The following `Geolocator` APIs are implemented on Android, iOS, macOS, and WASM
 * `DesiredAccuracy`
 * `DesiredAccuracyInMeters`
 
+### Platform-specific Requirements
+
+#### Android
+
+When using the `RequestAccessAsync` method on Android, you must configure one permission before using this API in your project. To do so, add the following to your `AndroidManifest.xml` file:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+```
+
+Additionally, when checking for this permission, ensure that `IsLocationEnabled` returns `true`; otherwise, the method will return `GeolocationAccessStatus.Denied`.
+
 ### Implementation notes
 
 `StatusChanged` event is delivered to all `Geolocator` instances which have subscribers as a "broadcast". This is unusual, but in line with the UWP implementation.


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/18152

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

Missing required permission for Android.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
