### PR TITLE
fix: Don't reload projects when moving to all TFMs but wasm

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
@@ -181,8 +181,21 @@ public partial class EntryPoint : IDisposable
 					(
 						previousFramework is not null
 						&& GetTargetFrameworkIdentifier(previousFramework) is { } previousTargetFrameworkIdentifier
-						&& (previousTargetFrameworkIdentifier is WasmTargetFrameworkIdentifier or DesktopTargetFrameworkIdentifier or Windows10TargetFrameworkIdentifier
-							|| targetFrameworkIdentifier is WasmTargetFrameworkIdentifier or DesktopTargetFrameworkIdentifier or Windows10TargetFrameworkIdentifier)
+						&& (
+							(
+								// 17.12 or later properly supports having their TFM anywhere in the
+								// TFMs lists, except Wasm.
+								GetVisualStudioReleaseVersion() >= new Version(17, 12)
+								&& (
+									previousTargetFrameworkIdentifier is WasmTargetFrameworkIdentifier
+									|| targetFrameworkIdentifier is WasmTargetFrameworkIdentifier))
+
+							|| (
+								// 17.11 or earlier needs reloading most TFMs
+								GetVisualStudioReleaseVersion() < new Version(17, 12)
+								&& (previousTargetFrameworkIdentifier is WasmTargetFrameworkIdentifier or DesktopTargetFrameworkIdentifier or Windows10TargetFrameworkIdentifier
+									|| targetFrameworkIdentifier is WasmTargetFrameworkIdentifier or DesktopTargetFrameworkIdentifier or Windows10TargetFrameworkIdentifier))
+						)
 					)
 				)
 			)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/18349

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix


## What is the new behavior?

Improve TFM reload in 17.12.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
