### PR TITLE
fix(hr): Update HR conditions

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Agent.cs
@@ -90,20 +90,10 @@ namespace Uno.UI.RemoteControl.HotReload
 				|| (!Debugger.IsAttached && !buildingInsideVisualStudio && isSkia)
 
 				// Mono Debugger under VS Win already handles metadata updates
-				// Mono Debugger under VS Code prevents metadata based hot reload
+				// Mono Debugger under VS Code & Rider prevents metadata based hot reload
 				|| (!Debugger.IsAttached && !buildingInsideVisualStudio && isWasm)
-
-				// Disabled until https://github.com/dotnet/runtime/issues/93860 is fixed
-				//
-				//||
-				//(
-				//	buildingInsideVisualStudio.Equals("true", StringComparison.OrdinalIgnoreCase)
-				//	&& (
-				//		// As of VS 17.8, when the debugger is not attached, mobile targets can use
-				//		// DevServer's hotreload workspace, as visual studio does not enable it on its own.
-				//		(!Debugger.IsAttached
-				//			&& (targetFramework.Contains("-android") || targetFramework.Contains("-ios")))))
-				;
+				|| (!Debugger.IsAttached && !buildingInsideVisualStudio && OperatingSystem.IsAndroid())
+				|| (!Debugger.IsAttached && !buildingInsideVisualStudio && OperatingSystem.IsIOS());
 
 			var vsEnabled = isForcedMetadata
 				|| (buildingInsideVisualStudio && isSkia)


### PR DESCRIPTION
## Bugfix
Update HR conditions

## What is the current behavior?
HR w/o cnomua is flagged as not enabled on VS code and Rider

## What is the new behavior?
HR is enabled properly

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
