### PR TITLE
fix: Adds support for standard protocol activations on wasm

### DIFF
--- a/doc/articles/features/protocol-activation.md
+++ b/doc/articles/features/protocol-activation.md
@@ -46,24 +46,53 @@ If your target framework is Android 12, you must also add `Exported = true` to t
 
 ### WASM
 
-WASM implementation uses the [`Navigator.registerProtocolHandler` API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler). This has several limitations for the custom scheme:
+WASM implementation uses the [`Navigator.registerProtocolHandler` API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler). 
+
+This has several limitations when using a custom scheme:
 
 - The custom scheme's name must begin with `web+`
 - The custom scheme's name must include at least 1 letter after the `web+` prefix
 - The custom scheme must have only lowercase ASCII letters in its name.
+
+You can also use one of the following supported schemes instead:
+
+- `bitcoin`
+- `ftp`
+- `ftps`
+- `geo`
+- `im`
+- `irc`
+- `ircs`
+- `magnet`
+- `mailto`
+- `matrix`
+- `mms`
+- `news`
+- `nntp`
+- `openpgp4fpr`
+- `sftp`
+- `sip`
+- `sms`
+- `smsto`
+- `ssh`
+- `tel`
+- `urn`
+- `webcal`
+- `wtai`
+- `xmpp`
 
 To register the custom theme, call the WASM-specific `Uno.Helpers.ProtocolActivation` API when appropriate to let the user confirm URI handler association:
 
 ```csharp
 #if __WASM__
    Uno.Helpers.ProtocolActivation.RegisterCustomScheme(
-      "web+myscheme", 
+      "web+myscheme",
       new System.Uri("http://localhost:55838/"), 
       "Can we handle web+myscheme links?");
 #endif
 ```
 
-The first argument is the scheme name, the second is the base URL of your application (it must match the current domain to be registered successfully), and the third is a text prompt, which will be displayed to the user to ask for permission.
+The first argument is the scheme name, the second is the base URL of your application (it must match the current domain to be registered successfully), and the third is a text prompt, which will be displayed to the user to ask for permission (this does not work on all browsers e.g. edge).
 
 When a link with the custom scheme gets executed, the browser will navigate to a your URL with additional `unoprotocolactivation` query string key, which will contain the custom URI. Uno internally recognizes this query string key and executes `OnActivated` appropriately.
 

--- a/doc/articles/features/protocol-activation.md
+++ b/doc/articles/features/protocol-activation.md
@@ -46,7 +46,7 @@ If your target framework is Android 12, you must also add `Exported = true` to t
 
 ### WASM
 
-WASM implementation uses the [`Navigator.registerProtocolHandler` API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler). 
+WASM implementation uses the [`Navigator.registerProtocolHandler` API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler).
 
 This has several limitations when using a custom scheme:
 

--- a/src/Uno.UWP/Helpers/ProtocolActivation.wasm.cs
+++ b/src/Uno.UWP/Helpers/ProtocolActivation.wasm.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.InteropServices.JavaScript;
-using System.Runtime.Intrinsics.X86;
 using System.Web;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
-using static System.Net.WebRequestMethods;
 
 namespace Uno.Helpers
 {

--- a/src/Uno.UWP/Helpers/ProtocolActivation.wasm.cs
+++ b/src/Uno.UWP/Helpers/ProtocolActivation.wasm.cs
@@ -1,16 +1,47 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.InteropServices.JavaScript;
+using System.Runtime.Intrinsics.X86;
 using System.Web;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
+using static System.Net.WebRequestMethods;
 
 namespace Uno.Helpers
 {
 	public static partial class ProtocolActivation
 	{
 		internal const string QueryKey = "unoprotocolactivation";
+
+		private static readonly IEnumerable<string> _predefinedPrefixes = [
+			"bitcoin",
+			"ftp",
+			"ftps",
+			"geo",
+			"im",
+			"irc",
+			"ircs",
+			"magnet",
+			"mailto",
+			"matrix",
+			"mms",
+			"news",
+			"nntp",
+			"openpgp4fpr",
+			"sftp",
+			"sip",
+			"sms",
+			"smsto",
+			"ssh",
+			"tel",
+			"urn",
+			"webcal",
+			"wtai",
+			"xmpp"
+		];
 
 		/// <summary>
 		/// Registers a custom URI scheme for protocol activation on WASM.
@@ -21,39 +52,38 @@ namespace Uno.Helpers
 		public static void RegisterCustomScheme(string scheme, Uri domain, string prompt)
 		{
 			// rules as per https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler
-
-			// The custom scheme's name begins with web+
-			if (!scheme.StartsWith("web+", StringComparison.Ordinal))
+			if (!_predefinedPrefixes.Contains(scheme))
 			{
-				throw new ArgumentException(
-					"Scheme must start with 'web+'",
-					nameof(scheme));
-			}
-
-			// The custom scheme's name includes at least 1 letter after the web+ prefix
-			if (scheme.Length == "web+".Length)
-			{
-				throw new ArgumentException(
-					"Scheme must include at least 1 letter after 'web+' prefix",
-					nameof(scheme));
-			}
-
-			// The custom scheme has only lowercase ASCII letters in its name.
-			for (int i = "web+".Length; i < scheme.Length; i++)
-			{
-				if (scheme[i] is not (>= 'a' and <= 'z'))
+				// The custom scheme's name begins with web+
+				if (!scheme.StartsWith("web+", StringComparison.Ordinal))
 				{
 					throw new ArgumentException(
-						"Scheme must include only lowercase ASCII letters after " +
-						"the 'web+' prefix",
+						"Scheme must start with 'web+'",
 						nameof(scheme));
+				}
+
+				// The custom scheme's name includes at least 1 letter after the web+ prefix
+				if (scheme.Length == "web+".Length)
+				{
+					throw new ArgumentException(
+						"Scheme must include at least 1 letter after 'web+' prefix",
+						nameof(scheme));
+				}
+
+				// The custom scheme has only lowercase ASCII letters in its name.
+				for (int i = "web+".Length; i < scheme.Length; i++)
+				{
+					if (scheme[i] is not (>= 'a' and <= 'z'))
+					{
+						throw new ArgumentException(
+							"Scheme must include only lowercase ASCII letters after " +
+							"the 'web+' prefix",
+							nameof(scheme));
+					}
 				}
 			}
 
-			if (domain == null)
-			{
-				throw new ArgumentNullException(nameof(domain));
-			}
+			ArgumentNullException.ThrowIfNull(domain);
 
 			if (!domain.IsAbsoluteUri)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #11203

## PR Type

What kind of change does this PR introduce?

- Feature 
- Enhancement

## What is the current behavior?

Currently, you can only activate a custom protocol on WASM with a `web+` prefix, despite browsers supporting some standard protocols [docs](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler).

## What is the new behavior?

Adds support for some standard protocols that are described in  [docs](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler) or in the issue.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
