### PR TITLE
docs: Update creating-custom-controls.md

### DIFF
--- a/doc/articles/guides/creating-custom-controls.md
+++ b/doc/articles/guides/creating-custom-controls.md
@@ -17,9 +17,9 @@ If you're not familiar with concepts such as **dependency properties**, **contro
 
 ## Ensuring Cross-Platform Compatibility
 
-To ensure your custom control functions properly across all platforms, make sure that the `Themes/generic.xaml` file is included in your Uno project and correctly referenced for each platform. On non-Windows platforms, this file might not be automatically included, and you may need to adjust your project settings or add custom build steps to ensure it is properly referenced.
+To ensure your custom control functions properly across all platforms, make sure that the `Themes/Generic.xaml` file is included in your Uno project and correctly referenced for each platform. On non-Windows platforms, this file might not be automatically included, and you may need to adjust your project settings or add custom build steps to ensure it is properly referenced.
 
-In WinUI apps, `Themes/generic.xaml` is the standard location for default styles. It should be supported across all platforms and automatically referenced when Uno searches for implicit or default styles in any `TemplatedControl` defined in `generic.xaml`. Additionally, it's common to use a `MergedDictionary` to reference resources from other directories within `generic.xaml`. Currently, styles defined in `Themes/generic.xaml` are not found automatically across platforms in Uno.
+In WinUI apps, `Themes/Generic.xaml` is the standard location for default styles. It should be supported across all platforms and automatically referenced when Uno searches for implicit or default styles in any `TemplatedControl` defined in `Generic.xaml`. Additionally, it's common to use a `MergedDictionary` to reference resources from other directories within `Generic.xaml`. Currently, styles defined in `Themes/Generic.xaml` are not found automatically across platforms in Uno.
 
 To resolve this, you can define styles in `App.xaml` and use a `MergedDictionary` to pull in the resources, as shown in the following example:
 


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Documentation content changes

## What is the current behavior?
> defining own ResourceDictionary I stumbled over this detail:
> https://platform.uno/docs/articles/guides/creating-custom-controls.html
> in the text the generic.xaml is lowercase and in the code sample its uppercase. I read somewhere (might be another uno doc page?) that especially for mobile devices the casing is important detail, because if its uppercase, they would not be able to use it. if thats true, this doc page should be updated to recommend lowercase instead in my opinion

## What is the new behavior?
unified the casing of "Themes/Generic.xaml" mentioned in this page.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
https://discord.com/channels/1182775715242967050/1182775715729526908/1314231281453760613