### PR TITLE
fix: Ensure HttpRequestMessage.Headers are assigned when default ctor is used

### DIFF
--- a/src/Uno.UWP/Web/Http/HttpRequestMessage.cs
+++ b/src/Uno.UWP/Web/Http/HttpRequestMessage.cs
@@ -13,9 +13,8 @@ public sealed partial class HttpRequestMessage : IDisposable, IStringable
 		Headers = new HttpRequestHeaderCollection(this);
 	}
 
-	public HttpRequestMessage()
+	public HttpRequestMessage() : this(HttpMethod.Get, null)
 	{
-		Method = new HttpMethod("GET");
 	}
 
 	public Uri RequestUri { get; set; }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

A `NullReferenceException` occurs when setting headers when the default constructor of `HttpRequestMessage` is used.


## What is the new behavior?

`Headers` is initialized for the default constructor. Also avoid allocating a `HttpMethod` for each instance since we can reuse the one from `HttpMethod.Get`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Partial for for SampleApp's `Webview[2]_WithHeaders` tests

Internal Issue (If applicable):

https://github.com/unoplatform/uno-private/issues/479
