### PR TITLE
Improved the way pings are done to the remote control / dev server

### DIFF
--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -656,7 +656,7 @@ public partial class RemoteControlClient : IRemoteControlClient
 
 		if (Interlocked.CompareExchange(ref _keepAliveTimer, timer, null) is null)
 		{
-			timer.Change(_keepAliveInterval, _keepAliveInterval);
+			timer.Change(TimeSpan.Zero, _keepAliveInterval);
 		}
 	}
 

--- a/src/Uno.UI.RemoteControl/RemoteControlStatus.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlStatus.cs
@@ -18,11 +18,7 @@ public record RemoteControlStatus(
 	/// </summary>
 	public bool IsAllGood =>
 		State == ConnectionState.Connected
-#if !DEBUG
-		// For debug builds, it's annoying to have the version mismatch preventing the connection
-		// Only Uno devs should get this issue, let's not block them.
 		&& IsVersionValid == true
-#endif
 		&& MissingRequiredProcessors.IsEmpty
 		&& KeepAlive.State == KeepAliveState.Ok
 		&& InvalidFrames.Count == 0;


### PR DESCRIPTION
# Bugfix

## What is the current behavior?
The first ping to dev server was done 30 seconds after the connection. Since some checks are only done during ping response, it was causing potential unwanted delay.

## What is the new behavior?
An initial ping is sent immediately after the connection has been established.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
