### PR TITLE
fix(wasm): unwanted preview shown when dragging over existing selection

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1098,6 +1098,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_Wasm_Selection.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FocusManager\FocusManagerTest.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6325,6 +6329,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_TestPage.xaml.cs">
       <DependentUpon>DragDrop_TestPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\DragAndDrop\DragDrop_Wasm_Selection.xaml.cs">
+      <DependentUpon>DragDrop_Wasm_Selection.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FocusManager\FocusManagerTest.xaml.cs">
       <DependentUpon>FocusManagerTest.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_Wasm_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_Wasm_Selection.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="UITests.Windows_UI_Xaml.DragAndDrop.DragDrop_Wasm_Selection"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	
+	<StackPanel Spacing="16">
+		<TextBlock Text="selectable text: // 1. select from HERE" IsTextSelectionEnabled="True" />
+
+		<!-- some controls that typically use drag gestures -->
+		<Slider />
+		<ScrollBar Orientation="Horizontal" IndicatorMode="MouseIndicator" />
+
+		<TextBlock Text="selectable text: // 2. to THERE" IsTextSelectionEnabled="True" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_Wasm_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_Wasm_Selection.xaml.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml.DragAndDrop;
+
+#if __WASM__
+[Sample(
+	Description = PageDescription,
+	IsManualTest = true,
+	IgnoreInSnapshotTests = true)]
+#endif
+public sealed partial class DragDrop_Wasm_Selection : UserControl
+{
+	private const string PageDescription =
+		"This is wasm-only manual test verifying against #18854. " +
+		"While selection covers both TextBlocks, try to drag the thumb of the Slider and ScrollBar, " +
+		"there should be no drag preview."; // see linked issue for a gif of what should not happen.
+
+	public DragDrop_Wasm_Selection()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI/ts/Windows/ApplicationModel/DataTransfer/DragAndDropExtension.ts
+++ b/src/Uno.UI/ts/Windows/ApplicationModel/DataTransfer/DragAndDropExtension.ts
@@ -55,6 +55,9 @@
 			//document.addEventListener("dragstart", this._dragHandler);
 			//document.addEventListener("drag", this._dragHandler);
 			//document.addEventListener("dragend", this._dragHandler);
+
+			// #18854: Prevent the browser default selection drag preview.
+			document.addEventListener('dragstart', e => e.preventDefault());
 		}
 
 		public dispose() {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #18854, closes unoplatform/kahua-private#228

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On WebAssembly, when there is selection underneath or around a control that typically uses drag gesture (eg: ScrollBar or Slider), the drag gesture will only work for the 1st frame/tick/delta, subsequent pointer capture events are lost, and there is an undesired browser dragging preview that follows the cursor.

## What is the new behavior?
The browser dragstart event are globally blocked. Note that doesn't affect the DragEventArgs.DragUIOverride preview as that is rendered on the uno side, nor the control's ability to receive drop (handled via dragenter & dragleave).

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information