### PR TITLE
chore: Revert "Make skia runtime tests green locally on Debug"

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -159,8 +159,11 @@ namespace SamplesApp
 			}
 
 			var sw = Stopwatch.StartNew();
-#if WINAPPSDK && DEBUG
-			// this.DebugSettings.EnableFrameRateCounter = true;
+#if DEBUG
+			if (System.Diagnostics.Debugger.IsAttached)
+			{
+				// this.DebugSettings.EnableFrameRateCounter = true;
+			}
 #endif
 			AssertInitialWindowSize();
 
@@ -546,7 +549,6 @@ namespace SamplesApp
 #if HAS_UNO
 			Uno.UI.FeatureConfiguration.TextBox.UseOverlayOnSkia = false;
 			Uno.UI.FeatureConfiguration.ToolTip.UseToolTips = true;
-			Uno.UI.FeatureConfiguration.DependencyProperty.ValidatePropertyOwnerOnReadWrite = true;
 
 			Uno.UI.FeatureConfiguration.Font.DefaultTextFontFamily = "ms-appx:///Uno.Fonts.OpenSans/Fonts/OpenSans.ttf";
 #endif

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UnitTest/UnitTestsControl.cs
@@ -940,7 +940,7 @@ namespace Uno.UI.Samples.Tests
 							}
 							else if (test.ExpectedException is null || !test.ExpectedException.IsInstanceOfType(e))
 							{
-								if (_currentRun.CurrentRepeatCount < config.Attempts - 1)
+								if (_currentRun.CurrentRepeatCount < config.Attempts - 1 && !Debugger.IsAttached)
 								{
 									_currentRun.CurrentRepeatCount++;
 									canRetry = true;

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/CalendarHelper.h.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/CalendarHelper.h.cs
@@ -236,7 +236,7 @@ namespace Private.Infrastructure
 			{
 				// we expect no event here, so below statement will timeout and throw WEX.Common.Exception.
 				TestServices.VERIFY_THROWS_WINRT<Exception>(
-					async () => await m_selectedDatesChangedEvent.WaitFor(TimeSpan.FromMilliseconds(5000)),
+					async () => await m_selectedDatesChangedEvent.WaitFor(TimeSpan.FromMilliseconds(5000), true /* enforceUnderDebugger */),
 					"SelectedDatesChanged event should not raise!");
 				TestServices.VERIFY_IS_FALSE(m_selectedDatesChangedEvent.HasFired());
 				m_selectedDatesChangedRegistration.Detach();

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/Event.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/Event.cs
@@ -74,5 +74,15 @@ namespace Microsoft.UI.Xaml.Tests.Enterprise
 		{
 			return WaitForDefault((int)timeout.TotalMilliseconds, ct);
 		}
+
+		internal Task WaitFor(TimeSpan timeout, bool enforceUnderDebugger, CancellationToken ct = default)
+		{
+			if (!enforceUnderDebugger && Debugger.IsAttached)
+			{
+				return Task.CompletedTask;
+			}
+
+			return WaitForDefault((int)timeout.TotalMilliseconds, ct);
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/MUX/Helpers/EventTester.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Helpers/EventTester.cs
@@ -15,7 +15,6 @@ using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using UIExecutor = MUXControlsTestApp.Utilities.RunOnUIThread;
 using MUXControlsTestApp.Utilities;
-using Uno.UI;
 
 namespace Microsoft/* UWP don't rename */.UI.Xaml.Tests.Common
 {
@@ -93,11 +92,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Tests.Common
 #if !__WASM__
 			if (this.options.HasFlag(EventTesterOptions.CaptureWindowBefore))
 			{
-				this.CaptureWindowAsync("Before").Wait(this.DefaultTimeout);
+				this.CaptureWindowAsync("Before").Wait(this.Timeout);
 			}
 			if (this.options.HasFlag(EventTesterOptions.CaptureScreenBefore))
 			{
-				this.CaptureScreenAsync("Before").Wait(this.DefaultTimeout);
+				this.CaptureScreenAsync("Before").Wait(this.Timeout);
 			}
 #endif
 		}
@@ -154,14 +153,22 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Tests.Common
 			return new RoutedEventTester<TEventArgs>(sender, eventName, action);
 		}
 
-		public TimeSpan DefaultTimeout =
-#if HAS_UNO
-			FeatureConfiguration.DebugOptions.WaitIndefinitelyInEventTester
-#else
-			Debugger.IsAttached
-#endif
-				? TimeSpan.FromMilliseconds(-1)
-				: EventTesterConfig.Timeout;
+		public TimeSpan DefaultTimeout = EventTesterConfig.Timeout;
+
+		private TimeSpan Timeout
+		{
+			get
+			{
+				if (Debugger.IsAttached)
+				{
+					return TimeSpan.FromMilliseconds(-1); // Wait indefinitely if debugger is attached.
+				}
+				else
+				{
+					return this.DefaultTimeout;
+				}
+			}
+		}
 
 		private TSender Sender
 		{
@@ -251,7 +258,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Tests.Common
 
 		public async Task<bool> Wait()
 		{
-			return await this.Wait(this.DefaultTimeout);
+			return await this.Wait(this.Timeout);
 		}
 
 		public async Task<bool> Wait(TimeSpan timeout)
@@ -325,7 +332,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Tests.Common
 
 		public async Task<bool> WaitAsync()
 		{
-			return await this.WaitAsync(this.DefaultTimeout);
+			return await this.WaitAsync(this.Timeout);
 		}
 
 		public async Task<bool> WaitAsync(TimeSpan timeout)
@@ -434,11 +441,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Tests.Common
 #if !__WASM__
 					if (this.options.HasFlag(EventTesterOptions.CaptureWindowAfter))
 					{
-						this.CaptureWindowAsync("After").Wait(this.DefaultTimeout);
+						this.CaptureWindowAsync("After").Wait(this.Timeout);
 					}
 					if (this.options.HasFlag(EventTesterOptions.CaptureScreenAfter))
 					{
-						this.CaptureScreenAsync("After").Wait(this.DefaultTimeout);
+						this.CaptureScreenAsync("After").Wait(this.Timeout);
 					}
 #endif
 

--- a/src/Uno.UI.RuntimeTests/MUX/Utilities/TestHelpers.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Utilities/TestHelpers.cs
@@ -139,7 +139,7 @@ namespace MUXControlsTestApp.Utilities
 {
 	public static class TestUtilities
 	{
-		public static int DefaultWaitMs = 5000;
+		public static int DefaultWaitMs = Debugger.IsAttached ? 120000 : 5000;
 
 		public static async Task SetAsVisualTreeRoot(FrameworkElement element)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/UnitTestsTests/Given_UnitTest.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/UnitTestsTests/Given_UnitTest.cs
@@ -10,7 +10,6 @@ namespace Uno.UI.RuntimeTests.Tests.UnitTestsTests
 	{
 		static int When_UnhandledException_Count;
 
-		// This tests that automatic retry is working.
 		[TestMethod]
 		public void When_UnhandledException()
 		{
@@ -26,7 +25,6 @@ namespace Uno.UI.RuntimeTests.Tests.UnitTestsTests
 	{
 		static int Initialize_Count;
 
-		// This tests that automatic retry is working.
 		[TestInitialize]
 		public void Initialize()
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -663,8 +663,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitFor(() => imageOpened);
 			var screenshot = await TakeScreenshot(image);
 			ImageAssert.HasColorAt(screenshot, 5, screenshot.Height / 2, Color.FromArgb(0xFF, 0xED, 0x1B, 0x24), tolerance: 5);
-			ImageAssert.HasColorAt(screenshot, screenshot.Width / 2.2f, screenshot.Height / 2, Color.FromArgb(0xFF, 0xED, 0x1B, 0x24), tolerance: 5);
-			ImageAssert.HasColorAt(screenshot, screenshot.Width / 1.8f, screenshot.Height / 2, Color.FromArgb(0xFF, 0x23, 0xB1, 0x4D), tolerance: 5);
+			ImageAssert.HasColorAt(screenshot, screenshot.Width / 2 - 10, screenshot.Height / 2, Color.FromArgb(0xFF, 0xED, 0x1B, 0x24), tolerance: 5);
+			ImageAssert.HasColorAt(screenshot, screenshot.Width / 2 + 10, screenshot.Height / 2, Color.FromArgb(0xFF, 0x23, 0xB1, 0x4D), tolerance: 5);
 			ImageAssert.HasColorAt(screenshot, screenshot.Width - 5, screenshot.Height / 2, Color.FromArgb(0xFF, 0x23, 0xB1, 0x4D), tolerance: 5);
 
 		}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -841,29 +841,6 @@ namespace Uno.UI
 			/// of having an undefined behavior and/or race conditions.
 			/// </summary>
 			public static bool DisableThreadingCheck { get; set; }
-
-			/// <summary>
-			/// Enables checks that make sure that <see cref="DependencyObjectStore.GetValue" /> and
-			/// <see cref="DependencyObjectStore.SetValue" /> are only called on the owner of the property being
-			/// set/got.
-			/// </summary>
-			public static bool ValidatePropertyOwnerOnReadWrite { get; set; } =
-#if DEBUG
-				true;
-#else
-				global::System.Diagnostics.Debugger.IsAttached;
-#endif
-		}
-
-		/// <summary>
-		/// This is for internal use to facilitate turning on/off certain logic that makes it easier/harder
-		/// to debug.
-		/// </summary>
-		internal static class DebugOptions
-		{
-			public static bool PreventKeyboardStateTrackerFromResettingOnWindowActivationChange { get; set; }
-
-			public static bool WaitIndefinitelyInEventTester { get; set; }
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/AppBar/AppBar.Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AppBar/AppBar.Partial.cs
@@ -769,8 +769,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			// If the AppBar is not live, then wait until it's loaded before
 			// responding to changes to opened state and firing our Opening/Opened events.
-			// Uno Specific: using IsLoaded instead of IsInLiveTree, which makes more sense because OnOpening (called below) -> SetupOverlayState expects OnApplyTemplate to have already been called
-			if (!IsLoaded)
+			if (!IsInLiveTree)
 			{
 				return;
 			}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -107,6 +107,8 @@ namespace Microsoft.UI.Xaml
 		/// </summary>
 		private SpecializedResourceDictionary.ResourceKey? _themeLastUsed;
 
+		private static readonly bool _validatePropertyOwner = Debugger.IsAttached;
+
 #if UNO_HAS_ENHANCED_LIFECYCLE
 		internal bool IsDisposed => _isDisposed;
 #endif
@@ -800,7 +802,7 @@ namespace Microsoft.UI.Xaml
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private void ValidatePropertyOwner(DependencyProperty property)
 		{
-			if (FeatureConfiguration.DependencyProperty.ValidatePropertyOwnerOnReadWrite)
+			if (_validatePropertyOwner)
 			{
 				var isFrameworkElement = _originalObjectType.Is(typeof(FrameworkElement));
 				var isMixinFrameworkElement = _originalObjectRef.Target is IFrameworkElement && !isFrameworkElement;

--- a/src/Uno.UI/UI/Xaml/UIElementCollection.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementCollection.cs
@@ -57,9 +57,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		public void Add(UIElement item)
 		{
-#if !__CROSSRUNTIME__ // SetParent is already called in AddCore and calling it here messes up the check inside AddCore for a preexisting parent. VerifyNavigationViewItemToolTipPaneDisplayMode (in DEBUG) fails otherwise because Enter is called multiple times on the same element
 			item.SetParent(_owner);
-#endif
 
 			AddCore(item);
 			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
@@ -269,10 +269,7 @@ internal abstract class BaseWindowImplementation : IWindowImplementation
 		CoreWindow?.OnActivated(coreWindowActivatedEventArgs);
 		Activated?.Invoke(Window, activatedEventArgs);
 		SystemThemeHelper.RefreshSystemTheme();
-		if (!FeatureConfiguration.DebugOptions.PreventKeyboardStateTrackerFromResettingOnWindowActivationChange)
-		{
-			KeyboardStateTracker.Reset();
-		}
+		KeyboardStateTracker.Reset();
 	}
 
 	public bool Close()

--- a/src/Uno.UWP/Buffers/DefaultArrayPoolBucket.cs
+++ b/src/Uno.UWP/Buffers/DefaultArrayPoolBucket.cs
@@ -40,13 +40,7 @@ namespace Uno.Buffers
 			/// </summary>
 			internal Bucket(int bufferLength, int numberOfBuffers, int poolId)
 			{
-				_lock = new SpinLock(
-#if DEBUG // thread tracking adds non-trivial overheads to Enter/Exit
-					true
-#else
-					global::System.Diagnostics.Debugger.IsAttached
-#endif
-					);
+				_lock = new SpinLock(Debugger.IsAttached); // only enable thread tracking if debugger is attached; it adds non-trivial overheads to Enter/Exit
 				_buffers = new T[numberOfBuffers][];
 				_bufferLength = bufferLength;
 				_poolId = poolId;

--- a/src/Uno.UWP/UI/Core/Internal/KeyboardStateTracker.cs
+++ b/src/Uno.UWP/UI/Core/Internal/KeyboardStateTracker.cs
@@ -98,7 +98,15 @@ internal static partial class KeyboardStateTracker
 		}
 	}
 
-	internal static void Reset() => _keyStates.Clear();
+	internal static void Reset()
+	{
+		// Clearing state when debugger is attached would
+		// make it hard to debug key events.
+		if (!System.Diagnostics.Debugger.IsAttached)
+		{
+			_keyStates.Clear();
+		}
+	}
 
 #if __WASM__
 #pragma warning disable IDE0051 // Remove unused private members


### PR DESCRIPTION
Reverts unoplatform/uno#18659, as it causes performance regressions: https://github.com/unoplatform/uno/issues/18908