### PR TITLE
fix: Fix invalid code gen when using markup extension in a style

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Given_HotReloadService.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Given_HotReloadService.cs
@@ -220,7 +220,7 @@ public class Given_HotReloadService
 			results.Add(await SUT.Update());
 			previousStep = currentStep;
 		}
-		
+
 		return results.ToArray();
 	}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Given_HotReloadService.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Given_HotReloadService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Uno.UI.SourceGenerators.MetadataUpdates;
@@ -21,6 +22,11 @@ public class Given_HotReloadService
 			}
 
 			var results = await ApplyScenario(projects, scenario.IsDebug, scenario.IsMono, scenario.UseXamlReaderReload, name);
+
+			if (scenario.PassResults.Length != results.Length)
+			{
+				Assert.Fail($"Scenario describes {scenario.PassResults.Length} results while the tests produced {results.Length} (you should have n+1 scenario.PassResults for n directory on disk).");
+			}
 
 			for (var i = 0; i < scenario.PassResults.Length; i++)
 			{
@@ -59,7 +65,7 @@ public class Given_HotReloadService
 			var path = Path.Combine(scenarioFolder, "Scenario.json");
 
 #if DEBUG && false
-			if (!path.Contains("When_DataTemplate_xLoad_xBind_Remove"))
+			if (!path.Contains("When_Base_Type_Grid_To_Page"))
 			{
 				continue;
 			}
@@ -120,7 +126,8 @@ public class Given_HotReloadService
 		, bool isDebugCompilation
 		, bool isMono
 		, bool useXamlReaderReload
-		, [CallerMemberName] string? name = null)
+		, [CallerMemberName] string? name = null
+		, CancellationToken ct = default)
 	{
 		if (name is null)
 		{
@@ -128,6 +135,7 @@ public class Given_HotReloadService
 		}
 
 		var scenarioFolder = Path.Combine(ScenariosFolder, name);
+		var scenarioFile = Path.Combine(scenarioFolder, "Scenario.json");
 
 		HotReloadWorkspace SUT = new(isDebugCompilation, isMono, useXamlReaderReload);
 		List<HotReloadWorkspace.UpdateResult> results = new();
@@ -136,51 +144,99 @@ public class Given_HotReloadService
 		{
 			foreach (var project in projects)
 			{
-				SUT.AddProject(
-					project.Name
-					, (project.ProjectReferences ?? Array.Empty<ProjectReference>()).Select(r => r.Name).ToArray());
+				SUT.AddProject(project.Name, (project.ProjectReferences ?? []).Select(r => r.Name).ToArray());
 			}
 		}
 
 		var steps = Directory
 			.GetFiles(scenarioFolder, "*.*", SearchOption.AllDirectories)
-			.OrderBy(f => f)
-			.GroupBy(f => Path.GetRelativePath(scenarioFolder, f).Split(Path.DirectorySeparatorChar)[0]);
+			.Where(file => file != scenarioFile)
+			.OrderBy(file => file)
+			.Select(file => ScenarioFileDescriptor.Create(scenarioFolder, file))
+			.GroupBy(file => file.StepIndex)
+			.Select(step => new Step(
+				step.Key,
+				step
+					.GroupBy(file => file.ProjectName)
+					.Select(filesPerProject => new StepProject(filesPerProject.Key, filesPerProject.Select(file => new StepFile(file.File)).ToImmutableList()))
+					.ToImmutableDictionary(project => project.Name)))
+			.ToImmutableDictionary(step => step.Index);
 
-		int index = 0;
-		foreach (var step in steps)
+		var initialStep = steps[0];
+		foreach (var project in initialStep.Projects.Values)
 		{
-			foreach (var file in step)
+			foreach (var file in project.Files)
 			{
-				if (file == Path.Combine(scenarioFolder, "Scenario.json"))
+				var content = await File.ReadAllTextAsync(Path.Combine(scenarioFolder, initialStep.Index.ToString(), project.Name, file.Path), ct);
+				if (file.IsCs)
 				{
-					continue;
-				}
-
-				var pathParts = Path.GetRelativePath(scenarioFolder, file).Split(Path.DirectorySeparatorChar);
-
-				var fileContent = File.ReadAllText(file);
-
-				if (Path.GetExtension(file) == ".cs")
-				{
-					SUT.SetSourceFile(pathParts[1], pathParts[2], fileContent);
+					SUT.UpdateSourceFile(project.Name, file.Path, content);
 				}
 				else
 				{
-					SUT.SetAdditionalFile(pathParts[1], pathParts[2], fileContent);
+					SUT.UpdateAdditionalFile(project.Name, file.Path, content);
+				}
+			}
+		}
+		await SUT.Initialize(ct);
+
+		var previousStep = initialStep;
+		for (var i = 1; i < steps.Count; i++)
+		{
+			var currentStep = steps[i];
+			if (!currentStep.Projects.Keys.SequenceEqual(previousStep.Projects.Keys))
+			{
+				throw new InvalidOperationException("Projects removal is not yet supported.");
+			}
+
+			foreach (var project in currentStep.Projects.Values)
+			{
+				foreach (var file in project.Files)
+				{
+					var content = await File.ReadAllTextAsync(Path.Combine(scenarioFolder, currentStep.Index.ToString(), project.Name, file.Path), ct);
+					if (file.IsCs)
+					{
+						SUT.UpdateSourceFile(project.Name, file.Path, content);
+					}
+					else
+					{
+						SUT.UpdateAdditionalFile(project.Name, file.Path, content);
+					}
+				}
+
+				foreach (var removedFile in previousStep.Projects[project.Name].Files.ExceptBy(project.Files.Select(file => file.Path), previousFile => previousFile.Path))
+				{
+					if (removedFile.IsCs)
+					{
+						SUT.UpdateSourceFile(project.Name, removedFile.Path, null);
+					}
+					else
+					{
+						SUT.UpdateAdditionalFile(project.Name, removedFile.Path, null);
+					}
 				}
 			}
 
-			if (index++ == 0)
-			{
-				await SUT.Initialize(CancellationToken.None);
-			}
-			else
-			{
-				results.Add(await SUT.Update());
-			}
+			results.Add(await SUT.Update());
+			previousStep = currentStep;
 		}
-
+		
 		return results.ToArray();
+	}
+
+	private readonly record struct ScenarioFileDescriptor(int StepIndex, string ProjectName, string File)
+	{
+		public static ScenarioFileDescriptor Create(string scenarioFolder, string filePath)
+		{
+			var parts = Path.GetRelativePath(scenarioFolder, filePath).Split(Path.DirectorySeparatorChar, 3);
+			return new ScenarioFileDescriptor(int.Parse(parts[0]), parts[1], parts[2]);
+		}
+	}
+
+	private record Step(int Index, IImmutableDictionary<string, StepProject> Projects);
+	private record StepProject(string Name, IImmutableList<StepFile> Files);
+	private record StepFile(string Path) // Path relative to the scenario/step/project (i.e. scenario/step/project/{PATH})
+	{
+		public bool IsCs { get; } = System.IO.Path.GetExtension(Path) == ".cs";
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/0/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/0/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/1/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple TextValue='Just a simple ...'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/1/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/0/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/0/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/1/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple TextValue='Just a simple ...'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/1/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Inc_Ext/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/0/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/0/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/1/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple TextValue='Just a simple ...'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/1/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/2/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/2/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/2/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/2/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove/Scenario.json
@@ -1,0 +1,32 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/0/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/0/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/1/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple TextValue='Just a simple ...'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/1/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/2/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/2/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/2/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/2/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Add_Remove_Inc_Ext/Scenario.json
@@ -1,0 +1,39 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// Removing class 'Simple' requires restarting the application.
+						{ "Id": "ENC0033" }
+					]
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// Removing class 'Simple' requires restarting the application.
+						{ "Id": "ENC0033" }
+					]
+				}
+			]
+		}
+	]
+}
+

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/0/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple TextValue='Just a simple ...'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/0/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/1/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/1/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/0/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple TextValue='Just a simple ...'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/0/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/1/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/1/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Remove_Inc_Ext/Scenario.json
@@ -1,0 +1,30 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// Removing class 'Simple' requires restarting the application.
+						{ "Id": "ENC0033" }
+					]
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 0,
+					"Diagnostics": [
+						// Removing class 'Simple' requires restarting the application.
+						{ "Id": "ENC0033" }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/0/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple TextValue='Just a simple ...'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/0/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/1/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple TextValue='Just a simple ... but edited'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/1/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/0/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple TextValue='Just a simple ...'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/0/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/1/p1/MainPage.xaml
@@ -1,0 +1,13 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Grid>
+		<TextBlock Text="{local:Simple EditedTextValue='Just a simple ... but edited'}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/1/p1/MainPage.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string EditedTextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return EditedTextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_MarkupExtension_Update_Inc_Ext/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/0/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/0/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="The content"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/0/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/0/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/1/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/1/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ...'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/1/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/1/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Inc_Ext/0/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Inc_Ext/0/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="The content"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Inc_Ext/1/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Inc_Ext/1/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ...'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Inc_Ext/1/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Inc_Ext/1/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Inc_Ext/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Inc_Ext/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/0/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/0/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="The content"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/0/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/0/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/1/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/1/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ...'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/1/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/1/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/2/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/2/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="The content"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/2/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/2/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove/Scenario.json
@@ -1,0 +1,32 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/0/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/0/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="The content"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/1/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/1/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ...'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/1/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/1/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/2/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/2/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="The content"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Add_Remove_Inc_Ext/Scenario.json
@@ -1,0 +1,32 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/0/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/0/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ...'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/0/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/0/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/1/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/1/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="The content"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/1/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/1/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove_Inc_Ext/0/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove_Inc_Ext/0/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ...'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove_Inc_Ext/0/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove_Inc_Ext/0/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove_Inc_Ext/1/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove_Inc_Ext/1/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="The content"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove_Inc_Ext/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Remove_Inc_Ext/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/0/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/0/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ...'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/0/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/0/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/1/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/1/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ... but edited'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/1/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/1/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/0/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/0/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ...'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/0/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/0/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/1/p1/ResDic.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/1/p1/ResDic.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ctrl="using:Microsoft.UI.Xaml.Controls"
+	xmlns:local="using:Test01">
+
+	<Style x:Key="ANamedStyle" TargetType="ctrl:ContentControl">
+		<Setter Property="Content" Value="{local:Simple TextValue='Just a simple ... but edited'}"/>
+	</Style>
+</ResourceDictionary>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/1/p1/SimpleMarkupExtension.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/1/p1/SimpleMarkupExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+[Microsoft.UI.Xaml.Markup.MarkupExtensionReturnType(ReturnType = typeof(string))]
+public class Simple : Microsoft.UI.Xaml.Markup.MarkupExtension
+{
+	public string TextValue { get; set; }
+
+	protected override object ProvideValue()
+	{
+		return TextValue + " markup extension";
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Style_MarkupExtension_Update_Inc_Ext/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using CommunityToolkit.Mvvm.SourceGenerators;
@@ -323,7 +324,7 @@ build_metadata.AdditionalFiles.SourceItemGroup = PRIResource
 				};
 
 				var unoUIBase = Path.Combine(
-					Path.GetDirectoryName(typeof(HotReloadWorkspace).Assembly.Location)!,
+					Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
 					"..",
 					"..",
 					"..",

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4670,7 +4670,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var thatCurrentResourceOwnerName = resourceOwner switch
 			{
 				not null => resourceOwner,
-				null when CurrentResourceOwner is { } owner => "__that." + owner,
+				null when CurrentResourceOwner is { } owner => owner,
 				_ => "this"
 			};
 


### PR DESCRIPTION
## Bugfix
Fix invalid code gen when using markup extension in a style

## What is the current behavior?
Generated code in invalid when using a custom markup extensions in a `Style` 

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
