### PR TITLE
chore: Add detection of uno.sdk.private

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/GlobalJsonObserver.cs
+++ b/src/Uno.UI.RemoteControl.VS/GlobalJsonObserver.cs
@@ -1,17 +1,12 @@
 ﻿using System;
 using System.IO;
 using System.Text.Json;
-using System.Linq;
-using EnvDTE;
-using Microsoft.VisualStudio.Shell;
-using EnvDTE80;
-using Microsoft.VisualStudio.Shell.Interop;
-using Uno.UI.RemoteControl.VS.Helpers;
-using Microsoft.VisualStudio.PlatformUI;
-using Uno.UI.RemoteControl.VS.Notifications;
-using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio;
 using System.Threading.Tasks;
+using EnvDTE;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Uno.UI.RemoteControl.VS.Notifications;
 
 namespace Uno.UI.RemoteControl.VS;
 
@@ -175,6 +170,11 @@ internal class GlobalJsonObserver
 			if (msbuildSdksElement.TryGetProperty("Uno.Sdk", out var unoSdkElement))
 			{
 				return unoSdkElement.ToString();
+			}
+			// Can't find Uno.Sdk, so fallback to look for Uno.Sdk.Private
+			if (msbuildSdksElement.TryGetProperty("Uno.Sdk.Private", out var unoSdkPrivateElement))
+			{
+				return unoSdkPrivateElement.ToString();
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?
- Feature

## What is the current behavior?

The global.json file is monitored for changes to uno.sdk and prompts for restart

## What is the new behavior?

If there's no uno.sdk in the global.json, it looks for uno.sdk.private and monitors that for change in value

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
