### PR TITLE
fix(hr): Fix invalid code gen when using x:bBind on resource

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/0/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Test01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyResource" Color="DeepSkyBlue" />
+	</Page.Resources>
+
+	<Grid>
+		<Border Background="{StaticResource MyResource}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/0/p1/MainPage.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/1/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Test01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyResource" Color="{x:Bind MyColor}" />
+	</Page.Resources>
+
+	<Grid>
+		<Border Background="{StaticResource MyResource}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/1/p1/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public Color MyColor => Colors.DeepPink;
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/0/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Test01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyResource" Color="DeepSkyBlue" />
+	</Page.Resources>
+
+	<Grid>
+		<Border Background="{StaticResource MyResource}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/0/p1/MainPage.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/1/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Test01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyResource" Color="{x:Bind MyColor}" />
+	</Page.Resources>
+
+	<Grid>
+		<Border Background="{StaticResource MyResource}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/1/p1/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public Color MyColor => Colors.DeepPink;
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/2/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/2/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Test01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyResource" Color="DeepSkyBlue" />
+	</Page.Resources>
+
+	<Grid>
+		<Border Background="{StaticResource MyResource}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/2/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/2/p1/MainPage.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Add_Remove/Scenario.json
@@ -1,0 +1,32 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				},
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/0/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Test01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyResource" Color="{x:Bind MyColor}" />
+	</Page.Resources>
+
+	<Grid>
+		<Border Background="{StaticResource MyResource}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/0/p1/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public Color MyColor => Colors.DeepPink;
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/1/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Test01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyResource" Color="DeepSkyBlue" />
+	</Page.Resources>
+
+	<Grid>
+		<Border Background="{StaticResource MyResource}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/1/p1/MainPage.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Remove/Scenario.json
@@ -1,0 +1,26 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"IsCrashingRoslyn": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"IsCrashingRoslyn": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/0/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Test01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyResource" Color="{x:Bind MyColor}" />
+	</Page.Resources>
+
+	<Grid>
+		<Border Background="{StaticResource MyResource}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/0/p1/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public Color MyColor => Colors.DeepPink;
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/1/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Test01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Page.Resources>
+		<SolidColorBrush x:Key="MyResource" Color="{x:Bind MyColor2}" />
+	</Page.Resources>
+
+	<Grid>
+		<Border Background="{StaticResource MyResource}" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/1/p1/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	public Color MyColor2 => Colors.DeepPink;
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Page_Res_xBind_Update/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_MvvmGeneratedMembers.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_MvvmGeneratedMembers.cs
@@ -267,11 +267,11 @@ public class Given_MvvmGeneratedMembers
 		test.ExpectedDiagnostics.AddRange(new[]
 		{
 			// Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\MainPage_d6cd66944958ced0c513e0a04797b51d.cs(75,239): error CS1061: 'MyViewModel' does not contain a definition for 'Name' and no accessible extension method 'Name' accepting a first argument of type 'MyViewModel' could be found (are you missing a using directive or an assembly reference?)
-			DiagnosticResult.CompilerError("CS1061").WithSpan(@"Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\MainPage_d6cd66944958ced0c513e0a04797b51d.cs", 72, 238, 72, 242).WithArguments("TestRepro.MyViewModel", "Name"),
+			DiagnosticResult.CompilerError("CS1061").WithSpan(@"Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\MainPage_d6cd66944958ced0c513e0a04797b51d.cs", 72, 252, 72, 256).WithArguments("TestRepro.MyViewModel", "Name"),
 			// Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\MainPage_d6cd66944958ced0c513e0a04797b51d.cs(97,239): error CS1061: 'MyViewModel' does not contain a definition for 'Name' and no accessible extension method 'Name' accepting a first argument of type 'MyViewModel' could be found (are you missing a using directive or an assembly reference?)
-			DiagnosticResult.CompilerError("CS1061").WithSpan(@"Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\MainPage_d6cd66944958ced0c513e0a04797b51d.cs", 94, 238, 94, 242).WithArguments("TestRepro.MyViewModel", "Name"),
+			DiagnosticResult.CompilerError("CS1061").WithSpan(@"Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\MainPage_d6cd66944958ced0c513e0a04797b51d.cs", 94, 252, 94, 256).WithArguments("TestRepro.MyViewModel", "Name"),
 			// Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\MainPage_d6cd66944958ced0c513e0a04797b51d.cs(119,239): error CS1061: 'MyViewModel' does not contain a definition for 'Name' and no accessible extension method 'Name' accepting a first argument of type 'MyViewModel' could be found (are you missing a using directive or an assembly reference?)
-			DiagnosticResult.CompilerError("CS1061").WithSpan(@"Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\MainPage_d6cd66944958ced0c513e0a04797b51d.cs", 116, 238, 116, 242).WithArguments("TestRepro.MyViewModel", "Name"),
+			DiagnosticResult.CompilerError("CS1061").WithSpan(@"Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator\MainPage_d6cd66944958ced0c513e0a04797b51d.cs", 116, 252, 116, 256).WithArguments("TestRepro.MyViewModel", "Name"),
 		});
 
 		await test.RunAsync();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TAA/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TAA/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -69,7 +69,7 @@ namespace TestRepro
 						{
 							Mode = BindingMode.OneTime,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime MyArray.Length*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), null ))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime MyArray.Length*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), null ))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIDFA/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIDFA/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -69,7 +69,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.TwoWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime MyFooInterface.Name*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.MyFooInterface.Name)) : (false, default), (___ctx, __value) => { if(___ctx is global::TestRepro.MainPage ___tctx) ___tctx.MyFooInterface.Name = (string)global::Microsoft.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof(string), __value); } , new [] {"MyFooInterface.Name"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime MyFooInterface.Name*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.MyFooInterface.Name)) : (false, default), (___ctx, __value) => { if(___ctx is global::TestRepro.MainPage ___tctx) ___tctx.MyFooInterface.Name = (string)global::Microsoft.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof(string), __value); } , new [] {"MyFooInterface.Name"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TPXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TPXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -94,7 +94,7 @@ namespace TestRepro
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.OneWay,
 							Converter = (global::Microsoft.UI.Xaml.Data.IValueConverter)global::Uno.UI.ResourceResolverSingleton.Instance.ResolveResourceStatic("NullableBoolConverter", typeof(global::Microsoft.UI.Xaml.Data.IValueConverter), context: global::MyProject.GlobalStaticResources.__ParseContext_),
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ToggleLoad.IsChecked*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ToggleLoad.IsChecked)) : (false, default), null , new [] {"ToggleLoad.IsChecked"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ToggleLoad.IsChecked*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ToggleLoad.IsChecked)) : (false, default), null , new [] {"ToggleLoad.IsChecked"}))
 					);
 					__that._component_1 = __p1;
 					var _component_1_update_That = (this as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;
@@ -148,7 +148,7 @@ namespace TestRepro
 						{
 							Mode = BindingMode.OneTime,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime */ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___ctx)) : (false, default), null ))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime */ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___ctx)) : (false, default), null ))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -168,7 +168,7 @@ namespace TestRepro
 						{
 							Mode = BindingMode.OneTime,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime IsLoaded*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), null ))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime IsLoaded*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), null ))
 					);
 					__that._component_1 = __p1;
 					var _component_1_update_That = (this as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTW/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTW/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -69,7 +69,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.TwoWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.P*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), (___ctx, __value) => { if(___ctx is global::TestRepro.MainPage ___tctx) TrySetInstance_xBind_1(___tctx, __value); } , new [] {"ViewModel.P"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.P*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), (___ctx, __value) => { if(___ctx is global::TestRepro.MainPage ___tctx) TrySetInstance_xBind_1(___tctx, __value); } , new [] {"ViewModel.P"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -94,7 +94,7 @@ namespace TestRepro
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.OneWay,
 							Converter = (global::Microsoft.UI.Xaml.Data.IValueConverter)global::Uno.UI.ResourceResolverSingleton.Instance.ResolveResourceStatic("NullableBoolConverter", typeof(global::Microsoft.UI.Xaml.Data.IValueConverter), context: global::MyProject.GlobalStaticResources.__ParseContext_),
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ToggleLoad.IsChecked*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ToggleLoad.IsChecked)) : (false, default), null , new [] {"ToggleLoad.IsChecked"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ToggleLoad.IsChecked*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ToggleLoad.IsChecked)) : (false, default), null , new [] {"ToggleLoad.IsChecked"}))
 					);
 					__that._component_1 = __p1;
 					var _component_1_update_That = (this as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;
@@ -149,7 +149,7 @@ namespace TestRepro
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.OneWay,
 							Converter = (global::Microsoft.UI.Xaml.Data.IValueConverter)global::Uno.UI.ResourceResolverSingleton.Instance.ResolveResourceStatic("NullableBoolConverter", typeof(global::Microsoft.UI.Xaml.Data.IValueConverter), context: global::MyProject.GlobalStaticResources.__ParseContext_),
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime LoadElement.IsChecked*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.LoadElement.IsChecked)) : (false, default), null , new [] {"LoadElement.IsChecked"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime LoadElement.IsChecked*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.LoadElement.IsChecked)) : (false, default), null , new [] {"LoadElement.IsChecked"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBOP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBOP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -71,7 +71,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.TwoWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.IsEnabled*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.IsEnabled)) : (false, default), (___ctx, __value) => { if(___ctx is global::TestRepro.MainPage ___tctx) ___tctx.ViewModel.IsEnabled = (bool)global::Microsoft.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof(bool), __value); } , new [] {"ViewModel.IsEnabled"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.IsEnabled*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.IsEnabled)) : (false, default), (___ctx, __value) => { if(___ctx is global::TestRepro.MainPage ___tctx) ___tctx.ViewModel.IsEnabled = (bool)global::Microsoft.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof(bool), __value); } , new [] {"ViewModel.IsEnabled"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WLCHB/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WLCHB/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -74,7 +74,7 @@ namespace TestRepro
 					{
 						Mode = global::Microsoft.UI.Xaml.Data.BindingMode.OneWay,
 					}
-						.BindingApply(___b =>  /*defaultBindModeOneTime InnerText*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), null , new [] {"InnerText"}))
+						.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime InnerText*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? (TryGetInstance_xBind_1(___tctx, out var bindResult1) ? (true, bindResult1) : (false, default)) : (false, default), null , new [] {"InnerText"}))
 				);
 				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 				__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNBOP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNBOP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -71,7 +71,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.TwoWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.SubModel.IsEnabled*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.SubModel.IsEnabled)) : (false, default), (___ctx, __value) => { if(___ctx is global::TestRepro.MainPage ___tctx) ___tctx.ViewModel.SubModel.IsEnabled = (bool)global::Microsoft.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof(bool), __value); } , new [] {"ViewModel.SubModel.IsEnabled"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.SubModel.IsEnabled*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.SubModel.IsEnabled)) : (false, default), (___ctx, __value) => { if(___ctx is global::TestRepro.MainPage ___tctx) ___tctx.ViewModel.SubModel.IsEnabled = (bool)global::Microsoft.UI.Xaml.Markup.XamlBindingHelper.ConvertValue(typeof(bool), __value); } , new [] {"ViewModel.SubModel.IsEnabled"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPADNE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPADNE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -69,7 +69,7 @@ namespace TestRepro
 						{
 							Mode = BindingMode.OneTime,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null ))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null ))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
@@ -91,7 +91,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.OneWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null , new [] {"ViewModel.Name"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null , new [] {"ViewModel.Name"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
@@ -113,7 +113,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.TwoWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), (___tctx, __value) => ViewModel.MyBindBack((string)__value) , new [] {"ViewModel.Name"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), (___tctx, __value) => ViewModel.MyBindBack((string)__value) , new [] {"ViewModel.Name"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE__name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE__name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -69,7 +69,7 @@ namespace TestRepro
 						{
 							Mode = BindingMode.OneTime,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null ))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null ))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
@@ -91,7 +91,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.OneWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null , new [] {"ViewModel.Name"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null , new [] {"ViewModel.Name"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
@@ -113,7 +113,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.TwoWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), (___tctx, __value) => ViewModel.MyBindBack((string)__value) , new [] {"ViewModel.Name"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), (___tctx, __value) => ViewModel.MyBindBack((string)__value) , new [] {"ViewModel.Name"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE_m_name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE_m_name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -69,7 +69,7 @@ namespace TestRepro
 						{
 							Mode = BindingMode.OneTime,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null ))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null ))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
@@ -91,7 +91,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.OneWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null , new [] {"ViewModel.Name"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null , new [] {"ViewModel.Name"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
@@ -113,7 +113,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.TwoWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), (___tctx, __value) => ViewModel.MyBindBack((string)__value) , new [] {"ViewModel.Name"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), (___tctx, __value) => ViewModel.MyBindBack((string)__value) , new [] {"ViewModel.Name"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE_name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE_name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -69,7 +69,7 @@ namespace TestRepro
 						{
 							Mode = BindingMode.OneTime,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null ))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null ))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
@@ -91,7 +91,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.OneWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null , new [] {"ViewModel.Name"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), null , new [] {"ViewModel.Name"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
@@ -113,7 +113,7 @@ namespace TestRepro
 						{
 							Mode = global::Microsoft.UI.Xaml.Data.BindingMode.TwoWay,
 						}
-							.BindingApply(___b =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, __that, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), (___tctx, __value) => ViewModel.MyBindBack((string)__value) , new [] {"ViewModel.Name"}))
+							.BindingApply(__that, (___b, ___t) =>  /*defaultBindModeOneTime ViewModel.Name.ToUpper()*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => ___ctx is global::TestRepro.MainPage ___tctx ? ((true, ___tctx.ViewModel.Name.ToUpper())) : (false, default), (___tctx, __value) => ViewModel.MyBindBack((string)__value) , new [] {"ViewModel.Name"}))
 					);
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3082,7 +3082,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 						extractionTargetMembers = _uiAutomationMappings
 							?.FirstOrDefault(m => _metadataHelper.FindTypeByFullName(m.Key) is INamedTypeSymbol mappingKeySymbol && (IsType(objectDefinitionType, mappingKeySymbol) || IsImplementingInterface(objectDefinitionType, mappingKeySymbol)))
 							.Value
-							?.ToArray() ?? Array.Empty<string>();
+							?.ToArray() ?? [];
 					}
 
 					if (hasChildrenWithPhase)
@@ -4265,12 +4265,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var modeMember = bindNode.Members.FirstOrDefault(m => m.Member.Name == "Mode")?.Value?.ToString() ?? GetDefaultBindMode();
 			var rawBindBack = bindNode.Members.FirstOrDefault(m => m.Member.Name == "BindBack")?.Value?.ToString();
 
-			var sourceInstance = CurrentResourceOwner is not null ? CurrentResourceOwnerName : "__that";
-
-			var applyBindingParameters = _isHotReloadEnabled
-				? $"{sourceInstance}, (___b, __that)"
-				: "___b";
-
 			if (isInsideDataTemplate)
 			{
 				var dataTypeObject = FindMember(dataTemplateObject!, "DataType", XamlConstants.XamlXmlNamespace);
@@ -4346,7 +4340,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					}
 				}
 
-				return $".BindingApply({applyBindingParameters} => /*defaultBindMode{GetDefaultBindMode()}*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, null, ___ctx => ___ctx is {GetType(dataType).GetFullyQualifiedTypeIncludingGlobal()} ___tctx ? ({contextFunction.Expression}) : (false, default), {buildBindBack()} {pathsArray}))";
+				return $".BindingApply(___b => /*defaultBindMode{GetDefaultBindMode()}*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, null, ___ctx => ___ctx is {GetType(dataType).GetFullyQualifiedTypeIncludingGlobal()} ___tctx ? ({contextFunction.Expression}) : (false, default), {buildBindBack()} {pathsArray}))";
 			}
 			else
 			{
@@ -4433,7 +4427,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					? ", new [] {" + string.Join(", ", formattedPaths) + "}"
 					: "";
 
-				return $".BindingApply({applyBindingParameters} =>  /*defaultBindMode{GetDefaultBindMode()} {rawFunction}*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, {sourceInstance}, ___ctx => {bindFunction}, {buildBindBack()} {pathsArray}))";
+				return $".BindingApply(__that, (___b, ___t) =>  /*defaultBindMode{GetDefaultBindMode()} {rawFunction}*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => {bindFunction}, {buildBindBack()} {pathsArray}))";
 			}
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4265,6 +4265,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var modeMember = bindNode.Members.FirstOrDefault(m => m.Member.Name == "Mode")?.Value?.ToString() ?? GetDefaultBindMode();
 			var rawBindBack = bindNode.Members.FirstOrDefault(m => m.Member.Name == "BindBack")?.Value?.ToString();
 
+			var sourceInstance = CurrentResourceOwner switch
+			{
+				null => "__that",
+				_ when _scopeStack is { Count: 1 } => "__that",
+				var owner => "__that." + owner
+			};
+
 			if (isInsideDataTemplate)
 			{
 				var dataTypeObject = FindMember(dataTemplateObject!, "DataType", XamlConstants.XamlXmlNamespace);
@@ -4427,7 +4434,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					? ", new [] {" + string.Join(", ", formattedPaths) + "}"
 					: "";
 
-				return $".BindingApply(__that, (___b, ___t) =>  /*defaultBindMode{GetDefaultBindMode()} {rawFunction}*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => {bindFunction}, {buildBindBack()} {pathsArray}))";
+				return $".BindingApply({sourceInstance}, (___b, ___t) =>  /*defaultBindMode{GetDefaultBindMode()} {rawFunction}*/ global::Uno.UI.Xaml.BindingHelper.SetBindingXBindProvider(___b, ___t, ___ctx => {bindFunction}, {buildBindBack()} {pathsArray}))";
 			}
 		}
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
Fix invalid code gen when using x:bBind on resource

## What is the current behavior?
When using x:Bind on a resource (out of a DataTemplate), gen'ed code does not compile

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
