### PR TITLE
fix: Allow building Samples App WinUI for .NET 9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,12 +27,16 @@
 		<NetPreviousWpf>$(NetPrevious)-windows</NetPreviousWpf>
 		<NetCurrentWpf>$(NetCurrent)-windows</NetCurrentWpf>
 
+		<NetPreviousWinAppSDK>$(NetPrevious)-windows10.0.19041.0</NetPreviousWinAppSDK>
+		<NetCurrentWinAppSDK>$(NetCurrent)-windows10.0.19041.0</NetCurrentWinAppSDK>
+
 		<NetMobilePreviousAndCurrent>$(NetPreviousNetCoreMobile);$(NetCurrentNetCoreMobile)</NetMobilePreviousAndCurrent>
 		<NetAndroidPreviousAndCurrent>$(NetPrevious)-android;$(NetCurrent)-android</NetAndroidPreviousAndCurrent>
 		<NetWpfPreviousAndCurrent>$(NetPreviousWpf);$(NetCurrentWpf)</NetWpfPreviousAndCurrent>
 		<NetWasmPreviousAndCurrent>$(NetPrevious);$(NetCurrent)</NetWasmPreviousAndCurrent>
 		<NetSkiaPreviousAndCurrent>$(NetPrevious);$(NetCurrent)</NetSkiaPreviousAndCurrent>
 		<NetReferencePreviousAndCurrent>$(NetPrevious);$(NetCurrent)</NetReferencePreviousAndCurrent>
+		<NetWinAppSDKPreviousAndCurrent>$(NetPreviousWinAppSDK);$(NetCurrentWinAppSDK)</NetWinAppSDKPreviousAndCurrent>
 		<NetUnitTests>$(NetPrevious)</NetUnitTests>
 
 		<NetUWPOrWinUI>uap10.0.19041</NetUWPOrWinUI>

--- a/build/ci/.azure-devops-wasdk.yml
+++ b/build/ci/.azure-devops-wasdk.yml
@@ -41,7 +41,7 @@ jobs:
       # ---
       # NOTE: The error says to specify a RuntimeIdentifier *OR* platform other than AnyCPU.
       # We already specify RuntimeIdentifier=win-x64 in the build below. Still, the error pops up.
-      msbuildArguments: /r /t:Publish /m /v:m /p:Configuration=Release /p:Platform=x64 /p:RuntimeIdentifier=win-x64 /p:TargetFramework=net8.0-windows10.0.19041.0 /p:BuildGraphics3DGLForWindows=true /p:GenerateAppxPackageOnBuild=true /detailedsummary /bl:$(build.artifactstagingdirectory)/build-wasdk.binlog
+      msbuildArguments: /r /t:Publish /m /v:m /p:Configuration=Release /p:Platform=x64 /p:RuntimeIdentifier=win-x64 /p:BuildGraphics3DGLForWindows=true /p:GenerateAppxPackageOnBuild=true /detailedsummary /bl:$(build.artifactstagingdirectory)/build-wasdk.binlog
       clean: false
       restoreNugetPackages: false
       logProjectEvents: false
@@ -50,7 +50,7 @@ jobs:
   - task: CopyFiles@2
     condition: always()
     inputs:
-      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Windows/bin/x64/Release/net8.0-windows10.0.19041.0/win-x64/AppPackages
+      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Windows/bin/x64/Release/net9.0-windows10.0.19041.0/win-x64/AppPackages
       Contents: '**'
       TargetFolder: $(build.artifactstagingdirectory)
       CleanTargetFolder: false

--- a/build/ci/.azure-devops-wasdk.yml
+++ b/build/ci/.azure-devops-wasdk.yml
@@ -41,7 +41,7 @@ jobs:
       # ---
       # NOTE: The error says to specify a RuntimeIdentifier *OR* platform other than AnyCPU.
       # We already specify RuntimeIdentifier=win-x64 in the build below. Still, the error pops up.
-      msbuildArguments: /r /t:Publish /m /v:m /p:Configuration=Release /p:Platform=x64 /p:RuntimeIdentifier=win-x64 /p:BuildGraphics3DGLForWindows=true /p:GenerateAppxPackageOnBuild=true /detailedsummary /bl:$(build.artifactstagingdirectory)/build-wasdk.binlog
+      msbuildArguments: /r /t:Publish /m /v:m /p:Configuration=Release /p:Platform=x64 /p:RuntimeIdentifier=win-x64 /p:TargetFramework=net9.0-windows10.0.19041.0 /p:BuildGraphics3DGLForWindows=true /p:GenerateAppxPackageOnBuild=true /detailedsummary /bl:$(build.artifactstagingdirectory)/build-wasdk.binlog
       clean: false
       restoreNugetPackages: false
       logProjectEvents: false
@@ -50,7 +50,7 @@ jobs:
   - task: CopyFiles@2
     condition: always()
     inputs:
-      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Windows/bin/x64/Release/net8.0-windows10.0.19041.0/win-x64/AppPackages
+      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Windows/bin/x64/Release/net9.0-windows10.0.19041.0/win-x64/AppPackages
       Contents: '**'
       TargetFolder: $(build.artifactstagingdirectory)
       CleanTargetFolder: false

--- a/build/ci/.azure-devops-wasdk.yml
+++ b/build/ci/.azure-devops-wasdk.yml
@@ -41,7 +41,7 @@ jobs:
       # ---
       # NOTE: The error says to specify a RuntimeIdentifier *OR* platform other than AnyCPU.
       # We already specify RuntimeIdentifier=win-x64 in the build below. Still, the error pops up.
-      msbuildArguments: /r /t:Publish /m /v:m /p:Configuration=Release /p:Platform=x64 /p:RuntimeIdentifier=win-x64 /p:TargetFramework=net9.0-windows10.0.19041.0 /p:BuildGraphics3DGLForWindows=true /p:GenerateAppxPackageOnBuild=true /detailedsummary /bl:$(build.artifactstagingdirectory)/build-wasdk.binlog
+      msbuildArguments: /r /t:Publish /m /v:m /p:Configuration=Release /p:Platform=x64 /p:RuntimeIdentifier=win-x64 /p:TargetFramework=net8.0-windows10.0.19041.0 /p:BuildGraphics3DGLForWindows=true /p:GenerateAppxPackageOnBuild=true /detailedsummary /bl:$(build.artifactstagingdirectory)/build-wasdk.binlog
       clean: false
       restoreNugetPackages: false
       logProjectEvents: false
@@ -50,7 +50,7 @@ jobs:
   - task: CopyFiles@2
     condition: always()
     inputs:
-      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Windows/bin/x64/Release/net9.0-windows10.0.19041.0/win-x64/AppPackages
+      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Windows/bin/x64/Release/net8.0-windows10.0.19041.0/win-x64/AppPackages
       Contents: '**'
       TargetFolder: $(build.artifactstagingdirectory)
       CleanTargetFolder: false

--- a/build/ci/.azure-devops-wasdk.yml
+++ b/build/ci/.azure-devops-wasdk.yml
@@ -50,7 +50,7 @@ jobs:
   - task: CopyFiles@2
     condition: always()
     inputs:
-      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Windows/bin/x64/Release/net9.0-windows10.0.19041.0/win-x64/AppPackages
+      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Windows/bin/x64/Release/net8.0-windows10.0.19041.0/win-x64/AppPackages
       Contents: '**'
       TargetFolder: $(build.artifactstagingdirectory)
       CleanTargetFolder: false

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFrameworks>$(NetPrevious)-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>$(NetWinAppSDKPreviousAndCurrent)</TargetFrameworks>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>SamplesApp.Windows</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>$(NetCurrentWinAppSDK)</TargetFramework>
+		<TargetFramework>$(NetPreviousWinAppSDK)</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>SamplesApp.Windows</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>$(NetPrevious)-windows10.0.19041.0</TargetFramework>
+		<TargetFrameworks>$(NetPrevious)-windows10.0.19041.0</TargetFrameworks>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>SamplesApp.Windows</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
@@ -18,6 +18,8 @@
 
 		<WindowsSdkPackageVersion>10.0.19041.53</WindowsSdkPackageVersion>
 	</PropertyGroup>
+
+	<Import Project="../../targetframework-override.props" />
 
 	<ItemGroup>
 		<Content Include="Assets\SplashScreen.scale-200.png" />

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFrameworks>$(NetWinAppSDKPreviousAndCurrent)</TargetFrameworks>
+		<TargetFramework>$(NetCurrentWinAppSDK)</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>SamplesApp.Windows</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/Uno.CrossTargetting.targets
+++ b/src/Uno.CrossTargetting.targets
@@ -102,7 +102,7 @@
 		<SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition=" '$(TargetFramework)' != 'uap10.0.19041' and '$(TargetFramework)'!='net8.0-windows10.0.19041.0' and '$(TargetPlatformIdentifier)' != 'UAP'">
+	<PropertyGroup Condition=" '$(TargetFramework)' != 'uap10.0.19041' and $(TargetFramework.EndsWith('-windows10.0.19041.0')) != 'true' and '$(TargetPlatformIdentifier)' != 'UAP'">
 		<DefineConstants>$(DefineConstants);HAS_UNO</DefineConstants>
 		<DefineConstants Condition="'$(UNO_UWP_BUILD)'!='true'">$(DefineConstants);HAS_UNO_WINUI</DefineConstants>
 
@@ -111,7 +111,7 @@
     	<DefaultXamlRuntime Condition="'$(DefaultXamlRuntime)'==''">WinUI</DefaultXamlRuntime>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'=='net8.0-windows10.0.19041.0'">
+	<PropertyGroup Condition="$(TargetFramework.EndsWith('-windows10.0.19041.0'))">
 		<DefineConstants>$(DefineConstants);HAS_INPUT_INJECTOR;WINDOWS_WINUI;HAS_RENDER_TARGET_BITMAP;HAS_COMPOSITION_API</DefineConstants>
 	</PropertyGroup>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Only .NET 8 is supported

## What is the new behavior?

Both 8 and 9 are supported

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
