### PR TITLE
chore: remove SkiaSharp.HarfBuzz and SkiaSharp.Views dependencies when unnecessary

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Gtk/Uno.UI.Runtime.Skia.Gtk.csproj
+++ b/src/Uno.UI.Runtime.Skia.Gtk/Uno.UI.Runtime.Skia.Gtk.csproj
@@ -37,7 +37,6 @@
 	<ItemGroup>
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" />
 		<PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
-		<PackageReference Include="SkiaSharp.Harfbuzz" />
 		<PackageReference Include="SkiaSharp" />
 		<PackageReference Include="GtkSharp" />
 	</ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Uno.UI.Runtime.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Uno.UI.Runtime.Skia.Linux.FrameBuffer.csproj
@@ -32,7 +32,6 @@
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" />
 		<PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
 		<PackageReference Include="SkiaSharp" />
-		<PackageReference Include="SkiaSharp.Harfbuzz" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.MacOS/Uno.UI.Runtime.Skia.MacOS.csproj
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Uno.UI.Runtime.Skia.MacOS.csproj
@@ -28,8 +28,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="SkiaSharp.NativeAssets.macos" />
-		<PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" Version="2.8.2.3" />
-		<PackageReference Include="SkiaSharp.Harfbuzz" />
+		<PackageReference Include="HarfBuzzSharp.NativeAssets.macOS" />
 		<PackageReference Include="SkiaSharp" />
 	</ItemGroup>
 

--- a/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
@@ -31,7 +31,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SkiaSharp.Views.WPF" />
 		<PackageReference Include="SkiaSharp.Harfbuzz" />
 
 		<PackageReference Include="Microsoft.Web.WebView2" Aliases="WpfWebView" PrivateAssets="all" />

--- a/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Uno.UI.Runtime.Skia.Wpf.csproj
@@ -31,8 +31,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SkiaSharp.Harfbuzz" />
-
 		<PackageReference Include="Microsoft.Web.WebView2" Aliases="WpfWebView" PrivateAssets="all" />
 
 		<!-- 

--- a/src/Uno.UI.Runtime.Skia.X11/Uno.UI.Runtime.Skia.X11.csproj
+++ b/src/Uno.UI.Runtime.Skia.X11/Uno.UI.Runtime.Skia.X11.csproj
@@ -32,7 +32,6 @@
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux" />
 		<PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" />
 		<PackageReference Include="SkiaSharp" />
-		<PackageReference Include="SkiaSharp.Harfbuzz" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
@jeromelaban I noticed SkiaSharp.Views being a dependenct in the wpf runtime project. It doesn't seem to be necessary at all. Can we remove it?