### PR TITLE
fix(textblock): Use the correct Command+C|A for copy/select all on macOS/skia

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -27,6 +27,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private Action? _selectionHighlightColorChanged;
 		private MenuFlyout? _contextMenu;
 		private readonly Dictionary<ContextMenuItem, MenuFlyoutItem> _flyoutItems = new();
+		private readonly VirtualKeyModifiers _platformCtrlKey = OperatingSystem.IsMacOS() ? VirtualKeyModifiers.Windows : VirtualKeyModifiers.Control;
 
 		public TextBlock()
 		{
@@ -204,11 +205,11 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			switch (args.Key)
 			{
-				case VirtualKey.C when args.KeyboardModifiers.HasFlag(VirtualKeyModifiers.Control):
+				case VirtualKey.C when args.KeyboardModifiers.HasFlag(_platformCtrlKey):
 					CopySelectionToClipboard();
 					args.Handled = true;
 					break;
-				case VirtualKey.A when args.KeyboardModifiers.HasFlag(VirtualKeyModifiers.Control):
+				case VirtualKey.A when args.KeyboardModifiers.HasFlag(_platformCtrlKey):
 					SelectAll();
 					args.Handled = true;
 					break;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`Copy` and `Select All` requires the use of `Control`, instead of `Command`, on `TextBlock`s

Using the _expected_ `Command` will simply have the Mac beep.

## What is the new behavior?

`Copy` and `Select All` now use `Command` on `TextBlock`s.

This match what the `TextBox` is already doing on macOS/skia.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
