### PR TITLE
feat(macOS): Add AppWindow positioning and sizing support

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml;
 using Uno.Disposables;
 using Uno.UI.Xaml.Controls;
 using Windows.Foundation;
+using Windows.Graphics;
 using Windows.UI.Core.Preview;
 
 namespace Uno.UI.Runtime.Skia.MacOS;
@@ -20,6 +21,10 @@ internal class MacOSWindowWrapper : NativeWindowWrapperBase
 		nativeWindow.Host.RasterizationScaleChanged += Host_RasterizationScaleChanged;
 		nativeWindow.Host.SizeChanged += (_, s) => OnHostSizeChanged(s);
 		OnHostSizeChanged(initialSize);
+		nativeWindow.Host.PositionChanged += (_, s) => OnHostPositionChanged(s.X, s.Y);
+		// the initial event occurred before the managed side was ready to handle it
+		NativeUno.uno_window_get_position(nativeWindow.Handle, out var x, out var y);
+		OnHostPositionChanged(x, y);
 
 		RasterizationScale = (float)_window.Host.RasterizationScale;
 	}
@@ -49,10 +54,44 @@ internal class MacOSWindowWrapper : NativeWindowWrapperBase
 		NativeUno.uno_window_activate(_window.Handle);
 	}
 
+	public override void Close()
+	{
+		NativeUno.uno_window_close(_window.Handle);
+	}
+
+	public override void Move(PointInt32 position)
+	{
+		// user input in physical pixels transformed into logical pixels
+		var x = position.X / RasterizationScale;
+		var y = position.Y / RasterizationScale;
+		NativeUno.uno_window_move(_window.Handle, x, y);
+	}
+
+	public override void Resize(SizeInt32 size)
+	{
+		// user input in physical pixels transformed into logical pixels
+		var w = size.Width / RasterizationScale;
+		var h = size.Height / RasterizationScale;
+		NativeUno.uno_window_resize(_window.Handle, w, h);
+	}
+
+	private void OnHostPositionChanged(double x, double y)
+	{
+		// in physical pixels
+		var sx = (int)(x * RasterizationScale);
+		var sy = (int)(y * RasterizationScale);
+		Position = new PointInt32(sx, sy);
+	}
+
 	private void OnHostSizeChanged(Size size)
 	{
+		// in logical pixels
 		Bounds = new Rect(default, size);
 		VisibleBounds = Bounds;
+		// in physical pixels
+		int w = (int)(size.Width * RasterizationScale);
+		int h = (int)(size.Height * RasterizationScale);
+		Size = new SizeInt32(w, h);
 	}
 
 	private void OnWindowClosing(object? sender, CancelEventArgs e)

--- a/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
@@ -187,7 +187,9 @@ internal static partial class NativeUno
 	internal static unsafe partial void uno_set_window_events_callbacks(
 		delegate* unmanaged[Cdecl]<nint, VirtualKey, VirtualKeyModifiers, uint, ushort, int> keyDownCallback,
 		delegate* unmanaged[Cdecl]<nint, VirtualKey, VirtualKeyModifiers, uint, ushort, int> keyUpCallback,
-		delegate* unmanaged[Cdecl]<nint, NativeMouseEventData*, int> pointerCallback);
+		delegate* unmanaged[Cdecl]<nint, NativeMouseEventData*, int> pointerCallback,
+		delegate* unmanaged[Cdecl]<nint, double, double, void> moveCallback,
+		delegate* unmanaged[Cdecl]<nint, double, double, void> resizeCallback);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial uint uno_get_system_theme();
@@ -206,6 +208,12 @@ internal static partial class NativeUno
 
 	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial void uno_window_invalidate(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_close(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_get_position(nint window, out double x, out double y);
 
 	[LibraryImport("libUnoNativeMac.dylib", StringMarshalling = StringMarshalling.Utf8)]
 	internal static partial string uno_window_get_title(nint window);
@@ -258,6 +266,9 @@ internal static partial class NativeUno
 
 	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static partial nint uno_window_get_metal_context(nint window);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static partial void uno_window_move(nint window, double x, double y);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
 	[return: MarshalAs(UnmanagedType.I1)]

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -9,9 +9,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (*resize_fn_ptr)(void* /* window */, double /* width */, double /* height */);
-resize_fn_ptr uno_get_resize_callback(void);
-void uno_set_resize_callback(resize_fn_ptr p);
+typedef void (*uno_drawable_resize_fn_ptr)(void* /* window */, double /* width */, double /* height */);
+uno_drawable_resize_fn_ptr uno_get_resize_callback(void);
+void uno_set_resize_callback(uno_drawable_resize_fn_ptr p);
+
+typedef void (*window_move_or_resize_fn_ptr)(NSWindow* /* window */, double /* x or width */, double /* y or height */);
+window_move_or_resize_fn_ptr uno_get_window_move_callback(void);
+window_move_or_resize_fn_ptr uno_get_window_resize_callback(void);
 
 @interface windowDidChangeScreenNoteClass : NSObject
 
@@ -32,6 +36,7 @@ void uno_set_resize_callback(resize_fn_ptr p);
 - (void)sendEvent:(NSEvent *)event;
 
 - (BOOL)windowShouldZoom:(NSWindow *)window toFrame:(NSRect)newFrame;
+- (void)windowDidMove:(NSNotification *)notification;
 - (bool)windowShouldClose:(NSWindow *)sender;
 - (void)windowWillClose:(NSNotification *)notification;
 
@@ -42,8 +47,11 @@ NSWindow* uno_app_get_main_window(void);
 NSWindow* uno_window_create(double width, double height);
 void uno_window_activate(NSWindow *window);
 void uno_window_invalidate(NSWindow *window);
+void uno_window_close(NSWindow *window);
+void uno_window_move(NSWindow *window, double x, double y);
 bool uno_window_resize(NSWindow *window, double width, double height);
 
+void uno_window_get_position(NSWindow *window, double *x, double *y);
 char* uno_window_get_title(NSWindow *window);
 void uno_window_set_title(NSWindow *window, const char* title);
 
@@ -296,7 +304,7 @@ struct MouseEventData {
 
 typedef int32_t (*window_key_callback_fn_ptr)(UNOWindow* window, VirtualKey key, VirtualKeyModifiers mods, uint32 scanCode, UniChar unicode);
 typedef int32_t (*window_mouse_callback_fn_ptr)(UNOWindow* window, struct MouseEventData *data);
-void uno_set_window_events_callbacks(window_key_callback_fn_ptr keyDown, window_key_callback_fn_ptr keyUp, window_mouse_callback_fn_ptr pointer);
+void uno_set_window_events_callbacks(window_key_callback_fn_ptr keyDown, window_key_callback_fn_ptr keyUp, window_mouse_callback_fn_ptr pointer, window_move_or_resize_fn_ptr move, window_move_or_resize_fn_ptr resize);
 
 typedef bool (*window_should_close_fn_ptr)(UNOWindow* window);
 window_should_close_fn_ptr uno_get_window_should_close_callback(void);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -16,11 +16,11 @@ static window_did_change_screen_parameters_fn_ptr window_did_change_screen_param
 // libSkiaSharp
 extern void* gr_direct_context_make_metal(id device, id queue);
 
-static resize_fn_ptr window_resize;
+static uno_drawable_resize_fn_ptr window_resize;
 static metal_draw_fn_ptr metal_draw;
 static soft_draw_fn_ptr soft_draw;
 
-inline resize_fn_ptr uno_get_resize_callback(void)
+inline uno_drawable_resize_fn_ptr uno_get_resize_callback(void)
 {
     return window_resize;
 }
@@ -35,7 +35,7 @@ inline soft_draw_fn_ptr uno_get_soft_draw_callback(void)
     return soft_draw;
 }
 
-void uno_set_drawing_callbacks(metal_draw_fn_ptr metal, soft_draw_fn_ptr soft, resize_fn_ptr resize)
+void uno_set_drawing_callbacks(metal_draw_fn_ptr metal, soft_draw_fn_ptr soft, uno_drawable_resize_fn_ptr resize)
 {
     metal_draw = metal;
     soft_draw = soft;
@@ -150,6 +150,22 @@ void uno_window_invalidate(NSWindow *window)
     window.contentViewController.view.needsDisplay = true;
 }
 
+void uno_window_close(NSWindow *window)
+{
+#if DEBUG
+    NSLog(@"uno_window_close %@", window);
+#endif
+    [window performClose:nil];
+}
+
+void uno_window_move(NSWindow *window, double x, double y)
+{
+#if DEBUG
+    NSLog(@"uno_window_move %@ x: %g y: %g", window, x, y);
+#endif
+    [window setFrameOrigin:NSMakePoint(x, y)];
+}
+
 bool uno_window_resize(NSWindow *window, double width, double height)
 {
 #if DEBUG
@@ -171,6 +187,16 @@ void uno_window_set_min_size(NSWindow *window, double width, double height)
     NSLog (@"uno_window_set_min_size %@ %f %f", window, width, height);
 #endif
     window.minSize = CGSizeMake(width, height);
+}
+
+void uno_window_get_position(NSWindow *window, double *x, double *y)
+{
+    CGPoint origin = window.frame.origin;
+#if DEBUG
+    NSLog (@"uno_window_get_position %@ %f %f", window, origin.x, origin.y);
+#endif
+    *x = origin.x;
+    *y = origin.y;
 }
 
 char* uno_window_get_title(NSWindow *window)
@@ -560,11 +586,27 @@ inline static window_mouse_callback_fn_ptr uno_get_window_mouse_event_callback(v
     return window_mouse_event;
 }
 
-void uno_set_window_events_callbacks(window_key_callback_fn_ptr keyDown, window_key_callback_fn_ptr keyUp, window_mouse_callback_fn_ptr pointer)
+static window_move_or_resize_fn_ptr window_move_event;
+
+inline static window_move_or_resize_fn_ptr uno_get_window_move_event_callback(void)
+{
+    return window_move_event;
+}
+
+static window_move_or_resize_fn_ptr window_resize_event;
+
+inline static window_move_or_resize_fn_ptr uno_get_window_resize_event_callback(void)
+{
+    return window_resize_event;
+}
+
+void uno_set_window_events_callbacks(window_key_callback_fn_ptr keyDown, window_key_callback_fn_ptr keyUp, window_mouse_callback_fn_ptr pointer, window_move_or_resize_fn_ptr move, window_move_or_resize_fn_ptr resize)
 {
     window_key_down = keyDown;
     window_key_up = keyUp;
     window_mouse_event = pointer;
+    window_move_event = move;
+    window_resize_event = resize;
 }
 
 static window_should_close_fn_ptr window_should_close;
@@ -772,6 +814,22 @@ void* uno_window_get_metal_context(UNOWindow* window)
 - (BOOL)windowShouldZoom:(NSWindow *)window toFrame:(NSRect)newFrame {
     // if we disable the (green) maximize button then we don't allow zooming
     return window.collectionBehavior != (NSWindowCollectionBehaviorFullScreenAuxiliary|NSWindowCollectionBehaviorFullScreenNone|NSWindowCollectionBehaviorFullScreenDisallowsTiling);
+}
+
+- (void)windowDidMove:(NSNotification *)notification {
+    CGPoint position = self.frame.origin;
+#if DEBUG
+    NSLog(@"UNOWindow %p windowDidMove %@ x: %g y: %g", self, notification, position.x, position.y);
+#endif
+    uno_get_window_move_event_callback()(self, position.x, position.y);
+}
+
+- (void)windowDidResize:(NSNotification *)notification {
+    CGSize size = self.frame.size;
+#if DEBUG
+    NSLog(@"UNOWindow %p windowDidMove %@ x: %g y: %g", self, notification, size.width, size.height);
+#endif
+    uno_get_window_resize_event_callback()(self, size.width, size.height);
 }
 
 - (bool)windowShouldClose:(NSWindow *)sender

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
@@ -151,7 +151,8 @@ public class Given_AppWindow
 	private void AssertPositioningAndSizingSupport()
 	{
 		if (!OperatingSystem.IsLinux() &&
-			!OperatingSystem.IsWindows() ||
+			!OperatingSystem.IsWindows() &&
+			!OperatingSystem.IsMacOS() ||
 			TestServices.WindowHelper.IsXamlIsland ||
 			IsGtk())
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #18638

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`netXX-desktop` does not support AppWindow positioning and sizing for macOS

## What is the new behavior?

`netXX-desktop` now support AppWindow positioning and sizing on macOS

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

New user API are using physical, not logical, pixels as mentioned in https://github.com/unoplatform/uno/issues/18638
