### PR TITLE
feat: Prevent HRI to move out of area by inertia

### DIFF
--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.Placement.cs
@@ -131,6 +131,18 @@ public sealed partial class DiagnosticsOverlay
 		_location.X += _origin.HasFlag(PlacementOrigin.Right) ? -e.Delta.Translation.X : e.Delta.Translation.X;
 		_location.Y += _origin.HasFlag(PlacementOrigin.Bottom) ? -e.Delta.Translation.Y : e.Delta.Translation.Y;
 
+		if (e.IsInertial)
+		{
+			var area = GetSafeArea();
+			if (_location.X < 0 || _location.X > area.Width
+				|| _location.Y < 0 || _location.Y > area.Height)
+			{
+				e.Complete();
+
+				return;
+			}
+		}
+
 		ApplyLocation();
 	}
 


### PR DESCRIPTION
linked to https://github.com/unoplatform/uno-private/issues/633

## Feature
Prevent HRI to move out of area by inertia

## What is the current behavior?
We can "launch" the HRI out of window's bounds

## What is the new behavior?
When HRI is manipulated by inertia, we clamp it in the bounds of the window.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
