### PR TITLE
feat: Define constants for packaged vs. unpackaged WinAppSDK

### DIFF
--- a/src/Uno.Sdk/targets/Uno.SingleProject.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.WinAppSdk.targets
@@ -31,6 +31,10 @@
 		<WindowsPackageType Condition="'$(WindowsPackageType)'==''">None</WindowsPackageType>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(WindowsPackageType)' == 'MSIX'">
+		<DefineConstants>$(DefineConstants);WINAPPSDK_PACKAGED</DefineConstants>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<!-- Exclude Manifest items that have already been added to avoid duplicates -->
 		<Manifest Include="$(ApplicationManifest)"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

No way to tell if app was build packaged/unpackaged

## What is the new behavior?

Two additional constants defined.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
