### PR TITLE
fix(pointers): Fix invalid timestamp causing incredible inertia on macOS

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -912,7 +912,7 @@ void uno_window_clip_svg(UNOWindow* window, const char* svg)
             NSTimeInterval ts = event.timestamp;
             
             data.frameId = (uint)(ts * 10.0);
-            data.timestamp = (uint64)(ts * 1000000);
+            data.timestamp = (uint64)(ts * 1000000.0);
 
             handled = uno_get_window_mouse_event_callback()(self, &data);
 #if DEBUG_MOUSE // very noisy


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/633

## Bugfix
 Fix invalid timestamp causing incredible inertia on macOS

## What is the current behavior?
Timestamp are rounded at the second level

## What is the new behavior?
Micro-second timestamps

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
