### PR TITLE
docs(unoislands-wpf): updated PackageReference version numbers

### DIFF
--- a/doc/articles/guides/uno-islands.md
+++ b/doc/articles/guides/uno-islands.md
@@ -22,13 +22,13 @@ To light-up the Uno Islands feature, we need to reference several Uno Platform N
 
 ```xml
 <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.5.0" />
-    <PackageReference Include="Uno.WinUI.DevServer" Version="4.5.0-dev.453" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.5.0-dev.453" />
-    <PackageReference Include="Uno.WinUI.XamlHost" Version="4.5.0-dev.453" />
-    <PackageReference Include="Uno.WinUI.XamlHost.Skia.Wpf" Version="4.5.0-dev.453" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+    <PackageReference Include="Uno.WinUI.Skia.Wpf" Version="5.6.33" />
+    <PackageReference Include="Uno.WinUI.DevServer" Version="5.6.33" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.6.33" />
+    <PackageReference Include="Uno.WinUI.XamlHost" Version="5.6.33" />
+    <PackageReference Include="Uno.WinUI.XamlHost.Skia.Wpf" Version="5.6.33" />
 </ItemGroup>
 <ItemGroup>
     <UpToDateCheckInput Include="..\UnoIslandsSampleApp.Shared\**\*.xaml" />


### PR DESCRIPTION
GitHub Issue: none

## PR Type

What kind of change does this PR introduce?

- Documentation content changes
- Other: Updated version numbers to the latest

## What is the current behavior?

https://platform.uno/docs/articles/guides/uno-islands.html#updating-the-wpf-application-project

this step results in nuget telling this Packages are not the latest versions and should get updated

## What is the new behavior?

Packages are up to date from copy-paste without having to run a seperate update of them

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been updated
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information

The [Shared project contents](https://platform.uno/docs/articles/guides/uno-islands.html#shared-project-contents) content of the same doc page is missunderstandable from my opinion and I would like to include this to this PR if wanted.
The reader is told to copy the assets folder from the repo shared project, which is in fact empty.
The font, which is mentioned there is located at the repositorys WPF project instead and the user would fail if just following this steps exactly.
This additional part is currently failing because of #19509 seems to make it not possible to build the application successfully