### PR TITLE
fix(ios): Tabview Selection when Bindings items

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
@@ -16,7 +16,6 @@ using TabViewItem = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TabViewItem
 
 using static Uno.UI.Extensions.ViewExtensions;
 using static Private.Infrastructure.TestServices;
-using UIKit;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
@@ -16,6 +16,7 @@ using TabViewItem = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TabViewItem
 
 using static Uno.UI.Extensions.ViewExtensions;
 using static Private.Infrastructure.TestServices;
+using UIKit;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
 
@@ -114,4 +115,107 @@ public class Given_TabView
 		Assert.AreEqual(0, SUT.SelectedIndex);
 		Assert.AreEqual("Tab 2", ((TabViewItem)SUT.TabItems[0]).Header);
 	}
+
+	[TestMethod]
+	public async Task When_SelectedItem_Changed()
+	{
+		var SUT = new TabView
+		{
+			TabItems =
+			{
+				new TabViewItem { Header = "Tab 1" },
+				new TabViewItem { Header = "Tab 2" }
+			}
+		};
+
+		await UITestHelper.Load(SUT);
+
+		Assert.AreEqual(0, SUT.SelectedIndex);
+
+		SUT.SelectedItem = SUT.TabItems[1];
+
+		await WindowHelper.WaitForIdle();
+
+		Assert.AreEqual(1, SUT.SelectedIndex);
+	}
+
+	[TestMethod]
+	public async Task When_DataBinding()
+	{
+		var vm = new ViewModel();
+		var SUT = new TabView();
+
+		SUT.SetBinding(TabView.TabItemsSourceProperty, new Microsoft.UI.Xaml.Data.Binding() { Path = new("TabItems") });
+		SUT.SetBinding(TabView.SelectedItemProperty, new Microsoft.UI.Xaml.Data.Binding() { Path = new("SelectedItem"), Mode = Microsoft.UI.Xaml.Data.BindingMode.TwoWay });
+
+		SUT.DataContext = vm;
+
+		await UITestHelper.Load(SUT);
+
+		Assert.AreEqual(2, SUT.TabItems.Count);
+		Assert.AreEqual(0, SUT.SelectedIndex);
+	}
+
+	[TestMethod]
+	public async Task When_SelectedItem_Changed_Binding()
+	{
+		var vm = new ViewModel();
+		var SUT = new TabView();
+
+		SUT.SetBinding(TabView.TabItemsSourceProperty, new Microsoft.UI.Xaml.Data.Binding() { Path = new("TabItems") });
+		SUT.SetBinding(TabView.SelectedItemProperty, new Microsoft.UI.Xaml.Data.Binding() { Path = new("SelectedItem"), Mode = Microsoft.UI.Xaml.Data.BindingMode.TwoWay });
+
+		SUT.DataContext = vm;
+
+		vm.SelectedItem = vm.TabItems[1];
+
+		await UITestHelper.Load(SUT);
+
+		Assert.AreEqual(1, SUT.SelectedIndex);
+	}
+
+	[TestMethod]
+	public async Task When_AddingTab_While_Binding()
+	{
+		var SUT = new TabView();
+
+		SUT.SetBinding(TabView.TabItemsSourceProperty, new Microsoft.UI.Xaml.Data.Binding() { Path = new("TabItems") });
+		SUT.SetBinding(TabView.SelectedItemProperty, new Microsoft.UI.Xaml.Data.Binding() { Path = new("SelectedItem"), Mode = Microsoft.UI.Xaml.Data.BindingMode.TwoWay });
+
+		SUT.DataContext = new ViewModel(addTab: true);
+
+		await UITestHelper.Load(SUT);
+
+		// It should select the newly added tab
+		Assert.AreEqual(2, SUT.SelectedIndex);
+
+		var tabviewItem = SUT.ContainerFromItem(SUT.SelectedItem) as TabViewItem;
+		Assert.IsTrue(tabviewItem.ActualWidth > 0, "TabViewItem should have a non-zero width.");
+		Assert.IsTrue(tabviewItem.ActualHeight > 0, "TabViewItem should have a non-zero height.");
+	}
+}
+
+public class ViewModel : ViewModelBase
+{
+	public ViewModel(bool addTab = false)
+	{
+		if (addTab)
+		{
+			TabItems.Add(new TabViewItem { Header = "Main Tab", Content = "Main Content" });
+			SelectedItem = TabItems[^1];
+		}
+	}
+	private TabViewItem _selectedItem;
+
+	public TabViewItem SelectedItem
+	{
+		get => _selectedItem;
+		set => SetAndRaiseIfChanged(ref _selectedItem, value);
+	}
+
+	public ObservableCollection<TabViewItem> TabItems { get; } = new ObservableCollection<TabViewItem>
+	{
+		new TabViewItem { Header = "Tab 1", Content = "Content 1" },
+		new TabViewItem { Header = "Tab 2", Content = "Content 2" }
+	};
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
@@ -551,6 +551,19 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 					TabItems = lvItems;
 				}
 
+				if (ReadLocalValue(SelectedItemProperty) != DependencyProperty.UnsetValue)
+				{
+					UpdateSelectedItem();
+				}
+				else
+				{
+					// If SelectedItem wasn't set, default to selecting the first tab
+					UpdateSelectedIndex();
+				}
+
+				SelectedIndex = listView.SelectedIndex;
+				SelectedItem = listView.SelectedItem;
+
 				// Find TabsItemsPresenter and listen for SizeChanged
 				ItemsPresenter GetItemsPresenter(ListView listView)
 				{
@@ -595,18 +608,6 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 						scrollViewer.UnregisterPropertyChangedCallback(ScrollViewer.ScrollableWidthProperty, scrollViewerScrollableWidthToken);
 					});
 				}
-
-				if (ReadLocalValue(SelectedItemProperty) != DependencyProperty.UnsetValue)
-				{
-					UpdateSelectedItem();
-				}
-				else
-				{
-					UpdateSelectedIndex();
-				}
-
-				SelectedIndex = listView.SelectedIndex;
-				SelectedItem = listView.SelectedItem;
 			}
 		}
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
@@ -1267,27 +1267,17 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 
 		private int GetItemCount()
 		{
-			var itemsSource = TabItemsSource;
-			if (itemsSource != null)
+			if (TabItemsSource is { } itemsSource)
 			{
-				var iterable = itemsSource as IEnumerable;
-				if (iterable != null)
+				if (itemsSource is IEnumerable iterable)
 				{
-					//int i = 1;
-					//var iter = iterable.First();
-					//while (iter.MoveNext())
-					//{
-					//	i++;
-					//}
-					//return i;
 					return iterable.Count();
 				}
 				return 0;
 			}
-
 			else
 			{
-				return (int)TabItems.Count;
+				return TabItems.Count;
 			}
 		}
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 // MUX Reference TabView.cpp, commit ed31e13
 
@@ -551,19 +551,6 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 					TabItems = lvItems;
 				}
 
-				if (ReadLocalValue(SelectedItemProperty) != DependencyProperty.UnsetValue)
-				{
-					UpdateSelectedItem();
-				}
-				else
-				{
-					// If SelectedItem wasn't set, default to selecting the first tab
-					UpdateSelectedIndex();
-				}
-
-				SelectedIndex = listView.SelectedIndex;
-				SelectedItem = listView.SelectedItem;
-
 				// Find TabsItemsPresenter and listen for SizeChanged
 				ItemsPresenter GetItemsPresenter(ListView listView)
 				{
@@ -608,6 +595,18 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 						scrollViewer.UnregisterPropertyChangedCallback(ScrollViewer.ScrollableWidthProperty, scrollViewerScrollableWidthToken);
 					});
 				}
+
+				if (ReadLocalValue(SelectedItemProperty) != DependencyProperty.UnsetValue)
+				{
+					UpdateSelectedItem();
+				}
+				else
+				{
+					UpdateSelectedIndex();
+				}
+
+				SelectedIndex = listView.SelectedIndex;
+				SelectedItem = listView.SelectedItem;
 			}
 		}
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
@@ -551,7 +551,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 					TabItems = lvItems;
 				}
 
-				if (ReadLocalValue(SelectedItemProperty) != DependencyProperty.UnsetValue)
+				if (ReadLocalValue(SelectedItemProperty) != DependencyProperty.UnsetValue
+#if __SKIA__ || __WASM__
+					&& SelectedItem is not null
+#endif
+					)
 				{
 					UpdateSelectedItem();
 				}

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/TabView/TabView.cs
@@ -551,11 +551,9 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 					TabItems = lvItems;
 				}
 
+				// ReadLocalValue() is not returning UnsetValue even though SelectedItem is not yet set
 				if (ReadLocalValue(SelectedItemProperty) != DependencyProperty.UnsetValue
-#if __SKIA__ || __WASM__
-					&& SelectedItem is not null
-#endif
-					)
+					&& SelectedItem is not null)
 				{
 					UpdateSelectedItem();
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.managed.cs
@@ -111,8 +111,10 @@ namespace Microsoft.UI.Xaml.Controls
 #endif
 					);
 
+				var orientation = ItemsPanelRoot?.PhysicalOrientation ?? Orientation.Vertical;
+
 				var (elementOffset, elementLength, presenterOffset, presenterViewportLength) =
-					ItemsPanelRoot.PhysicalOrientation is Orientation.Vertical
+					orientation is Orientation.Vertical
 						? (offsetXY.Y, element.ActualSize.Y, presenter.VerticalOffset, presenter.ViewportHeight)
 						: (offsetXY.X, element.ActualSize.X, presenter.HorizontalOffset, presenter.ViewportWidth);
 
@@ -130,7 +132,7 @@ namespace Microsoft.UI.Xaml.Controls
 					? elementOffset - presenterViewportLength + elementLength
 					: elementOffset;
 
-				if (ItemsPanelRoot.PhysicalOrientation is Orientation.Vertical)
+				if (orientation is Orientation.Vertical)
 				{
 					sv.ScrollToVerticalOffset(newOffset);
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -194,7 +194,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 			if (newIndex != -1 && IsInLiveTree)
 			{
 				if (this is ListViewBase lvb
-#if __IOS__ // TODO@andres: verify if this is also needed for android
+#if __IOS__
 					// workaround to prevent scrolling when it is not ready
 					// without this, the ios TabView could render blank if the selection happens too early.
 					&& ContainerFromIndex(newIndex) is FrameworkElement { IsLoaded: true }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -193,7 +193,13 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 #if !IS_UNIT_TESTS
 			if (newIndex != -1 && IsInLiveTree)
 			{
-				if (this is ListViewBase lvb)
+				if (this is ListViewBase lvb
+#if __IOS__ // TODO@andres: verify if this is also needed for android
+					// workaround to prevent scrolling when it is not ready
+					// without this, the ios TabView could render blank if the selection happens too early.
+					&& ContainerFromIndex(newIndex) is FrameworkElement { IsLoaded: true }
+#endif
+				)
 				{
 #if __IOS__ || __ANDROID__
 					lvb.InstantScrollToIndex(newIndex);


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/ziidms-private/issues/23

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
Using TabView with bound items and changing the SelectedItem is causing the TabView Tabs to display incorrectly.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
