### PR TITLE
fix: `AppWindow` on non-Skia targets should use physical units

### DIFF
--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.Android.cs
@@ -76,7 +76,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase
 
 		Bounds = new Rect(default, windowSize);
 		VisibleBounds = visibleBounds;
-		Size = windowSize.ToSizeInt32();
+		Size = new((int)(windowSize.Width * RasterizationScale), (int)(windowSize.Height * RasterizationScale));
 
 		if (_previousTrueVisibleBounds != trueVisibleBounds)
 		{

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.iOS.cs
@@ -68,7 +68,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase
 		var newWindowSize = GetWindowSize();
 
 		Bounds = new Rect(default, newWindowSize);
-		Size = newWindowSize.ToSizeInt32();
+		Size = new((int)(newWindowSize.Width * RasterizationScale), (int)(newWindowSize.Height * RasterizationScale));
 
 		SetVisibleBounds(_nativeWindow, newWindowSize);
 	}

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.unittests.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.unittests.cs
@@ -30,6 +30,6 @@ internal partial class NativeWindowWrapper : NativeWindowWrapperBase
 
 		Bounds = bounds;
 		VisibleBounds = bounds;
-		Size = bounds.Size.ToSizeInt32();
+		Size = new((int)(bounds.Width * RasterizationScale), (int)(bounds.Height * RasterizationScale));
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.wasm.cs
@@ -47,7 +47,7 @@ internal partial class NativeWindowWrapper : NativeWindowWrapperBase
 
 		Bounds = bounds;
 		VisibleBounds = bounds;
-		Size = bounds.Size.ToSizeInt32();
+		Size = new((int)(bounds.Width * RasterizationScale), (int)(bounds.Height * RasterizationScale));
 	}
 
 	protected override void ShowCore()


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
- 
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
