### PR TITLE
chore: Update WebView[2]_WithHeaders tests to use httpbin.org

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_WithHeaders.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_WithHeaders.xaml
@@ -18,12 +18,12 @@
 		  VerticalAlignment="Stretch">
 		<StackPanel Orientation="Vertical">
 			<TextBlock Text="WebView2_NavigateWithHttpRequestMessage" />
-			<mux:WebView2 Source="http://www.hslkdjghsldkjhlskjdhlsfjbvxcmnbxcmvnbjkhfksjdhf.com/"
+			<mux:WebView2 Source="about:blank"
 						 x:Name="MyWebView2"
 						 Height="100"
 						 Width="100" />
 			<TextBlock x:Name="MyTextBlock" TextWrapping="Wrap" />
-			<Button Content="Navigate to Requestb.in" x:Name="MyButton" />
+			<Button Content="Navigate to httpbin.org" x:Name="MyButton" />
 		</StackPanel>
 	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_WithHeaders.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_WithHeaders.xaml.cs
@@ -15,12 +15,30 @@ namespace SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests
 		{
 			InitializeComponent();
 			MyButton.Click += MyButton_OnClick;
+			MyWebView2.NavigationCompleted += async (s, e) =>
+			{
+				if (MyWebView2.Source.Scheme == "about")
+				{
+					MyTextBlock.Text = "Click button to send request with custom headers...";
+				}
+				else
+				{
+					var html = await MyWebView2.CoreWebView2.ExecuteScriptAsync("document.body.outerText");
+					if (html.Contains("\\\"Hello\\\": \\\"TESTTEST, TEST2\\\"") && html.Contains("\\\"Hello2\\\": \\\"TEST111\\\""))
+					{
+						MyTextBlock.Text = "Success! Found both HELLO and HELLO2 headers with their respective values";
+					}
+					else
+					{
+						MyTextBlock.Text = "Failed! Did not find expected HELLO and HELLO2 or they values. See HTML output...";
+					}
+				}
+			};
 		}
 
 		private void MyButton_OnClick(object sender, RoutedEventArgs e)
 		{
-			var url = "http://requestb.in/rw35narw";
-			MyTextBlock.Text = $"Inspect data at {url}?inspect";
+			var url = "https://httpbin.org/headers";
 			var request = new HttpRequestMessage
 			{
 				RequestUri = new Uri(url),

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_WithHeaders.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_WithHeaders.xaml
@@ -17,12 +17,12 @@
 		  VerticalAlignment="Stretch">
 		<StackPanel Orientation="Vertical">
 			<TextBlock Text="WebView_NavigateWithHttpRequestMessage" />
-			<WebView Source="http://www.hslkdjghsldkjhlskjdhlsfjbvxcmnbxcmvnbjkhfksjdhf.com/"
+			<WebView Source="about:blank"
 						 x:Name="MyWebView2"
 						 Height="100"
 						 Width="100" />
 			<TextBlock x:Name="MyTextBlock" TextWrapping="Wrap" />
-			<Button Content="Navigate to Requestb.in" x:Name="MyButton" />
+			<Button Content="Navigate to httpbin.org" x:Name="MyButton" />
 		</StackPanel>
 	</not_win:Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_WithHeaders.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_WithHeaders.xaml.cs
@@ -15,12 +15,30 @@ namespace Uno.UI.Samples.Content.UITests.WebView
 		{
 			InitializeComponent();
 			MyButton.Click += MyButton_OnClick;
+			MyWebView2.NavigationCompleted += async (s, e) =>
+			{
+				if (MyWebView2.Source is null)
+				{
+					MyTextBlock.Text = "Click button to send request with custom headers...";
+				}
+				else
+				{
+					var html = await MyWebView2.CoreWebView2.ExecuteScriptAsync("document.body.outerText");
+					if (html.Contains("\\\"Hello\\\": \\\"TESTTEST, TEST2\\\"") && html.Contains("\\\"Hello2\\\": \\\"TEST111\\\""))
+					{
+						MyTextBlock.Text = "Success! Found both HELLO and HELLO2 headers with their respective values";
+					}
+					else
+					{
+						MyTextBlock.Text = "Failed! Did not find expected HELLO and HELLO2 or they values. See HTML output...";
+					}
+				}
+			};
 		}
 
 		private void MyButton_OnClick(object sender, RoutedEventArgs e)
 		{
-			var url = "http://requestb.in/rw35narw";
-			MyTextBlock.Text = $"Inspect data at {url}?inspect";
+			var url = "https://httpbin.org/headers";
 			var request = new HttpRequestMessage(HttpMethod.Get, new Uri(url));
 			request.Headers.Add("HELLO", "TESTTEST, TEST2");
 			request.Headers.Add("HELLO2", "TEST111");


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Other... Please describe: Test update

## What is the current behavior?

The site `requestb.in` has been updated (and renamed) and now requires an account and authentication, which is not very test friendly.

The tests also required additional manual steps to confirm the results were valid.


## What is the new behavior?

Now using `httpbin.org` which works unauthenticated and also sends back the request so we can detect, in code, if the custom headers are correct.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

https://github.com/unoplatform/uno-private/issues/479

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
