### PR TITLE
fix: `Popup.Child` parent hierarchy, `ResourceDictionary` resolution

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/StyleFlowToPopup.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/StyleFlowToPopup.xaml
@@ -1,0 +1,24 @@
+﻿<Page
+    x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls.StyleFlowToPopup"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.Resources>
+			<Style TargetType="TextBlock">
+				<Setter Property="Foreground" Value="Red" />
+			</Style>
+		</Grid.Resources>
+		<StackPanel>
+			<TextBlock x:Name="InnerTextBlock" Text="Red foreground" />
+		</StackPanel>
+		<Popup x:Name="TestPopup">
+			<TextBlock x:Name="PopupContentTextBlock" Text="This should have red foreground too!" />
+		</Popup>
+	</Grid>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/StyleFlowToPopup.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Controls/StyleFlowToPopup.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
+
+public sealed partial class StyleFlowToPopup : Page
+{
+	public StyleFlowToPopup()
+	{
+		this.InitializeComponent();
+	}
+
+	public void ShowPopup() => TestPopup.IsOpen = true;
+
+	public TextBlock GridTextBlock => InnerTextBlock;
+
+	public TextBlock PopupTextBlock => PopupContentTextBlock;
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Style.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Style.cs
@@ -1,17 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using Uno.UI.Extensions;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Markup;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Private.Infrastructure;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
-using Uno.UI.RuntimeTests.Helpers;
-using SamplesApp.UITests;
+using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
+using Private.Infrastructure;
+using SamplesApp.UITests;
+using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml.Controls;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 {
@@ -87,6 +85,25 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			cc.Style = explicitStyle;
 
 			Assert.AreEqual(HorizontalAlignment.Left, cc.HorizontalContentAlignment);
+		}
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_Style_Flows_To_Popup()
+		{
+			var page = new StyleFlowToPopup();
+			TestServices.WindowHelper.WindowContent = page;
+			await UITestHelper.Load(page);
+
+			var foreground = (SolidColorBrush)page.GridTextBlock.Foreground;
+			Assert.AreEqual(Colors.Red, foreground.Color);
+
+			page.ShowPopup();
+
+			await TestServices.WindowHelper.WaitFor(() => VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot).Count > 0);
+
+			var popupForeground = (SolidColorBrush)page.PopupTextBlock.Foreground;
+			Assert.AreEqual(Colors.Red, popupForeground.Color);
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Style.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Style.cs
@@ -96,14 +96,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 			await UITestHelper.Load(page);
 
 			var foreground = (SolidColorBrush)page.GridTextBlock.Foreground;
-			Assert.AreEqual(Colors.Red, foreground.Color);
+			Assert.AreEqual(Microsoft.UI.Colors.Red, foreground.Color);
 
 			page.ShowPopup();
 
 			await TestServices.WindowHelper.WaitFor(() => VisualTreeHelper.GetOpenPopupsForXamlRoot(TestServices.WindowHelper.XamlRoot).Count > 0);
 
 			var popupForeground = (SolidColorBrush)page.PopupTextBlock.Foreground;
-			Assert.AreEqual(Colors.Red, popupForeground.Color);
+			Assert.AreEqual(Microsoft.UI.Colors.Red, popupForeground.Color);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Base.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Base.cs
@@ -138,6 +138,15 @@ public partial class Popup : FrameworkElement, IPopup
 
 	partial void OnChildChangedPartial(UIElement oldChild, UIElement newChild)
 	{
+		if (oldChild is FrameworkElement oldChildFe && oldChildFe.LogicalParentOverride == this)
+		{
+			oldChildFe.LogicalParentOverride = null;
+		}
+		if (newChild is FrameworkElement newChildFe)
+		{
+			newChildFe.LogicalParentOverride = this;
+		}
+
 		if (oldChild is IDependencyObjectStoreProvider provider &&
 			provider.Store.ReadLocalValue(provider.Store.DataContextProperty) != DependencyProperty.UnsetValue)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Base.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Base.cs
@@ -138,13 +138,13 @@ public partial class Popup : FrameworkElement, IPopup
 
 	partial void OnChildChangedPartial(UIElement oldChild, UIElement newChild)
 	{
-		if (oldChild is FrameworkElement oldChildFe && oldChildFe.LogicalParentOverride == this)
+		if (oldChild is FrameworkElement oldChildFe && oldChildFe.Parent == this)
 		{
-			oldChildFe.LogicalParentOverride = null;
+			oldChildFe.SetLogicalParent(null);
 		}
 		if (newChild is FrameworkElement newChildFe)
 		{
-			newChildFe.LogicalParentOverride = this;
+			newChildFe.SetLogicalParent(this);
 		}
 
 		if (oldChild is IDependencyObjectStoreProvider provider &&

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Base.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.Base.cs
@@ -138,7 +138,7 @@ public partial class Popup : FrameworkElement, IPopup
 
 	partial void OnChildChangedPartial(UIElement oldChild, UIElement newChild)
 	{
-		if (oldChild is FrameworkElement oldChildFe && oldChildFe.Parent == this)
+		if (oldChild is FrameworkElement oldChildFe && oldChildFe.LogicalParentOverride == this)
 		{
 			oldChildFe.SetLogicalParent(null);
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -238,7 +238,6 @@ internal partial class PopupPanel : Panel
 	private protected override void OnUnloaded()
 	{
 		base.OnUnloaded();
-		this.SetLogicalParent(null);
 
 		if (XamlRoot is { } xamlRoot)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -231,9 +231,6 @@ internal partial class PopupPanel : Panel
 	private protected override void OnLoaded()
 	{
 		base.OnLoaded();
-		// Set Parent to the Popup, to obtain the same behavior as UWP that the Popup (and therefore the rest of the main visual tree)
-		// is reachable by scaling the combined Parent/GetVisualParent() hierarchy.
-		this.SetLogicalParent(Popup);
 
 		this.XamlRoot.Changed += XamlRootChanged;
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupRoot.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupRoot.cs
@@ -17,7 +17,7 @@ using _WindowActivatedEventArgs = Windows.UI.Core.WindowActivatedEventArgs;
 
 namespace Microsoft.UI.Xaml.Controls.Primitives;
 
-internal partial class PopupRoot : Panel
+internal partial class PopupRoot : Canvas
 {
 	private readonly List<ManagedWeakReference> _openPopups = new();
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -19,6 +19,7 @@ using System.Globalization;
 using Windows.ApplicationModel.Calls;
 using Microsoft.UI.Xaml.Controls;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml.Media;
 
 
 
@@ -1637,9 +1638,13 @@ namespace Microsoft.UI.Xaml
 					{
 						yield return fe.Resources;
 					}
-				}
 
-				candidate = candidate.GetParent() as DependencyObject;
+					candidate = fe.Parent as FrameworkElement;
+				}
+				else
+				{
+					candidate = VisualTreeHelper.GetParent(candidate) as DependencyObject;
+				}
 			}
 
 			if (includeAppResources && Application.Current != null)

--- a/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/VisualTreeHelper.cs
@@ -270,6 +270,12 @@ namespace Microsoft.UI.Xaml.Media
 				return uiElement.GetVisualTreeParent() as DependencyObject;
 			}
 
+			if (realParent is PopupPanel)
+			{
+				// Skip the popup panel and go to PopupRoot instead.
+				realParent = GetParent(realParent);
+			}
+
 			return realParent;
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #18943

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- `Popup.Child` visual and logical parent hierarchy included `PopupPanel`, which is internal only
- Logical `Parent` of `Popup.Child` was not the `Popup` itself
- `ResourceDictionary` search for a popup in the visual tree did not include its actual parent

## What is the new behavior?

- `Popup.Child` parent hierarchy skips `PopupPanel`
- Logical `Parent` of `Popup.Child` is `Popup`
- We prefer logical parent for `ResourceDictionary` search when available

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.