### PR TITLE
Introducing Uno Platform Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Uno Platform Discord](https://img.shields.io/discord/1182775715242967050?label=Discord&color=f85977)](https://platform.uno/discord)
 [![Open Uno in Gitpod](https://img.shields.io/badge/gitpod-setup%20automated-159bff?logo=gitpod&style=flat)](https://gitpod.io/#https://github.com/unoplatform/uno)
 [![PRs Welcome](https://img.shields.io/badge/PRs-Welcome-brightgreen.svg?style=flat)](https://github.com/unoplatform/uno/blob/master/CONTRIBUTING.md)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Uno%20Platform%20Guru-006BFF?style=flat)](https://gurubase.io/g/uno-platform)
 
 # What is the Uno Platform?
 The Uno Platform is an Open-source platform for building single codebase native mobile, web, desktop, and embedded apps quickly.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Uno Platform Guru](https://gurubase.io/g/uno-platform) to Gurubase. Uno Platform Guru uses the data from this repo and data from the [docs](https://platform.uno) to answer questions by leveraging the LLM.

In this PR, I showcased the "Uno Platform Guru", which highlights that Uno Platform now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Uno Platform Guru in Gurubase, just let me know that's totally fine.
