### PR TITLE
perf: Don't use multicast delegates for DependencyObjectCollection.VectorChanged

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_DependencyObjectCollection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_DependencyObjectCollection.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.ObjectiveC;
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
+
+[TestClass]
+public class Given_DependencyObjectCollection
+{
+	[TestMethod]
+	public void When_Add_Multiple_And_Invoke()
+	{
+		DependencyObjectCollection c = new();
+
+		List<string> list = [];
+
+		void One(object sender, object args) => list.Add("One");
+		void Two(object sender, object args) => list.Add("Two");
+
+		c.VectorChanged += One;
+		c.VectorChanged += Two;
+		c.VectorChanged += One;
+		c.VectorChanged -= One;
+
+		c.Add(c);
+
+		Assert.IsTrue(list.SequenceEqual(["One", "Two"]));
+	}
+}

--- a/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
@@ -28,7 +28,8 @@ namespace Microsoft.UI.Xaml
 	{
 		private object _vectorChangedHandlersLock = new();
 
-		// Explicit handlers list to avoid the cost of multicast delegates handling
+		// Explicit handlers list to avoid the cost of generic multicast
+		// delegates handling on mono's AOT.
 		private List<VectorChangedEventHandler<T>> _vectorChangedHandlers;
 
 		public event VectorChangedEventHandler<T> VectorChanged


### PR DESCRIPTION
This change avoids the high cost of multicast delegates, particularly on mono-AOT environments. ~We also do not need the thread safety guarantees~.

Example:

![image](https://github.com/user-attachments/assets/f90386e7-160c-4e56-8ecc-e19028cbe257)
