### PR TITLE
feat: Allow simulating touch input in Samples app

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
@@ -449,6 +449,7 @@ namespace SampleControl.Presentation
 			}
 		}
 
+#if HAS_UNO
 		public bool SimulateTouch
 		{
 			get => WinRTFeatureConfiguration.DebugOptions.SimulateTouch;
@@ -459,7 +460,6 @@ namespace SampleControl.Presentation
 			}
 		}
 
-#if HAS_UNO
 		public bool PreventLightDismissOnWindowDeactivated
 		{
 			get => FeatureConfiguration.Popup.PreventLightDismissOnWindowDeactivated;

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
@@ -25,6 +25,7 @@ using Microsoft.UI.Xaml.Controls;
 using Uno.UI.Xaml.Core;
 using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
 using Uno.UI;
+using Uno;
 #endif
 
 namespace SampleControl.Presentation
@@ -445,6 +446,16 @@ namespace SampleControl.Presentation
 					Owner.FlowDirection = newValue;
 					RaisePropertyChanged();
 				}
+			}
+		}
+
+		public bool SimulateTouch
+		{
+			get => WinRTFeatureConfiguration.DebugOptions.SimulateTouch;
+			set
+			{
+				WinRTFeatureConfiguration.DebugOptions.SimulateTouch = value;
+				RaisePropertyChanged();
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewMode.Properties.cs
@@ -452,11 +452,17 @@ namespace SampleControl.Presentation
 #if HAS_UNO
 		public bool SimulateTouch
 		{
+#if DEBUG
 			get => WinRTFeatureConfiguration.DebugOptions.SimulateTouch;
+#else
+			get => false;
+#endif
 			set
 			{
+#if DEBUG
 				WinRTFeatureConfiguration.DebugOptions.SimulateTouch = value;
 				RaisePropertyChanged();
+#endif
 			}
 		}
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -573,6 +573,11 @@
 										<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE92F;" />
 									</not_win:ToggleMenuFlyoutItem.Icon>
 								</not_win:ToggleMenuFlyoutItem>
+								<not_win:ToggleMenuFlyoutItem Text="Simulate touch" IsChecked="{Binding SimulateTouch, Mode=TwoWay}">
+									<not_win:ToggleMenuFlyoutItem.Icon>
+										<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE815;" />
+									</not_win:ToggleMenuFlyoutItem.Icon>
+								</not_win:ToggleMenuFlyoutItem>
 								<MenuFlyoutItem Text="Log view dump" Command="{Binding LogViewDumpCommand}" Visibility="{Binding IsDebug, Converter={StaticResource TrueToVisible}}">
 									<MenuFlyoutItem.Icon>
 										<FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xEBD2;" />

--- a/src/Uno.UWP/Devices/Input/PointerDevice.cs
+++ b/src/Uno.UWP/Devices/Input/PointerDevice.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Serialization.Formatters;
+using Uno;
 
 namespace Windows.Devices.Input
 {
@@ -10,6 +11,13 @@ namespace Windows.Devices.Input
 
 		internal static PointerDevice For(PointerDeviceType type)
 		{
+#if DEBUG
+			if (WinRTFeatureConfiguration.DebugOptions.SimulateTouch)
+			{
+				type = PointerDeviceType.Touch;
+			}
+#endif
+
 			// We cache them as we don't implement any other properties than the PointerDeviceType
 			// but this is probably not really valid...
 			switch (type)

--- a/src/Uno.UWP/FeatureConfiguration/WinRTFeatureConfiguration.cs
+++ b/src/Uno.UWP/FeatureConfiguration/WinRTFeatureConfiguration.cs
@@ -46,6 +46,7 @@ public static partial class WinRTFeatureConfiguration
 	}
 #endif
 
+#if DEBUG
 	internal static class DebugOptions
 	{
 		/// <summary>
@@ -53,4 +54,5 @@ public static partial class WinRTFeatureConfiguration
 		/// </summary>
 		public static bool SimulateTouch { get; set; }
 	}
+#endif
 }

--- a/src/Uno.UWP/FeatureConfiguration/WinRTFeatureConfiguration.cs
+++ b/src/Uno.UWP/FeatureConfiguration/WinRTFeatureConfiguration.cs
@@ -45,4 +45,12 @@ public static partial class WinRTFeatureConfiguration
 		public static bool TestMode { get; set; }
 	}
 #endif
+
+	internal static class DebugOptions
+	{
+		/// <summary>
+		/// Adjusts all PointerPoint instances as if they were of type Touch.
+		/// </summary>
+		public static bool SimulateTouch { get; set; }
+	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

No way to at least partially test touch input without a touch device.

## What is the new behavior?

An optimistic implementation of touch simulation is added in Samples app

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
