### PR TITLE
fix(hr): Fix Frame stack cache update on HR

### DIFF
--- a/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.Uno.cs
+++ b/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.Uno.cs
@@ -4,5 +4,6 @@ namespace Microsoft.UI.Xaml.Navigation;
 
 partial class PageStackEntry
 {
+	// Note: LEGACY, not used by MUX (_useWinUIBehavior)
 	internal Page Instance { get; set; }
 }


### PR DESCRIPTION
closes https://github.com/unoplatform/private/issues/609
closes https://github.com/unoplatform/private/issues/548

## Bugfix
Frame stack cache update on HR

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
