### PR TITLE
fix(devSrv): Remove usage of the deprecated RemoteControl.config file

### DIFF
--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -52,27 +52,11 @@
 
 	<Target Name="InjectRemoteControlHost"
 			BeforeTargets="BeforeBuild"
-			Condition="exists('$(IntermediateOutputPath)\RemoteControlHost.config') and '$(BuildingInsideVisualStudio)'!='true'">
+			Condition="exists('$(IntermediateOutputPath)\RemoteControlHost.config') and '$(BuildingInsideVisualStudio)'!='true' and '$(Configuration)'=='Debug'">
 
-		<ItemGroup>
-			<WasmShellMonoEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
-		</ItemGroup>
-
-		<ReadLinesFromFile File="$(IntermediateOutputPath)\RemoteControlHost.config" >
-			<Output TaskParameter="Lines" ItemName="_RemoteControlHostContent"/>
-		</ReadLinesFromFile>
-
-		<ItemGroup>
-			<FileWrites Include="$(IntermediateOutputPath)\RemoteControlHost.config" />
-		</ItemGroup>
-
-		<CreateProperty
-			Value="@(_RemoteControlHostContent)">
-			<Output
-				TaskParameter="Value"
-				PropertyName="UnoRemoteControlHost" />
-		</CreateProperty>
-
+		<Warning
+			Text="The version of uno's extension installed on your IDE is obsolete, please update to the latest version.
+				  If error persists, try to delete obj folder and rebuild your solution." />
 	</Target>
 
 </Project>


### PR DESCRIPTION
linked to https://github.com/unoplatform/uno/issues/19226

## Bugfix
Remove usage of the deprecated RemoteControl.config file

## What is the current behavior?
If a stale `RemoteControl.config` file remaining on the disk, it's being considered by uno an breaks configuration of the dev-server endpoint configuration in the application.

## What is the new behavior?
Files are ignored in new versions of uno.
Note, thanks to https://github.com/unoplatform/uno.vscode/pull/915 files will be deleted by extensions for older versions of uno.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
