### PR TITLE
fix: ios PasswordBox changed event when focus

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxDelegate.iOS.cs
@@ -29,7 +29,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (textField is SinglelineTextBoxView textBoxView)
 			{
-				if (_textBox.GetTarget() is not TextBox textBox)
+				if (_textBox.GetTarget() is not { } textBox)
 				{
 					return false;
 				}
@@ -50,7 +50,7 @@ namespace Microsoft.UI.Xaml.Controls
 					// When replacing text from pasting (multiple characters at once)
 					// we should only allow it (return true) when the new text length
 					// is lower or equal to the allowed length (TextBox.MaxLength)
-					var newLength = textBoxView.Text.Length + replacementString.Length - range.Length;
+					var newLength = textBoxView.Text?.Length + replacementString.Length - range.Length;
 					return newLength <= textBox.MaxLength;
 				};
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
@@ -1,4 +1,5 @@
-﻿using System;
+#nullable enable
+using System;
 using System.Runtime.InteropServices;
 using CoreGraphics;
 using Foundation;
@@ -19,10 +20,10 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class SinglelineTextBoxView : UITextField, ITextBoxView, DependencyObject, IFontScalable
 	{
-		private SinglelineTextBoxDelegate _delegate;
+		private SinglelineTextBoxDelegate _delegate = null!;
 		private readonly WeakReference<TextBox> _textBox;
-		private Action _foregroundChanged;
-		private IDisposable _foregroundBrushChangedSubscription;
+		private Action? _foregroundChanged;
+		private IDisposable? _foregroundBrushChangedSubscription;
 
 		public SinglelineTextBoxView(TextBox textBox)
 		{
@@ -32,13 +33,13 @@ namespace Microsoft.UI.Xaml.Controls
 			Initialize();
 		}
 
-		public override void Paste(NSObject sender) => HandlePaste(() => base.Paste(sender));
+		public override void Paste(NSObject? sender) => HandlePaste(() => base.Paste(sender));
 
-		public override void PasteAndGo(NSObject sender) => HandlePaste(() => base.PasteAndGo(sender));
+		public override void PasteAndGo(NSObject? sender) => HandlePaste(() => base.PasteAndGo(sender));
 
-		public override void PasteAndMatchStyle(NSObject sender) => HandlePaste(() => base.PasteAndMatchStyle(sender));
+		public override void PasteAndMatchStyle(NSObject? sender) => HandlePaste(() => base.PasteAndMatchStyle(sender));
 
-		public override void PasteAndSearch(NSObject sender) => HandlePaste(() => base.PasteAndSearch(sender));
+		public override void PasteAndSearch(NSObject? sender) => HandlePaste(() => base.PasteAndSearch(sender));
 
 		public override void Paste(NSItemProvider[] itemProviders) => HandlePaste(() => base.Paste(itemProviders));
 
@@ -54,7 +55,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		internal TextBox TextBox => _textBox.GetTarget();
 
-		public override string Text
+		public override string? Text
 		{
 			get => base.Text;
 			set
@@ -69,15 +70,14 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		private void OnEditingChanged(object sender, EventArgs e)
+		private void OnEditingChanged(object? sender, EventArgs e)
 		{
 			OnTextChanged();
 		}
 
 		private void OnTextChanged()
 		{
-			var textBox = _textBox?.GetTarget();
-			if (textBox != null)
+			if (TextBox is { } textBox)
 			{
 				var text = textBox.ProcessTextInput(Text);
 				SetTextNative(text);
@@ -99,14 +99,12 @@ namespace Microsoft.UI.Xaml.Controls
 
 		partial void OnLoadedPartial()
 		{
-			this.EditingChanged += OnEditingChanged;
-			this.EditingDidEnd += OnEditingChanged;
+			SubscribeEditingEvents();
 		}
 
 		partial void OnUnloadedPartial()
 		{
-			this.EditingChanged -= OnEditingChanged;
-			this.EditingDidEnd -= OnEditingChanged;
+			UnsubscribeEditingEvents();
 		}
 
 		//Forces the secure UITextField to maintain its current value upon regaining focus
@@ -260,6 +258,18 @@ namespace Microsoft.UI.Xaml.Controls
 					textBox.OnSelectionChanged();
 				}
 			}
+		}
+
+		private void SubscribeEditingEvents()
+		{
+			EditingChanged += OnEditingChanged;
+			EditingDidEnd += OnEditingChanged;
+		}
+
+		private void UnsubscribeEditingEvents()
+		{
+			EditingChanged -= OnEditingChanged;
+			EditingDidEnd -= OnEditingChanged;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 using System;
 using System.Runtime.InteropServices;
 using CoreGraphics;
@@ -112,14 +112,27 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			var result = base.BecomeFirstResponder();
 
-			if (SecureTextEntry)
+			if (SecureTextEntry && !string.IsNullOrEmpty(Text))
 			{
+				UnsubscribeEditingEvents();
+
 				var text = Text;
-				Text = string.Empty;
+				UpdatePasswordText(string.Empty);
 				InsertText(text);
+				UpdatePasswordText(text);
+
+				SubscribeEditingEvents();
 			}
 
 			return result;
+
+			void UpdatePasswordText(string text)
+			{
+				if (TextBox is PasswordBox passwordBox)
+				{
+					passwordBox.Password = text;
+				}
+			}
 		}
 
 		public override CGSize SizeThatFits(CGSize size)


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
PasswordBox, when unfocused and focused, sends a TextChanged event.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
