### PR TITLE
Dev/jela/reduce resource resolutions

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -1632,7 +1632,7 @@ namespace Microsoft.UI.Xaml
 			{
 				if (candidate is FrameworkElement fe)
 				{
-					if (fe.Resources is { IsEmpty: false }) // It's legal (if pointless) on UWP to set Resources to null from user code, so check
+					if (fe.TryGetResources() is { IsEmpty: false }) // It's legal (if pointless) on UWP to set Resources to null from user code, so check
 					{
 						yield return fe.Resources;
 					}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -249,7 +249,6 @@ namespace Microsoft.UI.Xaml
 #if !UNO_REFERENCE_API
 			_layouter = new FrameworkElementLayouter(this, MeasureOverride, ArrangeOverride);
 #endif
-			Resources = new Microsoft.UI.Xaml.ResourceDictionary();
 
 			IFrameworkElementHelper.Initialize(this);
 		}
@@ -260,8 +259,16 @@ namespace Microsoft.UI.Xaml
 #endif
 		Microsoft.UI.Xaml.ResourceDictionary Resources
 		{
-			get; set;
+			get => _resources ??= new ResourceDictionary();
+			set => _resources = value;
 		}
+
+		/// <summary>
+		/// Tries getting the ResourceDictionary without initializing it.
+		/// </summary>
+		/// <returns>A ResourceDictionary instance or null</returns>
+		internal Microsoft.UI.Xaml.ResourceDictionary TryGetResources()
+			=> _resources;
 
 		/// <summary>
 		/// Gets the parent of this FrameworkElement in the object tree.
@@ -956,7 +963,7 @@ namespace Microsoft.UI.Xaml
 		/// </summary>
 		internal virtual void UpdateThemeBindings(ResourceUpdateReason updateReason)
 		{
-			Resources?.UpdateThemeBindings(updateReason);
+			TryGetResources()?.UpdateThemeBindings(updateReason);
 			(this as IDependencyObjectStoreProvider).Store.UpdateResourceBindings(updateReason);
 
 			if (updateReason == ResourceUpdateReason.ThemeResource)
@@ -972,6 +979,7 @@ namespace Microsoft.UI.Xaml
 		#region AutomationPeer
 #if !__IOS__ && !__ANDROID__ && !__MACOS__ // This code is generated in FrameworkElementMixins
 		private AutomationPeer _automationPeer;
+		private ResourceDictionary _resources;
 
 		protected override AutomationPeer OnCreateAutomationPeer()
 		{

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -395,11 +395,19 @@ namespace Uno.UI
 
 				var source = sourcesEnumerator.Current;
 
-				var dictionary = (source.Target as FrameworkElement)?.Resources
+				var dictionary = (source.Target as FrameworkElement)?.TryGetResources()
 					?? source.Target as ResourceDictionary;
-				if (dictionary != null && dictionary.TryGetValue(resourceKey, out value, shouldCheckSystem: false))
+
+				if (dictionary != null)
 				{
-					return true;
+					if (dictionary.TryGetValue(resourceKey, out value, shouldCheckSystem: false))
+					{
+						return true;
+					}
+				}
+				else
+				{
+
 				}
 			}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -1072,7 +1072,7 @@ namespace Microsoft.UI.Xaml
 			// are entered as well.
 			// The property we currently know it has an effect is Resources
 			// In WinUI, it happens in CDependencyObject::EnterImpl (the call to EnterSparseProperties)
-			if (this is FrameworkElement { Resources: { } resources })
+			if (this is FrameworkElement fe && fe.TryGetResources() is { } resources)
 			{
 				// Using ValuesInternal to avoid Enumerator boxing
 				foreach (var resource in resources.ValuesInternal)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Makes the `FrameworkElement.Resources` property lazy initialized
- Don't reevaluate all resources on measure