### PR TITLE
fix(hr): Don't import Microsoft.IO.RecyclableMemoryStream using nuget

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -85,3 +85,29 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+
+Microsoft.IO.RecyclableMemoryStream
+-----------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2016 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.

--- a/build/nuget/Uno.WinUI.DevServer.nuspec
+++ b/build/nuget/Uno.WinUI.DevServer.nuspec
@@ -22,7 +22,6 @@
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- net8.0-maccatalyst17.0 -->
@@ -31,7 +30,6 @@
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- net8.0-macos14.0 -->
@@ -40,7 +38,6 @@
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- net8.0-android -->
@@ -49,7 +46,6 @@
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- net9.0-ios18.0 -->
@@ -58,7 +54,6 @@
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- net9.0-maccatalyst18.0 -->
@@ -67,7 +62,6 @@
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- net9.0-macos15.0 -->
@@ -76,7 +70,6 @@
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- net9.0-android -->
@@ -85,7 +78,6 @@
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- .NET 9.0 (Reference API) -->
@@ -95,7 +87,6 @@
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Uno.Wasm.WebSockets" version="1.1.0" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- .NET 8.0 (Reference API) -->
@@ -105,7 +96,6 @@
 
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
 				<dependency id="Uno.Wasm.WebSockets" version="1.1.0" />
-				<dependency id="Microsoft.IO.RecyclableMemoryStream" version="2.3.2" />
 			</group>
 
 			<!-- .NET 9.0 (WinUI) -->

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Reference.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Reference.csproj
@@ -36,7 +36,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Skia.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Skia.csproj
@@ -35,7 +35,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Wasm.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.Wasm.csproj
@@ -31,7 +31,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.netcoremobile.csproj
+++ b/src/Uno.UI.RemoteControl/Uno.UI.RemoteControl.netcoremobile.csproj
@@ -45,7 +45,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" />
-		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RemoteControl/external/Microsoft.IO.RecyclableMemoryStream/EventArgs.cs
+++ b/src/Uno.UI.RemoteControl/external/Microsoft.IO.RecyclableMemoryStream/EventArgs.cs
@@ -1,0 +1,397 @@
+﻿// Imported from https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/commit/7df2ef7c95979774f783d4870cb959f03c38aade
+
+namespace Microsoft.IO
+{
+	using System;
+
+	public sealed partial class RecyclableMemoryStreamManager
+	{
+		/// <summary>
+		/// Arguments for the <see cref="StreamCreated"/> event.
+		/// </summary>
+		/// <remarks>
+		/// Initializes a new instance of the <see cref="StreamCreatedEventArgs"/> class.
+		/// </remarks>
+		/// <param name="guid">Unique ID of the stream.</param>
+		/// <param name="tag">Tag of the stream.</param>
+		/// <param name="requestedSize">The requested stream size.</param>
+		/// <param name="actualSize">The actual stream size.</param>
+		public sealed class StreamCreatedEventArgs(Guid guid, string? tag, long requestedSize, long actualSize) : EventArgs
+		{
+			/// <summary>
+			/// Unique ID for the stream.
+			/// </summary>
+			public Guid Id { get; } = guid;
+
+			/// <summary>
+			/// Optional Tag for the event.
+			/// </summary>
+			public string? Tag { get; } = tag;
+
+			/// <summary>
+			/// Requested stream size.
+			/// </summary>
+			public long RequestedSize { get; } = requestedSize;
+
+			/// <summary>
+			/// Actual stream size.
+			/// </summary>
+			public long ActualSize { get; } = actualSize;
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="StreamDisposed"/> event.
+		/// </summary>
+		/// <remarks>
+		/// Initializes a new instance of the <see cref="StreamDisposedEventArgs"/> class.
+		/// </remarks>
+		/// <param name="guid">Unique ID of the stream.</param>
+		/// <param name="tag">Tag of the stream.</param>
+		/// <param name="lifetime">Lifetime of the stream</param>
+		/// <param name="allocationStack">Stack of original allocation.</param>
+		/// <param name="disposeStack">Dispose stack.</param>
+		public sealed class StreamDisposedEventArgs(Guid guid, string? tag, TimeSpan lifetime, string? allocationStack, string? disposeStack) : EventArgs
+		{
+			/// <summary>
+			/// Unique ID for the stream.
+			/// </summary>
+			public Guid Id { get; } = guid;
+
+			/// <summary>
+			/// Optional Tag for the event.
+			/// </summary>
+			public string? Tag { get; } = tag;
+
+			/// <summary>
+			/// Stack where the stream was allocated.
+			/// </summary>
+			public string? AllocationStack { get; } = allocationStack;
+
+			/// <summary>
+			/// Stack where stream was disposed.
+			/// </summary>
+			public string? DisposeStack { get; } = disposeStack;
+
+			/// <summary>
+			/// Lifetime of the stream.
+			/// </summary>
+			public TimeSpan Lifetime { get; } = lifetime;
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="StreamDoubleDisposed"/> event.
+		/// </summary>
+		/// <remarks>
+		/// Initializes a new instance of the <see cref="StreamDoubleDisposedEventArgs"/> class.
+		/// </remarks>
+		/// <param name="guid">Unique ID of the stream.</param>
+		/// <param name="tag">Tag of the stream.</param>
+		/// <param name="allocationStack">Stack of original allocation.</param>
+		/// <param name="disposeStack1">First dispose stack.</param>
+		/// <param name="disposeStack2">Second dispose stack.</param>
+		public sealed class StreamDoubleDisposedEventArgs(Guid guid, string? tag, string? allocationStack, string? disposeStack1, string? disposeStack2) : EventArgs
+		{
+			/// <summary>
+			/// Unique ID for the stream.
+			/// </summary>
+			public Guid Id { get; } = guid;
+
+			/// <summary>
+			/// Optional Tag for the event.
+			/// </summary>
+			public string? Tag { get; } = tag;
+
+			/// <summary>
+			/// Stack where the stream was allocated.
+			/// </summary>
+			public string? AllocationStack { get; } = allocationStack;
+
+			/// <summary>
+			/// First dispose stack.
+			/// </summary>
+			public string? DisposeStack1 { get; } = disposeStack1;
+
+			/// <summary>
+			/// Second dispose stack.
+			/// </summary>
+			public string? DisposeStack2 { get; } = disposeStack2;
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="StreamFinalized"/> event.
+		/// </summary>
+		/// <remarks>
+		/// Initializes a new instance of the <see cref="StreamFinalizedEventArgs"/> class.
+		/// </remarks>
+		/// <param name="guid">Unique ID of the stream.</param>
+		/// <param name="tag">Tag of the stream.</param>
+		/// <param name="allocationStack">Stack of original allocation.</param>
+		public sealed class StreamFinalizedEventArgs(Guid guid, string? tag, string? allocationStack) : EventArgs
+		{
+			/// <summary>
+			/// Unique ID for the stream.
+			/// </summary>
+			public Guid Id { get; } = guid;
+
+			/// <summary>
+			/// Optional Tag for the event.
+			/// </summary>
+			public string? Tag { get; } = tag;
+
+			/// <summary>
+			/// Stack where the stream was allocated.
+			/// </summary>
+			public string? AllocationStack { get; } = allocationStack;
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="StreamConvertedToArray"/> event.
+		/// </summary>
+		/// <remarks>
+		/// Initializes a new instance of the <see cref="StreamConvertedToArrayEventArgs"/> class.
+		/// </remarks>
+		/// <param name="guid">Unique ID of the stream.</param>
+		/// <param name="tag">Tag of the stream.</param>
+		/// <param name="stack">Stack of ToArray call.</param>
+		/// <param name="length">Length of stream.</param>
+		public sealed class StreamConvertedToArrayEventArgs(Guid guid, string? tag, string? stack, long length) : EventArgs
+		{
+			/// <summary>
+			/// Unique ID for the stream.
+			/// </summary>
+			public Guid Id { get; } = guid;
+
+			/// <summary>
+			/// Optional Tag for the event.
+			/// </summary>
+			public string? Tag { get; } = tag;
+
+			/// <summary>
+			/// Stack where ToArray was called.
+			/// </summary>
+			public string? Stack { get; } = stack;
+
+			/// <summary>
+			/// Length of stack.
+			/// </summary>
+			public long Length { get; } = length;
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="StreamOverCapacity"/> event.
+		/// </summary>
+		public sealed class StreamOverCapacityEventArgs : EventArgs
+		{
+			/// <summary>
+			/// Unique ID for the stream.
+			/// </summary>
+			public Guid Id { get; }
+
+			/// <summary>
+			/// Optional Tag for the event.
+			/// </summary>
+			public string? Tag { get; }
+
+			/// <summary>
+			/// Original allocation stack.
+			/// </summary>
+			public string? AllocationStack { get; }
+
+			/// <summary>
+			/// Requested capacity.
+			/// </summary>
+			public long RequestedCapacity { get; }
+
+			/// <summary>
+			/// Maximum capacity.
+			/// </summary>
+			public long MaximumCapacity { get; }
+
+			/// <summary>
+			/// Initializes a new instance of the <see cref="StreamOverCapacityEventArgs"/> class.
+			/// </summary>
+			/// <param name="guid">Unique ID of the stream.</param>
+			/// <param name="tag">Tag of the stream.</param>
+			/// <param name="requestedCapacity">Requested capacity.</param>
+			/// <param name="maximumCapacity">Maximum stream capacity of the manager.</param>
+			/// <param name="allocationStack">Original allocation stack.</param>
+			internal StreamOverCapacityEventArgs(Guid guid, string? tag, long requestedCapacity, long maximumCapacity, string? allocationStack)
+			{
+				this.Id = guid;
+				this.Tag = tag;
+				this.RequestedCapacity = requestedCapacity;
+				this.MaximumCapacity = maximumCapacity;
+				this.AllocationStack = allocationStack;
+			}
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="BlockCreated"/> event.
+		/// </summary>
+		public sealed class BlockCreatedEventArgs : EventArgs
+		{
+			/// <summary>
+			/// How many bytes are currently in use from the small pool.
+			/// </summary>
+			public long SmallPoolInUse { get; }
+
+			/// <summary>
+			/// Initializes a new instance of the <see cref="BlockCreatedEventArgs"/> class.
+			/// </summary>
+			/// <param name="smallPoolInUse">Number of bytes currently in use from the small pool.</param>
+			internal BlockCreatedEventArgs(long smallPoolInUse)
+			{
+				this.SmallPoolInUse = smallPoolInUse;
+			}
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="LargeBufferCreated"/> events.
+		/// </summary>
+		public sealed class LargeBufferCreatedEventArgs : EventArgs
+		{
+			/// <summary>
+			/// Unique ID for the stream.
+			/// </summary>
+			public Guid Id { get; }
+
+			/// <summary>
+			/// Optional Tag for the event.
+			/// </summary>
+			public string? Tag { get; }
+
+			/// <summary>
+			/// Whether the buffer was satisfied from the pool or not.
+			/// </summary>
+			public bool Pooled { get; }
+
+			/// <summary>
+			/// Required buffer size.
+			/// </summary>
+			public long RequiredSize { get; }
+
+			/// <summary>
+			/// How many bytes are in use from the large pool.
+			/// </summary>
+			public long LargePoolInUse { get; }
+
+			/// <summary>
+			/// If the buffer was not satisfied from the pool, and <see cref="Options.GenerateCallStacks"/> is turned on, then.
+			/// this will contain the call stack of the allocation request.
+			/// </summary>
+			public string? CallStack { get; }
+
+			/// <summary>
+			/// Initializes a new instance of the <see cref="LargeBufferCreatedEventArgs"/> class.
+			/// </summary>
+			/// <param name="guid">Unique ID of the stream.</param>
+			/// <param name="tag">Tag of the stream.</param>
+			/// <param name="requiredSize">Required size of the new buffer.</param>
+			/// <param name="largePoolInUse">How many bytes from the large pool are currently in use.</param>
+			/// <param name="pooled">Whether the buffer was satisfied from the pool or not.</param>
+			/// <param name="callStack">Call stack of the allocation, if it wasn't pooled.</param>
+			internal LargeBufferCreatedEventArgs(Guid guid, string? tag, long requiredSize, long largePoolInUse, bool pooled, string? callStack)
+			{
+				this.RequiredSize = requiredSize;
+				this.LargePoolInUse = largePoolInUse;
+				this.Pooled = pooled;
+				this.Id = guid;
+				this.Tag = tag;
+				this.CallStack = callStack;
+			}
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="BufferDiscarded"/> event.
+		/// </summary>
+		public sealed class BufferDiscardedEventArgs : EventArgs
+		{
+			/// <summary>
+			/// Unique ID for the stream.
+			/// </summary>
+			public Guid Id { get; }
+
+			/// <summary>
+			/// Optional Tag for the event.
+			/// </summary>
+			public string? Tag { get; }
+
+			/// <summary>
+			/// Type of the buffer.
+			/// </summary>
+			public Events.MemoryStreamBufferType BufferType { get; }
+
+			/// <summary>
+			/// The reason this buffer was discarded.
+			/// </summary>
+			public Events.MemoryStreamDiscardReason Reason { get; }
+
+			/// <summary>
+			/// Initializes a new instance of the <see cref="BufferDiscardedEventArgs"/> class.
+			/// </summary>
+			/// <param name="guid">Unique ID of the stream.</param>
+			/// <param name="tag">Tag of the stream.</param>
+			/// <param name="bufferType">Type of buffer being discarded.</param>
+			/// <param name="reason">The reason for the discard.</param>
+			internal BufferDiscardedEventArgs(Guid guid, string? tag, Events.MemoryStreamBufferType bufferType, Events.MemoryStreamDiscardReason reason)
+			{
+				this.Id = guid;
+				this.Tag = tag;
+				this.BufferType = bufferType;
+				this.Reason = reason;
+			}
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="StreamLength"/> event.
+		/// </summary>
+		/// <remarks>
+		/// Initializes a new instance of the <see cref="StreamLengthEventArgs"/> class.
+		/// </remarks>
+		/// <param name="length">Length of the strength.</param>
+		public sealed class StreamLengthEventArgs(long length) : EventArgs
+		{
+			/// <summary>
+			/// Length of the stream.
+			/// </summary>
+			public long Length { get; } = length;
+		}
+
+		/// <summary>
+		/// Arguments for the <see cref="UsageReport"/> event.
+		/// </summary>
+		/// <remarks>
+		/// Initializes a new instance of the <see cref="UsageReportEventArgs"/> class.
+		/// </remarks>
+		/// <param name="smallPoolInUseBytes">Bytes from the small pool currently in use.</param>
+		/// <param name="smallPoolFreeBytes">Bytes from the small pool currently available.</param>
+		/// <param name="largePoolInUseBytes">Bytes from the large pool currently in use.</param>
+		/// <param name="largePoolFreeBytes">Bytes from the large pool currently available.</param>
+		public sealed class UsageReportEventArgs(
+			long smallPoolInUseBytes,
+			long smallPoolFreeBytes,
+			long largePoolInUseBytes,
+			long largePoolFreeBytes) : EventArgs
+		{
+			/// <summary>
+			/// Bytes from the small pool currently in use.
+			/// </summary>
+			public long SmallPoolInUseBytes { get; } = smallPoolInUseBytes;
+
+			/// <summary>
+			/// Bytes from the small pool currently available.
+			/// </summary>
+			public long SmallPoolFreeBytes { get; } = smallPoolFreeBytes;
+
+			/// <summary>
+			/// Bytes from the large pool currently in use.
+			/// </summary>
+			public long LargePoolInUseBytes { get; } = largePoolInUseBytes;
+
+			/// <summary>
+			/// Bytes from the large pool currently available.
+			/// </summary>
+			public long LargePoolFreeBytes { get; } = largePoolFreeBytes;
+		}
+	}
+}

--- a/src/Uno.UI.RemoteControl/external/Microsoft.IO.RecyclableMemoryStream/Events.cs
+++ b/src/Uno.UI.RemoteControl/external/Microsoft.IO.RecyclableMemoryStream/Events.cs
@@ -1,0 +1,263 @@
+﻿// Imported from https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/commit/7df2ef7c95979774f783d4870cb959f03c38aade
+
+#pragma warning disable CA2211 // Disable to keep original file
+#pragma warning disable IDE0051 // Disable to keep original file
+
+// ---------------------------------------------------------------------
+// Copyright (c) 2015 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ---------------------------------------------------------------------
+
+namespace Microsoft.IO
+{
+	using System;
+	using System.Diagnostics.Tracing;
+
+	public sealed partial class RecyclableMemoryStreamManager
+	{
+		/// <summary>
+		/// ETW events for RecyclableMemoryStream.
+		/// </summary>
+		[EventSource(Name = "Microsoft-IO-RecyclableMemoryStream", Guid = "{B80CD4E4-890E-468D-9CBA-90EB7C82DFC7}")]
+		public sealed class Events : EventSource
+		{
+			/// <summary>
+			/// Static log object, through which all events are written.
+			/// </summary>
+			public static Events Writer = new();
+
+			/// <summary>
+			/// Type of buffer.
+			/// </summary>
+			public enum MemoryStreamBufferType
+			{
+				/// <summary>
+				/// Small block buffer.
+				/// </summary>
+				Small,
+				/// <summary>
+				/// Large pool buffer.
+				/// </summary>
+				Large
+			}
+
+			/// <summary>
+			/// The possible reasons for discarding a buffer.
+			/// </summary>
+			public enum MemoryStreamDiscardReason
+			{
+				/// <summary>
+				/// Buffer was too large to be re-pooled.
+				/// </summary>
+				TooLarge,
+				/// <summary>
+				/// There are enough free bytes in the pool.
+				/// </summary>
+				EnoughFree
+			}
+
+			/// <summary>
+			/// Logged when a stream object is created.
+			/// </summary>
+			/// <param name="guid">A unique ID for this stream.</param>
+			/// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
+			/// <param name="requestedSize">Requested size of the stream.</param>
+			/// <param name="actualSize">Actual size given to the stream from the pool.</param>
+			[Event(1, Level = EventLevel.Verbose, Version = 2)]
+			public void MemoryStreamCreated(Guid guid, string? tag, long requestedSize, long actualSize)
+			{
+				if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
+				{
+					this.WriteEvent(1, guid, tag ?? string.Empty, requestedSize, actualSize);
+				}
+			}
+
+			/// <summary>
+			/// Logged when the stream is disposed.
+			/// </summary>
+			/// <param name="guid">A unique ID for this stream.</param>
+			/// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
+			/// <param name="lifetimeMs">Lifetime in milliseconds of the stream</param>
+			/// <param name="allocationStack">Call stack of initial allocation.</param>
+			/// <param name="disposeStack">Call stack of the dispose.</param>
+			[Event(2, Level = EventLevel.Verbose, Version = 3)]
+			public void MemoryStreamDisposed(Guid guid, string? tag, long lifetimeMs, string? allocationStack, string? disposeStack)
+			{
+				if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
+				{
+					this.WriteEvent(2, guid, tag ?? string.Empty, lifetimeMs, allocationStack ?? string.Empty, disposeStack ?? string.Empty);
+				}
+			}
+
+			/// <summary>
+			/// Logged when the stream is disposed for the second time.
+			/// </summary>
+			/// <param name="guid">A unique ID for this stream.</param>
+			/// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
+			/// <param name="allocationStack">Call stack of initial allocation.</param>
+			/// <param name="disposeStack1">Call stack of the first dispose.</param>
+			/// <param name="disposeStack2">Call stack of the second dispose.</param>
+			/// <remarks>Note: Stacks will only be populated if RecyclableMemoryStreamManager.GenerateCallStacks is true.</remarks>
+			[Event(3, Level = EventLevel.Critical)]
+			public void MemoryStreamDoubleDispose(Guid guid, string? tag, string? allocationStack, string? disposeStack1,
+												  string? disposeStack2)
+			{
+				if (this.IsEnabled())
+				{
+					this.WriteEvent(3, guid, tag ?? string.Empty, allocationStack ?? string.Empty,
+									disposeStack1 ?? string.Empty, disposeStack2 ?? string.Empty);
+				}
+			}
+
+			/// <summary>
+			/// Logged when a stream is finalized.
+			/// </summary>
+			/// <param name="guid">A unique ID for this stream.</param>
+			/// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
+			/// <param name="allocationStack">Call stack of initial allocation.</param>
+			/// <remarks>Note: Stacks will only be populated if RecyclableMemoryStreamManager.GenerateCallStacks is true.</remarks>
+			[Event(4, Level = EventLevel.Error)]
+			public void MemoryStreamFinalized(Guid guid, string? tag, string? allocationStack)
+			{
+				if (this.IsEnabled())
+				{
+					this.WriteEvent(4, guid, tag ?? string.Empty, allocationStack ?? string.Empty);
+				}
+			}
+
+			/// <summary>
+			/// Logged when ToArray is called on a stream.
+			/// </summary>
+			/// <param name="guid">A unique ID for this stream.</param>
+			/// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
+			/// <param name="stack">Call stack of the ToArray call.</param>
+			/// <param name="size">Length of stream.</param>
+			/// <remarks>Note: Stacks will only be populated if RecyclableMemoryStreamManager.GenerateCallStacks is true.</remarks>
+			[Event(5, Level = EventLevel.Verbose, Version = 2)]
+			public void MemoryStreamToArray(Guid guid, string? tag, string? stack, long size)
+			{
+				if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
+				{
+					this.WriteEvent(5, guid, tag ?? string.Empty, stack ?? string.Empty, size);
+				}
+			}
+
+			/// <summary>
+			/// Logged when the RecyclableMemoryStreamManager is initialized.
+			/// </summary>
+			/// <param name="blockSize">Size of blocks, in bytes.</param>
+			/// <param name="largeBufferMultiple">Size of the large buffer multiple, in bytes.</param>
+			/// <param name="maximumBufferSize">Maximum buffer size, in bytes.</param>
+			[Event(6, Level = EventLevel.Informational)]
+			public void MemoryStreamManagerInitialized(int blockSize, int largeBufferMultiple, int maximumBufferSize)
+			{
+				if (this.IsEnabled())
+				{
+					this.WriteEvent(6, blockSize, largeBufferMultiple, maximumBufferSize);
+				}
+			}
+
+			/// <summary>
+			/// Logged when a new block is created.
+			/// </summary>
+			/// <param name="smallPoolInUseBytes">Number of bytes in the small pool currently in use.</param>
+			[Event(7, Level = EventLevel.Warning, Version = 2)]
+			public void MemoryStreamNewBlockCreated(long smallPoolInUseBytes)
+			{
+				if (this.IsEnabled(EventLevel.Warning, EventKeywords.None))
+				{
+					this.WriteEvent(7, smallPoolInUseBytes);
+				}
+			}
+
+			/// <summary>
+			/// Logged when a new large buffer is created.
+			/// </summary>
+			/// <param name="requiredSize">Requested size.</param>
+			/// <param name="largePoolInUseBytes">Number of bytes in the large pool in use.</param>
+			[Event(8, Level = EventLevel.Warning, Version = 3)]
+			public void MemoryStreamNewLargeBufferCreated(long requiredSize, long largePoolInUseBytes)
+			{
+				if (this.IsEnabled(EventLevel.Warning, EventKeywords.None))
+				{
+					this.WriteEvent(8, requiredSize, largePoolInUseBytes);
+				}
+			}
+
+			/// <summary>
+			/// Logged when a buffer is created that is too large to pool.
+			/// </summary>
+			/// <param name="guid">Unique stream ID.</param>
+			/// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
+			/// <param name="requiredSize">Size requested by the caller.</param>
+			/// <param name="allocationStack">Call stack of the requested stream.</param>
+			/// <remarks>Note: Stacks will only be populated if RecyclableMemoryStreamManager.GenerateCallStacks is true.</remarks>
+			[Event(9, Level = EventLevel.Verbose, Version = 3)]
+			public void MemoryStreamNonPooledLargeBufferCreated(Guid guid, string? tag, long requiredSize, string? allocationStack)
+			{
+				if (this.IsEnabled(EventLevel.Verbose, EventKeywords.None))
+				{
+					this.WriteEvent(9, guid, tag ?? string.Empty, requiredSize, allocationStack ?? string.Empty);
+				}
+			}
+
+			/// <summary>
+			/// Logged when a buffer is discarded (not put back in the pool, but given to GC to clean up).
+			/// </summary>
+			/// <param name="guid">Unique stream ID.</param>
+			/// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
+			/// <param name="bufferType">Type of the buffer being discarded.</param>
+			/// <param name="reason">Reason for the discard.</param>
+			/// <param name="smallBlocksFree">Number of free small pool blocks.</param>
+			/// <param name="smallPoolBytesFree">Bytes free in the small pool.</param>
+			/// <param name="smallPoolBytesInUse">Bytes in use from the small pool.</param>
+			/// <param name="largeBlocksFree">Number of free large pool blocks.</param>
+			/// <param name="largePoolBytesFree">Bytes free in the large pool.</param>
+			/// <param name="largePoolBytesInUse">Bytes in use from the large pool.</param>
+			[Event(10, Level = EventLevel.Warning, Version = 2)]
+			public void MemoryStreamDiscardBuffer(Guid guid, string? tag, MemoryStreamBufferType bufferType,
+												  MemoryStreamDiscardReason reason, long smallBlocksFree, long smallPoolBytesFree, long smallPoolBytesInUse, long largeBlocksFree, long largePoolBytesFree, long largePoolBytesInUse)
+			{
+				if (this.IsEnabled(EventLevel.Warning, EventKeywords.None))
+				{
+					this.WriteEvent(10, guid, tag ?? string.Empty, bufferType, reason, smallBlocksFree, smallPoolBytesFree, smallPoolBytesInUse, largeBlocksFree, largePoolBytesFree, largePoolBytesInUse);
+				}
+			}
+
+			/// <summary>
+			/// Logged when a stream grows beyond the maximum capacity.
+			/// </summary>
+			/// <param name="guid">Unique stream ID</param>
+			/// <param name="requestedCapacity">The requested capacity.</param>
+			/// <param name="maxCapacity">Maximum capacity, as configured by RecyclableMemoryStreamManager.</param>
+			/// <param name="tag">A temporary ID for this stream, usually indicates current usage.</param>
+			/// <param name="allocationStack">Call stack for the capacity request.</param>
+			/// <remarks>Note: Stacks will only be populated if RecyclableMemoryStreamManager.GenerateCallStacks is true.</remarks>
+			[Event(11, Level = EventLevel.Error, Version = 3)]
+			public void MemoryStreamOverCapacity(Guid guid, string? tag, long requestedCapacity, long maxCapacity, string? allocationStack)
+			{
+				if (this.IsEnabled())
+				{
+					this.WriteEvent(11, guid, tag ?? string.Empty, requestedCapacity, maxCapacity, allocationStack ?? string.Empty);
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI.RemoteControl/external/Microsoft.IO.RecyclableMemoryStream/RecyclableMemoryStream.cs
+++ b/src/Uno.UI.RemoteControl/external/Microsoft.IO.RecyclableMemoryStream/RecyclableMemoryStream.cs
@@ -1,0 +1,1506 @@
+﻿// Imported from https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/commit/7df2ef7c95979774f783d4870cb959f03c38aade
+
+// The MIT License (MIT)
+//
+// Copyright (c) 2015-2016 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace Microsoft.IO
+{
+	using System;
+	using System.Buffers;
+	using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Runtime.CompilerServices;
+	using System.Threading;
+	using System.Threading.Tasks;
+
+	/// <summary>
+	/// MemoryStream implementation that deals with pooling and managing memory streams which use potentially large
+	/// buffers.
+	/// </summary>
+	/// <remarks>
+	/// This class works in tandem with the <see cref="RecyclableMemoryStreamManager"/> to supply <c>MemoryStream</c>-derived
+	/// objects to callers, while avoiding these specific problems:
+	/// <list type="number">
+	/// <item>
+	/// <term>LOH allocations</term>
+	/// <description>Since all large buffers are pooled, they will never incur a Gen2 GC</description>
+	/// </item>
+	/// <item>
+	/// <term>Memory waste</term><description>A standard memory stream doubles its size when it runs out of room. This
+	/// leads to continual memory growth as each stream approaches the maximum allowed size.</description>
+	/// </item>
+	/// <item>
+	/// <term>Memory copying</term>
+	/// <description>Each time a <c>MemoryStream</c> grows, all the bytes are copied into new buffers.
+	/// This implementation only copies the bytes when <see cref="GetBuffer"/> is called.</description>
+	/// </item>
+	/// <item>
+	/// <term>Memory fragmentation</term>
+	/// <description>By using homogeneous buffer sizes, it ensures that blocks of memory
+	/// can be easily reused.
+	/// </description>
+	/// </item>
+	/// </list>
+	/// <para>
+	/// The stream is implemented on top of a series of uniformly-sized blocks. As the stream's length grows,
+	/// additional blocks are retrieved from the memory manager. It is these blocks that are pooled, not the stream
+	/// object itself.
+	/// </para>
+	/// <para>
+	/// The biggest wrinkle in this implementation is when <see cref="GetBuffer"/> is called. This requires a single
+	/// contiguous buffer. If only a single block is in use, then that block is returned. If multiple blocks
+	/// are in use, we retrieve a larger buffer from the memory manager. These large buffers are also pooled,
+	/// split by size--they are multiples/exponentials of a chunk size (1 MB by default).
+	/// </para>
+	/// <para>
+	/// Once a large buffer is assigned to the stream the small blocks are NEVER again used for this stream. All operations take place on the
+	/// large buffer. The large buffer can be replaced by a larger buffer from the pool as needed. All blocks and large buffers
+	/// are maintained in the stream until the stream is disposed (unless AggressiveBufferReturn is enabled in the stream manager).
+	/// </para>
+	/// <para>
+	/// A further wrinkle is what happens when the stream is longer than the maximum allowable array length under .NET. This is allowed
+	/// when only blocks are in use, and only the Read/Write APIs are used. Once a stream grows to this size, any attempt to convert it
+	/// to a single buffer will result in an exception. Similarly, if a stream is already converted to use a single larger buffer, then
+	/// it cannot grow beyond the limits of the maximum allowable array size.
+	/// </para>
+	/// <para>
+	/// Any method that modifies the stream has the potential to throw an <c>OutOfMemoryException</c>, either because
+	/// the stream is beyond the limits set in <c>RecyclableStreamManager</c>, or it would result in a buffer larger than
+	/// the maximum array size supported by .NET.
+	/// </para>
+	/// </remarks>
+	public sealed class RecyclableMemoryStream : MemoryStream, IBufferWriter<byte>
+	{
+		/// <summary>
+		/// All of these blocks must be the same size.
+		/// </summary>
+		private readonly List<byte[]> blocks;
+
+		private readonly Guid id;
+
+		private readonly RecyclableMemoryStreamManager memoryManager;
+
+		private readonly string? tag;
+
+		private readonly long creationTimestamp;
+
+		/// <summary>
+		/// This list is used to store buffers once they're replaced by something larger.
+		/// This is for the cases where you have users of this class that may hold onto the buffers longer
+		/// than they should and you want to prevent race conditions which could corrupt the data.
+		/// </summary>
+		private List<byte[]>? dirtyBuffers;
+
+		private bool disposed;
+
+		/// <summary>
+		/// This is only set by GetBuffer() if the necessary buffer is larger than a single block size, or on
+		/// construction if the caller immediately requests a single large buffer.
+		/// </summary>
+		/// <remarks>If this field is non-null, it contains the concatenation of the bytes found in the individual
+		/// blocks. Once it is created, this (or a larger) largeBuffer will be used for the life of the stream.
+		/// </remarks>
+		private byte[]? largeBuffer;
+
+		/// <summary>
+		/// Unique identifier for this stream across its entire lifetime.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		internal Guid Id
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this.id;
+			}
+		}
+
+		/// <summary>
+		/// A temporary identifier for the current usage of this stream.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		internal string? Tag
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this.tag;
+			}
+		}
+
+		/// <summary>
+		/// Gets the memory manager being used by this stream.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		internal RecyclableMemoryStreamManager MemoryManager
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this.memoryManager;
+			}
+		}
+
+		/// <summary>
+		/// Call stack of the constructor. It is only set if <see cref="RecyclableMemoryStreamManager.Options.GenerateCallStacks"/> is true,
+		/// which should only be in debugging situations.
+		/// </summary>
+		internal string? AllocationStack { get; }
+
+		/// <summary>
+		/// Call stack of the <see cref="Dispose(bool)"/> call. It is only set if <see cref="RecyclableMemoryStreamManager.Options.GenerateCallStacks"/> is true,
+		/// which should only be in debugging situations.
+		/// </summary>
+		internal string? DisposeStack { get; private set; }
+
+		#region Constructors
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RecyclableMemoryStream"/> class.
+		/// </summary>
+		/// <param name="memoryManager">The memory manager.</param>
+		public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager)
+			: this(memoryManager, Guid.NewGuid(), null, 0, null) { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RecyclableMemoryStream"/> class.
+		/// </summary>
+		/// <param name="memoryManager">The memory manager.</param>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, Guid id)
+			: this(memoryManager, id, null, 0, null) { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RecyclableMemoryStream"/> class.
+		/// </summary>
+		/// <param name="memoryManager">The memory manager.</param>
+		/// <param name="tag">A string identifying this stream for logging and debugging purposes.</param>
+		public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, string? tag)
+			: this(memoryManager, Guid.NewGuid(), tag, 0, null) { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RecyclableMemoryStream"/> class.
+		/// </summary>
+		/// <param name="memoryManager">The memory manager.</param>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		/// <param name="tag">A string identifying this stream for logging and debugging purposes.</param>
+		public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, Guid id, string? tag)
+			: this(memoryManager, id, tag, 0, null) { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RecyclableMemoryStream"/> class.
+		/// </summary>
+		/// <param name="memoryManager">The memory manager.</param>
+		/// <param name="tag">A string identifying this stream for logging and debugging purposes.</param>
+		/// <param name="requestedSize">The initial requested size to prevent future allocations.</param>
+		public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, string? tag, long requestedSize)
+			: this(memoryManager, Guid.NewGuid(), tag, requestedSize, null) { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RecyclableMemoryStream"/> class.
+		/// </summary>
+		/// <param name="memoryManager">The memory manager</param>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		/// <param name="tag">A string identifying this stream for logging and debugging purposes.</param>
+		/// <param name="requestedSize">The initial requested size to prevent future allocations.</param>
+		public RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, Guid id, string? tag, long requestedSize)
+			: this(memoryManager, id, tag, requestedSize, null) { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RecyclableMemoryStream"/> class.
+		/// </summary>
+		/// <param name="memoryManager">The memory manager.</param>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		/// <param name="tag">A string identifying this stream for logging and debugging purposes.</param>
+		/// <param name="requestedSize">The initial requested size to prevent future allocations.</param>
+		/// <param name="initialLargeBuffer">An initial buffer to use. This buffer will be owned by the stream and returned to the memory manager upon Dispose.</param>
+		internal RecyclableMemoryStream(RecyclableMemoryStreamManager memoryManager, Guid id, string? tag, long requestedSize, byte[]? initialLargeBuffer)
+			: base([])
+		{
+			this.memoryManager = memoryManager;
+			this.id = id;
+			this.tag = tag;
+			this.blocks = [];
+			this.creationTimestamp = Stopwatch.GetTimestamp();
+
+			var actualRequestedSize = Math.Max(requestedSize, this.memoryManager.options.BlockSize);
+
+			if (initialLargeBuffer == null)
+			{
+				this.EnsureCapacity(actualRequestedSize);
+			}
+			else
+			{
+				this.largeBuffer = initialLargeBuffer;
+			}
+
+			if (this.memoryManager.options.GenerateCallStacks)
+			{
+				this.AllocationStack = Environment.StackTrace;
+			}
+
+			this.memoryManager.ReportStreamCreated(this.id, this.tag, requestedSize, actualRequestedSize);
+			this.memoryManager.ReportUsageReport();
+		}
+		#endregion
+
+		#region Dispose and Finalize
+		/// <summary>
+		/// The finalizer will be called when a stream is not disposed properly.
+		/// </summary>
+		/// <remarks>Failing to dispose indicates a bug in the code using streams. Care should be taken to properly account for stream lifetime.</remarks>
+		~RecyclableMemoryStream()
+		{
+			this.Dispose(false);
+		}
+
+		/// <summary>
+		/// Returns the memory used by this stream back to the pool.
+		/// </summary>
+		/// <param name="disposing">Whether we're disposing (true), or being called by the finalizer (false).</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (this.disposed)
+			{
+				string? doubleDisposeStack = null;
+				if (this.memoryManager.options.GenerateCallStacks)
+				{
+					doubleDisposeStack = Environment.StackTrace;
+				}
+
+				this.memoryManager.ReportStreamDoubleDisposed(this.id, this.tag, this.AllocationStack, this.DisposeStack, doubleDisposeStack);
+				return;
+			}
+
+			this.disposed = true;
+			var lifetime = TimeSpan.FromTicks((Stopwatch.GetTimestamp() - this.creationTimestamp) * TimeSpan.TicksPerSecond / Stopwatch.Frequency);
+
+			if (this.memoryManager.options.GenerateCallStacks)
+			{
+				this.DisposeStack = Environment.StackTrace;
+			}
+
+			this.memoryManager.ReportStreamDisposed(this.id, this.tag, lifetime, this.AllocationStack, this.DisposeStack);
+
+			if (disposing)
+			{
+				GC.SuppressFinalize(this);
+			}
+			else
+			{
+				// We're being finalized.
+				this.memoryManager.ReportStreamFinalized(this.id, this.tag, this.AllocationStack);
+
+				if (AppDomain.CurrentDomain.IsFinalizingForUnload())
+				{
+					// If we're being finalized because of a shutdown, don't go any further.
+					// We have no idea what's already been cleaned up. Triggering events may cause
+					// a crash.
+					base.Dispose(disposing);
+					return;
+				}
+			}
+
+			this.memoryManager.ReportStreamLength(this.length);
+
+			if (this.largeBuffer != null)
+			{
+				this.memoryManager.ReturnLargeBuffer(this.largeBuffer, this.id, this.tag);
+			}
+
+			if (this.dirtyBuffers != null)
+			{
+				foreach (var buffer in this.dirtyBuffers)
+				{
+					this.memoryManager.ReturnLargeBuffer(buffer, this.id, this.tag);
+				}
+			}
+
+			this.memoryManager.ReturnBlocks(this.blocks, this.id, this.tag);
+			this.memoryManager.ReportUsageReport();
+			this.blocks.Clear();
+
+			base.Dispose(disposing);
+		}
+
+		/// <summary>
+		/// Equivalent to <c>Dispose</c>.
+		/// </summary>
+		public override void Close()
+		{
+			this.Dispose(true);
+		}
+		#endregion
+
+		#region MemoryStream overrides
+		/// <summary>
+		/// Gets or sets the capacity.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Capacity is always in multiples of the memory manager's block size, unless
+		/// the large buffer is in use. Capacity never decreases during a stream's lifetime.
+		/// Explicitly setting the capacity to a lower value than the current value will have no effect.
+		/// This is because the buffers are all pooled by chunks and there's little reason to
+		/// allow stream truncation.
+		/// </para>
+		/// <para>
+		/// Writing past the current capacity will cause <see cref="Capacity"/> to automatically increase, until MaximumStreamCapacity is reached.
+		/// </para>
+		/// <para>
+		/// If the capacity is larger than <c>int.MaxValue</c>, then <c>InvalidOperationException</c> will be thrown. If you anticipate using
+		/// larger streams, use the <see cref="Capacity64"/> property instead.
+		/// </para>
+		/// </remarks>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		/// <exception cref="InvalidOperationException">Capacity is larger than int.MaxValue.</exception>
+		public override int Capacity
+		{
+			get
+			{
+				this.CheckDisposed();
+				if (this.largeBuffer != null)
+				{
+					return this.largeBuffer.Length;
+				}
+
+				long size = (long)this.blocks.Count * this.memoryManager.options.BlockSize;
+				if (size > int.MaxValue)
+				{
+					throw new InvalidOperationException($"{nameof(this.Capacity)} is larger than int.MaxValue. Use {nameof(this.Capacity64)} instead.");
+				}
+				return (int)size;
+			}
+			set
+			{
+				this.Capacity64 = value;
+			}
+		}
+
+		/// <summary>
+		/// Returns a 64-bit version of capacity, for streams larger than <c>int.MaxValue</c> in length.
+		/// </summary>
+		public long Capacity64
+		{
+			get
+			{
+				this.CheckDisposed();
+				if (this.largeBuffer != null)
+				{
+					return this.largeBuffer.Length;
+				}
+
+				long size = (long)this.blocks.Count * this.memoryManager.options.BlockSize;
+				return size;
+			}
+			set
+			{
+				this.CheckDisposed();
+				this.EnsureCapacity(value);
+			}
+		}
+
+		private long length;
+
+		/// <summary>
+		/// Gets the number of bytes written to this stream.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		/// <remarks>If the buffer has already been converted to a large buffer, then the maximum length is limited by the maximum allowed array length in .NET.</remarks>
+		public override long Length
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this.length;
+			}
+		}
+
+		private long position;
+
+		/// <summary>
+		/// Gets the current position in the stream.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">A negative value was passed.</exception>
+		/// <exception cref="InvalidOperationException">Stream is in large-buffer mode, but an attempt was made to set the position past the maximum allowed array length.</exception>
+		/// <remarks>If the buffer has already been converted to a large buffer, then the maximum length (and thus position) is limited by the maximum allowed array length in .NET.</remarks>
+		public override long Position
+		{
+			get
+			{
+				this.CheckDisposed();
+				return this.position;
+			}
+			set
+			{
+				this.CheckDisposed();
+				if (value < 0)
+				{
+					throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(value)} must be non-negative.");
+				}
+
+				if (this.largeBuffer != null && value > RecyclableMemoryStreamManager.MaxArrayLength)
+				{
+					throw new InvalidOperationException($"Once the stream is converted to a single large buffer, position cannot be set past {RecyclableMemoryStreamManager.MaxArrayLength}.");
+				}
+				this.position = value;
+			}
+		}
+
+		/// <summary>
+		/// Whether the stream can currently read.
+		/// </summary>
+		public override bool CanRead => !this.Disposed;
+
+		/// <summary>
+		/// Whether the stream can currently seek.
+		/// </summary>
+		public override bool CanSeek => !this.Disposed;
+
+		/// <summary>
+		/// Always false.
+		/// </summary>
+		public override bool CanTimeout => false;
+
+		/// <summary>
+		/// Whether the stream can currently write.
+		/// </summary>
+		public override bool CanWrite => !this.Disposed;
+
+		/// <summary>
+		/// Returns a single buffer containing the contents of the stream.
+		/// The buffer may be longer than the stream length.
+		/// </summary>
+		/// <returns>A byte[] buffer.</returns>
+		/// <remarks>IMPORTANT: Doing a <see cref="Write(byte[], int, int)"/> after calling <c>GetBuffer</c> invalidates the buffer. The old buffer is held onto
+		/// until <see cref="Dispose(bool)"/> is called, but the next time <c>GetBuffer</c> is called, a new buffer from the pool will be required.</remarks>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		/// <exception cref="OutOfMemoryException">stream is too large for a contiguous buffer.</exception>
+		public override byte[] GetBuffer()
+		{
+			this.CheckDisposed();
+
+			if (this.largeBuffer != null)
+			{
+				return this.largeBuffer;
+			}
+
+			if (this.blocks.Count == 1)
+			{
+				return this.blocks[0];
+			}
+
+			// Buffer needs to reflect the capacity, not the length, because
+			// it's possible that people will manipulate the buffer directly
+			// and set the length afterward. Capacity sets the expectation
+			// for the size of the buffer.
+
+			var newBuffer = this.memoryManager.GetLargeBuffer(this.Capacity64, this.id, this.tag);
+
+			// InternalRead will check for existence of largeBuffer, so make sure we
+			// don't set it until after we've copied the data.
+			this.AssertLengthIsSmall();
+			this.InternalRead(newBuffer, 0, (int)this.length, 0);
+			this.largeBuffer = newBuffer;
+
+			if (this.blocks.Count > 0 && this.memoryManager.options.AggressiveBufferReturn)
+			{
+				this.memoryManager.ReturnBlocks(this.blocks, this.id, this.tag);
+				this.blocks.Clear();
+			}
+
+			return this.largeBuffer;
+		}
+
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+		/// <inheritdoc/>
+		public override void CopyTo(Stream destination, int bufferSize)
+		{
+			this.WriteTo(destination, this.position, this.length - this.position);
+		}
+#endif
+
+		/// <summary>Asynchronously reads all the bytes from the current position in this stream and writes them to another stream.</summary>
+		/// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
+		/// <param name="bufferSize">This parameter is ignored.</param>
+		/// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+		/// <returns>A task that represents the asynchronous copy operation.</returns>
+		/// <exception cref="T:System.ArgumentNullException">
+		///   <paramref name="destination"/> is <see langword="null"/>.</exception>
+		/// <exception cref="T:System.ObjectDisposedException">Either the current stream or the destination stream is disposed.</exception>
+		/// <exception cref="T:System.NotSupportedException">The current stream does not support reading, or the destination stream does not support writing.</exception>
+		/// <remarks>Similarly to <c>MemoryStream</c>'s behavior, <c>CopyToAsync</c> will adjust the source stream's position by the number of bytes written to the destination stream, as a Read would do.</remarks>
+		public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+		{
+			if (destination == null)
+			{
+				throw new ArgumentNullException(nameof(destination));
+			}
+
+			this.CheckDisposed();
+
+			if (this.length == 0)
+			{
+				return Task.CompletedTask;
+			}
+
+			long startPos = this.position;
+			var count = this.length - startPos;
+			this.position += count;
+
+			if (destination is MemoryStream destinationRMS)
+			{
+				this.WriteTo(destinationRMS, startPos, count);
+				return Task.CompletedTask;
+			}
+			else
+			{
+				if (this.largeBuffer == null)
+				{
+					if (this.blocks.Count == 1)
+					{
+						this.AssertLengthIsSmall();
+						return destination.WriteAsync(this.blocks[0], (int)startPos, (int)count, cancellationToken);
+					}
+					else
+					{
+						return CopyToAsyncImpl(destination, this.GetBlockAndRelativeOffset(startPos), count, this.blocks, cancellationToken);
+					}
+				}
+				else
+				{
+					this.AssertLengthIsSmall();
+					return destination.WriteAsync(this.largeBuffer, (int)startPos, (int)count, cancellationToken);
+				}
+			}
+
+			static async Task CopyToAsyncImpl(Stream destination, BlockAndOffset blockAndOffset, long count, List<byte[]> blocks, CancellationToken cancellationToken)
+			{
+				var bytesRemaining = count;
+				int currentBlock = blockAndOffset.Block;
+				var currentOffset = blockAndOffset.Offset;
+				while (bytesRemaining > 0)
+				{
+					byte[] block = blocks[currentBlock];
+					int amountToCopy = (int)Math.Min(block.Length - currentOffset, bytesRemaining);
+					await destination.WriteAsync(block, currentOffset, amountToCopy, cancellationToken);
+					bytesRemaining -= amountToCopy;
+					++currentBlock;
+					currentOffset = 0;
+				}
+			}
+		}
+
+		private byte[]? bufferWriterTempBuffer;
+
+		/// <summary>
+		/// Notifies the stream that <paramref name="count"/> bytes were written to the buffer returned by <see cref="GetMemory(int)"/> or <see cref="GetSpan(int)"/>.
+		/// Seeks forward by <paramref name="count"/> bytes.
+		/// </summary>
+		/// <remarks>
+		/// You must request a new buffer after calling Advance to continue writing more data and cannot write to a previously acquired buffer.
+		/// </remarks>
+		/// <param name="count">How many bytes to advance.</param>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is negative.</exception>
+		/// <exception cref="InvalidOperationException"><paramref name="count"/> is larger than the size of the previously requested buffer.</exception>
+		public void Advance(int count)
+		{
+			this.CheckDisposed();
+			if (count < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(count), $"{nameof(count)} must be non-negative.");
+			}
+
+			byte[]? buffer = this.bufferWriterTempBuffer;
+			if (buffer != null)
+			{
+				if (count > buffer.Length)
+				{
+					throw new InvalidOperationException($"Cannot advance past the end of the buffer, which has a size of {buffer.Length}.");
+				}
+
+				this.Write(buffer, 0, count);
+				this.ReturnTempBuffer(buffer);
+				this.bufferWriterTempBuffer = null;
+			}
+			else
+			{
+				long bufferSize = this.largeBuffer == null
+					? this.memoryManager.options.BlockSize - this.GetBlockAndRelativeOffset(this.position).Offset
+					: this.largeBuffer.Length - this.position;
+
+				if (count > bufferSize)
+				{
+					throw new InvalidOperationException($"Cannot advance past the end of the buffer, which has a size of {bufferSize}.");
+				}
+
+				this.position += count;
+				this.length = Math.Max(this.position, this.length);
+			}
+		}
+
+		private void ReturnTempBuffer(byte[] buffer)
+		{
+			if (buffer.Length == this.memoryManager.options.BlockSize)
+			{
+				this.memoryManager.ReturnBlock(buffer, this.id, this.tag);
+			}
+			else
+			{
+				this.memoryManager.ReturnLargeBuffer(buffer, this.id, this.tag);
+			}
+		}
+
+		/// <inheritdoc/>
+		/// <remarks>
+		/// IMPORTANT: Calling Write(), GetBuffer(), TryGetBuffer(), Seek(), GetLength(), Advance(),
+		/// or setting Position after calling GetMemory() invalidates the memory.
+		/// </remarks>
+		public Memory<byte> GetMemory(int sizeHint = 0) => this.GetWritableBuffer(sizeHint);
+
+		/// <inheritdoc/>
+		/// <remarks>
+		/// IMPORTANT: Calling Write(), GetBuffer(), TryGetBuffer(), Seek(), GetLength(), Advance(),
+		/// or setting Position after calling GetSpan() invalidates the span.
+		/// </remarks>
+		public Span<byte> GetSpan(int sizeHint = 0) => this.GetWritableBuffer(sizeHint);
+
+		/// <summary>
+		/// When callers to GetSpan() or GetMemory() request a buffer that is larger than the remaining size of the current block
+		/// this method return a temp buffer. When Advance() is called, that temp buffer is then copied into the stream.
+		/// </summary>
+		private ArraySegment<byte> GetWritableBuffer(int sizeHint)
+		{
+			this.CheckDisposed();
+			if (sizeHint < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(sizeHint), $"{nameof(sizeHint)} must be non-negative.");
+			}
+
+			var minimumBufferSize = Math.Max(sizeHint, 1);
+
+			this.EnsureCapacity(this.position + minimumBufferSize);
+			if (this.bufferWriterTempBuffer != null)
+			{
+				this.ReturnTempBuffer(this.bufferWriterTempBuffer);
+				this.bufferWriterTempBuffer = null;
+			}
+
+			if (this.largeBuffer != null)
+			{
+				return new ArraySegment<byte>(this.largeBuffer, (int)this.position, this.largeBuffer.Length - (int)this.position);
+			}
+
+			BlockAndOffset blockAndOffset = this.GetBlockAndRelativeOffset(this.position);
+			int remainingBytesInBlock = this.MemoryManager.options.BlockSize - blockAndOffset.Offset;
+			if (remainingBytesInBlock >= minimumBufferSize)
+			{
+				return new ArraySegment<byte>(this.blocks[blockAndOffset.Block], blockAndOffset.Offset, this.MemoryManager.options.BlockSize - blockAndOffset.Offset);
+			}
+
+			this.bufferWriterTempBuffer = minimumBufferSize > this.memoryManager.options.BlockSize ?
+				this.memoryManager.GetLargeBuffer(minimumBufferSize, this.id, this.tag) :
+				this.memoryManager.GetBlock();
+
+			return new ArraySegment<byte>(this.bufferWriterTempBuffer);
+		}
+
+		/// <summary>
+		/// Returns a sequence containing the contents of the stream.
+		/// </summary>
+		/// <returns>A ReadOnlySequence of bytes.</returns>
+		/// <remarks>IMPORTANT: Calling Write(), GetMemory(), GetSpan(), Dispose(), or Close() after calling GetReadOnlySequence() invalidates the sequence.</remarks>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public ReadOnlySequence<byte> GetReadOnlySequence()
+		{
+			this.CheckDisposed();
+
+			if (this.largeBuffer != null)
+			{
+				this.AssertLengthIsSmall();
+				return new ReadOnlySequence<byte>(this.largeBuffer, 0, (int)this.length);
+			}
+
+			if (this.blocks.Count == 1)
+			{
+				this.AssertLengthIsSmall();
+				return new ReadOnlySequence<byte>(this.blocks[0], 0, (int)this.length);
+			}
+
+			var first = new BlockSegment(this.blocks[0]);
+			var last = first;
+
+			for (int blockIdx = 1; last.RunningIndex + last.Memory.Length < this.length; blockIdx++)
+			{
+				last = last.Append(this.blocks[blockIdx]);
+			}
+
+			return new ReadOnlySequence<byte>(first, 0, last, (int)(this.length - last.RunningIndex));
+		}
+
+		private sealed class BlockSegment : ReadOnlySequenceSegment<byte>
+		{
+			public BlockSegment(Memory<byte> memory) => this.Memory = memory;
+
+			public BlockSegment Append(Memory<byte> memory)
+			{
+				var nextSegment = new BlockSegment(memory) { RunningIndex = this.RunningIndex + this.Memory.Length };
+				this.Next = nextSegment;
+				return nextSegment;
+			}
+		}
+
+		/// <summary>
+		/// Returns an <c>ArraySegment</c> that wraps a single buffer containing the contents of the stream.
+		/// </summary>
+		/// <param name="buffer">An <c>ArraySegment</c> containing a reference to the underlying bytes.</param>
+		/// <returns>Returns <see langword="true"/> if a buffer can be returned; otherwise, <see langword="false"/>.</returns>
+		public override bool TryGetBuffer(out ArraySegment<byte> buffer)
+		{
+			this.CheckDisposed();
+
+			try
+			{
+				if (this.length <= RecyclableMemoryStreamManager.MaxArrayLength)
+				{
+					buffer = new ArraySegment<byte>(this.GetBuffer(), 0, (int)this.Length);
+					return true;
+				}
+			}
+			catch (OutOfMemoryException)
+			{
+			}
+
+#if NET6_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+			buffer = ArraySegment<byte>.Empty;
+#else
+            buffer = new ArraySegment<byte>();
+#endif
+			return false;
+		}
+
+		/// <summary>
+		/// Returns a new array with a copy of the buffer's contents. You should almost certainly be using <see cref="GetBuffer"/> combined with the <see cref="Length"/> to
+		/// access the bytes in this stream. Calling <c>ToArray</c> will destroy the benefits of pooled buffers, but it is included
+		/// for the sake of completeness.
+		/// </summary>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		/// <exception cref="NotSupportedException">The current <see cref="RecyclableMemoryStreamManager"/>object disallows <c>ToArray</c> calls.</exception>
+		/// <exception cref="OutOfMemoryException">The length of the stream is too long for a contiguous array.</exception>
+#pragma warning disable CS0809
+		[Obsolete("This method has degraded performance vs. GetBuffer and should be avoided.")]
+		public override byte[] ToArray()
+		{
+			this.CheckDisposed();
+
+			string? stack = this.memoryManager.options.GenerateCallStacks ? Environment.StackTrace : null;
+			this.memoryManager.ReportStreamToArray(this.id, this.tag, stack, this.length);
+
+			if (this.memoryManager.options.ThrowExceptionOnToArray)
+			{
+				throw new NotSupportedException("The underlying RecyclableMemoryStreamManager is configured to not allow calls to ToArray.");
+			}
+
+			var newBuffer = new byte[this.Length];
+
+			Debug.Assert(this.length <= int.MaxValue);
+			this.InternalRead(newBuffer, 0, (int)this.length, 0);
+
+			return newBuffer;
+		}
+#pragma warning restore CS0809
+
+		/// <summary>
+		/// Reads from the current position into the provided buffer.
+		/// </summary>
+		/// <param name="buffer">Destination buffer.</param>
+		/// <param name="offset">Offset into buffer at which to start placing the read bytes.</param>
+		/// <param name="count">Number of bytes to read.</param>
+		/// <returns>The number of bytes read.</returns>
+		/// <exception cref="ArgumentNullException">buffer is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">offset or count is less than 0.</exception>
+		/// <exception cref="ArgumentException">offset subtracted from the buffer length is less than count.</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			return this.SafeRead(buffer, offset, count, ref this.position);
+		}
+
+		/// <summary>
+		/// Reads from the specified position into the provided buffer.
+		/// </summary>
+		/// <param name="buffer">Destination buffer.</param>
+		/// <param name="offset">Offset into buffer at which to start placing the read bytes.</param>
+		/// <param name="count">Number of bytes to read.</param>
+		/// <param name="streamPosition">Position in the stream to start reading from.</param>
+		/// <returns>The number of bytes read.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="offset"/> or <paramref name="count"/> is less than 0.</exception>
+		/// <exception cref="ArgumentException"><paramref name="offset"/> subtracted from the buffer length is less than <paramref name="count"/>.</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public int SafeRead(byte[] buffer, int offset, int count, ref long streamPosition)
+		{
+			this.CheckDisposed();
+			if (buffer == null)
+			{
+				throw new ArgumentNullException(nameof(buffer));
+			}
+
+			if (offset < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(offset), $"{nameof(offset)} cannot be negative.");
+			}
+
+			if (count < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(count), $"{nameof(count)} cannot be negative.");
+			}
+
+			if (offset + count > buffer.Length)
+			{
+				throw new ArgumentException($"{nameof(buffer)} length must be at least {nameof(offset)} + {nameof(count)}.");
+			}
+
+			int amountRead = this.InternalRead(buffer, offset, count, streamPosition);
+			streamPosition += amountRead;
+			return amountRead;
+		}
+
+		/// <summary>
+		/// Reads from the current position into the provided buffer.
+		/// </summary>
+		/// <param name="buffer">Destination buffer.</param>
+		/// <returns>The number of bytes read.</returns>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+#if NETSTANDARD2_0
+        public int Read(Span<byte> buffer)
+#else
+		public override int Read(Span<byte> buffer)
+#endif
+		{
+			return this.SafeRead(buffer, ref this.position);
+		}
+
+		/// <summary>
+		/// Reads from the specified position into the provided buffer.
+		/// </summary>
+		/// <param name="buffer">Destination buffer.</param>
+		/// <param name="streamPosition">Position in the stream to start reading from.</param>
+		/// <returns>The number of bytes read.</returns>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public int SafeRead(Span<byte> buffer, ref long streamPosition)
+		{
+			this.CheckDisposed();
+
+			int amountRead = this.InternalRead(buffer, streamPosition);
+			streamPosition += amountRead;
+			return amountRead;
+		}
+
+		/// <summary>
+		/// Writes the buffer to the stream.
+		/// </summary>
+		/// <param name="buffer">Source buffer.</param>
+		/// <param name="offset">Start position.</param>
+		/// <param name="count">Number of bytes to write.</param>
+		/// <exception cref="ArgumentNullException">buffer is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">offset or count is negative.</exception>
+		/// <exception cref="ArgumentException">buffer.Length - offset is not less than count.</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public override void Write(byte[] buffer, int offset, int count)
+		{
+			this.CheckDisposed();
+			if (buffer == null)
+			{
+				throw new ArgumentNullException(nameof(buffer));
+			}
+
+			if (offset < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(offset), offset,
+					$"{nameof(offset)} must be in the range of 0 - {nameof(buffer)}.{nameof(buffer.Length)}-1.");
+			}
+
+			if (count < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(count), count, $"{nameof(count)} must be non-negative.");
+			}
+
+			if (count + offset > buffer.Length)
+			{
+				throw new ArgumentException($"{nameof(count)} must be greater than {nameof(buffer)}.{nameof(buffer.Length)} - {nameof(offset)}.");
+			}
+
+			int blockSize = this.memoryManager.options.BlockSize;
+			long end = this.position + count;
+
+			this.EnsureCapacity(end);
+
+			if (this.largeBuffer == null)
+			{
+				int bytesRemaining = count;
+				int bytesWritten = 0;
+				var blockAndOffset = this.GetBlockAndRelativeOffset(this.position);
+
+				while (bytesRemaining > 0)
+				{
+					byte[] currentBlock = this.blocks[blockAndOffset.Block];
+					int remainingInBlock = blockSize - blockAndOffset.Offset;
+					int amountToWriteInBlock = Math.Min(remainingInBlock, bytesRemaining);
+
+					Buffer.BlockCopy(buffer, offset + bytesWritten, currentBlock, blockAndOffset.Offset,
+									 amountToWriteInBlock);
+
+					bytesRemaining -= amountToWriteInBlock;
+					bytesWritten += amountToWriteInBlock;
+
+					++blockAndOffset.Block;
+					blockAndOffset.Offset = 0;
+				}
+			}
+			else
+			{
+				Buffer.BlockCopy(buffer, offset, this.largeBuffer, (int)this.position, count);
+			}
+			this.position = end;
+			this.length = Math.Max(this.position, this.length);
+		}
+
+		/// <summary>
+		/// Writes the buffer to the stream.
+		/// </summary>
+		/// <param name="source">Source buffer.</param>
+		/// <exception cref="ArgumentNullException">buffer is null.</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+#if NETSTANDARD2_0
+        public void Write(ReadOnlySpan<byte> source)
+#else
+		public override void Write(ReadOnlySpan<byte> source)
+#endif
+
+		{
+			this.CheckDisposed();
+
+			int blockSize = this.memoryManager.options.BlockSize;
+			long end = this.position + source.Length;
+
+			this.EnsureCapacity(end);
+
+			if (this.largeBuffer == null)
+			{
+				var blockAndOffset = this.GetBlockAndRelativeOffset(this.position);
+
+				while (source.Length > 0)
+				{
+					byte[] currentBlock = this.blocks[blockAndOffset.Block];
+					int remainingInBlock = blockSize - blockAndOffset.Offset;
+					int amountToWriteInBlock = Math.Min(remainingInBlock, source.Length);
+
+					source.Slice(0, amountToWriteInBlock)
+						.CopyTo(currentBlock.AsSpan(blockAndOffset.Offset));
+
+					source = source.Slice(amountToWriteInBlock);
+
+					++blockAndOffset.Block;
+					blockAndOffset.Offset = 0;
+				}
+			}
+			else
+			{
+				source.CopyTo(this.largeBuffer.AsSpan((int)this.position));
+			}
+			this.position = end;
+			this.length = Math.Max(this.position, this.length);
+		}
+
+		/// <summary>
+		/// Returns a useful string for debugging. This should not normally be called in actual production code.
+		/// </summary>
+		public override string ToString()
+		{
+			if (!this.disposed)
+			{
+				return $"Id = {this.Id}, Tag = {this.Tag}, Length = {this.Length:N0} bytes";
+			}
+			else
+			{
+				// Avoid properties because of the dispose check, but the fields themselves are not cleared.
+				return $"Disposed: Id = {this.id}, Tag = {this.tag}, Final Length: {this.length:N0} bytes";
+			}
+		}
+
+		/// <summary>
+		/// Writes a single byte to the current position in the stream.
+		/// </summary>
+		/// <param name="value">byte value to write.</param>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public override void WriteByte(byte value)
+		{
+			this.CheckDisposed();
+
+			long end = this.position + 1;
+
+			if (this.largeBuffer == null)
+			{
+				var blockSize = this.memoryManager.options.BlockSize;
+
+				var block = (int)Math.DivRem(this.position, blockSize, out var index);
+
+				if (block >= this.blocks.Count)
+				{
+					this.EnsureCapacity(end);
+				}
+
+				this.blocks[block][index] = value;
+			}
+			else
+			{
+				if (this.position >= this.largeBuffer.Length)
+				{
+					this.EnsureCapacity(end);
+				}
+
+				this.largeBuffer[this.position] = value;
+			}
+
+			this.position = end;
+
+			if (this.position > this.length)
+			{
+				this.length = this.position;
+			}
+		}
+
+		/// <summary>
+		/// Reads a single byte from the current position in the stream.
+		/// </summary>
+		/// <returns>The byte at the current position, or -1 if the position is at the end of the stream.</returns>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public override int ReadByte()
+		{
+			return this.SafeReadByte(ref this.position);
+		}
+
+		/// <summary>
+		/// Reads a single byte from the specified position in the stream.
+		/// </summary>
+		/// <param name="streamPosition">The position in the stream to read from.</param>
+		/// <returns>The byte at the current position, or -1 if the position is at the end of the stream.</returns>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public int SafeReadByte(ref long streamPosition)
+		{
+			this.CheckDisposed();
+			if (streamPosition == this.length)
+			{
+				return -1;
+			}
+			byte value;
+			if (this.largeBuffer == null)
+			{
+				var blockAndOffset = this.GetBlockAndRelativeOffset(streamPosition);
+				value = this.blocks[blockAndOffset.Block][blockAndOffset.Offset];
+			}
+			else
+			{
+				value = this.largeBuffer[streamPosition];
+			}
+			streamPosition++;
+			return value;
+		}
+
+		/// <summary>
+		/// Sets the length of the stream.
+		/// </summary>
+		/// <exception cref="ArgumentOutOfRangeException">value is negative or larger than <see cref="RecyclableMemoryStreamManager.Options.MaximumStreamCapacity"/>.</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public override void SetLength(long value)
+		{
+			this.CheckDisposed();
+			if (value < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(value)} must be non-negative.");
+			}
+
+			this.EnsureCapacity(value);
+
+			this.length = value;
+			if (this.position > value)
+			{
+				this.position = value;
+			}
+		}
+
+		/// <summary>
+		/// Sets the position to the offset from the seek location.
+		/// </summary>
+		/// <param name="offset">How many bytes to move.</param>
+		/// <param name="loc">From where.</param>
+		/// <returns>The new position.</returns>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="offset"/> is larger than <see cref="RecyclableMemoryStreamManager.Options.MaximumStreamCapacity"/>.</exception>
+		/// <exception cref="ArgumentException">Invalid seek origin.</exception>
+		/// <exception cref="IOException">Attempt to set negative position.</exception>
+		public override long Seek(long offset, SeekOrigin loc)
+		{
+			this.CheckDisposed();
+			long newPosition = loc switch
+			{
+				SeekOrigin.Begin => offset,
+				SeekOrigin.Current => offset + this.position,
+				SeekOrigin.End => offset + this.length,
+				_ => throw new ArgumentException("Invalid seek origin.", nameof(loc)),
+			};
+			if (newPosition < 0)
+			{
+				throw new IOException("Seek before beginning.");
+			}
+			this.position = newPosition;
+			return this.position;
+		}
+
+		/// <summary>
+		/// Synchronously writes this stream's bytes to the argument stream.
+		/// </summary>
+		/// <param name="stream">Destination stream.</param>
+		/// <remarks>Important: This does a synchronous write, which may not be desired in some situations.</remarks>
+		/// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public override void WriteTo(Stream stream)
+		{
+			this.WriteTo(stream, 0, this.length);
+		}
+
+		/// <summary>
+		/// Synchronously writes this stream's bytes, starting at offset, for count bytes, to the argument stream.
+		/// </summary>
+		/// <param name="stream">Destination stream.</param>
+		/// <param name="offset">Offset in source.</param>
+		/// <param name="count">Number of bytes to write.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// <paramref name="offset"/> is less than 0, or <paramref name="offset"/> + <paramref name="count"/> is beyond  this <paramref name="stream"/>'s length.
+		/// </exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public void WriteTo(Stream stream, long offset, long count)
+		{
+			this.CheckDisposed();
+			if (stream == null)
+			{
+				throw new ArgumentNullException(nameof(stream));
+			}
+
+			if (offset < 0 || offset + count > this.length)
+			{
+				throw new ArgumentOutOfRangeException(
+					message: $"{nameof(offset)} must not be negative and {nameof(offset)} + {nameof(count)} must not exceed the length of the {nameof(stream)}.",
+					innerException: null);
+			}
+
+			if (this.largeBuffer == null)
+			{
+				var blockAndOffset = this.GetBlockAndRelativeOffset(offset);
+				long bytesRemaining = count;
+				int currentBlock = blockAndOffset.Block;
+				int currentOffset = blockAndOffset.Offset;
+
+				while (bytesRemaining > 0)
+				{
+					byte[] block = this.blocks[currentBlock];
+					int amountToCopy = (int)Math.Min((long)block.Length - currentOffset, bytesRemaining);
+					stream.Write(block, currentOffset, amountToCopy);
+
+					bytesRemaining -= amountToCopy;
+
+					++currentBlock;
+					currentOffset = 0;
+				}
+			}
+			else
+			{
+				stream.Write(this.largeBuffer, (int)offset, (int)count);
+			}
+		}
+
+		/// <summary>
+		/// Writes bytes from the current stream to a destination <c>byte</c> array.
+		/// </summary>
+		/// <param name="buffer">Target buffer.</param>
+		/// <remarks>The entire stream is written to the target array.</remarks>
+		/// <exception cref="ArgumentNullException"><paramref name="buffer"/>> is null.</exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public void WriteTo(byte[] buffer)
+		{
+			this.WriteTo(buffer, 0, this.Length);
+		}
+
+		/// <summary>
+		/// Writes bytes from the current stream to a destination <c>byte</c> array.
+		/// </summary>
+		/// <param name="buffer">Target buffer.</param>
+		/// <param name="offset">Offset in the source stream, from which to start.</param>
+		/// <param name="count">Number of bytes to write.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="buffer"/>> is null.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// <paramref name="offset"/> is less than 0, or <paramref name="offset"/> + <paramref name="count"/> is beyond this stream's length.
+		/// </exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public void WriteTo(byte[] buffer, long offset, long count)
+		{
+			this.WriteTo(buffer, offset, count, 0);
+		}
+
+		/// <summary>
+		/// Writes bytes from the current stream to a destination <c>byte</c> array.
+		/// </summary>
+		/// <param name="buffer">Target buffer.</param>
+		/// <param name="offset">Offset in the source stream, from which to start.</param>
+		/// <param name="count">Number of bytes to write.</param>
+		/// <param name="targetOffset">Offset in the target byte array to start writing</param>
+		/// <exception cref="ArgumentNullException"><c>buffer</c> is null</exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// <paramref name="offset"/> is less than 0, or <paramref name="offset"/> + <paramref name="count"/> is beyond this stream's length.
+		/// </exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// <paramref name="targetOffset"/> is less than 0, or <paramref name="targetOffset"/> + <paramref name="count"/> is beyond the target <paramref name="buffer"/>'s length.
+		/// </exception>
+		/// <exception cref="ObjectDisposedException">Object has been disposed.</exception>
+		public void WriteTo(byte[] buffer, long offset, long count, int targetOffset)
+		{
+			this.CheckDisposed();
+			if (buffer == null)
+			{
+				throw new ArgumentNullException(nameof(buffer));
+			}
+
+			if (offset < 0 || offset + count > this.length)
+			{
+				throw new ArgumentOutOfRangeException(
+					message: $"{nameof(offset)} must not be negative and {nameof(offset)} + {nameof(count)} must not exceed the length of the stream.",
+					innerException: null);
+			}
+
+			if (targetOffset < 0 || count + targetOffset > buffer.Length)
+			{
+				throw new ArgumentOutOfRangeException(
+					message: $"{nameof(targetOffset)} must not be negative and {nameof(targetOffset)} + {nameof(count)} must not exceed the length of the target {nameof(buffer)}.",
+					innerException: null);
+			}
+
+			if (this.largeBuffer == null)
+			{
+				var blockAndOffset = this.GetBlockAndRelativeOffset(offset);
+				long bytesRemaining = count;
+				int currentBlock = blockAndOffset.Block;
+				int currentOffset = blockAndOffset.Offset;
+				int currentTargetOffset = targetOffset;
+
+				while (bytesRemaining > 0)
+				{
+					byte[] block = this.blocks[currentBlock];
+					int amountToCopy = (int)Math.Min((long)block.Length - currentOffset, bytesRemaining);
+					Buffer.BlockCopy(block, currentOffset, buffer, currentTargetOffset, amountToCopy);
+
+					bytesRemaining -= amountToCopy;
+
+					++currentBlock;
+					currentOffset = 0;
+					currentTargetOffset += amountToCopy;
+				}
+			}
+			else
+			{
+				this.AssertLengthIsSmall();
+				Buffer.BlockCopy(this.largeBuffer, (int)offset, buffer, targetOffset, (int)count);
+			}
+		}
+		#endregion
+
+		#region Helper Methods
+		private bool Disposed => this.disposed;
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private void CheckDisposed()
+		{
+			if (this.Disposed)
+			{
+				this.ThrowDisposedException();
+			}
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private void ThrowDisposedException()
+		{
+			throw new ObjectDisposedException($"The stream with Id {this.id} and Tag {this.tag} is disposed.");
+		}
+
+		private int InternalRead(byte[] buffer, int offset, int count, long fromPosition)
+		{
+			if (this.length - fromPosition <= 0)
+			{
+				return 0;
+			}
+
+			int amountToCopy;
+
+			if (this.largeBuffer == null)
+			{
+				var blockAndOffset = this.GetBlockAndRelativeOffset(fromPosition);
+				int bytesWritten = 0;
+				int bytesRemaining = (int)Math.Min(count, this.length - fromPosition);
+
+				while (bytesRemaining > 0)
+				{
+					byte[] block = this.blocks[blockAndOffset.Block];
+					amountToCopy = Math.Min(block.Length - blockAndOffset.Offset,
+												bytesRemaining);
+					Buffer.BlockCopy(block, blockAndOffset.Offset, buffer,
+									 bytesWritten + offset, amountToCopy);
+
+					bytesWritten += amountToCopy;
+					bytesRemaining -= amountToCopy;
+
+					++blockAndOffset.Block;
+					blockAndOffset.Offset = 0;
+				}
+				return bytesWritten;
+			}
+			amountToCopy = (int)Math.Min(count, this.length - fromPosition);
+			Buffer.BlockCopy(this.largeBuffer, (int)fromPosition, buffer, offset, amountToCopy);
+			return amountToCopy;
+		}
+
+		private int InternalRead(Span<byte> buffer, long fromPosition)
+		{
+			if (this.length - fromPosition <= 0)
+			{
+				return 0;
+			}
+
+			int amountToCopy;
+
+			if (this.largeBuffer == null)
+			{
+				var blockAndOffset = this.GetBlockAndRelativeOffset(fromPosition);
+				int bytesWritten = 0;
+				int bytesRemaining = (int)Math.Min(buffer.Length, this.length - fromPosition);
+
+				while (bytesRemaining > 0)
+				{
+					byte[] block = this.blocks[blockAndOffset.Block];
+					amountToCopy = Math.Min(block.Length - blockAndOffset.Offset,
+											bytesRemaining);
+					block.AsSpan(blockAndOffset.Offset, amountToCopy)
+						.CopyTo(buffer.Slice(bytesWritten));
+
+					bytesWritten += amountToCopy;
+					bytesRemaining -= amountToCopy;
+
+					++blockAndOffset.Block;
+					blockAndOffset.Offset = 0;
+				}
+				return bytesWritten;
+			}
+			amountToCopy = (int)Math.Min(buffer.Length, this.length - fromPosition);
+			this.largeBuffer.AsSpan((int)fromPosition, amountToCopy).CopyTo(buffer);
+			return amountToCopy;
+		}
+
+		private struct BlockAndOffset(int block, int offset)
+		{
+			public int Block = block;
+			public int Offset = offset;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private BlockAndOffset GetBlockAndRelativeOffset(long offset)
+		{
+			var blockSize = this.memoryManager.options.BlockSize;
+			int blockIndex = (int)Math.DivRem(offset, blockSize, out long offsetIndex);
+			return new BlockAndOffset(blockIndex, (int)offsetIndex);
+		}
+
+		private void EnsureCapacity(long newCapacity)
+		{
+			if (newCapacity > this.memoryManager.options.MaximumStreamCapacity && this.memoryManager.options.MaximumStreamCapacity > 0)
+			{
+				this.memoryManager.ReportStreamOverCapacity(this.id, this.tag, newCapacity, this.AllocationStack);
+
+				throw new OutOfMemoryException($"Requested capacity is too large: {newCapacity}. Limit is {this.memoryManager.options.MaximumStreamCapacity}.");
+			}
+
+			if (this.largeBuffer != null)
+			{
+				if (newCapacity > this.largeBuffer.Length)
+				{
+					var newBuffer = this.memoryManager.GetLargeBuffer(newCapacity, this.id, this.tag);
+					Debug.Assert(this.length <= Int32.MaxValue);
+					this.InternalRead(newBuffer, 0, (int)this.length, 0);
+					this.ReleaseLargeBuffer();
+					this.largeBuffer = newBuffer;
+				}
+			}
+			else
+			{
+				// Let's save some re-allocation of the blocks list
+				var blocksRequired = (newCapacity / this.memoryManager.options.BlockSize) + 1;
+				if (this.blocks.Capacity < blocksRequired)
+				{
+					this.blocks.Capacity = (int)blocksRequired;
+				}
+				while (this.Capacity64 < newCapacity)
+				{
+					this.blocks.Add((this.memoryManager.GetBlock()));
+				}
+			}
+		}
+
+		/// <summary>
+		/// Release the large buffer (either stores it for eventual release or returns it immediately).
+		/// </summary>
+		private void ReleaseLargeBuffer()
+		{
+			Debug.Assert(this.largeBuffer != null);
+
+			if (this.memoryManager.options.AggressiveBufferReturn)
+			{
+				this.memoryManager.ReturnLargeBuffer(this.largeBuffer!, this.id, this.tag);
+			}
+			else
+			{
+				// We most likely will only ever need space for one
+				this.dirtyBuffers ??= new List<byte[]>(1);
+				this.dirtyBuffers.Add(this.largeBuffer!);
+			}
+
+			this.largeBuffer = null;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private void AssertLengthIsSmall()
+		{
+			Debug.Assert(this.length <= Int32.MaxValue, "this.length was assumed to be <= Int32.MaxValue, but was larger.");
+		}
+		#endregion
+	}
+}

--- a/src/Uno.UI.RemoteControl/external/Microsoft.IO.RecyclableMemoryStream/RecyclableMemoryStreamManager.cs
+++ b/src/Uno.UI.RemoteControl/external/Microsoft.IO.RecyclableMemoryStream/RecyclableMemoryStreamManager.cs
@@ -1,0 +1,964 @@
+﻿// Imported from https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream/commit/7df2ef7c95979774f783d4870cb959f03c38aade
+
+#pragma warning disable CA1805 // Disable to keep original file
+#pragma warning disable IDE0051 // Disable to keep original file
+
+// ---------------------------------------------------------------------
+// Copyright (c) 2015-2016 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ---------------------------------------------------------------------
+
+namespace Microsoft.IO
+{
+	using System;
+	using System.Collections.Concurrent;
+	using System.Collections.Generic;
+	using System.Runtime.CompilerServices;
+	using System.Threading;
+	using static Microsoft.IO.RecyclableMemoryStreamManager;
+
+	/// <summary>
+	/// Manages pools of <see cref="RecyclableMemoryStream"/> objects.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// There are two pools managed in here. The small pool contains same-sized buffers that are handed to streams
+	/// as they write more data.
+	///</para>
+	///<para>
+	/// For scenarios that need to call <see cref="RecyclableMemoryStream.GetBuffer"/>, the large pool contains buffers of various sizes, all
+	/// multiples/exponentials of <see cref="Options.LargeBufferMultiple"/> (1 MB by default). They are split by size to avoid overly-wasteful buffer
+	/// usage. There should be far fewer 8 MB buffers than 1 MB buffers, for example.
+	/// </para>
+	/// </remarks>
+	public partial class RecyclableMemoryStreamManager
+	{
+		/// <summary>
+		/// Maximum length of a single array.
+		/// </summary>
+		/// <remarks>See documentation at https://docs.microsoft.com/dotnet/api/system.array?view=netcore-3.1
+		/// </remarks>
+		internal const int MaxArrayLength = 0X7FFFFFC7;
+
+		/// <summary>
+		/// Default block size, in bytes.
+		/// </summary>
+		public const int DefaultBlockSize = 128 * 1024;
+
+		/// <summary>
+		/// Default large buffer multiple, in bytes.
+		/// </summary>
+		public const int DefaultLargeBufferMultiple = 1024 * 1024;
+
+		/// <summary>
+		/// Default maximum buffer size, in bytes.
+		/// </summary>
+		public const int DefaultMaximumBufferSize = 128 * 1024 * 1024;
+
+		// 0 to indicate unbounded
+		private const long DefaultMaxSmallPoolFreeBytes = 0L;
+		private const long DefaultMaxLargePoolFreeBytes = 0L;
+
+		private readonly long[] largeBufferFreeSize;
+		private readonly long[] largeBufferInUseSize;
+
+		private readonly ConcurrentStack<byte[]>[] largePools;
+
+		private readonly ConcurrentStack<byte[]> smallPool;
+
+		private long smallPoolFreeSize;
+		private long smallPoolInUseSize;
+
+		internal readonly Options options;
+
+		/// <summary>
+		/// Settings for controlling the behavior of RecyclableMemoryStream
+		/// </summary>
+		public Options Settings => this.options;
+
+		/// <summary>
+		/// Number of bytes in small pool not currently in use.
+		/// </summary>
+		public long SmallPoolFreeSize => this.smallPoolFreeSize;
+
+		/// <summary>
+		/// Number of bytes currently in use by stream from the small pool.
+		/// </summary>
+		public long SmallPoolInUseSize => this.smallPoolInUseSize;
+
+		/// <summary>
+		/// Number of bytes in large pool not currently in use.
+		/// </summary>
+		public long LargePoolFreeSize
+		{
+			get
+			{
+				long sum = 0;
+				foreach (long freeSize in this.largeBufferFreeSize)
+				{
+					sum += freeSize;
+				}
+
+				return sum;
+			}
+		}
+
+		/// <summary>
+		/// Number of bytes currently in use by streams from the large pool.
+		/// </summary>
+		public long LargePoolInUseSize
+		{
+			get
+			{
+				long sum = 0;
+				foreach (long inUseSize in this.largeBufferInUseSize)
+				{
+					sum += inUseSize;
+				}
+
+				return sum;
+			}
+		}
+
+		/// <summary>
+		/// How many blocks are in the small pool.
+		/// </summary>
+		public long SmallBlocksFree => this.smallPool.Count;
+
+		/// <summary>
+		/// How many buffers are in the large pool.
+		/// </summary>
+		public long LargeBuffersFree
+		{
+			get
+			{
+				long free = 0;
+				foreach (var pool in this.largePools)
+				{
+					free += pool.Count;
+				}
+				return free;
+			}
+		}
+
+		/// <summary>
+		/// Parameters for customizing the behavior of <see cref="RecyclableMemoryStreamManager"/>
+		/// </summary>
+		public class Options
+		{
+			/// <summary>
+			/// Gets or sets the size of the pooled blocks. This must be greater than 0.
+			/// </summary>
+			/// <remarks>The default size 131,072 (128KB)</remarks>
+			public int BlockSize { get; set; } = DefaultBlockSize;
+
+			/// <summary>
+			/// Each large buffer will be a multiple exponential of this value
+			/// </summary>
+			/// <remarks>The default value is 1,048,576 (1MB)</remarks>
+			public int LargeBufferMultiple { get; set; } = DefaultLargeBufferMultiple;
+
+			/// <summary>
+			/// Buffer beyond this length are not pooled.
+			/// </summary>
+			/// <remarks>The default value is 134,217,728 (128MB)</remarks>
+			public int MaximumBufferSize { get; set; } = DefaultMaximumBufferSize;
+
+			/// <summary>
+			/// Maximum number of bytes to keep available in the small pool.
+			/// </summary>
+			/// <remarks>
+			/// <para>Trying to return buffers to the pool beyond this limit will result in them being garbage collected.</para>
+			/// <para>The default value is 0, but all users should set a reasonable value depending on your application's memory requirements.</para>
+			/// </remarks>
+			public long MaximumSmallPoolFreeBytes { get; set; }
+
+			/// <summary>
+			/// Maximum number of bytes to keep available in the large pools.
+			/// </summary>
+			/// <remarks>
+			/// <para>Trying to return buffers to the pool beyond this limit will result in them being garbage collected.</para>
+			/// <para>The default value is 0, but all users should set a reasonable value depending on your application's memory requirements.</para>
+			/// </remarks>
+			public long MaximumLargePoolFreeBytes { get; set; }
+
+			/// <summary>
+			/// Whether to use the exponential allocation strategy (see documentation).
+			/// </summary>
+			/// <remarks>The default value is false.</remarks>
+			public bool UseExponentialLargeBuffer { get; set; } = false;
+
+			/// <summary>
+			/// Maximum stream capacity in bytes. Attempts to set a larger capacity will
+			/// result in an exception.
+			/// </summary>
+			/// <remarks>The default value of 0 indicates no limit.</remarks>
+			public long MaximumStreamCapacity { get; set; } = 0;
+
+			/// <summary>
+			/// Whether to save call stacks for stream allocations. This can help in debugging.
+			/// It should NEVER be turned on generally in production.
+			/// </summary>
+			public bool GenerateCallStacks { get; set; } = false;
+
+			/// <summary>
+			/// Whether dirty buffers can be immediately returned to the buffer pool.
+			/// </summary>
+			/// <remarks>
+			/// <para>
+			/// When <see cref="RecyclableMemoryStream.GetBuffer"/> is called on a stream and creates a single large buffer, if this setting is enabled, the other blocks will be returned
+			/// to the buffer pool immediately.
+			/// </para>
+			/// <para>
+			/// Note when enabling this setting that the user is responsible for ensuring that any buffer previously
+			/// retrieved from a stream which is subsequently modified is not used after modification (as it may no longer
+			/// be valid).
+			/// </para>
+			/// </remarks>
+			public bool AggressiveBufferReturn { get; set; } = false;
+
+			/// <summary>
+			/// Causes an exception to be thrown if <see cref="RecyclableMemoryStream.ToArray"/> is ever called.
+			/// </summary>
+			/// <remarks>Calling <see cref="RecyclableMemoryStream.ToArray"/> defeats the purpose of a pooled buffer. Use this property to discover code that is calling <see cref="RecyclableMemoryStream.ToArray"/>. If this is
+			/// set and <see cref="RecyclableMemoryStream.ToArray"/> is called, a <c>NotSupportedException</c> will be thrown.</remarks>
+			public bool ThrowExceptionOnToArray { get; set; } = false;
+
+			/// <summary>
+			/// Zero out buffers on allocation and before returning them to the pool.
+			/// </summary>
+			/// <remarks>Setting this to true causes a performance hit and should only be set if one wants to avoid accidental data leaks.</remarks>
+			public bool ZeroOutBuffer { get; set; } = false;
+
+			/// <summary>
+			/// Creates a new <see cref="Options"/> object.
+			/// </summary>
+			public Options()
+			{
+
+			}
+
+			/// <summary>
+			/// Creates a new <see cref="Options"/> object with the most common options.
+			/// </summary>
+			/// <param name="blockSize">Size of the blocks in the small pool.</param>
+			/// <param name="largeBufferMultiple">Size of the large buffer multiple</param>
+			/// <param name="maximumBufferSize">Maximum poolable buffer size.</param>
+			/// <param name="maximumSmallPoolFreeBytes">Maximum bytes to hold in the small pool.</param>
+			/// <param name="maximumLargePoolFreeBytes">Maximum bytes to hold in each of the large pools.</param>
+			public Options(int blockSize, int largeBufferMultiple, int maximumBufferSize, long maximumSmallPoolFreeBytes, long maximumLargePoolFreeBytes)
+			{
+				this.BlockSize = blockSize;
+				this.LargeBufferMultiple = largeBufferMultiple;
+				this.MaximumBufferSize = maximumBufferSize;
+				this.MaximumSmallPoolFreeBytes = maximumSmallPoolFreeBytes;
+				this.MaximumLargePoolFreeBytes = maximumLargePoolFreeBytes;
+			}
+		}
+
+		/// <summary>
+		/// Initializes the memory manager with the default block/buffer specifications. This pool may have unbounded growth unless you modify <see cref="Options"/>.
+		/// </summary>
+		public RecyclableMemoryStreamManager()
+			: this(new Options()) { }
+
+
+		/// <summary>
+		/// Initializes the memory manager with the given block requiredSize.
+		/// </summary>
+		/// <param name="options">Object specifying options for stream behavior.</param>
+		/// <exception cref="InvalidOperationException">
+		/// <paramref name="options.BlockSize"/> is not a positive number,
+		/// or <paramref name="options.LargeBufferMultiple"/> is not a positive number,
+		/// or <paramref name="options.MaximumBufferSize"/> is less than options.BlockSize,
+		/// or <paramref name="options.MaximumSmallPoolFreeBytes"/> is negative,
+		/// or <paramref name="options.MaximumLargePoolFreeBytes"/> is negative,
+		/// or <paramref name="options.MaximumBufferSize"/> is not a multiple/exponential of <paramref name="options.LargeBufferMultiple"/>.
+		/// </exception>
+		public RecyclableMemoryStreamManager(Options options)
+		{
+			if (options.BlockSize <= 0)
+			{
+				throw new InvalidOperationException($"{nameof(options.BlockSize)} must be a positive number");
+			}
+
+			if (options.LargeBufferMultiple <= 0)
+			{
+				throw new InvalidOperationException($"{nameof(options.LargeBufferMultiple)} must be a positive number");
+			}
+
+			if (options.MaximumBufferSize < options.BlockSize)
+			{
+				throw new InvalidOperationException($"{nameof(options.MaximumBufferSize)} must be at least {nameof(options.BlockSize)}");
+			}
+
+			if (options.MaximumSmallPoolFreeBytes < 0)
+			{
+				throw new InvalidOperationException($"{nameof(options.MaximumSmallPoolFreeBytes)} must be non-negative");
+			}
+
+			if (options.MaximumLargePoolFreeBytes < 0)
+			{
+				throw new InvalidOperationException($"{nameof(options.MaximumLargePoolFreeBytes)} must be non-negative");
+			}
+
+			this.options = options;
+
+			if (!this.IsLargeBufferSize(options.MaximumBufferSize))
+			{
+				throw new InvalidOperationException(
+					$"{nameof(options.MaximumBufferSize)} is not {(options.UseExponentialLargeBuffer ? "an exponential" : "a multiple")} of {nameof(options.LargeBufferMultiple)}.");
+			}
+
+			this.smallPool = new ConcurrentStack<byte[]>();
+			var numLargePools = options.UseExponentialLargeBuffer
+									? ((int)Math.Log(options.MaximumBufferSize / options.LargeBufferMultiple, 2) + 1)
+									: (options.MaximumBufferSize / options.LargeBufferMultiple);
+
+			// +1 to store size of bytes in use that are too large to be pooled
+			this.largeBufferInUseSize = new long[numLargePools + 1];
+			this.largeBufferFreeSize = new long[numLargePools];
+
+			this.largePools = new ConcurrentStack<byte[]>[numLargePools];
+
+			for (var i = 0; i < this.largePools.Length; ++i)
+			{
+				this.largePools[i] = new ConcurrentStack<byte[]>();
+			}
+
+			Events.Writer.MemoryStreamManagerInitialized(options.BlockSize, options.LargeBufferMultiple, options.MaximumBufferSize);
+		}
+
+		/// <summary>
+		/// Removes and returns a single block from the pool.
+		/// </summary>
+		/// <returns>A <c>byte[]</c> array.</returns>
+		internal byte[] GetBlock()
+		{
+			Interlocked.Add(ref this.smallPoolInUseSize, this.options.BlockSize);
+
+			if (!this.smallPool.TryPop(out byte[]? block))
+			{
+				// We'll add this back to the pool when the stream is disposed
+				// (unless our free pool is too large)
+#if NET6_0_OR_GREATER
+				block = this.options.ZeroOutBuffer ? GC.AllocateArray<byte>(this.options.BlockSize) : GC.AllocateUninitializedArray<byte>(this.options.BlockSize);
+#else
+                block = new byte[this.options.BlockSize];
+#endif
+				this.ReportBlockCreated();
+			}
+			else
+			{
+				Interlocked.Add(ref this.smallPoolFreeSize, -this.options.BlockSize);
+			}
+
+			return block;
+		}
+
+		/// <summary>
+		/// Returns a buffer of arbitrary size from the large buffer pool. This buffer
+		/// will be at least the requiredSize and always be a multiple/exponential of largeBufferMultiple.
+		/// </summary>
+		/// <param name="requiredSize">The minimum length of the buffer.</param>
+		/// <param name="id">Unique ID for the stream.</param>
+		/// <param name="tag">The tag of the stream returning this buffer, for logging if necessary.</param>
+		/// <returns>A buffer of at least the required size.</returns>
+		/// <exception cref="OutOfMemoryException">Requested array size is larger than the maximum allowed.</exception>
+		internal byte[] GetLargeBuffer(long requiredSize, Guid id, string? tag)
+		{
+			requiredSize = this.RoundToLargeBufferSize(requiredSize);
+
+			if (requiredSize > MaxArrayLength)
+			{
+				throw new OutOfMemoryException($"Required buffer size exceeds maximum array length of {MaxArrayLength}.");
+			}
+
+			var poolIndex = this.GetPoolIndex(requiredSize);
+
+			bool createdNew = false;
+			bool pooled = true;
+			string? callStack = null;
+
+			byte[]? buffer;
+			if (poolIndex < this.largePools.Length)
+			{
+				if (!this.largePools[poolIndex].TryPop(out buffer))
+				{
+					buffer = AllocateArray(requiredSize, this.options.ZeroOutBuffer);
+					createdNew = true;
+				}
+				else
+				{
+					Interlocked.Add(ref this.largeBufferFreeSize[poolIndex], -buffer.Length);
+				}
+			}
+			else
+			{
+				// Buffer is too large to pool. They get a new buffer.
+
+				// We still want to track the size, though, and we've reserved a slot
+				// in the end of the in-use array for non-pooled bytes in use.
+				poolIndex = this.largeBufferInUseSize.Length - 1;
+
+				// We still want to round up to reduce heap fragmentation.
+				buffer = AllocateArray(requiredSize, this.options.ZeroOutBuffer);
+				if (this.options.GenerateCallStacks)
+				{
+					// Grab the stack -- we want to know who requires such large buffers
+					callStack = Environment.StackTrace;
+				}
+				createdNew = true;
+				pooled = false;
+			}
+
+			Interlocked.Add(ref this.largeBufferInUseSize[poolIndex], buffer.Length);
+			if (createdNew)
+			{
+				this.ReportLargeBufferCreated(id, tag, requiredSize, pooled: pooled, callStack);
+			}
+
+			return buffer;
+
+			[MethodImpl(MethodImplOptions.AggressiveInlining)]
+			static byte[] AllocateArray(long requiredSize, bool zeroInitializeArray) =>
+#if NET6_0_OR_GREATER
+				zeroInitializeArray ? GC.AllocateArray<byte>((int)requiredSize) : GC.AllocateUninitializedArray<byte>((int)requiredSize);
+#else
+                new byte[requiredSize];
+#endif
+		}
+
+		private long RoundToLargeBufferSize(long requiredSize)
+		{
+			if (this.options.UseExponentialLargeBuffer)
+			{
+				long pow = 1;
+				while (this.options.LargeBufferMultiple * pow < requiredSize)
+				{
+					pow <<= 1;
+				}
+				return this.options.LargeBufferMultiple * pow;
+			}
+			else
+			{
+				return ((requiredSize + this.options.LargeBufferMultiple - 1) / this.options.LargeBufferMultiple) * this.options.LargeBufferMultiple;
+			}
+		}
+
+		private bool IsLargeBufferSize(int value)
+		{
+			return (value != 0) && (this.options.UseExponentialLargeBuffer
+										? (value == this.RoundToLargeBufferSize(value))
+										: (value % this.options.LargeBufferMultiple) == 0);
+		}
+
+		private int GetPoolIndex(long length)
+		{
+			if (this.options.UseExponentialLargeBuffer)
+			{
+				int index = 0;
+				while ((this.options.LargeBufferMultiple << index) < length)
+				{
+					++index;
+				}
+				return index;
+			}
+			else
+			{
+				return (int)(length / this.options.LargeBufferMultiple - 1);
+			}
+		}
+
+		/// <summary>
+		/// Returns the buffer to the large pool.
+		/// </summary>
+		/// <param name="buffer">The buffer to return.</param>
+		/// <param name="id">Unique stream ID.</param>
+		/// <param name="tag">The tag of the stream returning this buffer, for logging if necessary.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null.</exception>
+		/// <exception cref="ArgumentException"><c>buffer.Length</c> is not a multiple/exponential of <see cref="Options.LargeBufferMultiple"/> (it did not originate from this pool).</exception>
+		internal void ReturnLargeBuffer(byte[] buffer, Guid id, string? tag)
+		{
+			if (buffer == null)
+			{
+				throw new ArgumentNullException(nameof(buffer));
+			}
+
+			if (!this.IsLargeBufferSize(buffer.Length))
+			{
+				throw new ArgumentException($"{nameof(buffer)} did not originate from this memory manager. The size is not " +
+											$"{(this.options.UseExponentialLargeBuffer ? "an exponential" : "a multiple")} of {this.options.LargeBufferMultiple}.");
+			}
+
+			this.ZeroOutMemoryIfEnabled(buffer);
+			var poolIndex = this.GetPoolIndex(buffer.Length);
+			if (poolIndex < this.largePools.Length)
+			{
+				if ((this.largePools[poolIndex].Count + 1) * buffer.Length <= this.options.MaximumLargePoolFreeBytes ||
+					this.options.MaximumLargePoolFreeBytes == 0)
+				{
+					this.largePools[poolIndex].Push(buffer);
+					Interlocked.Add(ref this.largeBufferFreeSize[poolIndex], buffer.Length);
+				}
+				else
+				{
+					this.ReportBufferDiscarded(id, tag, Events.MemoryStreamBufferType.Large, Events.MemoryStreamDiscardReason.EnoughFree);
+				}
+			}
+			else
+			{
+				// This is a non-poolable buffer, but we still want to track its size for in-use
+				// analysis. We have space in the InUse array for this.
+				poolIndex = this.largeBufferInUseSize.Length - 1;
+
+				this.ReportBufferDiscarded(id, tag, Events.MemoryStreamBufferType.Large, Events.MemoryStreamDiscardReason.TooLarge);
+			}
+
+			Interlocked.Add(ref this.largeBufferInUseSize[poolIndex], -buffer.Length);
+		}
+
+		/// <summary>
+		/// Returns the blocks to the pool.
+		/// </summary>
+		/// <param name="blocks">Collection of blocks to return to the pool.</param>
+		/// <param name="id">Unique Stream ID.</param>
+		/// <param name="tag">The tag of the stream returning these blocks, for logging if necessary.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="blocks"/> is null.</exception>
+		/// <exception cref="ArgumentException"><paramref name="blocks"/> contains buffers that are the wrong size (or null) for this memory manager.</exception>
+		internal void ReturnBlocks(List<byte[]> blocks, Guid id, string? tag)
+		{
+			if (blocks == null)
+			{
+				throw new ArgumentNullException(nameof(blocks));
+			}
+
+			long bytesToReturn = (long)blocks.Count * (long)this.options.BlockSize;
+			Interlocked.Add(ref this.smallPoolInUseSize, -bytesToReturn);
+
+			foreach (var block in blocks)
+			{
+				if (block == null || block.Length != this.options.BlockSize)
+				{
+					throw new ArgumentException($"{nameof(blocks)} contains buffers that are not {nameof(this.options.BlockSize)} in length.", nameof(blocks));
+				}
+			}
+
+			foreach (var block in blocks)
+			{
+				this.ZeroOutMemoryIfEnabled(block);
+				if (this.options.MaximumSmallPoolFreeBytes == 0 || this.SmallPoolFreeSize < this.options.MaximumSmallPoolFreeBytes)
+				{
+					Interlocked.Add(ref this.smallPoolFreeSize, this.options.BlockSize);
+					this.smallPool.Push(block);
+				}
+				else
+				{
+					this.ReportBufferDiscarded(id, tag, Events.MemoryStreamBufferType.Small, Events.MemoryStreamDiscardReason.EnoughFree);
+					break;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Returns a block to the pool.
+		/// </summary>
+		/// <param name="block">Block to return to the pool.</param>
+		/// <param name="id">Unique Stream ID.</param>
+		/// <param name="tag">The tag of the stream returning this, for logging if necessary.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="block"/> is null.</exception>
+		/// <exception cref="ArgumentException"><paramref name="block"/> is the wrong size for this memory manager.</exception>
+		internal void ReturnBlock(byte[] block, Guid id, string? tag)
+		{
+			var bytesToReturn = this.options.BlockSize;
+			Interlocked.Add(ref this.smallPoolInUseSize, -bytesToReturn);
+
+			if (block == null)
+			{
+				throw new ArgumentNullException(nameof(block));
+			}
+
+			if (block.Length != this.options.BlockSize)
+			{
+				throw new ArgumentException($"{nameof(block)} is not not {nameof(this.options.BlockSize)} in length.");
+			}
+			this.ZeroOutMemoryIfEnabled(block);
+			if (this.options.MaximumSmallPoolFreeBytes == 0 || this.SmallPoolFreeSize < this.options.MaximumSmallPoolFreeBytes)
+			{
+				Interlocked.Add(ref this.smallPoolFreeSize, this.options.BlockSize);
+				this.smallPool.Push(block);
+			}
+			else
+			{
+				this.ReportBufferDiscarded(id, tag, Events.MemoryStreamBufferType.Small, Events.MemoryStreamDiscardReason.EnoughFree);
+			}
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private void ZeroOutMemoryIfEnabled(byte[] buffer)
+		{
+			if (this.options.ZeroOutBuffer)
+			{
+#if NET6_0_OR_GREATER
+				Array.Clear(buffer);
+#else
+                Array.Clear(buffer, 0, buffer.Length);
+#endif
+			}
+		}
+
+		internal void ReportBlockCreated()
+		{
+			Events.Writer.MemoryStreamNewBlockCreated(this.smallPoolInUseSize);
+			this.BlockCreated?.Invoke(this, new BlockCreatedEventArgs(this.smallPoolInUseSize));
+		}
+
+		internal void ReportLargeBufferCreated(Guid id, string? tag, long requiredSize, bool pooled, string? callStack)
+		{
+			if (pooled)
+			{
+				Events.Writer.MemoryStreamNewLargeBufferCreated(requiredSize, this.LargePoolInUseSize);
+			}
+			else
+			{
+				Events.Writer.MemoryStreamNonPooledLargeBufferCreated(id, tag, requiredSize, callStack);
+			}
+			this.LargeBufferCreated?.Invoke(this, new LargeBufferCreatedEventArgs(id, tag, requiredSize, this.LargePoolInUseSize, pooled, callStack));
+		}
+
+		internal void ReportBufferDiscarded(Guid id, string? tag, Events.MemoryStreamBufferType bufferType, Events.MemoryStreamDiscardReason reason)
+		{
+			Events.Writer.MemoryStreamDiscardBuffer(id, tag, bufferType, reason,
+				this.SmallBlocksFree, this.smallPoolFreeSize, this.smallPoolInUseSize,
+				this.LargeBuffersFree, this.LargePoolFreeSize, this.LargePoolInUseSize);
+			this.BufferDiscarded?.Invoke(this, new BufferDiscardedEventArgs(id, tag, bufferType, reason));
+		}
+
+		internal void ReportStreamCreated(Guid id, string? tag, long requestedSize, long actualSize)
+		{
+			Events.Writer.MemoryStreamCreated(id, tag, requestedSize, actualSize);
+			this.StreamCreated?.Invoke(this, new StreamCreatedEventArgs(id, tag, requestedSize, actualSize));
+		}
+
+		internal void ReportStreamDisposed(Guid id, string? tag, TimeSpan lifetime, string? allocationStack, string? disposeStack)
+		{
+			Events.Writer.MemoryStreamDisposed(id, tag, (long)lifetime.TotalMilliseconds, allocationStack, disposeStack);
+			this.StreamDisposed?.Invoke(this, new StreamDisposedEventArgs(id, tag, lifetime, allocationStack, disposeStack));
+		}
+
+		internal void ReportStreamDoubleDisposed(Guid id, string? tag, string? allocationStack, string? disposeStack1, string? disposeStack2)
+		{
+			Events.Writer.MemoryStreamDoubleDispose(id, tag, allocationStack, disposeStack1, disposeStack2);
+			this.StreamDoubleDisposed?.Invoke(this, new StreamDoubleDisposedEventArgs(id, tag, allocationStack, disposeStack1, disposeStack2));
+		}
+
+		internal void ReportStreamFinalized(Guid id, string? tag, string? allocationStack)
+		{
+			Events.Writer.MemoryStreamFinalized(id, tag, allocationStack);
+			this.StreamFinalized?.Invoke(this, new StreamFinalizedEventArgs(id, tag, allocationStack));
+		}
+
+		internal void ReportStreamLength(long bytes)
+		{
+			this.StreamLength?.Invoke(this, new StreamLengthEventArgs(bytes));
+		}
+
+		internal void ReportStreamToArray(Guid id, string? tag, string? stack, long length)
+		{
+			Events.Writer.MemoryStreamToArray(id, tag, stack, length);
+			this.StreamConvertedToArray?.Invoke(this, new StreamConvertedToArrayEventArgs(id, tag, stack, length));
+		}
+
+		internal void ReportStreamOverCapacity(Guid id, string? tag, long requestedCapacity, string? allocationStack)
+		{
+			Events.Writer.MemoryStreamOverCapacity(id, tag, requestedCapacity, this.options.MaximumStreamCapacity, allocationStack);
+			this.StreamOverCapacity?.Invoke(this, new StreamOverCapacityEventArgs(id, tag, requestedCapacity, this.options.MaximumStreamCapacity, allocationStack));
+		}
+
+		internal void ReportUsageReport()
+		{
+			this.UsageReport?.Invoke(this, new UsageReportEventArgs(this.smallPoolInUseSize, this.smallPoolFreeSize, this.LargePoolInUseSize, this.LargePoolFreeSize));
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with no tag and a default initial capacity.
+		/// </summary>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream()
+		{
+			return new RecyclableMemoryStream(this);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with no tag and a default initial capacity.
+		/// </summary>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(Guid id)
+		{
+			return new RecyclableMemoryStream(this, id);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and a default initial capacity.
+		/// </summary>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(string? tag)
+		{
+			return new RecyclableMemoryStream(this, tag);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and a default initial capacity.
+		/// </summary>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(Guid id, string? tag)
+		{
+			return new RecyclableMemoryStream(this, id, tag);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and at least the given capacity.
+		/// </summary>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="requiredSize">The minimum desired capacity for the stream.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(string? tag, long requiredSize)
+		{
+			return new RecyclableMemoryStream(this, tag, requiredSize);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and at least the given capacity.
+		/// </summary>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="requiredSize">The minimum desired capacity for the stream.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(Guid id, string? tag, long requiredSize)
+		{
+			return new RecyclableMemoryStream(this, id, tag, requiredSize);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and at least the given capacity, possibly using
+		/// a single contiguous underlying buffer.
+		/// </summary>
+		/// <remarks>Retrieving a <see cref="RecyclableMemoryStream"/> which provides a single contiguous buffer can be useful in situations
+		/// where the initial size is known and it is desirable to avoid copying data between the smaller underlying
+		/// buffers to a single large one. This is most helpful when you know that you will always call <see cref="RecyclableMemoryStream.GetBuffer"/>
+		/// on the underlying stream.</remarks>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="requiredSize">The minimum desired capacity for the stream.</param>
+		/// <param name="asContiguousBuffer">Whether to attempt to use a single contiguous buffer.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(Guid id, string? tag, long requiredSize, bool asContiguousBuffer)
+		{
+			if (!asContiguousBuffer || requiredSize <= this.options.BlockSize)
+			{
+				return this.GetStream(id, tag, requiredSize);
+			}
+
+			return new RecyclableMemoryStream(this, id, tag, requiredSize, this.GetLargeBuffer(requiredSize, id, tag));
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and at least the given capacity, possibly using
+		/// a single contiguous underlying buffer.
+		/// </summary>
+		/// <remarks>Retrieving a <see cref="RecyclableMemoryStream"/> which provides a single contiguous buffer can be useful in situations
+		/// where the initial size is known and it is desirable to avoid copying data between the smaller underlying
+		/// buffers to a single large one. This is most helpful when you know that you will always call <see cref="RecyclableMemoryStream.GetBuffer"/>
+		/// on the underlying stream.</remarks>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="requiredSize">The minimum desired capacity for the stream.</param>
+		/// <param name="asContiguousBuffer">Whether to attempt to use a single contiguous buffer.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(string? tag, long requiredSize, bool asContiguousBuffer)
+		{
+			return this.GetStream(Guid.NewGuid(), tag, requiredSize, asContiguousBuffer);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and with contents copied from the provided
+		/// buffer. The provided buffer is not wrapped or used after construction.
+		/// </summary>
+		/// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="buffer">The byte buffer to copy data from.</param>
+		/// <param name="offset">The offset from the start of the buffer to copy from.</param>
+		/// <param name="count">The number of bytes to copy from the buffer.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(Guid id, string? tag, byte[] buffer, int offset, int count)
+		{
+			RecyclableMemoryStream? stream = null;
+			try
+			{
+				stream = new RecyclableMemoryStream(this, id, tag, count);
+				stream.Write(buffer, offset, count);
+				stream.Position = 0;
+				return stream;
+			}
+			catch
+			{
+				stream?.Dispose();
+				throw;
+			}
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the contents copied from the provided
+		/// buffer. The provided buffer is not wrapped or used after construction.
+		/// </summary>
+		/// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+		/// <param name="buffer">The byte buffer to copy data from.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(byte[] buffer)
+		{
+			return this.GetStream(null, buffer, 0, buffer.Length);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and with contents copied from the provided
+		/// buffer. The provided buffer is not wrapped or used after construction.
+		/// </summary>
+		/// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="buffer">The byte buffer to copy data from.</param>
+		/// <param name="offset">The offset from the start of the buffer to copy from.</param>
+		/// <param name="count">The number of bytes to copy from the buffer.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(string? tag, byte[] buffer, int offset, int count)
+		{
+			return this.GetStream(Guid.NewGuid(), tag, buffer, offset, count);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and with contents copied from the provided
+		/// buffer. The provided buffer is not wrapped or used after construction.
+		/// </summary>
+		/// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+		/// <param name="id">A unique identifier which can be used to trace usages of the stream.</param>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="buffer">The byte buffer to copy data from.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(Guid id, string? tag, ReadOnlySpan<byte> buffer)
+		{
+			RecyclableMemoryStream? stream = null;
+			try
+			{
+				stream = new RecyclableMemoryStream(this, id, tag, buffer.Length);
+				stream.Write(buffer);
+				stream.Position = 0;
+				return stream;
+			}
+			catch
+			{
+				stream?.Dispose();
+				throw;
+			}
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the contents copied from the provided
+		/// buffer. The provided buffer is not wrapped or used after construction.
+		/// </summary>
+		/// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+		/// <param name="buffer">The byte buffer to copy data from.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(ReadOnlySpan<byte> buffer)
+		{
+			return this.GetStream(null, buffer);
+		}
+
+		/// <summary>
+		/// Retrieve a new <see cref="RecyclableMemoryStream"/> object with the given tag and with contents copied from the provided
+		/// buffer. The provided buffer is not wrapped or used after construction.
+		/// </summary>
+		/// <remarks>The new stream's position is set to the beginning of the stream when returned.</remarks>
+		/// <param name="tag">A tag which can be used to track the source of the stream.</param>
+		/// <param name="buffer">The byte buffer to copy data from.</param>
+		/// <returns>A <see cref="RecyclableMemoryStream"/>.</returns>
+		public RecyclableMemoryStream GetStream(string? tag, ReadOnlySpan<byte> buffer)
+		{
+			return this.GetStream(Guid.NewGuid(), tag, buffer);
+		}
+
+		/// <summary>
+		/// Triggered when a new block is created.
+		/// </summary>
+		public event EventHandler<BlockCreatedEventArgs>? BlockCreated;
+
+		/// <summary>
+		/// Triggered when a new large buffer is created.
+		/// </summary>
+		public event EventHandler<LargeBufferCreatedEventArgs>? LargeBufferCreated;
+
+		/// <summary>
+		/// Triggered when a new stream is created.
+		/// </summary>
+		public event EventHandler<StreamCreatedEventArgs>? StreamCreated;
+
+		/// <summary>
+		/// Triggered when a stream is disposed.
+		/// </summary>
+		public event EventHandler<StreamDisposedEventArgs>? StreamDisposed;
+
+		/// <summary>
+		/// Triggered when a stream is disposed of twice (an error).
+		/// </summary>
+		public event EventHandler<StreamDoubleDisposedEventArgs>? StreamDoubleDisposed;
+
+		/// <summary>
+		/// Triggered when a stream is finalized.
+		/// </summary>
+		public event EventHandler<StreamFinalizedEventArgs>? StreamFinalized;
+
+		/// <summary>
+		/// Triggered when a stream is disposed to report the stream's length.
+		/// </summary>
+		public event EventHandler<StreamLengthEventArgs>? StreamLength;
+
+		/// <summary>
+		/// Triggered when a user converts a stream to array.
+		/// </summary>
+		public event EventHandler<StreamConvertedToArrayEventArgs>? StreamConvertedToArray;
+
+		/// <summary>
+		/// Triggered when a stream is requested to expand beyond the maximum length specified by the responsible RecyclableMemoryStreamManager.
+		/// </summary>
+		public event EventHandler<StreamOverCapacityEventArgs>? StreamOverCapacity;
+
+		/// <summary>
+		/// Triggered when a buffer of either type is discarded, along with the reason for the discard.
+		/// </summary>
+		public event EventHandler<BufferDiscardedEventArgs>? BufferDiscarded;
+
+		/// <summary>
+		/// Periodically triggered to report usage statistics.
+		/// </summary>
+		public event EventHandler<UsageReportEventArgs>? UsageReport;
+	}
+}


### PR DESCRIPTION
This avoids importing this package into the running app and cause dependency issues if the package is updated by the user.
