### PR TITLE
fix: Fix logging of add-in discovery

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Uno.Extensions;
 using Uno.UI.RemoteControl.Host.Extensibility;
 using Uno.UI.RemoteControl.Host.IdeChannel;
 using Uno.UI.RemoteControl.Services;
@@ -61,6 +62,11 @@ namespace Uno.UI.RemoteControl.Host
 				throw new ArgumentException($"The httpPort parameter is required.");
 			}
 
+			const LogLevel logLevel = LogLevel.Debug;
+
+			// During init, we dump the logs to the console, until the logger is set up
+			Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = LoggerFactory.Create(builder => builder.SetMinimumLevel(logLevel).AddConsole());
+
 			var builder = new WebHostBuilder()
 				.UseSetting("UseIISIntegration", false.ToString())
 				.UseKestrel()
@@ -81,13 +87,22 @@ namespace Uno.UI.RemoteControl.Host
 					services.AddSingleton<IIdeChannel, IdeChannelServer>();
 				});
 
+			Debugger.Launch();
+
 			if (solution is not null)
 			{
 				// For backward compatibility, we allow to not have a solution file specified.
 				builder.ConfigureAddIns(solution);
 			}
+			else
+			{
+				typeof(Program).Log().Log(LogLevel.Warning, "No solution file specified, add-ins will not be loaded.");
+			}
 
 			var host = builder.Build();
+
+			// Once the app has started, we use the logger from the host
+			Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
 
 			host.Services.GetService<IIdeChannel>();
 

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -87,8 +87,6 @@ namespace Uno.UI.RemoteControl.Host
 					services.AddSingleton<IIdeChannel, IdeChannelServer>();
 				});
 
-			Debugger.Launch();
-
 			if (solution is not null)
 			{
 				// For backward compatibility, we allow to not have a solution file specified.
@@ -96,7 +94,7 @@ namespace Uno.UI.RemoteControl.Host
 			}
 			else
 			{
-				typeof(Program).Log().Log(LogLevel.Warning, "No solution file specified, add-ins will not be loaded.");
+				typeof(Program).Log().Log(LogLevel.Warning, "No solution file specified, add-ins will not be loaded which means that you won't be able to use any of the uno-studio features. Usually this indicates that your version of uno's IDE extension is too old.");
 			}
 
 			var host = builder.Build();


### PR DESCRIPTION
linked https://github.com/unoplatform/uno.hotdesign/issues/2986#top

## Bugfix
Fix logging of add-in discovery

## What is the current behavior?
Logging uses  `NullLoggger`

## What is the new behavior?
Use temp console log during statup of dev-server

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
