### PR TITLE
fix: Always activate window on `Activate()`

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.Tests.cs
@@ -153,6 +153,11 @@ partial class App
 	private bool HandleAutoScreenshots(string args)
 	{
 #if __SKIA__ || __MACOS__
+		if (string.IsNullOrEmpty(args))
+		{
+			return false;
+		}
+
 		var autoScreenshotsOption = new Option<string>("--auto-screenshots");
 		var totalGroupsOption = new Option<int>("--total-groups", getDefaultValue: () => 1);
 		var currentGroupIndexOption = new Option<int>("--current-group-index", getDefaultValue: () => 0);

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -826,6 +826,11 @@ namespace SampleControl.Presentation
 
 		private async Task ToggleFavorite(CancellationToken ct, SampleChooserContent sample)
 		{
+			if (sample is null)
+			{
+				return;
+			}
+
 			var favorites = await GetFavoriteSamples(ct);
 
 			if (favorites.Contains(sample))

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkWindowWrapper.cs
@@ -50,12 +50,12 @@ internal class GtkWindowWrapper : NativeWindowWrapperBase
 	/// <summary>
 	/// GTK overrides show as the initialization is asynchronous.
 	/// </summary>
-	public override async void Show()
+	public override async void Show(bool activateWindow)
 	{
 		try
 		{
 			await _gtkWindow.Host.InitializeAsync();
-			base.Show();
+			base.Show(activateWindow);
 		}
 		catch (Exception ex)
 		{
@@ -73,7 +73,7 @@ internal class GtkWindowWrapper : NativeWindowWrapperBase
 
 	public override object NativeWindow => _gtkWindow;
 
-	protected override void Activate() => _gtkWindow.Activate();
+	internal protected override void Activate() => _gtkWindow.Activate();
 
 	protected override void CloseCore()
 	{

--- a/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Gtk/UI/Controls/GtkWindowWrapper.cs
@@ -73,11 +73,10 @@ internal class GtkWindowWrapper : NativeWindowWrapperBase
 
 	public override object NativeWindow => _gtkWindow;
 
-	public override void Activate() => _gtkWindow.Activate();
+	protected override void Activate() => _gtkWindow.Activate();
 
-	public override void Close()
+	protected override void CloseCore()
 	{
-		base.Close();
 		if (_wasShown)
 		{
 			_gtkWindow.Close();

--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
@@ -42,7 +42,7 @@ internal class MacOSWindowWrapper : NativeWindowWrapperBase
 		set => NativeUno.uno_window_set_title(_window.Handle, value);
 	}
 
-	protected override void Activate()
+	internal protected override void Activate()
 	{
 		NativeUno.uno_window_activate(_window.Handle);
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
@@ -42,12 +42,12 @@ internal class MacOSWindowWrapper : NativeWindowWrapperBase
 		set => NativeUno.uno_window_set_title(_window.Handle, value);
 	}
 
-	public override void Activate()
+	protected override void Activate()
 	{
 		NativeUno.uno_window_activate(_window.Handle);
 	}
 
-	public override void Close()
+	protected override void CloseCore()
 	{
 		NativeUno.uno_window_close(_window.Handle);
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
@@ -50,7 +50,6 @@ internal class MacOSWindowWrapper : NativeWindowWrapperBase
 	protected override void CloseCore()
 	{
 		NativeUno.uno_window_close(_window.Handle);
-		base.Close();
 	}
 
 	public override void Move(PointInt32 position)
@@ -91,13 +90,7 @@ internal class MacOSWindowWrapper : NativeWindowWrapperBase
 	private void OnWindowClosing(object? sender, CancelEventArgs e)
 	{
 		var closingArgs = RaiseClosing();
-		if (closingArgs.Cancel)
-		{
-			e.Cancel = true;
-		}
-
-		// All prerequisites passed, can safely close.
-		e.Cancel = false;
+		e.Cancel = closingArgs.Cancel;
 	}
 
 	protected override IDisposable ApplyFullScreenPresenter()

--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowWrapper.cs
@@ -47,13 +47,6 @@ internal class MacOSWindowWrapper : NativeWindowWrapperBase
 		NativeUno.uno_window_activate(_window.Handle);
 	}
 
-	protected override void ShowCore()
-	{
-		// the first call to `Window.Activate` does not reach the above `Activate` method
-		// https://github.com/unoplatform/uno/blob/fc8e58d77f8cf31d651135c22ea3105099c26fb7/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs#L81-L98
-		NativeUno.uno_window_activate(_window.Handle);
-	}
-
 	public override void Close()
 	{
 		NativeUno.uno_window_close(_window.Handle);

--- a/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/WpfWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/WpfWindowWrapper.cs
@@ -80,13 +80,9 @@ internal class WpfWindowWrapper : NativeWindowWrapperBase
 		UpdatePositionFromNative();
 	}
 
-	public override void Activate() => _wpfWindow.Activate();
+	protected override void Activate() => _wpfWindow.Activate();
 
-	public override void Close()
-	{
-		base.Close();
-		_wpfWindow.Close();
-	}
+	protected override void CloseCore() => _wpfWindow.Close();
 
 	public override void ExtendContentIntoTitleBar(bool extend)
 	{

--- a/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/WpfWindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/UI/Controls/WpfWindowWrapper.cs
@@ -80,7 +80,7 @@ internal class WpfWindowWrapper : NativeWindowWrapperBase
 		UpdatePositionFromNative();
 	}
 
-	protected override void Activate() => _wpfWindow.Activate();
+	internal protected override void Activate() => _wpfWindow.Activate();
 
 	protected override void CloseCore() => _wpfWindow.Close();
 

--- a/src/Uno.UI.Runtime.Skia.X11/X11WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/X11WindowWrapper.cs
@@ -85,9 +85,8 @@ internal class X11WindowWrapper : NativeWindowWrapperBase
 		// _ = XLib.XFlush(x11Window.Display);
 	}
 
-	public override void Close()
+	protected override void CloseCore()
 	{
-		base.Close();
 		var x11Window = _host.RootX11Window;
 		if (this.Log().IsEnabled(LogLevel.Information))
 		{

--- a/src/Uno.UI.Runtime.Skia.X11/X11WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/X11WindowWrapper.cs
@@ -62,7 +62,7 @@ internal class X11WindowWrapper : NativeWindowWrapperBase
 		VisibleBounds = new Rect(default, newWindowSize);
 	}
 
-	public override void Activate()
+	internal protected override void Activate()
 	{
 		var x11Window = _host.RootX11Window;
 		using var lockDiposable = X11Helper.XLock(x11Window.Display);

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
@@ -29,7 +29,6 @@ namespace Uno.UI.Xaml.Controls;
 
 internal abstract class BaseWindowImplementation : IWindowImplementation
 {
-	private bool _wasShown;
 	private CoreWindowActivationState _lastActivationState = CoreWindowActivationState.Deactivated;
 	private Size _lastSize = new Size(-1, -1);
 
@@ -85,15 +84,17 @@ internal abstract class BaseWindowImplementation : IWindowImplementation
 			throw new InvalidOperationException("Cannot reactivate a closed window.");
 		}
 
-		if (!_wasShown)
+		if (NativeWindowWrapper is null)
 		{
-			_wasShown = true;
-
-			SetVisibleBoundsFromNative();
-			NativeWindowWrapper?.Show();
+			throw new InvalidOperationException("Native window is not initialized.");
 		}
 
-		NativeWindowWrapper?.Activate();
+		if (!NativeWindowWrapper.WasShown)
+		{
+			SetVisibleBoundsFromNative();
+		}
+
+		NativeWindowWrapper?.Show(true);
 
 		OnActivationStateChanged(CoreWindowActivationState.CodeActivated);
 	}

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
@@ -92,10 +92,8 @@ internal abstract class BaseWindowImplementation : IWindowImplementation
 			SetVisibleBoundsFromNative();
 			NativeWindowWrapper?.Show();
 		}
-		else
-		{
-			NativeWindowWrapper?.Activate();
-		}
+
+		NativeWindowWrapper?.Activate();
 
 		OnActivationStateChanged(CoreWindowActivationState.CodeActivated);
 	}

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
@@ -220,7 +220,7 @@ internal abstract class BaseWindowImplementation : IWindowImplementation
 
 	private void OnNativeVisibilityChanged(object? sender, bool isVisible)
 	{
-		if (!_wasShown)
+		if (NativeWindowWrapper is not { WasShown: true })
 		{
 			return;
 		}
@@ -236,7 +236,7 @@ internal abstract class BaseWindowImplementation : IWindowImplementation
 
 	private void OnNativeActivationChanged(object? sender, CoreWindowActivationState state)
 	{
-		if (!_wasShown)
+		if (NativeWindowWrapper is not { WasShown: true })
 		{
 			return;
 		}
@@ -323,11 +323,6 @@ internal abstract class BaseWindowImplementation : IWindowImplementation
 				// because they check if window is closed already
 				Window.SetTitleBar(null);
 				Window.Content = null;
-			}
-			else
-			{
-				// Just reset the window to not shown state so it can be reactivated
-				_wasShown = false;
 			}
 
 			// _windowChrome.SetDesktopWindow(null);

--- a/src/Uno.UI/UI/Xaml/Window/Native/INativeWindowWrapper.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/INativeWindowWrapper.cs
@@ -24,6 +24,8 @@ internal interface INativeWindowWrapper : INativeAppWindow
 
 	float RasterizationScale { get; }
 
+	bool WasShown { get; }
+
 	event EventHandler<Size>? SizeChanged;
 
 	event EventHandler<Rect>? VisibleBoundsChanged;
@@ -35,10 +37,6 @@ internal interface INativeWindowWrapper : INativeAppWindow
 	event EventHandler<AppWindowClosingEventArgs>? Closing;
 
 	event EventHandler? Shown;
-
-	void Activate();
-
-	void Show();
 
 	void Close();
 

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.iOS.cs
@@ -52,7 +52,6 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase
 	{
 		_nativeWindow.RootViewController = _mainController;
 		_nativeWindow.MakeKeyAndVisible();
-		IsVisible = true;
 	}
 
 	internal RootViewController MainController => _mainController;

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.wasm.cs
@@ -24,14 +24,6 @@ internal partial class NativeWindowWrapper : NativeWindowWrapperBase
 
 	public override object NativeWindow => null;
 
-	public override void Activate()
-	{
-	}
-
-	public override void Close()
-	{
-	}
-
 	private void DispatchDpiChanged() =>
 		RasterizationScale = (float)_displayInformation.RawPixelsPerViewPixel;
 

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
@@ -183,7 +183,7 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	public event EventHandler<AppWindowClosingEventArgs>? Closing;
 	public event EventHandler? Shown;
 
-	protected virtual void Activate()
+	internal protected virtual void Activate()
 	{
 	}
 

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
@@ -51,6 +51,8 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 
 	internal protected Window? Window => _window;
 
+	public bool WasShown { get; private set; }
+
 	internal void SetWindow(Window window, XamlRoot xamlRoot)
 	{
 		_window = window;
@@ -181,7 +183,9 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	public event EventHandler<AppWindowClosingEventArgs>? Closing;
 	public event EventHandler? Shown;
 
-	public virtual void Activate() { }
+	protected virtual void Activate()
+	{
+	}
 
 	public virtual void Close()
 	{
@@ -190,14 +194,23 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 
 	public virtual void ExtendContentIntoTitleBar(bool extend) { }
 
-	public virtual void Show()
+	public virtual void Show(bool activateWindow)
 	{
-		ShowCore();
+		if (!WasShown)
+		{
+			WasShown = true;
+			ShowCore();
 
-		// On single-window targets, the window is already shown with splash screen
-		// so we must ensure the property is initialized correctly.
-		IsVisible = true;
-		Shown?.Invoke(this, EventArgs.Empty);
+			// On single-window targets, the window is already shown with splash screen
+			// so we must ensure the property is initialized correctly.
+			IsVisible = true;
+			Shown?.Invoke(this, EventArgs.Empty);
+		}
+
+		if (activateWindow)
+		{
+			Activate();
+		}
 	}
 
 	protected virtual void ShowCore() { }
@@ -248,13 +261,4 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	public void Destroy() { }
 
 	public void Hide() { }
-
-	public void Show(bool activateWindow)
-	{
-		Show();
-		if (activateWindow)
-		{
-			Activate();
-		}
-	}
 }

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
@@ -193,6 +193,7 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	public virtual void Show()
 	{
 		ShowCore();
+
 		// On single-window targets, the window is already shown with splash screen
 		// so we must ensure the property is initialized correctly.
 		IsVisible = true;

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
@@ -187,9 +187,21 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	{
 	}
 
-	public virtual void Close()
+	protected virtual void CloseCore()
 	{
+	}
+
+	public void Close()
+	{
+		CloseCore();
+
 		IsVisible = false;
+
+		// Allow the window to be re-shown on single-window targets.
+		if (!NativeWindowFactory.SupportsMultipleWindows)
+		{
+			WasShown = false;
+		}
 	}
 
 	public virtual void ExtendContentIntoTitleBar(bool extend) { }

--- a/src/Uno.UWP/Generated/3.0.0.0/Microsoft.UI.Windowing/AppWindow.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Microsoft.UI.Windowing/AppWindow.cs
@@ -41,7 +41,7 @@ namespace Microsoft.UI.Windowing
 		// Skipping already declared property TitleBar
 		// Skipping already declared property ClientSize
 		// Skipping already declared property DispatcherQueue
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void Show(bool activateWindow)
 		{
@@ -98,7 +98,7 @@ namespace Microsoft.UI.Windowing
 #endif
 		// Skipping already declared method Microsoft.UI.Windowing.AppWindow.SetPresenter(Microsoft.UI.Windowing.AppWindowPresenter)
 		// Skipping already declared method Microsoft.UI.Windowing.AppWindow.SetPresenter(Microsoft.UI.Windowing.AppWindowPresenterKind)
-#if __ANDROID__ || __IOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__ || __MACOS__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__", "__MACOS__")]
 		public void Show()
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #18620

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Activate does not actually activate the window if not shown yet.


## What is the new behavior?

Activated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.