### PR TITLE
chore: Point Fluent Icons to MDL2 Assets

### DIFF
--- a/src/Uno.UI/UI/Xaml/FontFamily.cs
+++ b/src/Uno.UI/UI/Xaml/FontFamily.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Uno.UI;
+using Windows.Networking;
 
 namespace Microsoft.UI.Xaml.Media
 {
@@ -11,8 +12,12 @@ namespace Microsoft.UI.Xaml.Media
 		public FontFamily(string familyName)
 		{
 			Source = familyName;
-
 			Init(familyName);
+
+			if (familyName.Equals("Segoe Fluent Icons,Segoe MDL2 Assets", StringComparison.OrdinalIgnoreCase))
+			{
+				Source = "Segoe MDL2 Assets";
+			}
 
 			// This instance is immutable, we can cache the hash code.
 			_hashCode = familyName.GetHashCode();


### PR DESCRIPTION
GitHub Issue (If applicable): closes #17591

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

The fix updates the FontFamily class to recognize the specific font family name ("Segoe Fluent Icons,Segoe MDL2 Assets") and re-route the font source to UnoSymbols for proper icon rendering.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.