### PR TITLE
fix(hr): Ensure to keep ordering of generated properties

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/0/p1/MainPage.xaml
@@ -1,0 +1,15 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:CSHRTest01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Grid>
+		<Button x:Name="abc" Content="Hello" />
+		<Button x:Name="def" Content="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/0/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/1/p1/MainPage.xaml
@@ -1,0 +1,15 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:CSHRTest01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<Grid>
+		<Button x:Name="def" Content="Hello" />
+		<Button x:Name="abc" Content="Hello" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/1/p1/MainPage.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_xName_Reorder/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -286,6 +286,18 @@ namespace TestRepro
 				__p1.CreationComplete();
 			}
 
+		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _NarrowStateSubject { get; set; } = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+		private global::Microsoft.UI.Xaml.VisualState NarrowState
+		{
+			get
+			{
+				return (global::Microsoft.UI.Xaml.VisualState)_NarrowStateSubject.ElementInstance;
+			}
+			set
+			{
+				_NarrowStateSubject.ElementInstance = value;
+			}
+		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _TheListViewSubject { get; set; } = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		private global::Microsoft.UI.Xaml.Controls.ListView TheListView
 		{
@@ -308,18 +320,6 @@ namespace TestRepro
 			set
 			{
 				_WideStateSubject.ElementInstance = value;
-			}
-		}
-		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _NarrowStateSubject { get; set; } = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-		private global::Microsoft.UI.Xaml.VisualState NarrowState
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.VisualState)_NarrowStateSubject.ElementInstance;
-			}
-			set
-			{
-				_NarrowStateSubject.ElementInstance = value;
 			}
 		}
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TPXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TPXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -223,18 +223,6 @@ namespace TestRepro
 				_LoadElementSubject.ElementInstance = value;
 			}
 		}
-		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _button1Subject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-		public global::Microsoft.UI.Xaml.Controls.Button button1
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Controls.Button)_button1Subject.ElementInstance;
-			}
-			set
-			{
-				_button1Subject.ElementInstance = value;
-			}
-		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _ToggleLoadSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		public global::Microsoft.UI.Xaml.Controls.Primitives.ToggleButton ToggleLoad
 		{
@@ -245,6 +233,18 @@ namespace TestRepro
 			set
 			{
 				_ToggleLoadSubject.ElementInstance = value;
+			}
+		}
+		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _button1Subject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+		public global::Microsoft.UI.Xaml.Controls.Button button1
+		{
+			get
+			{
+				return (global::Microsoft.UI.Xaml.Controls.Button)_button1Subject.ElementInstance;
+			}
+			set
+			{
+				_button1Subject.ElementInstance = value;
 			}
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -248,18 +248,6 @@ namespace TestRepro
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
 		}
-		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _inner1ButtonSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-		private global::Microsoft.UI.Xaml.Controls.Button inner1Button
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Controls.Button)_inner1ButtonSubject.ElementInstance;
-			}
-			set
-			{
-				_inner1ButtonSubject.ElementInstance = value;
-			}
-		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _inner1Subject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		private global::Microsoft.UI.Xaml.Controls.StackPanel inner1
 		{
@@ -270,6 +258,18 @@ namespace TestRepro
 			set
 			{
 				_inner1Subject.ElementInstance = value;
+			}
+		}
+		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _inner1ButtonSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+		private global::Microsoft.UI.Xaml.Controls.Button inner1Button
+		{
+			get
+			{
+				return (global::Microsoft.UI.Xaml.Controls.Button)_inner1ButtonSubject.ElementInstance;
+			}
+			set
+			{
+				_inner1ButtonSubject.ElementInstance = value;
 			}
 		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _inner2Subject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
@@ -284,18 +284,6 @@ namespace TestRepro
 				_inner2Subject.ElementInstance = value;
 			}
 		}
-		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _inner3ButtonSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-		private global::Microsoft.UI.Xaml.Controls.Button inner3Button
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Controls.Button)_inner3ButtonSubject.ElementInstance;
-			}
-			set
-			{
-				_inner3ButtonSubject.ElementInstance = value;
-			}
-		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _inner3Subject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		private global::Microsoft.UI.Xaml.Controls.StackPanel inner3
 		{
@@ -306,6 +294,18 @@ namespace TestRepro
 			set
 			{
 				_inner3Subject.ElementInstance = value;
+			}
+		}
+		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _inner3ButtonSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+		private global::Microsoft.UI.Xaml.Controls.Button inner3Button
+		{
+			get
+			{
+				return (global::Microsoft.UI.Xaml.Controls.Button)_inner3ButtonSubject.ElementInstance;
+			}
+			set
+			{
+				_inner3ButtonSubject.ElementInstance = value;
 			}
 		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _outerGridSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -224,18 +224,6 @@ namespace TestRepro
 				_LoadElementSubject.ElementInstance = value;
 			}
 		}
-		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _button1Subject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
-		public global::Microsoft.UI.Xaml.Controls.Button button1
-		{
-			get
-			{
-				return (global::Microsoft.UI.Xaml.Controls.Button)_button1Subject.ElementInstance;
-			}
-			set
-			{
-				_button1Subject.ElementInstance = value;
-			}
-		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _ToggleLoadSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		public global::Microsoft.UI.Xaml.Controls.Primitives.ToggleButton ToggleLoad
 		{
@@ -246,6 +234,18 @@ namespace TestRepro
 			set
 			{
 				_ToggleLoadSubject.ElementInstance = value;
+			}
+		}
+		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _button1Subject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
+		public global::Microsoft.UI.Xaml.Controls.Button button1
+		{
+			get
+			{
+				return (global::Microsoft.UI.Xaml.Controls.Button)_button1Subject.ElementInstance;
+			}
+			set
+			{
+				_button1Subject.ElementInstance = value;
 			}
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -841,7 +841,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			var rAccessor = _isHotReloadEnabled ? " { get; set; }" : null; // We use property for HR so we can remove them without causing rude edit.
 
 			TryAnnotateWithGeneratorSource(writer);
-			foreach (var backingFieldDefinition in CurrentScope.BackingFields.Distinct())
+			foreach (var backingFieldDefinition in CurrentScope.BackingFields.Distinct().OrderBy(f => f.Name, StringComparer.Ordinal))
 			{
 				var sanitizedFieldName = SanitizeResourceName(backingFieldDefinition.Name);
 
@@ -866,13 +866,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 			}
 
-			foreach (var xBindEventHandler in CurrentScope.xBindEventsHandlers)
+			foreach (var xBindEventHandler in CurrentScope.xBindEventsHandlers.OrderBy(f => f.Name, StringComparer.Ordinal))
 			{
 				// Create load-time subjects for ElementName references not in local scope
 				writer.AppendLineIndented($"{FormatAccessibility(xBindEventHandler.Accessibility)} {xBindEventHandler.GlobalizedTypeName} {xBindEventHandler.Name}{rAccessor ?? ";"}");
 			}
 
-			foreach (var remainingReference in CurrentScope.ReferencedElementNames)
+			foreach (var remainingReference in CurrentScope.ReferencedElementNames.OrderBy(f => f, StringComparer.Ordinal))
 			{
 				// Create load-time subjects for ElementName references not in local scope
 				writer.AppendLineIndented($"private global::Microsoft.UI.Xaml.Data.ElementNameSubject _{remainingReference}Subject{rAccessor} = new global::Microsoft.UI.Xaml.Data.ElementNameSubject(isRuntimeBound: true, name: \"{remainingReference}\");");
@@ -1134,10 +1134,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private void BuildComponentFields(IIndentedStringBuilder writer)
 		{
-			for (var i = 0; i < CurrentScope.Components.Count; i++)
+			foreach (var current in CurrentScope.Components.OrderBy(c => c.MemberName, StringComparer.Ordinal))
 			{
-				var current = CurrentScope.Components[i];
-
 				var componentName = current.MemberName;
 				var typeName = GetType(current.XamlObject.Type).GetFullyQualifiedTypeIncludingGlobal();
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.hotdesign/issues/3251

## Bugfix
Ensure to keep ordering of generated properties

## What is the current behavior?
Might get ENC1002 when changing order of named elements in XAML

## What is the new behavior?
Generated properties are order by name, preventing the ENC1002

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
