### PR TITLE
Refactor: Use static Lazy instance for all sensors

### DIFF
--- a/src/Uno.UWP/Devices/Sensors/Accelerometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Accelerometer.Android.cs
@@ -27,7 +27,7 @@ namespace Windows.Devices.Sensors
 					return;
 				}
 
-				lock (_syncLock)
+				lock (_readingChangedWrapper.SyncLock)
 				{
 					_reportInterval = value;
 

--- a/src/Uno.UWP/Devices/Sensors/Accelerometer.iOS.cs
+++ b/src/Uno.UWP/Devices/Sensors/Accelerometer.iOS.cs
@@ -40,7 +40,7 @@ namespace Windows.Devices.Sensors
 
 		internal static void HandleShake()
 		{
-			_instance?.OnShaken(DateTimeOffset.UtcNow);
+			_instance.Value?.OnShaken(DateTimeOffset.UtcNow);
 		}
 
 		private static Accelerometer? TryCreateInstance()

--- a/src/Uno.UWP/Devices/Sensors/Accelerometer.wasm.cs
+++ b/src/Uno.UWP/Devices/Sensors/Accelerometer.wasm.cs
@@ -83,22 +83,22 @@ namespace Windows.Devices.Sensors
 		/// <returns>0 - needed to bind method from WASM</returns>
 		internal static int DispatchReading(float x, float y, float z)
 		{
-			if (_instance == null)
+			if (_instance.Value == null)
 			{
 				throw new InvalidOperationException("Accelerometer:DispatchReading can be called only after Accelerometer is initialized");
 			}
 			var now = DateTimeOffset.UtcNow;
-			if ((now - _instance._lastReading).TotalMilliseconds >= _instance.ReportInterval * 0.8)
+			if ((now - _instance.Value._lastReading).TotalMilliseconds >= _instance.Value.ReportInterval * 0.8)
 			{
-				_instance._lastReading = now;
-				_instance.OnReadingChanged(
+				_instance.Value._lastReading = now;
+				_instance.Value.OnReadingChanged(
 					new AccelerometerReading(
 						x / Gravity * -1,
 						y / Gravity * -1,
 						z / Gravity * -1,
 						now));
 			}
-			_instance._shakeDetector?.OnSensorChanged(x, y, z, DateTimeOffset.UtcNow);
+			_instance.Value._shakeDetector?.OnSensorChanged(x, y, z, DateTimeOffset.UtcNow);
 			return 0;
 		}
 	}

--- a/src/Uno.UWP/Devices/Sensors/Barometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Barometer.Android.cs
@@ -26,7 +26,7 @@ namespace Windows.Devices.Sensors
 					return;
 				}
 
-				lock (_syncLock)
+				lock (_readingChangedWrapper.SyncLock)
 				{
 					_reportInterval = value;
 

--- a/src/Uno.UWP/Devices/Sensors/Barometer.cs
+++ b/src/Uno.UWP/Devices/Sensors/Barometer.cs
@@ -1,5 +1,7 @@
 #if __ANDROID__ || __IOS__
+#nullable enable
 
+using System;
 using Uno.Helpers;
 using Windows.Foundation;
 
@@ -10,10 +12,7 @@ namespace Windows.Devices.Sensors
 	/// </summary>
 	public partial class Barometer
 	{
-		private static readonly object _syncLock = new();
-
-		private static bool _initializationAttempted;
-		private static Barometer _instance;
+		private readonly static Lazy<Barometer?> _instance = new Lazy<Barometer?>(() => TryCreateInstance());
 
 		private readonly StartStopTypedEventWrapper<Barometer, BarometerReadingChangedEventArgs> _readingChangedWrapper;
 
@@ -24,30 +23,14 @@ namespace Windows.Devices.Sensors
 		{
 			_readingChangedWrapper = new StartStopTypedEventWrapper<Barometer, BarometerReadingChangedEventArgs>(
 				() => StartReading(),
-				() => StopReading(),
-				_syncLock);
+				() => StopReading());
 		}
 
 		/// <summary>
 		/// Returns the default barometer sensor.
 		/// </summary>
 		/// <returns>If no barometer sensor is available, this method will return null.</returns>
-		public static Barometer GetDefault()
-		{
-			if (_initializationAttempted)
-			{
-				return _instance;
-			}
-			lock (_syncLock)
-			{
-				if (!_initializationAttempted)
-				{
-					_instance = TryCreateInstance();
-					_initializationAttempted = true;
-				}
-				return _instance;
-			}
-		}
+		public static Barometer? GetDefault() => _instance.Value;
 
 		/// <summary>
 		/// Occurs each time the barometer reports a new sensor reading.

--- a/src/Uno.UWP/Devices/Sensors/Compass.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Compass.Android.cs
@@ -27,7 +27,7 @@ public partial class Compass
 		get => _reportInterval;
 		set
 		{
-			lock (_syncLock)
+			lock (_readingChangedWrapper.SyncLock)
 			{
 				if (_reportInterval == value)
 				{

--- a/src/Uno.UWP/Devices/Sensors/Compass.cs
+++ b/src/Uno.UWP/Devices/Sensors/Compass.cs
@@ -1,4 +1,7 @@
 #if __IOS__ || __ANDROID__ || __WASM__
+#nullable enable
+
+using System;
 using Uno.Helpers;
 using Windows.Foundation;
 
@@ -10,10 +13,7 @@ namespace Windows.Devices.Sensors;
 /// </summary>
 public partial class Compass
 {
-	private readonly static object _syncLock = new();
-
-	private static Compass _instance;
-	private static bool _initializationAttempted;
+	private readonly static Lazy<Compass?> _instance = new Lazy<Compass?>(() => TryCreateInstance());
 
 	private readonly StartStopTypedEventWrapper<Compass, CompassReadingChangedEventArgs> _readingChangedWrapper;
 
@@ -24,30 +24,14 @@ public partial class Compass
 	{
 		_readingChangedWrapper = new StartStopTypedEventWrapper<Compass, CompassReadingChangedEventArgs>(
 			() => StartReadingChanged(),
-			() => StopReadingChanged(),
-			_syncLock);
+			() => StopReadingChanged());
 	}
 
 	/// <summary>
 	/// Returns the default compass.
 	/// </summary>
 	/// <returns>The default compass or null if no integrated compasses are found.</returns>
-	public static Compass GetDefault()
-	{
-		if (_initializationAttempted)
-		{
-			return _instance;
-		}
-		lock (_syncLock)
-		{
-			if (!_initializationAttempted)
-			{
-				_instance = TryCreateInstance();
-				_initializationAttempted = true;
-			}
-			return _instance;
-		}
-	}
+	public static Compass? GetDefault() => _instance.Value;
 
 	/// <summary>
 	/// Occurs each time the compass reports a new sensor reading.

--- a/src/Uno.UWP/Devices/Sensors/Compass.wasm.cs
+++ b/src/Uno.UWP/Devices/Sensors/Compass.wasm.cs
@@ -28,7 +28,7 @@ public partial class Compass
 				return;
 			}
 
-			lock (_syncLock)
+			lock (_readingChangedWrapper.SyncLock)
 			{
 				_reportInterval = value;
 

--- a/src/Uno.UWP/Devices/Sensors/Gyrometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Gyrometer.Android.cs
@@ -27,7 +27,7 @@ namespace Windows.Devices.Sensors
 					return;
 				}
 
-				lock (_syncLock)
+				lock (_readingChangedWrapper.SyncLock)
 				{
 					_reportInterval = value;
 

--- a/src/Uno.UWP/Devices/Sensors/Gyrometer.cs
+++ b/src/Uno.UWP/Devices/Sensors/Gyrometer.cs
@@ -1,4 +1,7 @@
 #if __IOS__ || __ANDROID__ || __WASM__
+#nullable enable
+
+using System;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.Helpers;
@@ -11,10 +14,7 @@ namespace Windows.Devices.Sensors
 	/// </summary>
 	public partial class Gyrometer
 	{
-		private readonly static object _syncLock = new();
-
-		private static Gyrometer _instance;
-		private static bool _initializationAttempted;
+		private readonly static Lazy<Gyrometer?> _instance = new Lazy<Gyrometer?>(() => TryCreateInstance());
 
 		private readonly StartStopTypedEventWrapper<Gyrometer, GyrometerReadingChangedEventArgs> _readingChangedWrapper;
 
@@ -25,30 +25,14 @@ namespace Windows.Devices.Sensors
 		{
 			_readingChangedWrapper = new StartStopTypedEventWrapper<Gyrometer, GyrometerReadingChangedEventArgs>(
 				() => StartReading(),
-				() => StopReading(),
-				_syncLock);
+				() => StopReading());
 		}
 
 		/// <summary>
 		/// Returns the default gyrometer.
 		/// </summary>
 		/// <returns>Null if no integrated gyrometers are found.</returns>
-		public static Gyrometer GetDefault()
-		{
-			if (_initializationAttempted)
-			{
-				return _instance;
-			}
-			lock (_syncLock)
-			{
-				if (!_initializationAttempted)
-				{
-					_instance = TryCreateInstance();
-					_initializationAttempted = true;
-				}
-				return _instance;
-			}
-		}
+		public static Gyrometer? GetDefault() => _instance.Value;
 
 		/// <summary>
 		/// Occurs each time the gyrometer reports the current sensor reading.

--- a/src/Uno.UWP/Devices/Sensors/Gyrometer.wasm.cs
+++ b/src/Uno.UWP/Devices/Sensors/Gyrometer.wasm.cs
@@ -47,15 +47,15 @@ namespace Windows.Devices.Sensors
 		[JSExport]
 		internal static int DispatchReading(float x, float y, float z)
 		{
-			if (_instance == null)
+			if (_instance.Value == null)
 			{
 				throw new InvalidOperationException("Gyrometer:DispatchReading can be called only after Gyrometer is initialized");
 			}
 			var now = DateTimeOffset.UtcNow;
-			if ((now - _instance._lastReading).TotalMilliseconds >= _instance.ReportInterval * 0.8)
+			if ((now - _instance.Value._lastReading).TotalMilliseconds >= _instance.Value.ReportInterval * 0.8)
 			{
-				_instance._lastReading = now;
-				_instance.OnReadingChanged(
+				_instance.Value._lastReading = now;
+				_instance.Value.OnReadingChanged(
 					new GyrometerReading(
 						x * SensorConstants.RadToDeg,
 						y * SensorConstants.RadToDeg,

--- a/src/Uno.UWP/Devices/Sensors/Magnetometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Magnetometer.Android.cs
@@ -27,7 +27,7 @@ namespace Windows.Devices.Sensors
 					return;
 				}
 
-				lock (_syncLock)
+				lock (_readingChangedWrapper.SyncLock)
 				{
 					_reportInterval = value;
 

--- a/src/Uno.UWP/Devices/Sensors/Magnetometer.cs
+++ b/src/Uno.UWP/Devices/Sensors/Magnetometer.cs
@@ -1,4 +1,6 @@
 ﻿#if __IOS__ || __ANDROID__ || __WASM__
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,10 +16,7 @@ namespace Windows.Devices.Sensors
 	/// </summary>
 	public partial class Magnetometer
 	{
-		private readonly static object _syncLock = new();
-
-		private static Magnetometer _instance;
-		private static bool _initializationAttempted;
+		private readonly static Lazy<Magnetometer?> _instance = new Lazy<Magnetometer?>(() => TryCreateInstance());
 
 		private readonly StartStopTypedEventWrapper<Magnetometer, MagnetometerReadingChangedEventArgs> _readingChangedWrapper;
 
@@ -28,30 +27,14 @@ namespace Windows.Devices.Sensors
 		{
 			_readingChangedWrapper = new StartStopTypedEventWrapper<Magnetometer, MagnetometerReadingChangedEventArgs>(
 				() => StartReading(),
-				() => StopReading(),
-				_syncLock);
+				() => StopReading());
 		}
 
 		/// <summary>
 		/// Returns the default magnetometer.
 		/// </summary>
 		/// <returns>The default magnetometer.</returns>
-		public static Magnetometer GetDefault()
-		{
-			if (_initializationAttempted)
-			{
-				return _instance;
-			}
-			lock (_syncLock)
-			{
-				if (!_initializationAttempted)
-				{
-					_instance = TryCreateInstance();
-					_initializationAttempted = true;
-				}
-				return _instance;
-			}
-		}
+		public static Magnetometer? GetDefault() => _instance.Value;
 
 		/// <summary>
 		/// Occurs each time the compass reports a new sensor reading.

--- a/src/Uno.UWP/Devices/Sensors/Magnetometer.wasm.cs
+++ b/src/Uno.UWP/Devices/Sensors/Magnetometer.wasm.cs
@@ -47,15 +47,15 @@ namespace Windows.Devices.Sensors
 		[JSExport]
 		internal static int DispatchReading(float x, float y, float z)
 		{
-			if (_instance == null)
+			if (_instance.Value == null)
 			{
 				throw new InvalidOperationException("Magnetometer:DispatchReading can be called only after Magnetometer is initialized");
 			}
 			var now = DateTimeOffset.UtcNow;
-			if ((now - _instance._lastReading).TotalMilliseconds >= _instance.ReportInterval * 0.8)
+			if ((now - _instance.Value._lastReading).TotalMilliseconds >= _instance.Value.ReportInterval * 0.8)
 			{
-				_instance._lastReading = now;
-				_instance.OnReadingChanged(
+				_instance.Value._lastReading = now;
+				_instance.Value.OnReadingChanged(
 					new MagnetometerReading(
 						x,
 						y,

--- a/src/Uno.UWP/Devices/Sensors/Pedometer.Android.cs
+++ b/src/Uno.UWP/Devices/Sensors/Pedometer.Android.cs
@@ -26,7 +26,7 @@ namespace Windows.Devices.Sensors
 					return;
 				}
 
-				lock (_syncLock)
+				lock (_readingChangedWrapper.SyncLock)
 				{
 					_reportInterval = value;
 

--- a/src/Uno.UWP/Devices/Sensors/SimpleOrientationSensor.cs
+++ b/src/Uno.UWP/Devices/Sensors/SimpleOrientationSensor.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Windows.UI.Core;
 using Windows.Foundation;
@@ -10,9 +12,7 @@ namespace Windows.Devices.Sensors
 		private readonly StartStopTypedEventWrapper<SimpleOrientationSensor, SimpleOrientationSensorOrientationChangedEventArgs> _orientationChangedWrapper;
 
 		#region Static
-		private static SimpleOrientationSensor _instance;
-		private static bool _initialized;
-		private readonly static object _syncLock = new();
+		private readonly static Lazy<SimpleOrientationSensor?> _instance = new Lazy<SimpleOrientationSensor?>(() => TryCreateInstance());
 
 		/// <summary>
 		/// Gets the default simple orientation sensor.
@@ -20,26 +20,9 @@ namespace Windows.Devices.Sensors
 		/// <returns>
 		/// The default simple orientation sensor or null if no simple orientation sensors are found.
 		/// </returns>
-		public static SimpleOrientationSensor GetDefault()
-		{
-			if (_initialized)
-			{
-				return _instance;
-			}
+		public static SimpleOrientationSensor? GetDefault() => _instance.Value;
 
-			lock (_syncLock)
-			{
-				if (!_initialized)
-				{
-					_instance = TryCreateInstance();
-					_initialized = true;
-				}
-
-				return _instance;
-			}
-		}
-
-		private static partial SimpleOrientationSensor TryCreateInstance();
+		private static partial SimpleOrientationSensor? TryCreateInstance();
 		#endregion
 
 		partial void StartListeningOrientationChanged();
@@ -57,8 +40,7 @@ namespace Windows.Devices.Sensors
 		{
 			_orientationChangedWrapper = new StartStopTypedEventWrapper<SimpleOrientationSensor, SimpleOrientationSensorOrientationChangedEventArgs>(
 				() => StartListeningOrientationChanged(),
-				() => StopListeningOrientationChanged(),
-				_syncLock);
+				() => StopListeningOrientationChanged());
 
 			Initialize();
 		}
@@ -69,7 +51,7 @@ namespace Windows.Devices.Sensors
 		/// Gets the device identifier.
 		/// </summary>
 		[Uno.NotImplemented]
-		public string DeviceId { get; }
+		public string DeviceId { get; } = string.Empty;
 
 		/// <summary>
 		/// Gets or sets the transformation that needs to be applied to sensor data. Transformations to be applied are tied to the display orientation with which to align the sensor data.


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/19274

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Most sensor classes use a static instance and track with an boolean if the instance is already created. This caused code duplication and wasn't implemented like the `LightSensor.cs` implementation.

## What is the new behavior?

Use a static `Lazy` instance for instance creation, which removes the object lock, as well as the boolean. This follows the implementation already in `LightSensor.cs`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
