### PR TITLE
fix: align DepObjCol indexer behavior with winui

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_DependencyObjectCollection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_DependencyObjectCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices.ObjectiveC;
 using Microsoft.UI.Xaml;
@@ -27,5 +28,17 @@ public class Given_DependencyObjectCollection
 		c.Add(c);
 
 		Assert.IsTrue(list.SequenceEqual(["One", "Two"]));
+	}
+
+	[TestMethod]
+	public void When_Indexer_Get_IndexOutOfRange()
+	{
+		Assert.IsNull(new DependencyObjectCollection()[int.MaxValue]);
+	}
+
+	[TestMethod]
+	public void When_Indexer_Get_NegativeIndex()
+	{
+		Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DependencyObjectCollection()[-1]);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
@@ -127,7 +127,7 @@ namespace Microsoft.UI.Xaml
 
 		public T this[int index]
 		{
-			get => _list[index];
+			get => index < _list.Count ? _list[index] : default;
 			set
 			{
 				ValidateItem(value);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #19253, closes unoplatform/kahua-private#256

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On Uno, `new BehaviorCollection()[2]` throws:
```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
```

## What is the new behavior?
It will return `null` like on WinUI.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.