### PR TITLE
fix: Restore publish menu for some scenarios

### DIFF
--- a/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
+++ b/src/Uno.Sdk/targets/Uno.ProjectCapabilities.targets
@@ -32,9 +32,16 @@
 		<ProjectCapability Include="WindowsUniversalMultiViews"/>
 	</ItemGroup>
 
-	<ItemGroup>
-		<!-- Required since VS 2022 17.4 Preview 1 -->
-		<!-- Moved to root capabilities as Visual Studio doesn't like it in the SingleProject specific capabilities -->
+	<ItemGroup Condition=" '$(TargetFrameworks)' != '' AND ( $(TargetFrameworks.Contains('-ios')) OR $(TargetFrameworks.Contains('-android')) OR $(TargetFrameworks.Contains('-catalyst')) )">
+		<!-- 
+		Required since VS 2022 17.4 Preview 1
+		Moved to root capabilities as Visual Studio doesn't like it in the SingleProject specific 
+		capabilities, in order to have project properties panel to work properly.
+
+		This block is conditional to having iOS/Android/Catalyst as targets, in order to work around 
+		the "publish" context menu being disabled when those caps are set.
+		https://github.com/unoplatform/uno/issues/18577
+		-->
 		<ProjectCapability Include="MauiCore" Exclude="@(ProjectCapability)" />
 		<ProjectCapability Include="Maui" Exclude="@(ProjectCapability)" />
 		<ProjectCapability Include="UseMauiCore" Exclude="@(ProjectCapability)" />


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno/issues/18577

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Restores the publish under when ios/android/catalyst are not present. If present, the VS issue is still active.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
