### PR TITLE
fix(hr): Ignore bin and obj folders

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/RemoteControl/RemoteControlGenerator.cs
@@ -47,7 +47,8 @@ namespace Uno.UI.SourceGenerators.RemoteControl
 			"MSBuildVersion",
 			"UnoHotReloadDiagnosticsLogPath",
 			"AppendRuntimeIdentifierToOutputPath",
-			"OutputPath"
+			"OutputPath",
+			"IntermediateOutputPath"
 		};
 
 		public void Initialize(GeneratorInitializationContext context)

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -38,7 +38,6 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 		private bool InitializeMetadataUpdater(ConfigureServer configureServer)
 		{
-			Debugger.Launch();
 			_ = bool.TryParse(_remoteControlServer.GetServerConfiguration("metadata-updates"), out _useRoslynHotReload);
 
 			_useRoslynHotReload = _useRoslynHotReload || configureServer.EnableMetadataUpdates;

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -23,7 +23,8 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 {
 	partial class ServerHotReloadProcessor : IServerProcessor, IDisposable
 	{
-		private static readonly StringComparer _pathsComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+		private static readonly StringComparer _pathsComparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+		private static readonly StringComparison _pathsComparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
 		private FileSystemWatcher[]? _solutionWatchers;
 		private IDisposable? _solutionWatcherEventsDisposable;
@@ -37,6 +38,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 		private bool InitializeMetadataUpdater(ConfigureServer configureServer)
 		{
+			Debugger.Launch();
 			_ = bool.TryParse(_remoteControlServer.GetServerConfiguration("metadata-updates"), out _useRoslynHotReload);
 
 			_useRoslynHotReload = _useRoslynHotReload || configureServer.EnableMetadataUpdates;
@@ -96,6 +98,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						&& bool.TryParse(appendStr, out var append)
 						&& append;
 					var hasOutputPath = properties.Remove("OutputPath", out var outputPath);
+					properties.Remove("IntermediateOutputPath", out var intermediateOutputPath);
 
 					if (properties.Remove("RuntimeIdentifier", out var runtimeIdentifier))
 					{
@@ -116,7 +119,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						properties,
 						CancellationToken.None);
 
-					ObserveSolutionPaths(result.Item1);
+					ObserveSolutionPaths(result.Item1, intermediateOutputPath, outputPath);
 
 					await _remoteControlServer.SendFrame(new HotReloadWorkspaceLoadResult { WorkspaceInitialized = true });
 					await Notify(HotReloadEvent.Ready);
@@ -136,16 +139,26 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			CancellationToken.None);
 		}
 
-		private void ObserveSolutionPaths(Solution solution)
+		private void ObserveSolutionPaths(Solution solution, params string?[] excludedDir)
 		{
 			var observedPaths =
 				solution.Projects
-					.SelectMany(p => p
-						.Documents
-						.Select(d => d.FilePath)
-						.Concat(p.AdditionalDocuments
-							.Select(d => d.FilePath)))
-					.Select(Path.GetDirectoryName)
+					.SelectMany(project =>
+					{
+						var projectDir = Path.GetDirectoryName(project.FilePath);
+						ImmutableArray<string> excludedProjectDir = [.. from dir in excludedDir where dir is not null select Path.Combine(projectDir!, dir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)];
+						
+						var paths = project
+							.Documents
+							.Select(d => d.FilePath)
+							.Concat(project.AdditionalDocuments.Select(d => d.FilePath))
+							.Select(Path.GetDirectoryName)
+							.Where(path => path is not null && !excludedProjectDir.Any(dir => path.StartsWith(dir, _pathsComparison)))
+							.Distinct()
+							.ToArray();
+
+						return paths;
+					})
 					.Distinct()
 					.ToArray();
 

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -146,7 +146,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					{
 						var projectDir = Path.GetDirectoryName(project.FilePath);
 						ImmutableArray<string> excludedProjectDir = [.. from dir in excludedDir where dir is not null select Path.Combine(projectDir!, dir).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)];
-						
+
 						var paths = project
 							.Documents
 							.Select(d => d.FilePath)

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -215,7 +215,7 @@ public partial class ClientHotReloadProcessor
 		{
 			return Types
 				.Select(GetFriendlyName)
-				.Where(name => name is { Length: > 0 } and not "HRException")
+				.Where(name => name is { Length: > 0 } and not "HotReloadException")
 				.Distinct()
 				.ToArray()!;
 

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -215,7 +215,7 @@ public partial class ClientHotReloadProcessor
 		{
 			return Types
 				.Select(GetFriendlyName)
-				.Where(name => name is { Length: > 0 })
+				.Where(name => name is { Length: > 0 } and not "HRException")
 				.Distinct()
 				.ToArray()!;
 


### PR DESCRIPTION
closes https://github.com/unoplatform/private/issues/630

## Bugfix
Ignore bin and obj folders

## What is the current behavior?
cf. issue

## What is the new behavior?
`OutputPath` an `IntermediateOutputPath` are ignore by the HR workspace

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

