### PR TITLE
ci: Enable dry-run for stale PRs

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,34 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+  workflow_dispatch:
+
+permissions:
+  contents: write # only for delete-branch option
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # docs: https://github.com/actions/stale?tab=readme-ov-file
+
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+
+          days-before-pr-stale: 60
+          days-before-pr-close: 10
+
+          # disable issue closing
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Flag older PRs first
+          ascending: true
+
+          debug-only: true


### PR DESCRIPTION
This PR will enable the flagging of stale PRs after 60 days of inactivity. Dry-run for now.