### PR TITLE
feat(hr): Add ability to remove root of a DataTemplate with HR without cnomua

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Given_HotReloadService.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Given_HotReloadService.cs
@@ -65,7 +65,7 @@ public class Given_HotReloadService
 			var path = Path.Combine(scenarioFolder, "Scenario.json");
 
 #if DEBUG && false
-			if (!path.Contains("When_Base_Type_Grid_To_Page"))
+			if (!path.Contains("When_DataTemplate_Root_Remove"))
 			{
 				continue;
 			}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Given_HotReloadService.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Given_HotReloadService.cs
@@ -62,18 +62,18 @@ public class Given_HotReloadService
 		foreach (var scenarioFolder in Directory.EnumerateDirectories(ScenariosFolder, "*.*", SearchOption.TopDirectoryOnly))
 		{
 			var scenarioName = Path.GetFileName(scenarioFolder);
-			var path = Path.Combine(scenarioFolder, "Scenario.json");
+			var scenarioConfig = Path.Combine(scenarioFolder, "Scenario.json");
 
 #if DEBUG && false
-			if (!path.Contains("When_DataTemplate_Root_Remove"))
+			if (!scenarioName.Contains("When_DataTemplate_Event_Add"))
 			{
 				continue;
 			}
 #endif
 
-			if (File.Exists(path))
+			if (File.Exists(scenarioConfig))
 			{
-				var scenariosDescriptor = ReadScenarioConfig(path);
+				var scenariosDescriptor = ReadScenarioConfig(scenarioConfig);
 
 				if (scenariosDescriptor is not null)
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/0/p1/MainPage.xaml
@@ -1,0 +1,17 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyDataTemplate" />
+	</Page.Resources>
+
+	<Grid>
+		<ContentPresenter Content="Hello" ContentTemplate="{StaticResource MyDataTemplate}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/0/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/1/p1/MainPage.xaml
@@ -1,0 +1,19 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyDataTemplate">
+			<TextBlock Text="DataTemplateRoot" />
+		</DataTemplate>
+	</Page.Resources>
+
+	<Grid>
+		<ContentPresenter Content="Hello" ContentTemplate="{StaticResource MyDataTemplate}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/1/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/0/p1/MainPage.xaml
@@ -1,0 +1,17 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyDataTemplate" />
+	</Page.Resources>
+
+	<Grid>
+		<ContentPresenter Content="Hello" ContentTemplate="{StaticResource MyDataTemplate}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/0/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/1/p1/MainPage.xaml
@@ -1,0 +1,19 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyDataTemplate">
+			<TextBlock Text="DataTemplateRoot" />
+		</DataTemplate>
+	</Page.Resources>
+
+	<Grid>
+		<ContentPresenter Content="Hello" ContentTemplate="{StaticResource MyDataTemplate}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/1/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/2/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/2/p1/MainPage.xaml
@@ -1,0 +1,17 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyDataTemplate" />
+	</Page.Resources>
+
+	<Grid>
+		<ContentPresenter Content="Hello" ContentTemplate="{StaticResource MyDataTemplate}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/2/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/2/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Add_Remove/Scenario.json
@@ -1,0 +1,32 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/0/p1/MainPage.xaml
@@ -1,0 +1,19 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyDataTemplate">
+			<TextBlock Text="DataTemplateRoot" />
+		</DataTemplate>
+	</Page.Resources>
+
+	<Grid>
+		<ContentPresenter Content="Hello" ContentTemplate="{StaticResource MyDataTemplate}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/0/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/1/p1/MainPage.xaml
@@ -1,0 +1,17 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyDataTemplate" />
+	</Page.Resources>
+
+	<Grid>
+		<ContentPresenter Content="Hello" ContentTemplate="{StaticResource MyDataTemplate}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/1/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Remove/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/0/p1/MainPage.xaml
@@ -1,0 +1,19 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyDataTemplate">
+			<TextBlock Text="DataTemplateRoot" />
+		</DataTemplate>
+	</Page.Resources>
+
+	<Grid>
+		<ContentPresenter Content="Hello" ContentTemplate="{StaticResource MyDataTemplate}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/0/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/1/p1/MainPage.xaml
@@ -1,0 +1,19 @@
+﻿<Page x:Class="Test01.MainPage"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Test01"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<Page.Resources>
+		<DataTemplate x:Key="MyDataTemplate">
+			<Border />
+		</DataTemplate>
+	</Page.Resources>
+
+	<Grid>
+		<ContentPresenter Content="Hello" ContentTemplate="{StaticResource MyDataTemplate}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/1/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_DataTemplate_Root_Update/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -104,6 +104,7 @@ namespace TestRepro
 				__p1.CreationComplete();
 			}
 
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -104,6 +104,8 @@ namespace TestRepro
 				__p1.CreationComplete();
 			}
 
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
 		private interface IMainPage_Bindings
 		{
 			void Initialize();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -105,7 +105,9 @@ namespace TestRepro
 			}
 
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
+		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
+		{
+		}
 		private interface IMainPage_Bindings
 		{
 			void Initialize();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -104,7 +104,7 @@ namespace TestRepro
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 			{
 				return 
-					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new SubClasses._MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0().Build(__owner)
+					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.SC0().Build(__owner)
 					)					.GenericApply(__that, __nameScope, (ApplyMethod_6					))
 				;
 			}
@@ -116,7 +116,7 @@ namespace TestRepro
 			{
 				IsParsing = true,
 				Name = "TheListView",
-				HeaderTemplate = 				new global::Microsoft.UI.Xaml.DataTemplate(this, (__owner) => 				new SubClasses._MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC1().Build(__owner)
+				HeaderTemplate = 				new global::Microsoft.UI.Xaml.DataTemplate(this, (__owner) => 				new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.SC1().Build(__owner)
 				)				.GenericApply(__that, __nameScope, (ApplyMethod_7				))
 				,
 				// Source 0\MainPage.xaml (Line 40:4)
@@ -323,13 +323,12 @@ namespace TestRepro
 			}
 		}
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
-		partial class SubClasses
+		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-			public class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0
+			public class SC0
 			{
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
@@ -400,7 +399,7 @@ namespace TestRepro
 					var owner = this;
 					_component_0.UpdateResourceBindings();
 				}
-											private void ApplyMethod_17(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+											private void ApplyMethod_17(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 							{
 								__p1.SetBinding(
 									global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
@@ -413,7 +412,7 @@ namespace TestRepro
 								__p1.CreationComplete();
 							}
 
-											private void ApplyMethod_18(global::Microsoft.UI.Xaml.Controls.Button __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+											private void ApplyMethod_18(global::Microsoft.UI.Xaml.Controls.Button __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 							{
 								/* _isTopLevelDictionary:False */
 								__that._component_0 = __p1;
@@ -422,22 +421,21 @@ namespace TestRepro
 								__p1.CreationComplete();
 							}
 
-									private void ApplyMethod_19(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+									private void ApplyMethod_19(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 					{
 						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
 						__p1.CreationComplete();
 					}
 
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-				private partial class SubClasses;
+				private class __MainPage_d6cd66944958ced0c513e0a04797b51d_MyProject__ResourcesSC0_TestReproMainPage
+				{
+				}
 			}
-		}
-		partial class SubClasses
-		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-			public class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC1
+			public class SC1
 			{
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
@@ -470,14 +468,16 @@ namespace TestRepro
 					}
 					return __rootInstance;
 				}
-									private void ApplyMethod_20(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC1 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+									private void ApplyMethod_20(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, SC1 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 					{
 						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 43, 10);
 						__p1.CreationComplete();
 					}
 
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-				private partial class SubClasses;
+				private class __MainPage_d6cd66944958ced0c513e0a04797b51d_MyProject__ResourcesSC1_TestReproMainPage
+				{
+				}
 			}
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -322,6 +322,7 @@ namespace TestRepro
 				_NarrowStateSubject.ElementInstance = value;
 			}
 		}
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
 		{
@@ -427,6 +428,7 @@ namespace TestRepro
 						__p1.CreationComplete();
 					}
 
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 				private class __MainPage_d6cd66944958ced0c513e0a04797b51d_MyProject__ResourcesSC0_TestReproMainPage
 				{
@@ -474,6 +476,7 @@ namespace TestRepro
 						__p1.CreationComplete();
 					}
 
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 				private class __MainPage_d6cd66944958ced0c513e0a04797b51d_MyProject__ResourcesSC1_TestReproMainPage
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -104,7 +104,7 @@ namespace TestRepro
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 			{
 				return 
-					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0().Build(__owner)
+					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new SubClasses._MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0().Build(__owner)
 					)					.GenericApply(__that, __nameScope, (ApplyMethod_6					))
 				;
 			}
@@ -116,7 +116,7 @@ namespace TestRepro
 			{
 				IsParsing = true,
 				Name = "TheListView",
-				HeaderTemplate = 				new global::Microsoft.UI.Xaml.DataTemplate(this, (__owner) => 				new _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC1().Build(__owner)
+				HeaderTemplate = 				new global::Microsoft.UI.Xaml.DataTemplate(this, (__owner) => 				new SubClasses._MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC1().Build(__owner)
 				)				.GenericApply(__that, __nameScope, (ApplyMethod_7				))
 				,
 				// Source 0\MainPage.xaml (Line 40:4)
@@ -322,151 +322,163 @@ namespace TestRepro
 				_NarrowStateSubject.ElementInstance = value;
 			}
 		}
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-		private class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
+		partial class SubClasses
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
-			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
-			global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
-			global::System.Object __ResourceOwner_1;
-			_View __rootInstance = null;
-			public _View Build(object __ResourceOwner_1)
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+			public class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0
 			{
-				var __that = this;
-				this.__ResourceOwner_1 = __ResourceOwner_1;
-				this.__rootInstance = 
-				new global::Microsoft.UI.Xaml.Controls.StackPanel
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
+				global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
+				global::System.Object __ResourceOwner_1;
+				_View __rootInstance = null;
+				public _View Build(object __ResourceOwner_1)
 				{
-					IsParsing = true,
-					// Source 0\MainPage.xaml (Line 14:8)
-					Children = 
+					var __that = this;
+					this.__ResourceOwner_1 = __ResourceOwner_1;
+					this.__rootInstance = 
+					new global::Microsoft.UI.Xaml.Controls.StackPanel
 					{
-						new global::Microsoft.UI.Xaml.Controls.TextBlock
+						IsParsing = true,
+						// Source 0\MainPage.xaml (Line 14:8)
+						Children = 
 						{
-							IsParsing = true,
-							// Source 0\MainPage.xaml (Line 15:10)
+							new global::Microsoft.UI.Xaml.Controls.TextBlock
+							{
+								IsParsing = true,
+								// Source 0\MainPage.xaml (Line 15:10)
+							}
+							.GenericApply(__that, __nameScope, (ApplyMethod_17							))
+							,
+							new global::Microsoft.UI.Xaml.Controls.Button
+							{
+								IsParsing = true,
+								Content = @"DoSomething",
+								// Source 0\MainPage.xaml (Line 16:10)
+							}
+							.GenericApply(__that, __nameScope, (ApplyMethod_18							))
+							,
 						}
-						.GenericApply(__that, __nameScope, (ApplyMethod_17						))
-						,
-						new global::Microsoft.UI.Xaml.Controls.Button
+					}
+					.GenericApply(__that, __nameScope, (ApplyMethod_19					))
+					;
+					if (__rootInstance is FrameworkElement __fe)
+					{
+						__fe.Loading += __UpdateBindingsAndResources;
+					}
+					if (__rootInstance is DependencyObject d)
+					{
+						if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
 						{
-							IsParsing = true,
-							Content = @"DoSomething",
-							// Source 0\MainPage.xaml (Line 16:10)
+							global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
+							__nameScope.Owner = d;
 						}
-						.GenericApply(__that, __nameScope, (ApplyMethod_18						))
-						,
+						global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					}
+					return __rootInstance;
+				}
+				private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
+				private global::Microsoft.UI.Xaml.Controls.Button _component_0
+				{
+					get
+					{
+						return (global::Microsoft.UI.Xaml.Controls.Button)_component_0_Holder.Instance;
+					}
+					set
+					{
+						_component_0_Holder.Instance = value;
 					}
 				}
-				.GenericApply(__that, __nameScope, (ApplyMethod_19				))
-				;
-				if (__rootInstance is FrameworkElement __fe)
+				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 				{
-					__fe.Loading += __UpdateBindingsAndResources;
+					var owner = this;
+					_component_0.UpdateResourceBindings();
 				}
-				if (__rootInstance is DependencyObject d)
-				{
-					if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+											private void ApplyMethod_17(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+							{
+								__p1.SetBinding(
+									global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
+									new Microsoft.UI.Xaml.Data.Binding()
+									{
+										Path = @"",
+									}
+								);
+								global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 15, 10);
+								__p1.CreationComplete();
+							}
+
+											private void ApplyMethod_18(global::Microsoft.UI.Xaml.Controls.Button __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+							{
+								/* _isTopLevelDictionary:False */
+								__that._component_0 = __p1;
+								global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Button.StyleProperty, "MyCustomButtonStyle", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+								global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 16, 10);
+								__p1.CreationComplete();
+							}
+
+									private void ApplyMethod_19(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 					{
-						global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
-						__nameScope.Owner = d;
+						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
+						__p1.CreationComplete();
 					}
-					global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
-				}
-				return __rootInstance;
-			}
-			private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
-			private global::Microsoft.UI.Xaml.Controls.Button _component_0
-			{
-				get
-				{
-					return (global::Microsoft.UI.Xaml.Controls.Button)_component_0_Holder.Instance;
-				}
-				set
-				{
-					_component_0_Holder.Instance = value;
-				}
-			}
-			private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
-			{
-				var owner = this;
-				_component_0.UpdateResourceBindings();
-			}
-									private void ApplyMethod_17(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-						{
-							__p1.SetBinding(
-								global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
-								new Microsoft.UI.Xaml.Data.Binding()
-								{
-									Path = @"",
-								}
-							);
-							global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 15, 10);
-							__p1.CreationComplete();
-						}
 
-									private void ApplyMethod_18(global::Microsoft.UI.Xaml.Controls.Button __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-						{
-							/* _isTopLevelDictionary:False */
-							__that._component_0 = __p1;
-							global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Button.StyleProperty, "MyCustomButtonStyle", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-							global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 16, 10);
-							__p1.CreationComplete();
-						}
-
-							private void ApplyMethod_19(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-				{
-					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
-					__p1.CreationComplete();
-				}
-
+				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+				private partial class SubClasses;
+			}
 		}
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-		private class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC1
+		partial class SubClasses
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
-			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
-			global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
-			global::System.Object __ResourceOwner_1;
-			_View __rootInstance = null;
-			public _View Build(object __ResourceOwner_1)
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+			public class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC1
 			{
-				var __that = this;
-				this.__ResourceOwner_1 = __ResourceOwner_1;
-				this.__rootInstance = 
-				new global::Microsoft.UI.Xaml.Controls.TextBlock
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
+				global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
+				global::System.Object __ResourceOwner_1;
+				_View __rootInstance = null;
+				public _View Build(object __ResourceOwner_1)
 				{
-					IsParsing = true,
-					Text = "Header",
-					// Source 0\MainPage.xaml (Line 43:10)
-				}
-				.GenericApply(__that, __nameScope, (ApplyMethod_20				))
-				;
-				if (__rootInstance is DependencyObject d)
-				{
-					if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+					var __that = this;
+					this.__ResourceOwner_1 = __ResourceOwner_1;
+					this.__rootInstance = 
+					new global::Microsoft.UI.Xaml.Controls.TextBlock
 					{
-						global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
-						__nameScope.Owner = d;
+						IsParsing = true,
+						Text = "Header",
+						// Source 0\MainPage.xaml (Line 43:10)
 					}
-					global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					.GenericApply(__that, __nameScope, (ApplyMethod_20					))
+					;
+					if (__rootInstance is DependencyObject d)
+					{
+						if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+						{
+							global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
+							__nameScope.Owner = d;
+						}
+						global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					}
+					return __rootInstance;
 				}
-				return __rootInstance;
-			}
-							private void ApplyMethod_20(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC1 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-				{
-					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 43, 10);
-					__p1.CreationComplete();
-				}
+									private void ApplyMethod_20(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC1 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+					{
+						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 43, 10);
+						__p1.CreationComplete();
+					}
 
+				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+				private partial class SubClasses;
+			}
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.ListView _component_0

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLR/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLR/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -172,6 +172,7 @@ namespace TestRepro
 				__p1.CreationComplete();
 			}
 
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
 		{
@@ -277,6 +278,7 @@ namespace TestRepro
 						__p1.CreationComplete();
 					}
 
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 				private class __MainPage_d6cd66944958ced0c513e0a04797b51d_MyProject__ResourcesSC0_TestReproMainPage
 				{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLR/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLR/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -104,7 +104,7 @@ namespace TestRepro
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 			{
 				return 
-					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new SubClasses._MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0().Build(__owner)
+					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.SC0().Build(__owner)
 					)					.GenericApply(__that, __nameScope, (ApplyMethod_6					))
 				;
 			}
@@ -173,13 +173,12 @@ namespace TestRepro
 			}
 
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
-		partial class SubClasses
+		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-			public class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0
+			public class SC0
 			{
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
@@ -250,7 +249,7 @@ namespace TestRepro
 					var owner = this;
 					_component_0.UpdateResourceBindings();
 				}
-											private void ApplyMethod_10(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+											private void ApplyMethod_10(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 							{
 								__p1.SetBinding(
 									global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
@@ -263,7 +262,7 @@ namespace TestRepro
 								__p1.CreationComplete();
 							}
 
-											private void ApplyMethod_11(global::Microsoft.UI.Xaml.Controls.Button __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+											private void ApplyMethod_11(global::Microsoft.UI.Xaml.Controls.Button __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 							{
 								/* _isTopLevelDictionary:False */
 								__that._component_0 = __p1;
@@ -272,14 +271,16 @@ namespace TestRepro
 								__p1.CreationComplete();
 							}
 
-									private void ApplyMethod_12(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+									private void ApplyMethod_12(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 					{
 						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
 						__p1.CreationComplete();
 					}
 
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-				private partial class SubClasses;
+				private class __MainPage_d6cd66944958ced0c513e0a04797b51d_MyProject__ResourcesSC0_TestReproMainPage
+				{
+				}
 			}
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLR/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLR/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -104,7 +104,7 @@ namespace TestRepro
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 			{
 				return 
-					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0().Build(__owner)
+					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new SubClasses._MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0().Build(__owner)
 					)					.GenericApply(__that, __nameScope, (ApplyMethod_6					))
 				;
 			}
@@ -172,108 +172,115 @@ namespace TestRepro
 				__p1.CreationComplete();
 			}
 
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-		private class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
+		partial class SubClasses
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
-			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
-			global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
-			global::System.Object __ResourceOwner_1;
-			_View __rootInstance = null;
-			public _View Build(object __ResourceOwner_1)
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+			public class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0
 			{
-				var __that = this;
-				this.__ResourceOwner_1 = __ResourceOwner_1;
-				this.__rootInstance = 
-				new global::Microsoft.UI.Xaml.Controls.StackPanel
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
+				global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
+				global::System.Object __ResourceOwner_1;
+				_View __rootInstance = null;
+				public _View Build(object __ResourceOwner_1)
 				{
-					IsParsing = true,
-					// Source 0\MainPage.xaml (Line 14:8)
-					Children = 
+					var __that = this;
+					this.__ResourceOwner_1 = __ResourceOwner_1;
+					this.__rootInstance = 
+					new global::Microsoft.UI.Xaml.Controls.StackPanel
 					{
-						new global::Microsoft.UI.Xaml.Controls.TextBlock
+						IsParsing = true,
+						// Source 0\MainPage.xaml (Line 14:8)
+						Children = 
 						{
-							IsParsing = true,
-							// Source 0\MainPage.xaml (Line 15:10)
+							new global::Microsoft.UI.Xaml.Controls.TextBlock
+							{
+								IsParsing = true,
+								// Source 0\MainPage.xaml (Line 15:10)
+							}
+							.GenericApply(__that, __nameScope, (ApplyMethod_10							))
+							,
+							new global::Microsoft.UI.Xaml.Controls.Button
+							{
+								IsParsing = true,
+								Content = @"DoSomething",
+								// Source 0\MainPage.xaml (Line 16:10)
+							}
+							.GenericApply(__that, __nameScope, (ApplyMethod_11							))
+							,
 						}
-						.GenericApply(__that, __nameScope, (ApplyMethod_10						))
-						,
-						new global::Microsoft.UI.Xaml.Controls.Button
+					}
+					.GenericApply(__that, __nameScope, (ApplyMethod_12					))
+					;
+					if (__rootInstance is FrameworkElement __fe)
+					{
+						__fe.Loading += __UpdateBindingsAndResources;
+					}
+					if (__rootInstance is DependencyObject d)
+					{
+						if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
 						{
-							IsParsing = true,
-							Content = @"DoSomething",
-							// Source 0\MainPage.xaml (Line 16:10)
+							global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
+							__nameScope.Owner = d;
 						}
-						.GenericApply(__that, __nameScope, (ApplyMethod_11						))
-						,
+						global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					}
+					return __rootInstance;
+				}
+				private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
+				private global::Microsoft.UI.Xaml.Controls.Button _component_0
+				{
+					get
+					{
+						return (global::Microsoft.UI.Xaml.Controls.Button)_component_0_Holder.Instance;
+					}
+					set
+					{
+						_component_0_Holder.Instance = value;
 					}
 				}
-				.GenericApply(__that, __nameScope, (ApplyMethod_12				))
-				;
-				if (__rootInstance is FrameworkElement __fe)
+				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 				{
-					__fe.Loading += __UpdateBindingsAndResources;
+					var owner = this;
+					_component_0.UpdateResourceBindings();
 				}
-				if (__rootInstance is DependencyObject d)
-				{
-					if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+											private void ApplyMethod_10(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+							{
+								__p1.SetBinding(
+									global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
+									new Microsoft.UI.Xaml.Data.Binding()
+									{
+										Path = @"",
+									}
+								);
+								global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 15, 10);
+								__p1.CreationComplete();
+							}
+
+											private void ApplyMethod_11(global::Microsoft.UI.Xaml.Controls.Button __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+							{
+								/* _isTopLevelDictionary:False */
+								__that._component_0 = __p1;
+								global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Button.StyleProperty, "MyCustomButtonStyle", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+								global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 16, 10);
+								__p1.CreationComplete();
+							}
+
+									private void ApplyMethod_12(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
 					{
-						global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
-						__nameScope.Owner = d;
+						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
+						__p1.CreationComplete();
 					}
-					global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
-				}
-				return __rootInstance;
-			}
-			private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
-			private global::Microsoft.UI.Xaml.Controls.Button _component_0
-			{
-				get
-				{
-					return (global::Microsoft.UI.Xaml.Controls.Button)_component_0_Holder.Instance;
-				}
-				set
-				{
-					_component_0_Holder.Instance = value;
-				}
-			}
-			private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
-			{
-				var owner = this;
-				_component_0.UpdateResourceBindings();
-			}
-									private void ApplyMethod_10(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-						{
-							__p1.SetBinding(
-								global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
-								new Microsoft.UI.Xaml.Data.Binding()
-								{
-									Path = @"",
-								}
-							);
-							global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 15, 10);
-							__p1.CreationComplete();
-						}
 
-									private void ApplyMethod_11(global::Microsoft.UI.Xaml.Controls.Button __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-						{
-							/* _isTopLevelDictionary:False */
-							__that._component_0 = __p1;
-							global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Button.StyleProperty, "MyCustomButtonStyle", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-							global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 16, 10);
-							__p1.CreationComplete();
-						}
-
-							private void ApplyMethod_12(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-				{
-					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
-					__p1.CreationComplete();
-				}
-
+				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+				private partial class SubClasses;
+			}
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.Page _component_0

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLS/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLS/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -156,7 +156,9 @@ namespace TestRepro
 			}
 
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
+		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
+		{
+		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.Page _component_0
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLS/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLS/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -155,6 +155,8 @@ namespace TestRepro
 				__p1.CreationComplete();
 			}
 
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.Page _component_0
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLS/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLS/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -155,6 +155,7 @@ namespace TestRepro
 				__p1.CreationComplete();
 			}
 
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFRT/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFRT/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -121,6 +121,8 @@ namespace TestRepro
 				__p1.CreationComplete();
 			}
 
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.Page _component_0
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFRT/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFRT/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -122,7 +122,9 @@ namespace TestRepro
 			}
 
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
+		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
+		{
+		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder { get; } = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.Page _component_0
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFRT/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFRT/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -121,6 +121,7 @@ namespace TestRepro
 				__p1.CreationComplete();
 			}
 
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFTLRD/XamlCodeGenerator_MyDictionary_b7707bcf1e73425b710b6a5d04177088.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFTLRD/XamlCodeGenerator_MyDictionary_b7707bcf1e73425b710b6a5d04177088.cs
@@ -47,7 +47,9 @@ namespace TestNamespace
 		}
 
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
+		private class __MyDictionary_b7707bcf1e73425b710b6a5d04177088_TestNamespaceTestClass
+		{
+		}
 	}
 }
 namespace MyProject
@@ -119,5 +121,7 @@ namespace MyProject
 namespace MyProject.__Resources
 {
 	[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-	internal partial class SubClasses;
+	internal class __MyDictionary_b7707bcf1e73425b710b6a5d04177088_MyDictionaryRD
+	{
+	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFTLRD/XamlCodeGenerator_MyDictionary_b7707bcf1e73425b710b6a5d04177088.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFTLRD/XamlCodeGenerator_MyDictionary_b7707bcf1e73425b710b6a5d04177088.cs
@@ -46,6 +46,8 @@ namespace TestNamespace
 			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(this, "OriginalSourceLocation", "file:///C:/Project/0/MyDictionary.xaml#L1:2");
 		}
 
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
 	}
 }
 namespace MyProject
@@ -116,4 +118,6 @@ namespace MyProject
 }
 namespace MyProject.__Resources
 {
+	[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+	internal partial class SubClasses;
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFTLRD/XamlCodeGenerator_MyDictionary_b7707bcf1e73425b710b6a5d04177088.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFTLRD/XamlCodeGenerator_MyDictionary_b7707bcf1e73425b710b6a5d04177088.cs
@@ -46,6 +46,7 @@ namespace TestNamespace
 			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(this, "OriginalSourceLocation", "file:///C:/Project/0/MyDictionary.xaml#L1:2");
 		}
 
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MyDictionary_b7707bcf1e73425b710b6a5d04177088_TestNamespaceTestClass
 		{
@@ -120,6 +121,7 @@ namespace MyProject
 }
 namespace MyProject.__Resources
 {
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 	[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 	internal class __MyDictionary_b7707bcf1e73425b710b6a5d04177088_MyDictionaryRD
 	{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
@@ -48,7 +48,7 @@ namespace TestRepro
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 			{
 				return 
-					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new SubClasses._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0().Build(__owner)
+					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new __MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionary.SC0().Build(__owner)
 					)				;
 			}
 			)
@@ -56,13 +56,12 @@ namespace TestRepro
 		}
 
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
-		partial class SubClasses
+		private class __MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionary
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-			public class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0
+			public class SC0
 			{
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
@@ -196,7 +195,7 @@ namespace MyProject
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
 			private object Get_1(object __ResourceOwner_1) =>
-				new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 				new __Resources.SubClasses._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1().Build(__owner)
+				new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 				new __Resources.__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRD.SC1().Build(__owner)
 				)				;
 
 			private global::Microsoft.UI.Xaml.ResourceDictionary _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
@@ -217,7 +216,7 @@ namespace MyProject
 							new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 							{
 								return 
-									new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 									new __Resources.SubClasses._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2().Build(__owner)
+									new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 									new __Resources.__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRD.SC2().Build(__owner)
 									)								;
 							}
 							)
@@ -240,13 +239,12 @@ namespace MyProject
 namespace MyProject.__Resources
 {
 	[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-	internal partial class SubClasses;
-	partial class SubClasses
+	internal class __MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRD
 	{
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-		public class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1
+		public class SC1
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
@@ -337,13 +335,10 @@ namespace MyProject.__Resources
 				return true;
 			}
 		}
-	}
-	partial class SubClasses
-	{
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-		public class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2
+		public class SC2
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
@@ -48,17 +48,205 @@ namespace TestRepro
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 			{
 				return 
-					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0().Build(__owner)
+					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new SubClasses._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0().Build(__owner)
 					)				;
 			}
 			)
 			;
 		}
 
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
+		partial class SubClasses
+		{
+			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+			public class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0
+			{
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
+				global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
+				global::System.Object __ResourceOwner_1;
+				_View __rootInstance = null;
+				public _View Build(object __ResourceOwner_1)
+				{
+					var __that = this;
+					this.__ResourceOwner_1 = __ResourceOwner_1;
+					this.__rootInstance = 
+					new global::Microsoft.UI.Xaml.Controls.TextBlock
+					{
+						IsParsing = true,
+						Name = "tb",
+						// Source 0\MyResourceDictionary.xaml (Line 12:5)
+					}
+					.MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_XamlApply((MyResourceDictionary_92716e07ff456818f6d4125e055d4d57XamlApplyExtensions.XamlApplyHandler0)(__p1 => 
+					{
+					/* _isTopLevelDictionary:True */
+					__that._component_0 = __p1;
+					__nameScope.RegisterName("tb", __p1);
+					__that.tb = __p1;
+					__p1.SetBinding(
+						global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
+						new Microsoft.UI.Xaml.Data.Binding()
+						{
+							Mode = BindingMode.OneWay,
+						}
+							.BindingApply(___b => /*defaultBindModeOneWay*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, null, ___ctx => ___ctx is global::TestRepro.MyModel ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), null , new [] {"MyString"}))
+					);
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57);
+					__p1.CreationComplete();
+					}
+					))
+					;
+					if (__rootInstance is FrameworkElement __fe)
+					{
+						__fe.Loading += __UpdateBindingsAndResources;
+					}
+					if (__rootInstance is DependencyObject d)
+					{
+						if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+						{
+							global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
+							__nameScope.Owner = d;
+						}
+						global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					}
+					return __rootInstance;
+				}
+				private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
+				private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
+				{
+					get
+					{
+						return (global::Microsoft.UI.Xaml.Controls.TextBlock)_component_0_Holder.Instance;
+					}
+					set
+					{
+						_component_0_Holder.Instance = value;
+					}
+				}
+				private global::Microsoft.UI.Xaml.Data.ElementNameSubject _tbSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+				private global::Microsoft.UI.Xaml.Controls.TextBlock tb
+				{
+					get
+					{
+						return (global::Microsoft.UI.Xaml.Controls.TextBlock)_tbSubject.ElementInstance;
+					}
+					set
+					{
+						_tbSubject.ElementInstance = value;
+					}
+				}
+				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
+				{
+					var owner = this;
+					_component_0.UpdateResourceBindings();
+					_component_0.ApplyXBind();
+				}
+				private static bool TryGetInstance_xBind_1(global::TestRepro.MyModel ___tctx, out object o)
+				{
+					o = null;
+					o = ___tctx.MyString;
+					return true;
+				}
+			}
+		}
+	}
+}
+namespace MyProject
+{
+	[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+	[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+	public sealed partial class GlobalStaticResources
+	{
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+		private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+		private const string __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
+		// This non-static inner class is a means of reducing size of AOT compilations by avoiding many accesses to static members from a static callsite, which adds costly class initializer checks each time.
+		internal sealed class ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 : global::Uno.UI.IXamlResourceDictionaryProvider
+		{
+			private static global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
+			private static global::Uno.UI.IXamlResourceDictionaryProvider __that;
+			internal static global::Uno.UI.IXamlResourceDictionaryProvider Instance
+			{
+				get
+				{
+					if (__that == null)
+					{
+						__that = new ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57();
+					}
+
+					return __that;
+				}
+			}
+
+			private readonly global::Uno.UI.Xaml.XamlParseContext __ParseContext_;
+			internal static global::Uno.UI.Xaml.XamlParseContext GetParseContext() => ((ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57)Instance).__ParseContext_;
+
+			public ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
+			{
+				__ParseContext_ = global::MyProject.GlobalStaticResources.__ParseContext_;
+			}
+
+			// Method for resource myTemplate 
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+			private object Get_1(object __ResourceOwner_1) =>
+				new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 				new __Resources.SubClasses._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1().Build(__owner)
+				)				;
+
+			private global::Microsoft.UI.Xaml.ResourceDictionary _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
+
+			internal global::Microsoft.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary
+			{
+				get
+				{
+					if (_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary == null)
+					{
+						_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary = 
+						new global::Microsoft.UI.Xaml.ResourceDictionary
+						{
+							IsParsing = true,
+							[
+							"myTemplate"
+							] = 
+							new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
+							{
+								return 
+									new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 									new __Resources.SubClasses._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2().Build(__owner)
+									)								;
+							}
+							)
+							,
+						}
+						;
+						_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary.Source = new global::System.Uri("ms-resource:///Files/C:/Project/0/MyResourceDictionary.xaml");
+						_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary.CreationComplete();
+					}
+					return _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
+				}
+			}
+
+			global::Microsoft.UI.Xaml.ResourceDictionary global::Uno.UI.IXamlResourceDictionaryProvider.GetResourceDictionary() => MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
+		}
+
+		internal static global::Microsoft.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.GetResourceDictionary();
+	}
+}
+namespace MyProject.__Resources
+{
+	[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+	internal partial class SubClasses;
+	partial class SubClasses
+	{
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-		private class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionarySC0
+		public class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
@@ -90,7 +278,7 @@ namespace TestRepro
 					{
 						Mode = BindingMode.OneWay,
 					}
-						.BindingApply(___b => /*defaultBindModeOneWay*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, null, ___ctx => ___ctx is global::TestRepro.MyModel ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), null , new [] {"MyString"}))
+						.BindingApply(___b => /*defaultBindModeOneWay*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, null, ___ctx => ___ctx is global::TestRepro.MyModel ___tctx ? (TryGetInstance_xBind_2(___tctx, out var bindResult2) ? (true, bindResult2) : (false, default)) : (false, default), null , new [] {"MyString"}))
 				);
 				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57);
 				__p1.CreationComplete();
@@ -142,7 +330,7 @@ namespace TestRepro
 				_component_0.UpdateResourceBindings();
 				_component_0.ApplyXBind();
 			}
-			private static bool TryGetInstance_xBind_1(global::TestRepro.MyModel ___tctx, out object o)
+			private static bool TryGetInstance_xBind_2(global::TestRepro.MyModel ___tctx, out object o)
 			{
 				o = null;
 				o = ___tctx.MyString;
@@ -150,276 +338,101 @@ namespace TestRepro
 			}
 		}
 	}
-}
-namespace MyProject
-{
-	[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-	[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-	public sealed partial class GlobalStaticResources
+	partial class SubClasses
 	{
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		private const string __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
-		// This non-static inner class is a means of reducing size of AOT compilations by avoiding many accesses to static members from a static callsite, which adds costly class initializer checks each time.
-		internal sealed class ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 : global::Uno.UI.IXamlResourceDictionaryProvider
+		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+		public class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2
 		{
-			private static global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
-			private static global::Uno.UI.IXamlResourceDictionaryProvider __that;
-			internal static global::Uno.UI.IXamlResourceDictionaryProvider Instance
+			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
+			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			private const string __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
+			global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
+			global::System.Object __ResourceOwner_1;
+			_View __rootInstance = null;
+			public _View Build(object __ResourceOwner_1)
+			{
+				var __that = this;
+				this.__ResourceOwner_1 = __ResourceOwner_1;
+				this.__rootInstance = 
+				new global::Microsoft.UI.Xaml.Controls.TextBlock
+				{
+					IsParsing = true,
+					Name = "tb",
+					// Source 0\MyResourceDictionary.xaml (Line 12:5)
+				}
+				.MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_XamlApply((MyResourceDictionary_92716e07ff456818f6d4125e055d4d57XamlApplyExtensions.XamlApplyHandler0)(__p1 => 
+				{
+				/* _isTopLevelDictionary:True */
+				__that._component_0 = __p1;
+				__nameScope.RegisterName("tb", __p1);
+				__that.tb = __p1;
+				__p1.SetBinding(
+					global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
+					new Microsoft.UI.Xaml.Data.Binding()
+					{
+						Mode = BindingMode.OneWay,
+					}
+						.BindingApply(___b => /*defaultBindModeOneWay*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, null, ___ctx => ___ctx is global::TestRepro.MyModel ___tctx ? (TryGetInstance_xBind_3(___tctx, out var bindResult3) ? (true, bindResult3) : (false, default)) : (false, default), null , new [] {"MyString"}))
+				);
+				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57);
+				__p1.CreationComplete();
+				}
+				))
+				;
+				if (__rootInstance is FrameworkElement __fe)
+				{
+					__fe.Loading += __UpdateBindingsAndResources;
+				}
+				if (__rootInstance is DependencyObject d)
+				{
+					if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+					{
+						global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
+						__nameScope.Owner = d;
+					}
+					global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+				}
+				return __rootInstance;
+			}
+			private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
+			private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
 			{
 				get
 				{
-					if (__that == null)
-					{
-						__that = new ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57();
-					}
-
-					return __that;
+					return (global::Microsoft.UI.Xaml.Controls.TextBlock)_component_0_Holder.Instance;
+				}
+				set
+				{
+					_component_0_Holder.Instance = value;
 				}
 			}
-
-			private readonly global::Uno.UI.Xaml.XamlParseContext __ParseContext_;
-			internal static global::Uno.UI.Xaml.XamlParseContext GetParseContext() => ((ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57)Instance).__ParseContext_;
-
-			public ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57()
-			{
-				__ParseContext_ = global::MyProject.GlobalStaticResources.__ParseContext_;
-			}
-
-			// Method for resource myTemplate 
-			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-			private object Get_1(object __ResourceOwner_1) =>
-				new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 				new __Resources._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1().Build(__owner)
-				)				;
-
-			private global::Microsoft.UI.Xaml.ResourceDictionary _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
-
-			internal global::Microsoft.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary
+			private global::Microsoft.UI.Xaml.Data.ElementNameSubject _tbSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+			private global::Microsoft.UI.Xaml.Controls.TextBlock tb
 			{
 				get
 				{
-					if (_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary == null)
-					{
-						_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary = 
-						new global::Microsoft.UI.Xaml.ResourceDictionary
-						{
-							IsParsing = true,
-							[
-							"myTemplate"
-							] = 
-							new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
-							{
-								return 
-									new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 									new __Resources._MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2().Build(__owner)
-									)								;
-							}
-							)
-							,
-						}
-						;
-						_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary.Source = new global::System.Uri("ms-resource:///Files/C:/Project/0/MyResourceDictionary.xaml");
-						_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary.CreationComplete();
-					}
-					return _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
+					return (global::Microsoft.UI.Xaml.Controls.TextBlock)_tbSubject.ElementInstance;
 				}
-			}
-
-			global::Microsoft.UI.Xaml.ResourceDictionary global::Uno.UI.IXamlResourceDictionaryProvider.GetResourceDictionary() => MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary;
-		}
-
-		internal static global::Microsoft.UI.Xaml.ResourceDictionary MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_ResourceDictionary => ResourceDictionarySingleton__MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.Instance.GetResourceDictionary();
-	}
-}
-namespace MyProject.__Resources
-{
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-	[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-	 class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC1
-	{
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		private const string __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
-		global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
-		global::System.Object __ResourceOwner_1;
-		_View __rootInstance = null;
-		public _View Build(object __ResourceOwner_1)
-		{
-			var __that = this;
-			this.__ResourceOwner_1 = __ResourceOwner_1;
-			this.__rootInstance = 
-			new global::Microsoft.UI.Xaml.Controls.TextBlock
-			{
-				IsParsing = true,
-				Name = "tb",
-				// Source 0\MyResourceDictionary.xaml (Line 12:5)
-			}
-			.MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_XamlApply((MyResourceDictionary_92716e07ff456818f6d4125e055d4d57XamlApplyExtensions.XamlApplyHandler0)(__p1 => 
-			{
-			/* _isTopLevelDictionary:True */
-			__that._component_0 = __p1;
-			__nameScope.RegisterName("tb", __p1);
-			__that.tb = __p1;
-			__p1.SetBinding(
-				global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
-				new Microsoft.UI.Xaml.Data.Binding()
+				set
 				{
-					Mode = BindingMode.OneWay,
+					_tbSubject.ElementInstance = value;
 				}
-					.BindingApply(___b => /*defaultBindModeOneWay*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, null, ___ctx => ___ctx is global::TestRepro.MyModel ___tctx ? (TryGetInstance_xBind_2(___tctx, out var bindResult2) ? (true, bindResult2) : (false, default)) : (false, default), null , new [] {"MyString"}))
-			);
-			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57);
-			__p1.CreationComplete();
 			}
-			))
-			;
-			if (__rootInstance is FrameworkElement __fe)
+			private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 			{
-				__fe.Loading += __UpdateBindingsAndResources;
+				var owner = this;
+				_component_0.UpdateResourceBindings();
+				_component_0.ApplyXBind();
 			}
-			if (__rootInstance is DependencyObject d)
+			private static bool TryGetInstance_xBind_3(global::TestRepro.MyModel ___tctx, out object o)
 			{
-				if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
-				{
-					global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
-					__nameScope.Owner = d;
-				}
-				global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+				o = null;
+				o = ___tctx.MyString;
+				return true;
 			}
-			return __rootInstance;
-		}
-		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
-		private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Controls.TextBlock)_component_0_Holder.Instance;
-			}
-			set
-			{
-				_component_0_Holder.Instance = value;
-			}
-		}
-		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _tbSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-		private global::Microsoft.UI.Xaml.Controls.TextBlock tb
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Controls.TextBlock)_tbSubject.ElementInstance;
-			}
-			set
-			{
-				_tbSubject.ElementInstance = value;
-			}
-		}
-		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
-		{
-			var owner = this;
-			_component_0.UpdateResourceBindings();
-			_component_0.ApplyXBind();
-		}
-		private static bool TryGetInstance_xBind_2(global::TestRepro.MyModel ___tctx, out object o)
-		{
-			o = null;
-			o = ___tctx.MyString;
-			return true;
-		}
-	}
-	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-	[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-	[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-	 class _MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRDSC2
-	{
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		private const string __baseUri_prefix_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		private const string __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57 = "ms-appx:///TestProject/";
-		global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
-		global::System.Object __ResourceOwner_1;
-		_View __rootInstance = null;
-		public _View Build(object __ResourceOwner_1)
-		{
-			var __that = this;
-			this.__ResourceOwner_1 = __ResourceOwner_1;
-			this.__rootInstance = 
-			new global::Microsoft.UI.Xaml.Controls.TextBlock
-			{
-				IsParsing = true,
-				Name = "tb",
-				// Source 0\MyResourceDictionary.xaml (Line 12:5)
-			}
-			.MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_XamlApply((MyResourceDictionary_92716e07ff456818f6d4125e055d4d57XamlApplyExtensions.XamlApplyHandler0)(__p1 => 
-			{
-			/* _isTopLevelDictionary:True */
-			__that._component_0 = __p1;
-			__nameScope.RegisterName("tb", __p1);
-			__that.tb = __p1;
-			__p1.SetBinding(
-				global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
-				new Microsoft.UI.Xaml.Data.Binding()
-				{
-					Mode = BindingMode.OneWay,
-				}
-					.BindingApply(___b => /*defaultBindModeOneWay*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, null, ___ctx => ___ctx is global::TestRepro.MyModel ___tctx ? (TryGetInstance_xBind_3(___tctx, out var bindResult3) ? (true, bindResult3) : (false, default)) : (false, default), null , new [] {"MyString"}))
-			);
-			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57);
-			__p1.CreationComplete();
-			}
-			))
-			;
-			if (__rootInstance is FrameworkElement __fe)
-			{
-				__fe.Loading += __UpdateBindingsAndResources;
-			}
-			if (__rootInstance is DependencyObject d)
-			{
-				if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
-				{
-					global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
-					__nameScope.Owner = d;
-				}
-				global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
-			}
-			return __rootInstance;
-		}
-		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
-		private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Controls.TextBlock)_component_0_Holder.Instance;
-			}
-			set
-			{
-				_component_0_Holder.Instance = value;
-			}
-		}
-		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _tbSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-		private global::Microsoft.UI.Xaml.Controls.TextBlock tb
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Controls.TextBlock)_tbSubject.ElementInstance;
-			}
-			set
-			{
-				_tbSubject.ElementInstance = value;
-			}
-		}
-		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
-		{
-			var owner = this;
-			_component_0.UpdateResourceBindings();
-			_component_0.ApplyXBind();
-		}
-		private static bool TryGetInstance_xBind_3(global::TestRepro.MyModel ___tctx, out object o)
-		{
-			o = null;
-			o = ___tctx.MyString;
-			return true;
 		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
@@ -55,6 +55,7 @@ namespace TestRepro
 			;
 		}
 
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_TestReproMyResourceDictionary
 		{
@@ -238,6 +239,7 @@ namespace MyProject
 }
 namespace MyProject.__Resources
 {
+	[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 	[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 	internal class __MyResourceDictionary_92716e07ff456818f6d4125e055d4d57_MyResourceDictionaryRD
 	{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -99,7 +99,7 @@ namespace TestRepro
 							{
 								IsParsing = true,
 								Name = "inner2",
-								Template = 								new global::Microsoft.UI.Xaml.Controls.ControlTemplate(this, (__owner) => 								new _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0().Build(__owner)
+								Template = 								new global::Microsoft.UI.Xaml.Controls.ControlTemplate(this, (__owner) => 								new SubClasses._MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0().Build(__owner)
 								)								,
 								// Source 0\MainPage.xaml (Line 15:5)
 							}
@@ -320,89 +320,94 @@ namespace TestRepro
 				_outerGridSubject.ElementInstance = value;
 			}
 		}
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-		private class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
+		partial class SubClasses
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
-			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
-			global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
-			global::System.Object __ResourceOwner_1;
-			_View __rootInstance = null;
-			public _View Build(object __ResourceOwner_1)
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+			public class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0
 			{
-				var __that = this;
-				this.__ResourceOwner_1 = __ResourceOwner_1;
-				this.__rootInstance = 
-				new global::Microsoft.UI.Xaml.Controls.Grid
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";
+				global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
+				global::System.Object __ResourceOwner_1;
+				_View __rootInstance = null;
+				public _View Build(object __ResourceOwner_1)
 				{
-					IsParsing = true,
-					Name = "gridInsideTemplate",
-					// Source 0\MainPage.xaml (Line 18:8)
-					Children = 
+					var __that = this;
+					this.__ResourceOwner_1 = __ResourceOwner_1;
+					this.__rootInstance = 
+					new global::Microsoft.UI.Xaml.Controls.Grid
 					{
-						new global::Microsoft.UI.Xaml.Controls.Grid
+						IsParsing = true,
+						Name = "gridInsideTemplate",
+						// Source 0\MainPage.xaml (Line 18:8)
+						Children = 
 						{
-							IsParsing = true,
-							Name = "gridInsideGridInsideTemplate",
-							// Source 0\MainPage.xaml (Line 19:9)
+							new global::Microsoft.UI.Xaml.Controls.Grid
+							{
+								IsParsing = true,
+								Name = "gridInsideGridInsideTemplate",
+								// Source 0\MainPage.xaml (Line 19:9)
+							}
+							.MainPage_d6cd66944958ced0c513e0a04797b51d_XamlApply((MainPage_d6cd66944958ced0c513e0a04797b51dXamlApplyExtensions.XamlApplyHandler2)(__p1 => 
+							{
+							__nameScope.RegisterName("gridInsideGridInsideTemplate", __p1);
+							__that.gridInsideGridInsideTemplate = __p1;
+							global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
+							__p1.CreationComplete();
+							}
+							))
+							,
 						}
-						.MainPage_d6cd66944958ced0c513e0a04797b51d_XamlApply((MainPage_d6cd66944958ced0c513e0a04797b51dXamlApplyExtensions.XamlApplyHandler2)(__p1 => 
+					}
+					.MainPage_d6cd66944958ced0c513e0a04797b51d_XamlApply((MainPage_d6cd66944958ced0c513e0a04797b51dXamlApplyExtensions.XamlApplyHandler2)(__p1 => 
+					{
+					__nameScope.RegisterName("gridInsideTemplate", __p1);
+					__that.gridInsideTemplate = __p1;
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
+					__p1.CreationComplete();
+					}
+					))
+					;
+					if (__rootInstance is DependencyObject d)
+					{
+						if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
 						{
-						__nameScope.RegisterName("gridInsideGridInsideTemplate", __p1);
-						__that.gridInsideGridInsideTemplate = __p1;
-						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
-						__p1.CreationComplete();
+							global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
+							__nameScope.Owner = d;
 						}
-						))
-						,
+						global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					}
+					return __rootInstance;
+				}
+				private global::Microsoft.UI.Xaml.Data.ElementNameSubject _gridInsideGridInsideTemplateSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+				private global::Microsoft.UI.Xaml.Controls.Grid gridInsideGridInsideTemplate
+				{
+					get
+					{
+						return (global::Microsoft.UI.Xaml.Controls.Grid)_gridInsideGridInsideTemplateSubject.ElementInstance;
+					}
+					set
+					{
+						_gridInsideGridInsideTemplateSubject.ElementInstance = value;
 					}
 				}
-				.MainPage_d6cd66944958ced0c513e0a04797b51d_XamlApply((MainPage_d6cd66944958ced0c513e0a04797b51dXamlApplyExtensions.XamlApplyHandler2)(__p1 => 
+				private global::Microsoft.UI.Xaml.Data.ElementNameSubject _gridInsideTemplateSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+				private global::Microsoft.UI.Xaml.Controls.Grid gridInsideTemplate
 				{
-				__nameScope.RegisterName("gridInsideTemplate", __p1);
-				__that.gridInsideTemplate = __p1;
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
-				__p1.CreationComplete();
-				}
-				))
-				;
-				if (__rootInstance is DependencyObject d)
-				{
-					if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+					get
 					{
-						global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
-						__nameScope.Owner = d;
+						return (global::Microsoft.UI.Xaml.Controls.Grid)_gridInsideTemplateSubject.ElementInstance;
 					}
-					global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
-				}
-				return __rootInstance;
-			}
-			private global::Microsoft.UI.Xaml.Data.ElementNameSubject _gridInsideGridInsideTemplateSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-			private global::Microsoft.UI.Xaml.Controls.Grid gridInsideGridInsideTemplate
-			{
-				get
-				{
-					return (global::Microsoft.UI.Xaml.Controls.Grid)_gridInsideGridInsideTemplateSubject.ElementInstance;
-				}
-				set
-				{
-					_gridInsideGridInsideTemplateSubject.ElementInstance = value;
-				}
-			}
-			private global::Microsoft.UI.Xaml.Data.ElementNameSubject _gridInsideTemplateSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-			private global::Microsoft.UI.Xaml.Controls.Grid gridInsideTemplate
-			{
-				get
-				{
-					return (global::Microsoft.UI.Xaml.Controls.Grid)_gridInsideTemplateSubject.ElementInstance;
-				}
-				set
-				{
-					_gridInsideTemplateSubject.ElementInstance = value;
+					set
+					{
+						_gridInsideTemplateSubject.ElementInstance = value;
+					}
 				}
 			}
 		}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -99,7 +99,7 @@ namespace TestRepro
 							{
 								IsParsing = true,
 								Name = "inner2",
-								Template = 								new global::Microsoft.UI.Xaml.Controls.ControlTemplate(this, (__owner) => 								new SubClasses._MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0().Build(__owner)
+								Template = 								new global::Microsoft.UI.Xaml.Controls.ControlTemplate(this, (__owner) => 								new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.SC0().Build(__owner)
 								)								,
 								// Source 0\MainPage.xaml (Line 15:5)
 							}
@@ -321,13 +321,12 @@ namespace TestRepro
 			}
 		}
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
-		partial class SubClasses
+		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-			public class _MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPageSC0
+			public class SC0
 			{
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				private const string __baseUri_prefix_MainPage_d6cd66944958ced0c513e0a04797b51d = "ms-appx:///TestProject/";

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -320,6 +320,7 @@ namespace TestRepro
 				_outerGridSubject.ElementInstance = value;
 			}
 		}
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
@@ -115,6 +115,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 				_topLevelSubject.ElementInstance = value;
 			}
 		}
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_Template
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
@@ -59,7 +59,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 						IsParsing = true,
 						Name = "topLevel",
 						Tag = @"42",
-						ContentTemplate = 						new global::Microsoft.UI.Xaml.DataTemplate(this, (__owner) => 						new SubClasses._Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0().Build(__owner)
+						ContentTemplate = 						new global::Microsoft.UI.Xaml.DataTemplate(this, (__owner) => 						new __Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_Template.SC0().Build(__owner)
 						)						,
 						// Source 0\Binding_ElementName_In_Template.xaml (Line 11:4)
 					}
@@ -116,13 +116,12 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 			}
 		}
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
-		partial class SubClasses
+		private class __Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_Template
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-			public class _Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0
+			public class SC0
 			{
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				private const string __baseUri_prefix_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca = "ms-appx:///TestProject/";

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
@@ -59,7 +59,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 						IsParsing = true,
 						Name = "topLevel",
 						Tag = @"42",
-						ContentTemplate = 						new global::Microsoft.UI.Xaml.DataTemplate(this, (__owner) => 						new _Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0().Build(__owner)
+						ContentTemplate = 						new global::Microsoft.UI.Xaml.DataTemplate(this, (__owner) => 						new SubClasses._Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0().Build(__owner)
 						)						,
 						// Source 0\Binding_ElementName_In_Template.xaml (Line 11:4)
 					}
@@ -115,92 +115,97 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 				_topLevelSubject.ElementInstance = value;
 			}
 		}
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-		private class _Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
+		partial class SubClasses
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_prefix_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca = "ms-appx:///TestProject/";
-			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca = "ms-appx:///TestProject/";
-			global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
-			global::System.Object __ResourceOwner_1;
-			_View __rootInstance = null;
-			public _View Build(object __ResourceOwner_1)
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+			public class _Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_UnoUITestsWindows_UI_Xaml_DataBindingTestsControlsBinding_ElementName_In_TemplateSC0
 			{
-				var __that = this;
-				this.__ResourceOwner_1 = __ResourceOwner_1;
-				this.__rootInstance = 
-				new global::Microsoft.UI.Xaml.Controls.TextBlock
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_prefix_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca = "ms-appx:///TestProject/";
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca = "ms-appx:///TestProject/";
+				global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
+				global::System.Object __ResourceOwner_1;
+				_View __rootInstance = null;
+				public _View Build(object __ResourceOwner_1)
 				{
-					IsParsing = true,
-					Name = "innerTextBlock",
-					// Source 0\Binding_ElementName_In_Template.xaml (Line 14:7)
-				}
-				.Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_XamlApply((Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237ecaXamlApplyExtensions.XamlApplyHandler3)(__p1 => 
-				{
-				/* _isTopLevelDictionary:False */
-				__that._component_0 = __p1;
-				__nameScope.RegisterName("innerTextBlock", __p1);
-				__that.innerTextBlock = __p1;
-				__p1.SetBinding(
-					global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
-					new Microsoft.UI.Xaml.Data.Binding()
+					var __that = this;
+					this.__ResourceOwner_1 = __ResourceOwner_1;
+					this.__rootInstance = 
+					new global::Microsoft.UI.Xaml.Controls.TextBlock
 					{
-						Path = @"Tag",
-						ElementName = _topLevelSubject,
+						IsParsing = true,
+						Name = "innerTextBlock",
+						// Source 0\Binding_ElementName_In_Template.xaml (Line 14:7)
 					}
-				);
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca);
-				__p1.CreationComplete();
-				}
-				))
-				;
-				if (__rootInstance is FrameworkElement __fe)
-				{
-					__fe.Loading += __UpdateBindingsAndResources;
-				}
-				if (__rootInstance is DependencyObject d)
-				{
-					if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+					.Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca_XamlApply((Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237ecaXamlApplyExtensions.XamlApplyHandler3)(__p1 => 
 					{
-						global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
-						__nameScope.Owner = d;
+					/* _isTopLevelDictionary:False */
+					__that._component_0 = __p1;
+					__nameScope.RegisterName("innerTextBlock", __p1);
+					__that.innerTextBlock = __p1;
+					__p1.SetBinding(
+						global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
+						new Microsoft.UI.Xaml.Data.Binding()
+						{
+							Path = @"Tag",
+							ElementName = _topLevelSubject,
+						}
+					);
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca);
+					__p1.CreationComplete();
 					}
-					global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					))
+					;
+					if (__rootInstance is FrameworkElement __fe)
+					{
+						__fe.Loading += __UpdateBindingsAndResources;
+					}
+					if (__rootInstance is DependencyObject d)
+					{
+						if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+						{
+							global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
+							__nameScope.Owner = d;
+						}
+						global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					}
+					return __rootInstance;
 				}
-				return __rootInstance;
-			}
-			private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
-			private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
-			{
-				get
+				private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
+				private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
 				{
-					return (global::Microsoft.UI.Xaml.Controls.TextBlock)_component_0_Holder.Instance;
+					get
+					{
+						return (global::Microsoft.UI.Xaml.Controls.TextBlock)_component_0_Holder.Instance;
+					}
+					set
+					{
+						_component_0_Holder.Instance = value;
+					}
 				}
-				set
+				private global::Microsoft.UI.Xaml.Data.ElementNameSubject _innerTextBlockSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+				private global::Microsoft.UI.Xaml.Controls.TextBlock innerTextBlock
 				{
-					_component_0_Holder.Instance = value;
+					get
+					{
+						return (global::Microsoft.UI.Xaml.Controls.TextBlock)_innerTextBlockSubject.ElementInstance;
+					}
+					set
+					{
+						_innerTextBlockSubject.ElementInstance = value;
+					}
 				}
-			}
-			private global::Microsoft.UI.Xaml.Data.ElementNameSubject _innerTextBlockSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-			private global::Microsoft.UI.Xaml.Controls.TextBlock innerTextBlock
-			{
-				get
+				private global::Microsoft.UI.Xaml.Data.ElementNameSubject _topLevelSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject(isRuntimeBound: true, name: "topLevel");
+				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 				{
-					return (global::Microsoft.UI.Xaml.Controls.TextBlock)_innerTextBlockSubject.ElementInstance;
+					var owner = this;
+					_component_0.UpdateResourceBindings();
 				}
-				set
-				{
-					_innerTextBlockSubject.ElementInstance = value;
-				}
-			}
-			private global::Microsoft.UI.Xaml.Data.ElementNameSubject _topLevelSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject(isRuntimeBound: true, name: "topLevel");
-			private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
-			{
-				var owner = this;
-				_component_0.UpdateResourceBindings();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
@@ -80,6 +80,7 @@ namespace Uno.UI.Tests.Given_ResourceDictionary
 
 		}
 		partial void OnInitializeCompleted();
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_Event
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
@@ -52,7 +52,7 @@ namespace Uno.UI.Tests.Given_ResourceDictionary
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 			{
 				return 
-					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new SubClasses._ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_EventSC0().Build(__owner)
+					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new __ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_Event.SC0().Build(__owner)
 					)				;
 			}
 			)
@@ -81,13 +81,12 @@ namespace Uno.UI.Tests.Given_ResourceDictionary
 		}
 		partial void OnInitializeCompleted();
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
-		private partial class SubClasses;
-		partial class SubClasses
+		private class __ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_Event
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
 			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-			public class _ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_EventSC0
+			public class SC0
 			{
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				private const string __baseUri_prefix_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20 = "ms-appx:///TestProject/";

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
@@ -52,7 +52,7 @@ namespace Uno.UI.Tests.Given_ResourceDictionary
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 			{
 				return 
-					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new _ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_EventSC0().Build(__owner)
+					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new SubClasses._ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_EventSC0().Build(__owner)
 					)				;
 			}
 			)
@@ -80,124 +80,129 @@ namespace Uno.UI.Tests.Given_ResourceDictionary
 
 		}
 		partial void OnInitializeCompleted();
-		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
-		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
-		private class _ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_EventSC0
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private partial class SubClasses;
+		partial class SubClasses
 		{
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_prefix_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20 = "ms-appx:///TestProject/";
-			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private const string __baseUri_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20 = "ms-appx:///TestProject/";
-			global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
-			global::System.Object __ResourceOwner_1;
-			_View __rootInstance = null;
-			public _View Build(object __ResourceOwner_1)
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026")]
+			[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
+			public class _ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_EventSC0
 			{
-				var __that = this;
-				this.__ResourceOwner_1 = __ResourceOwner_1;
-				this.__rootInstance = 
-				new global::Microsoft.UI.Xaml.Controls.Border
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_prefix_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20 = "ms-appx:///TestProject/";
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				private const string __baseUri_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20 = "ms-appx:///TestProject/";
+				global::Microsoft.UI.Xaml.NameScope __nameScope = new global::Microsoft.UI.Xaml.NameScope();
+				global::System.Object __ResourceOwner_1;
+				_View __rootInstance = null;
+				public _View Build(object __ResourceOwner_1)
 				{
-					IsParsing = true,
-					Resources = {
-					[
-					"SiblingResource"
-					] = 
-					new global::Microsoft.UI.Xaml.Controls.FontIconSource
+					var __that = this;
+					this.__ResourceOwner_1 = __ResourceOwner_1;
+					this.__rootInstance = 
+					new global::Microsoft.UI.Xaml.Controls.Border
 					{
-						// Source 0\ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event.xaml (Line 14:7)
-					}
-					,
-					[
-					"FailingResource"
-					] = 
-					new global::Uno.UI.Xaml.WeakResourceInitializer(__ResourceOwner_1, __ResourceOwner_2 => 
-					{
-						return 
-							new global::Microsoft.UI.Xaml.Controls.SwipeItems
-							{
-								// Source 0\ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event.xaml (Line 15:7)
-							}
-							.ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_XamlApply((ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20XamlApplyExtensions.XamlApplyHandler1)(__p1 => 
-							{
-							__p1.Add(
-								new global::Microsoft.UI.Xaml.Controls.SwipeItem
+						IsParsing = true,
+						Resources = {
+						[
+						"SiblingResource"
+						] = 
+						new global::Microsoft.UI.Xaml.Controls.FontIconSource
+						{
+							// Source 0\ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event.xaml (Line 14:7)
+						}
+						,
+						[
+						"FailingResource"
+						] = 
+						new global::Uno.UI.Xaml.WeakResourceInitializer(__ResourceOwner_1, __ResourceOwner_2 => 
+						{
+							return 
+								new global::Microsoft.UI.Xaml.Controls.SwipeItems
 								{
-									// Source 0\ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event.xaml (Line 16:8)
+									// Source 0\ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event.xaml (Line 15:7)
 								}
-								.ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_XamlApply((ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20XamlApplyExtensions.XamlApplyHandler2)(__p1 => 
+								.ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_XamlApply((ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20XamlApplyExtensions.XamlApplyHandler1)(__p1 => 
 								{
-								/* _isTopLevelDictionary:False */
-								__that._component_0 = __p1;
-								global::Microsoft.UI.Xaml.NameScope.SetNameScope(__that._component_0, __nameScope);
-								global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.SwipeItem.IconSourceProperty, "SiblingResource", isThemeResourceExtension: false, isHotReloadSupported: false, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-								var Invoked_AnEventHandler_That = (__ResourceOwner_2 as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;
-								/* second level */ __p1.Invoked += (AnEventHandler_sender,AnEventHandler_args) => (Invoked_AnEventHandler_That.Target as global::Uno.UI.Tests.Given_ResourceDictionary.When_Nested_With_Sibling_Ref_And_Event)?.AnEventHandler(AnEventHandler_sender,AnEventHandler_args);
+								__p1.Add(
+									new global::Microsoft.UI.Xaml.Controls.SwipeItem
+									{
+										// Source 0\ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event.xaml (Line 16:8)
+									}
+									.ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_XamlApply((ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20XamlApplyExtensions.XamlApplyHandler2)(__p1 => 
+									{
+									/* _isTopLevelDictionary:False */
+									__that._component_0 = __p1;
+									global::Microsoft.UI.Xaml.NameScope.SetNameScope(__that._component_0, __nameScope);
+									global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.SwipeItem.IconSourceProperty, "SiblingResource", isThemeResourceExtension: false, isHotReloadSupported: false, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+									var Invoked_AnEventHandler_That = (__ResourceOwner_2 as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;
+									/* second level */ __p1.Invoked += (AnEventHandler_sender,AnEventHandler_args) => (Invoked_AnEventHandler_That.Target as global::Uno.UI.Tests.Given_ResourceDictionary.When_Nested_With_Sibling_Ref_And_Event)?.AnEventHandler(AnEventHandler_sender,AnEventHandler_args);
+									}
+									))
+								);
 								}
 								))
-							);
-							}
-							))
-						;
+							;
+						}
+						)
+						,
+						},
+						// Source 0\ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event.xaml (Line 12:5)
 					}
-					)
-					,
-					},
-					// Source 0\ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event.xaml (Line 12:5)
-				}
-				.ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_XamlApply((ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20XamlApplyExtensions.XamlApplyHandler3)(__p1 => 
-				{
-				/* _isTopLevelDictionary:False */
-				__that._component_1 = __p1;
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20);
-				__p1.CreationComplete();
-				}
-				))
-				;
-				if (__rootInstance is FrameworkElement __fe)
-				{
-					__fe.Loading += __UpdateBindingsAndResources;
-				}
-				if (__rootInstance is DependencyObject d)
-				{
-					if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+					.ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_XamlApply((ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20XamlApplyExtensions.XamlApplyHandler3)(__p1 => 
 					{
-						global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
-						__nameScope.Owner = d;
+					/* _isTopLevelDictionary:False */
+					__that._component_1 = __p1;
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20);
+					__p1.CreationComplete();
 					}
-					global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					))
+					;
+					if (__rootInstance is FrameworkElement __fe)
+					{
+						__fe.Loading += __UpdateBindingsAndResources;
+					}
+					if (__rootInstance is DependencyObject d)
+					{
+						if (global::Microsoft.UI.Xaml.NameScope.GetNameScope(d) == null)
+						{
+							global::Microsoft.UI.Xaml.NameScope.SetNameScope(d, __nameScope);
+							__nameScope.Owner = d;
+						}
+						global::Uno.UI.FrameworkElementHelper.AddObjectReference(d, this);
+					}
+					return __rootInstance;
 				}
-				return __rootInstance;
-			}
-			private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
-			private global::Microsoft.UI.Xaml.Controls.SwipeItem _component_0
-			{
-				get
+				private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
+				private global::Microsoft.UI.Xaml.Controls.SwipeItem _component_0
 				{
-					return (global::Microsoft.UI.Xaml.Controls.SwipeItem)_component_0_Holder.Instance;
+					get
+					{
+						return (global::Microsoft.UI.Xaml.Controls.SwipeItem)_component_0_Holder.Instance;
+					}
+					set
+					{
+						_component_0_Holder.Instance = value;
+					}
 				}
-				set
+				private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_1_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
+				private global::Microsoft.UI.Xaml.Controls.Border _component_1
 				{
-					_component_0_Holder.Instance = value;
+					get
+					{
+						return (global::Microsoft.UI.Xaml.Controls.Border)_component_1_Holder.Instance;
+					}
+					set
+					{
+						_component_1_Holder.Instance = value;
+					}
 				}
-			}
-			private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_1_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
-			private global::Microsoft.UI.Xaml.Controls.Border _component_1
-			{
-				get
+				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 				{
-					return (global::Microsoft.UI.Xaml.Controls.Border)_component_1_Holder.Instance;
+					var owner = this;
+					_component_0.UpdateResourceBindings();
 				}
-				set
-				{
-					_component_1_Holder.Instance = value;
-				}
-			}
-			private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
-			{
-				var owner = this;
-				_component_0.UpdateResourceBindings();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
@@ -1,6 +1,8 @@
-﻿// Uncomment the following line to write expected files to disk
+﻿#if DEBUG
+// Uncomment the following line to write expected files to disk
 // Don't commit this line uncommented.
 // #define WRITE_EXPECTED
+#endif
 
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Subclass.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/Subclass.cs
@@ -8,19 +8,5 @@ using System.Threading.Tasks;
 
 namespace Uno.UI.SourceGenerators.XamlGenerator
 {
-	internal class Subclass
-	{
-		public Subclass(XamlMemberDefinition contentOwner, string returnType, string defaultBindMode)
-		{
-			ContentOwner = contentOwner;
-			ReturnType = returnType;
-			DefaultBindMode = defaultBindMode;
-		}
-
-		public XamlMemberDefinition ContentOwner { get; }
-
-		public string ReturnType { get; }
-
-		public string DefaultBindMode { get; }
-	}
+	internal record Subclass(XamlMemberDefinition ContentOwner, string ReturnType, string DefaultBindMode);
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -905,6 +905,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				if (_isHotReloadEnabled || CurrentScope.Subclasses is { Count: >= 1 })
 				{
 					// If _isHotReloadEnabled we generate it anyway so we can remove sub-classes without causing rude edit.
+					writer.AppendLineIndented("[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
 					writer.AppendLineIndented("[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]");
 					return writer.BlockInvariant($"{(isTopLevel ? "internal" : "private")} class __{_fileUniqueId}_{string.Join("_", _scopeStack.Select(scope => scope.Name))}");
 				}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.hotdesign/issues/3187

## Feature
Add ability to remove root of a `DataTemplate` with HR without `cnomua`

## What is the current behavior?
Since we removed the `cnomua`, we get a rude edit when we remove the root element of a `DataTemplate`

## What is the new behavior?
We wrap sub classes into a class tagged with `cnomua`, so we can remove a sub class (issued for a `DataTemplate`) without causing a rude-edit.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
