### PR TITLE
fix: Fix UpdateFileAsync requesting HR before VS detects file change

### DIFF
--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Threading/AsyncLock.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Threading/AsyncLock.cs
@@ -1,3 +1,4 @@
+#nullable enable
 // ******************************************************************
 // Copyright � 2015-2018 Uno Platform Inc. All rights reserved.
 //
@@ -18,27 +19,37 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Uno.Disposables;
+namespace Uno.Threading;
 
-namespace Uno.Threading
+/// <summary>
+/// An asynchronous lock, that can be used in conjuction with C# async/await
+/// </summary>
+internal sealed class AsyncLock
 {
+	private readonly SemaphoreSlim _semaphore = new(1, 1);
+	private ulong _handleId;
+
 	/// <summary>
-	/// An asynchronous lock, that can be used in conjuction with C# async/await
+	/// Acquires the lock, then provides a disposable to release it.
+	/// WARNING: This DOES NOT support reentrancy.
 	/// </summary>
-	internal sealed class AsyncLock
+	/// <param name="ct">A cancellation token to cancel the lock</param>
+	/// <returns>An IDisposable instance that allows the release of the lock.</returns>
+	public async ValueTask<Handle> LockAsync(CancellationToken ct)
 	{
-		private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+		await _semaphore.WaitAsync(ct);
 
-		/// <summary>
-		/// Acquires the lock, then provides a disposable to release it.
-		/// </summary>
-		/// <param name="ct">A cancellation token to cancel the lock</param>
-		/// <returns>An IDisposable instance that allows the release of the lock.</returns>
-		public async Task<IDisposable> LockAsync(CancellationToken ct)
+		return new Handle(this, _handleId);
+	}
+
+	public record struct Handle(AsyncLock Lock, ulong Id) : IDisposable
+	{
+		public void Dispose()
 		{
-			await _semaphore.WaitAsync(ct);
-
-			return Disposable.Create(() => _semaphore.Release());
+			if (Interlocked.CompareExchange(ref Lock._handleId, Id + 1, Id) == Id) // This avoids (concurrent) double dispose / release
+			{
+				Lock._semaphore.Release();
+			}
 		}
 	}
 }

--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Threading/AsyncLock.cs
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.Compatibility/Threading/AsyncLock.cs
@@ -27,7 +27,7 @@ namespace Uno.Threading;
 internal sealed class AsyncLock
 {
 	private readonly SemaphoreSlim _semaphore = new(1, 1);
-	private ulong _handleId;
+	private long _handleId;
 
 	/// <summary>
 	/// Acquires the lock, then provides a disposable to release it.
@@ -42,7 +42,7 @@ internal sealed class AsyncLock
 		return new Handle(this, _handleId);
 	}
 
-	public record struct Handle(AsyncLock Lock, ulong Id) : IDisposable
+	public record struct Handle(AsyncLock Lock, long Id) : IDisposable
 	{
 		public void Dispose()
 		{

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -28,7 +28,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 	{
 		private FileSystemWatcher[]? _watchers;
 		private CompositeDisposable? _watcherEventsDisposable;
-		private IRemoteControlServer _remoteControlServer;
+		private readonly IRemoteControlServer _remoteControlServer;
 
 		public ServerHotReloadProcessor(IRemoteControlServer remoteControlServer)
 		{
@@ -219,6 +219,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			private ImmutableHashSet<string> _filePaths;
 			private int /* HotReloadResult */ _result = -1;
 			private CancellationTokenSource? _deferredCompletion;
+			private int _noChangesRetry;
 
 			public long Id { get; } = Interlocked.Increment(ref _count);
 
@@ -291,6 +292,12 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			}
 
 			/// <summary>
+			/// Configure a simple auto-retry strategy if no changes are detected.
+			/// </summary>
+			public void EnableAutoRetryIfNoChanges()
+				=> _noChangesRetry = 1;
+
+			/// <summary>
 			/// As errors might get a bit after the complete from the IDE, we can defer the completion of the operation.
 			/// </summary>
 			public async ValueTask DeferComplete(HotReloadServerResult result, Exception? exception = null)
@@ -313,6 +320,14 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 			private async ValueTask Complete(HotReloadServerResult result, Exception? exception, bool isFromNext)
 			{
+				if (_result is -1
+					&& result is HotReloadServerResult.NoChanges
+					&& Interlocked.Decrement(ref _noChangesRetry) >= 0
+					&& await _owner.RequestHotReloadToIde(Id))
+				{
+					return;
+				}
+
 				Debug.Assert(result != HotReloadServerResult.InternalError || exception is not null); // For internal error we should always provide an exception!
 
 				// Remove this from current
@@ -441,13 +456,14 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				var (result, error) = message switch
 				{
 					{ FilePath: null or { Length: 0 } } => (FileUpdateResult.BadRequest, "Invalid request (file path is empty)"),
-					{ OldText: not null, NewText: not null } => DoUpdate(message.OldText, message.NewText),
-					{ OldText: null, NewText: not null } => DoWrite(message.NewText),
-					{ NewText: null, IsCreateDeleteAllowed: true } => DoDelete(),
+					{ OldText: not null, NewText: not null } => await DoUpdate(message.OldText, message.NewText),
+					{ OldText: null, NewText: not null } => await DoWrite(message.NewText),
+					{ NewText: null, IsCreateDeleteAllowed: true } => await DoDelete(),
 					_ => (FileUpdateResult.BadRequest, "Invalid request")
 				};
 				if ((int)result < 300 && !message.IsForceHotReloadDisabled)
 				{
+					hotReload.EnableAutoRetryIfNoChanges();
 					await RequestHotReloadToIde(hotReload.Id);
 				}
 
@@ -459,7 +475,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				await _remoteControlServer.SendFrame(new UpdateFileResponse(message.RequestId, message.FilePath ?? "", FileUpdateResult.Failed, ex.Message));
 			}
 
-			(FileUpdateResult, string?) DoUpdate(string oldText, string newText)
+			async ValueTask<(FileUpdateResult, string?)> DoUpdate(string oldText, string newText)
 			{
 				if (!File.Exists(message.FilePath))
 				{
@@ -471,7 +487,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					return (FileUpdateResult.FileNotFound, $"Requested file '{message.FilePath}' does not exists.");
 				}
 
-				var originalContent = File.ReadAllText(message.FilePath);
+				var originalContent = await File.ReadAllTextAsync(message.FilePath);
 				if (this.Log().IsEnabled(LogLevel.Trace))
 				{
 					this.Log().LogTrace($"Original content: {originalContent} [{message.RequestId}].");
@@ -493,11 +509,14 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					return (FileUpdateResult.NoChanges, null);
 				}
 
-				File.WriteAllText(message.FilePath, updatedContent);
+				var effectiveUpdate = WaitForFileUpdated(message.FilePath);
+				await File.WriteAllTextAsync(message.FilePath, updatedContent);
+				await effectiveUpdate;
+
 				return (FileUpdateResult.Success, null);
 			}
 
-			(FileUpdateResult, string?) DoWrite(string newText)
+			async ValueTask<(FileUpdateResult, string?)> DoWrite(string newText)
 			{
 				if (!message.IsCreateDeleteAllowed && !File.Exists(message.FilePath))
 				{
@@ -514,11 +533,14 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					this.Log().LogTrace($"Write content: {newText} [{message.RequestId}].");
 				}
 
-				File.WriteAllText(message.FilePath, newText);
+				var effectiveUpdate = WaitForFileUpdated(message.FilePath);
+				await File.WriteAllTextAsync(message.FilePath, newText);
+				await effectiveUpdate;
+
 				return (FileUpdateResult.Success, null);
 			}
 
-			(FileUpdateResult, string?) DoDelete()
+			async ValueTask<(FileUpdateResult, string?)> DoDelete()
 			{
 				if (!File.Exists(message.FilePath))
 				{
@@ -530,8 +552,40 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					return (FileUpdateResult.FileNotFound, $"Requested file '{message.FilePath}' does not exists.");
 				}
 
+				var effectiveUpdate = WaitForFileUpdated(message.FilePath);
 				File.Delete(message.FilePath);
+				await effectiveUpdate;
+
 				return (FileUpdateResult.Success, null);
+			}
+
+			static async Task WaitForFileUpdated(string path)
+			{
+				var file = new FileInfo(path);
+				var dir = file.Directory;
+				while (dir is { Exists: false })
+				{
+					dir = dir.Parent;
+				}
+
+				if (dir is null)
+				{
+					return;
+				}
+
+				var tcs = new TaskCompletionSource();
+				using var watcher = new FileSystemWatcher(dir.FullName);
+				watcher.Changed += async (snd, e) =>
+				{
+					if (e.FullPath.Equals(file.FullName, StringComparison.OrdinalIgnoreCase))
+					{
+						await Task.Delay(500);
+						tcs.TrySetResult();
+					}
+				};
+				watcher.EnableRaisingEvents = true;
+
+				await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(2)));
 			}
 		}
 
@@ -545,6 +599,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
 				await using var ctReg = cts.Token.Register(() => hrRequested.TrySetCanceled());
 
+				_pendingHotReloadRequestToIde.TryAdd(hrRequest.CorrelationId, hrRequested);
 				await _remoteControlServer.SendMessageToIDEAsync(hrRequest);
 
 				return await hrRequested.Task is { IsSuccess: true };

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -61,7 +61,7 @@ public partial class ClientHotReloadProcessor
 		/// The max delay to wait for the local application to process a hot-reload delta.
 		/// </summary>
 		/// <remarks>This includes the time to apply the delta locally and then to run all local handlers.</remarks>
-		public TimeSpan LocalHotReloadTimeout { get; set; } = TimeSpan.FromSeconds(3);
+		public TimeSpan LocalHotReloadTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
 		public UpdateRequest WithExtendedTimeouts(float? factor = null)
 		{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -287,7 +287,7 @@ public partial class ClientHotReloadProcessor
 				EndTime = DateTimeOffset.Now;
 				_onUpdated();
 			}
-			else
+			else if (_result != (int)HotReloadClientResult.Ignored) // ReportIgnored auto completes but caller usually does not expect it (use ReportCompleted in finally)
 			{
 				Debug.Fail("The result should not have already been set.");
 			}

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -32,7 +32,7 @@ namespace Uno.UI.RemoteControl.HotReload;
 partial class ClientHotReloadProcessor
 {
 	private static int _isWaitingForTypeMapping;
-	private static readonly AsyncLock _uiUpdateGate = new();
+	private static readonly AsyncLock _uiUpdateGate = new(); // We can use the simple AsyncLock here as we don't need reentrancy.
 
 	private static ElementUpdateAgent? _elementAgent;
 

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -19,6 +19,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Uno.Diagnostics.UI;
+using Uno.Threading;
 
 #if HAS_UNO_WINUI
 using _WindowActivatedEventArgs = Microsoft.UI.Xaml.WindowActivatedEventArgs;
@@ -31,6 +32,7 @@ namespace Uno.UI.RemoteControl.HotReload;
 partial class ClientHotReloadProcessor
 {
 	private static int _isWaitingForTypeMapping;
+	private static readonly AsyncLock _uiUpdateGate = new();
 
 	private static ElementUpdateAgent? _elementAgent;
 
@@ -105,6 +107,8 @@ partial class ClientHotReloadProcessor
 	/// </summary>
 	private static async Task ReloadWithUpdatedTypes(HotReloadClientOperation? hrOp, Window window, Type[] updatedTypes)
 	{
+		using var sequentialUiUpdateLock = await _uiUpdateGate.LockAsync(default);
+
 		var handlerActions = ElementAgent?.ElementHandlerActions;
 
 		var uiUpdating = true;

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Windows.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.Windows.csproj
@@ -30,6 +30,7 @@
 
 	<ItemGroup Condition="'$(UNO_UWP_BUILD)'!='true'">
 		<Compile Include="..\Uno.Foundation\Uno.Core.Extensions\Uno.Core.Extensions.Collections\EnumerableExtensions.cs" Link="Uno.Foundation\Uno.Core.Extensions\Uno.Core.Extensions.Collections\EnumerableExtensions.cs" />
+		<Compile Include="..\Uno.Foundation\Uno.Core.Extensions\Uno.Core.Extensions.Compatibility\Threading\AsyncLock.cs" Link="Uno.Foundation\Uno.Core.Extensions\Uno.Core.Extensions.Compatibility\Threading\AsyncLock.cs" />
 
 		<Compile Include="..\Uno.UI\Extensions\PrettyPrint.cs" Link="Uno.UI\Extensions\PrettyPrint.cs" />
 		<Compile Include="..\Uno.UI\Extensions\ViewExtensions.visual-tree.cs" Link="Uno.UI\Extensions\ViewExtensions.visual-tree.cs" />


### PR DESCRIPTION
## Bugfix
Fix UpdateFileAsync requesting HR before VS detects file change

## What is the current behavior?
HR is requested before VS detects file update

## What is the new behavior?
We wait hopefully long enough after file change to trigger HR on VS, *AND* if a no-changes is reported, we re-trigger a second HR on VS.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
