### PR TITLE
test: remove sampleapp more button's transition

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -551,7 +551,10 @@
 						<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xEC46;" />
 					</CheckBox>
 
-					<Button Grid.Column="10" Margin="0,0,8,0">
+					<!-- Overflow More(...) Button -->
+					<Button Grid.Column="10"
+							Margin="0,0,8,0"
+							Style="{StaticResource SampleControlButtonStyle}">
 						<SymbolIcon Symbol="More" />
 						<Button.Flyout>
 							<MenuFlyout>


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Other... Please describe: sample app & ci screenshot tests improvement

## What is the current behavior?
In the SampleApp's top bar, there is a more `...` button that contains a background transition. It seems to affect screenshot comparison tests result in unintended way.

## What is the new behavior?
Said button style was changed to avoid such problem.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.