### PR TITLE
fix: Drag and Drop initialization on mobile

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_DragDrop.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_DragDrop.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Xaml_Core;
+
+[TestClass]
+public class Given_DragDrop
+{
+#if HAS_UNO // InputManager is internal.
+	[TestMethod]
+	[RunsOnUIThread]
+	public void Verify_Initialized()
+	{
+		var xamlRoot = TestServices.WindowHelper.XamlRoot;
+		var contentRoot = xamlRoot.VisualTree.ContentRoot;
+		Assert.IsNotNull(contentRoot.InputManager.DragDrop);
+	}
+#endif
+}

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.cs
@@ -22,10 +22,6 @@ internal partial class InputManager : IInputInjectorTarget
 		ConstructKeyboardManager();
 
 		ConstructPointerManager();
-
-#if ANDROID // for some reason, moving InitDragAndDrop to Initialize breaks Android in CI
-		InitDragAndDrop();
-#endif
 	}
 
 	partial void ConstructKeyboardManager();
@@ -39,9 +35,7 @@ internal partial class InputManager : IInputInjectorTarget
 	{
 		InitializeKeyboard(host);
 		InitializePointers(host);
-#if !ANDROID
 		InitDragAndDrop();
-#endif
 	}
 
 	partial void InitializeKeyboard(object host);

--- a/src/Uno.UI/UI/Xaml/Window/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.cs
@@ -240,7 +240,7 @@ partial class Window
 		if (_windowType is WindowType.CoreWindow)
 		{
 			WinUICoreServices.Instance.InitCoreWindowContentRoot();
-#if __WASM__ // We normally call SetHost from the NativeWindowWrapper on DesktopXamlSource targets, but for WASM we put it here.
+#if __WASM__ || __ANDROID__ || __IOS__ // We normally call SetHost from the NativeWindowWrapper on DesktopXamlSource targets, but for WASM we put it here.
 			WinUICoreServices.Instance.MainVisualTree!.ContentRoot.SetHost(this);
 #endif
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/19522

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Drag and drop is not initialized correctly on mobile


## What is the new behavior?

Initialized in line with Skia and WebAssembly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.