### PR TITLE
feat(macOS): override ms-appx location when app is bundled

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowNative.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowNative.cs
@@ -54,6 +54,10 @@ internal class MacOSWindowNative
 
 		NativeWindowReady?.Invoke(this, this);
 
+		if (NativeUno.uno_application_is_bundled())
+		{
+			Windows.Storage.StorageFile.ResourcePathBase = IOPath.Combine(Windows.ApplicationModel.Package.Current.InstalledPath, "..", "Resources");
+		}
 		UpdateWindowPropertiesFromPackage();
 		UpdateWindowPropertiesFromApplicationView();
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
@@ -167,6 +167,10 @@ internal static partial class NativeUno
 	internal static partial bool uno_application_query_url_support(string url);
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	[return: MarshalAs(UnmanagedType.I1)]
+	internal static partial bool uno_application_is_bundled();
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static unsafe partial void uno_set_drawing_callbacks(
 		delegate* unmanaged[Cdecl]<nint, double, double, nint, void> metalCallback,
 		delegate* unmanaged[Cdecl]<nint, double, double, nint*, int*, int*, void> softCallback,

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.h
@@ -22,6 +22,7 @@ void uno_application_set_badge(const char *badge);
 void uno_application_set_icon(const char *path);
 bool uno_application_open_url(const char *url);
 bool uno_application_query_url_support(const char *url);
+bool uno_application_is_bundled(void);
 
 typedef bool (*application_can_exit_fn_ptr)(void);
 application_can_exit_fn_ptr uno_get_application_can_exit_callback(void);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m
@@ -102,6 +102,11 @@ void uno_set_application_can_exit_callback(application_can_exit_fn_ptr p)
     application_can_exit = p;
 }
 
+bool uno_application_is_bundled(void)
+{
+    return NSRunningApplication.currentApplication.bundleIdentifier != nil;
+}
+
 void uno_application_quit(void)
 {
 #if DEBUG

--- a/src/Uno.UWP/Storage/StorageFile.skia.cs
+++ b/src/Uno.UWP/Storage/StorageFile.skia.cs
@@ -12,6 +12,8 @@ namespace Windows.Storage
 {
 	partial class StorageFile
 	{
+		internal static string ResourcePathBase { get; set; } = Package.Current.InstalledPath;
+
 		private static async Task<StorageFile> GetFileFromApplicationUri(CancellationToken ct, Uri uri)
 		{
 			if (uri.Scheme != "ms-appx")
@@ -22,7 +24,7 @@ namespace Windows.Storage
 
 			var path = Uri.UnescapeDataString(uri.PathAndQuery).TrimStart('/');
 
-			var resourcePathname = global::System.IO.Path.Combine(Package.Current.InstalledPath, uri.Host, path);
+			var resourcePathname = global::System.IO.Path.Combine(ResourcePathBase, uri.Host, path);
 
 			if (resourcePathname != null)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Resource files are always looked up from the same directory where the executables are present. 

## What is the new behavior?

if the app is bundled (macOS `.app`) then we look under `Resources` for data files, while executables are inside the `MacOS` directory.

```
bundle.app/
	Contents/
		Info.plist
		MacOS/
		Resources/
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
