### PR TITLE
fix: Adjust ContentPresenter automatic propagation

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentControl.cs
@@ -62,6 +62,22 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[RunsOnUIThread]
+		[DataRow(typeof(Grid))]
+		[DataRow(typeof(StackPanel))]
+		[DataRow(typeof(Border))]
+		[DataRow(typeof(ContentPresenter))]
+		public async Task When_SelfLoading(Type type)
+		{
+			var control = (FrameworkElement)Activator.CreateInstance(type);
+
+			control.Width = 200;
+			control.Height = 200;
+
+			await UITestHelper.Load(control);
+		}
+
+		[TestMethod]
 		public async Task When_Binding_Within_Control_Template()
 		{
 			var contentControl = new ContentControl

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -662,6 +662,9 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 #if ANDROID || __IOS__
 				&& this is not NativeCommandBarPresenter // Uno specific: NativeCommandBarPresenter breaks if you inherit from the TP
 #endif
+				// Uno Specific: Workaround to avoid creating a circular reference when TemplatedParent
+				// is incorrectly inherited. See https://github.com/unoplatform/uno/issues/17470.
+				&& !pTemplatedParent.IsLoaded
 				)
 			{
 				// bool needsRefresh = false;

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -662,9 +662,10 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 #if ANDROID || __IOS__
 				&& this is not NativeCommandBarPresenter // Uno specific: NativeCommandBarPresenter breaks if you inherit from the TP
 #endif
-				// Uno Specific: Workaround to avoid creating a circular reference when TemplatedParent
-				// is incorrectly inherited. See https://github.com/unoplatform/uno/issues/17470.
-				&& !pTemplatedParent.IsLoaded
+				// Uno Specific: Workaround to avoid creating a circular reference when TemplatedParent's
+				// Content being a FrameworkElement is incorrectly inherited.
+				// See https://github.com/unoplatform/uno/issues/17470.
+				&& !(pTemplatedParent.Content is FrameworkElement { IsLoaded: true })
 				)
 			{
 				// bool needsRefresh = false;


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/17470

Conditionally disables `TemplatedParent` automatic propagation to specific properties when the `TemplatedParent` itself is already in the visual tree.
