### PR TITLE
fix: Restore inertia

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Inertia.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Inertia.xaml
@@ -1,26 +1,12 @@
 ﻿<Page
-    x:Class="UITests.Windows_UI_Input.GestureRecognizerTests.Manipulation_Inertia"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UITests.Windows_UI_Input.GestureRecognizerTests"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+	x:Class="UITests.Windows_UI_Input.GestureRecognizerTests.Manipulation_Inertia"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:runtimeTests="using:RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-	<Grid
-		Background="Orange"
-		ManipulationMode="All"
-		ManipulationInertiaStarting="InertiaStarting"
-		ManipulationDelta="ManipDelta">
-
-		<Rectangle
-			x:Name="_element" 
-			Width="200"
-			Height="200"
-			Fill="DeepPink"
-			RenderTransformOrigin=".5,.5" />
-
-		<Button VerticalAlignment="Top" HorizontalAlignment="Right" Content="Reset" Click="Reset" />
-	</Grid>
+	<runtimeTests:Manipulation_Inertia />
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Inertia.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Input/GestureRecognizerTests/Manipulation_Inertia.xaml.cs
@@ -1,76 +1,16 @@
 ﻿using System;
 using System.Linq;
-using Windows.Foundation;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
 using Uno.UI.Samples.Controls;
-
-#if HAS_UNO_WINUI || WINAPPSDK
-using Microsoft.UI.Input;
-#else
-using Windows.Devices.Input;
-using Windows.UI.Input;
-#endif
 
 namespace UITests.Windows_UI_Input.GestureRecognizerTests
 {
-	[Sample("Gesture Recognizer")]
+	[Sample("Gesture Recognizer", IsManualTest = true)]
 	public sealed partial class Manipulation_Inertia : Page
 	{
 		public Manipulation_Inertia()
 		{
 			this.InitializeComponent();
 		}
-
-		private long _inertiaStart = 0;
-
-		private void InertiaStarting(object sender, ManipulationInertiaStartingRoutedEventArgs e)
-		{
-			_inertiaStart = DateTimeOffset.UtcNow.Ticks;
-
-			//e.TranslationBehavior.DesiredDisplacement = 5;
-			//e.TranslationBehavior.DesiredDeceleration = .00001;
-
-			Log(@$"[INERTIA] Inertia starting: {F(default, e.Delta, e.Cumulative, e.Velocities)}
-tr: ↘={e.TranslationBehavior.DesiredDeceleration} | ⌖={e.TranslationBehavior.DesiredDisplacement}
-θ: ↘={e.RotationBehavior.DesiredDeceleration} | ⌖={e.RotationBehavior.DesiredRotation}
-s: ↘={e.ExpansionBehavior.DesiredDeceleration} | ⌖={e.ExpansionBehavior.DesiredExpansion}");
-		}
-
-		private void ManipDelta(object sender, ManipulationDeltaRoutedEventArgs e)
-		{
-			if (!(_element.RenderTransform is CompositeTransform tr))
-			{
-				_element.RenderTransform = tr = new CompositeTransform();
-			}
-
-			tr.TranslateX = e.Cumulative.Translation.X;
-			tr.TranslateY = e.Cumulative.Translation.Y;
-			tr.Rotation = e.Cumulative.Rotation;
-			tr.ScaleX = e.Cumulative.Scale;
-			tr.ScaleY = e.Cumulative.Scale;
-
-			Log(
-				$"[DELTA] {F(e.Position, e.Delta, e.Cumulative, e.Velocities)} "
-				+ (e.IsInertial ? $"{TimeSpan.FromTicks(DateTimeOffset.UtcNow.Ticks - _inertiaStart).TotalMilliseconds} ms" : ""));
-		}
-
-		private void Reset(object sender, RoutedEventArgs e)
-		{
-			_element.RenderTransform = new CompositeTransform();
-		}
-
-		private static string F(Point position, ManipulationDelta delta, ManipulationDelta cumulative, ManipulationVelocities velocities)
-			=> $"@=[{position.X:000.00},{position.Y:000.00}] "
-				+ $"| X=(Σ:{cumulative.Translation.X:' '000.00;'-'000.00} / Δ:{delta.Translation.X:' '00.00;'-'00.00} / c:{velocities.Linear.X:F2}) "
-				+ $"| Y=(Σ:{cumulative.Translation.Y:' '000.00;'-'000.00} / Δ:{delta.Translation.Y:' '00.00;'-'00.00} / c:{velocities.Linear.Y:F2}) "
-				+ $"| θ=(Σ:{cumulative.Rotation:' '000.00;'-'000.00} / Δ:{delta.Rotation:' '00.00;'-'00.00} / c:{velocities.Angular:F2}) "
-				+ $"| s=(Σ:{cumulative.Scale:000.00} / Δ:{delta.Scale:00.00} / c:{velocities.Expansion:F2}) "
-				+ $"| e=(Σ:{cumulative.Expansion:' '000.00;'-'000.00} / Δ:{delta.Expansion:' '00.00;'-'00.00} / c:{velocities.Expansion:F2})";
-
-		private static void Log(string text)
-			=> global::System.Diagnostics.Debug.WriteLine(text);
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
@@ -12,7 +12,6 @@ using Windows.Storage.Streams;
 using Windows.System;
 using Windows.UI.Input.Preview.Injection;
 using Windows.UI.Popups;
-using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -26,6 +25,13 @@ using SamplesApp.UITests;
 #if !HAS_UNO
 using System.Runtime.InteropServices;
 #endif
+
+#if HAS_UNO_WINUI || WINAPPSDK
+using PointerDeviceType = Microsoft.UI.Input.PointerDeviceType;
+#else
+using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
+#endif
+
 namespace Uno.UI.RuntimeTests.Helpers;
 
 // Note: This file contains a bunch of helpers that are expected to be moved to the test engine among the pointer injection work

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker.cs
@@ -224,7 +224,7 @@ public partial class Given_InteractionTracker
 
 		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
 		var finger = injector.GetFinger();
-		finger.Drag(new(position.Left + 50, position.Top + 50), new(position.Left + 100, position.Top + 50));
+		finger.Drag(new(position.Left + 50, position.Top + 50), new(position.Left + 100, position.Top + 50), stepOffsetInMilliseconds: 0);
 
 		string logs = await WaitTrackerLogs(tracker);
 		var helper = new TrackerAssertHelper(logs);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
@@ -9,6 +9,10 @@ using RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 
+#if WINAPPSDK
+using Uno.UI.Toolkit.Extensions;
+#endif
+
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 {
 	[TestClass]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Windows.UI.Input.Preview.Injection;
+using FluentAssertions;
+using Microsoft.UI.Input;
+using RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages;
+using Uno.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
+{
+	[TestClass]
+	public class Given_GestureRecognizer
+	{
+		[TestMethod]
+		[RunsOnUIThread]
+#if !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+#if !WINAPPSDK
+		[DataRow(PointerDeviceType.Mouse)]
+#endif
+		[DataRow(PointerDeviceType.Touch)]
+		public async Task When_ManipulateWithVelocity_Then_InertiaKicksIn(PointerDeviceType type)
+		{
+			var sample = new Manipulation_Inertia();
+			await UITestHelper.Load(sample);
+
+			var started = false;
+			var completed = new TaskCompletionSource();
+			var completedTimeout = new CancellationTokenSource(15000);
+			using var _ = completedTimeout.Token.Register(() => completed.TrySetException(new TimeoutException("Cannot get complete in given delay.")));
+			sample.IsRunningChanged += (snd, isRunning) =>
+			{
+				if (isRunning)
+				{
+					started = true;
+				}
+				else
+				{
+					completed.TrySetResult();
+				}
+			};
+
+			var origin = sample.Element.GetAbsoluteBounds().GetCenter();
+			var pointer = (InputInjector.TryCreate() ?? throw new InvalidOperationException("Input injection is not supported on this device")).GetPointer(type);
+			pointer.Press(origin);
+			pointer.MoveTo(new Point(origin.X, origin.Y + 25), steps: 100); // 1 step per ms!
+
+			started.Should().Be(true, "Manipulation should have started.");
+
+			pointer.Release();
+
+			await completed.Task;
+
+			sample.Validate().Should().BeTrue();
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
@@ -4,13 +4,18 @@ using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.UI.Input.Preview.Injection;
 using FluentAssertions;
-using Microsoft.UI.Input;
 using RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 
 #if WINAPPSDK
 using Uno.UI.Toolkit.Extensions;
+#endif
+
+#if HAS_UNO_WINUI || WINAPPSDK
+using PointerDeviceType = Microsoft.UI.Input.PointerDeviceType;
+#else
+using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 #endif
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/Given_GestureRecognizer.cs
@@ -25,8 +25,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Input
 	{
 		[TestMethod]
 		[RunsOnUIThread]
-#if !HAS_INPUT_INJECTOR
-		[Ignore("InputInjector is not supported on this platform.")]
+#if !HAS_INPUT_INJECTOR || (!HAS_UNO_WINUI && !WINAPPSDK) // Requires pointer injection and WinUI API
+		[Ignore("This test is not supported on this platform.")]
 #endif
 #if !WINAPPSDK
 		[DataRow(PointerDeviceType.Mouse)]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/Manipulation_Inertia.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/Manipulation_Inertia.xaml
@@ -1,0 +1,41 @@
+﻿<Page
+	x:Class="RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages.Manipulation_Inertia"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+	HorizontalAlignment="Stretch"
+	VerticalAlignment="Stretch">
+
+	<Grid Background="Orange">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition />
+			<ColumnDefinition Width="Auto" />
+		</Grid.ColumnDefinitions>
+
+		<Grid
+			ManipulationMode="All"
+			ManipulationStarting="ManipStarting"
+			ManipulationInertiaStarting="InertiaStarting"
+			ManipulationDelta="ManipDelta"
+			ManipulationCompleted="ManipCompleted"
+			Background="Transparent">
+
+			<Rectangle
+				x:Name="_element"
+				Width="200"
+				Height="200"
+				Fill="DeepPink"
+				RenderTransformOrigin=".5,.5" />
+
+			<TextBlock x:Name="Output" VerticalAlignment="Top" FontSize="8" Text="Swipe the pink square, observe it to move WITH INERTIA, then click the validate button to ensure logs are valid." />
+		</Grid>
+
+		<StackPanel Grid.Column="1" Background="#33000000" VerticalAlignment="Stretch" Padding="5" Spacing="5">
+			<Button HorizontalAlignment="Stretch" Content="Reset" Click="Reset" />
+			<Button HorizontalAlignment="Stretch" Content="Validate" Click="Validate" />
+		</StackPanel>
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/Manipulation_Inertia.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/Manipulation_Inertia.xaml.cs
@@ -1,0 +1,113 @@
+﻿#pragma warning disable SYSLIB1045
+using System;
+using System.Linq;
+using Windows.Foundation;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Input;
+using System.Text.RegularExpressions;
+
+namespace RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages
+{
+	public sealed partial class Manipulation_Inertia : Page
+	{
+		public Manipulation_Inertia()
+		{
+			this.InitializeComponent();
+		}
+
+		private long _inertiaStart = 0;
+
+		public event EventHandler<bool> IsRunningChanged;
+
+		public FrameworkElement Element => _element;
+
+		public bool IsRunning { get; private set; }
+
+		private void ManipStarting(object sender, ManipulationStartingRoutedEventArgs e)
+		{
+			IsRunning = true;
+			IsRunningChanged?.Invoke(this, true);
+			Reset(null, null);
+		}
+
+		private void InertiaStarting(object sender, ManipulationInertiaStartingRoutedEventArgs e)
+		{
+			_inertiaStart = DateTimeOffset.UtcNow.Ticks;
+
+			//e.TranslationBehavior.DesiredDisplacement = 5;
+			//e.TranslationBehavior.DesiredDeceleration = .00001;
+
+			Log(@$"[INERTIA] Inertia starting: {F(default, e.Delta, e.Cumulative, e.Velocities)}
+tr: ↘={e.TranslationBehavior.DesiredDeceleration} | ⌖={e.TranslationBehavior.DesiredDisplacement}
+θ: ↘={e.RotationBehavior.DesiredDeceleration} | ⌖={e.RotationBehavior.DesiredRotation}
+s: ↘={e.ExpansionBehavior.DesiredDeceleration} | ⌖={e.ExpansionBehavior.DesiredExpansion}");
+		}
+
+		private void ManipDelta(object sender, ManipulationDeltaRoutedEventArgs e)
+		{
+			if (!(_element.RenderTransform is CompositeTransform tr))
+			{
+				_element.RenderTransform = tr = new CompositeTransform();
+			}
+
+			tr.TranslateX = e.Cumulative.Translation.X;
+			tr.TranslateY = e.Cumulative.Translation.Y;
+			tr.Rotation = e.Cumulative.Rotation;
+			tr.ScaleX = e.Cumulative.Scale;
+			tr.ScaleY = e.Cumulative.Scale;
+
+			Log(
+				$"[DELTA] {F(e.Position, e.Delta, e.Cumulative, e.Velocities)} "
+				+ (e.IsInertial ? $"{TimeSpan.FromTicks(DateTimeOffset.UtcNow.Ticks - _inertiaStart).TotalMilliseconds} ms" : ""));
+		}
+
+		private void ManipCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
+		{
+			IsRunning = false;
+			IsRunningChanged?.Invoke(this, false);
+		}
+
+		private void Reset(object sender, RoutedEventArgs e)
+		{
+			_element.RenderTransform = new CompositeTransform();
+			Output.Text = string.Empty;
+		}
+
+		public bool Validate()
+		{
+			Validate(null, null);
+			return Output.Text.Contains("PASSED", StringComparison.OrdinalIgnoreCase);
+		}
+
+		private void Validate(object sender, RoutedEventArgs e)
+		{
+			var log = Output.Text;
+
+			Output.Text = log?.IndexOf("[INERTIA]", StringComparison.OrdinalIgnoreCase) switch
+			{
+				null => "FAILED - Test not ran",
+				<= -1 => "FAILED - No inertia detected",
+				{ } i when Regex.Count((ReadOnlySpan<char>)log[i..], "\\[DELTA\\]") > 1 => "PASSED - Inertia detected",
+				_ => "FAILED - No delta detected after inertia started",
+			};
+		}
+
+		private static string F(Point position, ManipulationDelta delta, ManipulationDelta cumulative, ManipulationVelocities velocities)
+			=> $"@=[{position.X:000.00},{position.Y:000.00}] "
+				+ $"| X=(Σ:{cumulative.Translation.X:' '000.00;'-'000.00} / Δ:{delta.Translation.X:' '00.00;'-'00.00} / c:{velocities.Linear.X:F2}) "
+				+ $"| Y=(Σ:{cumulative.Translation.Y:' '000.00;'-'000.00} / Δ:{delta.Translation.Y:' '00.00;'-'00.00} / c:{velocities.Linear.Y:F2}) "
+				+ $"| θ=(Σ:{cumulative.Rotation:' '000.00;'-'000.00} / Δ:{delta.Rotation:' '00.00;'-'00.00} / c:{velocities.Angular:F2}) "
+				+ $"| s=(Σ:{cumulative.Scale:000.00} / Δ:{delta.Scale:00.00} / c:{velocities.Expansion:F2}) "
+				+ $"| e=(Σ:{cumulative.Expansion:' '000.00;'-'000.00} / Δ:{delta.Expansion:' '00.00;'-'00.00} / c:{velocities.Expansion:F2})";
+
+		private void Log(string text)
+		{
+			global::System.Diagnostics.Debug.WriteLine(text);
+
+			Output.Text += text + Environment.NewLine;
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/Manipulation_Inertia.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Input/TestPages/Manipulation_Inertia.xaml.cs
@@ -39,11 +39,12 @@ namespace RuntimeTests.Tests.Windows_UI_Xaml_Input.TestPages
 
 			//e.TranslationBehavior.DesiredDisplacement = 5;
 			//e.TranslationBehavior.DesiredDeceleration = .00001;
-
+#if HAS_UNO_WINUI || WINAPPSDK
 			Log(@$"[INERTIA] Inertia starting: {F(default, e.Delta, e.Cumulative, e.Velocities)}
 tr: ↘={e.TranslationBehavior.DesiredDeceleration} | ⌖={e.TranslationBehavior.DesiredDisplacement}
 θ: ↘={e.RotationBehavior.DesiredDeceleration} | ⌖={e.RotationBehavior.DesiredRotation}
 s: ↘={e.ExpansionBehavior.DesiredDeceleration} | ⌖={e.ExpansionBehavior.DesiredExpansion}");
+#endif
 		}
 
 		private void ManipDelta(object sender, ManipulationDeltaRoutedEventArgs e)
@@ -59,9 +60,11 @@ s: ↘={e.ExpansionBehavior.DesiredDeceleration} | ⌖={e.ExpansionBehavior.Desi
 			tr.ScaleX = e.Cumulative.Scale;
 			tr.ScaleY = e.Cumulative.Scale;
 
+#if HAS_UNO_WINUI || WINAPPSDK
 			Log(
 				$"[DELTA] {F(e.Position, e.Delta, e.Cumulative, e.Velocities)} "
 				+ (e.IsInertial ? $"{TimeSpan.FromTicks(DateTimeOffset.UtcNow.Ticks - _inertiaStart).TotalMilliseconds} ms" : ""));
+#endif
 		}
 
 		private void ManipCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
@@ -95,6 +98,7 @@ s: ↘={e.ExpansionBehavior.DesiredDeceleration} | ⌖={e.ExpansionBehavior.Desi
 			};
 		}
 
+#if HAS_UNO_WINUI || WINAPPSDK
 		private static string F(Point position, ManipulationDelta delta, ManipulationDelta cumulative, ManipulationVelocities velocities)
 			=> $"@=[{position.X:000.00},{position.Y:000.00}] "
 				+ $"| X=(Σ:{cumulative.Translation.X:' '000.00;'-'000.00} / Δ:{delta.Translation.X:' '00.00;'-'00.00} / c:{velocities.Linear.X:F2}) "
@@ -102,6 +106,7 @@ s: ↘={e.ExpansionBehavior.DesiredDeceleration} | ⌖={e.ExpansionBehavior.Desi
 				+ $"| θ=(Σ:{cumulative.Rotation:' '000.00;'-'000.00} / Δ:{delta.Rotation:' '00.00;'-'00.00} / c:{velocities.Angular:F2}) "
 				+ $"| s=(Σ:{cumulative.Scale:000.00} / Δ:{delta.Scale:00.00} / c:{velocities.Expansion:F2}) "
 				+ $"| e=(Σ:{cumulative.Expansion:' '000.00;'-'000.00} / Δ:{delta.Expansion:' '00.00;'-'00.00} / c:{velocities.Expansion:F2})";
+#endif
 
 		private void Log(string text)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/ScrollViewer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/ScrollViewer.cs
@@ -125,7 +125,7 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 #endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public bool IsScrollInertiaEnabled
 		{
@@ -316,7 +316,7 @@ namespace Microsoft.UI.Xaml.Controls
 			typeof(global::Microsoft.UI.Xaml.Controls.ScrollViewer),
 			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(bool)));
 #endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static global::Microsoft.UI.Xaml.DependencyProperty IsScrollInertiaEnabledProperty { get; } =
 		Microsoft.UI.Xaml.DependencyProperty.RegisterAttached(
@@ -645,14 +645,14 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 #endif
 		// Forced skipping of method Microsoft.UI.Xaml.Controls.ScrollViewer.IsScrollInertiaEnabledProperty.get
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static bool GetIsScrollInertiaEnabled(global::Microsoft.UI.Xaml.DependencyObject element)
 		{
 			return (bool)element.GetValue(IsScrollInertiaEnabledProperty);
 		}
 #endif
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || false || __NETSTD_REFERENCE__ || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public static void SetIsScrollInertiaEnabled(global::Microsoft.UI.Xaml.DependencyObject element, bool isScrollInertiaEnabled)
 		{

--- a/src/Uno.UI/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UI/UI/Input/GestureRecognizer.cs
@@ -157,14 +157,7 @@ namespace Windows.UI.Input
 				_log.Debug($"{Owner} Received a 'Up' for a pointer which was not considered as down. Ignoring event.");
 			}
 
-			if (isRelevant)
-			{
-				_manipulation?.Remove(value);
-			}
-			else
-			{
-				_manipulation?.Complete();
-			}
+			_manipulation?.Remove(value);
 		}
 
 #if IS_UNIT_TESTS

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using Microsoft.UI.Xaml.Input;
 using Windows.Devices.Input;
 using Windows.Foundation;
-using Uno.UI.Xaml;
 using Uno.Disposables;
 
 
@@ -216,6 +215,11 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				e.Mode = ManipulationModes.None;
 				return;
+			}
+
+			if (Scroller?.IsScrollInertiaEnabled is true)
+			{
+				e.Mode |= ManipulationModes.TranslateInertia;
 			}
 
 			if (!CanVerticallyScroll || ExtentHeight <= 0)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Managed.cs
@@ -18,6 +18,25 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class ScrollViewer
 	{
+		public bool IsScrollInertiaEnabled
+		{
+			get => (bool)GetValue(IsScrollInertiaEnabledProperty);
+			set => SetValue(IsScrollInertiaEnabledProperty, value);
+		}
+
+		public static DependencyProperty IsScrollInertiaEnabledProperty { get; } =
+			DependencyProperty.RegisterAttached(
+				nameof(IsScrollInertiaEnabled),
+				typeof(bool),
+				typeof(ScrollViewer),
+				new FrameworkPropertyMetadata(true));
+
+		public static bool GetIsScrollInertiaEnabled(DependencyObject element) =>
+			(bool)element.GetValue(IsScrollInertiaEnabledProperty);
+
+		public static void SetIsScrollInertiaEnabled(DependencyObject element, bool isScrollInertiaEnabled) => 
+			element.SetValue(IsScrollInertiaEnabledProperty, isScrollInertiaEnabled);
+
 		internal Size ScrollBarSize => (_presenter as ScrollContentPresenter)?.ScrollBarSize ?? default;
 
 		private bool ChangeViewNative(double? horizontalOffset, double? verticalOffset, double? zoomFactor, bool disableAnimation)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.Managed.cs
@@ -34,7 +34,7 @@ namespace Microsoft.UI.Xaml.Controls
 		public static bool GetIsScrollInertiaEnabled(DependencyObject element) =>
 			(bool)element.GetValue(IsScrollInertiaEnabledProperty);
 
-		public static void SetIsScrollInertiaEnabled(DependencyObject element, bool isScrollInertiaEnabled) => 
+		public static void SetIsScrollInertiaEnabled(DependencyObject element, bool isScrollInertiaEnabled) =>
 			element.SetValue(IsScrollInertiaEnabledProperty, isScrollInertiaEnabled);
 
 		internal Size ScrollBarSize => (_presenter as ScrollContentPresenter)?.ScrollBarSize ?? default;

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputMouseInfo.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputMouseInfo.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using Windows.Devices.Input;
 using Windows.Foundation;
 using Windows.System;

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputState.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputState.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Windows.Devices.Input;
 using Windows.Foundation;
@@ -30,8 +31,8 @@ internal class InjectedInputState
 
 	public void StartNewSequence()
 	{
-		Timestamp = (ulong)DateTime.Now.Ticks;
-		FrameId = (uint)(Timestamp / TimeSpan.TicksPerMillisecond);
+		Timestamp = (ulong)Stopwatch.GetElapsedTime(Stopwatch.GetTimestamp()).TotalMicroseconds;
+		FrameId = (uint)(Timestamp / 1000);
 	}
 
 	public void Update(PointerEventArgs args)

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputState.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputState.cs
@@ -11,6 +11,8 @@ namespace Windows.UI.Input.Preview.Injection;
 
 internal class InjectedInputState
 {
+	private static long _initialTimestamp = Stopwatch.GetTimestamp();
+
 	public InjectedInputState(PointerDeviceType type)
 	{
 		Type = type;
@@ -31,7 +33,7 @@ internal class InjectedInputState
 
 	public void StartNewSequence()
 	{
-		Timestamp = (ulong)Stopwatch.GetElapsedTime(Stopwatch.GetTimestamp()).TotalMicroseconds;
+		Timestamp = (ulong)Stopwatch.GetElapsedTime(_initialTimestamp).TotalMicroseconds;
 		FrameId = (uint)(Timestamp / 1000);
 	}
 

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputState.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputState.cs
@@ -16,7 +16,7 @@ internal class InjectedInputState
 	public InjectedInputState(PointerDeviceType type)
 	{
 		Type = type;
-		StartNewSequence();
+		StartNewSequence(true);
 	}
 
 	public PointerDeviceType Type { get; }
@@ -31,9 +31,17 @@ internal class InjectedInputState
 
 	public PointerPointProperties Properties { get; set; } = new();
 
-	public void StartNewSequence()
+	public void StartNewSequence(bool initial = false)
 	{
-		Timestamp = (ulong)Stopwatch.GetElapsedTime(_initialTimestamp).TotalMicroseconds;
+		if (initial)
+		{
+			Timestamp = (ulong)Stopwatch.GetElapsedTime(_initialTimestamp).TotalMicroseconds;
+		}
+		else
+		{
+			Timestamp = Timestamp + 1000; // Continue from the previous timestamp, but move forward in time by 1ms
+		}
+
 		FrameId = (uint)(Timestamp / 1000);
 	}
 


### PR DESCRIPTION
linked https://github.com/unoplatform/uno-private/issues/626

## Bugfix
Restore inertia

## What is the current behavior?
The inertia is cancelled right after having been started so we get at most one inertia event.

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
* Draft until a test is prevent any new regression.
* Linked to work done in https://github.com/unoplatform/uno/pull/18293
