### PR TITLE
docs: Adjust Uno.Templates uninstall command as use of 'dotnet new --uninstall' is deprecated

### DIFF
--- a/doc/articles/get-started-dotnet-new.md
+++ b/doc/articles/get-started-dotnet-new.md
@@ -101,7 +101,7 @@ For additional information about UI Tests creation, visit the [Uno.UITest](https
 Using a command line or terminal, run the following command:
 
 ```dotnetcli
-dotnet new -u Uno.Templates
+dotnet new uninstall Uno.Templates
 ```
 
 [!include[getting-help](includes/getting-help.md)]


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

The use of 'dotnet new --uninstall' is deprecated.
![image](https://github.com/user-attachments/assets/d0d0330c-2ab5-4cea-a074-802417bd8721)


## What is the new behavior?

Command updated to `dotnet new uninstall Uno.Templates` instead in the documentation.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
