### PR TITLE
fix: Reset last input type before test execution

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -769,7 +769,7 @@ namespace Uno.UI.Samples.Tests
 						canRetry = false;
 						var cleanupActions = new List<Func<Task>>
 						{
-							GenericCleanupAsync
+							GeneralCleanupAsync
 						};
 
 						try
@@ -799,6 +799,8 @@ namespace Uno.UI.Samples.Tests
 									});
 								});
 							}
+
+							await GeneralInitAsync();
 
 							object returnValue = null;
 							var methodArguments = testCase.Parameters;
@@ -976,14 +978,24 @@ namespace Uno.UI.Samples.Tests
 				}
 			}
 
-			async Task GenericCleanupAsync()
+			async Task GeneralInitAsync()
+			{
+#if HAS_UNO
+				await TestServices.WindowHelper.RootElementDispatcher.RunAsync(() =>
+				{
+					ResetLastInputDeviceType();
+				});
+#else
+				await Task.CompletedTask;
+#endif
+			}
+
+			async Task GeneralCleanupAsync()
 			{
 				await TestServices.WindowHelper.RootElementDispatcher.RunAsync(() =>
 				{
 					CloseRemainingPopups();
-#if HAS_UNO
-					ResetLastInputDeviceType();
-#endif
+
 				});
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When tests are run manually, the last input type would be dependent on whether the user uses touch, mouse, or keyboard to execute the button.

## What is the new behavior?

Always consistent

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
