### PR TITLE
fix(xamlreader): add proper support for markup-extension parsing

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
@@ -1,20 +1,25 @@
 ﻿#if HAS_UNO
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using Uno.UI.Extensions;
 using Uno.UI.Helpers;
 using Uno.Xaml;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Shapes;
 using Windows.Foundation;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Markup;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 {
 	[TestClass]
 	[RunsOnUIThread]
-	public class Given_XamlReader
+	public partial class Given_XamlReader
 	{
 		[TestMethod]
 		public void When_DoubleCollection()
@@ -335,6 +340,341 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 			var xaml = XamlHelper.LoadXaml<Style>(xamlString);
 			Assert.IsInstanceOfType(xaml, typeof(Style));
 		}
+
+		[TestMethod]
+		public void When_MarkupExtension_FullName_NodeSyntax()
+		{
+			var value = XamlHelper.LoadXaml<object>("""
+				<local:TestMarkupExtension xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup" />
+			""");
+
+			Assert.IsInstanceOfType<bool>(value);
+			Assert.IsTrue(value as bool? ?? false);
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_ShortName_NodeSyntax()
+		{
+			var value = XamlHelper.LoadXaml<object>("""
+				<local:TestMarkup xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup" />
+			""");
+
+			Assert.IsInstanceOfType<bool>(value);
+			Assert.IsTrue(value as bool? ?? false);
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_FullName_AttributeSyntax_Generic()
+		{
+			var host = XamlHelper.LoadXaml<Border>("""
+				<Border Tag="{local:TestMarkupExtension}"
+					xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup"
+					 />
+			""");
+
+			Assert.IsInstanceOfType<bool>(host.Tag);
+			Assert.IsTrue(host.Tag as bool? ?? false);
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_ShortName_AttributeSyntax_Generic()
+		{
+			var host = XamlHelper.LoadXaml<Border>("""
+				<Border Tag="{local:TestMarkup}"
+					xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup"
+					 />
+			""");
+
+			Assert.IsInstanceOfType<bool>(host.Tag);
+			Assert.IsTrue(host.Tag as bool? ?? false);
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_FullName_AttributeSyntax_TextBlock()
+		{
+			var host = XamlHelper.LoadXaml<TextBlock>("""
+				<TextBlock Tag="{local:TestMarkupExtension}"
+					xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup"
+					 />
+			""");
+
+			Assert.IsInstanceOfType<bool>(host.Tag);
+			Assert.IsTrue(host.Tag as bool? ?? false);
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_ShortName_AttributeSyntax_TextBlock()
+		{
+			var host = XamlHelper.LoadXaml<TextBlock>("""
+				<TextBlock Tag="{local:TestMarkup}"
+					xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup"
+					 />
+			""");
+
+			Assert.IsInstanceOfType<bool>(host.Tag);
+			Assert.IsTrue(host.Tag as bool? ?? false);
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_TextBlock_Inlines_Explicit()
+		{
+			var host = XamlHelper.LoadXaml<TextBlock>("""
+				<TextBlock xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup">
+					<TextBlock.Inlines>
+						<Run Text="{local:ReturnStringAsd}" />
+						<Run Text="{local:ReturnStringAsd}" />
+						<Span>
+							<Run Text="{local:ReturnStringAsd}" />
+						</Span>
+					</TextBlock.Inlines>
+				</TextBlock>
+			""");
+			var expectation = """
+					0	Run // Text='Asd'
+					1	Run // Text='Asd'
+					2	Span
+					3		Run // Text='Asd'
+			""";
+
+			VerifyInlineTree(expectation, host, DescribeInline);
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_TextBlock_Inlines_Implicit()
+		{
+			var host = XamlHelper.LoadXaml<TextBlock>("""
+				<TextBlock xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup">
+					<Run Text="{local:ReturnStringAsd}" />
+					<Run Text="{local:ReturnStringAsd}" />
+					<Span>
+						<Run Text="{local:ReturnStringAsd}" />
+					</Span>
+				</TextBlock>
+			""");
+			// note: when using this "implicit" syntax, a one-space run is inserted between elements of same level.
+			var expectation = """
+				0	Run // Text='Asd'
+				1	Run // Text=' '
+				2	Run // Text='Asd'
+				3	Run // Text=' '
+				4	Span
+				5		Run // Text='Asd'
+			""";
+
+			VerifyInlineTree(expectation, host, DescribeInline);
+		}
+
+#if false
+		[TestMethod]
+		public void When_MarkupExtension_ServiceProvider_SelfRoot()
+		{
+			var provider = XamlHelper.LoadXaml<IXamlServiceProvider>("""
+				<local:DebugMarkupExtension xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup"/>
+			""");
+			//IProvideValueTarget
+			//	.TargetObject       // crash: AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
+			//	.TargetProperty     // throws: XamlParseException: Markup extension could not provide value. 
+			//IRootObjectProvider
+			//	.RootObject         // {DependecyObject}
+			//IUriContext
+			//	.BaseUri            // null
+		}
+#endif
+
+		[TestMethod]
+		public void When_MarkupExtension_ServiceProvider_DirectDP()
+		{
+			var setup = XamlHelper.LoadXaml<TextBlock>("""
+				<TextBlock
+					xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup"
+					Text="{local:DebugMarkupExtension Behavior=AssignToTag}"
+					/>
+			""");
+			Assert.IsInstanceOfType<IXamlServiceProvider>(setup.Tag);
+			//IProvideValueTarget
+			//	.TargetObject       // {Microsoft.UI.Xaml.Controls.TextBlock}
+			//	.TargetProperty     // {Microsoft.UI.Xaml.Markup.ProvideValueTargetProperty}
+			//		.DeclaringType  // typeof(TextBlock)
+			//		.Type           // typeof(string)
+			//		.Name           // "Text"
+			//IRootObjectProvider
+			//	.RootObject         // {Microsoft.UI.Xaml.Controls.TextBlock}
+			//IUriContext
+			//	.BaseUri            // null
+			var sut = (IXamlServiceProvider)setup.Tag;
+			var pvt = sut.GetService<IProvideValueTarget>();
+			var pvtp = pvt?.TargetProperty as ProvideValueTargetProperty;
+			var rop = sut.GetService<IRootObjectProvider>();
+
+			var expectedDP = TextBlock.TextProperty;
+
+			Assert.AreEqual(setup, pvt?.TargetObject, "IProvideValueTarget.TargetObject");
+			Assert.AreEqual(expectedDP.OwnerType, pvtp.DeclaringType, "IProvideValueTarget.TargetProperty.DeclaringType");
+			Assert.AreEqual(expectedDP.Name, pvtp.Name, "IProvideValueTarget.TargetProperty.Name");
+			Assert.AreEqual(expectedDP.Type, pvtp.Type, "IProvideValueTarget.TargetProperty.Type");
+			Assert.AreEqual(setup, rop.RootObject, "IRootObjectProvider.RootObject");
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_ServiceProvider_InheritedDP()
+		{
+			var setup = XamlHelper.LoadXaml<TextBlock>("""
+				<TextBlock
+					xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup"
+					Tag="{local:DebugMarkupExtension Behavior=ReturnProvider}"
+					/>
+			""");
+			Assert.IsInstanceOfType<IXamlServiceProvider>(setup.Tag);
+			//IProvideValueTarget
+			//    .TargetObject       // {Microsoft.UI.Xaml.Controls.TextBlock}
+			//    .TargetProperty     // {Microsoft.UI.Xaml.Markup.ProvideValueTargetProperty} <-- diff
+			//        .DeclaringType  // typeof(FrameworkElement)
+			//        .Type           // typeof(object)
+			//        .Name           // "Tag"
+			//IRootObjectProvider
+			//    .RootObject         // {Microsoft.UI.Xaml.Controls.TextBlock}
+			//IUriContext
+			//    .BaseUri            // null
+			var sut = (IXamlServiceProvider)setup.Tag;
+			var pvt = sut.GetService<IProvideValueTarget>();
+			var pvtp = pvt?.TargetProperty as ProvideValueTargetProperty;
+			var rop = sut.GetService<IRootObjectProvider>();
+
+			var expectedDP = FrameworkElement.TagProperty;
+
+			Assert.AreEqual(setup, pvt?.TargetObject, "IProvideValueTarget.TargetObject");
+			Assert.AreEqual(expectedDP.OwnerType, pvtp.DeclaringType, "IProvideValueTarget.TargetProperty.DeclaringType");
+			Assert.AreEqual(expectedDP.Name, pvtp.Name, "IProvideValueTarget.TargetProperty.Name");
+			Assert.AreEqual(expectedDP.Type, pvtp.Type, "IProvideValueTarget.TargetProperty.Type");
+			Assert.AreEqual(setup, rop.RootObject, "IRootObjectProvider.RootObject");
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_ServiceProvider_Nested()
+		{
+			var setup = XamlHelper.LoadXaml<Grid>("""
+				<Grid xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup">
+					<TextBlock Text="{local:DebugMarkupExtension Behavior=AssignToTag}" />
+				</Grid>
+			""");
+			var host = (TextBlock)setup.Children[0];
+			Assert.IsInstanceOfType<IXamlServiceProvider>(host.Tag);
+			//IProvideValueTarget
+			//    .TargetObject       // {Microsoft.UI.Xaml.Controls.TextBlock}
+			//    .TargetProperty     // {Microsoft.UI.Xaml.Markup.ProvideValueTargetProperty}
+			//        .DeclaringType  // typeof(TextBlock)
+			//        .Type           // typeof(string)
+			//        .Name           // "Text"
+			//IRootObjectProvider
+			//    .RootObject         // {Microsoft.UI.Xaml.Controls.Grid}  <-- diff
+			//IUriContext
+			//    .BaseUri            // null
+
+			var sut = (IXamlServiceProvider)host.Tag;
+			var pvt = sut.GetService<IProvideValueTarget>();
+			var pvtp = pvt?.TargetProperty as ProvideValueTargetProperty;
+			var rop = sut.GetService<IRootObjectProvider>();
+
+			var expectedDP = TextBlock.TextProperty;
+
+			Assert.AreEqual(host, pvt?.TargetObject, "IProvideValueTarget.TargetObject");
+			Assert.AreEqual(expectedDP.OwnerType, pvtp.DeclaringType, "IProvideValueTarget.TargetProperty.DeclaringType");
+			Assert.AreEqual(expectedDP.Name, pvtp.Name, "IProvideValueTarget.TargetProperty.Name");
+			Assert.AreEqual(expectedDP.Type, pvtp.Type, "IProvideValueTarget.TargetProperty.Type");
+			Assert.AreEqual(setup, rop.RootObject, "IRootObjectProvider.RootObject");
+		}
+
+		[TestMethod]
+		public void When_MarkupExtension_ServiceProvider_InlineLiteral()
+		{
+			var rootGrid = XamlHelper.LoadXaml<Grid>("""
+				<Grid xmlns:local="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup">
+					<StackPanel>
+						<local:DebugMarkupExtension Behavior="ReturnTextBlockWithProviderInTag" />
+					</StackPanel>
+				</Grid>
+			""");
+			var stackPanel = (StackPanel)rootGrid.Children[0];
+			var textBlock = (TextBlock)stackPanel.Children[0];
+
+			Assert.IsInstanceOfType<IXamlServiceProvider>(textBlock.Tag);
+			//IProvideValueTarget
+			//    .TargetObject       // {Microsoft.UI.Xaml.Controls.StackPanel}
+			//    .TargetProperty     // {Microsoft.UI.Xaml.Markup.ProvideValueTargetProperty}
+			//        .DeclaringType  // typeof(Panel)
+			//        .Type           // typeof(UIElementCollection)
+			//        .Name           // "Children"
+			//IRootObjectProvider
+			//    .RootObject         // {Microsoft.UI.Xaml.Controls.Grid}
+			//IUriContext
+			//    .BaseUri            // null
+
+			var sut = (IXamlServiceProvider)textBlock.Tag;
+			var pvt = sut.GetService<IProvideValueTarget>();
+			var pvtp = pvt?.TargetProperty as ProvideValueTargetProperty;
+			var rop = sut.GetService<IRootObjectProvider>();
+
+			var expectedDP = new // note: there is no such property in WinUI neither
+			{
+				OwnerType = typeof(Panel),
+				Name = nameof(Panel.Children),
+				Type = typeof(UIElementCollection),
+			};
+
+			Assert.AreEqual(stackPanel, pvt?.TargetObject, "IProvideValueTarget.TargetObject");
+			Assert.AreEqual(expectedDP.OwnerType, pvtp.DeclaringType, "IProvideValueTarget.TargetProperty.DeclaringType");
+			Assert.AreEqual(expectedDP.Name, pvtp.Name, "IProvideValueTarget.TargetProperty.Name");
+			Assert.AreEqual(expectedDP.Type, pvtp.Type, "IProvideValueTarget.TargetProperty.Type");
+			Assert.AreEqual(rootGrid, rop.RootObject, "IRootObjectProvider.RootObject");
+		}
+	}
+
+	public partial class Given_XamlReader
+	{
+		private static void VerifyInlineTree(string expectedTree, TextBlock tb, Func<Inline, IEnumerable<string>> describe)
+		{
+			var expectations = expectedTree.Split('\n', StringSplitOptions.TrimEntries);
+			var descendants = FlattenInlines(tb.Inlines).ToArray();
+
+			Assert.AreEqual(expectations.Length, descendants.Length, "Mismatched descendant size");
+			for (int i = 0; i < expectations.Length; i++)
+			{
+				var line = expectations[i].TrimStart("0123456789. ".ToArray());
+				var parts = line.Split(" // ", count: 2);
+				var depth = parts[0].TakeWhile(x => x == '\t').Count() - 1; // first tab is used as separator
+				parts[0] = parts[0].TrimStart('\t');
+
+				var node = descendants[i];
+				var name = node.Inline.GetType().Name;
+				var description = string.Join(", ", describe(node.Inline));
+
+				Assert.AreEqual(depth, node.Depth, $"Incorrect depth on line {i}");
+				Assert.AreEqual(parts[0], name, $"Incorrect node on line {i}");
+				Assert.AreEqual(parts.ElementAtOrDefault(1) ?? "", description, $"Invalid description on line {i}");
+			}
+		}
+
+		private static IEnumerable<(int Depth, Inline Inline)> FlattenInlines(InlineCollection inlines, int depth = 0)
+		{
+			// depth first traverse
+			foreach (var inline in inlines)
+			{
+				yield return (depth, inline);
+
+				if (inline is Span span)
+				{
+					foreach (var nested in FlattenInlines(span.Inlines, depth + 1))
+					{
+						yield return nested;
+					}
+				}
+			}
+		}
+
+		private static IEnumerable<string> DescribeInline(Inline inline)
+		{
+			if (inline is Run run) yield return $"Text='{run.Text}'";
+		}
 	}
 
 	public static partial class Given_AttachedDP
@@ -367,6 +707,94 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 
 	public class Given_XamlReader_CustomResDict2 : ResourceDictionary
 	{
+	}
+
+	public class TestMarkupExtension : MarkupExtension
+	{
+		public object ServiceProvider { get; private set; }
+		public bool ProvideValueCalled { get; private set; }
+
+		protected override object ProvideValue(IXamlServiceProvider serviceProvider)
+		{
+			ServiceProvider = serviceProvider;
+
+			return ProvideValue();
+		}
+		protected override object ProvideValue()
+		{
+			return ProvideValueCalled = true;
+		}
+	}
+
+	public class ReturnStringAsd : MarkupExtension
+	{
+		protected override object ProvideValue() => "Asd";
+	}
+
+	public static class DebugMarkupAttachable
+	{
+		#region DependencyProperty: Value
+
+		public static DependencyProperty ValueProperty { get; } = DependencyProperty.RegisterAttached(
+			"Value",
+			typeof(object),
+			typeof(DebugMarkupAttachable),
+			new PropertyMetadata(default(object)));
+
+		public static object GetValue(DependencyObject obj) => (object)obj.GetValue(ValueProperty);
+		public static void SetValue(DependencyObject obj, object value) => obj.SetValue(ValueProperty, value);
+
+		#endregion
+		#region DependencyProperty: Value2
+
+		public static DependencyProperty Value2Property { get; } = DependencyProperty.RegisterAttached(
+			"Value2",
+			typeof(int),
+			typeof(DebugMarkupAttachable),
+			new PropertyMetadata(default(int)));
+
+		public static int GetValue2(DependencyObject obj) => (int)obj.GetValue(Value2Property);
+		public static void SetValue2(DependencyObject obj, int value) => obj.SetValue(Value2Property, value);
+
+		#endregion
+	}
+
+	public class DebugMarkupExtension : MarkupExtension
+	{
+		public enum DebugBehavior { ReturnProvider, ReturnTextBlockWithProviderInTag, AssignToTag, AssignToAttachableValue }
+
+		public DebugBehavior Behavior { get; set; } = DebugBehavior.ReturnProvider;
+		protected override object ProvideValue(IXamlServiceProvider serviceProvider)
+		{
+			if (Behavior == DebugBehavior.ReturnProvider)
+			{
+				return serviceProvider;
+			}
+			else if (Behavior == DebugBehavior.ReturnTextBlockWithProviderInTag)
+			{
+				return new TextBlock { Tag = serviceProvider };
+			}
+			else
+			{
+				if (serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget pvt &&
+					pvt.TargetObject is FrameworkElement fe &&
+					pvt.TargetProperty is ProvideValueTargetProperty pvtp)
+				{
+					if (Behavior == DebugBehavior.AssignToTag)
+					{
+						fe.Tag = serviceProvider;
+					}
+					else
+					{
+						DebugMarkupAttachable.SetValue(fe, serviceProvider);
+					}
+
+					return pvtp.Type.IsValueType ? Activator.CreateInstance(pvtp.Type) : null;
+				}
+
+				return DependencyProperty.UnsetValue;
+			}
+		}
 	}
 }
 #endif

--- a/src/Uno.UI/Helpers/XamlHelper.cs
+++ b/src/Uno.UI/Helpers/XamlHelper.cs
@@ -19,7 +19,7 @@ internal static partial class XamlHelper
 	/// <summary>
 	/// Matches any tag without xmlns prefix.
 	/// </summary>
-	[GeneratedRegex(@"<\w+[ />]")]
+	[GeneratedRegex(@"<\w+[\s/>]")]
 	private static partial Regex NonXmlnsTagRegex();
 
 	private static readonly IReadOnlyDictionary<string, string> KnownXmlnses = new Dictionary<string, string>

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlConstants.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlConstants.cs
@@ -17,6 +17,26 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 		public const string BaseXamlNamespace = "Microsoft.UI.Xaml";
 		public const string UnoXamlNamespace = "Microsoft.UI.Xaml";
 
+		public const string UnknownContent = "_UnknownContent";
+
+		public static class Xmlnses
+		{
+			/// <summary>
+			/// <code>xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"</code>
+			/// </summary>
+			public const string Default = PresentationXamlXmlNamespace;
+
+			/// <summary>
+			/// <code>xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"</code>
+			/// </summary>
+			public const string X = XamlXmlNamespace;
+
+			/// <summary>
+			/// <code>xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"</code>
+			/// </summary>
+			public const string MC = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+		}
+
 		public static class Namespaces
 		{
 			public const string Controls = BaseXamlNamespace + ".Controls";

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -2,23 +2,26 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using Uno.Extensions;
-using Uno.UI;
-using Uno.UI.Helpers.Xaml;
-using Uno.UI.Xaml;
-using Uno.Xaml;
+using Windows.Foundation.Metadata;
+using Windows.UI.Text;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Documents;
-using Windows.UI.Text;
-using Windows.Foundation.Metadata;
-using Color = Windows.UI.Color;
 using Microsoft.UI.Xaml.Resources;
-using System.Diagnostics.CodeAnalysis;
+using Uno.Extensions;
+using Uno.UI;
+using Uno.UI.Extensions;
+using Uno.UI.Helpers.Xaml;
+using Uno.UI.Xaml;
+using Uno.UI.Xaml.Markup;
+using Uno.Xaml;
+
+using Color = Windows.UI.Color;
 
 #if __ANDROID__
 using _View = Android.Views.View;
@@ -98,6 +101,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 			object? rootInstance,
 			object? component = null,
 			TemplateMaterializationSettings? settings = null,
+			MemberInitializationContext? memberContext = null,
 			bool createInstanceFromXClass = false)
 		{
 			if (control == null)
@@ -105,16 +109,11 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				return null;
 			}
 
-			if (
-				control.Type.Name == "NullExtension"
-				&& control.Type.PreferredXamlNamespace == XamlConstants.XamlXmlNamespace
-			)
+			if (control.Type.PreferredXamlNamespace == XamlConstants.Xmlnses.X &&
+				control.Type.Name == "NullExtension")
 			{
 				return null;
 			}
-
-			var type = TypeResolver.FindType(control.Type);
-			var classMember = control.Members.FirstOrDefault(m => m.Member.Name == "Class" && m.Member.PreferredXamlNamespace == XamlConstants.XamlXmlNamespace);
 
 			void TrySetContextualProperties(object? instance, XamlObjectDefinition control)
 			{
@@ -132,7 +131,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				}
 			}
 
-			if (createInstanceFromXClass && TypeResolver.FindType(classMember?.Value?.ToString()) is { } classType)
+			if (createInstanceFromXClass && TypeResolver.FindTypeByXClass(control) is { } classType)
 			{
 				var created = Activator.CreateInstance(classType);
 				TrySetContextualProperties(created, control);
@@ -140,16 +139,52 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				return created;
 			}
 
+			var type = TypeResolver.FindType(control.Type);
+#if false
+			// This region is a failed attempt at "-Extension" resolution priority. It is disabled because we still don't understand the exact behavior.
+
+			// The order of lookup is to look for the Extension-suffixed class name first and then look for the class name without the Extension suffix.
+			// -- https://learn.microsoft.com/en-us/dotnet/desktop/xaml-services/markup-extensions-overview#defining-the-support-type-for-a-custom-markup-extension
+			// This rule is quite complicated..:
+			// ScenarioA. Given (Sanity,SanityExtension) defined:
+			//		{Sanity}->SanityExtension, {SanityExtension}->SanityExtension
+			// ScenarioB. Given (Sanity,SanityExtension,SanityExtensionExtension) defined:
+			//		{Sanity}->SanityExtension, {SanityExtension}->SanityExtension, {SanityExtensionExtension}->SanityExtensionExtension
+			// ScenarioC. Given (SanityExtensionExtension) defined:
+			//		{SanityExtension}->SanityExtensionExtension
+			// ScenarioD. Given (SanityExtension,SanityExtensionExtension) defined:
+			//		{SanityExtension}->SanityExtensionExtension, {SanityExtensionExtension}->SanityExtensionExtension
+			// ^ And, it doesnt explain why {SanityExtension} resolves to different things between scenario B and D...
+			if (type?.Is<MarkupExtension>() == true && !control.Type.Name.EndsWith("Extension", StringComparison.Ordinal))
+			{
+				// prefer $"{name}Extension" match if we dont already have this suffix
+				if (TypeResolver.FindType(control.Type.PreferredXamlNamespace, control.Type.Name + "Extension") is { } extensionType &&
+					extensionType.Is<MarkupExtension>())
+				{
+					type = extensionType;
+				}
+			}
+#endif
 			if (type == null)
 			{
-				throw new InvalidOperationException($"Unable to find type {control.Type}. If the linker is enabled, more info at https://aka.platform.uno/XXX");
+				// If we can match a $"{name}Extension" class and it extends from MarkupExtension, that is also a valid match.
+				// This shortcut syntax is not limited for {Markup} markup declaration syntax, but also works on <Markup> xaml-node declaration. (verified on WinAppSdk)
+				// note: On windows, the custom markup type MUST BE ALREADY used/referenced in the xaml once, in order for XamlReader to work with it, otherwise it will throws:
+				//		Microsoft.UI.Xaml.Markup.XamlParseException: 'The text associated with this error code could not be found.
+				//		The type 'Sanity' was not found. [Line: 1 Position: 9]'
+				if (TypeResolver.FindType(control.Type.PreferredXamlNamespace, control.Type.Name + "Extension") is { } extensionType &&
+					extensionType.Is<MarkupExtension>())
+				{
+					type = extensionType;
+				}
+				else
+				{
+					throw new InvalidOperationException($"Unable to find type {control.Type}. If the linker is enabled, more info at https://aka.platform.uno/linker-configuration");
+				}
 			}
 
-			var unknownContent = control.Members.Where(m => m.Member.Name == "_UnknownContent").FirstOrDefault();
-			var unknownContentValue = unknownContent?.Value;
+			var unknownContent = control.Members.Where(m => m.Member.Name == XamlConstants.UnknownContent).FirstOrDefault();
 			var initializationMember = control.Members.Where(m => m.Member.Name == "_Initialization").FirstOrDefault();
-
-			var isBrush = type == typeof(Media.Brush);
 
 			if (type.Is<FrameworkTemplate>())
 			{
@@ -165,28 +200,53 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 
 				return created;
 			}
+			else if (type.Is<MarkupExtension>())
+			{
+				var instance = Activator.CreateInstance(type) as MarkupExtension ??
+					throw new InvalidCastException($"Can not cast from '{type.FullName}' to '{nameof(MarkupExtension)}'.");
+
+				foreach (var member in control.Members)
+				{
+					ProcessNamedMember(control, instance, member, rootInstance ?? instance, settings);
+				}
+
+				var provider = new XamlServiceProviderContext
+				{
+					TargetObject = memberContext?.Target,
+					TargetProperty = memberContext?.Property is { } pi
+						? new ProvideValueTargetProperty
+						{
+							DeclaringType = pi.DeclaringType,
+							Name = pi.Name,
+							Type = pi.PropertyType,
+						}
+						: null,
+					RootObject = rootInstance,
+				};
+
+				var value = ((IMarkupExtensionOverrides)instance).ProvideValue(provider);
+
+				// It seems WinUI will generally throw: "Failed to assign to property '{fullname of dp}'"
+				// like for returning true(bool) to a string dp. So there is no conversion needed here.
+				// We can just let the caller to throw when invalid assignment eventually occurs.
+
+				return value;
+			}
 			else if (type.Is<ResourceDictionary>())
 			{
-				var contentOwner = unknownContent;
+				var instance = Activator.CreateInstance(type) as ResourceDictionary ??
+					throw new InvalidCastException($"Can not cast from '{type.FullName}' to '{nameof(ResourceDictionary)}'.");
 
-				if (Activator.CreateInstance(type) is ResourceDictionary rd)
+				foreach (var member in control.Members.Where(m => m != unknownContent))
 				{
-					foreach (var member in control.Members.Where(m => m != unknownContent))
-					{
-						ProcessNamedMember(control, rd, member, rd, settings: null);
-					}
-
-					if (unknownContent is { })
-					{
-						ProcessResourceDictionaryContent(rd, unknownContent, rootInstance);
-					}
-
-					return rd;
+					ProcessNamedMember(control, instance, member, instance, settings: null);
 				}
-				else
+				if (unknownContent is { })
 				{
-					throw new InvalidCastException();
+					ProcessResourceDictionaryContent(instance, unknownContent, rootInstance);
 				}
+
+				return instance;
 			}
 			else if (type.IsPrimitive && initializationMember?.Value is string primitiveValue)
 			{
@@ -196,15 +256,13 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 			{
 				return stringValue;
 			}
-			else if (type == typeof(Media.Geometry) && unknownContentValue is string geometryStringValue)
+			else if (type == typeof(Media.Geometry) && unknownContent?.Value is string geometryStringValue)
 			{
 				var generated = Uno.Media.Parsers.ParseGeometry(geometryStringValue);
 
 				return (Media.Geometry)generated;
 			}
-			else if (
-				_genericConvertibles.Contains(type)
-				&& control.Members.Where(m => m.Member.Name == "_UnknownContent").FirstOrDefault()?.Value is string otherContentValue)
+			else if (_genericConvertibles.Contains(type) && unknownContent?.Value is string otherContentValue)
 			{
 				return XamlBindingHelper.ConvertValue(type, otherContentValue);
 			}
@@ -213,18 +271,18 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				var instance = component ?? Activator.CreateInstance(type)!;
 				rootInstance ??= instance;
 
-				var instanceAsFrameworkElement = instance as FrameworkElement;
-				if (instanceAsFrameworkElement is { })
+				var instanceAsFE = instance as FrameworkElement;
+				if (instanceAsFE is { })
 				{
-					instanceAsFrameworkElement.IsParsing = true;
-					TrySetContextualProperties(instanceAsFrameworkElement, control);
+					instanceAsFE.IsParsing = true;
+					TrySetContextualProperties(instanceAsFE, control);
 				}
 
 				IDisposable? TryProcessStyle()
 				{
 					if (instance is Style style)
 					{
-						if (control.Members.FirstOrDefault(m => m.Member.Name == "TargetType") is XamlMemberDefinition targetTypeDefinition)
+						if (control.Members.FirstOrDefault(m => m.Member.Name == "TargetType") is { } targetTypeDefinition)
 						{
 							if (BuildLiteralValue(targetTypeDefinition) is Type targetType)
 							{
@@ -247,7 +305,6 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 
 					return null;
 				}
-
 				using (TryProcessStyle())
 				{
 					foreach (var member in control.Members)
@@ -256,7 +313,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 					}
 				}
 
-				instanceAsFrameworkElement?.CreationComplete();
+				instanceAsFE?.CreationComplete();
 
 				return instance;
 			}
@@ -318,26 +375,29 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 			object rootInstance,
 			TemplateMaterializationSettings? settings)
 		{
+			var isAttached = TypeResolver.IsAttachedProperty(member);
+			var isNestedChildNode = IsNestedChildNode(member);
+
 			// Exclude attached properties, must be set in the extended apply section.
 			// If there is no type attached, this can be a binding.
 			if (TypeResolver.IsType(control.Type, member.Member.DeclaringType)
-				&& !TypeResolver.IsAttachedProperty(member)
-				|| member.Member.Name == "_UnknownContent"
+				&& !isAttached
+				|| isNestedChildNode
 			// && FindEventType(member.Member) == null
 			)
 			{
 				if (instance is TextBlock textBlock)
 				{
-					ProcessTextBlock(control, textBlock, member, rootInstance);
+					ProcessTextBlock(control, textBlock, member, rootInstance, settings);
 				}
-				else if (instance is Documents.Span span && member.Member.Name == "_UnknownContent")
+				else if (instance is Documents.Span span && isNestedChildNode)
 				{
 					ProcessSpan(control, span, member, rootInstance);
 				}
 				// WinUI assigned ContentProperty syntax
 				else if (
 					instance is ColumnDefinition columnDefinition &&
-					member.Member.Name == "_UnknownContent" &&
+					isNestedChildNode &&
 					member.Value is string columnDefinitionContent &&
 					!string.IsNullOrWhiteSpace(columnDefinitionContent))
 				{
@@ -345,17 +405,17 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				}
 				else if (
 					instance is RowDefinition rowDefinition &&
-					member.Member.Name == "_UnknownContent" &&
+					isNestedChildNode &&
 					member.Value is string rowDefinitionContent &&
 					!string.IsNullOrWhiteSpace(rowDefinitionContent))
 				{
 					rowDefinition.Height = GridLength.ParseGridLength(rowDefinitionContent.Trim()).FirstOrDefault();
 				}
-				else if (member.Member.Name == "_UnknownContent"
+				else if (isNestedChildNode
 					&& TypeResolver.FindContentProperty(TypeResolver.FindType(control.Type)) == null
 					&& TypeResolver.IsCollectionOrListType(TypeResolver.FindType(control.Type)))
 				{
-					AddCollectionItems(instance, member.Objects, rootInstance, settings);
+					AddCollectionItems(instance, member.Objects, rootInstance, settings, null);
 				}
 				else if (GetMemberProperty(control, member) is PropertyInfo propertyInfo)
 				{
@@ -434,7 +494,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 					// throw new InvalidOperationException($"The Property {member.Member.Name} does not exist on {member.Member.DeclaringType}");
 				}
 			}
-			else if (TypeResolver.IsAttachedProperty(member))
+			else if (isAttached)
 			{
 				var dependencyProperty = TypeResolver.FindDependencyProperty(member);
 
@@ -562,28 +622,51 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 			}
 		}
 
-		private void ProcessTextBlock(XamlObjectDefinition control, TextBlock instance, XamlMemberDefinition member, object rootInstance)
+		private void ProcessTextBlock(XamlObjectDefinition control, TextBlock instance, XamlMemberDefinition member, object rootInstance, TemplateMaterializationSettings? settings)
 		{
-			if (member.Objects.Any())
+			if (IsBlankBaseMember(member))
 			{
-				if (IsMarkupExtension(member))
+			}
+			else if (IsNestedChildNode(member) || member.Member.Name == nameof(TextBlock.Inlines))
+			{
+				foreach (var node in member.Objects)
 				{
-					ProcessMemberMarkupExtension(instance, rootInstance, member, null);
-				}
-				else
-				{
-					foreach (var node in member.Objects)
+					var value = LoadObject(node, rootInstance);
+
+					if ((TypeResolver.FindType(node.Type) ?? TypeResolver.FindType(node.Type.PreferredXamlNamespace, node.Type.Name + "Extension"))?.Is<MarkupExtension>() == true)
 					{
-						if (LoadObject(node, rootInstance) is Inline inline)
-						{
-							instance.Inlines.Add(inline);
-						}
+						// WinUI will actually throw an exception for markup that returns `string` or `Run` here:
+						// > XamlParseException: The text associated with this error code could not be found.
+						// > Run -> Failed to assign to property 'Microsoft.UI.Xaml.Controls.TextBlock.Inlines' because the type 'Microsoft.UI.Xaml.Documents.Run' cannot be assigned to the type 'Microsoft.UI.Xaml.Documents.InlineCollection'. [Line: 22 Position: 8]'
+						// > string -> Failed to assign to property 'Microsoft.UI.Xaml.Controls.TextBlock.Inlines'. [Line: 20 Position: 7]'
+						throw new XamlParseException(value is Inline
+							? $"Failed to assign to property '{typeof(TextBlock).FullName}.{nameof(TextBlock.Inlines)}' because the type '{value.GetType().FullName}' cannot be assigned to the type '{typeof(InlineCollection).FullName}'."
+							: $"Failed to assign to property '{typeof(TextBlock).FullName}.{nameof(TextBlock.Inlines)}'."
+						);
+					}
+					if (value is Inline inline)
+					{
+						instance.Inlines.Add(inline);
 					}
 				}
 			}
 			else if (GetMemberProperty(control, member) is PropertyInfo propertyInfo)
 			{
-				GetPropertySetter(propertyInfo).Invoke(instance, new[] { BuildLiteralValue(member, propertyInfo.PropertyType) });
+				if (member.Objects.Count == 0)
+				{
+					GetPropertySetter(propertyInfo).Invoke(instance, new[] { BuildLiteralValue(member, propertyInfo.PropertyType) });
+				}
+				else
+				{
+					if (IsMarkupExtension(member))
+					{
+						ProcessMemberMarkupExtension(instance, rootInstance, member, propertyInfo);
+					}
+					else
+					{
+						ProcessMemberElements(instance, member, propertyInfo, rootInstance, settings);
+					}
+				}
 			}
 		}
 
@@ -643,7 +726,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 
 				var collection = BuildInstance();
 
-				AddCollectionItems(collection, member.Objects, rootInstance, settings);
+				AddCollectionItems(collection, member.Objects, rootInstance, settings, null);
 
 				instance.SetValue(property, collection);
 			}
@@ -750,7 +833,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 					&& TypeResolver.IsNewableType(propertyInfo.PropertyType))
 				{
 					var collection = Activator.CreateInstance(propertyInfo.PropertyType);
-					AddCollectionItems(collection!, member.Objects, rootInstance, settings);
+					AddCollectionItems(collection!, member.Objects, rootInstance, settings, new(instance, propertyInfo));
 
 					GetPropertySetter(propertyInfo).Invoke(instance, new[] { collection });
 				}
@@ -771,7 +854,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						}
 						else
 						{
-							AddCollectionItems(propertyInstance, member.Objects, rootInstance, settings);
+							AddCollectionItems(propertyInstance, member.Objects, rootInstance, settings, new(instance, propertyInfo));
 						}
 					}
 					else
@@ -786,10 +869,12 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 			}
 			else
 			{
-				GetPropertySetter(propertyInfo).Invoke(instance, new[]
-				{
-					LoadObject(member.Objects.First(), rootInstance: rootInstance, settings: settings)
-				});
+				GetPropertySetter(propertyInfo).Invoke(instance, [LoadObject(
+					member.Objects.First(),
+					rootInstance: rootInstance,
+					settings: settings,
+					memberContext: new(instance, propertyInfo))
+				]);
 			}
 		}
 
@@ -1161,13 +1246,14 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 			object collectionInstance,
 			IEnumerable<XamlObjectDefinition> nonBindingObjects,
 			object rootInstance,
-			TemplateMaterializationSettings? settings)
+			TemplateMaterializationSettings? settings,
+			MemberInitializationContext? memberContext)
 		{
 			var collectionType = collectionInstance.GetType();
 
 			foreach (var child in nonBindingObjects)
 			{
-				var item = LoadObject(child, rootInstance: rootInstance, settings: settings);
+				var item = LoadObject(child, rootInstance: rootInstance, settings: settings, memberContext: memberContext);
 				var itemType = item?.GetType() ?? typeof(object);
 
 				var addMethodInfo =
@@ -1345,6 +1431,19 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 			}
 		}
 
+		private static bool IsBlankBaseMember(XamlMemberDefinition member) =>
+			member.Member.Name == "base" &&
+			member.Objects.Count == 0 &&
+			member.Value as string == string.Empty;
+
+		/// <summary>
+		/// Check if the member is a nested child node (implicit [ContentProperty] value(s)).
+		/// </summary>
+		/// <remarks>
+		/// This will return false for member child node (member property).
+		/// </remarks>
+		private static bool IsNestedChildNode(XamlMemberDefinition member) => member.Member.Name == XamlConstants.UnknownContent;
+
 		private class EventHandlerWrapper
 		{
 			private readonly object _instance;
@@ -1366,6 +1465,8 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				_method.Invoke(_instance, Array.Empty<object>());
 			}
 		}
+
+		private record MemberInitializationContext(object Target, PropertyInfo Property);
 
 		[GeneratedRegex(@"(\(.*?\))")]
 		private static partial Regex AttachedPropertyMatching();

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -12,6 +12,7 @@ using Uno.Xaml;
 using Windows.UI;
 using Windows.Foundation;
 using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
 
 namespace Microsoft.UI.Xaml.Markup.Reader
 {
@@ -301,44 +302,51 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 
 			return _findType(name);
 		}
+		public Type? FindType(string xmlns, string name)
+		{
+			if (xmlns == XamlConstants.Xmlnses.X)
+			{
+				if (name == "Bind")
+				{
+					return _findType(XamlConstants.Namespaces.Data + ".Binding");
+				}
+				else if (_findType("System." + name) is Type systemType)
+				{
+					return systemType;
+				}
+			}
+
+			var ns = FileDefinition.Namespaces.FirstOrDefault(n => n.Namespace == xmlns);
+			var isKnownNamespace = ns?.Prefix is { Length: > 0 };
+			var fullName = (!isKnownNamespace && xmlns.StartsWith("using:", StringComparison.Ordinal))
+				? xmlns.TrimStart("using:") + "." + name
+				: isKnownNamespace ? ns?.Prefix + ":" + name : name;
+
+			return _findType(fullName);
+		}
 
 		public Type? FindType(XamlType? type)
 		{
 			if (type != null)
 			{
-				var ns = FileDefinition.Namespaces.FirstOrDefault(n => n.Namespace == type.PreferredXamlNamespace);
-				var isKnownNamespace = ns?.Prefix is { Length: > 0 };
-
-				if (type.PreferredXamlNamespace == XamlConstants.XamlXmlNamespace)
-				{
-					if (type.Name == "Bind")
-					{
-						return _findType(XamlConstants.Namespaces.Data + ".Binding");
-					}
-					else if (_findType("System." + type.Name) is Type systemType)
-					{
-						return systemType;
-					}
-				}
-
-				string getFullName()
-				{
-					if (!isKnownNamespace && type.PreferredXamlNamespace.StartsWith("using:", StringComparison.Ordinal))
-					{
-						return type.PreferredXamlNamespace.TrimStart("using:") + "." + type.Name;
-					}
-					else
-					{
-						return isKnownNamespace ? ns?.Prefix + ":" + type.Name : type.Name;
-					}
-				}
-
-				return _findType(getFullName());
+				return FindType(type.PreferredXamlNamespace, type.Name);
 			}
 			else
 			{
 				return null;
 			}
+		}
+
+		public Type? FindTypeByXClass(XamlObjectDefinition? definition)
+		{
+			if (definition is { } &&
+				FindXClass(definition) is { } name &&
+				!name.IsNullOrWhiteSpace())
+			{
+				return _findType(name);
+			}
+
+			return null;
 		}
 
 		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Types may be removed or not present as part of the normal operations of that method")]
@@ -592,5 +600,10 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 					(itemType ?? typeof(object)).Is(arg0.ParameterType)
 				);
 		}
+
+		private static string? FindXClass(XamlObjectDefinition definition) =>
+			definition.Members
+				.FirstOrDefault(x => x.Member.PreferredXamlNamespace == XamlConstants.Xmlnses.X && x.Member.Name == "Class")
+				?.Value?.ToString();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Markup/XamlServiceProviderExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/XamlServiceProviderExtensions.cs
@@ -1,0 +1,6 @@
+﻿namespace Microsoft.UI.Xaml;
+
+internal static class XamlServiceProviderExtensions
+{
+	public static T GetService<T>(this IXamlServiceProvider provider) => (T)provider.GetService(typeof(T));
+}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #3399

## PR Type
What kind of change does this PR introduce?
- Bugfix
- Feature
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
## What is the new behavior?
- XamlReader fully supports dynamic parsing of custom MarkupExtension:
  - Markup's ProvideValue method will be evaluated and the return value will be insert in its document position.
  - an IXamlServiceProvider will be injected for ProvideValue(IXamlServiceProvider).
  - the `-Extension` suffix can be optionally omitted.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.