### PR TITLE
fix(hr): Update HR conditions

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
@@ -107,7 +107,10 @@ namespace Uno.UI.RemoteControl.HotReload
 
 			var vsEnabled = isForcedMetadata
 				|| (buildingInsideVisualStudio && isSkia)
-				|| (buildingInsideVisualStudio && isWasm);
+				|| (buildingInsideVisualStudio && isWasm)
+				|| (buildingInsideVisualStudio && Debugger.IsAttached && OperatingSystem.IsAndroid())
+				|| (buildingInsideVisualStudio && Debugger.IsAttached && OperatingSystem.IsIOS());
+
 
 			_supportsMetadataUpdates = devServerEnabled || vsEnabled;
 			_serverMetadataUpdatesEnabled = devServerEnabled;


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.hotdesign/issues/3179

## Bugfix
Update HR conditions

## What is the current behavior?
HR is not enabled properly considering last updates

## What is the new behavior?
HR will self enable itself properly considering last updates

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
