### PR TITLE
fix(Button): Command binding resetting on CanExecution exception

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -16,6 +16,7 @@ using Windows.Foundation;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Color = Windows.UI.Color;
+using Microsoft.UI.Xaml.Data;
 
 #if HAS_UNO_WINUI || WINAPPSDK || WINUI
 using Colors = Microsoft.UI.Colors;
@@ -317,6 +318,26 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 #endif
 
+		[TestMethod]
+		public async Task When_Command_CanExecute_Throws()
+		{
+			// Here we are testing against a bug where
+			// a data-bound ICommand that throws in its CanExecute
+			// can cause the binding to reset to its FallbackValue.
+			var vm = new
+			{
+				UnstableCommand = new DelegateCommand(x => throw new Exception("fail...")),
+			};
+
+			var sut = new Button();
+			sut.SetBinding(Button.CommandProperty, new Binding { Path = new(nameof(vm.UnstableCommand)), FallbackValue = new NoopCommand() });
+			sut.DataContext = vm;
+
+			await UITestHelper.Load(sut, x => x.IsLoaded);
+
+			Assert.AreEqual(vm.UnstableCommand, sut.Command, "Binding did not set the proper value.");
+		}
+
 		private async Task RunIsExecutingCommandCommon(IsExecutingCommand command)
 		{
 			void FocusManager_LosingFocus(object sender, LosingFocusEventArgs e)
@@ -421,5 +442,26 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 			}
 		}
+
+		public class DelegateCommand : ICommand
+		{
+			private readonly Func<object, bool> canExecuteImpl;
+			private readonly Action<object> executeImpl;
+
+			public event EventHandler CanExecuteChanged;
+
+			public DelegateCommand(Func<object, bool> canExecute = null, Action<object> execute = null)
+			{
+				this.canExecuteImpl = canExecute;
+				this.executeImpl = execute;
+			}
+
+			public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, default);
+
+			public bool CanExecute(object parameter) => canExecuteImpl?.Invoke(parameter) ?? true;
+			public void Execute(object parameter) => executeImpl?.Invoke(parameter);
+		}
+
+		public class NoopCommand() : DelegateCommand(null, null) { }
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.mux.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Windows.Input;
 using Uno.Disposables;
+using Uno.Foundation.Logging;
 using Uno.UI.Xaml.Core;
 using Windows.Devices.Input;
 using Windows.Foundation;
@@ -86,7 +87,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			}
 			else if (args.Property == CommandParameterProperty)
 			{
-				UpdateCanExecute();
+				UpdateCanExecuteSafe();
 			}
 			else if (args.Property == VisibilityProperty)
 			{
@@ -273,7 +274,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			}
 
 			// Coerce the button enabled state with the CanExecute state of the command.
-			UpdateCanExecute();
+			UpdateCanExecuteSafe();
 		}
 
 		/// <summary>
@@ -295,6 +296,24 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			// If command is present and cannot be executed, disable the button.
 			var suppress = !canExecute;
 			SuppressIsEnabled(suppress);
+		}
+
+		private void UpdateCanExecuteSafe()
+		{
+			// uno specific workaround:
+			// If Button::Command binding produces an ICommand value that throws Exception in its CanExecute,
+			// this value will be canceled and replaced by the Binding::FallbackValue.
+			try
+			{
+				UpdateCanExecute();
+			}
+			catch (Exception e)
+			{
+				if (this.Log().IsEnabled(LogLevel.Error))
+				{
+					this.Log().Error($"Failed to update CanExecute", e);
+				}
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/kahua-private#199

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
If Button::Command binding produces an ICommand value that throws Exception in its CanExecute, this value will be canceled and replaced by the Binding::FallbackValue. This does not happen on windows.

## What is the new behavior?
^ should not happen anymore.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.