### PR TITLE
Refactor: Use shared StartStopTypedEventHandler for Sensors

### DIFF
--- a/src/Uno.UWP/Devices/Sensors/Accelerometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Accelerometer.Android.cs
@@ -31,7 +31,7 @@ namespace Windows.Devices.Sensors
 				{
 					_reportInterval = value;
 
-					if (_readingChanged != null)
+					if (_readingChangedWrapper.Event != null)
 					{
 						//restart reading to apply interval
 						StopReadingChanged();

--- a/src/Uno.UWP/Devices/Sensors/Accelerometer.cs
+++ b/src/Uno.UWP/Devices/Sensors/Accelerometer.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Uno.Helpers;
+using Windows.Foundation;
 
 namespace Windows.Devices.Sensors
 {
@@ -10,13 +12,13 @@ namespace Windows.Devices.Sensors
 	/// </summary>
 	public partial class Accelerometer
 	{
-		private readonly static object _syncLock = new object();
+		private readonly static object _syncLock = new();
 
 		private static Accelerometer _instance;
 		private static bool _initializationAttempted;
 
-		private Foundation.TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs> _readingChanged;
-		private Foundation.TypedEventHandler<Accelerometer, AccelerometerShakenEventArgs> _shaken;
+		private readonly StartStopTypedEventWrapper<Accelerometer, AccelerometerReadingChangedEventArgs> _readingChangedWrapper;
+		private readonly StartStopTypedEventWrapper<Accelerometer, AccelerometerShakenEventArgs> _shakenWrapper;
 
 		/// <summary>
 		/// Gets or sets the transformation that needs to be applied to sensor data. Transformations to be applied are tied to the display orientation with which to align the sensor data.
@@ -32,6 +34,14 @@ namespace Windows.Devices.Sensors
 		/// </summary>
 		private Accelerometer()
 		{
+			_readingChangedWrapper = new StartStopTypedEventWrapper<Accelerometer, AccelerometerReadingChangedEventArgs>(
+				() => StartReadingChanged(),
+				() => StopReadingChanged(),
+				_syncLock);
+			_shakenWrapper = new StartStopTypedEventWrapper<Accelerometer, AccelerometerShakenEventArgs>(
+				() => StartShaken(),
+				() => StopShaken(),
+				_syncLock);
 		}
 
 		/// <summary>
@@ -58,71 +68,29 @@ namespace Windows.Devices.Sensors
 		/// <summary>
 		/// Occurs each time the accelerometer reports a new sensor reading.
 		/// </summary>
-		public event Foundation.TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs> ReadingChanged
+		public event TypedEventHandler<Accelerometer, AccelerometerReadingChangedEventArgs> ReadingChanged
 		{
-			add
-			{
-				lock (_syncLock)
-				{
-					bool isFirstSubscriber = _readingChanged == null;
-					_readingChanged += value;
-					if (isFirstSubscriber)
-					{
-						StartReadingChanged();
-					}
-				}
-			}
-			remove
-			{
-				lock (_syncLock)
-				{
-					_readingChanged -= value;
-					if (_readingChanged == null)
-					{
-						StopReadingChanged();
-					}
-				}
-			}
+			add => _readingChangedWrapper.AddHandler(value);
+			remove => _readingChangedWrapper.RemoveHandler(value);
 		}
 
 		/// <summary>
 		/// Occurs when the accelerometer detects that the device has been shaken.
 		/// </summary>
-		public event Foundation.TypedEventHandler<Accelerometer, AccelerometerShakenEventArgs> Shaken
+		public event TypedEventHandler<Accelerometer, AccelerometerShakenEventArgs> Shaken
 		{
-			add
-			{
-				lock (_syncLock)
-				{
-					bool isFirstSubscriber = _shaken == null;
-					_shaken += value;
-					if (isFirstSubscriber)
-					{
-						StartShaken();
-					}
-				}
-			}
-			remove
-			{
-				lock (_syncLock)
-				{
-					_shaken -= value;
-					if (_shaken == null)
-					{
-						StopShaken();
-					}
-				}
-			}
+			add => _shakenWrapper.AddHandler(value);
+			remove => _shakenWrapper.RemoveHandler(value);
 		}
 
 		private void OnReadingChanged(AccelerometerReading reading)
 		{
-			_readingChanged?.Invoke(this, new AccelerometerReadingChangedEventArgs(reading));
+			_readingChangedWrapper.Invoke(this, new AccelerometerReadingChangedEventArgs(reading));
 		}
 
 		internal void OnShaken(DateTimeOffset timestamp)
 		{
-			_shaken?.Invoke(this, new AccelerometerShakenEventArgs(timestamp));
+			_shakenWrapper.Invoke(this, new AccelerometerShakenEventArgs(timestamp));
 		}
 	}
 }

--- a/src/Uno.UWP/Devices/Sensors/Accelerometer.wasm.cs
+++ b/src/Uno.UWP/Devices/Sensors/Accelerometer.wasm.cs
@@ -54,7 +54,7 @@ namespace Windows.Devices.Sensors
 		{
 			//if both delegates are not null,
 			//we have already started reading previously
-			if (_shaken == null || _readingChanged == null)
+			if (_shakenWrapper.Event == null || _readingChangedWrapper.Event == null)
 			{
 				NativeMethods.StartReading();
 			}
@@ -64,7 +64,7 @@ namespace Windows.Devices.Sensors
 		private void DetachDeviceMotion()
 		{
 			//we only stop when both are null
-			if (_shaken == null && _readingChanged == null)
+			if (_shakenWrapper.Event == null && _readingChangedWrapper.Event == null)
 			{
 				NativeMethods.StopReading();
 			}

--- a/src/Uno.UWP/Devices/Sensors/Barometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Barometer.Android.cs
@@ -30,7 +30,7 @@ namespace Windows.Devices.Sensors
 				{
 					_reportInterval = value;
 
-					if (_readingChanged != null)
+					if (_readingChangedWrapper.Event != null)
 					{
 						//restart reading to apply interval
 						StopReading();
@@ -96,7 +96,7 @@ namespace Windows.Devices.Sensors
 				var barometerReading = new BarometerReading(
 					values[0],
 					SensorHelpers.TimestampToDateTimeOffset(e.Timestamp));
-				_barometer._readingChanged?.Invoke(
+				_barometer._readingChangedWrapper?.Invoke(
 					_barometer,
 					new BarometerReadingChangedEventArgs(barometerReading));
 			}

--- a/src/Uno.UWP/Devices/Sensors/Barometer.cs
+++ b/src/Uno.UWP/Devices/Sensors/Barometer.cs
@@ -1,5 +1,6 @@
 #if __ANDROID__ || __IOS__
 
+using Uno.Helpers;
 using Windows.Foundation;
 
 namespace Windows.Devices.Sensors
@@ -9,17 +10,22 @@ namespace Windows.Devices.Sensors
 	/// </summary>
 	public partial class Barometer
 	{
-		private static readonly object _syncLock = new object();
+		private static readonly object _syncLock = new();
+
 		private static bool _initializationAttempted;
 		private static Barometer _instance;
 
-		private TypedEventHandler<Barometer, BarometerReadingChangedEventArgs> _readingChanged;
+		private readonly StartStopTypedEventWrapper<Barometer, BarometerReadingChangedEventArgs> _readingChangedWrapper;
 
 		/// <summary>
 		/// Hides the public parameterless constructor
 		/// </summary>
 		private Barometer()
 		{
+			_readingChangedWrapper = new StartStopTypedEventWrapper<Barometer, BarometerReadingChangedEventArgs>(
+				() => StartReading(),
+				() => StopReading(),
+				_syncLock);
 		}
 
 		/// <summary>
@@ -48,29 +54,8 @@ namespace Windows.Devices.Sensors
 		/// </summary>
 		public event TypedEventHandler<Barometer, BarometerReadingChangedEventArgs> ReadingChanged
 		{
-			add
-			{
-				lock (_syncLock)
-				{
-					bool isFirstSubscriber = _readingChanged == null;
-					_readingChanged += value;
-					if (isFirstSubscriber)
-					{
-						StartReading();
-					}
-				}
-			}
-			remove
-			{
-				lock (_syncLock)
-				{
-					_readingChanged -= value;
-					if (_readingChanged == null)
-					{
-						StopReading();
-					}
-				}
-			}
+			add => _readingChangedWrapper.AddHandler(value);
+			remove => _readingChangedWrapper.RemoveHandler(value);
 		}
 	}
 }

--- a/src/Uno.UWP/Devices/Sensors/Barometer.iOS.cs
+++ b/src/Uno.UWP/Devices/Sensors/Barometer.iOS.cs
@@ -38,7 +38,7 @@ namespace Windows.Devices.Sensors
 			var barometerReading = new BarometerReading(
 				KPaToHPa(data.Pressure.DoubleValue),
 				SensorHelpers.TimestampToDateTimeOffset(data.Timestamp));
-			_readingChanged?.Invoke(
+			_readingChangedWrapper.Invoke(
 				this,
 				new BarometerReadingChangedEventArgs(barometerReading));
 		}

--- a/src/Uno.UWP/Devices/Sensors/Compass.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Compass.Android.cs
@@ -36,7 +36,7 @@ public partial class Compass
 
 				_reportInterval = value;
 
-				if (_readingChanged != null)
+				if (_readingChangedWrapper.Event != null)
 				{
 					//restart reading to apply interval
 					StopReadingChanged();

--- a/src/Uno.UWP/Devices/Sensors/Compass.wasm.cs
+++ b/src/Uno.UWP/Devices/Sensors/Compass.wasm.cs
@@ -37,7 +37,7 @@ public partial class Compass
 					return;
 				}
 
-				if (_readingChanged != null)
+				if (_readingChangedWrapper.Event != null)
 				{
 					//restart reading to apply interval
 					StopReadingChanged();

--- a/src/Uno.UWP/Devices/Sensors/Gyrometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Gyrometer.Android.cs
@@ -31,7 +31,7 @@ namespace Windows.Devices.Sensors
 				{
 					_reportInterval = value;
 
-					if (_readingChanged != null)
+					if (_readingChangedWrapper.Event != null)
 					{
 						//restart reading to apply interval
 						StopReading();

--- a/src/Uno.UWP/Devices/Sensors/Magnetometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Magnetometer.Android.cs
@@ -31,7 +31,7 @@ namespace Windows.Devices.Sensors
 				{
 					_reportInterval = value;
 
-					if (_readingChanged != null)
+					if (_readingChangedWrapper.Event != null)
 					{
 						//restart reading to apply interval
 						StopReading();

--- a/src/Uno.UWP/Devices/Sensors/Magnetometer.cs
+++ b/src/Uno.UWP/Devices/Sensors/Magnetometer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Uno.Helpers;
 using Windows.Foundation;
 
 namespace Windows.Devices.Sensors
@@ -13,18 +14,22 @@ namespace Windows.Devices.Sensors
 	/// </summary>
 	public partial class Magnetometer
 	{
-		private readonly static object _syncLock = new object();
+		private readonly static object _syncLock = new();
 
 		private static Magnetometer _instance;
 		private static bool _initializationAttempted;
 
-		private TypedEventHandler<Magnetometer, MagnetometerReadingChangedEventArgs> _readingChanged;
+		private readonly StartStopTypedEventWrapper<Magnetometer, MagnetometerReadingChangedEventArgs> _readingChangedWrapper;
 
 		/// <summary>
 		/// Hides the public parameterless constructor
 		/// </summary>
 		private Magnetometer()
 		{
+			_readingChangedWrapper = new StartStopTypedEventWrapper<Magnetometer, MagnetometerReadingChangedEventArgs>(
+				() => StartReading(),
+				() => StopReading(),
+				_syncLock);
 		}
 
 		/// <summary>
@@ -53,34 +58,13 @@ namespace Windows.Devices.Sensors
 		/// </summary>
 		public event TypedEventHandler<Magnetometer, MagnetometerReadingChangedEventArgs> ReadingChanged
 		{
-			add
-			{
-				lock (_syncLock)
-				{
-					var isFirstSubscriber = _readingChanged == null;
-					_readingChanged += value;
-					if (isFirstSubscriber)
-					{
-						StartReading();
-					}
-				}
-			}
-			remove
-			{
-				lock (_syncLock)
-				{
-					_readingChanged -= value;
-					if (_readingChanged == null)
-					{
-						StopReading();
-					}
-				}
-			}
+			add => _readingChangedWrapper.AddHandler(value);
+			remove => _readingChangedWrapper.RemoveHandler(value);
 		}
 
 		private void OnReadingChanged(MagnetometerReading reading)
 		{
-			_readingChanged?.Invoke(this, new MagnetometerReadingChangedEventArgs(reading));
+			_readingChangedWrapper.Invoke(this, new MagnetometerReadingChangedEventArgs(reading));
 		}
 	}
 }

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.Android.cs
@@ -30,7 +30,7 @@ namespace Windows.Devices.Sensors
 				{
 					_reportInterval = value;
 
-					if (_readingChanged != null)
+					if (_readingChangedWrapper.Event != null)
 					{
 						//restart reading to apply interval
 						StopReading();

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.cs
@@ -1,6 +1,7 @@
 #if __IOS__ || __ANDROID__
 using System;
 using System.Threading.Tasks;
+using Uno.Helpers;
 using Windows.Foundation;
 
 namespace Windows.Devices.Sensors
@@ -11,18 +12,22 @@ namespace Windows.Devices.Sensors
 	/// </summary>
 	public partial class Pedometer
 	{
-		private readonly static object _syncLock = new object();
+		private readonly static object _syncLock = new();
 
 		private static bool _initializationAttempted;
 		private static Task<Pedometer> _instanceTask;
 
-		private TypedEventHandler<Pedometer, PedometerReadingChangedEventArgs> _readingChanged;
+		private readonly StartStopTypedEventWrapper<Pedometer, PedometerReadingChangedEventArgs> _readingChangedWrapper;
 
 		/// <summary>
 		/// Hides the public parameterless constructor
 		/// </summary>
 		private Pedometer()
 		{
+			_readingChangedWrapper = new StartStopTypedEventWrapper<Pedometer, PedometerReadingChangedEventArgs>(
+				() => StartReading(),
+				() => StopReading(),
+				_syncLock);
 		}
 
 		public static IAsyncOperation<Pedometer> GetDefaultAsync() => GetDefaultImplAsync().AsAsyncOperation();
@@ -46,34 +51,13 @@ namespace Windows.Devices.Sensors
 
 		public event TypedEventHandler<Pedometer, PedometerReadingChangedEventArgs> ReadingChanged
 		{
-			add
-			{
-				lock (_syncLock)
-				{
-					var isFirstSubscriber = _readingChanged == null;
-					_readingChanged += value;
-					if (isFirstSubscriber)
-					{
-						StartReading();
-					}
-				}
-			}
-			remove
-			{
-				lock (_syncLock)
-				{
-					_readingChanged -= value;
-					if (_readingChanged == null)
-					{
-						StopReading();
-					}
-				}
-			}
+			add => _readingChangedWrapper.AddHandler(value);
+			remove => _readingChangedWrapper.RemoveHandler(value);
 		}
 
 		private void OnReadingChanged(PedometerReading reading)
 		{
-			_readingChanged?.Invoke(this, new PedometerReadingChangedEventArgs(reading));
+			_readingChangedWrapper.Invoke(this, new PedometerReadingChangedEventArgs(reading));
 		}
 	}
 }

--- a/src/Uno.UWP/Devices/Sensors/ProximitySensor.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/ProximitySensor.Android.cs
@@ -95,7 +95,7 @@ public partial class ProximitySensor
 
 	internal void OnReadingChanged(ProximitySensorReading reading)
 	{
-		_readingChangedWrapper.Event?.Invoke(this, new(reading));
+		_readingChangedWrapper.Invoke(this, new(reading));
 	}
 
 	private sealed class ProximitySensorListener : Java.Lang.Object, ISensorEventListener, IDisposable


### PR DESCRIPTION
GitHub Issue: closes #19131

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Most sensors used an `TypedEventHandler` field and had duplicated logic on the event handling.

## What is the new behavior?

Refactoring to use `StartStopTypedEventHandler` that encapsulates the logic for event-handling. 
This is now used in the sensor classes instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
