### PR TITLE
fix: Define the working directory for add-in discovery

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
@@ -17,8 +17,9 @@ public class AddIns
 	public static IImmutableList<string> Discover(string solutionFile)
 	{
 		var tmp = Path.GetTempFileName();
-		var command = $"build \"{solutionFile}\" --target:UnoDumpTargetFrameworks \"-p:UnoDumpTargetFrameworksTargetFile={tmp}\" --verbosity quiet";
-		var result = ProcessHelper.RunProcess("dotnet", command);
+		var wd = Path.GetDirectoryName(solutionFile);
+		var command = $"build \"{solutionFile}\" -t:UnoDumpTargetFrameworks \"-p:UnoDumpTargetFrameworksTargetFile={tmp}\" --verbosity quiet";
+		var result = ProcessHelper.RunProcess("dotnet", command, wd);
 		var targetFrameworks = Read(tmp);
 
 		if (targetFrameworks.IsEmpty)
@@ -50,8 +51,8 @@ public class AddIns
 		foreach (var targetFramework in targetFrameworks)
 		{
 			tmp = Path.GetTempFileName();
-			command = $"build \"{solutionFile}\" --target:UnoDumpRemoteControlAddIns \"-p:UnoDumpRemoteControlAddInsTargetFile={tmp}\" --verbosity quiet --framework \"{targetFramework}\" -nowarn:MSB4057";
-			result = ProcessHelper.RunProcess("dotnet", command);
+			command = $"build \"{solutionFile}\" -t:UnoDumpRemoteControlAddIns \"-p:UnoDumpRemoteControlAddInsTargetFile={tmp}\" --verbosity quiet --framework \"{targetFramework}\" -nowarn:MSB4057";
+			result = ProcessHelper.RunProcess("dotnet", command, wd);
 			if (!string.IsNullOrWhiteSpace(result.error))
 			{
 				if (_log.IsEnabled(LogLevel.Warning))


### PR DESCRIPTION
linked https://github.com/unoplatform/uno.hotdesign/issues/2986

## Bugfix
Attempt to define the working directory

## What is the current behavior?
Command fails for some user with:

```
[DEBUG][19:09:17.92]       Failed to get target frameworks of solution 'C:\Temp\Counter\Counter.sln'. This usually indicates that the solution is in an invalid state (e.g. a referenced project is missing on disk). Please fix and restart your IDE (command used: `dotnet build "C:\Temp\Counter\Counter.sln" --target:UnoDumpTargetFrameworks "-p:UnoDumpTargetFrameworksTargetFile=C:\Users\lcaze\AppData\Local\Temp\tmpint0b0.tmp" --verbosity quiet`). (cf. inner exception for more details.)
[DEBUG][19:09:17.92]       System.Exception: Unhandled exception. Microsoft.Build.Shared.InternalErrorException: MSB0001: Internal MSBuild Error: The switch name extracted from either the partially or completely unquoted arg should be the same.
[DEBUG][19:09:17.92]          at Microsoft.Build.Shared.ErrorUtilities.ThrowInternalError(String message, Exception innerException, Object[] args)
[DEBUG][19:09:17.92]          at Microsoft.Build.CommandLine.MSBuildApp.ExtractSwitchParameters(String commandLineArg, String unquotedCommandLineArg, Int32 doubleQuotesRemovedFromArg, String switchName, Int32 switchParameterIndicator)
[DEBUG][19:09:17.92]          at Microsoft.Build.CommandLine.MSBuildApp.GatherCommandLineSwitches(List`1 commandLineArgs, CommandLineSwitches commandLineSwitches)
[DEBUG][19:09:17.92]          at Microsoft.Build.CommandLine.MSBuildApp.GatherAllSwitches(String[] commandLine, CommandLineSwitches& switchesFromAutoResponseFile, CommandLineSwitches& switchesNotFromAutoResponseFile)
[DEBUG][19:09:17.92]          at Microsoft.Build.CommandLine.MSBuildApp.Execute(String[] commandLine)
[DEBUG][19:09:17.92]          at Microsoft.Build.CommandLine.MSBuildApp.Main(String[] args)

```

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This is an attempt to workaround the issue for testing purposes. We might rollback this later.
