### PR TITLE
perf(anim): Don't refresh triggers and transitions during parsing

### DIFF
--- a/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
+++ b/src/Uno.UI/UI/Xaml/VisualStateGroup.cs
@@ -162,8 +162,7 @@ namespace Microsoft.UI.Xaml
 
 		private void OnOwnerElementChanged()
 		{
-			if (this.GetParent() is IFrameworkElement fe
-				&& fe.IsParsing)
+			if (this.GetParent() is IFrameworkElement { IsParsing: true })
 			{
 				_pendingOnOwnerElementChanged = true;
 				return;
@@ -518,8 +517,7 @@ namespace Microsoft.UI.Xaml
 
 		internal void RefreshStateTriggers(bool force = false)
 		{
-			if (this.GetParent() is IFrameworkElement fe
-				&& fe.IsParsing)
+			if (this.GetParent() is IFrameworkElement { IsParsing: true })
 			{
 				return;
 			}


### PR DESCRIPTION
## What is the new behavior?

`VisualState` instances changes in `VisualStateGroup` won't trigger updates during XAML parsing, avoiding intermediate discarded animations.
