### PR TITLE
chore(devSrv): Improve reliability of connection by catching generic errors

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -7,6 +7,7 @@
 		<RollForward>minor</RollForward>
 		<Nullable>enable</Nullable>
 		<NoWarn>$(NoWarn);VSTHRD200</NoWarn>
+		<DefineConstants>$(DefineConstants);IS_DEVSERVER</DefineConstants>
 	</PropertyGroup>
 
 	<Import Project="../targetframework-override-noplatform.props" />

--- a/src/Uno.UI.RemoteControl/Helpers/WebSocketHelper.cs
+++ b/src/Uno.UI.RemoteControl/Helpers/WebSocketHelper.cs
@@ -46,17 +46,17 @@ public static class WebSocketHelper
 					}
 					catch (Exception error)
 					{
-#if __CROSSRUNTIME__ // Client side
-						var log = Uno.Foundation.Logging.LogExtensionPoint.Log(typeof(Frame));
-						if (log.IsEnabled(Uno.Foundation.Logging.LogLevel.Error))
-						{
-							log.LogError("Failed to read frame", error);
-						}
-#else // (dev-)server side
+#if IS_DEVSERVER
 						var log = Uno.Extensions.LogExtensionPoint.Log(typeof(Frame));
 						if (log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Error))
 						{
 							Microsoft.Extensions.Logging.LoggerExtensions.LogError(log, error, "Failed to read frame");
+						}
+#else // Client
+						var log = Uno.Foundation.Logging.LogExtensionPoint.Log(typeof(Frame));
+						if (log.IsEnabled(Uno.Foundation.Logging.LogLevel.Error))
+						{
+							log.LogError("Failed to read frame", error);
 						}
 #endif
 

--- a/src/Uno.UI.RemoteControl/Helpers/WebSocketHelper.cs
+++ b/src/Uno.UI.RemoteControl/Helpers/WebSocketHelper.cs
@@ -4,6 +4,7 @@ using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IO;
+using Uno.Foundation.Logging;
 using Uno.UI.RemoteControl.HotReload.Messages;
 
 namespace Uno.UI.RemoteControl.Helpers;
@@ -40,7 +41,21 @@ public static class WebSocketHelper
 				{
 					mem.Position = 0;
 
-					return Frame.Read(mem);
+					try
+					{
+						return Frame.Read(mem);
+					}
+					catch (Exception error)
+					{
+						var log = typeof(Frame).Log();
+						if (log.IsEnabled(LogLevel.Error))
+						{
+							log.Error("Failed to read frame", error);
+						}
+
+						mem.Position = 0;
+						mem.SetLength(0);
+					}
 				}
 			}
 		}

--- a/src/Uno.UI.RemoteControl/Helpers/WebSocketHelper.cs
+++ b/src/Uno.UI.RemoteControl/Helpers/WebSocketHelper.cs
@@ -4,7 +4,6 @@ using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IO;
-using Uno.Foundation.Logging;
 using Uno.UI.RemoteControl.HotReload.Messages;
 
 namespace Uno.UI.RemoteControl.Helpers;
@@ -47,11 +46,19 @@ public static class WebSocketHelper
 					}
 					catch (Exception error)
 					{
-						var log = typeof(Frame).Log();
-						if (log.IsEnabled(LogLevel.Error))
+#if __CROSSRUNTIME__ // Client side
+						var log = Uno.Foundation.Logging.LogExtensionPoint.Log(typeof(Frame));
+						if (log.IsEnabled(Uno.Foundation.Logging.LogLevel.Error))
 						{
-							log.Error("Failed to read frame", error);
+							log.LogError("Failed to read frame", error);
 						}
+#else // (dev-)server side
+						var log = Uno.Extensions.LogExtensionPoint.Log(typeof(Frame));
+						if (log.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Error))
+						{
+							Microsoft.Extensions.Logging.LoggerExtensions.LogError(log, error, "Failed to read frame");
+						}
+#endif
 
 						mem.Position = 0;
 						mem.SetLength(0);


### PR DESCRIPTION
## Bugfix
Improve reliability of connection by catching generic errors (like a serilization issue)

## What is the current behavior?
Connection is dropped if there is a serilization (for instance due a the linker)

## What is the new behavior?
Log error and wait for next frame.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
