### PR TITLE
fix(hr): Fix ENC1002 when dealing with event handlers

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/0/p1/MainPage.xaml
@@ -1,0 +1,19 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:CSHRTest01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	
+	<Grid>
+		<TextBlock Text="Hello world!" />
+
+		<Button Click="Button_Click" />
+
+		<Button Click="Button_Click" Content="Button 2" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/0/p1/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	private async void Button_Click(object sender, RoutedEventArgs e)
+	{
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/1/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:CSHRTest01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	
+	<Grid>
+		<Button Click="Button_Click" />
+
+		<TextBlock Text="Hello world!" /><!--WARNING : The blank line MUST be removed (compared to original) for the test to fail!-->
+		<Button Click="Button_Click" Content="Button 2" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/1/p1/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	private async void Button_Click(object sender, RoutedEventArgs e)
+	{
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/0/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/0/p1/MainPage.xaml
@@ -1,0 +1,19 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:CSHRTest01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	
+	<Grid>
+		<TextBlock Text="Hello world!" />
+
+		<Button Click="{x:Bind Button_Click}" />
+
+		<Button Click="{x:Bind Button_Click}" Content="Button 2" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/0/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/0/p1/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	private async void Button_Click(object sender, RoutedEventArgs e)
+	{
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/1/p1/MainPage.xaml
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/1/p1/MainPage.xaml
@@ -1,0 +1,18 @@
+﻿<Page
+	x:Class="Test01.MainPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:CSHRTest01"
+	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	
+	<Grid>
+		<Button Click="{x:Bind Button_Click}" />
+
+		<TextBlock Text="Hello world!" /><!--WARNING : The blank line MUST be removed (compared to original) for the test to fail!-->
+		<Button Click="{x:Bind Button_Click}" Content="Button 2" />
+	</Grid>
+</Page>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/1/p1/MainPage.xaml.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/1/p1/MainPage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Test01;
+
+public sealed partial class MainPage : Page
+{
+	public MainPage()
+	{
+		this.InitializeComponent();
+	}
+
+	private async void Button_Click(object sender, RoutedEventArgs e)
+	{
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/Scenario.json
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/MetadataUpdateTests/Scenarios/When_Simple_Xaml_Delegates_Fuzzy_Matching_1_xBind/Scenario.json
@@ -1,0 +1,24 @@
+{
+	"Scenarios": [
+		{
+			"IsDebug": true,
+			"IsMono": false,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		},
+		{
+			"IsDebug": true,
+			"IsMono": true,
+			"PassResults": [
+				{
+					"MetadataUpdates": 1,
+					"Diagnostics": []
+				}
+			]
+		}
+	]
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIM/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIM/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -135,10 +135,16 @@ namespace TestRepro
 			private bool __is__ApplyMethod_0_Click_Initialized ;
 		
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private void __ApplyMethod_0_Click_Initialize()
+			private void __ApplyMethod_0_Click_Initialize(bool init)
 			{
 				if (__is__ApplyMethod_0_Click_Initialized || _component_0 is null)
 				{
+					if (!init)
+					{
+						__is__ApplyMethod_0_Click_Initialized = false;
+						// Note: _component_0 will be collected, no needs to unsubscribe
+					}
+					
 					return;
 				}
 		
@@ -149,10 +155,16 @@ namespace TestRepro
 			private bool __is__ApplyMethod_1_Click_Initialized ;
 		
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private void __ApplyMethod_1_Click_Initialize()
+			private void __ApplyMethod_1_Click_Initialize(bool init)
 			{
 				if (__is__ApplyMethod_1_Click_Initialized || _component_1 is null)
 				{
+					if (!init)
+					{
+						__is__ApplyMethod_1_Click_Initialized = false;
+						// Note: _component_1 will be collected, no needs to unsubscribe
+					}
+					
 					return;
 				}
 		
@@ -163,10 +175,16 @@ namespace TestRepro
 			private bool __is__ApplyMethod_2_Click_Initialized ;
 		
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-			private void __ApplyMethod_2_Click_Initialize()
+			private void __ApplyMethod_2_Click_Initialize(bool init)
 			{
 				if (__is__ApplyMethod_2_Click_Initialized || _component_2 is null)
 				{
+					if (!init)
+					{
+						__is__ApplyMethod_2_Click_Initialized = false;
+						// Note: _component_2 will be collected, no needs to unsubscribe
+					}
+					
 					return;
 				}
 		
@@ -186,7 +204,7 @@ namespace TestRepro
 				{
 					public void Invoke(object sender, global::Microsoft.UI.Xaml.RoutedEventArgs e)
 					{
-						(target.Target as global::TestRepro.MainPage)?.P1.Button_Click(sender, e);
+						(target.Target as global::TestRepro.MainPage)?.P1?.Button_Click(sender, e);
 					}
 				}
 
@@ -194,7 +212,7 @@ namespace TestRepro
 				{
 					public void Invoke(object sender, global::Microsoft.UI.Xaml.RoutedEventArgs e)
 					{
-						(target.Target as global::TestRepro.MainPage)?.P2.Button_Click(sender, e);
+						(target.Target as global::TestRepro.MainPage)?.P2?.Button_Click(sender, e);
 					}
 				}
 
@@ -202,7 +220,7 @@ namespace TestRepro
 				{
 					public void Invoke(object sender, global::Microsoft.UI.Xaml.RoutedEventArgs e)
 					{
-						(target.Target as global::TestRepro.MainPage)?.P3.Button_Click(sender, e);
+						(target.Target as global::TestRepro.MainPage)?.P3?.Button_Click(sender, e);
 					}
 				}
 
@@ -289,20 +307,20 @@ namespace TestRepro
 			{
 				var owner = Owner;
 				owner._component_0.ApplyXBind();
-				owner.__ApplyMethod_0_Click_Initialize();
-				owner.__ApplyMethod_1_Click_Initialize();
-				owner.__ApplyMethod_2_Click_Initialize();
+				owner.__ApplyMethod_0_Click_Initialize(true);
+				owner.__ApplyMethod_1_Click_Initialize(true);
+				owner.__ApplyMethod_2_Click_Initialize(true);
 				owner._component_1.ApplyXBind();
-				owner.__ApplyMethod_0_Click_Initialize();
-				owner.__ApplyMethod_1_Click_Initialize();
-				owner.__ApplyMethod_2_Click_Initialize();
+				owner.__ApplyMethod_0_Click_Initialize(true);
+				owner.__ApplyMethod_1_Click_Initialize(true);
+				owner.__ApplyMethod_2_Click_Initialize(true);
 				owner._component_2.ApplyXBind();
-				owner.__ApplyMethod_0_Click_Initialize();
-				owner.__ApplyMethod_1_Click_Initialize();
-				owner.__ApplyMethod_2_Click_Initialize();
-				owner.__ApplyMethod_0_Click_Initialize();
-				owner.__ApplyMethod_1_Click_Initialize();
-				owner.__ApplyMethod_2_Click_Initialize();
+				owner.__ApplyMethod_0_Click_Initialize(true);
+				owner.__ApplyMethod_1_Click_Initialize(true);
+				owner.__ApplyMethod_2_Click_Initialize(true);
+				owner.__ApplyMethod_0_Click_Initialize(true);
+				owner.__ApplyMethod_1_Click_Initialize(true);
+				owner.__ApplyMethod_2_Click_Initialize(true);
 			}
 			void IMainPage_Bindings.UpdateResources()
 			{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIM/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIM/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -63,16 +63,6 @@ namespace TestRepro
 					{
 					/* _isTopLevelDictionary:False */
 					__that._component_0 = __p1;
-					__that.__0_Click_P1_Button_Click_Builder = (__owner) => 
-					{
-						var Click_P1_Button_Click_That = (__that as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;
-						/* first level targetMethod:TestRepro.C1.Button_Click(object, Microsoft.UI.Xaml.RoutedEventArgs) */ __owner.Click += (_sender,_e) => 
-						{
-							(Click_P1_Button_Click_That.Target as global::TestRepro.MainPage)?.P1.Button_Click(_sender,_e);
-						}
-						;
-					}
-					;
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
 					}
@@ -87,16 +77,6 @@ namespace TestRepro
 					{
 					/* _isTopLevelDictionary:False */
 					__that._component_1 = __p1;
-					__that.__1_Click_P2_Button_Click_Builder = (__owner) => 
-					{
-						var Click_P2_Button_Click_That = (__that as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;
-						/* first level targetMethod:TestRepro.ImplicitImpl.Button_Click(object, Microsoft.UI.Xaml.RoutedEventArgs) */ __owner.Click += (_sender,_e) => 
-						{
-							(Click_P2_Button_Click_That.Target as global::TestRepro.MainPage)?.P2.Button_Click(_sender,_e);
-						}
-						;
-					}
-					;
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
 					}
@@ -111,16 +91,6 @@ namespace TestRepro
 					{
 					/* _isTopLevelDictionary:False */
 					__that._component_2 = __p1;
-					__that.__2_Click_P3_Button_Click_Builder = (__owner) => 
-					{
-						var Click_P3_Button_Click_That = (__that as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;
-						/* first level targetMethod:TestRepro.I.Button_Click(object, Microsoft.UI.Xaml.RoutedEventArgs) */ __owner.Click += (_sender,_e) => 
-						{
-							(Click_P3_Button_Click_That.Target as global::TestRepro.MainPage)?.P3.Button_Click(_sender,_e);
-						}
-						;
-					}
-					;
 					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d);
 					__p1.CreationComplete();
 					}
@@ -161,14 +131,82 @@ namespace TestRepro
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
 		}
 		partial void OnInitializeCompleted();
+			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			private bool __is__ApplyMethod_0_Click_Initialized ;
+		
+			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			private void __ApplyMethod_0_Click_Initialize()
+			{
+				if (__is__ApplyMethod_0_Click_Initialized || _component_0 is null)
+				{
+					return;
+				}
+		
+				_component_0.Click += new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.ApplyMethod_0_Click_Handler((this as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference).Invoke;
+				__is__ApplyMethod_0_Click_Initialized = true;
+			}
+			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			private bool __is__ApplyMethod_1_Click_Initialized ;
+		
+			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			private void __ApplyMethod_1_Click_Initialize()
+			{
+				if (__is__ApplyMethod_1_Click_Initialized || _component_1 is null)
+				{
+					return;
+				}
+		
+				_component_1.Click += new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.ApplyMethod_1_Click_Handler((this as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference).Invoke;
+				__is__ApplyMethod_1_Click_Initialized = true;
+			}
+			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			private bool __is__ApplyMethod_2_Click_Initialized ;
+		
+			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			private void __ApplyMethod_2_Click_Initialize()
+			{
+				if (__is__ApplyMethod_2_Click_Initialized || _component_2 is null)
+				{
+					return;
+				}
+		
+				_component_2.Click += new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.ApplyMethod_2_Click_Handler((this as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference).Invoke;
+				__is__ApplyMethod_2_Click_Initialized = true;
+			}
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
 		}
-		private global::System.Action<global::Microsoft.UI.Xaml.Controls.Primitives.ButtonBase> __0_Click_P1_Button_Click_Builder;
-		private global::System.Action<global::Microsoft.UI.Xaml.Controls.Primitives.ButtonBase> __1_Click_P2_Button_Click_Builder;
-		private global::System.Action<global::Microsoft.UI.Xaml.Controls.Primitives.ButtonBase> __2_Click_P3_Button_Click_Builder;
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
+		{
+				public class ApplyMethod_0_Click_Handler(global::Uno.UI.DataBinding.ManagedWeakReference target)
+				{
+					public void Invoke(object sender, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+					{
+						(target.Target as global::TestRepro.MainPage)?.P1.Button_Click(sender, e);
+					}
+				}
+
+				public class ApplyMethod_1_Click_Handler(global::Uno.UI.DataBinding.ManagedWeakReference target)
+				{
+					public void Invoke(object sender, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+					{
+						(target.Target as global::TestRepro.MainPage)?.P2.Button_Click(sender, e);
+					}
+				}
+
+				public class ApplyMethod_2_Click_Handler(global::Uno.UI.DataBinding.ManagedWeakReference target)
+				{
+					public void Invoke(object sender, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+					{
+						(target.Target as global::TestRepro.MainPage)?.P3.Button_Click(sender, e);
+					}
+				}
+
+		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.Button _component_0
 		{
@@ -251,32 +289,20 @@ namespace TestRepro
 			{
 				var owner = Owner;
 				owner._component_0.ApplyXBind();
-				owner.__0_Click_P1_Button_Click_Builder?.Invoke( owner._component_0);
-				owner.__0_Click_P1_Button_Click_Builder = null;
-				owner.__1_Click_P2_Button_Click_Builder?.Invoke( owner._component_1);
-				owner.__1_Click_P2_Button_Click_Builder = null;
-				owner.__2_Click_P3_Button_Click_Builder?.Invoke( owner._component_2);
-				owner.__2_Click_P3_Button_Click_Builder = null;
+				owner.__ApplyMethod_0_Click_Initialize();
+				owner.__ApplyMethod_1_Click_Initialize();
+				owner.__ApplyMethod_2_Click_Initialize();
 				owner._component_1.ApplyXBind();
-				owner.__0_Click_P1_Button_Click_Builder?.Invoke( owner._component_0);
-				owner.__0_Click_P1_Button_Click_Builder = null;
-				owner.__1_Click_P2_Button_Click_Builder?.Invoke( owner._component_1);
-				owner.__1_Click_P2_Button_Click_Builder = null;
-				owner.__2_Click_P3_Button_Click_Builder?.Invoke( owner._component_2);
-				owner.__2_Click_P3_Button_Click_Builder = null;
+				owner.__ApplyMethod_0_Click_Initialize();
+				owner.__ApplyMethod_1_Click_Initialize();
+				owner.__ApplyMethod_2_Click_Initialize();
 				owner._component_2.ApplyXBind();
-				owner.__0_Click_P1_Button_Click_Builder?.Invoke( owner._component_0);
-				owner.__0_Click_P1_Button_Click_Builder = null;
-				owner.__1_Click_P2_Button_Click_Builder?.Invoke( owner._component_1);
-				owner.__1_Click_P2_Button_Click_Builder = null;
-				owner.__2_Click_P3_Button_Click_Builder?.Invoke( owner._component_2);
-				owner.__2_Click_P3_Button_Click_Builder = null;
-				owner.__0_Click_P1_Button_Click_Builder?.Invoke( owner._component_0);
-				owner.__0_Click_P1_Button_Click_Builder = null;
-				owner.__1_Click_P2_Button_Click_Builder?.Invoke( owner._component_1);
-				owner.__1_Click_P2_Button_Click_Builder = null;
-				owner.__2_Click_P3_Button_Click_Builder?.Invoke( owner._component_2);
-				owner.__2_Click_P3_Button_Click_Builder = null;
+				owner.__ApplyMethod_0_Click_Initialize();
+				owner.__ApplyMethod_1_Click_Initialize();
+				owner.__ApplyMethod_2_Click_Initialize();
+				owner.__ApplyMethod_0_Click_Initialize();
+				owner.__ApplyMethod_1_Click_Initialize();
+				owner.__ApplyMethod_2_Click_Initialize();
 			}
 			void IMainPage_Bindings.UpdateResources()
 			{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WEOTLNDO/XamlCodeGenerator_MainWindow_c93db19a7202d9eb84ddc41d72fcb89b.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WEOTLNDO/XamlCodeGenerator_MainWindow_c93db19a7202d9eb84ddc41d72fcb89b.cs
@@ -58,8 +58,8 @@ namespace TestRepro
 			.MainWindow_c93db19a7202d9eb84ddc41d72fcb89b_XamlApply((MainWindow_c93db19a7202d9eb84ddc41d72fcb89bXamlApplyExtensions.XamlApplyHandler0)(__p1 => 
 			{
 			// Class TestRepro.MainWindow
-			var Closed_Window_Closed_That = (__that as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;
-			/* second level */ __p1.Closed += (Window_Closed_sender,Window_Closed_args) => (Closed_Window_Closed_That.Target as global::TestRepro.MainWindow)?.Window_Closed(Window_Closed_sender,Window_Closed_args);
+			var Closed_Handler = new __MainWindow_c93db19a7202d9eb84ddc41d72fcb89b_TestReproMainWindow.ApplyMethod_1_Closed_Handler((this as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference);
+			/* second level */ __p1.Closed += Closed_Handler.Invoke;
 			}
 			))
 			;
@@ -71,6 +71,19 @@ namespace TestRepro
 
 		}
 		partial void OnInitializeCompleted();
+		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+		private class __MainWindow_c93db19a7202d9eb84ddc41d72fcb89b_TestReproMainWindow
+		{
+				public class ApplyMethod_1_Closed_Handler(global::Uno.UI.DataBinding.ManagedWeakReference target)
+				{
+					public void Invoke(object sender, global::Microsoft.UI.Xaml.WindowEventArgs args)
+					{
+						(target.Target as global::TestRepro.MainWindow)?.Window_Closed(sender, args);
+					}
+				}
+
+		}
 	}
 }
 namespace MyProject

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
@@ -136,8 +136,8 @@ namespace Uno.UI.Tests.Given_ResourceDictionary
 									__that._component_0 = __p1;
 									global::Microsoft.UI.Xaml.NameScope.SetNameScope(__that._component_0, __nameScope);
 									global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.SwipeItem.IconSourceProperty, "SiblingResource", isThemeResourceExtension: false, isHotReloadSupported: false, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-									var Invoked_AnEventHandler_That = (__ResourceOwner_2 as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;
-									/* second level */ __p1.Invoked += (AnEventHandler_sender,AnEventHandler_args) => (Invoked_AnEventHandler_That.Target as global::Uno.UI.Tests.Given_ResourceDictionary.When_Nested_With_Sibling_Ref_And_Event)?.AnEventHandler(AnEventHandler_sender,AnEventHandler_args);
+									var Invoked_Handler = new __ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_MyProject__ResourcesSC0_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_Event.ApplyMethod_3_Invoked_Handler((__ResourceOwner_2 as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference);
+									/* second level */ __p1.Invoked += Invoked_Handler.Invoke;
 									}
 									))
 								);
@@ -202,6 +202,19 @@ namespace Uno.UI.Tests.Given_ResourceDictionary
 				{
 					var owner = this;
 					_component_0.UpdateResourceBindings();
+				}
+				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
+				private class __ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20_MyProject__ResourcesSC0_UnoUITestsGiven_ResourceDictionaryWhen_Nested_With_Sibling_Ref_And_Event
+				{
+						public class ApplyMethod_3_Invoked_Handler(global::Uno.UI.DataBinding.ManagedWeakReference target)
+						{
+							public void Invoke(global::Microsoft.UI.Xaml.Controls.SwipeItem sender, global::Microsoft.UI.Xaml.Controls.SwipeItemInvokedEventArgs args)
+							{
+								(target.Target as global::Uno.UI.Tests.Given_ResourceDictionary.When_Nested_With_Sibling_Ref_And_Event)?.AnEventHandler(sender, args);
+							}
+						}
+
 				}
 			}
 		}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
@@ -1,6 +1,9 @@
-﻿// Uncomment the following line to write expected files to disk
+﻿#if DEBUG
+// Uncomment the following line to write expected files to disk
 // Don't commit this line uncommented.
 // #define WRITE_EXPECTED
+#define WRITE_EXPECTED
+#endif
 
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Content/Uno.UI.SourceGenerators.props
@@ -211,6 +211,7 @@
 		<XamlGeneratorAnalyzerSuppressions Include="csharp-105 // Ignore duplicate namespaces" />
 		<XamlGeneratorAnalyzerSuppressions Include="csharp-1591 // Ignore missing XML comment warnings" />
 		<XamlGeneratorAnalyzerSuppressions Include="csharp-CS8669 // Ignore annotation for nullable reference types" />
+		<XamlGeneratorAnalyzerSuppressions Include="csharp-CS9113 // Parameter is unread" />
 	</ItemGroup>
 
 	<!--Default UI automation member mappings-->

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/BackingFieldDefinition.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/BackingFieldDefinition.cs
@@ -1,11 +1,8 @@
 ﻿#nullable enable
 
+using System;
 using Microsoft.CodeAnalysis;
 
-namespace Uno.UI.SourceGenerators.XamlGenerator
-{
-	internal record BackingFieldDefinition(string GlobalizedTypeName, string Name, Accessibility Accessibility);
+namespace Uno.UI.SourceGenerators.XamlGenerator;
 
-	internal record EventHandlerBackingFieldDefinition(string GlobalizedTypeName, string Name, Accessibility Accessibility, string ComponentName)
-		: BackingFieldDefinition(GlobalizedTypeName, Name, Accessibility);
-}
+internal record BackingFieldDefinition(string GlobalizedTypeName, string Name, Accessibility Accessibility);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/NameScope.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/NameScope.cs
@@ -46,7 +46,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		public Dictionary<string, Subclass> Subclasses { get; } = [];
 
-		public List<Action<IIndentedStringBuilder>> Subclasses2 { get; } = [];
+		public List<Action<IIndentedStringBuilder>> SubclassBuilders { get; } = [];
 
 		public List<ComponentDefinition> Components { get; } = [];
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/NameScope.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/NameScope.cs
@@ -23,7 +23,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// Name of the root class for all sub-classes
 		/// </summary>
 		/// <remarks>All sub-classes will be generated nested to this class, which is flagged with CreateNewOnMetadataUpdate attribute to avoid issues with HR.</remarks>
-		public string SubClassesRoot => $"__{FileUniqueId}_{string.Join("_", [Name, ..Parents.Select(scope => scope.Name)])}";
+		public string SubClassesRoot => $"__{FileUniqueId}_{string.Join("_", [Name, .. Parents.Select(scope => scope.Name)])}";
 
 		/// <summary>
 		/// Used to detect duplicate x:Name and report error for those.

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XBindEventInitializerDefinition.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XBindEventInitializerDefinition.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using Uno.Extensions;
+
+namespace Uno.UI.SourceGenerators.XamlGenerator;
+
+/// <summary>
+/// The Initialize method of an event handler databind using x:Bind
+/// </summary>
+/// <param name="MethodName">Name of the initialize method</param>
+/// <param name="Build">Body of the method</param>
+internal record XBindEventInitializerDefinition(string MethodName, Action<string, IIndentedStringBuilder> Build);

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XLoadScope.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XLoadScope.cs
@@ -12,7 +12,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		/// <summary>
 		/// List of action handlers for registering x:Bind events
 		/// </summary>
-		public List<EventHandlerBackingFieldDefinition> xBindEventsHandlers { get; } = new();
+		public List<XBindEventInitializerDefinition> xBindEventsHandlers { get; } = new();
 
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -899,7 +899,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			using var _ = isTopLevel ? writer.BlockInvariant($"namespace {ns}") : null;
 
 			// If _isHotReloadEnabled we generate it anyway so we can remove sub-classes without causing rude edit.
-			if (!_isHotReloadEnabled && CurrentScope.Subclasses is not { Count: > 0 } && CurrentScope.Subclasses2 is not { Count: > 0 })
+			if (!_isHotReloadEnabled && CurrentScope.Subclasses is not { Count: > 0 } && CurrentScope.SubclassBuilders is not { Count: > 0 })
 			{
 				return;
 			}
@@ -980,7 +980,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					}
 				}
 
-				foreach (var subClass in CurrentScope.Subclasses2)
+				foreach (var subClass in CurrentScope.SubclassBuilders)
 				{
 					subClass(writer);
 					writer.AppendLine();
@@ -4026,7 +4026,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private string RegisterChildSubclass(string name, Action<string, IIndentedStringBuilder> build)
 		{
 			var fullName = $"{CurrentScope.SubClassesRoot}.{name}";
-			CurrentScope.Subclasses2.Add(writer => build(name, writer));
+			CurrentScope.SubclassBuilders.Add(writer => build(name, writer));
 
 			return fullName;
 		}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -186,10 +186,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 		private const string DictionaryProviderInterfaceName = "global::Uno.UI.IXamlResourceDictionaryProvider";
 
-		private string RoField(string type, string name)
-			=> _isHotReloadEnabled
-				? $"private {type} {name} {{ get; }}"
-				: $"private readonly {type} {name};";
 		private string Field(string type, string name)
 			=> $"private {type} {name} {(_isHotReloadEnabled ? "{ get; set; }" : ";")}";
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlLazyApplyBlockIIndentedStringBuilder.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlLazyApplyBlockIIndentedStringBuilder.cs
@@ -24,9 +24,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 		private readonly IDisposable? _parentDisposable;
 		private readonly bool _exposeContext;
 		private readonly Action<string> _onRegisterApplyMethodBody;
-		private readonly string? _exposeContextMethod;
+		private readonly string _exposeContextMethod;
 		private readonly string _appliedType;
 		private readonly string _topLevelType;
+
+		public string? MethodName => _exposeContext ? _exposeContextMethod : null;
 
 		public XamlLazyApplyBlockIIndentedStringBuilder(
 			IIndentedStringBuilder source,
@@ -37,7 +39,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			Action<string> onRegisterApplyMethodBody,
 			string appliedType,
 			string topLevelType,
-			string? exposeContextMethod,
+			string exposeContextMethod,
 			IDisposable? parentDisposable = null)
 		{
 			_closureName = closureName;


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.hotdesign/issues/3289
closes https://github.com/unoplatform/uno.hotdesign/issues/3299

Potentially also fixes: 
https://github.com/unoplatform/uno.hotdesign/issues/3290
https://github.com/unoplatform/uno.hotdesign/issues/3281

## Bugfix
Fix ENC1002 when dealing with event handlers

## What is the current behavior?
Get ENC1002 pretty easily when dealing with element that has event handlers (code behind or x:Bind)

## What is the new behavior?
HR

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
