### PR TITLE
fix: Fix HRI not being draggable

### DIFF
--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -352,11 +352,11 @@ public sealed partial class DiagnosticsOverlay : Control
 	/// <inheritdoc />
 	protected override void OnApplyTemplate()
 	{
-		if (_anchor is not null)
+		if (_toolbar is not null)
 		{
 			//_anchor.Tapped -= OnAnchorTapped;
-			_anchor.ManipulationDelta -= OnAnchorManipulated;
-			_anchor.ManipulationCompleted -= OnAnchorManipulatedCompleted;
+			_toolbar.ManipulationDelta -= OnAnchorManipulated;
+			_toolbar.ManipulationCompleted -= OnAnchorManipulatedCompleted;
 		}
 		if (_notificationPresenter is not null)
 		{
@@ -377,12 +377,12 @@ public sealed partial class DiagnosticsOverlay : Control
 		_anchor = GetTemplateChild(AnchorPartName) as UIElement;
 		_notificationPresenter = GetTemplateChild(NotificationPartName) as ContentPresenter;
 
-		if (_anchor is not null)
+		if (_toolbar is not null)
 		{
 			//_anchor.Tapped += OnAnchorTapped;
-			_anchor.ManipulationDelta += OnAnchorManipulated;
-			_anchor.ManipulationCompleted += OnAnchorManipulatedCompleted;
-			_anchor.ManipulationMode = ManipulationModes.TranslateX | ManipulationModes.TranslateY | ManipulationModes.TranslateInertia;
+			_toolbar.ManipulationDelta += OnAnchorManipulated;
+			_toolbar.ManipulationCompleted += OnAnchorManipulatedCompleted;
+			_toolbar.ManipulationMode = ManipulationModes.TranslateX | ManipulationModes.TranslateY | ManipulationModes.TranslateInertia;
 			RenderTransform = new TranslateTransform();
 		}
 		if (_notificationPresenter is not null)
@@ -399,9 +399,14 @@ public sealed partial class DiagnosticsOverlay : Control
 		static void OnToolBarSizeChanged(object sender, SizeChangedEventArgs args)
 		{
 			// Patches pointer event dispatch on a 0x0 Canvas
-			if (sender is UIElement uie && uie.GetTemplatedParent() is DiagnosticsOverlay { TemplatedRoot: Canvas canvas })
+			if (sender is UIElement uie && uie.GetTemplatedParent() is DiagnosticsOverlay { TemplatedRoot: Canvas canvas } overlay)
 			{
 				canvas.Width = args.NewSize.Width;
+
+#if __ANDROID__
+				// Required for Android to effectively update the ActualSize allowing the RenderTransformAdapter to accept to apply the transform.
+				overlay.DispatcherQueue.TryEnqueue(() => canvas.InvalidateMeasure());
+#endif
 			}
 		}
 #endif


### PR DESCRIPTION
closes https://github.com/unoplatform/ziidms-private/issues/15

## Bugfix
HRI not draggable on Android

## What is the current behavior?
Transform is not applied because the `DiagnosticOverlay` is `ActualWidth = 0`.

## What is the new behavior?
We force an invalidation of the `DiagnosticOverlay` to force re-computation of the `ActualSize`, driving the `RanderTransform` to be applied properly

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
