### PR TITLE
fix(netstd): late template application is ignored

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/TemplatedParent/TemplatedParentTests.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/TemplatedParent/TemplatedParentTests.cs
@@ -289,6 +289,40 @@ public partial class TemplatedParentTests // tests
 		""";
 		VerifyTree(expectations, setup, checkVSG: true);
 	}
+
+	[TestMethod]
+	public Task LateTemplateSwapping_NonContentControl() => LateTemplateSwapping<TextBox>();
+
+	[TestMethod]
+	public Task LateTemplateSwapping_ContentControl() => LateTemplateSwapping<ContentControl>();
+
+	public async Task LateTemplateSwapping<TControl>() where TControl : Control, new()
+	{
+		var templateA = XamlHelper.LoadXaml<ControlTemplate>("""
+			<ControlTemplate>
+				<Grid x:Name="RootA" Width="150" Height="50" Background="SkyBlue">
+					<TextBlock>Template A</TextBlock>
+				</Grid>
+			</ControlTemplate>
+		""");
+		var templateB = XamlHelper.LoadXaml<ControlTemplate>("""
+			<ControlTemplate>
+				<Grid x:Name="RootB" Width="150" Height="50" Background="Pink">
+					<TextBlock>Template B</TextBlock>
+				</Grid>
+			</ControlTemplate>
+		""");
+
+		var sut = new TControl();
+
+		sut.Template = templateA;
+		await UITestHelper.Load(sut, x => x.IsLoaded);
+		sut.FindFirstDescendantOrThrow<Grid>("RootA");
+
+		sut.Template = templateB;
+		await UITestHelper.WaitForIdle();
+		sut.FindFirstDescendantOrThrow<Grid>("RootB");
+	}
 }
 public partial class TemplatedParentTests // helper methods
 {

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewBaseItemChrome.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarViewBaseItemChrome.cs
@@ -112,9 +112,7 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 #endif
 
-		private UIElement GetFirstChildNoAddRef() => GetFirstChild();
-
-		private UIElement GetFirstChild()
+		internal override UIElement GetFirstChild()
 		{
 			UIElement spFirstChild;
 			// added in UIElement.GetFirstChild()

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -207,7 +207,30 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private protected virtual void OnTemplateChanged(DependencyPropertyChangedEventArgs e)
 		{
-#if !UNO_HAS_ENHANCED_LIFECYCLE
+#if UNO_HAS_ENHANCED_LIFECYCLE
+			if (e.OldValue != e.NewValue)
+			{
+				// Reset the template bindings for this control
+				//ClearPropertySubscriptions();
+
+				// When the control template property is set, we clear the visual children
+				var pUIElement = this.GetFirstChild();
+				if (pUIElement is { })
+				{
+					//CFrameworkTemplate* pNewTemplate = NULL;
+					//if (e.NewValue?.GetType() == valueObject)
+					//{
+					//	IFC(DoPointerCast(pNewTemplate, args.m_value.AsObject()));
+					//}
+					//else if (args.m_value.GetType() != valueNull)
+					//{
+					//	IFC(E_INVALIDARG);
+					//}
+					RemoveChild(pUIElement);
+					//IFC(GetContext()->RemoveNameScope(this, Jupiter::NameScoping::NameScopeType::TemplateNameScope));
+				}
+			}
+#else
 			_updateTemplate = true;
 			SetUpdateControlTemplate();
 #endif

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -1064,7 +1064,9 @@ namespace Microsoft.UI.Xaml
 			return GetFirstChild() is not null;
 		}
 
-		private UIElement/*?*/ GetFirstChild()
+		internal UIElement GetFirstChildNoAddRef() => GetFirstChild();
+
+		internal virtual UIElement/*?*/ GetFirstChild()
 		{
 #if __CROSSRUNTIME__ && !__NETSTD_REFERENCE__
 			if (GetChildren() is { Count: > 0 } children)


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/add-private#18

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Setting a value to Control.Template has no effect once the template materialization had occured.

## What is the new behavior?
^ no more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This regression was introduced with the life cycle refactor(ac1b54c35564027bfab3645b674aa905366c5322) that was bundled into templated-parent refactor (#17645).