### PR TITLE
IDE Channel Client: Have a generic OnMessageReceived 

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -426,9 +426,6 @@ public partial class EntryPoint : IDisposable
 		{
 			switch (devServerMessage)
 			{
-				case KeepAliveIdeMessage:
-					_debugAction?.Invoke($"Keep alive from Dev Server");
-					break;
 				case AddMenuItemRequestIdeMessage amir:
 					await OnAddMenuItemRequestIdeMessageAsync(sender, amir);
 					break;

--- a/src/Uno.UI.RemoteControl.VS/IDEChannel/IDEChannelClient.cs
+++ b/src/Uno.UI.RemoteControl.VS/IDEChannel/IDEChannelClient.cs
@@ -89,14 +89,18 @@ internal class IdeChannelClient
 			_logger.Verbose($"IDE: IDEChannel message received {devServerMessage}");
 
 			var process = Task.CompletedTask;
-			if (devServerMessage is IdeMessage message)
+			switch (devServerMessage)
 			{
-				_logger.Verbose($"Dev Server Message {message.GetType()} requested");
-				process = OnMessageReceived.InvokeAsync(this, message);
-			}
-			else
-			{
-				_logger.Verbose($"Unknown message type {devServerMessage?.GetType()} from DevServer");
+				case KeepAliveIdeMessage:
+					_logger.Verbose($"Keep alive from Dev Server");
+					break;
+				case IdeMessage message:
+					_logger.Verbose($"Dev Server Message {message.GetType()} requested");
+					process = OnMessageReceived.InvokeAsync(this, message);
+					break;
+				default:
+					_logger.Verbose($"Unknown message type {devServerMessage?.GetType()} from DevServer");
+					break;
 			}
 
 			_ = process.ContinueWith(


### PR DESCRIPTION
GitHub Issue (If applicable): closes: #18448


## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

We have several messages and events on the IDEChannelClient.

## What is the new behavior?

Now we only have one, and the messages are being handled by the EntryPoint.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
