### PR TITLE
fix(net9): Allow for builds to happen even if a RID is explicitly set

### DIFF
--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -347,6 +347,9 @@ $projects =
     # Publishing validation
     @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-desktop", "-p:PackageFormat=app"), @("OnlyMacOS", "NetCore", "Publish"))
 
+    # Ensure that build can happen even if a RID is specified
+    @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-android", "-r", "android-arm64"), @("macOS", "NetCore")),
+
     ## Note for contributors
     ##
     ## When adding new template versions, create them in a separate version named folder

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -345,10 +345,10 @@ $projects =
     @(4, "5.2/uno52AppWithLib/uno52AppWithLib/uno52AppWithLib.csproj", @("-p:Platform=x86" , "-p:TargetFramework=net8.0-windows10.0.19041"), @()),
 
     # Publishing validation
-    @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-desktop", "-p:PackageFormat=app"), @("OnlyMacOS", "NetCore", "Publish"))
+    @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-desktop", "-p:PackageFormat=app"), @("OnlyMacOS", "NetCore", "Publish")),
 
     # Ensure that build can happen even if a RID is specified
-    @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-android", "-r", "android-arm64"), @("macOS", "NetCore")),
+    @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-android", "-r", "android-arm64"), @("macOS", "NetCore"))
 
     ## Note for contributors
     ##

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -30,7 +30,7 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 
 	<!-- Replacement for restore targets for Wasm when an explicit RID is specified -->
 	<Import Project="$(_UnoSdkTargetsDirectory)Uno.Wasm.UnsupportedRid.targets"
-			Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm' AND '$(RuntimeIdentifier)' != 'browser-wasm' "/>
+			Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm' AND '$(RuntimeIdentifier)' != '' AND '$(RuntimeIdentifier)' != 'browser-wasm' "/>
 	
 	<!-- Targets and props to be executed last after the default .NET SDK has been imported -->
 	<Import Project="$(_UnoSdkTargetsDirectory)Uno.Sdk.After.targets" />

--- a/src/Uno.Sdk/Sdk/Sdk.targets
+++ b/src/Uno.Sdk/Sdk/Sdk.targets
@@ -27,6 +27,10 @@ Copyright (C) Uno Platform Inc. All rights reserved.
 
 	<!-- Microsoft.NET.Sdk should be loaded last. This ensures our targets are evaluated before all others. -->
 	<Import Sdk="$(_DefaultMicrosoftNETSdk)" Project="Sdk.targets" />
+
+	<!-- Replacement for restore targets for Wasm when an explicit RID is specified -->
+	<Import Project="$(_UnoSdkTargetsDirectory)Uno.Wasm.UnsupportedRid.targets"
+			Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm' AND '$(RuntimeIdentifier)' != 'browser-wasm' "/>
 	
 	<!-- Targets and props to be executed last after the default .NET SDK has been imported -->
 	<Import Project="$(_UnoSdkTargetsDirectory)Uno.Sdk.After.targets" />

--- a/src/Uno.Sdk/targets/Uno.Wasm.UnsupportedRid.targets
+++ b/src/Uno.Sdk/targets/Uno.Wasm.UnsupportedRid.targets
@@ -1,0 +1,17 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<!-- 
+	This file recreates the targets from NuGet.target that are needed when
+	building with `-r` to specify a RID. In this case, inclusion conditions in the
+	WebAssembly SDK do not include any of the nuget targets, causing the restore
+	to fail. Those targets are intentionally empty to keep the restore going.
+	-->
+
+	<Target Name="_GetRestoreSettingsPerFramework" />
+	
+	<Target Name="GetAllRuntimeIdentifiers"
+			Returns="browser-wasm" />
+	
+	<Target Name="_GenerateProjectRestoreGraphPerFramework" />
+
+</Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/18796

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Ensures that nuget targets can still be called when a RID is not matching wasm.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
