### PR TITLE
feat: Dev-server add-in improvements

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/Extensibility/AddInsExtensions.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/AddInsExtensions.cs
@@ -10,8 +10,8 @@ public static class AddInsExtensions
 {
 	public static IWebHostBuilder ConfigureAddIns(this IWebHostBuilder builder, string solutionFile)
 	{
-		AssemblyHelper.Load(AddIns.Discover(solutionFile), throwIfLoadFailed: true);
+		AssemblyHelper.Load(AddIns.Discover(solutionFile), throwIfLoadFailed: false);
 
-		return builder.ConfigureServices(svc => svc.AddFromAttribute());
+		return builder.ConfigureServices(svc => svc.AddFromAttributes());
 	}
 }

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/Uno.Utils.DependencyInjection/ServiceAttribute.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/Uno.Utils.DependencyInjection/ServiceAttribute.cs
@@ -10,7 +10,7 @@ namespace Uno.Utils.DependencyInjection;
 /// <param name="contract">Type of the contract (i.e. interface) implemented by the concrete <see cref="Implementation"/> type.</param>
 /// <param name="implementation">Concrete type to register in the service collection.</param>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-public class ServiceAttribute(Type contract, Type implementation) : Attribute
+public sealed class ServiceAttribute(Type contract, Type implementation) : Attribute
 {
 	/// <summary>
 	/// Creates a new instance of the <see cref="ServiceAttribute"/> class with only a concrete type (used as contract and implementation).

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/Uno.Utils.DependencyInjection/ServiceCollectionExtensionAttribute.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/Uno.Utils.DependencyInjection/ServiceCollectionExtensionAttribute.cs
@@ -14,7 +14,7 @@ namespace Uno.Utils.DependencyInjection;
 /// so the implementation will be able to add some custom services on it.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-public class ServiceCollectionExtensionAttribute(Type type) : Attribute
+public sealed class ServiceCollectionExtensionAttribute(Type type) : Attribute
 {
 	/// <summary>
 	/// Type of the extension that should be instantiated with a <see cref="IServiceCollection"/> as parameter.

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/Uno.Utils.DependencyInjection/ServiceCollectionExtensionAttribute.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/Uno.Utils.DependencyInjection/ServiceCollectionExtensionAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Uno.Utils.DependencyInjection;
+
+/// <summary>
+/// Attribute to define a type able to registers some services in a service collection.
+/// </summary>
+/// <param name="type">Type of the extension that should be instantiated with a <see cref="IServiceCollection"/> as parameter.</param>
+/// <remarks>
+/// The given type is expected to have a single constructor which takes a single parameter of type <see cref="IServiceCollection"/>.
+/// An instance of the given type will be created during the service collection registration process (with the service collection as parameter),
+/// so the implementation will be able to add some custom services on it.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public class ServiceCollectionExtensionAttribute(Type type) : Attribute
+{
+	/// <summary>
+	/// Type of the extension that should be instantiated with a <see cref="IServiceCollection"/> as parameter.
+	/// </summary>
+	public Type Type { get; } = type;
+}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -18,7 +18,7 @@ public class AssemblyHelper
 		{
 			try
 			{
-				_log.Log(LogLevel.Information, $"Loading add-in assembly '{dll}'.");
+				_log.Log(LogLevel.Debug, $"Loading add-in assembly '{dll}'.");
 
 				assemblies.Add(Assembly.LoadFrom(dll));
 			}

--- a/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/Helpers/AssemblyHelper.cs
@@ -18,6 +18,8 @@ public class AssemblyHelper
 		{
 			try
 			{
+				_log.Log(LogLevel.Information, $"Loading add-in assembly '{dll}'.");
+
 				assemblies.Add(Assembly.LoadFrom(dll));
 			}
 			catch (Exception err)

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -21,7 +21,7 @@ public partial class ClientHotReloadProcessor
 	/// <summary>
 	/// Result details of a file update
 	/// </summary>
-	/// <param name="FileUpdated">Indicates if is known to have been updated on server-side.</param>
+	/// <param name="FileUpdated">Indicates if file is known to have been updated on server-side.</param>
 	/// <param name="ApplicationUpdated">Indicates if the change had an impact on the compilation of the application (might be a success-full build or an error).</param>
 	/// <param name="Error">Gets the error if any happened during the update.</param>
 	public record struct UpdateResult(

--- a/src/Uno.UI.RemoteControl/RemoteControlStatus.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlStatus.cs
@@ -14,7 +14,8 @@ public record RemoteControlStatus(
 {
 
 	/// <summary>
-	/// A boolean indicating if everything is fine with the connection and the handshaking succeeded.
+	/// An ***aggregated*** state of the connection to determine if everything is fine.
+	/// This is for visual representation only, the actual state of the connection is in <see cref="State"/>.
 	/// </summary>
 	public bool IsAllGood =>
 		State == ConnectionState.Connected
@@ -28,11 +29,8 @@ public record RemoteControlStatus(
 		&& InvalidFrames.Count == 0;
 
 	/// <summary>
-	/// If the connection is problematic, meaning that the connection is not in a good state.
+	/// Not <see cref="IsAllGood"/> (for binding purposes).
 	/// </summary>
-	/// <remarks>
-	/// It's just a negation of <see cref="IsAllGood"/>.
-	/// </remarks>
 	public bool IsProblematic => !IsAllGood;
 
 	public (Classification kind, string message) GetSummary()


### PR DESCRIPTION
## Feature
Enhance support of add-ins in dev-server

## What is the current behavior?
* We throw if we fail to load an add-in assembly
* All services has to be explicitly exposed using the `ServiceAttribute`

## What is the new behavior?
* We only log if the load of an add-in fails (improve stability of the dev-server and user experience)
* Add-ins are able to get complete access to the `IServiceCollection` to register their services.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
