### PR TITLE
fix: Align trimming with net9 options

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -329,6 +329,7 @@
 			OutputPath="$(ProjectDir)$(IntermediateOutputPath)/linkerhints"
 			ReferencePath="@(_UnoLinkerHintsPass1AssembliesForReferencePaths)"
 			ILLinkerPath="$(_UnoLinkerHintGeneratorILLinkerPath)"
+			TrimmerRootDescriptor="@(TrimmerRootDescriptor)"
 			TargetFramework="$(TargetFramework)"
 			TargetFrameworkVersion="$(TargetFrameworkVersion.Substring(1))"
 			UnoUIPackageBasePath="$(_UnoUIPackageBasePath)"

--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
@@ -148,8 +148,8 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				$"--feature UnoBindableMetadata false",
 				$"--verbose",
 				$"--deterministic",
-				// $"--used-attrs-only true", // not used to keep additional linker hints
-				$"--skip-unresolved true",
+				$"--trim-mode link",
+				$"--action link",
 				$"-b true",
 				$"-a {AssemblyPath} entrypoint",
 				$"-out {outputPath}",

--- a/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/LinkerHintsGenerator/LinkerHintGeneratorTask.cs
@@ -55,6 +55,9 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 		public string UnoRuntimeIdentifier { get; set; } = "";
 
 		[Required]
+		public Microsoft.Build.Framework.ITaskItem[] TrimmerRootDescriptor { get; set; } = [];
+
+		[Required]
 		public Microsoft.Build.Framework.ITaskItem[]? ReferencePath { get; set; }
 
 		[Output]
@@ -143,6 +146,10 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				.Distinct()
 				.Select(r => $"-reference \"{r}\" "));
 
+			var rootDescriptors = string.Join(
+				" ",
+				TrimmerRootDescriptor.Select(selector => $"-x \"{selector.GetMetadata("FullPath")}\""));
+
 			var parameters = new List<string>()
 			{
 				$"--feature UnoBindableMetadata false",
@@ -153,6 +160,7 @@ namespace Uno.UI.Tasks.LinkerHintsGenerator
 				$"-b true",
 				$"-a {AssemblyPath} entrypoint",
 				$"-out {outputPath}",
+				rootDescriptors,
 				referencedAssemblies,
 				features,
 			};


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Align linker hints generation parameters for net9, ensuring that linker descriptors are passed to the xaml trimming tooling.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
