### PR TITLE
fix(pointers): Fix possible missing pointer exited event with touch using wasm on iOS/iPad

### DIFF
--- a/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
+++ b/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
@@ -15,6 +15,7 @@ using _PointerIdentifier = Windows.Devices.Input.PointerIdentifier; // internal 
 using _NativeMethods = __Windows.UI.Core.CoreWindow.NativeMethods;
 using System.Runtime.InteropServices;
 using Windows.System;
+using Microsoft.UI.Xaml;
 
 namespace Uno.UI.Runtime;
 
@@ -30,6 +31,7 @@ internal partial class BrowserPointerInputSource : IUnoCorePointerInputSource
 
 	// TODO: Verify the boot time unit (ms or ticks)
 	private ulong _bootTime;
+	private bool _isIOs;
 	private bool _isOver;
 	private PointerPoint? _lastPoint;
 	private CoreCursor _pointerCursor = new(CoreCursorType.Arrow, 0);
@@ -56,11 +58,19 @@ internal partial class BrowserPointerInputSource : IUnoCorePointerInputSource
 	private static partial void Initialize([JSMarshalAs<JSType.Any>] object inputSource);
 
 	[JSExport]
-	private static void OnInitialized([JSMarshalAs<JSType.Any>] object inputSource, double bootTime)
+	private static void OnInitialized([JSMarshalAs<JSType.Any>] object inputSource, double bootTime, string userAgent)
 	{
-		((BrowserPointerInputSource)inputSource)._bootTime = (ulong)bootTime;
+		if (inputSource is BrowserPointerInputSource that)
+		{
+			that._bootTime = (ulong)bootTime;
+			that._isIOs = userAgent.Contains("iPhone") || userAgent.Contains("iPad"); // Note: OperatingSystem.IsIOS() is false
 
-		_logTrace?.Trace("Complete initialization of BrowserPointerInputSource, we are now ready to receive pointer events!");
+			_logTrace?.Trace("Complete initialization of BrowserPointerInputSource, we are now ready to receive pointer events!");
+		}
+		else if (_log.IsEnabled(LogLevel.Error))
+		{
+			_log.Error("Requested init using an invalid source.");
+		}
 	}
 
 	[JSExport]
@@ -122,6 +132,7 @@ internal partial class BrowserPointerInputSource : IUnoCorePointerInputSource
 				case HtmlPointerEvent.pointerleave:
 					that._isOver = false;
 					that.PointerExited?.Invoke(that, args);
+					_PointerIdentifierPool.ReleaseManaged(pointerIdentifier);
 					break;
 
 				case HtmlPointerEvent.pointerdown:
@@ -131,7 +142,13 @@ internal partial class BrowserPointerInputSource : IUnoCorePointerInputSource
 				case HtmlPointerEvent.pointerup:
 					//case HtmlPointerEvent.lostpointercapture: // if pointer is captured, we don't get a up, just a capture lost (with skia for wasm)
 					that.PointerReleased?.Invoke(that, args);
-					_PointerIdentifierPool.ReleaseManaged(pointerIdentifier);
+					if (that._isIOs && args is { CurrentPoint.PointerDeviceType: PointerDeviceType.Touch, DispatchResult: UIElement.PointerEventDispatchResult { VisualTreeAltered: true } })
+					{
+						// On iOS, when the element under the pointer is removed, the browser won't send any pointer leave event.
+
+						args.DispatchResult = null; // To be clean only, the value is not used in the leave case.
+						goto case HtmlPointerEvent.pointerleave;
+					}
 					break;
 
 				case HtmlPointerEvent.pointermove:

--- a/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
+++ b/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
@@ -63,7 +63,10 @@ internal partial class BrowserPointerInputSource : IUnoCorePointerInputSource
 		if (inputSource is BrowserPointerInputSource that)
 		{
 			that._bootTime = (ulong)bootTime;
-			that._isIOs = userAgent.Contains("iPhone") || userAgent.Contains("iPad"); // Note: OperatingSystem.IsIOS() is false
+
+			// Note: OperatingSystem.IsIOS() is false
+			that._isIOs = userAgent.Contains("iPhone", StringComparison.OrdinalIgnoreCase)
+				|| userAgent.Contains("iPad", StringComparison.OrdinalIgnoreCase);
 
 			_logTrace?.Trace("Complete initialization of BrowserPointerInputSource, we are now ready to receive pointer events!");
 		}

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
@@ -239,10 +239,9 @@ internal partial class InputManager
 #endif
 
 			var routedArgs = new PointerRoutedEventArgs(args, originalSource) { IsInjected = isInjected };
-			var result = default(PointerEventDispatchResult);
 
 			// First raise the event, either on the OriginalSource or on the capture owners if any
-			result = RaiseUsingCaptures(Wheel, originalSource, routedArgs, setCursor: true);
+			var result = RaiseUsingCaptures(Wheel, originalSource, routedArgs, setCursor: true);
 
 			// Scrolling can change the element underneath the pointer, so we need to update
 			(originalSource, var staleBranch) = HitTest(args, caller: "OnPointerWheelChanged_post_wheel", isStale: _isOver);

--- a/src/Uno.UI/ts/Runtime/BrowserPointerInputSource.ts
+++ b/src/Uno.UI/ts/Runtime/BrowserPointerInputSource.ts
@@ -54,7 +54,9 @@
 			this._bootTime = Date.now() - performance.now();
 			this._source = manageSource;
 
-			BrowserPointerInputSource._exports.OnInitialized(manageSource, this._bootTime);
+			var userAgent = navigator.userAgent || navigator.vendor || window.opera;
+
+			BrowserPointerInputSource._exports.OnInitialized(manageSource, this._bootTime, userAgent);
 			this.subscribePointerEvents(); // Subscribe only after the managed initialization is done
 		}
 

--- a/src/Uno.UWP/UI/Core/PointerEventArgs.cs
+++ b/src/Uno.UWP/UI/Core/PointerEventArgs.cs
@@ -21,6 +21,14 @@ namespace Windows.UI.Core
 		public IList<PointerPoint> GetIntermediatePoints()
 			=> new List<PointerPoint> { CurrentPoint };
 
+#nullable enable
+		/// <summary>
+		/// Gets the dispatch result of this event, if any.
+		/// This is defined by the InputManager if the event goes though it.
+		/// </summary>
+		internal object? DispatchResult { get; set; }
+#nullable restore
+
 		/// <inheritdoc />
 		public override string ToString()
 			=> $"{CurrentPoint} | modifiers: {KeyModifiers}";


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/18599

## Bugfix
Fix possible missing pointer exited event with touch using wasm on iOS/iPad

## What is the current behavior?
Browser does not raise the `pointerleave` event when the target lement is being removed from the screen.

## What is the new behavior?
We forcefully inject it when needed

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] ~~[Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
