### PR TITLE
docs: Revert to previous commit hash as latest workshops doc changes are not ready for release

### DIFF
--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -16,7 +16,7 @@ $external_docs = @{
     "uno.resizetizer"    = "dce3eabef076e37b38fe058b427eb84f1d19b881" #latest main commit
     "uno.uitest"         = "9669fd2783187d06c36dd6a717c1b9f08d1fa29c" #latest master commit
     "uno.extensions"     = "9dd31137f4aeed1f004613387f4edf2b5f08e609" #latest release branch commit
-    "workshops"          = "e3c2a11a588b184d8cd3a6f88813e5615cca891d" #latest master commit
+    "workshops"          = "df05737f9e3088a4e60179f6fa2cd2fc6866d2c7" #latest master commit
     "uno.samples"        = "ef30b74b84bd470521ae1383b49ced4afcfeab1d" #latest master commit
 }
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## Description

When I updated the commit hashes for the documentation two weeks ago in this [PR](https://github.com/unoplatform/uno/pull/18110/files), I mistakenly used the latest commit hash for the workshops. However, I had previously left a comment in the related doc PR ([workshops PR #167](https://github.com/unoplatform/workshops/pull/167#issuecomment-2313616822)) to remind myself that these changes should only be released together with the upcoming MVUX updates.

This PR reverts to the previous commit hash for the workshops to ensure that the latest workshop changes are not pushed prematurely, and we maintain consistency with the release schedule for MVUX-related changes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

