### PR TITLE
fix: Ensure Custom NumberFormatter is applied in `NumberBox` validation

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NumberBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NumberBox.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.RuntimeTests.Helpers;
+using Windows.Globalization.NumberFormatting;
 using static Private.Infrastructure.TestServices;
 
 #if WINAPPSDK
@@ -54,5 +55,34 @@ public class Given_NumberBox
 
 		Assert.AreEqual(lightThemeForeground, (placeholderTextContentPresenter.Foreground as SolidColorBrush)?.Color);
 	}
+
+	[TestMethod]
+	public async Task NumberBox_Should_Apply_CustomFormatter()
+	{
+		var numberBox = new NumberBox();
+
+		WindowHelper.WindowContent = numberBox;
+		await WindowHelper.WaitForLoaded(numberBox);
+
+		var customFormatter = new CustomNumberFormatter();
+		numberBox.NumberFormatter = customFormatter;
+
+		numberBox.Value = 123.456;
+		var formattedText = numberBox.Text;
+
+		Assert.AreEqual("123.46 units", formattedText);
+	}
+}
+
+internal class CustomNumberFormatter : INumberFormatter2, INumberParser
+{
+	public string FormatDouble(double value) => value.ToString("0.00") + " units";
+	public double? ParseDouble(string text) => throw new NotImplementedException();
+
+	public string FormatInt(long value) => throw new NotImplementedException();
+	public string FormatUInt(ulong value) => throw new NotImplementedException();
+
+	public long? ParseInt(string text) => throw new NotImplementedException();
+	public ulong? ParseUInt(string text) => throw new NotImplementedException();
 }
 #endif

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.cs
@@ -682,15 +682,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 				{
 					// Rounding the value here will prevent displaying digits caused by floating point imprecision.
 					var roundedValue = m_displayRounder.RoundDouble(value);
-
-					if (ApiInformation.IsTypePresent(NumberFormatter.GetType().FullName))
-					{
-						newText = NumberFormatter.FormatDouble(roundedValue);
-					}
-					else
-					{
-						newText = roundedValue.ToString($"0." + new string('#', 6), CultureInfo.CurrentCulture);
-					}
+					newText = NumberFormatter.FormatDouble(roundedValue);
 				}
 
 				m_textBox.Text = newText;

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NumberBox/NumberBox.cs
@@ -534,11 +534,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 
 					var value = AcceptsExpression
 						? NumberBoxParser.Compute(text, numberParser)
-						: ApiInformation.IsTypePresent(numberParser?.GetType().FullName)
-							? numberParser.ParseDouble(text)
-							: double.TryParse(text, out var v)
-								? (double?)v
-								: null;
+						: numberParser.ParseDouble(text);
 
 					if (value == null)
 					{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/18308

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

NumberFormatter is not working on a number of platforms. The methods are not properly called. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

The behavior is brought closer to WinUI3 source, which fixes the issue. Source for reference https://github.com/microsoft/microsoft-ui-xaml/blob/f31293f4227cd3b4f7c151106528b8e1367bda11/src/controls/dev/NumberBox/NumberBox.cpp#L496

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.