### PR TITLE
fix(codegen): ContentPresenter.Content binding compilation error

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -98,6 +98,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		internal Lazy<INamedTypeSymbol?> AssemblyMetadataSymbol { get; }
 		internal Lazy<INamedTypeSymbol> ElementStubSymbol { get; }
+		internal Lazy<INamedTypeSymbol> ContentControlSymbol { get; }
 		internal Lazy<INamedTypeSymbol> ContentPresenterSymbol { get; }
 		internal Lazy<INamedTypeSymbol> StringSymbol { get; }
 		internal Lazy<INamedTypeSymbol> ObjectSymbol { get; }
@@ -267,6 +268,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			AssemblyMetadataSymbol = GetOptionalSymbolAsLazy("System.Reflection.AssemblyMetadataAttribute");
 			ElementStubSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.ElementStub);
 			SetterSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.Setter);
+			ContentControlSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.ContentControl);
 			ContentPresenterSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.ContentPresenter);
 			FrameworkElementSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.FrameworkElement);
 			UIElementSymbol = GetMandatorySymbolAsLazy(XamlConstants.Types.UIElement);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlConstants.cs
@@ -21,6 +21,27 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		public const int MaxFluentResourcesVersion = 2;
 
+		public const string UnknownContent = "_UnknownContent";
+		public const string PositionalParameters = "_PositionalParameters";
+
+		public static class Xmlnses
+		{
+			/// <summary>
+			/// <code>xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"</code>
+			/// </summary>
+			public const string Default = PresentationXamlXmlNamespace;
+
+			/// <summary>
+			/// <code>xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"</code>
+			/// </summary>
+			public const string X = XamlXmlNamespace;
+
+			/// <summary>
+			/// <code>xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"</code>
+			/// </summary>
+			public const string MC = "http://schemas.openxmlformats.org/markup-compatibility/2006";
+		}
+
 		public static class Namespaces
 		{
 			public const string Base = BaseXamlNamespace;

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -548,11 +548,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return null;
 		}
 
-		private INamedTypeSymbol GetType(string name, XamlObjectDefinition? objectDefinition = null)
+		private INamedTypeSymbol? ResolveType(string? name, XamlObjectDefinition? xmlnsContextProvider = null)
 		{
-			while (objectDefinition is not null)
+			if (name == null)
 			{
-				var namespaces = objectDefinition.Namespaces;
+				return null;
+			}
+
+			while (xmlnsContextProvider is not null)
+			{
+				var namespaces = xmlnsContextProvider.Namespaces;
 				if (namespaces is { Count: > 0 } && name.IndexOf(':') is int indexOfColon && indexOfColon > 0)
 				{
 					var ns = name.AsSpan().Slice(0, indexOfColon);
@@ -570,18 +575,14 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					}
 				}
 
-				objectDefinition = objectDefinition.Owner;
+				xmlnsContextProvider = xmlnsContextProvider.Owner;
 			}
 
-			var type = _findType!(name);
-
-			if (type == null)
-			{
-				throw new InvalidOperationException("The type {0} could not be found".InvariantCultureFormat(name));
-			}
-
-			return type;
+			return _findType!(name);
 		}
+		private INamedTypeSymbol GetType(string name, XamlObjectDefinition? objectDefinition = null) =>
+			ResolveType(name, objectDefinition) ??
+			throw new InvalidOperationException("The type {0} could not be found".InvariantCultureFormat(name));
 
 		private INamedTypeSymbol GetType(XamlType type)
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3844,31 +3844,67 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private void TryValidateContentPresenterBinding(IIndentedStringBuilder writer, XamlObjectDefinition objectDefinition, XamlMemberDefinition member)
 		{
 			TryAnnotateWithGeneratorSource(writer);
-			if (
-				SymbolEqualityComparer.Default.Equals(FindType(objectDefinition.Type), Generation.ContentPresenterSymbol.Value)
-				&& member.Member.Name == "Content"
-			)
+
+			// detect content binding in: <ContentPresenter Content="{Binding}" />
+			if (FindType(objectDefinition.Type)?.Is(Generation.ContentPresenterSymbol.Value) == true &&
+				member.Member.Name == "Content" &&
+				member.Objects.FirstOrDefault(x => x.Type.Name == "Binding") is { } binding)
 			{
-				var binding = member.Objects.FirstOrDefault(o => o.Type.Name == "Binding");
+				// In Uno, ContentPresenter.Content overrides the local value of ContentPresenter.DataContext,
+				// which in turn breaks the binding source for the Content binding. However, there are certain exceptions
+				// where it would be fine.
 
-				if (binding != null)
+				// It can either be TemplatedParent or Self. In either cases, it does not use the inherited
+				// DataContext, which falls outside of the scenario we want to avoid.
+				if (binding.Members.Any(x => x.Member.Name == "RelativeSource"))
 				{
-					var hasRelativeSource = binding.Members
-						.Any(m =>
-							m.Member.Name == "RelativeSource"
-						// It can either be TemplatedParent or Self. In either cases, it does not use the inherited
-						// DataContext, which falls outside of the scenario we want to avoid.
-						);
-
-					if (!hasRelativeSource)
-					{
-						writer.AppendLine();
-						writer.AppendIndented("#error Using a non-template binding expression on Content " +
-							"will likely result in an undefined runtime behavior, as ContentPresenter.Content overrides " +
-							"the local value of ContentPresenter.DataContent. " +
-							"Use ContentControl instead if you really need a normal binding on Content.\n");
-					}
+					return;
 				}
+
+				// {Binding} is fine, because it doesnt alter the data-context.
+				if (binding.Members.Count == 0)
+				{
+					return;
+				}
+
+				// {Binding .} or {Binding Path=.} are fine too, because it doesnt alter the data-context.
+				if ((FindImplicitContentMember(binding, XamlConstants.PositionalParameters) ?? FindImplicitContentMember(binding, "Path")) is { } path &&
+					path.Value?.ToString() == ".")
+				{
+					return;
+				}
+
+				// Not inside any template.
+				var template = FindAncestor(objectDefinition, x => FrameworkTemplateTypes.Contains(x.Type.Name));
+				if (template == null)
+				{
+					return;
+				}
+
+				// If it is within a <ControlTemplate>, regardless if it descends from ContentControl or not.
+				if (template?.Type.Name is "ControlTemplate")
+				{
+					return;
+				}
+
+				// note: <DataTemplate> with ContentPresenter.Content bound to arbitrary path should work.
+				// but is failing to resolve somehow. We will not allow this case to compile:
+				// 	<ContentControl Content="new TestData { Text='lalala' }">
+				//		<ContentControl.ContentTemplate>
+				//			<DataTemplate>
+				//				<ContentPresenter Content="{Binding Text}" />
+				//	ContentControl // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+				//		ContentPresenter // DC=TestData, Content=TestData, Content.Binding=[Path=Content, RelativeSource=TemplatedParent]
+				//			ContentPresenter // DC=TestData, Content=null, Content.Binding=[Path=Text, RelativeSource=]
+				//												^ the binding didnt produces the expected value
+				//				ImplicitTextBlock // DC=TestData, Text=''
+
+				writer.AppendLine();
+				writer.AppendIndented(
+					"#error Using a non-template binding expression on Content " +
+					"will likely result in an undefined runtime behavior, as ContentPresenter.Content overrides " +
+					"the local value of ContentPresenter.DataContent. " +
+					"Use ContentControl instead if you really need a normal binding on Content.\n");
 			}
 		}
 
@@ -5087,6 +5123,21 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				if (FindType(objectDefinition.Type) is { } type)
 				{
 					return type;
+				}
+
+				objectDefinition = objectDefinition.Owner;
+			}
+
+			return null;
+		}
+
+		private XamlObjectDefinition? FindAncestor(XamlObjectDefinition? objectDefinition, Func<XamlObjectDefinition, bool> predicate)
+		{
+			while (objectDefinition is not null)
+			{
+				if (predicate(objectDefinition))
+				{
+					return objectDefinition;
 				}
 
 				objectDefinition = objectDefinition.Owner;

--- a/src/SourceGenerators/XamlGenerationTests/ContentPresenter_ContentBinding.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/ContentPresenter_ContentBinding.xaml
@@ -1,0 +1,55 @@
+﻿<Page x:Class="XamlGenerationTests.ContentPresenter_ContentBinding"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:XamlGenerationTests"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:void="There is no mistake so great that it cannot be undone."
+	  mc:Ignorable="d void">
+	<Page.Resources>
+
+		<!-- OK: should work; unaffected in uno -->
+		<DataTemplate x:Key="DTCPCB_DataTemplate">
+			<ContentPresenter Content="{Binding}" />
+		</DataTemplate>
+
+		<!-- OK: should work; unaffected in uno -->
+		<ControlTemplate x:Key="DTCPCB_UntypedCtrlTemplate_BindingBlank">
+			<ContentPresenter Content="{Binding}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_UntypedCtrlTemplate_BindingDot">
+			<ContentPresenter Content="{Binding .}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_ContentCtrlTemplate" TargetType="ContentControl">
+			<ContentPresenter Content="{Binding}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_DerivedContentCtrlTemplate" TargetType="Button">
+			<ContentPresenter Content="{Binding}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_NonContentCtrlTemplate" TargetType="TextBox">
+			<ContentPresenter Content="{Binding}" />
+		</ControlTemplate>
+
+		<!-- OK: ControlTemplate\ContentPresenter.Content with Path works -->
+		<ControlTemplate x:Key="DTCPCB_DerivedContentCtrlTemplate_SomePath_1" TargetType="Button">
+			<ContentPresenter Content="{Binding SomePath}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_DerivedContentCtrlTemplate_SomePath_2" TargetType="Button">
+			<ContentPresenter Content="{Binding Mode=OneTime, Path=SomePath}" />
+		</ControlTemplate>
+		
+		<!-- FAIL: DataTemplate\ContentPresenter.Content with Path should work, but doesn't -->
+		<!-- for now, it should not compile-->
+		<void:DataTemplate x:Key="DTCPCB_ContentDataTemplate_SomePath">
+			<ContentPresenter Content="{Binding SomePath}" />
+		</void:DataTemplate>
+
+	</Page.Resources>
+
+	<StackPanel>
+		<!-- OK: should work; unaffected in uno -->
+		<ContentPresenter Content="{Binding}" />
+		<ContentPresenter Content="{Binding SomePath}" />
+	</StackPanel>
+
+</Page>

--- a/src/Uno.UI.RuntimeTests/Extensions/StringExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Extensions/StringExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Uno.UI.RuntimeTests.Extensions;
+
+public static class StringExtensions
+{
+	/// <summary>
+	/// Split a string by a separator, while ignoring certain regex pattern to be splitted.
+	/// </summary>
+	/// <param name="input"></param>
+	/// <param name="separator"></param>
+	/// <param name="ignoredPattern"></param>
+	/// <param name="options"></param>
+	/// <remarks>This is typically used to split separator-seperator string that contains brackets.</remarks>
+	/// <returns></returns>
+	public static string[] SplitWithIgnore(this string input, char separator, string ignoredPattern, StringSplitOptions options = StringSplitOptions.None)
+	{
+		var ignores = Regex.Matches(input, ignoredPattern);
+
+		var shards = new List<string>();
+		for (int i = 0; i < input.Length; i++)
+		{
+			var nextSeparator = input.IndexOf(separator, i);
+
+			// find the next separator, if we are within the ignored pattern
+			while (nextSeparator != -1 && ignores.FirstOrDefault(x => InRange(x, nextSeparator)) is { } enclosingIgnore)
+			{
+				nextSeparator = enclosingIgnore.Index + enclosingIgnore.Length is { } afterIgnore && afterIgnore < input.Length
+					? input.IndexOf(separator, afterIgnore)
+					: -1;
+			}
+
+			if (nextSeparator != -1)
+			{
+				shards.Add(input.Substring(i, nextSeparator - i));
+				i = nextSeparator;
+
+				// skip multiple continuous spaces
+				while (options.HasFlag(StringSplitOptions.RemoveEmptyEntries) && i + 1 < input.Length && input[i + 1] == separator) i++;
+			}
+			else
+			{
+				shards.Add(input.Substring(i));
+				break;
+			}
+		}
+
+		if (options.HasFlag(StringSplitOptions.TrimEntries))
+		{
+			return shards.Select(x => x.Trim()).ToArray();
+		}
+		else
+		{
+			return shards.ToArray();
+		}
+
+		bool InRange(Match x, int index) => x.Index <= index && index < (x.Index + x.Length);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Helpers/TreeAssert.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/TreeAssert.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Uno.Extensions;
+using Uno.UI.Extensions;
+using Windows.Media.Core;
+
+#if __IOS__
+using UIKit;
+using _View = UIKit.UIView;
+#elif __MACOS__
+using AppKit;
+using _View = AppKit.NSView;
+#elif __ANDROID__
+using _View = Android.Views.View;
+#else
+using _View = Microsoft.UI.Xaml.DependencyObject;
+#endif
+
+namespace Uno.UI.RuntimeTests.Helpers;
+
+internal static class TreeAssert
+{
+	private record NodeInfo(int Line, int Depth, string Name, string Description);
+
+	/// <summary>
+	/// Verify every node in a tree matches the description as in the expected values
+	/// </summary>
+	/// <param name="expectedTree"></param>
+	/// <param name="root"></param>
+	/// <param name="flatten"></param>
+	/// <param name="describe"></param>
+	/// <exception cref="ArgumentNullException"></exception>
+	public static void VerifyTree(string expectedTree, object root, Func<object, IEnumerable<(int Depth, object Node)>> flatten = null, Func<object, IEnumerable<string>> describe = null)
+	{
+		if (root is null) throw new ArgumentNullException(nameof(root));
+
+		var expectations = expectedTree
+			.Split('\n', StringSplitOptions.TrimEntries)
+			.Select((x, i) =>
+			{
+				var line = x.TrimStart("0123456789. ".ToArray());
+				var depth = line.TakeWhile(x => x == '\t').Count() - 1;
+				var parts = line.Split("//", 2, StringSplitOptions.TrimEntries);
+
+				return new NodeInfo(i, depth, parts[0], parts.ElementAtOrDefault(1) ?? string.Empty);
+			})
+#if __ANDROID__ || __IOS__
+			// On droid and ios, ContentPresenter bypass can be potentially enabled (based on if a base control template is present, or not).
+			// As such, ContentPresenter may be omitted, and altering its visual descendants.
+			.Aggregate(
+				new { DroppedDepths = new Stack<int>(), Results = new List<NodeInfo>() },
+				(acc, x) => // drop ignored line, and repair depth from dropped item
+				{
+					if (x.Description.Contains("IGNORE_FOR_MOBILE_CP_BYPASS"))
+					{
+						acc.DroppedDepths.Push(x.Depth);
+						return acc;
+					}
+
+					if (acc.DroppedDepths.TryPeek(out var dropped))
+					{
+						if (dropped >= x.Depth) acc.DroppedDepths.Pop();
+						acc.Results.Add(x with { Depth = x.Depth - acc.DroppedDepths.Count(y => y < x.Depth) });
+					}
+					else
+					{
+						acc.Results.Add(x);
+					}
+
+					return acc;
+				},
+				acc => acc.Results
+			)
+#endif
+			.ToList();
+		var descendants = (flatten?.Invoke(root) ?? FlattenVT(root)).ToArray();
+
+		Assert.AreEqual(expectations.Count, descendants.Length, "Mismatched descendant size");
+		for (int i = 0; i < expectations.Count; i++)
+		{
+			var expected = expectations[i];
+
+			var node = descendants[i];
+			var name = PrettyPrint.FormatType(node.Node);
+
+			Assert.AreEqual(expected.Depth, node.Depth, $"Incorrect depth on line {expected.Line}");
+			Assert.AreEqual(expected.Name, name, $"Incorrect node on line {expected.Line}");
+			if (!expected.Description.Contains("SKIP_DESC_COMPARE"))
+			{
+				var description = string.Join(", ", describe?.Invoke(node.Node) ?? Array.Empty<string>());
+				Assert.AreEqual(expected.Description, description, $"Invalid description on line {expected.Line}");
+			}
+		}
+	}
+
+	private static IEnumerable<(int Depth, object Node)> FlattenVT(object node, int depth = 0)
+	{
+		yield return (depth, node);
+
+		var children = (node as _View)?.EnumerateChildren().Cast<object>();
+		if (children is { })
+		{
+			foreach (var child in children)
+			{
+				foreach (var nested in FlattenVT(child, depth + 1))
+				{
+					yield return nested;
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_ContentBindings.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_ContentBindings.xaml
@@ -1,0 +1,77 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ContentPresenterPages.ContentPresenter_ContentBindings"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:void="There is no mistake so great that it cannot be undone."
+	  mc:Ignorable="d void">
+
+	<Page.Resources>
+
+		<DataTemplate x:Key="DTCPCB_DataTemplate_RawCP">
+			<ContentPresenter />
+		</DataTemplate>
+		<DataTemplate x:Key="DTCPCB_DataTemplate_CPContentBinding">
+			<ContentPresenter Content="{Binding}" />
+		</DataTemplate>
+		<void:DataTemplate x:Key="DTCPCB_TextDataTemplate">
+			<!-- fixme: not working; binding doesnt resolve -->
+			<ContentPresenter Content="{Binding Text}" />
+		</void:DataTemplate>
+		<ControlTemplate x:Key="DTCPCB_TextCtrlTemplate" TargetType="Button">
+			<ContentPresenter Content="{Binding Text}" />
+		</ControlTemplate>
+
+		<ControlTemplate x:Key="DTCPCB_UntypedCtrlTemplate_BindingBlank">
+			<ContentPresenter Content="{Binding}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_UntypedCtrlTemplate_BindingDot">
+			<ContentPresenter Content="{Binding .}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_ContentCtrlTemplate" TargetType="ContentControl">
+			<ContentPresenter Content="{Binding}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_DerivedContentCtrlTemplate" TargetType="Button">
+			<ContentPresenter Content="{Binding}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_NonContentCtrlTemplate" TargetType="TextBox">
+			<ContentPresenter Content="{Binding}" />
+		</ControlTemplate>
+
+		<ControlTemplate x:Key="DTCPCB_DerivedContentCtrlTemplate_SomePath_1" TargetType="Button">
+			<ContentPresenter Content="{Binding SomePath}" />
+		</ControlTemplate>
+		<ControlTemplate x:Key="DTCPCB_DerivedContentCtrlTemplate_SomePath_2" TargetType="Button">
+			<ContentPresenter Content="{Binding Mode=OneTime, Path=SomePath}" />
+		</ControlTemplate>
+	</Page.Resources>
+
+	<StackPanel x:Name="SutPanel">
+		<ContentPresenter x:Name="CP_Content_Binding" Content="{Binding}" />
+		<ContentPresenter x:Name="CP_Content_Binding_SomePath" Content="{Binding SomePath}" />
+
+		<ContentControl x:Name="CC_ContentTemplate_RawCP"
+						Content="{Binding}"
+						ContentTemplate="{StaticResource DTCPCB_DataTemplate_RawCP}" />
+		<ContentControl x:Name="CP_ContentTemplate_CPContentBinding"
+						Content="{Binding}"
+						ContentTemplate="{StaticResource DTCPCB_DataTemplate_CPContentBinding}" />
+		<Button x:Name="Button_ControlTemplate_CPContentBinding"
+				Content="{Binding}"
+				Template="{StaticResource DTCPCB_DerivedContentCtrlTemplate}">
+			<!-- yes, we are using Template (ControlTemplate) here, and not ContentTemplate -->
+		</Button>
+
+		<void:ContentControl x:Name="CP_ContentTemplate_CPContentBindingPath"
+							 Content="{Binding}"
+							 ContentTemplate="{StaticResource DTCPCB_TextDataTemplate}">
+			<!-- fixme: DTCPCB_TextDataTemplate not working; binding doesnt resolve -->
+		</void:ContentControl>
+		<Button x:Name="Button_ControlTemplate_CPContentBindingPath"
+				Content="{Binding}"
+				Template="{StaticResource DTCPCB_TextCtrlTemplate}">
+			<!-- yes, we are using Template (ControlTemplate) here, and not ContentTemplate -->
+		</Button>
+	</StackPanel>
+
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_ContentBindings.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_ContentBindings.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.ContentPresenterPages;
+
+public sealed partial class ContentPresenter_ContentBindings : Page
+{
+	public ContentPresenter_ContentBindings()
+	{
+		this.InitializeComponent();
+		this.DataContext = new TestData();
+	}
+
+	public class TestData
+	{
+		public string Text { get; set; } = "lalala~";
+
+		public override string ToString() => GetType().Name;
+	}
+}
+

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentPresenter.cs
@@ -14,6 +14,8 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
 using MUXControlsTestApp.Utilities;
 using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.Extensions;
+using System.Text.RegularExpressions;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 
@@ -23,7 +25,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 #if __MACOS__
 [Ignore("Currently fails on macOS, part of #9282! epic")]
 #endif
-public class Given_ContentPresenter
+public partial class Given_ContentPresenter // test cases
 {
 	[TestMethod]
 	public async Task When_Padding_Set_In_SizeChanged()
@@ -214,8 +216,110 @@ public class Given_ContentPresenter
 		Assert.AreEqual("42", GetTextBlockText(sut, "nullContentChanged"));
 	}
 
-	static string GetTextBlockText(FrameworkElement sut, string v)
-		=> (sut.FindName(v) as TextBlock)?.Text ?? "";
+	[TestMethod]
+	public async Task When_ContentPresenter_Content()
+	{
+		var setup = new ContentPresenter_ContentBindings();
+
+		await UITestHelper.Load(setup, x => x.IsLoaded);
+
+#if false // WinAppSdk result for reference:
+		StackPanel#SutPanel // DC=TestData
+			ContentPresenter#CP_Content_Binding // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+				TextBlock // DC=TestData, Text='redacted47.TestData'
+			ContentPresenter#CP_Content_Binding_SomePath // DC=TestData, Content=, Content.Binding=[Path=SomePath, RelativeSource=]
+
+			ContentControl#CC_ContentTemplate_RawCP // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+				ContentPresenter // DC=TestData, Content=TestData
+					ContentPresenter // DC=TestData, Content=
+			ContentControl#CP_ContentTemplate_CPContentBinding // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+				ContentPresenter // DC=TestData, Content=TestData
+					ContentPresenter // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+						TextBlock // DC=TestData, Text='redacted47.TestData'
+			Button#Button_ControlTemplate_CPContentBinding // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+				ContentPresenter // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+					TextBlock // DC=TestData, Text='redacted47.TestData'
+
+			ContentControl#CP_ContentTemplate_CPContentBindingPath // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+				ContentPresenter // DC=TestData, Content=TestData
+					ContentPresenter // DC=String, Content=String, Content.Binding=[Path=Text, RelativeSource=]
+						TextBlock // DC=String, Text='lalala~'
+			Button#Button_ControlTemplate_CPContentBindingPath // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+				ContentPresenter // DC=String, Content=String, Content.Binding=[Path=Text, RelativeSource=]
+					TextBlock // DC=String, Text='lalala~'
+		^ main distinction should be TextBlock vs ImplicitTextBlock, and the implicit ContentPresenter's content uses binding on uno vs direct assignment.
+#endif
+
+		static IEnumerable<string> Describe(object x)
+		{
+			//if ((x as IDependencyObjectStoreProvider)?.Store is { } dos)
+			//{
+			//	yield return $"TP={PrettyPrint.FormatType(dos.GetTemplatedParent2())}";
+			//}
+			if (x is FrameworkElement fe)
+			{
+				yield return $"DC={PrettyPrint.FormatType(fe.DataContext)}";
+			}
+			if (x is ContentControl cc)
+			{
+				yield return $"Content={PrettyPrint.FormatType(cc.Content)}";
+				if (cc.GetBindingExpression(ContentControl.ContentProperty)?.ParentBinding is { } b)
+				{
+					yield return $"Content.Binding=[Path={b.Path?.Path}, RelativeSource={b.RelativeSource?.Mode}]";
+				}
+			}
+			if (x is ContentPresenter cp)
+			{
+				yield return $"Content={PrettyPrint.FormatType(cp.Content)}";
+				if (cp.GetBindingExpression(ContentPresenter.ContentProperty)?.ParentBinding is { } b)
+				{
+					yield return $"Content.Binding=[Path={b.Path?.Path}, RelativeSource={b.RelativeSource?.Mode}]";
+				}
+			}
+			if (x is TextBlock tb)
+			{
+				yield return $"Text='{tb.Text}'";
+			}
+		}
+		var tree = setup.Content.TreeGraph(Describe);
+		var expectedTree = """
+		0	StackPanel#SutPanel // DC=TestData
+		1		ContentPresenter#CP_Content_Binding // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+		2			ImplicitTextBlock // DC=TestData, Text='TestData'
+		3		ContentPresenter#CP_Content_Binding_SomePath // DC=TestData, Content=null, Content.Binding=[Path=SomePath, RelativeSource=]
+		4		ContentControl#CC_ContentTemplate_RawCP // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+		5			ContentPresenter // SKIP_DESC_COMPARE, IGNORE_FOR_MOBILE_CP_BYPASS
+		6				ContentPresenter // DC=TestData, Content=null
+		7		ContentControl#CP_ContentTemplate_CPContentBinding // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+		8			ContentPresenter // SKIP_DESC_COMPARE, IGNORE_FOR_MOBILE_CP_BYPASS
+		9				ContentPresenter // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+		10					ImplicitTextBlock // DC=TestData, Text='TestData'
+		11		Button#Button_ControlTemplate_CPContentBinding // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+		12			ContentPresenter // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+		13				ImplicitTextBlock // DC=TestData, Text='TestData'
+		14		Button#Button_ControlTemplate_CPContentBindingPath // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+		15			ContentPresenter // DC=String, Content=String, Content.Binding=[Path=Text, RelativeSource=]
+		16				ImplicitTextBlock // DC=String, Text='lalala~'
+		""";
+#if __ANDROID__ || __IOS__
+		// not sure why this has different data-context, but we mostly care about the Text value here.
+		expectedTree = expectedTree.Replace(
+			"16\t\t\t\tImplicitTextBlock // DC=String, Text='lalala~'",
+			"16\t\t\t\tImplicitTextBlock // DC=TestData, Text='lalala~'");
+#endif
+
+		// fixme:
+		//N+0		ContentControl#CP_ContentTemplate_CPContentBindingPath // DC=TestData, Content=TestData, Content.Binding=[Path=, RelativeSource=]
+		//N+1			ContentPresenter // DC=TestData, Content=TestData
+		//expected:
+		//N+2				ContentPresenter // DC=String, Content=String, Content.Binding=[Path=Text, RelativeSource=]
+		//N+3					ImplicitTextBlock // DC=String, Text='lalala~'
+		//actual:
+		//N+2				ContentPresenter // DC=String, Content='', Content.Binding=[Path=Text, RelativeSource=]
+		//N+3					ImplicitTextBlock // DC=String, Text=''
+
+		TreeAssert.VerifyTree(expectedTree, setup.Content, describe: Describe);
+	}
 
 	public static IEnumerable<object[]> GetAlignments()
 	{
@@ -359,6 +463,11 @@ public class Given_ContentPresenter
 			return new(o);
 		}
 	}
+}
+public partial class Given_ContentPresenter
+{
+	private static string GetTextBlockText(FrameworkElement sut, string v)
+		=> (sut.FindName(v) as TextBlock)?.Text ?? "";
 
 	private async Task AssertCollectedReference(WeakReference reference)
 	{


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/ziidms-private#47

## PR Type
What kind of change does this PR introduce?
- Bugfix
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
Using ContentPresenter with Content binding currently lead to compilation error.

## What is the new behavior?
In certain cases where permitted, the compilation error is no longer thrown:
- `{Binding}` without implicit or explicit Path
- `{Binding}` used within a `<ControlTemplate>`
- `{Binding}` used with TemplatedParent or Self as the RelativeSource (it works before this pr as well)

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.