### PR TITLE
doc: Add some troubleshooting for Apple Developer Accounts

### DIFF
--- a/doc/articles/uno-publishing-desktop-macos.md
+++ b/doc/articles/uno-publishing-desktop-macos.md
@@ -218,3 +218,18 @@ An app bundle (.app) can be submitted to Apple's [App Store](https://www.apple.c
 
 > [!NOTE]
 > Notarization of the app bundle is **not** required as the Apple App Store will be taking care of your app binary distribution.
+
+## Troubleshooting
+
+### Apple Developer Account
+
+An active Apple Developer Account is **required** for code signing and notarization.
+
+An error, such as the one below, means that the Apple Developer Account is not active or the necessary agreements have not been signed.
+
+```text
+Uno.Sdk.Extras.Publish.MacOS.targets(75,3): error : Failed to submit tmpcZQgA4.zip to Apple's notarization service. Exit code: 1: Error: HTTP status code: 403. A required agreement is missing or has expired. This request requires an in-effect agreement that has not been signed or has expired. Ensure your team has signed the necessary legal agreements and that they are not expired.
+```
+
+Try logging into your [Apple Developer Account](https://developer.apple.com/account) to see if any action is required to activate your account.
+Once re-enabled it might take a few minutes (for the update to propagate) before you'll be able to sign or notarize your app bundle.


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

Apple Developer Accounts can be inactive when subscription is over or when new necessary agreements needs to be accepted. This leads to errors when trying to code sign or notarize app bundles.

## What is the new behavior?

Add documentation to troubleshoot such occurrences.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
