### PR TITLE
fix: Use Rgba8888 for Skia/macOS/metal

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
@@ -108,7 +108,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 
 		// we can't cache anything since the texture will be different on next calls
 		using var target = MacOSMetalRenderer.CreateTarget(_context!, nativeWidth, nativeHeight, texture);
-		using var surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Bgra8888);
+		using var surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
 
 		surface.Canvas.Scale(scale, scale);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMetalViewDelegate.m
@@ -19,7 +19,7 @@
         _device = mtkView.device;
         self.queue = [_device newCommandQueue];
         
-        mtkView.colorPixelFormat = MTLPixelFormatBGRA8Unorm;
+        mtkView.colorPixelFormat = MTLPixelFormatRGBA8Unorm;
         mtkView.depthStencilPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
         mtkView.sampleCount = 1;
         // this property has no effect on x86_64, only on arm64, and is required for sampling (which acrylicbrush does)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

https://github.com/ScottPlot/ScottPlot/issues/4257

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Metal-based rendering was using `Bgra888` and copying `Rgba888` memory surface into it is swapping the `R` and `B` channels.

## What is the new behavior?

Metal-based rendering was using `Rgba888`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
