### PR TITLE
Fix ALC loading of HR workspace

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -11,6 +11,7 @@ using Uno.UI.RemoteControl.Helpers;
 using System.Collections.Generic;
 using System.Runtime.Loader;
 using Microsoft.Extensions.Logging;
+using System.Composition.Hosting;
 
 namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 {
@@ -228,7 +229,17 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 
 			AppDomain.CurrentDomain.AssemblyResolve += (snd, e) => Load(e.Name);
 			AppDomain.CurrentDomain.TypeResolve += (snd, e) => Load(e.Name);
-			AssemblyLoadContext.Default.Resolving += (snd, e) => Load(e.FullName);
+
+			// Processors are loaded in a separate ALC in `RemoteControlServer`, which requires
+			// to load the files in same ALC to avoid invalid cross-ALC references.
+			if (AssemblyLoadContext.GetLoadContext(typeof(CompilationWorkspaceProvider).Assembly) is { } alc)
+			{
+				alc.Resolving += (snd, e) => Load(e.FullName);
+			}
+			else
+			{
+				throw new InvalidOperationException($"Unable to determine the ALC for {nameof(CompilationWorkspaceProvider)}");
+			}
 		}
 
 	}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Adjust assembly loading with proper loading of Roslyn assemblies in the appropriate ALC.
- Load assemblies using file loading, not stream loading in order to have Assembly.Location set properly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
