### PR TITLE
fix: Downgrade BuildTools

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -268,7 +268,7 @@
 	},
 	{
 	  "group": "Extensions",
-	  "version": "5.1.0-dev.67",
+	  "version": "5.2.0-dev.20",
 	  "packages": [
 		"Uno.Extensions.Authentication.WinUI",
 		"Uno.Extensions.Authentication.MSAL.WinUI",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -88,7 +88,7 @@
 	},
 	{
 		"group": "hotdesign",
-		"version": "1.0.51",
+		"version": "1.0.160",
 		"packages": [
 			"Uno.UI.HotDesign"
 		]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -121,7 +121,7 @@
 	},
 	{
 	  "group": "WinAppSdkBuildTools",
-	  "version": "10.0.26100.1742",
+	  "version": "10.0.22621.3233", // Keep this version until https://github.com/microsoft/WindowsAppSDK/issues/4480 is resolved
 	  "packages": [
 		"Microsoft.Windows.SDK.BuildTools"
 	  ]

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -121,7 +121,7 @@
 	},
 	{
 	  "group": "WinAppSdkBuildTools",
-	  "version": "10.0.22621.3233", // Keep this version until https://github.com/microsoft/WindowsAppSDK/issues/4480 is resolved
+	  "version": "10.0.22621.3233",
 	  "packages": [
 		"Microsoft.Windows.SDK.BuildTools"
 	  ]


### PR DESCRIPTION
GitHub Issue (If applicable): part of https://github.com/unoplatform/uno/issues/18840

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The latest version of Build Tools is unsupported by Microsoft Store and block users from publishing their apps


## What is the new behavior?

Downgraded until support is added

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
