### PR TITLE
fix: Workaround non-UIElement UIViews in Grid layout

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
@@ -1374,6 +1374,12 @@ namespace Microsoft.UI.Xaml.Controls
 					while (childrenEnumerator.MoveNext())
 					{
 						var currentChild = childrenEnumerator.Current;
+#if __IOS__ // Uno specific: On iOS an additional non-UIElement is added the the parent of a focused TextBox control, we need to skip it.
+						if (currentChild is null)
+						{
+							continue;
+						}
+#endif
 						ASSERT(currentChild is { });
 
 						currentChild.EnsureLayoutStorage();
@@ -1414,6 +1420,12 @@ namespace Microsoft.UI.Xaml.Controls
 				for (Xuint childIndex = 0; childIndex < count; childIndex++)
 				{
 					UIElement currentChild = children[childIndex];
+#if __IOS__ // Uno specific: On iOS an additional non-UIElement is added the the parent of a focused TextBox control, we need to skip it.
+					if (currentChild is null)
+					{
+						continue;
+					}
+#endif
 					ASSERT(currentChild is { });
 
 					DefinitionBase row = GetRowNoRef(currentChild);


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/17997, closes https://github.com/unoplatform/uno/issues/14013

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Focusing a text input on iOS causes the framework to temporarily add a non-UIElement child to the parent's `Grid`, which is then surfaced to the `Grid` as a `null`

## What is the new behavior?

No longer crashing. This is a workaround, ideally we would want to ensure that `Children` as a `UIElementCollection` only reflects the actual `UIElements` in the `ChildrenShadow`. This however means more complex logic to properly handle indexes, etc. This workaround seems to be sufficient for now to handle the cases we encountered. Created https://github.com/unoplatform/uno/issues/18474 to track this

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
