### PR TITLE
Settings app opening on top - Change to ProcessID

### DIFF
--- a/src/Uno.UI.RemoteControl.Messaging/IDEChannel/CommandRequestIdeMessage.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IDEChannel/CommandRequestIdeMessage.cs
@@ -6,10 +6,10 @@ namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
 /// <summary>
 /// A message sent by the IDE to the dev-server when a command is issued (like a menuitem invoked).
 /// </summary>
-/// <param name="WindowId">Id of the window that send the command (so handler can display some UI over it).</param>
+/// <param name="processId">Id of the process that send the command (so handler can display some UI over it).</param>
 /// <param name="Command">The name/id of the command (e.g. uno.hotreload.open_hotreload_window).</param>
 /// <param name="CommandParameter">A json serialized parameter to execute the command.</param>
-public record CommandRequestIdeMessage(long WindowId, string Command, string? CommandParameter = null) : IdeMessage(WellKnownScopes.Ide)
+public record CommandRequestIdeMessage(long processId, string Command, string? CommandParameter = null) : IdeMessage(WellKnownScopes.Ide)
 {
 	/// <summary>
 	/// A unique identifier of this command execution request that could be used to track the response (if any produced by the remote handler).

--- a/src/Uno.UI.RemoteControl.VS/Commands/UnoMenuCommand.cs
+++ b/src/Uno.UI.RemoteControl.VS/Commands/UnoMenuCommand.cs
@@ -96,7 +96,7 @@ internal sealed class UnoMenuCommand
 		{
 			var cmdMessage =
 				new CommandRequestIdeMessage(
-					System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle.ToInt64(),
+					System.Diagnostics.Process.GetCurrentProcess().Id,
 					cmd.Name,
 					cmd.Parameter);
 

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -527,7 +527,7 @@ public partial class EntryPoint : IDisposable
 					{
 						var cmd =
 							new CommandRequestIdeMessage(
-								System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle.ToInt64(),
+								System.Diagnostics.Process.GetCurrentProcess().Id,
 								command,
 								action.ActionContext?.ToString());
 						await _ideChannelClient.SendToDevServerAsync(cmd, _ct.Token);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

Related to [PR](https://github.com/unoplatform/uno.licensing/pull/163/files) 

Before, this is a extra change. 
https://github.com/unoplatform/uno/pull/18592

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

We are passing the MainWindowHandle as int64

## What is the new behavior?

Now we are passing the ProcessID

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
