### PR TITLE
fix(hr): Fix HR not working on android with Rider

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -73,6 +73,8 @@
 		<CompilerVisibleProperty Include="UnoRemoteControlProcessorsPath" />
 		<CompilerVisibleProperty Include="UnoRemoteControlConfigCookie" />
 		<CompilerVisibleProperty Include="UnoHotReloadDiagnosticsLogPath" />
+		<CompilerVisibleProperty Include="AppendRuntimeIdentifierToOutputPath" />
+		<CompilerVisibleProperty Include="OutputPath" />
 		<CompilerVisibleProperty Include="UnoDisableBindableTypeProvidersGeneration" />
 		<CompilerVisibleProperty Include="ShouldWriteErrorOnInvalidXaml" />
 		<CompilerVisibleProperty Include="IsUiAutomationMappingEnabled" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
@@ -46,6 +46,8 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 			"DevEnvDir",
 			"MSBuildVersion",
 			"UnoHotReloadDiagnosticsLogPath",
+			"AppendRuntimeIdentifierToOutputPath",
+			"OutputPath"
 		};
 
 		public void Initialize(GeneratorInitializationContext context)

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -99,7 +99,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 					if (properties.Remove("RuntimeIdentifier", out var runtimeIdentifier))
 					{
-						if (appendIdToPath && hasOutputPath && outputPath!.EndsWith(runtimeIdentifier, StringComparison.OrdinalIgnoreCase))
+						if (appendIdToPath && hasOutputPath && Path.TrimEndingDirectorySeparator(outputPath ?? "").EndsWith(runtimeIdentifier, StringComparison.OrdinalIgnoreCase))
 						{
 							// Set the RuntimeIdentifier as a temporary property so that we do not force the
 							// property as a read-only global property that would be transitively applied to


### PR DESCRIPTION
## Bugfix
Fix HR not working on android with Rider

## What is the current behavior?
Rider does not specify the runtime identifier when building while we do in the hot-relaod processor. This drives the HR to not being able to produce value updates.

## What is the new behavior?
🙃

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
