### PR TITLE
fix: Fix pointer events timestamp being in ms instead of ticks on X11

### DIFF
--- a/src/Uno.UI.Runtime.Skia.X11/X11PointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/X11PointerInputSource.cs
@@ -188,7 +188,7 @@ internal partial class X11PointerInputSource : IUnoCorePointerInputSource
 		// This matches the format of WinUI. See also: https://github.com/unoplatform/uno/issues/14535
 		var point = new PointerPoint(
 			frameId: (uint)time, // UNO TODO: How should set the frame, timestamp may overflow.
-			timestamp: (uint)time,
+			timestamp: (ulong)(time * TimeSpan.TicksPerMillisecond),
 			PointerDevice.For(PointerDeviceType.Mouse),
 			0, // TODO: XInput
 			new Point(_mousePosition.X / scale, _mousePosition.Y / scale),


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/519
closes https://github.com/unoplatform/uno-private/issues/633

## Bugfix
Fix pointer events timestamp being in ms instead of ticks on X11

## What is the current behavior?
Pointer events timestamp is in ms instead of ticks on X11, causing the inertia processor to start with a crazy speed

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This PR deprecates https://github.com/unoplatform/uno/pull/18187
