### PR TITLE
fix: Improve DateTimeFormatter template matching and mappings

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Globalization/Given_DateTimeFormatter.cs
@@ -104,19 +104,18 @@ public class Given_DateTimeFormatter
 		}
 	}
 
-	// TODO(DT): Currently is throwing unexpected results on WinUI as well, can't compare the expected results
-	/* [TestMethod]
+	[TestMethod]
 	public void When_FormattingTimeVariants_ShouldProduceExpectedFormats()
 	{
 		var expectedResults = new Dictionary<string, string>
 		{
 			{ "{hour.integer}:{minute.integer}", "14:30" },
-			{ "{hour.integer}:{minute.integer}:{second.integer}", "14:30:00" },
+			{ "{hour.integer}:{minute.integer}:{second.integer(2)}", "14:30:00" },
 			{ "{hour.integer}:{minute.integer} {period.abbreviated(2)}", "2:30 PM" },
-			{ "{hour.integer}:{minute.integer}:{second.integer} {period.abbreviated(2)}", "2:30:00 PM" },
-			{ "{minute.integer}:{second.integer}", "30:00" },
+			{ "{hour.integer}:{minute.integer}:{second.integer} {period.abbreviated(2)}", "2:30:0 PM" },
+			{ "{minute.integer}:{second.integer}", "30:0" },
 			{ "{second.integer}", "0" },
-			{ "{hour.integer}:{minute.integer}:{second.integer} UTC", "14:30:00 UTC" }
+			{ "{hour.integer}:{minute.integer}:{second.integer(2)} UTC", "14:30:00 UTC" }
 		};
 
 		foreach (var kvp in expectedResults)
@@ -124,11 +123,12 @@ public class Given_DateTimeFormatter
 			var template = kvp.Key;
 			var expected = kvp.Value;
 
-			var formatter = new DateTimeFormatter(template);
-			var formattedTime = formatter.Format(_testDate);
+			var clock = template.Contains("period") ? ClockIdentifiers.TwelveHour : ClockIdentifiers.TwentyFourHour;
+
+			var formatter = new DateTimeFormatter(template, ["en-US"], "US", CalendarIdentifiers.Gregorian, clock);
+			var formattedTime = formatter.Format(new DateTime(2024, 6, 17, 14, 30, 0));
 
 			Assert.AreEqual(expected, formattedTime, $"Mismatch for template: {template}");
-			Console.WriteLine($"Template: {template}, Result: {formattedTime}");
 		}
-	}*/
+	}
 }

--- a/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
+++ b/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
@@ -303,43 +303,90 @@ public sealed partial class DateTimeFormatter
 		var info = new CultureInfo(language).DateTimeFormat;
 
 		map = new Dictionary<string, string>
-		{
+		{	
+			// Predefined patterns
 			{ "longdate"                             , info.LongDatePattern } ,
 			{ "shortdate"                            , info.ShortDatePattern } ,
 			{ "longtime"                             , info.LongTimePattern } ,
 			{ "shorttime"                            , info.ShortTimePattern } ,
+    
+			// Compound patterns
 			{ "dayofweek day month year"             , info.FullDateTimePattern } ,
 			{ "dayofweek day month"                  , "D" } ,
 			{ "day month year"                       , info.ShortDatePattern } ,
 			{ "day month.full year"                  , info.ShortDatePattern } ,
 			{ "day month"                            , info.MonthDayPattern } ,
 			{ "month year"                           , info.YearMonthPattern } ,
-			{ "dayofweek.full"                       , "dddd" } ,
-			{ "dayofweek.abbreviated"                , "ddd" } ,
-			{ "month.full"                           , "MMMM" } ,
-			{ "month.abbreviated"                    , "MMM" } ,
-			{ "month.numeric"                        , "%M" } ,
-			{ "year.abbreviated"                     , "yy" } ,
-			{ "year.full"                            , "yyyy" } ,
 			{ "hour minute second"                   , info.LongTimePattern },
 			{ "hour minute"                          , info.ShortTimePattern },
-			{ "timezone.abbreviated"                 , "zz" },
-			{ "timezone.full"                        , "zzz" },
+			//{ "year month day hour"                  , "" },
+
+			// Day of week formats
 			{ "dayofweek"                            , "dddd" } ,
-			{ "day.integer"                          , "d" },
+			{ "dayofweek.full"                       , "dddd" } ,
+			{ "dayofweek.abbreviated"                , "ddd" } ,
+			{ "dayofweek.abbreviated(1)"             , "dd" } ,
+			{ "dayofweek.abbreviated(2)"             , "ddd" } ,
+			{ "dayofweek.solo.full"                  , "dddd" } ,
+			{ "dayofweek.solo.abbreviated"           , "ddd" } ,
+
+			// Day formats
 			{ "day"                                  , "%d" } ,
-			{ "month.integer"                        , "M" },
+			{ "day.integer"                          , "%d" },
+			{ "day.integer(1)"                       , "%d" },
+			{ "day.integer(2)"                       , "dd" },
+
+			// Month formats
 			{ "month"                                , "MMMM" } ,
+			{ "month.full"                           , "MMMM" } ,
+			{ "month.abbreviated"                    , "MMM" } ,
+			{ "month.abbreviated(1)"                 , "%M" } ,
+			{ "month.abbreviated(2)"                 , "MMM" } ,
+			{ "month.numeric"                        , "%M" } ,
+			{ "month.integer"                        , "%M" } ,
+			{ "month.integer(1)"                     , "%M" } ,
+			{ "month.integer(2)"                     , "MM" } ,
+			{ "month.solo.full"                      , "MMMM" } ,
+			{ "month.solo.abbreviated"               , "MMM" } ,
+
+			// Year formats
 			{ "year"                                 , "yyyy" } ,
-			{ "hour.integer(1)"                      , "%h" },
-			{ "hour"                                 , "H tt" } ,
-			{ "minute.integer(2)"                    , "mm" },
-			{ "minute.integer"                       , "%m" },
-			{ "minute"                               , "%m" },
-			{ "second"                               , "%s" },
-			{ "timezone"                             , "%z" },
-			{ "period.abbreviated(2)"                , "tt" },
-			// { "year month day hour"                  , "" } ,
+			{ "year.full"                            , "yyyy" } ,
+			{ "year.abbreviated"                     , "yy" } ,
+			{ "year.abbreviated(1)"                  , "%y" } ,
+			{ "year.abbreviated(2)"                  , "yy" } ,
+
+			// Hour formats
+			{ "hour"                                 , "%H" } ,
+			{ "hour.integer"                         , "%H" } ,
+			{ "hour.integer(1)"                      , "%h" } ,
+			{ "hour.integer(2)"                      , "HH" } ,
+
+			// Period (AM/PM) formats
+			{ "period"                               , "tt" } ,
+			{ "period.full"                          , "tt" } ,
+			{ "period.abbreviated"                   , "tt" } ,
+			{ "period.abbreviated(1)"                , "t" } ,
+			{ "period.abbreviated(2)"                , "tt" } ,
+
+			// Minute formats
+			{ "minute"                               , "%m" } ,
+			{ "minute.integer"                       , "%m" } ,
+			{ "minute.integer(1)"                    , "%m" } ,
+			{ "minute.integer(2)"                    , "mm" } ,
+
+			// Second formats
+			{ "second"                               , "%s" } ,
+			{ "second.integer"                       , "%s" } ,
+			{ "second.integer(1)"                    , "%s" } ,
+			{ "second.integer(2)"                    , "ss" } ,
+
+			// Timezone formats
+			{ "timezone"                             , "%z" } ,
+			{ "timezone.full"                        , "zzz" } ,
+			{ "timezone.abbreviated"                 , "zz" } ,
+			{ "timezone.abbreviated(1)"              , "%z" } ,
+			{ "timezone.abbreviated(2)"              , "zz" }
 		};
 
 		return _mapCache[language] = map;
@@ -370,15 +417,20 @@ public sealed partial class DateTimeFormatter
 
 		var map = _maps![0];
 
-		foreach (var p in map)
-		{
-			result = result.Replace(p.Key, p.Value);
+		var sortedKeys = map.Keys.OrderByDescending(k => k.Length);
 
+		foreach (var key in sortedKeys)
+		{
+			result = result.Replace(key, map[key]);
 		}
 
 		if (result.Contains("h") && Clock == ClockIdentifiers.TwentyFourHour)
 		{
 			result = result.Replace("h", "H");
+		}
+		else if (result.Contains("H") && Clock == ClockIdentifiers.TwelveHour)
+		{
+			result = result.Replace("H", "h");
 		}
 
 		return result;


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/18975

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Currently the returned values for Time are very off from what they are supposed to compared to WinUI.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

The logic for DateTimeFormatter has been improved to prioritize keys by length, starting with the longest. Previously, the Lookup dictionary had to be manually ordered, which could lead to issues. Additional mapping values have been added based on Microsoft documentation, and the dictionary has been cleaned up for better readability. A runtime test has also been added.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.