### PR TITLE
fix(hr): Add dummy class at the end of the generated file

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -403,6 +403,26 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							BuildXBindTryGetDeclarations(writer);
 						}
 					}
+
+					if (_isHotReloadEnabled && Generation.IOSViewSymbol.Value is not null)
+					{
+						// Workaround for HR behaving incorrectly on iOS
+						// https://github.com/xamarin/xamarin-macios/issues/22102
+
+						using (writer.BlockInvariant($"namespace __internal"))
+						{
+							writer.AppendLineIndented("/// <remarks>Internal Use for iOS only.</remarks>");
+							writer.AppendLineIndented("[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
+							writer.AppendLineIndented("[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]");
+							using (writer.BlockInvariant($"static partial class __{_xClassName.ClassName}_Dummy"))
+							{
+								using (writer.BlockInvariant("private static class Dummy_Bindings"))
+								{
+									writer.AppendLineIndented("private static object Owner { get; set; }");
+								}
+							}
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
Works around https://github.com/xamarin/xamarin-macios/issues/22102
Fixes https://github.com/unoplatform/uno.hotdesign/issues/3281