### PR TITLE
docs(dialogs): Fixed Link in dialogs.md documenation: Link to HowTo-ShowDialog was broken

### DIFF
--- a/doc/articles/features/dialogs.md
+++ b/doc/articles/features/dialogs.md
@@ -120,7 +120,7 @@ new Button()
 
 ---
 
-If you are using Uno.Extensions Navigation, you can utilize its features to display a dialog. For more information, check out this documentation: [Dialogs with Uno.Extensions Navigation](xref:Uno.Extensions.Navigation.HowTo-ShowDialog).
+If you are using Uno.Extensions Navigation, you can utilize its features to display a dialog. For more information, check out this documentation: [Dialogs with Uno.Extensions.Navigation](https://platform.uno/docs/articles/external/uno.extensions/doc/Learn/Navigation/HowTo-ShowDialog.html).
 
 Considering adding a dialog to your app? Check out our comprehensive video for detailed guidance on the implementation:
 

--- a/doc/articles/features/dialogs.md
+++ b/doc/articles/features/dialogs.md
@@ -120,7 +120,7 @@ new Button()
 
 ---
 
-If you are using Uno.Extensions Navigation, you can utilize its features to display a dialog. For more information, check out this documentation: [Dialogs with Uno.Extensions.Navigation](https://platform.uno/docs/articles/external/uno.extensions/doc/Learn/Navigation/HowTo-ShowDialog.html).
+If you are using Uno.Extensions Navigation, you can utilize its features to display a dialog. For more information, check out this documentation: [Dialogs with Uno.Extensions.Navigation](xref:Uno.Extensions.Navigation.HowToShowDialog).
 
 Considering adding a dialog to your app? Check out our comprehensive video for detailed guidance on the implementation:
 


### PR DESCRIPTION
updated the link-address to be now working as expected

GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type
What kind of change does this PR introduce?
- Documentation content changes
- Bugfix
What kind of change does this PR introduce?

## What is the current behavior?
Link directs to no where, not useable

## What is the new behavior?

fixed the Link-Address to the official wiki to HowTo-ShowDialog on plattform.uno, checked functionallity, works on my side

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ x ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ x ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
Marked as no breaking changes, since its "just" a broken Link that didn't worked
TODO:
Add actual c#-markup How To to that article since its actually only including xaml markup support for that

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
Generated no issue before because it was a quick fix of a Link