### PR TITLE
fix(hr): Improve retry logic when using UpdateFile in case of NoChanges

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
@@ -43,6 +43,18 @@ public class UpdateFile : IMessage
 	[JsonProperty]
 	public bool IsForceHotReloadDisabled { get; set; }
 
+	/// <summary>
+	/// The delay to wait before forcing (**OR RETRYING**) a hot reload in Visual Studio.
+	/// </summary>
+	[JsonProperty]
+	public TimeSpan? ForceHotReloadDelay { get; set; }
+
+	/// <summary>
+	/// Number of times to retry the hot reload in Visual Studio **if not changes are detected**.
+	/// </summary>
+	[JsonProperty]
+	public int? ForceHotReloadAttempts { get; set; }
+
 	[JsonIgnore]
 	public string Scope => WellKnownScopes.HotReload;
 


### PR DESCRIPTION
## Bugfix
Improve retry logic when using UpdateFile in case of NoChanges

## What is the current behavior?
We might get a NoChnages when there are actual changes pending

## What is the new behavior?
We retry more and longer ... and app can customize the retry logic if needed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
