### PR TITLE
fix: Don't include non-existing pwa manifest

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -67,7 +67,7 @@
 	},
 	{
 	  "group": "Resizetizer",
-	  "version": "1.6.0-dev.31",
+	  "version": "1.7.0-dev.2",
 	  "packages": [
 		"Uno.Resizetizer"
 	  ]

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Wasm.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Wasm.targets
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<UnoIsWebAssemblyBrowserHead>true</UnoIsWebAssemblyBrowserHead>
-		<WasmPWAManifestFile Condition="$(WasmPWAManifestFile) == ''">$(WasmProjectFolder)manifest.webmanifest</WasmPWAManifestFile>
+		<WasmPWAManifestFile Condition="$(WasmPWAManifestFile) == '' AND exists('$(WasmProjectFolder)manifest.webmanifest')">$(WasmProjectFolder)manifest.webmanifest</WasmPWAManifestFile>
 		<!--
 			Supports Deep Linking Routes
 			https://aka.platform.uno/wasm-deeplink


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Fixes the ability to disable the PWA manifest

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
