### PR TITLE
fix(droid): TabView header not showing

### DIFF
--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/TabView.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/TabView.xaml
@@ -703,9 +703,9 @@
 
                             <!-- Uno workaround: On Android, the Height of ContentPresenters inside this Grid is not bing calculated correctly -->
                             <!-- It can be removed once this PR is merged: https://github.com/unoplatform/uno/pull/18261 -->
-                            <Grid.RowDefinitions>
+                            <android:Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
+                            </android:Grid.RowDefinitions>
 
                             <Viewbox x:Name="IconBox"
                                     MaxWidth="{ThemeResource TabViewItemHeaderIconSize}"

--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/TabView.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/TabView.xaml
@@ -701,7 +701,8 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
-                            <!-- Uno workaround: On Android, the ContentPresenters inside this are not calculating correctly -->
+                            <!-- Uno workaround: On Android, the Height of ContentPresenters inside this Grid is not bing calculated correctly -->
+                            <!-- It can be removed once this PR is merged: https://github.com/unoplatform/uno/pull/18261 -->
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>

--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/TabView.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/TabView.xaml
@@ -701,6 +701,11 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
+                            <!-- Uno workaround: On Android, the ContentPresenters inside this are not calculating correctly -->
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
                             <Viewbox x:Name="IconBox"
                                     MaxWidth="{ThemeResource TabViewItemHeaderIconSize}"
                                     MaxHeight="{ThemeResource TabViewItemHeaderIconSize}"

--- a/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
+++ b/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
@@ -22960,10 +22960,11 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
-              <!-- Uno workaround: On Android, the ContentPresenters inside this are not calculating correctly -->
-              <Grid.RowDefinitions>
+              <!-- Uno workaround: On Android, the Height of ContentPresenters inside this Grid is not bing calculated correctly -->
+              <!-- It can be removed once this PR is merged: https://github.com/unoplatform/uno/pull/18261 -->
+              <android:Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-              </Grid.RowDefinitions>
+              </android:Grid.RowDefinitions>
               <Viewbox x:Name="IconBox" MaxWidth="{ThemeResource TabViewItemHeaderIconSize}" MaxHeight="{ThemeResource TabViewItemHeaderIconSize}" Margin="{ThemeResource TabViewItemHeaderIconMargin}">
                 <ContentControl x:Name="IconControl" Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.IconElement}" IsTabStop="False" Foreground="{ThemeResource TabViewItemIconForeground}" HighContrastAdjustment="None" />
               </Viewbox>

--- a/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
+++ b/src/Uno.UI.FluentTheme.v2/themeresources_v2.xaml
@@ -22960,6 +22960,10 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
               </Grid.ColumnDefinitions>
+              <!-- Uno workaround: On Android, the ContentPresenters inside this are not calculating correctly -->
+              <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+              </Grid.RowDefinitions>
               <Viewbox x:Name="IconBox" MaxWidth="{ThemeResource TabViewItemHeaderIconSize}" MaxHeight="{ThemeResource TabViewItemHeaderIconSize}" Margin="{ThemeResource TabViewItemHeaderIconMargin}">
                 <ContentControl x:Name="IconControl" Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TabViewTemplateSettings.IconElement}" IsTabStop="False" Foreground="{ThemeResource TabViewItemIconForeground}" HighContrastAdjustment="None" />
               </Viewbox>

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
@@ -19,6 +19,8 @@ using static Private.Infrastructure.TestServices;
 
 #if __IOS__
 using UIKit;
+#elif __MACOS__
+using AppKit;
 #endif
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
@@ -182,8 +184,8 @@ public class Given_TabView
 		var closeButton1 = (Button)tabviewItem1.GetTemplateChild("CloseButton");
 
 		var buttonLabel1 =
-#if __IOS__
-        closeButton1.FindFirstChild<ImplicitTextBlock>();
+#if __IOS__ || __MACOS__
+		closeButton1.FindFirstChild<ImplicitTextBlock>();
 #else
 		((ContentPresenter)closeButton1.GetTemplateChild("ContentPresenter")).FindFirstChild<ImplicitTextBlock>();
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
@@ -155,6 +155,7 @@ public class Given_TabView
 		Assert.AreEqual(0, SUT.SelectedIndex);
 	}
 
+#if !WINAPPSDK // GetTemplateChild is protected in UWP while public in Uno.
 	[TestMethod]
 	public async Task When_Items_Should_ShowHeader()
 	{
@@ -170,21 +171,22 @@ public class Given_TabView
 		await UITestHelper.Load(SUT);
 
 		var tabviewItem1 = SUT.ContainerFromIndex(0) as TabViewItem;
-		var headerPresenter1 = tabviewItem1.GetTemplateChild<ContentPresenter>("ContentPresenter");
+		var headerPresenter1 = (ContentPresenter)tabviewItem1.GetTemplateChild("ContentPresenter");
 		Assert.IsTrue(headerPresenter1.ActualWidth > 0, "TabViewItem header for index  0 should have a non-zero width.");
 		Assert.IsTrue(headerPresenter1.ActualHeight > 0, "TabViewItem header for index  0 should have a non-zero height.");
 
-		var closeButton1 = tabviewItem1.GetTemplateChild<Button>("CloseButton");
-		var buttonLabel1 = closeButton1.GetTemplateChild<ContentPresenter>("ContentPresenter").FindFirstChild<ImplicitTextBlock>();
+		var closeButton1 = (Button)tabviewItem1.GetTemplateChild("CloseButton");
+		var buttonLabel1 = ((ContentPresenter)closeButton1.GetTemplateChild("ContentPresenter")).FindFirstChild<ImplicitTextBlock>();
 
 		Assert.IsTrue(buttonLabel1.ActualWidth > 0, "TabViewItem Button for index 0 should have a non-zero width.");
 		Assert.IsTrue(buttonLabel1.ActualHeight > 0, "TabViewItem Button  for index 0 should have a non-zero height.");
 
 		var tabviewItem2 = SUT.ContainerFromIndex(1) as TabViewItem;
-		var headerPresenter2 = tabviewItem2.GetTemplateChild<ContentPresenter>("ContentPresenter");
+		var headerPresenter2 = (ContentPresenter)tabviewItem2.GetTemplateChild("ContentPresenter");
 		Assert.IsTrue(headerPresenter2.ActualWidth > 0, "TabViewItem header for index  1  should have a non-zero width.");
 		Assert.IsTrue(headerPresenter2.ActualHeight > 0, "TabViewItem header for index  1  should have a non-zero height.");
 	}
+#endif
 
 	[TestMethod]
 	public async Task When_SelectedItem_Changed_Binding()

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
@@ -156,6 +156,37 @@ public class Given_TabView
 	}
 
 	[TestMethod]
+	public async Task When_Items_Should_ShowHeader()
+	{
+		var SUT = new TabView
+		{
+			TabItems =
+			{
+				new TabViewItem { Header = "Tab 1" },
+				new TabViewItem { Header = "Tab 2" }
+			}
+		};
+
+		await UITestHelper.Load(SUT);
+
+		var tabviewItem1 = SUT.ContainerFromIndex(0) as TabViewItem;
+		var headerPresenter1 = tabviewItem1.GetTemplateChild<ContentPresenter>("ContentPresenter");
+		Assert.IsTrue(headerPresenter1.ActualWidth > 0, "TabViewItem header for index  0 should have a non-zero width.");
+		Assert.IsTrue(headerPresenter1.ActualHeight > 0, "TabViewItem header for index  0 should have a non-zero height.");
+
+		var closeButton1 = tabviewItem1.GetTemplateChild<Button>("CloseButton");
+		var buttonLabel1 = closeButton1.GetTemplateChild<ContentPresenter>("ContentPresenter").FindFirstChild<ImplicitTextBlock>();
+
+		Assert.IsTrue(buttonLabel1.ActualWidth > 0, "TabViewItem Button for index 0 should have a non-zero width.");
+		Assert.IsTrue(buttonLabel1.ActualHeight > 0, "TabViewItem Button  for index 0 should have a non-zero height.");
+
+		var tabviewItem2 = SUT.ContainerFromIndex(1) as TabViewItem;
+		var headerPresenter2 = tabviewItem2.GetTemplateChild<ContentPresenter>("ContentPresenter");
+		Assert.IsTrue(headerPresenter2.ActualWidth > 0, "TabViewItem header for index  1  should have a non-zero width.");
+		Assert.IsTrue(headerPresenter2.ActualHeight > 0, "TabViewItem header for index  1  should have a non-zero height.");
+	}
+
+	[TestMethod]
 	public async Task When_SelectedItem_Changed_Binding()
 	{
 		var vm = new ViewModel();

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TabView.cs
@@ -17,6 +17,10 @@ using TabViewItem = Microsoft/* UWP don't rename */.UI.Xaml.Controls.TabViewItem
 using static Uno.UI.Extensions.ViewExtensions;
 using static Private.Infrastructure.TestServices;
 
+#if __IOS__
+using UIKit;
+#endif
+
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls;
 
 [TestClass]
@@ -176,7 +180,13 @@ public class Given_TabView
 		Assert.IsTrue(headerPresenter1.ActualHeight > 0, "TabViewItem header for index  0 should have a non-zero height.");
 
 		var closeButton1 = (Button)tabviewItem1.GetTemplateChild("CloseButton");
-		var buttonLabel1 = ((ContentPresenter)closeButton1.GetTemplateChild("ContentPresenter")).FindFirstChild<ImplicitTextBlock>();
+
+		var buttonLabel1 =
+#if __IOS__
+        closeButton1.FindFirstChild<ImplicitTextBlock>();
+#else
+		((ContentPresenter)closeButton1.GetTemplateChild("ContentPresenter")).FindFirstChild<ImplicitTextBlock>();
+#endif
 
 		Assert.IsTrue(buttonLabel1.ActualWidth > 0, "TabViewItem Button for index 0 should have a non-zero width.");
 		Assert.IsTrue(buttonLabel1.ActualHeight > 0, "TabViewItem Button  for index 0 should have a non-zero height.");


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/ziidms-private/issues/31

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

TabView header not showing on Android.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
