### PR TITLE
fix(fb): Ensure that FB has a Window to render to

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Renderer.cs
@@ -72,6 +72,13 @@ namespace Uno.UI.Runtime.Skia
 				{
 					_host.RootElement.XamlRoot!.Compositor.RenderRootVisual(surface, rootVisual, null);
 				}
+				else
+				{
+					if (this.Log().IsEnabled(LogLevel.Debug))
+					{
+						this.Log().Debug($"Unable to render frame, _host.RootElement?.Visual is null");
+					}
+				}
 
 				_fbDev.VSync();
 

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/UI/FrameBufferWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/UI/FrameBufferWindowWrapper.cs
@@ -21,12 +21,11 @@ internal class FrameBufferWindowWrapper : NativeWindowWrapperBase
 
 	public override object? NativeWindow => null;
 
-	internal Window? Window { get; private set; }
-
 	internal void RaiseNativeSizeChanged(Size newWindowSize)
 	{
 		Bounds = new Rect(default, newWindowSize);
 		VisibleBounds = new Rect(default, newWindowSize);
+		Size = new((int)newWindowSize.Width, (int)newWindowSize.Height);
 	}
 
 	internal void OnNativeVisibilityChanged(bool visible) => IsVisible = visible;

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
@@ -47,7 +47,9 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 
 	public ContentSiteView ContentSiteView => _contentSite.View;
 
-	protected XamlRoot? XamlRoot => _xamlRoot;
+	internal protected XamlRoot? XamlRoot => _xamlRoot;
+
+	internal protected Window? Window => _window;
 
 	internal void SetWindow(Window window, XamlRoot xamlRoot)
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/672

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores the use of the Window after https://github.com/unoplatform/uno/pull/16535, adds a debug message when the top-level XamlRoot is not available to render frames.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
