### PR TITLE
fix: Premature vertical arrangement of `InfoBar` Content

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarPanel.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/InfoBar/InfoBarPanel.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
-// MUX reference InfoBarPanel.cpp, tag winui3/release/1.4.2
+// MUX reference InfoBarPanel.cpp, tag winui3/release/1.7-stable
 
 using System;
 using Windows.Foundation;
@@ -48,7 +48,6 @@ public partial class InfoBarPanel : Panel
 			{
 				// Add up the width of all items if they were laid out horizontally
 				var horizontalMargin = GetHorizontalOrientationMargin(child);
-				totalWidth += childDesiredSize.Width + (nItems > 0 ? (float)horizontalMargin.Left : 0) + (float)horizontalMargin.Right;
 				// Ignore left margin of first and right margin of last child
 				totalWidth += childDesiredSize.Width +
 					(nItems > 0 ? (float)horizontalMargin.Left : 0) +


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/19217

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

Adjust the calculation of `totalWidth` to be inline with WinUI behavior. Currently the width is calculated twice and it is added to the total sum which makes the vertical arrangement premature.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.