### PR TITLE
fix: Avoid subscribing to touch scroll events twice

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -1512,6 +1512,43 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+#if !HAS_INPUT_INJECTOR
+		[Ignore("InputInjector is not supported on this platform.")]
+#endif
+		public async Task When_ScrollViewer_Touch_Scrolled()
+		{
+			var stackPanel = new StackPanel();
+			var random = Random.Shared;
+			for (int i = 0; i < 10; i++)
+			{
+				stackPanel.Children.Add(
+					new Rectangle()
+					{
+						Width = 50,
+						Height = 50,
+						Fill = new SolidColorBrush(Color.FromArgb(255, (byte)random.Next(256), (byte)random.Next(256), (byte)random.Next(256)))
+					});
+			}
+
+			var SUT = new ScrollViewer
+			{
+				Height = 300,
+				Content = stackPanel
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var input = InputInjector.TryCreate() ?? throw new InvalidOperationException("Pointer injection not available on this platform.");
+			using var finger = input.GetFinger();
+			var bounds = SUT.GetAbsoluteBounds();
+			finger.Press(bounds.GetCenter());
+			finger.MoveTo(bounds.GetCenter().Offset(0, -50));
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+			Assert.AreEqual(50, SUT.VerticalOffset);
+		}
+
+		[TestMethod]
 		public async Task When_Zero_Size_With_Margin()
 		{
 			var SUT = new ScrollViewer()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -1512,8 +1512,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-#if !HAS_INPUT_INJECTOR
-		[Ignore("InputInjector is not supported on this platform.")]
+#if !HAS_INPUT_INJECTOR || !UNO_HAS_MANAGED_SCROLL_PRESENTER
+		[Ignore("This test only applies to managed scroll presenter and requires input injector.")]
 #endif
 		public async Task When_ScrollViewer_Touch_Scrolled()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -4,6 +4,8 @@ using Microsoft.UI.Xaml.Input;
 using Windows.Devices.Input;
 using Windows.Foundation;
 using Uno.UI.Xaml;
+using Uno.Disposables;
+
 
 #if HAS_UNO_WINUI
 using _PointerDeviceType = global::Microsoft.UI.Input.PointerDeviceType;
@@ -56,6 +58,8 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private object RealContent => Content;
 
+		private readonly SerialDisposable _eventSubscriptions = new();
+
 		partial void InitializePartial()
 		{
 #if __SKIA__
@@ -71,6 +75,8 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private void HookScrollEvents(ScrollViewer sv)
 		{
+			UnhookScrollEvents(sv);
+
 			// Note: the way WinUI does scrolling is very different, and doesn't use
 			// PointerWheelChanged changes, etc.
 			// We can either subscribe on the ScrollViewer or the SCP directly, but due to
@@ -87,16 +93,21 @@ namespace Microsoft.UI.Xaml.Controls
 			ManipulationStarted += TouchScrollStarted;
 			ManipulationDelta += UpdateTouchScroll;
 			ManipulationCompleted += CompleteTouchScroll;
+
+			_eventSubscriptions.Disposable = Disposable.Create(() =>
+			{
+				sv.PointerWheelChanged -= PointerWheelScroll;
+
+				ManipulationStarting -= PrepareTouchScroll;
+				ManipulationStarted -= TouchScrollStarted;
+				ManipulationDelta -= UpdateTouchScroll;
+				ManipulationCompleted -= CompleteTouchScroll;
+			});
 		}
 
 		private void UnhookScrollEvents(ScrollViewer sv)
 		{
-			sv.PointerWheelChanged -= PointerWheelScroll;
-
-			ManipulationStarting -= PrepareTouchScroll;
-			ManipulationStarted -= TouchScrollStarted;
-			ManipulationDelta -= UpdateTouchScroll;
-			ManipulationCompleted -= CompleteTouchScroll;
+			_eventSubscriptions.Disposable = null;
 		}
 
 		private protected override void OnLoaded()


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/703

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`ScrollContentPresenter` was duplicating its touch event subscriptions. Because of that it caused various issue - e.g. scrolling twice as fast as finger movement.


## What is the new behavior?

We make sure to unsubscribe when a new subscription is requested.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.