### PR TITLE
fix(macOS): adjust scrollwheel speed for normal/PC mouses

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -790,8 +790,15 @@ void* uno_window_get_metal_context(UNOWindow* window)
             // scrollwheel
             if (mouse == MouseEventsScrollWheel) {
                 // do not call if not in the scrollwheel event -> *** Assertion failure in -[NSEvent scrollingDeltaX], NSEvent.m:2202
-                data.scrollingDeltaX = (int32_t)event.scrollingDeltaX;
-                data.scrollingDeltaY = (int32_t)event.scrollingDeltaY;
+
+                // trackpad / magic mouse sends about 10x more events than a _normal_ (PC) mouse
+                // this is often refered as a line scroll versus a pixel scroll
+                double factor = event.hasPreciseScrollingDeltas ? 1.0 : 10.0;
+                data.scrollingDeltaX = (int32_t)(event.scrollingDeltaX * factor);
+                data.scrollingDeltaY = (int32_t)(event.scrollingDeltaY * factor);
+#if DEBUG_MOUSE // very noisy
+                NSLog(@"NSEventTypeMouse*: %@ %g %g delta %g %g %s scrollingDelta %d %d", event, data.x, data.y, event.deltaX, event.deltaY, event.hasPreciseScrollingDeltas ? "precise" : "non-precise", data.scrollingDeltaX, data.scrollingDeltaY);
+#endif
             }
 
             // other


### PR DESCRIPTION
GitHub Issue (If applicable): closes #16400


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Normal (PC) mouse does not send as much events when the scroll wheel is used, making it appear slow.

## What is the new behavior?

Detect when a high precision mouse is used and, if not, multiply the scrolling delta. This makes up for the lower number of events being generated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
