### PR TITLE
Update get-started-counter-csharp-mvux.md

### DIFF
--- a/doc/articles/getting-started/counterapp/get-started-counter-csharp-mvux.md
+++ b/doc/articles/getting-started/counterapp/get-started-counter-csharp-mvux.md
@@ -89,12 +89,12 @@ Also, for more information on all the template options, see [Using the Uno Platf
 
 ## Data Binding
 
-Now that we have the **`MainViewModel`** class, we can update the **`MainPage`** to use data binding to connect the UI to the application logic.
+Now that we have the **`MainModel`** class, we can update the **`MainPage`** to use data binding to connect the UI to the application logic.
 
-- Let's add the **`DataContext`** to our page. To do so, add `.DataContext(new MainViewModel(), (page, vm) => page` before `.Background(...)`. Remember to close the **`DataContext`** expression with a `)` at the end of the code. It should look similar to the code below:
+- Let's add the **`DataContext`** to our page. To do so, add `.DataContext(new MainModel(), (page, vm) => page` before `.Background(...)`. Remember to close the **`DataContext`** expression with a `)` at the end of the code. It should look similar to the code below:
 
     ```csharp
-    this.DataContext(new MainViewModel(), (page, vm) => page
+    this.DataContext(new MainModel(), (page, vm) => page
         .Background(ThemeResource.Get<Brush>("ApplicationPageBackgroundThemeBrush"))
         .Content(
             ...
@@ -102,7 +102,7 @@ Now that we have the **`MainViewModel`** class, we can update the **`MainPage`**
     );
     ```
 
-- Update the **`TextBlock`** by removing its current text content and replacing it with a binding expression for the **`Countable.Count`** property of the **`MainViewModel`**. Modify the existing **`Text`** property with `() => vm.Countable.Count, txt => $"Counter: {txt}"`. The adjusted code is as follows:
+- Update the **`TextBlock`** by removing its current text content and replacing it with a binding expression for the **`Countable.Count`** property of the **`MainModel`**. Modify the existing **`Text`** property with `() => vm.Countable.Count, txt => $"Counter: {txt}"`. The adjusted code is as follows:
 
     ```csharp
     new TextBlock()
@@ -112,7 +112,7 @@ Now that we have the **`MainViewModel`** class, we can update the **`MainPage`**
         .Text(() => vm.Countable.Count, txt => $"Counter: {txt}")
     ```
 
-- Update the **`TextBox`** by binding the **`Text`** property to the **`Countable.Step`** property of the **MainViewModel**. The **`Mode`** of the binding is set to **`TwoWay`** so that the **`Countable.Step`** property is updated when the user changes the value in the **`TextBox`**.
+- Update the **`TextBox`** by binding the **`Text`** property to the **`Countable.Step`** property of the **MainModel**. The **`Mode`** of the binding is set to **`TwoWay`** so that the **`Countable.Step`** property is updated when the user changes the value in the **`TextBox`**.
 
     ```csharp
     new TextBox()
@@ -123,7 +123,7 @@ Now that we have the **`MainViewModel`** class, we can update the **`MainPage`**
         .Text(x => x.Binding(() => vm.Countable.Step).TwoWay())
     ```
 
-- Update the **`Button`** to add a **`Command`** property that is bound to the **`IncrementCounter`** task of the **`MainViewModel`**.
+- Update the **`Button`** to add a **`Command`** property that is bound to the **`IncrementCounter`** task of the **`MainModel`**.
 
     ```csharp
     new Button()
@@ -142,7 +142,7 @@ Now that we have the **`MainViewModel`** class, we can update the **`MainPage`**
     {
         public MainPage()
         {
-            this.DataContext(new MainViewModel(), (page, vm) => page
+            this.DataContext(new MainModel(), (page, vm) => page
                 .Background(ThemeResource.Get<Brush>("ApplicationPageBackgroundThemeBrush"))
                 .Content(
                     new StackPanel()


### PR DESCRIPTION
- The [MainModel](https://platform.uno/docs/articles/getting-started/counterapp/get-started-counter-csharp-mvux.html?tabs=vs#mainmodel) walks you through the creation of `MainModel.cs` which defines the partial record `MainModel`.
- However the [DataBinding](https://platform.uno/docs/articles/getting-started/counterapp/get-started-counter-csharp-mvux.html?tabs=vs#data-binding) only refers to `MainViewModel` which is never defined.

This PR renames `MainViewModel` references in the **DataBinding** section to be `MainModel`, as the examples would not compile otherwise.

----

Alternatively if the intent was to use `MainViewModel` then the `MainModel` section should be updated instead.