### PR TITLE
fix: Use temp file for AddIn discovery instead of output parsing

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Build.targets
+++ b/src/Uno.Sdk/targets/Uno.Build.targets
@@ -148,6 +148,12 @@
 			It is useful to determine all target frameworks used by all projects of a solution.
 		-->
 		<Message Text="&lt;TargetFrameworks&gt;$(TargetFramework);$(TargetFrameworks)&lt;/TargetFrameworks&gt;" Importance="High" />
+		<WriteLinesToFile
+			Condition="$(UnoDumpTargetFrameworksTargetFile) != ''"
+			File="$(UnoDumpTargetFrameworksTargetFile)"
+			Lines="$(TargetFramework);$(TargetFrameworks)"
+			Overwrite="false"
+			Encoding="Unicode"/>
 	</Target>
 
 	<Import Project="Uno.SingleProject.VS.Build.targets"

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
@@ -65,8 +65,8 @@ public class AddIns
 		var values = File
 			.ReadAllLines(file, Encoding.Unicode)
 			.SelectMany(line => line.Split(['\r', '\n', ';', ','], StringSplitOptions.RemoveEmptyEntries))
-			.Select(liene => liene.Trim())
-			.Where(line => line is { Length: > 0 })
+			.Select(value => value.Trim())
+			.Where(value => value is { Length: > 0 })
 			.Distinct(StringComparer.OrdinalIgnoreCase)
 			.ToImmutableList();
 

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
 using Uno.UI.RemoteControl.Helpers;
@@ -15,14 +16,9 @@ public class AddIns
 
 	public static IImmutableList<string> Discover(string solutionFile)
 	{
-		// Note: With .net 9 we need to specify --verbosity detailed to get messages with High importance.
-		var result = ProcessHelper.RunProcess("dotnet", $"build \"{solutionFile}\" --target:UnoDumpTargetFrameworks --verbosity detailed");
-		var targetFrameworks = GetConfigurationValue(result.output ?? "", "TargetFrameworks")
-			.SelectMany(tfms => tfms.Split(['\r', '\n', ';', ','], StringSplitOptions.RemoveEmptyEntries))
-			.Select(tfm => tfm.Trim())
-			.Where(tfm => tfm is { Length: > 0 })
-			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.ToImmutableList();
+		var tmp = Path.GetTempFileName();
+		var result = ProcessHelper.RunProcess("dotnet", $"build \"{solutionFile}\" --target:UnoDumpTargetFrameworks \"-p:UnoDumpTargetFrameworksTargetFile={tmp}\" --verbosity quiet");
+		var targetFrameworks = Read(tmp);
 
 		if (targetFrameworks.IsEmpty)
 		{
@@ -37,7 +33,8 @@ public class AddIns
 
 		foreach (var targetFramework in targetFrameworks)
 		{
-			result = ProcessHelper.RunProcess("dotnet", $"build \"{solutionFile}\" --target:UnoDumpRemoteControlAddIns --verbosity detailed --framework \"{targetFramework}\" -nowarn:MSB4057");
+			tmp = Path.GetTempFileName();
+			result = ProcessHelper.RunProcess("dotnet", $"build \"{solutionFile}\" --target:UnoDumpRemoteControlAddIns \"-p:UnoDumpRemoteControlAddInsTargetFile={tmp}\" --verbosity quiet --framework \"{targetFramework}\" -nowarn:MSB4057");
 			if (!string.IsNullOrWhiteSpace(result.error))
 			{
 				if (_log.IsEnabled(LogLevel.Warning))
@@ -48,13 +45,7 @@ public class AddIns
 				continue;
 			}
 
-			var addIns = GetConfigurationValue(result.output, "RemoteControlAddIns")
-				.SelectMany(tfms => tfms.Split(['\r', '\n', ';', ','], StringSplitOptions.RemoveEmptyEntries))
-				.Select(tfm => tfm.Trim())
-				.Where(tfm => tfm is { Length: > 0 })
-				.Distinct(StringComparer.OrdinalIgnoreCase)
-				.ToImmutableList();
-
+			var addIns = Read(tmp);
 			if (!addIns.IsEmpty)
 			{
 				return addIns;
@@ -69,9 +60,22 @@ public class AddIns
 		return ImmutableArray<string>.Empty;
 	}
 
-	private static IEnumerable<string> GetConfigurationValue(string msbuildResult, string nodeName)
-		=> Regex
-			.Matches(msbuildResult, $"<{nodeName}>(?<value>[^\\<\\>]*)</{nodeName}>", RegexOptions.Singleline)
-			.Where(match => match.Success)
-			.Select(match => match.Groups["value"].Value);
+	private static ImmutableList<string> Read(string file)
+	{
+		var values = File
+			.ReadAllLines(file, Encoding.Unicode)
+			.SelectMany(line => line.Split(['\r', '\n', ';', ','], StringSplitOptions.RemoveEmptyEntries))
+			.Select(liene => liene.Trim())
+			.Where(line => line is { Length: > 0 })
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.ToImmutableList();
+
+		try
+		{
+			File.Delete(file);
+		}
+		catch { }
+
+		return values;
+	}
 }

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
@@ -62,13 +62,18 @@ public class AddIns
 
 	private static ImmutableList<string> Read(string file)
 	{
-		var values = File
-			.ReadAllLines(file, Encoding.Unicode)
-			.SelectMany(line => line.Split(['\r', '\n', ';', ','], StringSplitOptions.RemoveEmptyEntries))
-			.Select(value => value.Trim())
-			.Where(value => value is { Length: > 0 })
-			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.ToImmutableList();
+		var values = ImmutableList<string>.Empty;
+		try
+		{
+			values = File
+				.ReadAllLines(file, Encoding.Unicode)
+				.SelectMany(line => line.Split(['\r', '\n', ';', ','], StringSplitOptions.RemoveEmptyEntries))
+				.Select(value => value.Trim())
+				.Where(value => value is { Length: > 0 })
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.ToImmutableList();
+		}
+		catch { }
 
 		try
 		{

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -33,6 +33,12 @@
 
 	<Target Name="UnoDumpRemoteControlAddIns">
 		<Message Text="&lt;RemoteControlAddIns&gt;@(UnoRemoteControlAddIns)&lt;/RemoteControlAddIns&gt;" Importance="High" />
+		<WriteLinesToFile
+			Condition="$(UnoDumpRemoteControlAddInsTargetFile) != ''"
+			File="$(UnoDumpRemoteControlAddInsTargetFile)"
+			Lines="@(UnoRemoteControlAddIns)"
+			Overwrite="false"
+			Encoding="Unicode"/>
 	</Target>
 
 	<!-- .NET 7 and earlier compatibility for .NET8 msbuild CLI `getProperty` equivalent -->


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/18732

## Bugfix
Use temp file for AddIn discovery instead of output parsing

## What is the current behavior?
We rely on some XML like tags in build output to discover add-ins

## What is the new behavior?
We now dump values in a temp file that we read at the end of the build. This makes sure we are not impacted by encoding issues in output.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
