### PR TITLE
Grouped `CollectionView` enumeration

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Data/Given_CollectionView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Data/Given_CollectionView.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml;
+using Windows.Foundation.Collections;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Data;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_CollectionView
+{
+	[TestMethod]
+	public void When_Grouped_With_ItemsPath()
+	{
+		var data = new List<GroupItemDto>
+		{
+			new("1", "Test 1|1", "Group 1"),
+			new("2", "Test 2|1", "Group 1"),
+			new("3", "Test 3|1", "Group 1"),
+			new("4", "Test 1|2", "Group 2"),
+			new("5", "Test 2|2", "Group 2"),
+			new("6", "Test 3|2", "Group 2"),
+			new("7", "Test 1|3", "Group 3"),
+			new("8", "Test 2|3", "Group 3"),
+			new("9", "Test 3|3", "Group 3"),
+		};
+
+		var groupedItems = from item in data
+						   group item by item.GroupName into g
+						   select new { GroupName = g.Key, Items = g.ToList() };
+
+		var cvs = new CollectionViewSource();
+		cvs.IsSourceGrouped = true;
+		cvs.ItemsPath = new PropertyPath("Items");
+		cvs.Source = groupedItems.ToList();
+
+		var type = GetItemType(cvs.View);
+		Assert.AreEqual(typeof(GroupItemDto), type);
+	}
+
+	[TestMethod]
+	public void When_Grouped_Get_Count()
+	{
+		var data = new List<GroupItemDto>
+		{
+			new("1", "Test 1|1", "Group 1"),
+			new("2", "Test 2|1", "Group 1"),
+			new("3", "Test 3|1", "Group 1"),
+			new("4", "Test 1|2", "Group 2"),
+			new("5", "Test 2|2", "Group 2"),
+			new("6", "Test 3|2", "Group 2"),
+			new("7", "Test 1|3", "Group 3"),
+			new("8", "Test 2|3", "Group 3"),
+			new("9", "Test 3|3", "Group 3"),
+		};
+
+		var groupedItems = from item in data
+						   group item by item.GroupName into g
+						   select new { GroupName = g.Key, Items = g.ToList() };
+
+		var cvs = new CollectionViewSource();
+		cvs.IsSourceGrouped = true;
+		cvs.ItemsPath = new PropertyPath("Items");
+		cvs.Source = groupedItems.ToList();
+
+		var count = GetCount(cvs.View);
+		Assert.AreEqual(9, count);
+	}
+
+	private int GetCount(ICollectionView view)
+	{
+		int num = 0;
+		IEnumerable dataSource = view;
+		if (dataSource != null)
+		{
+			IEnumerator enumerator = dataSource.GetEnumerator();
+			if (enumerator != null)
+			{
+				while (enumerator.MoveNext())
+				{
+					num++;
+				}
+			}
+		}
+		return num;
+	}
+
+	private Type GetItemType(IEnumerable list)
+	{
+		Type type = list.GetType();
+		Type type2 = null;
+		bool flag = false;
+		if (type2 == null || type2 == typeof(object) || flag)
+		{
+			Type type3 = null;
+			IEnumerator enumerator = list.GetEnumerator();
+			type3 = ((!enumerator.MoveNext() || enumerator.Current == null) ?
+				(from object x in list select x.GetType()).FirstOrDefault() : enumerator.Current.GetType());
+			if (type3 != typeof(object))
+			{
+				return type3;
+			}
+		}
+		if (flag)
+		{
+			return null;
+		}
+		return type2;
+	}
+
+	private record GroupItemDto(string Number, string Name, string GroupName);
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
@@ -311,9 +311,7 @@ namespace Uno.UI.Tests.ItemsControlTests
 
 			SUT.ItemsSource = cvs;
 
-			// This behavior is not the UWP one, this assertion
-			// is present to freeze the behavior.
-			Assert.AreEqual(0, count);
+			Assert.AreEqual(11, count);
 		}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/Data/CollectionView.cs
+++ b/src/Uno.UI/UI/Xaml/Data/CollectionView.cs
@@ -172,16 +172,6 @@ namespace Microsoft.UI.Xaml.Data
 		public event VectorChangedEventHandler<object> VectorChanged; //TODO: this should be raised if underlying source implements INotifyCollectionChanged
 #pragma warning restore 67 // Unused member
 
-		public IEnumerator<object> GetEnumerator()
-		{
-			// In Windows if CollectionView is from a CollectionViewSource marked grouped, it enumerates the flattened list of objects
-			if (_isGrouped)
-			{
-				return (_collection as IEnumerable<IEnumerable<object>> ?? Enumerable.Empty<IEnumerable<object>>()).SelectMany(g => g).GetEnumerator();
-			}
-			return (_collection as IEnumerable<object>)?.GetEnumerator();
-		}
-
 		public IAsyncOperation<LoadMoreItemsResult> LoadMoreItemsAsync(uint count)
 		{
 			throw new NotSupportedException();
@@ -260,23 +250,18 @@ namespace Microsoft.UI.Xaml.Data
 			_collection?.ToObjectArray().CopyTo(array, arrayIndex);
 		}
 
-		IEnumerator<object> IEnumerable<object>.GetEnumerator()
-		{
-			var enumerator = (this as IEnumerable).GetEnumerator();
-			while (enumerator.MoveNext())
-			{
-				yield return enumerator.Current;
-			}
-		}
+		IEnumerator<object> IEnumerable<object>.GetEnumerator() => GetEnumerator();
 
-		IEnumerator IEnumerable.GetEnumerator()
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		public IEnumerator<object> GetEnumerator()
 		{
 			// In Windows if CollectionView is from a CollectionViewSource marked grouped, it enumerates the flattened list of objects
 			if (_isGrouped)
 			{
-				return (_collection as IEnumerable<IEnumerable> ?? Enumerable.Empty<IEnumerable>()).SelectManyUntyped(g => g).GetEnumerator();
+				return CollectionGroups.OfType<ICollectionViewGroup>().SelectMany(c => c.GroupItems).GetEnumerator();
 			}
-			return (_collection as IEnumerable).GetEnumerator();
+			return (_collection as IEnumerable<object>)?.GetEnumerator();
 		}
 
 		public int IndexOf(object item) => _collection.IndexOf(item);

--- a/src/Uno.UI/UI/Xaml/Data/CollectionView.cs
+++ b/src/Uno.UI/UI/Xaml/Data/CollectionView.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Text;
 using Uno;
 using Uno.Extensions;
 using Uno.Extensions.Specialized;
@@ -250,9 +249,24 @@ namespace Microsoft.UI.Xaml.Data
 			_collection?.ToObjectArray().CopyTo(array, arrayIndex);
 		}
 
-		IEnumerator<object> IEnumerable<object>.GetEnumerator() => GetEnumerator();
+		IEnumerator<object> IEnumerable<object>.GetEnumerator()
+		{
+			var enumerator = (this as IEnumerable).GetEnumerator();
+			while (enumerator.MoveNext())
+			{
+				yield return enumerator.Current;
+			}
+		}
 
-		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			// In Windows if CollectionView is from a CollectionViewSource marked grouped, it enumerates the flattened list of objects
+			if (_isGrouped)
+			{
+				return CollectionGroups.OfType<ICollectionViewGroup>().SelectManyUntyped(c => c.GroupItems).GetEnumerator();
+			}
+			return (_collection as IEnumerable).GetEnumerator();
+		}
 
 		public IEnumerator<object> GetEnumerator()
 		{

--- a/src/Uno.UI/UI/Xaml/Data/CollectionViewSource.cs
+++ b/src/Uno.UI/UI/Xaml/Data/CollectionViewSource.cs
@@ -62,7 +62,7 @@ namespace Microsoft.UI.Xaml.Data
 			private set => SetValue(ViewProperty, value);
 		}
 
-		public global::Microsoft.UI.Xaml.PropertyPath ItemsPath
+		public PropertyPath ItemsPath
 		{
 			get => (PropertyPath)this.GetValue(ItemsPathProperty);
 			set => this.SetValue(ItemsPathProperty, value);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Grouped collection view does not enumerate correctly in some scenarios

## What is the new behavior?

Enumeration works

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
