### PR TITLE
fix(devSrv): Do not fail connection if a client processor fails

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.cs
@@ -65,7 +65,7 @@ public partial class ClientHotReloadProcessor : IClientProcessor
 	private async Task ConfigureServer()
 	{
 		var assembly = _rcClient.AppType.Assembly;
-		if (assembly.GetCustomAttributes(typeof(ProjectConfigurationAttribute), false) is ProjectConfigurationAttribute[]{Length: >0} configs)
+		if (assembly.GetCustomAttributes(typeof(ProjectConfigurationAttribute), false) is ProjectConfigurationAttribute[] { Length: > 0 } configs)
 		{
 			_status.ReportServerState(HotReloadState.Initializing);
 

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -536,14 +536,23 @@ public partial class RemoteControlClient : IRemoteControlClient
 						this.Log().Trace($"Received frame [{frame.Scope}/{frame.Name}]");
 					}
 
-					bool skipProcessing = false;
-
+					var skipProcessing = false;
 					foreach (var preProcessor in _preprocessors)
 					{
-						if (await preProcessor.SkipProcessingFrame(frame))
+						try
 						{
-							skipProcessing = true;
-							break;
+							if (await preProcessor.SkipProcessingFrame(frame))
+							{
+								skipProcessing = true;
+								break;
+							}
+						}
+						catch (Exception error)
+						{
+							if (this.Log().IsEnabled(LogLevel.Error))
+							{
+								this.Log().LogError($"Error while **PRE**processing frame [{frame.Scope}/{frame.Name}]", error);
+							}
 						}
 					}
 
@@ -564,9 +573,9 @@ public partial class RemoteControlClient : IRemoteControlClient
 				}
 				else
 				{
-					if (this.Log().IsEnabled(LogLevel.Error))
+					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
-						this.Log().LogError($"Unknown Frame scope {frame.Scope}");
+						this.Log().Trace($"Unknown Frame scope {frame.Scope}");
 					}
 				}
 			}

--- a/src/Uno.UI.RemoteControl/RemoteControlClient.cs
+++ b/src/Uno.UI.RemoteControl/RemoteControlClient.cs
@@ -499,7 +499,17 @@ public partial class RemoteControlClient : IRemoteControlClient
 
 		foreach (var processor in _processors)
 		{
-			await processor.Value.Initialize();
+			try
+			{
+				await processor.Value.Initialize();
+			}
+			catch (Exception error)
+			{
+				if (this.Log().IsEnabled(LogLevel.Error))
+				{
+					this.Log().LogError($"Failed to initialize processor '{processor}'.", error);
+				}
+			}
 		}
 
 		StartKeepAliveTimer();


### PR DESCRIPTION
## Bugfix
Do not fail connection if a client processor initialization fails

## What is the current behavior?
If a client processor fails (like HR client if not properly configured), then connection to the dev-server is not initialized properly.

## What is the new behavior?
* We are still listening for incoming frames if a client processor initialization fails.
* HR client processor init does not crash if config is invalid.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
