### PR TITLE
fix: Adjust android wait script

### DIFF
--- a/build/test-scripts/android-uitest-wait-systemui.sh
+++ b/build/test-scripts/android-uitest-wait-systemui.sh
@@ -92,12 +92,12 @@ while [[ -z ${LAUNCHER_READY} ]]; do
 done
 
 # Force terminate system UI to restart clean
-adb shell am force-stop com.android.systemui
+"$ANDROID_HOME/platform-tools/adb" shell am force-stop com.android.systemui
 
 # disable system animations
-adb shell settings put global animator_duration_scale 0
-adb shell settings put global transition_animation_scale 0
-adb shell settings put global window_animation_scale 0
+"$ANDROID_HOME/platform-tools/adb" shell settings put global animator_duration_scale 0
+"$ANDROID_HOME/platform-tools/adb" shell settings put global transition_animation_scale 0
+"$ANDROID_HOME/platform-tools/adb" shell settings put global window_animation_scale 0
 
 echo "Launcher is ready!"
 

--- a/build/test-scripts/android-uitest-wait-systemui.sh
+++ b/build/test-scripts/android-uitest-wait-systemui.sh
@@ -67,18 +67,17 @@ while [[ -z ${LAUNCHER_READY} ]]; do
     echo "(DEBUG $SECONDS) Current focus: ${UI_FOCUS}"
 
     case $UI_FOCUS in
+    *"Not Responding"*)
+        echo "Detected an ANR! Dismissing..."
+        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_DPAD_RIGHT
+        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_ENTER
+    ;;  
     *"Launcher"*)
         LAUNCHER_READY=true
     ;;
     "")
         echo "Waiting for window service..."
         sleep 3
-    ;;
-    *"Not Responding"*)
-        echo "Detected an ANR! Dismissing..."
-        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_DPAD_DOWN
-        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_DPAD_DOWN
-        $ANDROID_HOME/platform-tools/adb shell input keyevent KEYCODE_ENTER
     ;;
     *)
         echo "Waiting for launcher..."
@@ -92,4 +91,13 @@ while [[ -z ${LAUNCHER_READY} ]]; do
     esac
 done
 
+# Force terminate system UI to restart clean
+adb shell am force-stop com.android.systemui
+
+# disable system animations
+adb shell settings put global animator_duration_scale 0
+adb shell settings put global transition_animation_scale 0
+adb shell settings put global window_animation_scale 0
+
 echo "Launcher is ready!"
+

--- a/build/test-scripts/android-uitest-wait-systemui.sh
+++ b/build/test-scripts/android-uitest-wait-systemui.sh
@@ -92,7 +92,7 @@ while [[ -z ${LAUNCHER_READY} ]]; do
 done
 
 # Force terminate system UI to restart clean
-"$ANDROID_HOME/platform-tools/adb" shell am force-stop com.android.systemui
+# "$ANDROID_HOME/platform-tools/adb" shell am force-stop com.android.systemui
 
 # disable system animations
 "$ANDROID_HOME/platform-tools/adb" shell settings put global animator_duration_scale 0


### PR DESCRIPTION
Adjust for occasional emulator startup issues that cause retries.

- Don't assume the order of ANR process reporting
- Terminate the system UI preemptively in order to restart clean after boot
