### PR TITLE
fix: Closing `ContentDialog` after event cancellation

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -536,7 +536,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitFor(() => (button = (Button)VisualTreeUtils.FindVisualChildByName(contentDialog, buttonName)) != null);
 
 			await WindowHelper.WaitForLoaded(button);
-			(button.GetAutomationPeer() as ButtonAutomationPeer).Invoke();
+			(FrameworkElementAutomationPeer.CreatePeerForElement(button) as ButtonAutomationPeer).Invoke();
 
 			await WindowHelper.WaitFor(() => closed);
 
@@ -580,7 +580,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitFor(() => (button = (Button)VisualTreeUtils.FindVisualChildByName(contentDialog, buttonName)) != null);
 
 			await WindowHelper.WaitForLoaded(button);
-			(button.GetAutomationPeer() as ButtonAutomationPeer).Invoke();
+			(FrameworkElementAutomationPeer.CreatePeerForElement(button) as ButtonAutomationPeer).Invoke();
 
 			await WindowHelper.WaitFor(() => closed);
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -18,6 +18,8 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Tests.Enterprise;
 using static Private.Infrastructure.TestServices;
 using Windows.UI.Input.Preview.Injection;
+using Microsoft.UI.Xaml.Automation.Peers;
+using MUXControlsTestApp.Utilities;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -478,6 +480,113 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 					SUT.Hide();
 				}
 			}
+		}
+
+		[TestMethod]
+		[DataRow(ContentDialogButton.Primary)]
+		[DataRow(ContentDialogButton.Secondary)]
+		[DataRow(ContentDialogButton.Close)]
+		public async Task When_Hide_In_Click(ContentDialogButton buttonType)
+		{
+			var contentDialog = new ContentDialog
+			{
+				Content = "Test",
+				PrimaryButtonText = "Primary",
+				SecondaryButtonText = "Secondary",
+				CloseButtonText = "Close",
+				XamlRoot = WindowHelper.XamlRoot,
+			};
+
+			static void OnButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs e)
+			{
+				e.Cancel = true;
+				sender.Hide();
+			};
+
+			switch (buttonType)
+			{
+				case ContentDialogButton.Primary:
+					contentDialog.PrimaryButtonClick += OnButtonClick;
+					break;
+				case ContentDialogButton.Secondary:
+					contentDialog.SecondaryButtonClick += OnButtonClick;
+					break;
+				case ContentDialogButton.Close:
+					contentDialog.CloseButtonClick += OnButtonClick;
+					break;
+			}
+
+			int closingCount = 0;
+			var closed = false;
+			contentDialog.Closed += (s, e) => closed = true;
+			contentDialog.Closing += (s, e) => closingCount++;
+
+			var dialogTask = contentDialog.ShowAsync();
+
+			Button button = null;
+
+			var buttonName = buttonType switch
+			{
+				ContentDialogButton.Primary => "PrimaryButton",
+				ContentDialogButton.Secondary => "SecondaryButton",
+				ContentDialogButton.Close => "CloseButton",
+				_ => throw new NotSupportedException()
+			};
+
+			await WindowHelper.WaitFor(() => (button = (Button)VisualTreeUtils.FindVisualChildByName(contentDialog, buttonName)) != null);
+
+			await WindowHelper.WaitForLoaded(button);
+			(button.GetAutomationPeer() as ButtonAutomationPeer).Invoke();
+
+			await WindowHelper.WaitFor(() => closed);
+
+			await dialogTask;
+
+			Assert.AreEqual(1, closingCount);
+		}
+
+		[TestMethod]
+		[DataRow(ContentDialogButton.Primary)]
+		[DataRow(ContentDialogButton.Secondary)]
+		[DataRow(ContentDialogButton.Close)]
+		public async Task When_Button_Click(ContentDialogButton buttonType)
+		{
+			var contentDialog = new ContentDialog
+			{
+				Content = "Test",
+				PrimaryButtonText = "Primary",
+				SecondaryButtonText = "Secondary",
+				CloseButtonText = "Close",
+				XamlRoot = WindowHelper.XamlRoot,
+			};
+
+			int closingCount = 0;
+			var closed = false;
+			contentDialog.Closed += (s, e) => closed = true;
+			contentDialog.Closing += (s, e) => closingCount++;
+
+			var dialogTask = contentDialog.ShowAsync();
+
+			Button button = null;
+
+			var buttonName = buttonType switch
+			{
+				ContentDialogButton.Primary => "PrimaryButton",
+				ContentDialogButton.Secondary => "SecondaryButton",
+				ContentDialogButton.Close => "CloseButton",
+				_ => throw new NotSupportedException()
+			};
+
+			await WindowHelper.WaitFor(() => (button = (Button)VisualTreeUtils.FindVisualChildByName(contentDialog, buttonName)) != null);
+
+			await WindowHelper.WaitForLoaded(button);
+			(button.GetAutomationPeer() as ButtonAutomationPeer).Invoke();
+
+			await WindowHelper.WaitFor(() => closed);
+
+			await dialogTask;
+
+			Assert.AreEqual(1, closingCount);
 		}
 
 #if HAS_UNO

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.cs
@@ -195,12 +195,12 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				return;
 			}
-			_hiding = true;
 			Hide(ContentDialogResult.None);
 		}
 
 		internal bool Hide(ContentDialogResult result)
 		{
+			_hiding = true;
 			void Complete(ContentDialogClosingEventArgs args)
 			{
 				if (!args.Cancel)
@@ -476,7 +476,6 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				return;
 			}
-			_hiding = true;
 
 			var args = new ContentDialogButtonClickEventArgs(Complete);
 			CloseButtonClick?.Invoke(this, args);
@@ -507,7 +506,6 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				return;
 			}
-			_hiding = true;
 
 			var args = new ContentDialogButtonClickEventArgs(Complete);
 			SecondaryButtonClick?.Invoke(this, args);
@@ -540,7 +538,6 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				return;
 			}
-			_hiding = true;
 
 			var args = new ContentDialogButtonClickEventArgs(Complete);
 			PrimaryButtonClick?.Invoke(this, args);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #18609

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Cancelling the click handler prevents `Hide()`

## What is the new behavior?

After cancelling click handler, it is possible to still `Hide()`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.