### PR TITLE
fix: lazy element descendants not receiving correct templated-parent

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
@@ -50,6 +50,13 @@ public static class UITestHelper
 	{
 		TestServices.WindowHelper.WindowContent = element;
 
+		await WaitForLoaded(element, isLoaded);
+
+		return element.GetAbsoluteBounds();
+	}
+
+	public static async Task WaitForLoaded<T>(T element, Func<T, bool>? isLoaded = null) where T : FrameworkElement
+	{
 		if (isLoaded is null)
 		{
 			await TestServices.WindowHelper.WaitForLoaded(element);
@@ -59,8 +66,6 @@ public static class UITestHelper
 			await TestServices.WindowHelper.WaitFor(() => isLoaded(element), message: $"Timeout waiting on {element} to be loaded with custom criteria.");
 		}
 		await TestServices.WindowHelper.WaitForIdle();
-
-		return element.GetAbsoluteBounds();
 	}
 
 	public static Task WaitForIdle() => TestServices.WindowHelper.WaitForIdle();

--- a/src/Uno.UI.RuntimeTests/Tests/TemplatedParent/Setup/Uno19264.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/TemplatedParent/Setup/Uno19264.xaml
@@ -1,0 +1,18 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.TemplatedParent.Setup.Uno19264"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<Button x:Name="HostButton" x:FieldModifier="Public" Content="AsdAsd">
+		<Button.Template>
+			<ControlTemplate TargetType="Button">
+				<StackPanel Orientation="Vertical">
+					<TextBlock Text="Qwe" />
+					<ContentControl x:Name="LazyContentControl" x:Load="False">
+						<ContentPresenter x:Name="LazyDescendant" Content="{TemplateBinding Content}" />
+					</ContentControl>
+					<TextBlock Text="Zxc" />
+				</StackPanel>
+			</ControlTemplate>
+		</Button.Template>
+	</Button>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/TemplatedParent/Setup/Uno19264.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/TemplatedParent/Setup/Uno19264.xaml.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests.TemplatedParent.Setup;
+
+public sealed partial class Uno19264 : Page
+{
+	public Uno19264()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/TemplatedParent/TemplatedParentTests.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/TemplatedParent/TemplatedParentTests.cs
@@ -323,6 +323,35 @@ public partial class TemplatedParentTests // tests
 		await UITestHelper.WaitForIdle();
 		sut.FindFirstDescendantOrThrow<Grid>("RootB");
 	}
+
+	[TestMethod]
+	public async Task Uno19264_Test()
+	{
+		var setup = new Uno19264();
+		await UITestHelper.Load(setup);
+
+		// force lazily load element to load, and wait until done
+		var lazy = setup.HostButton.FindName("LazyContentControl") as ContentControl ?? throw new Exception("failed to ContentControl#LazyContentControl");
+		await UITestHelper.WaitForLoaded(lazy, x => x.IsLoaded);
+
+		/* var tree = setup.TreeGraph();
+		Uno19264 // TP=null, DC=null, Content=Button
+			Button // TP=null, DC=null, Content=String
+				StackPanel // TP=Button, DC=null
+					TextBlock // TP=Button, DC=null, Text=String
+					ContentControl#LazyContentControl // TP=Button, DC=null, Content=ContentPresenter
+						ContentPresenter // TP=ContentControl#LazyContentControl, DC=null, Content=ContentPresenter, Content.bind=[Path=Content, TemplatedParent]
+							ContentPresenter#LazyDescendant // TP=Button, DC=String, Content=String, Content.bind=[Path=Content, TemplatedParent]
+								ImplicitTextBlock // TP=ContentPresenter, DC=String, Text=String, Text.bind=[Path=Content, TemplatedParent]
+					TextBlock // TP=Button, DC=null, Text=String
+		 */
+
+		Assert.AreEqual(setup.HostButton, GetTemplatedParentCompat(lazy), "The lazy element didnt receive the correct templated-parent.");
+
+		var descendent = setup.FindFirstDescendantOrThrow<ContentPresenter>("LazyDescendant");
+		Assert.AreEqual(setup.HostButton, GetTemplatedParentCompat(descendent), "The lazy descendant didnt receive the correct templated-parent.");
+		Assert.AreEqual(setup.HostButton.Content, descendent.Content, "The lazy descendant didnt have its template-binding applied correctly");
+	}
 }
 public partial class TemplatedParentTests // helper methods
 {

--- a/src/Uno.UI/Extensions/PrettyPrint.cs
+++ b/src/Uno.UI/Extensions/PrettyPrint.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Media;
 using Windows.Foundation;
 using Windows.UI;
@@ -70,7 +71,8 @@ public static class PrettyPrint
 		return $"[{x.Width:0.#}x{x.Height:0.#}@{x.Left:0.#},{x.Top:0.#}]";
 	}
 #endif
-	public static string FormatSize(Size size) => $"{size.Width:0.#}x{size.Height:0.#}";
+	public static string FormatSize(Size size) => FormatSize(size.Width, size.Height);
+	public static string FormatSize(double width, double height) => $"{width:0.#}x{height:0.#}";
 	public static string FormatBrush(Brush b)
 	{
 		if (b is SolidColorBrush scb) return
@@ -102,7 +104,19 @@ public static class PrettyPrint
 		},
 		_ => /* CS8524: (GridUnitType)123 */ $"{value:#.##}{type}"
 	};
+	public static string FormatPoint(Point p) => FormatPoint(p.X, p.Y);
+	public static string FormatPoint(double x, double y) => $"{x:0.#},{y:0.#}";
+	public static string FormatBinding(BindingExpression be)
+	{
+		if (be == null) return "null";
 
+		var descriptions = new List<string>();
+		descriptions.Add($"Path={be.ParentBinding.Path?.Path}");
+		if (be.ParentBinding.Mode != BindingMode.OneWay) descriptions.Add(be.ParentBinding.Mode.ToString());
+		if (be.ParentBinding.RelativeSource is { Mode: not RelativeSourceMode.None } rs) descriptions.Add(rs.Mode.ToString());
+
+		return $"[{string.Join(", ", descriptions)}]";
+	}
 	public static string EscapeMultiline(string s, bool escapeTabs = false)
 	{
 		s = s

--- a/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
@@ -101,6 +101,7 @@ static partial class ViewExtensions
 
 		static IEnumerable<string> GetDetails(object x)
 		{
+#if true // positioning properties/hints
 			if (x is FrameworkElement { Parent: Grid } fe3)
 			{
 				int c = Grid.GetColumn(fe3), cspan = Grid.GetColumnSpan(fe3),
@@ -124,7 +125,17 @@ static partial class ViewExtensions
 			{
 				yield return $"Index={(ItemsControl.ItemsControlFromItemContainer(lvi)?.IndexFromContainer(lvi) ?? -1)}";
 			}
-			// =====
+#endif
+#if false // binding: templated-parent and data-context
+			if (x is UIElement uie)
+			{
+#if HAS_UNO
+				yield return $"TP={FormatType(uie.GetTemplatedParent())}";
+#endif
+				yield return $"DC={FormatType(uie.DataContext)}";
+			}
+#endif
+#if false // native layout coordinates
 #if __ANDROID__
 			if (x is Android.Views.View v)
 			{
@@ -137,9 +148,15 @@ static partial class ViewExtensions
 				yield return $"Abs=[Rect {view.Frame.Width:0.#}x{view.Frame.Height:0.#}@{abs.X:0.#},{abs.Y:0.#}]";
 			}
 #endif
+#endif
+#if true // framework layout properties
 			if (x is FrameworkElement fe)
 			{
-				yield return $"Actual={fe.ActualWidth}x{fe.ActualHeight}";
+				yield return $"Actual={FormatSize(fe.ActualWidth, fe.ActualHeight)}";
+				if (fe.Parent is FrameworkElement parent)
+				{
+					yield return $"XY={FormatPoint(fe.TransformToVisual(parent).TransformPoint(default))}";
+				}
 #if HAS_UNO
 				//yield return $"Available={FormatSize(fe.m_previousAvailableSize)}";
 #endif
@@ -149,18 +166,19 @@ static partial class ViewExtensions
 				//if ($"{(fe.IsMeasureDirty ? "M" : null)}{(fe.IsMeasureDirtyPath ? "m" : null)}{(fe.IsArrangeDirty ? "A" : null)}{(fe.IsArrangeDirtyPath ? "a" : null)}" is { Length: > 0 } dirty)
 				//	yield return $"Dirty={dirty}";
 #endif
-				yield return $"Constraints=[{fe.MinWidth},{fe.Width},{fe.MaxWidth}]x[{fe.MinHeight},{fe.Height},{fe.MaxHeight}]";
+				yield return $"Constraints=[{fe.MinWidth:0.#},{fe.Width:0.#},{fe.MaxWidth:0.#}]x[{fe.MinHeight:0.#},{fe.Height:0.#},{fe.MaxHeight:0.#}]";
 				yield return $"HV={fe.HorizontalAlignment}/{fe.VerticalAlignment}";
 			}
 			if (x is ScrollViewer sv)
 			{
-				yield return $"Offset={sv.HorizontalOffset:0.#},{sv.VerticalOffset:0.#}";
-				yield return $"Viewport={sv.ViewportWidth:0.#}x{sv.ViewportHeight:0.#}";
-				yield return $"Extent={sv.ExtentWidth:0.#}x{sv.ExtentHeight:0.#}";
+				yield return $"Offset={FormatPoint(sv.HorizontalOffset, sv.VerticalOffset)}";
+				yield return $"Viewport={FormatSize(sv.ViewportWidth, sv.ViewportHeight)}";
+				yield return $"Extent={FormatSize(sv.ExtentWidth, sv.ExtentHeight)}";
 			}
 			//if (TryGetDpValue<CornerRadius>(x, "CornerRadius", out var cr)) yield return $"CornerRadius={FormatCornerRadius(cr)}";
 			if (TryGetDpValue<Thickness>(x, "Margin", out var margin)) yield return $"Margin={FormatThickness(margin)}";
 			if (TryGetDpValue<Thickness>(x, "Padding", out var padding)) yield return $"Padding={FormatThickness(padding)}";
+#endif
 
 			if (TryGetDpValue<double>(x, "Opacity", out var opacity)) yield return $"Opacity={opacity}";
 			if (TryGetDpValue<Visibility>(x, "Visibility", out var visibility)) yield return $"Visibility={visibility}";

--- a/src/Uno.UI/UI/Xaml/ElementStub.cs
+++ b/src/Uno.UI/UI/Xaml/ElementStub.cs
@@ -57,6 +57,10 @@ namespace Microsoft.UI.Xaml
 		/// </summary>
 		private bool _isMaterializing;
 
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
+		private bool _fromLegacyTemplate;
+#endif
+
 		/// <summary>
 		/// A delegate used to raise materialization changes in <see cref="ElementStub.MaterializationChanged"/>
 		/// </summary>
@@ -116,6 +120,10 @@ namespace Microsoft.UI.Xaml
 			ContentBuilder = () => (View)methodInfo.Invoke(delegateTarget.Target, null);
 #else
 			ContentBuilder = contentBuilder;
+#endif
+
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
+			_fromLegacyTemplate = TemplatedParentScope.GetCurrentTemplate() is { IsLegacyTemplate: true };
 #endif
 		}
 
@@ -193,19 +201,19 @@ namespace Microsoft.UI.Xaml
 				try
 				{
 					_isMaterializing = true;
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
+					TemplatedParentScope.PushScope(GetTemplatedParent(), _fromLegacyTemplate);
+#endif
 
 					_content = SwapViews(oldView: (FrameworkElement)this, newViewProvider: ContentBuilder);
-#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
-					// note: This can be safely removed, once moving away from legacy impl.
-					// In the new impl, the templated-parent would be immediately available
-					// before any binding is applied, so there is no need to force update.
-					TemplatedParentScope.UpdateTemplatedParent(_content as DependencyObject, GetTemplatedParent(), reapplyTemplateBindings: true);
-#endif
 
 					MaterializationChanged?.Invoke(this);
 				}
 				finally
 				{
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
+					TemplatedParentScope.PopScope();
+#endif
 					_isMaterializing = false;
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/VisualState.cs
+++ b/src/Uno.UI/UI/Xaml/VisualState.cs
@@ -21,8 +21,9 @@ namespace Microsoft.UI.Xaml
 		/// optionally fill <see cref="Storyboard"/> and <see cref="Setters"/>.
 		/// </summary>
 		internal Action LazyBuilder { get; set; }
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 		internal bool? FromLegacyTemplate { get; set; }
-
+#endif
 		public VisualState()
 		{
 			InitializeBinder();
@@ -165,12 +166,16 @@ namespace Microsoft.UI.Xaml
 				LazyBuilder = null;
 				try
 				{
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 					TemplatedParentScope.PushScope(this.GetTemplatedParent(), FromLegacyTemplate == true);
+#endif
 					builder.Invoke();
 				}
 				finally
 				{
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 					TemplatedParentScope.PopScope();
+#endif
 				}
 
 				// Resolve all theme resources from storyboard children

--- a/src/Uno.UI/UI/Xaml/VisualTransition.cs
+++ b/src/Uno.UI/UI/Xaml/VisualTransition.cs
@@ -18,8 +18,9 @@ namespace Microsoft.UI.Xaml
 		/// optionally fill <see cref="Storyboard"/>.
 		/// </summary>
 		internal Action LazyBuilder { get; set; }
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 		internal bool? FromLegacyTemplate { get; set; }
-
+#endif
 		public VisualTransition()
 		{
 			IsAutoPropertyInheritanceEnabled = false;
@@ -51,12 +52,16 @@ namespace Microsoft.UI.Xaml
 				LazyBuilder = null;
 				try
 				{
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 					TemplatedParentScope.PushScope(this.GetTemplatedParent(), FromLegacyTemplate == true);
+#endif
 					builder.Invoke();
 				}
 				finally
 				{
+#if ENABLE_LEGACY_TEMPLATED_PARENT_SUPPORT
 					TemplatedParentScope.PopScope();
+#endif
 				}
 
 				if (Storyboard is IDependencyObjectStoreProvider storyboardProvider)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #19264

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The descendants of a lazily loaded element (x:Load=False, x:DeferedLoadingStrategy=Lazy) don't receive the proper templated-parent.

## What is the new behavior?
They will now receive the correct templated-parent, on materialization.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
regression from: #17645