### PR TITLE
fix: Move to jsimport for bbox

### DIFF
--- a/src/Uno.UI/UI/Xaml/Window/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window/WindowManagerInterop.wasm.cs
@@ -15,6 +15,7 @@ using Microsoft.UI.Xaml;
 
 using System.Runtime.InteropServices.JavaScript;
 using Microsoft.UI.Xaml.Controls;
+using System.Xml.Linq;
 
 namespace Uno.UI.Xaml
 {
@@ -517,14 +518,8 @@ namespace Uno.UI.Xaml
 
 		internal static Rect GetBBox(IntPtr htmlId)
 		{
-			var parms = new WindowManagerGetBBoxParams
-			{
-				HtmlId = htmlId
-			};
-
-			var ret = (WindowManagerGetBBoxReturn)TSInteropMarshaller.InvokeJS("Uno:getBBoxNative", parms, typeof(WindowManagerGetBBoxReturn));
-
-			return new Rect(ret.X, ret.Y, ret.Width, ret.Height);
+			var ret = NativeMethods.GetBBox(htmlId);
+			return new Rect(ret[0], ret[1], ret[2], ret[3]);
 		}
 
 		[TSInteropMessage]
@@ -890,6 +885,9 @@ namespace Uno.UI.Xaml
 
 			[JSImport("globalThis.Uno.UI.WindowManager.current.setUnsetCssClasses")]
 			internal static partial void SetUnsetCssClasses(IntPtr htmlId, string[] cssClassesToSet, string[] cssClassesToUnset);
+
+			[JSImport("globalThis.Uno.UI.WindowManager.current.getBBox")]
+			internal static partial double[] GetBBox(IntPtr htmlId);
 		}
 	}
 }

--- a/src/Uno.UI/ts/WindowManager.ts
+++ b/src/Uno.UI/ts/WindowManager.ts
@@ -984,24 +984,7 @@ namespace Uno.UI {
 			delete this.allActiveElementsById[elementId];
 		}
 
-		public getBBoxNative(pParams: number, pReturn: number): boolean {
-
-			const params = WindowManagerGetBBoxParams.unmarshal(pParams);
-
-			const bbox = this.getBBoxInternal(params.HtmlId);
-
-			const ret = new WindowManagerGetBBoxReturn();
-			ret.X = bbox.x;
-			ret.Y = bbox.y;
-			ret.Width = bbox.width;
-			ret.Height = bbox.height;
-
-			ret.marshal(pReturn);
-
-			return true;
-		}
-
-		private getBBoxInternal(elementId: number): any {
+		public getBBox(elementId: number): any {
 
 			const element = this.getView(elementId) as SVGGraphicsElement;
 			let unconnectedRoot: HTMLElement | SVGGraphicsElement = null;
@@ -1028,12 +1011,17 @@ namespace Uno.UI {
 					this.containerElement.appendChild(unconnectedRoot);
 				}
 
-				return element.getBBox();
+				let bbox = element.getBBox();
+
+				return [
+					bbox.x,
+					bbox.y,
+					bbox.width,
+					bbox.height];
 			}
 			finally {
 				cleanupUnconnectedRoot(this.containerElement);
 			}
-
 		}
 
 		public setSvgElementRect(pParams: number): boolean {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Move to jsimport for getBBox to improve wasm performance

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
