### PR TITLE
perf(anim): Register only once to the JS animationframe callback

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/RenderingLoopAnimator.Interop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/RenderingLoopAnimator.Interop.wasm.cs
@@ -1,29 +1,65 @@
 ﻿using System;
 using System.Runtime.InteropServices.JavaScript;
+using Uno.Disposables;
+using Uno.Foundation.Logging;
+using Windows.UI.Core;
 
-namespace __Microsoft.UI.Xaml.Media.Animation
+namespace Microsoft.UI.Xaml.Media.Animation
 {
 	internal partial class RenderingLoopAnimator
 	{
+		private static WeakEventHelper.WeakEventCollection _frameHandlers = new();
+
+		internal static IDisposable RegisterFrameEvent(Action action)
+		{
+			var requiresEnable = _frameHandlers.IsEmpty;
+
+			var disposable = WeakEventHelper.RegisterEvent(
+				_frameHandlers,
+				action,
+				(h, s, a) => (h as Action)?.Invoke());
+
+			if (requiresEnable)
+			{
+				SetEnabledNative(true);
+			}
+
+			return Disposable.Create(() =>
+			{
+				disposable.Dispose();
+
+				if (_frameHandlers.IsEmpty)
+				{
+					SetEnabledNative(false);
+				}
+			});
+		}
+
+		[JSExport]
+		public static void OnFrame()
+		{
+			_frameHandlers.Invoke(null, null);
+
+			if (_frameHandlers.IsEmpty)
+			{
+				SetEnabledNative(false);
+			}
+		}
+
+		private static void SetEnabledNative(bool enabled)
+		{
+			if (typeof(RenderingLoopAnimator).Log().IsEnabled(LogLevel.Trace))
+			{
+				typeof(RenderingLoopAnimator).Log().Trace($"SetEnabledNative: {enabled}");
+			}
+
+			NativeMethods.SetEnabled(enabled);
+		}
+
 		internal static partial class NativeMethods
 		{
-			[JSImport("globalThis.Microsoft.UI.Xaml.Media.Animation.RenderingLoopAnimator.createInstance")]
-			internal static partial void CreateInstance(IntPtr managedHandle, double id);
-
-			[JSImport("globalThis.Microsoft.UI.Xaml.Media.Animation.RenderingLoopAnimator.destroyInstance")]
-			internal static partial void DestroyInstance(double jsHandle);
-
-			[JSImport("globalThis.Microsoft.UI.Xaml.Media.Animation.RenderingLoopAnimator.disableFrameReporting")]
-			internal static partial void DisableFrameReporting(double jsHandle);
-
-			[JSImport("globalThis.Microsoft.UI.Xaml.Media.Animation.RenderingLoopAnimator.enableFrameReporting")]
-			internal static partial void EnableFrameReporting(double jsHandle);
-
-			[JSImport("globalThis.Microsoft.UI.Xaml.Media.Animation.RenderingLoopAnimator.setAnimationFramesInterval")]
-			internal static partial void SetAnimationFramesInterval(double jsHandle);
-
-			[JSImport("globalThis.Microsoft.UI.Xaml.Media.Animation.RenderingLoopAnimator.setStartFrameDelay")]
-			internal static partial void SetStartFrameDelay(double jsHandle, double delayMs);
+			[JSImport("globalThis.Microsoft.UI.Xaml.Media.Animation.RenderingLoopAnimator.setEnabled")]
+			internal static partial void SetEnabled(bool enabled);
 		}
 	}
 }

--- a/src/Uno.UI/ts/Windows/UI/Xaml/Animation/RenderingLoopAnimator.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/Animation/RenderingLoopAnimator.ts
@@ -1,111 +1,48 @@
 ﻿namespace Microsoft.UI.Xaml.Media.Animation {
 	export class RenderingLoopAnimator {
-		private static activeInstances: { [jsHandle: number]: RenderingLoopAnimator} = {};
 
-		public static createInstance(managedHandle: number, jsHandle: number) {
-			RenderingLoopAnimator.activeInstances[jsHandle] = new RenderingLoopAnimator(managedHandle);
-		}
+		private static dispatchFrame: () => number;
 
-		public static getInstance(jsHandle: number): RenderingLoopAnimator {
-			return RenderingLoopAnimator.activeInstances[jsHandle];
-		}
-
-		public static destroyInstance(jsHandle: number) {
-			var instance = RenderingLoopAnimator.getInstance(jsHandle);
-			// If the JSObjectHandle is being disposed before the animator is stopped (GC collecting JSObjectHandle before the animator)
-			// we won't be able to DisableFrameReporting anymore.
-			if (instance) {
-				instance.DisableFrameReporting();
-			}
-			delete RenderingLoopAnimator.activeInstances[jsHandle];
-		}
-
-		private constructor(private managedHandle: number) {
-		}
-
-		public static setStartFrameDelay(jsHandle: number, delay: number) {
-			RenderingLoopAnimator.getInstance(jsHandle).SetStartFrameDelay(delay);
-		}
-
-		public SetStartFrameDelay(delay: number) {
-			this.unscheduleFrame();
-
-			if (this._isEnabled) {
-				this.scheduleDelayedFrame(delay);
+		private static init() {
+			if (!RenderingLoopAnimator.dispatchFrame) {
+				if ((<any>globalThis).DotnetExports !== undefined) {
+					RenderingLoopAnimator.dispatchFrame = (<any>globalThis).DotnetExports.UnoUI.Microsoft.UI.Xaml.Media.Animation.RenderingLoopAnimator.OnFrame;
+				} else {
+					throw `Unable to find dotnet exports`;
+				}
 			}
 		}
 
-		public static setAnimationFramesInterval(jsHandle: number) {
-			RenderingLoopAnimator.getInstance(jsHandle).SetAnimationFramesInterval();
-		}
+		public static setEnabled(enabled: boolean) {
+			RenderingLoopAnimator.init();
 
-		public SetAnimationFramesInterval() {
-			this.unscheduleFrame();
+			RenderingLoopAnimator._isEnabled = enabled;
 
-			if (this._isEnabled) {
-				this.onFrame();
+			if (enabled) {
+				RenderingLoopAnimator.scheduleAnimationFrame();
+			} else if (RenderingLoopAnimator._frameRequestId != null) {
+				window.cancelAnimationFrame(RenderingLoopAnimator._frameRequestId);
+				RenderingLoopAnimator._frameRequestId = null;
 			}
 		}
 
-		public static enableFrameReporting(jsHandle: number) {
-			RenderingLoopAnimator.getInstance(jsHandle).EnableFrameReporting();
-		}
-
-		public EnableFrameReporting() {
-			if (this._isEnabled) {
-				return;
-			}
-
-			this._isEnabled = true;
-			this.scheduleAnimationFrame();
-		}
-
-		public static disableFrameReporting(jsHandle: number) {
-			RenderingLoopAnimator.getInstance(jsHandle).DisableFrameReporting();
-		}
-
-		public DisableFrameReporting() {
-			this._isEnabled = false;
-			this.unscheduleFrame();
-		}
-
-		private onFrame() {
-			Uno.Foundation.Interop.ManagedObject.dispatch(this.managedHandle, "OnFrame", null);
-
-			// Schedule a new frame only if still enabled and no frame was scheduled by the managed OnFrame
-			if (this._isEnabled && this._frameRequestId == null && this._delayRequestId == null) {
-				this.scheduleAnimationFrame();
+		private static scheduleAnimationFrame() {
+			if (RenderingLoopAnimator._frameRequestId == null) {
+				RenderingLoopAnimator._frameRequestId = window.requestAnimationFrame(RenderingLoopAnimator.onAnimationFrame);
 			}
 		}
 
-		private unscheduleFrame() {
-			if (this._delayRequestId != null) {
-				clearTimeout(this._delayRequestId);
-				this._delayRequestId = null;
+		private static onAnimationFrame() {
+			RenderingLoopAnimator.dispatchFrame();
+
+			RenderingLoopAnimator._frameRequestId = null;
+
+			if (RenderingLoopAnimator._isEnabled) {
+				RenderingLoopAnimator.scheduleAnimationFrame();
 			}
-			if (this._frameRequestId != null) {
-				window.cancelAnimationFrame(this._frameRequestId);
-				this._frameRequestId = null;
-			}
 		}
 
-		private scheduleDelayedFrame(delay: number) {
-			this._delayRequestId = setTimeout(() => {
-					this._delayRequestId = null;
-					this.onFrame();
-				},
-				delay);
-		}
-
-		private scheduleAnimationFrame() {
-			this._frameRequestId = window.requestAnimationFrame(() => {
-				this._frameRequestId = null;
-				this.onFrame();
-			});
-		}
-
-		private _delayRequestId?: number;
-		private _frameRequestId?: number;
-		private _isEnabled = false;
+		private static _frameRequestId?: number;
+		private static _isEnabled = false;
 	}
 }

--- a/src/Uno.UWP/UI/Core/WeakEventHelper.cs
+++ b/src/Uno.UWP/UI/Core/WeakEventHelper.cs
@@ -71,6 +71,17 @@ namespace Windows.UI.Core
 				_provider = provider ?? new DefaultTrimProvider();
 			}
 
+			public bool IsEmpty
+			{
+				get
+				{
+					lock (_lock)
+					{
+						return _handlers.Count == 0;
+					}
+				}
+			}
+
 			private bool Trim()
 			{
 				lock (_lock)


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?

Only register once to the native animationframe callback to reduce interop calls.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
