### PR TITLE
fix(macos): Bring window to top when activated

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
@@ -37,6 +37,18 @@ internal class MacOSWindowWrapper : NativeWindowWrapperBase
 		set => NativeUno.uno_window_set_title(_window.Handle, value);
 	}
 
+	public override void Activate()
+	{
+		NativeUno.uno_window_activate(_window.Handle);
+	}
+
+	protected override void ShowCore()
+	{
+		// the first call to `Window.Activate` does not reach the above `Activate` method
+		// https://github.com/unoplatform/uno/blob/fc8e58d77f8cf31d651135c22ea3105099c26fb7/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs#L81-L98
+		NativeUno.uno_window_activate(_window.Handle);
+	}
+
 	private void OnHostSizeChanged(Size size)
 	{
 		Bounds = new Rect(default, size);

--- a/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
@@ -202,6 +202,9 @@ internal static partial class NativeUno
 	internal static partial nint uno_window_create(double width, double height);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_activate(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial void uno_window_invalidate(nint window);
 
 	[LibraryImport("libUnoNativeMac.dylib", StringMarshalling = StringMarshalling.Utf8)]

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -40,6 +40,7 @@ void uno_set_resize_callback(resize_fn_ptr p);
 NSWindow* uno_app_get_main_window(void);
 
 NSWindow* uno_window_create(double width, double height);
+void uno_window_activate(NSWindow *window);
 void uno_window_invalidate(NSWindow *window);
 bool uno_window_resize(NSWindow *window, double width, double height);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -126,6 +126,14 @@ NSWindow* uno_window_create(double width, double height)
     return window;
 }
 
+void uno_window_activate(NSWindow *window)
+{
+#if DEBUG
+    NSLog(@"uno_window_activate %@", window);
+#endif
+    [window orderFront:nil];
+}
+
 void uno_window_notify_screen_change(NSWindow *window)
 {
     assert(windowDidChangeScreen);


### PR DESCRIPTION
GitHub Issue (If applicable):

Partial (macOS) fix for https://github.com/unoplatform/uno/issues/18620

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Calling `Window.Activate` does not bring the window on top of other windows in the desktop.

## What is the new behavior?

Calling `Window.Activate` brings the window to the top.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
