### PR TITLE
fix(hr): Dev-server HR support for mobile targets

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -295,6 +295,7 @@
 		<XmlPoke XmlInputPath=".\nuget\Uno.WinUI.nuspec" Query="/x:package/x:files/x:file[@target='buildTransitive\net8.0-windows\uno.winui.targets']/@target" Value="buildTransitive\net8.0-windows\$(PackageNamePrefix).targets" Namespaces="$(NugetNamespace)" Condition="'$(UNO_UWP_BUILD)'=='true'"/>
 
 		<!-- remote control -->
+		<Move SourceFiles="..\src\Uno.UI.RemoteControl\buildTransitive\Uno.WinUI.DevServer.props" DestinationFiles="..\src\Uno.UI.RemoteControl\buildTransitive\$(PackageNamePrefix).DevServer.props" Condition="'$(UNO_UWP_BUILD)'=='true'"/>
 		<Move SourceFiles="..\src\Uno.UI.RemoteControl\buildTransitive\Uno.WinUI.DevServer.targets" DestinationFiles="..\src\Uno.UI.RemoteControl\buildTransitive\$(PackageNamePrefix).DevServer.targets" Condition="'$(UNO_UWP_BUILD)'=='true'"/>
 
 		<!-- Lottie move file -->

--- a/build/nuget/Uno.WinUI.DevServer.nuspec
+++ b/build/nuget/Uno.WinUI.DevServer.nuspec
@@ -159,6 +159,7 @@
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net8.0\*.pdb" target="tools\rc\processors\net8.0" />
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net9.0\*.dll" target="tools\rc\processors\net9.0" />
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net9.0\*.pdb" target="tools\rc\processors\net9.0" />
+		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net9.0\BuildHost-netcore\**" target="tools\rc\processors\net9.0\BuildHost-netcore" />
 
 		<!-- Build targets -->
 		<file src="..\..\src\Uno.UI.RemoteControl\buildTransitive\*" target="buildTransitive" />

--- a/build/nuget/Uno.WinUI.DevServer.nuspec
+++ b/build/nuget/Uno.WinUI.DevServer.nuspec
@@ -21,7 +21,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
@@ -30,7 +30,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
@@ -39,7 +39,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
@@ -48,7 +48,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
@@ -57,7 +57,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
@@ -66,7 +66,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
@@ -75,7 +75,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
@@ -84,7 +84,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
@@ -93,7 +93,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Uno.Wasm.WebSockets" version="1.1.0" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
@@ -103,7 +103,7 @@
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Uno.Wasm.WebSockets" version="1.1.0" />
 				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>

--- a/build/nuget/Uno.WinUI.Lottie.nuspec
+++ b/build/nuget/Uno.WinUI.Lottie.nuspec
@@ -37,7 +37,7 @@
 				<dependency id="SkiaSharp.NativeAssets.android" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 			</group>
 			<group targetFramework="net8.0-ios17.0">
 				<dependency id="SkiaSharp.Skottie" version="2.88.7" />
@@ -70,7 +70,7 @@
 				<dependency id="SkiaSharp.NativeAssets.android" version="2.88.7" />
 
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Newtonsoft.Json" version="13.0.2" />
+				<dependency id="Newtonsoft.Json" version="13.0.3" />
 			</group>
 			<group targetFramework="net9.0-ios18.0">
 				<dependency id="SkiaSharp.Skottie" version="2.88.7" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -147,7 +147,7 @@
 		<PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" />
 		<PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" />
 		<PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" />
-		<PackageReference Update="Newtonsoft.Json" Version="13.0.2" />
+		<PackageReference Update="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Update="CommunityToolkit.Mvvm" Version="$(CommunityToolkitMvvmVersion)" />
 		<PackageReference Update="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 		<PackageReference Update="Microsoft.Web.WebView2" Version="1.0.2592.51" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -72,7 +72,7 @@
 		<CompilerVisibleProperty Include="UnoRemoteControlHost" />
 		<CompilerVisibleProperty Include="UnoRemoteControlProcessorsPath" />
 		<CompilerVisibleProperty Include="UnoRemoteControlConfigCookie" />
-		<CompilerVisibleProperty Include="UnoEnCLogPath" />
+		<CompilerVisibleProperty Include="UnoHotReloadDiagnosticsLogPath" />
 		<CompilerVisibleProperty Include="UnoDisableBindableTypeProvidersGeneration" />
 		<CompilerVisibleProperty Include="ShouldWriteErrorOnInvalidXaml" />
 		<CompilerVisibleProperty Include="IsUiAutomationMappingEnabled" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
@@ -45,6 +45,7 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 			"VSIDEResolvedNonMSBuildProjectOutputs",
 			"DevEnvDir",
 			"MSBuildVersion",
+			"UnoHotReloadDiagnosticsLogPath",
 		};
 
 		public void Initialize(GeneratorInitializationContext context)

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -191,35 +191,6 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 					return null;
 				}
 
-				// Lookup for the highest version matching assembly in the current app domain.
-				// There may be an existing one that already matches, even though the
-				// fusion loader did not find an exact match.
-				var loadedAsm = (
-									from asm in AppDomain.CurrentDomain.GetAssemblies()
-									where asm.GetName().Name == assembly.Name
-									orderby asm.GetName().Version descending
-									select asm
-								).ToArray();
-
-				if (loadedAsm.Length > 1)
-				{
-					var duplicates = loadedAsm
-						.Skip(1)
-						.Where(a => a.GetName().Version == loadedAsm[0].GetName().Version)
-						.ToArray();
-
-					if (duplicates.Length != 0)
-					{
-						Console.WriteLine($"Selecting first occurrence of assembly [{name}] which can be found at [{duplicates.Select(d => d.Location).JoinBy("; ")}]");
-					}
-
-					return loadedAsm[0];
-				}
-				else if (loadedAsm.Length == 1)
-				{
-					return loadedAsm[0];
-				}
-
 				Assembly? LoadAssembly(string filePath)
 				{
 					if (File.Exists(filePath))

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -31,7 +31,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 				// https://github.com/dotnet/roslyn/blob/fc6e0c25277ff440ca7ded842ac60278ee6c9695/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs#L72
 				Environment.SetEnvironmentVariable("Microsoft_CodeAnalysis_EditAndContinue_LogDir", logPath);
 
-                // Unconditionally enable binlog generation in msbuild. See https://github.com/dotnet/project-system/blob/4210ce79cfd35154dbd858f056bfb9101f290e69/docs/design-time-builds.md?L61
+				// Unconditionally enable binlog generation in msbuild. See https://github.com/dotnet/project-system/blob/4210ce79cfd35154dbd858f056bfb9101f290e69/docs/design-time-builds.md?L61
 				Environment.SetEnvironmentVariable("MSBUILDDEBUGENGINE", "1");
 				Environment.SetEnvironmentVariable("MSBUILDDEBUGPATH", logPath);
 			}

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -31,6 +31,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 				// https://github.com/dotnet/roslyn/blob/fc6e0c25277ff440ca7ded842ac60278ee6c9695/src/Features/Core/Portable/EditAndContinue/EditAndContinueService.cs#L72
 				Environment.SetEnvironmentVariable("Microsoft_CodeAnalysis_EditAndContinue_LogDir", logPath);
 
+                // Unconditionally enable binlog generation in msbuild. See https://github.com/dotnet/project-system/blob/4210ce79cfd35154dbd858f056bfb9101f290e69/docs/design-time-builds.md?L61
 				Environment.SetEnvironmentVariable("MSBUILDDEBUGENGINE", "1");
 				Environment.SetEnvironmentVariable("MSBUILDDEBUGPATH", logPath);
 			}

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -65,7 +65,14 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						.MSBuildProperties
 						.ToDictionary();
 
+                    // Flag the current build as created for hot reload, which allows for running targets or settings
+                    // props/items in the context of the hot reload workspace.
 					properties["UnoIsHotReloadHost"] = "True";
+					
+                    // Set the RuntimeIdentifier as a temporary property so that we do not force the
+                    // property as a read-only global property that would be transitively applied to
+                    // projects that are not supporting the head's RuntimeIdentifier. (e.g. an android app
+                    // which references a netstd2.0 library project)
 					if (properties.Remove("RuntimeIdentifier", out var runtimeIdentifier))
 					{
 						properties["UnoHotReloadRuntimeIdentifier"] = runtimeIdentifier;

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -65,14 +65,14 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						.MSBuildProperties
 						.ToDictionary();
 
-                    // Flag the current build as created for hot reload, which allows for running targets or settings
-                    // props/items in the context of the hot reload workspace.
+					// Flag the current build as created for hot reload, which allows for running targets or settings
+					// props/items in the context of the hot reload workspace.
 					properties["UnoIsHotReloadHost"] = "True";
-					
-                    // Set the RuntimeIdentifier as a temporary property so that we do not force the
-                    // property as a read-only global property that would be transitively applied to
-                    // projects that are not supporting the head's RuntimeIdentifier. (e.g. an android app
-                    // which references a netstd2.0 library project)
+
+					// Set the RuntimeIdentifier as a temporary property so that we do not force the
+					// property as a read-only global property that would be transitively applied to
+					// projects that are not supporting the head's RuntimeIdentifier. (e.g. an android app
+					// which references a netstd2.0 library project)
 					if (properties.Remove("RuntimeIdentifier", out var runtimeIdentifier))
 					{
 						properties["UnoHotReloadRuntimeIdentifier"] = runtimeIdentifier;

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -61,11 +61,21 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				{
 					await Notify(HotReloadEvent.Initializing);
 
+					var properties = configureServer
+						.MSBuildProperties
+						.ToDictionary();
+
+					properties["UnoIsHotReloadHost"] = "True";
+					if (properties.Remove("RuntimeIdentifier", out var runtimeIdentifier))
+					{
+						properties["UnoHotReloadRuntimeIdentifier"] = runtimeIdentifier;
+					}
+
 					var result = await CompilationWorkspaceProvider.CreateWorkspaceAsync(
 						configureServer.ProjectPath,
 						_reporter,
 						configureServer.MetadataUpdateCapabilities,
-						configureServer.MSBuildProperties.Where(kvp => !kvp.Key.StartsWith("MSBuild", StringComparison.OrdinalIgnoreCase)).ToDictionary(),
+						properties,
 						CancellationToken.None);
 
 					ObserveSolutionPaths(result.Item1);

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -22,8 +22,6 @@
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
 		<PackageReference Include="Uno.Core.Extensions" />
 		<PackageReference Include="Uno.Core.Extensions.Disposables" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 
 		<!-- Avoid transitive dependency from Microsoft.Build on 7.0.3 which has a vulnerability -->
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
@@ -36,6 +34,8 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
@@ -48,15 +48,17 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.12.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.12.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.12.0" />
 		<!-- TODO: Use version 9 when compiling against .NET 9? -->
-		<PackageReference Include="Microsoft.Build" Version="17.3.0" ExcludeAssets="runtime" />
-		<PackageReference Include="Microsoft.Build.Framework" Version="17.3.0" ExcludeAssets="runtime" />
-		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.3.0" ExcludeAssets="runtime" />
-		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.0" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build" Version="17.7.2" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="17.7.2" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.7.2" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.7.2" ExcludeAssets="runtime" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.netcoremobile.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.netcoremobile.csproj
@@ -33,6 +33,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Content Include="buildTransitive\*.DevServer.props">
+			<PackagePath>build</PackagePath>
+			<Pack>true</Pack>
+		</Content>
 		<Content Include="buildTransitive\*.DevServer.targets">
 			<PackagePath>build</PackagePath>
 			<Pack>true</Pack>

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.props
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<PropertyGroup Condition="'$(UnoIsHotReloadHost)'=='true'">
+		<RuntimeIdentifier Condition="'$(UnoHotReloadRuntimeIdentifier)' != ''">$(UnoHotReloadRuntimeIdentifier)</RuntimeIdentifier>
+	</PropertyGroup>
+
+</Project>

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -59,4 +59,24 @@
 				  If error persists, try to delete obj folder and rebuild your solution." />
 	</Target>
 
+	<Target
+		Name="_UnoHotReloadConfigAndroidEnv"
+		BeforeTargets="BeforeBuild"
+		Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'android' and '$(Optimize)'!='true'">
+
+		<PropertyGroup>
+			<_UnoHotReloadEnvironmentConfig>$(IntermediateOutputPath)environment.hotreload.conf</_UnoHotReloadEnvironmentConfig>
+		</PropertyGroup>
+
+		<WriteLinesToFile
+			Overwrite="True"
+			File="$(_UnoHotReloadEnvironmentConfig)"
+			Lines="DOTNET_MODIFIABLE_ASSEMBLIES=debug" />
+
+		<ItemGroup>
+			<AndroidEnvironment Include="$(_UnoHotReloadEnvironmentConfig)" />
+			<FileWrites Include="$(_UnoHotReloadEnvironmentConfig)" />
+		</ItemGroup>
+	</Target>
+
 </Project>

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -79,4 +79,12 @@
 		</ItemGroup>
 	</Target>
 
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'ios' and '$(Optimize)'!='true'">
+		<MlaunchEnvironmentVariables  Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'browserwasm' and '$(Optimize)'!='true'">
+		<WasmShellMonoEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
+	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/19293, closes https://github.com/unoplatform/uno/issues/15918

## Bugfix
Dev-server HR support for mobile targets

## What is the current behavior?
HR does not work with dev-server on mobile targets

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
