### PR TITLE
fix: adjust workaround for android popuppanel layout

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -177,6 +177,10 @@ internal partial class PopupPanel : Panel
 
 			ArrangeElement(child, finalFrame);
 
+			// Temporary workaround to avoid layout cycle on iOS. This block was added specifically for a bug on Android's
+			// MenuFlyout so, for now, we restrict to to only Android
+			// This can be re-evaluated and removed after https://github.com/unoplatform/uno/pull/18261 merges
+#if __ANDROID__
 			var updatedFinalFrame = new Rect(
 				anchorLocation.X + (float)Popup.HorizontalOffset,
 				anchorLocation.Y + (float)Popup.VerticalOffset,
@@ -191,8 +195,9 @@ internal partial class PopupPanel : Panel
 				// We re-arrange with the new updated finalFrame.
 				// Note: This might be a lifecycle issue, so this workaround needs to be revised in the future and deleted if possible.
 				// See MenuFlyoutSubItem_Placement sample.
-				ArrangeElement(child, updatedFinalFrame);
+				//ArrangeElement(child, updatedFinalFrame);
 			}
+#endif
 
 			if (this.Log().IsEnabled(LogLevel.Debug))
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -195,7 +195,7 @@ internal partial class PopupPanel : Panel
 				// We re-arrange with the new updated finalFrame.
 				// Note: This might be a lifecycle issue, so this workaround needs to be revised in the future and deleted if possible.
 				// See MenuFlyoutSubItem_Placement sample.
-				//ArrangeElement(child, updatedFinalFrame);
+				ArrangeElement(child, updatedFinalFrame);
 			}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -180,8 +180,8 @@ internal partial class PopupPanel : Panel
 			// Temporary workaround to avoid layout cycle on iOS. This block was added specifically for a bug on Android's
 			// MenuFlyout so, for now, we restrict to to only Android
 			// This can be re-evaluated and removed after https://github.com/unoplatform/uno/pull/18261 merges
-#if __ANDROID__
-			var updatedFinalFrame = new Rect(
+#if !__IOS__
+				var updatedFinalFrame = new Rect(
 				anchorLocation.X + (float)Popup.HorizontalOffset,
 				anchorLocation.Y + (float)Popup.VerticalOffset,
 				size.Width,

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -181,7 +181,7 @@ internal partial class PopupPanel : Panel
 			// MenuFlyout so, for now, we restrict to to only Android
 			// This can be re-evaluated and removed after https://github.com/unoplatform/uno/pull/18261 merges
 #if !__IOS__
-				var updatedFinalFrame = new Rect(
+			var updatedFinalFrame = new Rect(
 				anchorLocation.X + (float)Popup.HorizontalOffset,
 				anchorLocation.Y + (float)Popup.VerticalOffset,
 				size.Width,


### PR DESCRIPTION
closes #17656

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

App freezes when moving slider with tooltip

## What is the new behavior?

Avoid freeze by ignoring extra ArrangeElement from a workaround added for an Android case

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
