### PR TITLE
Removed the waiting for TypeMappings to be resumed during HR

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1781,7 +1781,7 @@
 			<Member fullName="System.Void Windows.UI.Xaml.Controls.TimePickerFlyout.OnClockIdentifierChanged(System.String oldClockIdentifier, System.String newClockIdentifier)" reason="Not present in WinUI" />
 			<Member fullName="System.Void Windows.UI.Xaml.Controls.TimePickerFlyoutPresenter..ctor()" reason="Not present in WinUI" />
 			<!-- END TimePicker -->
-			
+
 			<!-- Multiple XamlRoots -->
 			<Member fullName="System.Void Windows.UI.Core.CoreWindow..ctor(UIKit.UIWindow window)" reason="Does not exist in UWP" />
 			<Member fullName="System.Void Windows.UI.Core.CoreWindow..ctor(AppKit.NSWindow window)" reason="Does not exist in UWP" />
@@ -1801,7 +1801,7 @@
 			<Member fullName="Microsoft.UI.Dispatching.DispatcherQueueTimer" reason="Only in UWP build. It shouldn't have existed." />
 
 			<Member fullName="Microsoft.UI.Xaml.Hosting.HostingContract" reason="No longer exists in WinAppSDK 1.4" />
-			
+
 			<Member fullName="Uno.WinUI.Runtime.Skia.LinuxFB.EventLoop" reason="Should be internal" />
 		</Types>
 
@@ -1827,7 +1827,7 @@
 			<Member fullName="System.Void Windows.ApplicationModel.Activation.SplashScreen..ctor()" reason="The signature differs in MUX" />
 			<Member fullName="System.Void Microsoft.UI.Xaml.Input.PointerRoutedEventArgs..ctor()" reason="Does not exist in WinUI" />
 			<Member fullName="System.Void Windows.UI.Xaml.Input.PointerRoutedEventArgs..ctor()" reason="Does not exist in WinUI" />
-			
+
 			<!-- Begin Skia Builder-->
 			<Member fullName="System.Void Uno.UI.Runtime.Skia.Linux.FrameBuffer.FrameBufferHost.Run()" reason="Non-breaking API, moved to SkiaHost" />
 			<!-- End Skia Builder-->
@@ -1905,7 +1905,7 @@
 
 		<Events>
 		</Events>
-		
+
 		<Fields>
 		</Fields>
 
@@ -1951,9 +1951,40 @@
 			<Member fullName="System.Void Microsoft.UI.Xaml.Controls.Primitives.Selector.SetFocusedItem(System.Int32 index, System.Boolean shouldScrollIntoView, System.Boolean animateIfBringIntoView, Microsoft.UI.Xaml.Input.FocusNavigationDirection focusNavigationDirection)" reason="Does not exist in WinUI" />
 			<Member fullName="System.Void Microsoft.UI.Xaml.Controls.Primitives.Selector.SetFocusedItem(System.Int32 index, System.Boolean shouldScrollIntoView)" reason="Does not exist in WinUI" />
 			<!-- END ComboBox.IsEditable -->
+
+			<!-- BEGIN TypeMappings -->
+			<Member fullName="System.Threading.Tasks.Task Uno.UI.Helpers.TypeMappings.WaitForMappingsToResume()" reason="Not really considered a public API, used by internal tooling" />
+			<Member fullName="System.Threading.Tasks.Task`1<System.Boolean> Uno.UI.Helpers.TypeMappings.WaitForResume()" reason="Not really considered a public API, used by internal tooling" />
+			<Member fullName="System.Void Uno.UI.Helpers.TypeMappings.Resume(System.Boolean updateLayout)" reason="Not really considered a public API, used by internal tooling" />
+			<!-- END TypeMappings -->
 		</Methods>
 	</IgnoreSet>
+
+	<IgnoreSet baseVersion="5.5">
+		<Assemblies>
+		</Assemblies>
+
+		<Types>
+		</Types>
+
+		<Events>
+		</Events>
+
+		<Fields>
+		</Fields>
 	
+		<Properties>
+		</Properties>
+	
+		<Methods>
+			<!-- BEGIN TypeMappings -->
+			<Member fullName="System.Threading.Tasks.Task Uno.UI.Helpers.TypeMappings.WaitForMappingsToResume()" reason="Not really considered a public API, used by internal tooling" />
+			<Member fullName="System.Threading.Tasks.Task`1<System.Boolean> Uno.UI.Helpers.TypeMappings.WaitForResume()" reason="Not really considered a public API, used by internal tooling" />
+			<Member fullName="System.Void Uno.UI.Helpers.TypeMappings.Resume(System.Boolean updateLayout)" reason="Not really considered a public API, used by internal tooling" />
+			<!-- END TypeMappings -->
+		</Methods>
+	</IgnoreSet>
+
 	<![CDATA[
 		The 'baseVersion' should be the current latest stable version published on nuget, 
 		NOT what will be published by the PR in progress.

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1954,7 +1954,7 @@
 
 			<!-- BEGIN TypeMappings -->
 			<Member fullName="System.Threading.Tasks.Task Uno.UI.Helpers.TypeMappings.WaitForMappingsToResume()" reason="Not really considered a public API, used by internal tooling" />
-			<Member fullName="System.Threading.Tasks.Task`1<System.Boolean> Uno.UI.Helpers.TypeMappings.WaitForResume()" reason="Not really considered a public API, used by internal tooling" />
+			<Member fullName="System.Threading.Tasks.Task`1&lt;System.Boolean&gt; Uno.UI.Helpers.TypeMappings.WaitForResume()" reason="Not really considered a public API, used by internal tooling" />
 			<Member fullName="System.Void Uno.UI.Helpers.TypeMappings.Resume(System.Boolean updateLayout)" reason="Not really considered a public API, used by internal tooling" />
 			<!-- END TypeMappings -->
 		</Methods>
@@ -1972,14 +1972,14 @@
 
 		<Fields>
 		</Fields>
-	
+
 		<Properties>
 		</Properties>
-	
+
 		<Methods>
 			<!-- BEGIN TypeMappings -->
 			<Member fullName="System.Threading.Tasks.Task Uno.UI.Helpers.TypeMappings.WaitForMappingsToResume()" reason="Not really considered a public API, used by internal tooling" />
-			<Member fullName="System.Threading.Tasks.Task`1<System.Boolean> Uno.UI.Helpers.TypeMappings.WaitForResume()" reason="Not really considered a public API, used by internal tooling" />
+			<Member fullName="System.Threading.Tasks.Task`1&lt;System.Boolean&gt; Uno.UI.Helpers.TypeMappings.WaitForResume()" reason="Not really considered a public API, used by internal tooling" />
 			<Member fullName="System.Void Uno.UI.Helpers.TypeMappings.Resume(System.Boolean updateLayout)" reason="Not really considered a public API, used by internal tooling" />
 			<!-- END TypeMappings -->
 		</Methods>

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -31,7 +31,6 @@ namespace Uno.UI.RemoteControl.HotReload;
 
 partial class ClientHotReloadProcessor
 {
-	private static int _isWaitingForTypeMapping;
 	private static readonly AsyncLock _uiUpdateGate = new(); // We can use the simple AsyncLock here as we don't need reentrancy.
 
 	private static ElementUpdateAgent? _elementAgent;
@@ -53,23 +52,12 @@ partial class ClientHotReloadProcessor
 		}
 	}
 
-	private static async Task<(bool value, string reason)> ShouldReload()
+	private static (bool value, string reason) ShouldReload()
 	{
-		if (Interlocked.CompareExchange(ref _isWaitingForTypeMapping, 1, 0) == 1)
-		{
-			return (false, "another reload is already waiting for type mapping to resume");
-		}
-		try
-		{
-			var shouldReload = await TypeMappings.WaitForResume();
-			return shouldReload
-				? (true, string.Empty)
-				: (false, "type mapping prevent reload");
-		}
-		finally
-		{
-			Interlocked.Exchange(ref _isWaitingForTypeMapping, 0);
-		}
+		var isPaused = TypeMappings.IsPaused;
+		return isPaused
+			? (false, "type mapping prevent reload")
+			: (true, string.Empty);
 	}
 
 	internal static void SetWindow(Window window, bool disableIndicator)
@@ -116,7 +104,7 @@ partial class ClientHotReloadProcessor
 		{
 			hrOp?.SetCurrent();
 
-			if (await ShouldReload() is { value: false } prevent)
+			if (ShouldReload() is { value: false } prevent)
 			{
 				uiUpdating = false;
 				hrOp?.ReportIgnored(prevent.reason);

--- a/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/HotReloadStatusView.cs
@@ -206,29 +206,35 @@ public sealed partial class HotReloadStatusView : Control
 	private void UpdateLog(Status? oldStatus, Status status)
 	{
 		// Add or update the entries for the **operations** (server and the application).
-		foreach (var srvOp in status.Server.Operations)
+		if (status.Server.Operations is { }) // can be null during loading, creating a NRE
 		{
-			ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(_serverHrEntries, srvOp.Id, out var exists);
-			if (exists)
+			foreach (var srvOp in status.Server.Operations)
 			{
-				entry!.Update(srvOp);
-			}
-			else
-			{
-				entry = new ServerEntry(srvOp);
+				ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(_serverHrEntries, srvOp.Id, out var exists);
+				if (exists)
+				{
+					entry!.Update(srvOp);
+				}
+				else
+				{
+					entry = new ServerEntry(srvOp);
+				}
 			}
 		}
 
-		foreach (var localOp in status.Local.Operations)
+		if (status.Local.Operations is { }) // can be null during loading, creating a NRE
 		{
-			ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(_appHrEntries, localOp.Id, out var exists);
-			if (exists)
+			foreach (var localOp in status.Local.Operations)
 			{
-				entry!.Update(localOp);
-			}
-			else
-			{
-				entry = new ApplicationEntry(localOp);
+				ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(_appHrEntries, localOp.Id, out var exists);
+				if (exists)
+				{
+					entry!.Update(localOp);
+				}
+				else
+				{
+					entry = new ApplicationEntry(localOp);
+				}
 			}
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Frame.cs
@@ -160,7 +160,7 @@ public class Given_Frame : BaseTestClass
 		finally
 		{
 			// Resume HR
-			TypeMappings.Resume(false);
+			TypeMappings.Resume();
 		}
 
 		// Although HR has been un-paused (resumed) the UI should not have updated at this point
@@ -211,7 +211,7 @@ public class Given_Frame : BaseTestClass
 				FirstPageTextBlockChangedText,
 				async () =>
 				{
-					// Confirm that reload compeleted has fired
+					// Confirm that reload completed has fired
 					var uiUpdated = await waitingTask.WaitAsync(ct);
 					Assert.IsFalse(uiUpdated, "UI should not have updated whilst ui updates paused");
 					await frame.ValidateTextOnChildTextBlock(FirstPageTextBlockOriginalText);
@@ -221,7 +221,7 @@ public class Given_Frame : BaseTestClass
 		finally
 		{
 			// Resume HR
-			TypeMappings.Resume(false);
+			TypeMappings.Resume();
 		}
 
 		// Although HR has been un-paused (resumed) the UI should not have updated at this point


### PR DESCRIPTION
# Bugfix

## What is the current behavior?
HotReload was waiting for _Type Mappings_ to be resumed to know if changes should be applied or not. That feature has been removed because it was deadlocking with the possibility to pause type mappings while sending a file update from the client app.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
