### PR TITLE
`Frame` should throw on page exceptions

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
@@ -454,7 +454,11 @@ public class Given_Frame
 
 		var exception = Assert.ThrowsException<NotSupportedException>(() => SUT.Navigate(typeof(ExceptionInCtorPage)));
 		Assert.AreEqual("Crashed", exception.Message);
-		Assert.IsFalse(navigationFailed);
+		if (FeatureConfiguration.Frame.UseWinUIBehavior)
+		{
+			// This is only valid with WinUI Frame behavior
+			Assert.IsFalse(navigationFailed);
+		}
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
@@ -437,6 +437,22 @@ public class Given_Frame
 		Assert.IsTrue(_navigateOrderTracker.FrameNavigated);
 	}
 
+	[TestMethod]
+	public async Task When_Exception_In_Page_Ctor()
+	{
+		var SUT = new Frame()
+		{
+			Width = 200,
+			Height = 200
+		};
+
+		TestServices.WindowHelper.WindowContent = SUT;
+		await TestServices.WindowHelper.WaitForLoaded(SUT);
+
+		var exception = Assert.ThrowsException<NotSupportedException>(() => SUT.Navigate(typeof(CrashOnlyPage)));
+		Assert.AreEqual("Crashed", exception.Message);
+	}
+
 	[TestCleanup]
 	public void Cleanup()
 	{
@@ -612,4 +628,12 @@ public partial class FrameNavigateFirstPage : Page
 
 public partial class FrameNavigateSecondPage : Page
 {
+}
+
+public partial class CrashOnlyPage : Page
+{
+	public CrashOnlyPage()
+	{
+		throw new NotSupportedException("Crashed");
+	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
@@ -446,19 +446,23 @@ public class Given_Frame
 			Height = 200
 		};
 
+#if HAS_UNO
 		bool navigationFailed = false;
 		SUT.NavigationFailed += (s, e) => navigationFailed = true;
+#endif
 
 		TestServices.WindowHelper.WindowContent = SUT;
 		await TestServices.WindowHelper.WaitForLoaded(SUT);
 
 		var exception = Assert.ThrowsException<NotSupportedException>(() => SUT.Navigate(typeof(ExceptionInCtorPage)));
 		Assert.AreEqual("Crashed", exception.Message);
+#if HAS_UNO
 		if (FeatureConfiguration.Frame.UseWinUIBehavior)
 		{
 			// This is only valid with WinUI Frame behavior
 			Assert.IsFalse(navigationFailed);
 		}
+#endif
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
@@ -676,7 +676,11 @@ public partial class ExceptionInOnNavigatedToPage : Page
 	{
 	}
 
-	protected internal override void OnNavigatedTo(NavigationEventArgs e)
+	protected
+#if HAS_UNO
+	internal
+#endif
+	override void OnNavigatedTo(NavigationEventArgs e)
 	{
 		base.OnNavigatedTo(e);
 		throw new NotSupportedException("Crashed");

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.legacy.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.legacy.cs
@@ -153,7 +153,7 @@ public partial class Frame : ContentControl
 				Application.Current.RaiseRecoverableUnhandledException(new InvalidOperationException("Navigation failed", exception));
 			}
 
-			return false;
+			throw;
 		}
 		finally
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.partial.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.partial.mux.cs
@@ -301,6 +301,7 @@ partial class Frame
 			catch
 			{
 				pCanNavigate = false;
+				throw;
 			}
 		Cleanup:
 			;
@@ -585,6 +586,8 @@ partial class Frame
 			{
 				Content = oldObject;
 			}
+
+			throw;
 		}
 	}
 


### PR DESCRIPTION
…avigateGitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

In WinUI, exceptions thrown on `Page` instances propagate to corresponding `Frame.Navigate`, but this is not the case in Uno Platform targets


## What is the new behavior?

Exceptions bubble up

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
