### PR TITLE
fix: Use newer project capability for WSL in VS 17.13

### DIFF
--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -131,7 +131,7 @@ See how to [make platforms conditional](xref:Uno.GettingStarted.CreateAnApp.Ride
 
 ### UNOB0015: The desktop TargetFramework must be placed first
 
-In Visual Studio 17.12 or later, when both mobile (`-ios`, `-android`, `-maccatalyst`) and `desktop` target frameworks are used, the `-desktop` target framework must be placed first in order for WSL debugging to work.
+In Visual Studio 17.13 or earlier, when both mobile (`-ios`, `-android`, `-maccatalyst`) and `desktop` target frameworks are used, the `-desktop` target framework must be placed first in order for WSL debugging to work.
 
 If `-desktop` is not first, the following message will appear:
 
@@ -139,7 +139,7 @@ If `-desktop` is not first, the following message will appear:
 The project doesn't know how to run the profile with name 'MyApp (Desktop WSL2)' and command 'WSL2'.
 ```
 
-To fix the issue, reorder the items in your `.csproj` so that `TargetFrameworks` contains `netX.0-desktop` as the first target framework.
+To fix the issue, reorder the items in your `.csproj` so that `TargetFrameworks` contains `netX.0-desktop` as the first target framework, or upgrade to Visual Studio 17.13 (when a stable release will be available).
 
 The Uno Platform team is following this [Visual Studio issue](https://developercommunity.visualstudio.com/t/WSL-launch-profile-cannot-be-found-when/10776961).
 

--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -142,4 +142,12 @@
 		<EmbeddedResource Include="appsettings.json" />
 		<EmbeddedResource Include="appsettings.*.json" DependentUpon="appsettings.json" />
 	</ItemGroup>
+
+	<!-- Enable WSL support in VS 17.13 Pre 2 and later, when a desktop target is present -->
+	<ItemGroup Condition="
+			   $([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.13.0)) 
+			   AND '$(TargetFrameworks)' != '' 
+			   AND $(TargetFrameworks.Contains('desktop')) ">
+		<ProjectCapability Include="DotNetWslLaunch" />
+	</ItemGroup>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.Sdk.After.targets
+++ b/src/Uno.Sdk/targets/Uno.Sdk.After.targets
@@ -126,6 +126,7 @@
 				AND '$(BuildingInsideVisualStudio)' == 'true'
 				AND '$(OutputType)'!='Library'
 				AND $([MSBuild]::VersionGreaterThanOrEquals($(MSBuildVersion), 17.12.0))
+				AND $([MSBuild]::VersionLessThan($(MSBuildVersion), 17.13.0))
 				AND '$(_UnoTargetFrameworkCount)' != ''
 				AND $(_UnoTargetFrameworkCount) &gt; 1
 				AND $(TargetFrameworks.Contains('-desktop'))
@@ -136,8 +137,8 @@
 				)
 				AND $([MSBuild]::GetTargetPlatformIdentifier($(_UnoFirstOriginalTargetFramework))) != 'desktop'">
 
-		<Warning Code="UNOB0014"
-					Text="The desktop TargetFramework must be placed first in the TargetFrameworks property in order for WSL debugging to work, when mobile targets are also used. (See https://aka.platform.uno/UNOB0014)" />
+		<Warning Code="UNOB0015"
+					Text="The desktop TargetFramework must be placed first in the TargetFrameworks property in order for WSL debugging to work, when mobile targets are also used. (See https://aka.platform.uno/UNOB0015)" />
 	</Target>
 
 	<Target Name="_UnoVSWarnWindowsIsFirst"


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/private/issues/555

See https://developercommunity.visualstudio.com/t/WSL-launch-profile-cannot-be-found-when/10776961#T-N10813979 for more details.