### PR TITLE
fix: Adjust tf reordering for VS 17.12 or later

### DIFF
--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -129,6 +129,18 @@ When building with Rider on Linux or macOS, unsupported target frameworks are [n
 
 See how to [make platforms conditional](xref:Uno.GettingStarted.CreateAnApp.Rider#considerations-for-macos-and-linux) for Rider.
 
+### UNOB0015: The desktop TargetFramework must be placed first
+
+In Visual Studio 17.12 or later, when both mobile (`-ios`, `-android`, `-maccatalyst`) and `desktop` target frameworks are used, the `-desktop` target framework must be placed first in order for WSL debugging to work.
+
+If `-desktop` is not first, the following message will appear:
+
+```text
+The project doesn't know how to run the profile with name 'MyApp (Desktop WSL2)' and command 'WSL2'.
+```
+
+To fix the issue, reorder the items in your `.csproj` so that `TargetFrameworks` contains `netX.0-desktop` as the first target framework.
+
 ## Compiler Errors
 
 ### UNO0001

--- a/src/Uno.Sdk/targets/Uno.Sdk.After.targets
+++ b/src/Uno.Sdk/targets/Uno.Sdk.After.targets
@@ -106,8 +106,8 @@
 				BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems;ResolveFrameworkReferences"
 				Condition="
 				'$(UnoDisableVSWarnDesktopIsFirst)' != 'true'
-				AND $([MSBuild]::VersionLessThan($(MSBuildVersion), 17.12.0))
 				AND '$(BuildingInsideVisualStudio)' == 'true'
+				AND $([MSBuild]::VersionLessThan($(MSBuildVersion), 17.12.0))
 				AND '$(_UnoTargetFrameworkCount)' != ''
 				AND $(_UnoTargetFrameworkCount) &gt; 1
 				AND $([MSBuild]::GetTargetPlatformIdentifier($(_UnoFirstOriginalTargetFramework))) == 'desktop'">
@@ -120,15 +120,20 @@
 				BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems;ResolveFrameworkReferences"
 				Condition="
 				'$(UnoDisableVSWarnDesktopIsNotFirst)' != 'true'
-				AND $([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12.0))
 				AND '$(BuildingInsideVisualStudio)' == 'true'
+				AND $([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12.0))
 				AND '$(_UnoTargetFrameworkCount)' != ''
 				AND $(_UnoTargetFrameworkCount) &gt; 1
 				AND $(TargetFrameworks.Contains('-desktop'))
+				AND (
+					$(TargetFrameworks.Contains('-ios'))
+					OR $(TargetFrameworks.Contains('-android'))
+					OR $(TargetFrameworks.Contains('-maccatalyst'))
+				)
 				AND $([MSBuild]::GetTargetPlatformIdentifier($(_UnoFirstOriginalTargetFramework))) != 'desktop'">
 
 		<Warning Code="UNOB0014"
-					Text="The desktop TargetFramework must be placed first in the TargetFrameworks property in order for WSL debugging to work. (See https://aka.platform.uno/UNOB0014)" />
+					Text="The desktop TargetFramework must be placed first in the TargetFrameworks property in order for WSL debugging to work, when mobile targets are also used. (See https://aka.platform.uno/UNOB0014)" />
 	</Target>
 
 	<Target Name="_UnoVSWarnWindowsIsFirst"

--- a/src/Uno.Sdk/targets/Uno.Sdk.After.targets
+++ b/src/Uno.Sdk/targets/Uno.Sdk.After.targets
@@ -41,10 +41,23 @@
 		<When Condition="
 				'$(BuildingInsideVisualStudio)' == 'true'
 				AND '$(UnoDisableFirstTargetFrameworkRewrite)' != 'true'
-				AND (
-					$([MSBuild]::GetTargetPlatformIdentifier($(_UnoSelectedTargetFramework))) == 'browserwasm'
-					OR $([MSBuild]::GetTargetPlatformIdentifier($(_UnoSelectedTargetFramework))) == 'desktop'
-					OR $([MSBuild]::GetTargetPlatformIdentifier($(_UnoSelectedTargetFramework))) == 'windows'
+				AND 
+				(
+					(
+						$([MSBuild]::VersionLessThan($(MSBuildVersion), 17.12.0))
+						AND (
+							$([MSBuild]::GetTargetPlatformIdentifier($(_UnoSelectedTargetFramework))) == 'browserwasm'
+							OR $([MSBuild]::GetTargetPlatformIdentifier($(_UnoSelectedTargetFramework))) == 'desktop'
+							OR $([MSBuild]::GetTargetPlatformIdentifier($(_UnoSelectedTargetFramework))) == 'windows'
+						)
+					)
+					OR
+					(
+						$([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12.0))
+						AND (
+							$([MSBuild]::GetTargetPlatformIdentifier($(_UnoSelectedTargetFramework))) == 'browserwasm'
+						)
+					)
 				)
 				AND '$(TargetFrameworks)' != ''
 				AND '$(_UnoFirstOriginalTargetFramework)' != '$(_UnoSelectedTargetFramework)'
@@ -76,12 +89,13 @@
 	</Choose>
 
 	<Target Name="_UnoVSWarnBrowserIsFirst"
-			BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems"
+			BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems;ResolveFrameworkReferences"
 			Condition=" 
 			'$(UnoDisableVSWarnBrowserIsFirst)' != 'true'
 			AND '$(BuildingInsideVisualStudio)' == 'true'
 			AND '$(_UnoTargetFrameworkCount)' != ''
 			AND $(_UnoTargetFrameworkCount) &gt; 1
+			AND $(TargetFrameworks.Contains('-browserwasm'))
 			AND $([MSBuild]::GetTargetPlatformIdentifier($(_UnoFirstOriginalTargetFramework))) == 'browserwasm'">
 
 		<Warning Code="UNOB0010"
@@ -89,9 +103,10 @@
 	</Target>
 
 	<Target Name="_UnoVSWarnDesktopIsFirst"
-				BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems"
+				BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems;ResolveFrameworkReferences"
 				Condition="
 				'$(UnoDisableVSWarnDesktopIsFirst)' != 'true'
+				AND $([MSBuild]::VersionLessThan($(MSBuildVersion), 17.12.0))
 				AND '$(BuildingInsideVisualStudio)' == 'true'
 				AND '$(_UnoTargetFrameworkCount)' != ''
 				AND $(_UnoTargetFrameworkCount) &gt; 1
@@ -101,13 +116,29 @@
 					Text="The desktop TargetFramework must not be placed first in the TargetFrameworks property in order for other platforms debugging to work. (See https://aka.platform.uno/UNOB0011)" />
 	</Target>
 
+	<Target Name="_UnoVSWarnDesktopIsNotFirst"
+				BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems;ResolveFrameworkReferences"
+				Condition="
+				'$(UnoDisableVSWarnDesktopIsNotFirst)' != 'true'
+				AND $([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12.0))
+				AND '$(BuildingInsideVisualStudio)' == 'true'
+				AND '$(_UnoTargetFrameworkCount)' != ''
+				AND $(_UnoTargetFrameworkCount) &gt; 1
+				AND $(TargetFrameworks.Contains('-desktop'))
+				AND $([MSBuild]::GetTargetPlatformIdentifier($(_UnoFirstOriginalTargetFramework))) != 'desktop'">
+
+		<Warning Code="UNOB0014"
+					Text="The desktop TargetFramework must be placed first in the TargetFrameworks property in order for WSL debugging to work. (See https://aka.platform.uno/UNOB0014)" />
+	</Target>
+
 	<Target Name="_UnoVSWarnWindowsIsFirst"
-				BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems"
+				BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems;ResolveFrameworkReferences"
 				Condition="
 				'$(UnoDisableVSWarnWindowsIsFirst)' != 'true'
 				AND '$(BuildingInsideVisualStudio)' == 'true'
 				AND '$(_UnoTargetFrameworkCount)' != ''
 				AND $(_UnoTargetFrameworkCount) &gt; 1
+				AND $(TargetFrameworks.Contains('-windows'))
 				AND $([MSBuild]::GetTargetPlatformIdentifier($(_UnoFirstOriginalTargetFramework))) == 'windows'">
 
 		<Warning Code="UNOB0012"
@@ -115,7 +146,7 @@
 	</Target>
 
 	<Target Name="_UnoVSWarnNetIsFirst"
-			BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems"
+			BeforeTargets="_SetBuildInnerTarget;_ComputeTargetFrameworkItems;ResolveFrameworkReferences"
 			Condition=" 
 			'$(UnoDisableVSWarnNetIsFirst)' != 'true'
 			AND '$(BuildingInsideVisualStudio)' == 'true'


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

In VS 17.12, only reload projects from/to browserwasm target. Other targets support reordering properly, except for desktop which needs still be first for the WSL debugger to be enabled, only when mobile targets are also present.