### PR TITLE
Dev/dr/dev srv

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.Entries.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.Entries.cs
@@ -54,7 +54,7 @@ internal record EngineEntry() : HotReloadLogEntry(EntrySource.Engine, -1, DateTi
 		=> (oldStatus?.State ?? HotReloadState.Initializing, status.State) switch
 		{
 			( < HotReloadState.Ready, HotReloadState.Ready) => new EngineEntry { Title = "Connected", Icon = EntryIcon.Connection | EntryIcon.Success },
-			(not HotReloadState.Disabled, HotReloadState.Disabled) => new EngineEntry { Title = "Cannot initialize", Icon = EntryIcon.Connection | EntryIcon.Error },
+			(not HotReloadState.Disabled, HotReloadState.Disabled) => new EngineEntry { Title = "Cannot initialize with debugger attached", Icon = EntryIcon.Connection | EntryIcon.Error },
 			_ => null
 		};
 }
@@ -151,7 +151,7 @@ public enum EntryIcon
 
 
 [Microsoft.UI.Xaml.Data.Bindable]
-internal record HotReloadLogEntry(EntrySource Source, long Id, DateTimeOffset Timestamp) : INotifyPropertyChanged
+public record HotReloadLogEntry(EntrySource Source, long Id, DateTimeOffset Timestamp) : INotifyPropertyChanged
 {
 	/// <inheritdoc />
 	public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
closes https://github.com/unoplatform/private/issues/521
closes https://github.com/unoplatform/uno/issues/17837

## Feature
- Improve connection failure messages
- Allow usage for HR indicator in external tool

## What is the current behavior?
- Unclear message
- HR indicator is internal

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
