### PR TITLE
fix(droid): add workaround for NavView leaving blank on IsBackButtonVisible update

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
@@ -1,18 +1,24 @@
-﻿using System.Threading.Tasks;
-#if WINAPPSDK
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+using Uno.Extensions;
+using Uno.Extensions.Specialized;
 using Uno.UI.Extensions;
-#elif __IOS__
+using Uno.UI.RuntimeTests.Helpers;
+
+using static Private.Infrastructure.TestServices;
+using MUXC = Microsoft/* UWP don't rename */.UI.Xaml.Controls;
+
+#if __IOS__
 using UIKit;
 #elif __MACOS__
 using AppKit;
-#else
 #endif
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using static Private.Infrastructure.TestServices;
-using Windows.UI;
-using Microsoft.UI.Xaml.Media;
-using Uno.UI.RuntimeTests.Helpers;
 
 namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 {
@@ -27,16 +33,16 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 #endif
 		public async Task When_SelectedItem_Set_Before_Load_And_Theme_Changed()
 		{
-			var navView = new Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationView()
+			var navView = new MUXC.NavigationView()
 			{
 				MenuItems =
 				{
-					new Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewItem {Content = "Item 1"},
-					new Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewItem {Content = "Item 2"},
-					new Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewItem {Content = "Item 3"},
+					new MUXC.NavigationViewItem {Content = "Item 1"},
+					new MUXC.NavigationViewItem {Content = "Item 2"},
+					new MUXC.NavigationViewItem {Content = "Item 3"},
 				},
-				PaneDisplayMode = Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal,
-				IsBackButtonVisible = Microsoft/* UWP don't rename */.UI.Xaml.Controls.NavigationViewBackButtonVisible.Collapsed,
+				PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.LeftMinimal,
+				IsBackButtonVisible = MUXC.NavigationViewBackButtonVisible.Collapsed,
 			};
 			navView.SelectedItem = navView.MenuItems[1];
 			var hostGrid = new Grid() { MinWidth = 20, MinHeight = 20 };
@@ -53,9 +59,9 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 
 			await WindowHelper.WaitForIdle();
 
-			var togglePaneButton = navView.FindFirstChild<Button>(b => b.Name == "TogglePaneButton");
-			var icon = togglePaneButton?.FindFirstChild<FrameworkElement>(f => f.Name == "Icon");
-			var iconTextBlock = icon?.FindFirstChild<TextBlock>(includeCurrent: true);
+			var togglePaneButton = navView.FindFirstDescendant<Button>(b => b.Name == "TogglePaneButton");
+			var icon = togglePaneButton?.FindFirstDescendant<FrameworkElement>(f => f.Name == "Icon");
+			var iconTextBlock = icon as TextBlock ?? icon?.FindFirstDescendant<TextBlock>();
 
 			Assert.IsNotNull(iconTextBlock);
 
@@ -72,6 +78,104 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 				Assert.AreEqual((Android.Graphics.Color)((iconTextBlock.Foreground as SolidColorBrush).Color), iconTextBlock.NativeArrangedColor);
 #endif
 			}
+		}
+
+		[TestMethod]
+		public async Task When_IsBackButtonVisible_Toggled()
+		{
+			// unoplatform/uno#19516
+			// droid-specific: There is a bug where setting IsBackButtonVisible would "lock" the size of all NVIs
+			// preventing resizing on items expansion/collapse.
+
+			var sut = new MUXC.NavigationView()
+			{
+				Height = 500,
+				IsBackButtonVisible = MUXC.NavigationViewBackButtonVisible.Collapsed,
+				IsPaneToggleButtonVisible = false,
+				PaneDisplayMode = MUXC.NavigationViewPaneDisplayMode.Left,
+				CompactModeThresholdWidth = 10,
+				ExpandedModeThresholdWidth = 50,
+			};
+			sut.ItemInvoked += (s, e) =>
+			{
+				// manual trigger for deepest/inner-most items
+				if (e.InvokedItemContainer is MUXC.NavigationViewItem nvi &&
+					nvi.MenuItems.Count == 0)
+				{
+					sut.IsBackButtonVisible = MUXC.NavigationViewBackButtonVisible.Visible;
+				}
+			};
+
+			var nvis = new Dictionary<string, MUXC.NavigationViewItem>();
+			//AddItems(sut.MenuItems, "", count: 4, depth: 1, maxDepth: 2);
+			AddItems(sut.MenuItems, "", count: 3, depth: 1, maxDepth: 3);
+			void AddItems(IList<object> target, string prefix, int count, int depth, int maxDepth)
+			{
+				for (int i = 0; i < count; i++)
+				{
+					var header = prefix + (char)('A' + i);
+					var item = new MUXC.NavigationViewItem() { Content = header };
+
+					if (depth < maxDepth) AddItems(item.MenuItems, header, count, depth + 1, maxDepth);
+
+					target.Add(item);
+					nvis.Add(header, item);
+				}
+			}
+
+			// for debugging
+			var panel = new StackPanel();
+			void AddTestButton(string label, Action action)
+			{
+				var button = new Button() { Content = label };
+				button.Click += (s, e) => action();
+				panel.Children.Add(button);
+			}
+			AddTestButton("InvalidateMeasure", () =>
+			{
+				foreach (var ir in sut.EnumerateDescendants().OfType<MUXC.ItemsRepeater>())
+				{
+					ir.InvalidateMeasure();
+				}
+			});
+			AddTestButton("IsBackButtonVisible toggle", () =>
+				sut.IsBackButtonVisible = sut.IsBackButtonVisible == MUXC.NavigationViewBackButtonVisible.Collapsed
+					? MUXC.NavigationViewBackButtonVisible.Visible
+					: MUXC.NavigationViewBackButtonVisible.Collapsed);
+			panel.Children.Add(sut);
+
+			await UITestHelper.Load(panel, x => x.IsLoaded);
+
+			var initialHeight = nvis["B"].ActualHeight;
+
+			nvis["B"].IsExpanded = true;
+			await UITestHelper.WaitForIdle();
+			var partiallyExpandedHeight = nvis["B"].ActualHeight;
+
+			nvis["BB"].IsExpanded = true;
+			await UITestHelper.WaitForIdle();
+			var fullyExpandedHeight = nvis["B"].ActualHeight;
+
+			// trigger the bug
+			await Task.Delay(2000); // necessary
+			sut.IsBackButtonVisible = MUXC.NavigationViewBackButtonVisible.Visible;
+			await UITestHelper.WaitForIdle();
+
+			nvis["BB"].IsExpanded = false;
+			await UITestHelper.WaitForIdle();
+			var partiallyCollapsedHeight = nvis["B"].ActualHeight;
+
+			nvis["B"].IsExpanded = false;
+			await UITestHelper.WaitForIdle();
+			var fullyCollapsedHeight = nvis["B"].ActualHeight;
+
+			// sanity check
+			Assert.IsTrue(initialHeight < partiallyExpandedHeight, $"Expanding 'B' should increase item 'B' height: {initialHeight} -> {partiallyExpandedHeight}");
+			Assert.IsTrue(partiallyExpandedHeight < fullyExpandedHeight, $"Expanding 'BB' should increase item 'B' height: {partiallyExpandedHeight} -> {fullyExpandedHeight}");
+
+			// verifying fix
+			Assert.IsTrue(fullyExpandedHeight > partiallyCollapsedHeight, $"Collapsing 'BB' should reduce item 'B' height: {fullyExpandedHeight} -> {partiallyCollapsedHeight}");
+			Assert.IsTrue(partiallyCollapsedHeight > fullyCollapsedHeight, $"Collapsing 'B' should reduce item 'B' height: {partiallyCollapsedHeight} -> {fullyCollapsedHeight}");
 		}
 	}
 }

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -929,5 +929,15 @@ namespace Uno.UI
 			}
 		}
 #endif
+
+		public static class NavigationView
+		{
+#if __ANDROID__
+			/// <summary>
+			/// Workaround for unoplatform/uno#19516 where toggling IsBackButtonVisible would stop NVIs from updating their layout/size when expanded/collapsed.
+			/// </summary>
+			public static bool EnableUno19516Workaround { get; set; } = true;
+#endif
+		}
 	}
 }

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -9,12 +9,15 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Globalization;
+using System.Linq;
 using System.Numerics;
 using Microsoft/* UWP don't rename */.UI.Xaml.Automation.Peers;
 using Microsoft/* UWP don't rename */.UI.Xaml.Controls.AnimatedVisuals;
 using Uno.Disposables;
 using Uno.Foundation.Logging;
+using Uno.UI;
 using Uno.UI.DataBinding;
+using Uno.UI.Extensions;
 using Uno.UI.Helpers.WinUI;
 using Windows.ApplicationModel.Core;
 using Windows.Foundation;
@@ -4353,6 +4356,19 @@ public partial class NavigationView : ContentControl
 			{
 				backButton.UpdateLayout();
 			}
+
+#if __ANDROID__
+			// workaround for unoplatform/uno#19516 where toggling IsBackButtonVisible would stop NVIs from updating their layout/size when expanded/collapsed.
+			if (FeatureConfiguration.NavigationView.EnableUno19516Workaround &&
+				m_appliedTemplate && IsLoaded)
+			{
+				foreach (var ir in this.EnumerateDescendants().OfType<ItemsRepeater>())
+				{
+					ir.InvalidateMeasure();
+				}
+			}
+#endif
+
 			UpdatePaneLayout();
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #19516, closes unoplatform/ziidms-private#46

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
after changing NavView::IsBackButtonVisible value, all NVItems would stop updating their layout/size when expanded/collapsed.

## What is the new behavior?
added a workaround for this issue

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.