### PR TITLE
feat: Recognize `.WinAppSDK.cs` in Uno.SDK

### DIFF
--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -273,13 +273,14 @@ Many Uno projects and libraries make use of a `winappsdk-workaround.targets` fil
 By Default when using the Uno.Sdk you get the added benefit of default includes for an easier time building Cross Targeted Applications. The supported file extensions are as shown below:
 
 - `*.crossruntime.cs` (WASM, Skia, or Reference)
-- `*.wasm.cs`
-- `*.skia.cs`
-- `*.reference.cs`
+- `*.wasm.cs` (WebAssembly)
+- `*.skia.cs` (Skia)
+- `*.reference.cs` (Reference only)
 - `*.iOS.cs`(iOS & MacCatalyst)
 - `*.macOS.cs` (MacOS not MacCatalyst)
 - `*.iOSmacOS.cs` (iOS, MacCatalyst, & MacOS)
-- `*.Android.cs`
+- `*.Android.cs` (Android)
+- `*.WinAppSDK.cs` (Windows App SDK)
 
 As discussed above setting `EnableDefaultUnoItems` to false will disable these includes.
 

--- a/src/Uno.Sdk/targets/Uno.CrossTargeting.targets
+++ b/src/Uno.Sdk/targets/Uno.CrossTargeting.targets
@@ -29,6 +29,9 @@
 
 		<None Include="**\*.Android.cs" Exclude="bin\**\*.Android.cs;obj\**\*.Android.cs" Condition="!$(IsAndroid)" />
 		<Compile Remove="**\*.Android.cs" Condition="!$(IsAndroid)" />
+
+		<None Include="**\*.WinAppSDK.cs" Exclude="bin\**\*.WinAppSDK.cs;obj\**\*.WinAppSDK.cs" Condition="!$(IsWinAppSDK)" />
+		<Compile Remove="**\*.WinAppSDK.cs" Condition="!$(IsWinAppSDK)" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

All targets have a platform-specific C# suffix, except for WinUI

## What is the new behavior?

`.WinAppSDK.cs` files are only going to be included on WinAppSDK target

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
