### PR TITLE
fix(iOS): textbox selection clear button

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.iOS.cs
@@ -26,6 +26,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 		protected Size MeasureChildOverride(View view, Size slotSize)
 		{
+			if (view is null)
+			{
+				return default;
+			}
+
 			var ret = view
 				.SizeThatFits(slotSize.LogicalToPhysicalPixels())
 				.PhysicalToLogicalPixels()

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/LayoutInformation.mobile.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/LayoutInformation.mobile.cs
@@ -56,6 +56,12 @@ partial class LayoutInformation
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	internal static Size GetDesiredSize(object view)
 	{
+		if (view is null)
+		{
+			// TODO: should we let it break or return default?
+			return default;
+		}
+
 		switch (view)
 		{
 			case UIElement iue:

--- a/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/StackPanel/StackPanel.Layout.cs
@@ -51,7 +51,10 @@ partial class StackPanel
 
 		for (int i = 0; i < count; i++)
 		{
-			var view = Children[i];
+			if (Children[i] is not { } view)
+			{
+				continue;
+			}
 
 			var measuredSize = MeasureElement(view, slotSize);
 			view.EnsureLayoutStorage();


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/Uno.Themes/issues/1458

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When the iOS selection in the TextBox occurs, an exception is sometimes raised, causing the clear button textbox not to show.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
