### PR TITLE
HR: Changed the way code (XAML) is updated through Hot Reload

### DIFF
--- a/src/Uno.UI.RemoteControl.Messaging/IDEChannel/ForceHotReloadIdeMessage.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IDEChannel/ForceHotReloadIdeMessage.cs
@@ -4,7 +4,4 @@ using System.Collections.Generic;
 
 namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
 
-public record ForceHotReloadIdeMessage(
-	long CorrelationId,
-	IReadOnlyDictionary<string, string>? OptionalUpdatedFilesContent,
-	bool ForceFileSave = false) : IdeMessage(WellKnownScopes.HotReload);
+public record ForceHotReloadIdeMessage(long CorrelationId) : IdeMessageWithCorrelationId(CorrelationId, WellKnownScopes.HotReload);

--- a/src/Uno.UI.RemoteControl.Messaging/IDEChannel/ForceHotReloadIdeMessage.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IDEChannel/ForceHotReloadIdeMessage.cs
@@ -1,5 +1,10 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
 
-public record ForceHotReloadIdeMessage(long CorrelationId) : IdeMessage(WellKnownScopes.HotReload);
+public record ForceHotReloadIdeMessage(
+	long CorrelationId,
+	IReadOnlyDictionary<string, string>? OptionalUpdatedFilesContent,
+	bool ForceFileSave = false) : IdeMessage(WellKnownScopes.HotReload);

--- a/src/Uno.UI.RemoteControl.Messaging/IDEChannel/HotReloadRequestedIdeMessage.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IDEChannel/HotReloadRequestedIdeMessage.cs
@@ -1,10 +1,3 @@
-﻿#nullable enable
+﻿namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
 
-namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
-
-/// <summary>
-/// A message sent by the IDE to the dev-server to confirm a <see cref="ForceHotReloadIdeMessage"/> request has been processed.
-/// </summary>
-/// <param name="RequestId"><see cref="ForceHotReloadIdeMessage.CorrelationId"/> of the request.</param>
-/// <param name="Result">Result of the request.</param>
-public record HotReloadRequestedIdeMessage(long RequestId, Result Result) : IdeMessage(WellKnownScopes.HotReload);
+public record HotReloadRequestedIdeMessage(long IdeCorrelationId, Result Result) : IdeMessage(WellKnownScopes.HotReload);

--- a/src/Uno.UI.RemoteControl.Messaging/IDEChannel/IdeMessageWithCorrelationId.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IDEChannel/IdeMessageWithCorrelationId.cs
@@ -1,0 +1,4 @@
+﻿#nullable enable
+namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
+
+public record IdeMessageWithCorrelationId(long CorrelationId, string Scope) : IdeMessage(Scope);

--- a/src/Uno.UI.RemoteControl.Messaging/IDEChannel/IdeResultMessage.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IDEChannel/IdeResultMessage.cs
@@ -1,0 +1,5 @@
+﻿#nullable enable
+
+namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
+
+public record IdeResultMessage(long IdeCorrelationId, Result Result) : IdeMessage(WellKnownScopes.HotReload);

--- a/src/Uno.UI.RemoteControl.Messaging/IDEChannel/UpdateFileIdeMessage.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IDEChannel/UpdateFileIdeMessage.cs
@@ -1,0 +1,7 @@
+﻿namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
+
+public record UpdateFileIdeMessage(
+	long CorrelationId,
+	string FileFullName,
+	string FileContent,
+	bool ForceSaveOnDisk) : IdeMessageWithCorrelationId(CorrelationId, WellKnownScopes.HotReload);

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -36,7 +37,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 		private bool _useRoslynHotReload;
 
-		private bool InitializeMetadataUpdater(ConfigureServer configureServer)
+		private bool InitializeMetadataUpdater(ConfigureServer configureServer, Dictionary<string, string> properties)
 		{
 			_ = bool.TryParse(_remoteControlServer.GetServerConfiguration("metadata-updates"), out _useRoslynHotReload);
 
@@ -49,7 +50,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				// of a missing path on assemblies loaded from a memory stream.
 				CompilationWorkspaceProvider.RegisterAssemblyLoader();
 
-				InitializeInner(configureServer);
+				InitializeInner(configureServer, properties);
 
 				return true;
 			}
@@ -59,7 +60,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			}
 		}
 
-		private void InitializeInner(ConfigureServer configureServer)
+		private void InitializeInner(ConfigureServer configureServer, Dictionary<string, string> properties)
 		{
 			if (Assembly.Load("Microsoft.CodeAnalysis.Workspaces") is { } wsAsm)
 			{
@@ -80,10 +81,6 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				try
 				{
 					await Notify(HotReloadEvent.Initializing);
-
-					var properties = configureServer
-						.MSBuildProperties
-						.ToDictionary();
 
 					// Flag the current build as created for hot reload, which allows for running targets or settings
 					// props/items in the context of the hot reload workspace.

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -480,11 +480,16 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					_ => (FileUpdateResult.BadRequest, "Invalid request")
 				};
 
-				if ((int)result < 300 && !message.IsForceHotReloadDisabled)
+				var isIdeSupportingHotReload = _isRunningInsideVisualStudio;
+
+				if (message.IsForceHotReloadDisabled is false && (int)result < 300)
 				{
 					hotReload.EnableAutoRetryIfNoChanges(message.ForceHotReloadAttempts, message.ForceHotReloadDelay);
 
-					await RequestHotReloadToIde();
+					if (isIdeSupportingHotReload)
+					{
+						await RequestHotReloadToIde();
+					}
 				}
 
 				await _remoteControlServer.SendFrame(new UpdateFileResponse(message.RequestId, message.FilePath ?? "", result, error, hotReload.Id));

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -26,6 +26,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 {
 	partial class ServerHotReloadProcessor : IServerProcessor, IDisposable
 	{
+		private static readonly TimeSpan _waitForIdeResultTimeout = TimeSpan.FromSeconds(25);
 		private readonly IRemoteControlServer _remoteControlServer;
 
 		public ServerHotReloadProcessor(IRemoteControlServer remoteControlServer)
@@ -439,7 +440,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			var tcs = new TaskCompletionSource<Result>();
 			try
 			{
-				using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+				using var cts = new CancellationTokenSource(_waitForIdeResultTimeout);
 				await using var ctReg = cts.Token.Register(() => tcs.TrySetCanceled());
 
 				_pendingRequestsToIde.TryAdd(message.CorrelationId, tcs);
@@ -622,7 +623,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				};
 				watcher.EnableRaisingEvents = true;
 
-				if (await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(2))) != tcs.Task
+				if (await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(5))) != tcs.Task
 					&& this.Log().IsEnabled(LogLevel.Debug))
 				{
 					this.Log().LogDebug($"File update event not received for '{message.FilePath}', continuing anyway [{message.RequestId}].");

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -438,6 +438,8 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				var (result, error) = message switch
 				{
 					{ FilePath: null or { Length: 0 } } => (FileUpdateResult.BadRequest, "Invalid request (file path is empty)"),
+					// Right now, when running on VS, we're delegating the file update to the code that is running inside VS.
+					// we're not doing this for other file operations because they are not/less required for hot-reload. We may need to revisit this eventually.
 					{ OldText: not null, NewText: not null } when !_isRunningInsideVisualStudio => await DoUpdate(message.OldText, message.NewText),
 					{ OldText: null, NewText: not null } => await DoWrite(message.NewText),
 					{ NewText: null, IsCreateDeleteAllowed: true } => await DoDelete(),

--- a/src/Uno.UI.RemoteControl.VS/AbsolutePathComparer.cs
+++ b/src/Uno.UI.RemoteControl.VS/AbsolutePathComparer.cs
@@ -22,7 +22,7 @@ internal class AbsolutePathComparer : IEqualityComparer<string?>
 
 	public static readonly AbsolutePathComparer Comparer = new(ignoreCase: false);
 	public static readonly AbsolutePathComparer ComparerIgnoreCase = new(ignoreCase: true);
-	
+
 	private enum PathType
 	{
 		Relative,
@@ -99,7 +99,7 @@ internal class AbsolutePathComparer : IEqualityComparer<string?>
 		var (type, drive, segments) = ParsePath(path.AsSpan());
 
 		var hash = 17;
-		
+
 		// Include the path type in the hash
 		hash = unchecked(hash * 79 + (int)type);
 

--- a/src/Uno.UI.RemoteControl.VS/AbsolutePathComparer.cs
+++ b/src/Uno.UI.RemoteControl.VS/AbsolutePathComparer.cs
@@ -1,0 +1,275 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace Uno.UI.Helpers;
+
+/// <summary>
+/// Compares two absolute path strings for equality. Supports Windows, Unix, and UNC path formats. URIs are not supported.
+/// </summary>
+/// <remarks>
+/// This will resolve "." and ".." segments and normalize slashes vs backslashes before doing the comparison.
+/// Relative paths will always compare as unequal. Same for empty paths (C:\ or / on unix/max).
+/// IMPORTANT: This comparer WILL NOT resolve symbolic links or check if the filesystem is case-sensitive.
+/// It's just comparing the strings as paths, no I/O is performed.
+/// </remarks>
+internal class AbsolutePathComparer : IEqualityComparer<string?>
+{
+	private readonly bool _ignoreCase;
+
+	public static readonly AbsolutePathComparer Comparer = new(ignoreCase: false);
+	public static readonly AbsolutePathComparer ComparerIgnoreCase = new(ignoreCase: true);
+	
+	private enum PathType
+	{
+		Relative,
+		Unix,
+		Windows,
+		UNC,
+	}
+
+	private AbsolutePathComparer(bool ignoreCase = true)
+	{
+		_ignoreCase = ignoreCase;
+	}
+
+	/// <summary>
+	/// Determines if two path strings are equal.
+	/// </summary>
+	public bool Equals(string? x, string? y)
+	{
+		if (x == null || y == null)
+		{
+			return false;
+		}
+
+		var spanX = x.AsSpan();
+		var spanY = y.AsSpan();
+
+		// Parse each path into a drive (if any) and segments
+		var (typeX, driveX, segmentsX) = ParsePath(spanX);
+		var (typeY, driveY, segmentsY) = ParsePath(spanY);
+
+		// Compare path types (e.g., relative, UNC, Windows, or Unix)
+		if (typeX != typeY)
+		{
+			return false;
+		}
+
+		// Compare drive letters (e.g., "C:" vs "D:") or empty if UNC or no drive
+		if (driveX != driveY)
+		{
+			return false;
+		}
+
+		// Compare the number of segments, ensure at least one segment
+		if (segmentsX.Count == 0 || segmentsX.Count != segmentsY.Count)
+		{
+			return false;
+		}
+
+		// Compare each corresponding segment
+		for (var i = 0; i < segmentsX.Count; i++)
+		{
+			var segX = segmentsX[i];
+			var segY = segmentsY[i];
+
+			if (!SegmentEquals(spanX, segX.start, segX.length, spanY, segY.start, segY.length))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	/// Computes a hash code for the given path string.
+	/// </summary>
+	public int GetHashCode(string? path)
+	{
+		if (path is null || path.Length == 0)
+		{
+			return -1;
+		}
+
+		var (type, drive, segments) = ParsePath(path.AsSpan());
+
+		var hash = 17;
+		
+		// Include the path type in the hash
+		hash = unchecked(hash * 79 + (int)type);
+
+		// Include the drive in the hash (no effect is drive is '\0')
+		hash = unchecked(hash * 31 + NormalizeChar(drive));
+
+		// Include each segment in the hash
+		foreach (var (start, length) in segments)
+		{
+			for (var i = 0; i < length; i++)
+			{
+				var c = path[start + i];
+				hash = unchecked(hash * 31 + NormalizeChar(c));
+			}
+			// Use a slash as a separator between segments
+			hash = unchecked(hash * 31 + '/');
+		}
+
+		return hash;
+	}
+
+	/// <summary>
+	/// Parses a path into an optional drive (e.g., "C:") and a list of segments.
+	/// Also handles UNC paths that begin with "//" or "\\".
+	/// </summary>
+	private (PathType type, char drive, List<(int start, int length)>) ParsePath(ReadOnlySpan<char> path)
+	{
+		if (!IsPathFullyQualified(path))
+		{
+			return (PathType.Relative, '\0', []); // Only fully-qualified paths are supported
+		}
+
+		var segments = new List<(int start, int length)>();
+
+		var type = PathType.Unix; // Assume Unix-style path
+		var drive = '\0'; // '\0' means no drive letter
+		var idx = 0;
+
+		// 1) Check for UNC path (starts with "//" or "\\")
+		if (path.Length >= 2 && IsPathSegmentSeparator(path[0]) && IsPathSegmentSeparator(path[1]))
+		{
+			// Skip the initial double slash
+			type = PathType.UNC;
+			idx = 2;
+		}
+		// 2) Otherwise, check for local drive (e.g., "C:")
+		else if (path.Length >= 2 && path[1] == ':')
+		{
+			// Extract the drive letter advance to the next character after the colon
+			type = PathType.Windows;
+			drive = char.ToUpper(path[0], CultureInfo.InvariantCulture);
+			idx = 2;
+		}
+
+		// Skip any additional slashes after drive or UNC prefix
+		while (idx < path.Length && IsPathSegmentSeparator(path[idx]))
+		{
+			idx++;
+		}
+
+		// Parse segments until we reach the end
+		while (idx < path.Length)
+		{
+			var segStart = idx;
+
+			// Move until the next slash or end of string
+			while (idx < path.Length && !IsPathSegmentSeparator(path[idx]))
+			{
+				idx++;
+			}
+
+			var segLength = idx - segStart;
+
+			if (segLength == 1 && path[segStart] == '.')
+			{
+				// Ignore single-dot segments
+			}
+			else if (segLength == 2 && path[segStart] == '.' && path[segStart + 1] == '.')
+			{
+				// Pop the last segment for ".." if possible
+				if (segments.Count > 0)
+				{
+					segments.RemoveAt(segments.Count - 1);
+				}
+			}
+			else if (segLength > 0)
+			{
+				// Normal segment => record its start/length
+				segments.Add((segStart, segLength));
+			}
+
+			// Skip any consecutive slashes
+			while (idx < path.Length && IsPathSegmentSeparator(path[idx]))
+			{
+				idx++;
+			}
+		}
+
+		return (type, drive, segments);
+	}
+
+	// Determines if the given path is fully qualified (e.g., "C:\foo", "\\server\share\foo", or "/foo").
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private bool IsPathFullyQualified(ReadOnlySpan<char> path)
+	{
+		if (path.Length == 0)
+		{
+			return false;
+		}
+
+		// Unix-like, UNC or non-drive specific path
+		if (IsPathSegmentSeparator(path[0]))
+		{
+			return true;
+		}
+
+		// Drive letter (must be followed by a colon and a path separator) - must also be a valid drive letter
+		if (path.Length >= 3 && path[1] == ':' && IsPathSegmentSeparator(path[2]) && char.IsLetter(path[0]))
+		{
+			return true;
+		}
+
+		// Relative path
+		return false;
+	}
+
+	/// <summary>
+	/// Compares two path segments [start..start+length] for equality (respecting or ignoring case).
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private bool SegmentEquals(ReadOnlySpan<char> a, int startA, int lenA, ReadOnlySpan<char> b, int startB, int lenB)
+	{
+		if (lenA != lenB)
+		{
+			return false; // Should never happen (already checked in the caller)
+		}
+
+		if (_ignoreCase)
+		{
+			for (var i = 0; i < lenA; i++)
+			{
+				if (char.ToLowerInvariant(a[startA + i]) != char.ToLowerInvariant(b[startB + i]))
+				{
+					return false;
+				}
+			}
+		}
+		else
+		{
+			for (var i = 0; i < lenA; i++)
+			{
+				if (a[startA + i] != b[startB + i])
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	/// Normalizes a character (e.g., converting it to lowercase if ignoring case).
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private char NormalizeChar(char c) => _ignoreCase ? char.ToLowerInvariant(c) : c;
+
+	/// <summary>
+	/// Returns true if the given character is a slash ('/' or '\').
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private bool IsPathSegmentSeparator(char c) => c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
+}

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -591,8 +591,6 @@ public partial class EntryPoint : IDisposable
 					throw new InvalidOperationException($"Failed to open document {filePath}");
 				}
 
-				document.Activate(); // Sometimes the document is "soft closed", so we need to activate it for the user to see it.
-
 				// Replace the content of the document with the new content.
 
 				// Flags: 0b0000_0011 = vsEPReplaceTextOptions.vsEPReplaceTextKeepMarkers | vsEPReplaceTextOptions.vsEPReplaceTextNormalizeNewLines

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -447,7 +447,10 @@ public partial class EntryPoint : IDisposable
 					await OnAddMenuItemRequestedAsync(sender, amir);
 					break;
 				case ForceHotReloadIdeMessage fhr:
-					await OnForceHotReloadRequestedAsync(sender, fhr);
+					await OnForceHotReloadRequestedAsync(fhr);
+					break;
+				case UpdateFileIdeMessage ufm:
+					await OnUpdateFileRequestedAsync(ufm);
 					break;
 				case NotificationRequestIdeMessage nr:
 					await OnNotificationRequestedAsync(sender, nr);
@@ -536,63 +539,10 @@ public partial class EntryPoint : IDisposable
 		}
 	}
 
-	private async Task OnForceHotReloadRequestedAsync(object? sender, ForceHotReloadIdeMessage request)
+	private async Task OnForceHotReloadRequestedAsync(ForceHotReloadIdeMessage request)
 	{
 		try
 		{
-			if (request.OptionalUpdatedFilesContent is { Count: > 0 } fileUpdates)
-			{
-				foreach (var file in fileUpdates)
-				{
-					var filePath = file.Key;
-					var fileContent = file.Value;
-
-					if (fileContent is not { Length: > 0 })
-					{
-						continue; // Skip empty content.
-					}
-
-					// Update the file content in the IDE using the DTE API.
-					var document = _dte2.Documents
-						.OfType<Document>()
-						.FirstOrDefault(d => AbsolutePathComparer.ComparerIgnoreCase.Equals(d.FullName, filePath));
-
-					var textDocument = document?.Object("TextDocument") as TextDocument;
-
-					if (textDocument is null) // The document is not open in the IDE, so we need to open it.
-					{
-						// Resolve the path to the document (in case it's not open in the IDE).
-						// The path may contain a mix of forward and backward slashes, so we normalize it by using Path.GetFullPath.
-						var adjustedPathForOpening = Path.GetFullPath(filePath);
-
-						document = _dte2.Documents.Open(adjustedPathForOpening);
-						textDocument = document?.Object("TextDocument") as TextDocument;
-					}
-
-					if (document is null || textDocument is null)
-					{
-						throw new InvalidOperationException($"Failed to open document {filePath}");
-					}
-
-					document.Activate(); // Sometimes the document is "soft closed", so we need to activate it for the user to see it.
-
-					// Replace the content of the document with the new content.
-
-					// Flags: 0b0000_0011 = vsEPReplaceTextOptions.vsEPReplaceTextKeepMarkers | vsEPReplaceTextOptions.vsEPReplaceTextNormalizeNewLines
-					// https://learn.microsoft.com/en-us/dotnet/api/envdte.vsepreplacetextoptions?view=visualstudiosdk-2022#fields
-					const int flags = 0b0000_0011;
-
-					textDocument.StartPoint.CreateEditPoint()
-						.ReplaceText(textDocument.EndPoint, fileContent, flags);
-
-					if (request.ForceFileSave)
-					{
-						// Save the document.
-						document.Save();
-					}
-				}
-			}
-
 			// Programmatically trigger the "Apply Code Changes" command in Visual Studio.
 			// Which will trigger the hot reload.
 			_dte.ExecuteCommand("Debug.ApplyCodeChanges");
@@ -600,12 +550,76 @@ public partial class EntryPoint : IDisposable
 			// Send a message back to indicate that the request has been received and acted upon.
 			if (_ideChannelClient is not null)
 			{
-				await _ideChannelClient.SendToDevServerAsync(new HotReloadRequestedIdeMessage(request.CorrelationId, Result.Success()), _ct.Token);
+				await _ideChannelClient.SendToDevServerAsync(new IdeResultMessage(request.CorrelationId, Result.Success()), _ct.Token);
 			}
 		}
 		catch (Exception e) when (_ideChannelClient is not null)
 		{
-			await _ideChannelClient.SendToDevServerAsync(new HotReloadRequestedIdeMessage(request.CorrelationId, Result.Fail(e)), _ct.Token);
+			await _ideChannelClient.SendToDevServerAsync(new IdeResultMessage(request.CorrelationId, Result.Fail(e)), _ct.Token);
+
+			throw;
+		}
+	}
+
+	private async Task OnUpdateFileRequestedAsync(UpdateFileIdeMessage request)
+	{
+		try
+		{
+			if (request.FileContent is { Length: > 0 } fileContent)
+			{
+				var filePath = request.FileFullName;
+
+				// Update the file content in the IDE using the DTE API.
+				var document = _dte2.Documents
+					.OfType<Document>()
+					.FirstOrDefault(d => AbsolutePathComparer.ComparerIgnoreCase.Equals(d.FullName, filePath));
+
+				var textDocument = document?.Object("TextDocument") as TextDocument;
+
+				if (textDocument is null) // The document is not open in the IDE, so we need to open it.
+				{
+					// Resolve the path to the document (in case it's not open in the IDE).
+					// The path may contain a mix of forward and backward slashes, so we normalize it by using Path.GetFullPath.
+					var adjustedPathForOpening = Path.GetFullPath(filePath);
+
+					document = _dte2.Documents.Open(adjustedPathForOpening);
+					textDocument = document?.Object("TextDocument") as TextDocument;
+				}
+
+				if (document is null || textDocument is null)
+				{
+					throw new InvalidOperationException($"Failed to open document {filePath}");
+				}
+
+				document.Activate(); // Sometimes the document is "soft closed", so we need to activate it for the user to see it.
+
+				// Replace the content of the document with the new content.
+
+				// Flags: 0b0000_0011 = vsEPReplaceTextOptions.vsEPReplaceTextKeepMarkers | vsEPReplaceTextOptions.vsEPReplaceTextNormalizeNewLines
+				// https://learn.microsoft.com/en-us/dotnet/api/envdte.vsepreplacetextoptions?view=visualstudiosdk-2022#fields
+				const int flags = 0b0000_0011;
+
+				textDocument.StartPoint.CreateEditPoint()
+					.ReplaceText(textDocument.EndPoint, fileContent, flags);
+
+				if (request.ForceSaveOnDisk)
+				{
+					// Save the document.
+					document.Save();
+				}
+
+				// Send a message back to indicate that the request has been received and acted upon.
+				if (_ideChannelClient is not null)
+				{
+					await _ideChannelClient.SendToDevServerAsync(
+						new IdeResultMessage(request.CorrelationId, Result.Success()), _ct.Token);
+				}
+			}
+		}
+		catch (Exception e) when (_ideChannelClient is not null)
+		{
+			// Send a message back to indicate that the request has failed.
+			await _ideChannelClient.SendToDevServerAsync(new IdeResultMessage(request.CorrelationId, Result.Fail(e)), _ct.Token);
 
 			throw;
 		}

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -40,6 +40,7 @@ public partial class ClientHotReloadProcessor
 		string FilePath,
 		string? OldText,
 		string? NewText,
+		bool ForceSaveToDisk = true, // Temporary set to true until this issue is fixed: https://github.com/unoplatform/uno.hotdesign/issues/3454
 		bool WaitForHotReload = true)
 	{
 		/// <summary>
@@ -95,6 +96,9 @@ public partial class ClientHotReloadProcessor
 	public Task UpdateFileAsync(string filePath, string? oldText, string newText, bool waitForHotReload, CancellationToken ct)
 		=> UpdateFileAsync(new UpdateRequest(filePath, oldText, newText, waitForHotReload), ct);
 
+	public Task UpdateFileAsync(string filePath, string? oldText, string newText, bool waitForHotReload, bool forceSaveToDisk, CancellationToken ct)
+		=> UpdateFileAsync(new UpdateRequest(filePath, oldText, newText, waitForHotReload, forceSaveToDisk), ct);
+
 	public async Task UpdateFileAsync(UpdateRequest req, CancellationToken ct)
 	{
 		if (await TryUpdateFileAsync(req, ct) is { Error: { } error })
@@ -133,7 +137,7 @@ public partial class ClientHotReloadProcessor
 				NewText = req.NewText,
 				ForceHotReloadDelay = req.HotReloadNoChangesRetryDelay,
 				ForceHotReloadAttempts = req.HotReloadNoChangesRetryAttempts,
-				ForceSaveOnDisk = true,
+				ForceSaveOnDisk = req.ForceSaveToDisk,
 			};
 			var response = await UpdateFileCoreAsync(request, req.ServerUpdateTimeout, ct);
 

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -132,7 +132,8 @@ public partial class ClientHotReloadProcessor
 				OldText = req.OldText,
 				NewText = req.NewText,
 				ForceHotReloadDelay = req.HotReloadNoChangesRetryDelay,
-				ForceHotReloadAttempts = req.HotReloadNoChangesRetryAttempts
+				ForceHotReloadAttempts = req.HotReloadNoChangesRetryAttempts,
+				ForceSaveOnDisk = true,
 			};
 			var response = await UpdateFileCoreAsync(request, req.ServerUpdateTimeout, ct);
 

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -40,7 +40,7 @@ public partial class ClientHotReloadProcessor
 		string FilePath,
 		string? OldText,
 		string? NewText,
-		bool ForceSaveToDisk = true, // Temporary set to true until this issue is fixed: https://github.com/unoplatform/uno.hotdesign/issues/3454
+		bool? ForceSaveToDisk = null,
 		bool WaitForHotReload = true)
 	{
 		/// <summary>

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.ClientApi.cs
@@ -40,9 +40,17 @@ public partial class ClientHotReloadProcessor
 		string FilePath,
 		string? OldText,
 		string? NewText,
-		bool? ForceSaveToDisk = null,
 		bool WaitForHotReload = true)
 	{
+		/// <summary>
+		/// Indicates if the file should be saved to disk.
+		/// </summary>
+		/// <remarks>
+		/// Some IDE supports the ability to update the file in memory without saving it to disk.
+		/// Null means that the default behavior of the IDE should be used.
+		/// </remarks>
+		public bool? ForceSaveToDisk { get; init; }
+
 		/// <summary>
 		/// The max delay to wait for the server to process a file update request.
 		/// </summary>
@@ -97,7 +105,7 @@ public partial class ClientHotReloadProcessor
 		=> UpdateFileAsync(new UpdateRequest(filePath, oldText, newText, waitForHotReload), ct);
 
 	public Task UpdateFileAsync(string filePath, string? oldText, string newText, bool waitForHotReload, bool forceSaveToDisk, CancellationToken ct)
-		=> UpdateFileAsync(new UpdateRequest(filePath, oldText, newText, waitForHotReload, forceSaveToDisk), ct);
+		=> UpdateFileAsync(new UpdateRequest(filePath, oldText, newText, waitForHotReload) { ForceSaveToDisk = forceSaveToDisk }, ct);
 
 	public async Task UpdateFileAsync(UpdateRequest req, CancellationToken ct)
 	{

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
@@ -33,6 +33,7 @@ public class UpdateFile : IMessage
 
 	/// <summary>
 	/// If true, the file will be saved on disk, even if the content is the same.
+	/// NULL means the default behavior will be used according to the capabilities of the IDE (our integration).
 	/// </summary>
 	/// <remarks>
 	/// Currently, this is only used for VisualStudio, because the update requires a file save on disk for other IDEs.

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
@@ -32,6 +32,15 @@ public class UpdateFile : IMessage
 	public string? NewText { get; set; }
 
 	/// <summary>
+	/// If true, the file will be saved on disk, even if the content is the same.
+	/// </summary>
+	/// <remarks>
+	/// Currently, this is only used for VisualStudio, because the update requires a file save on disk for other IDEs.
+	/// On VisualStudio, the save to disk is not required for doing Hot Reload.
+	/// </remarks>
+	public bool ForceSaveOnDisk { get; set; }
+
+	/// <summary>
 	/// Indicates if the file can be created or deleted.
 	/// </summary>
 	[JsonProperty]

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/UpdateFile.cs
@@ -38,7 +38,7 @@ public class UpdateFile : IMessage
 	/// Currently, this is only used for VisualStudio, because the update requires a file save on disk for other IDEs.
 	/// On VisualStudio, the save to disk is not required for doing Hot Reload.
 	/// </remarks>
-	public bool ForceSaveOnDisk { get; set; }
+	public bool? ForceSaveOnDisk { get; set; }
 
 	/// <summary>
 	/// Indicates if the file can be created or deleted.

--- a/src/Uno.UI.Tests/Helpers/Given_AbsolutePathComparer.cs
+++ b/src/Uno.UI.Tests/Helpers/Given_AbsolutePathComparer.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.UI.Helpers;
 
+#pragma warning disable IDE0055 // Fix formatting
 namespace Uno.UI.Tests.Helpers;
 
 [TestClass]

--- a/src/Uno.UI.Tests/Helpers/Given_AbsolutePathComparer.cs
+++ b/src/Uno.UI.Tests/Helpers/Given_AbsolutePathComparer.cs
@@ -1,0 +1,295 @@
+﻿#nullable enable
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Helpers;
+
+namespace Uno.UI.Tests.Helpers;
+
+[TestClass]
+public class Given_AbsolutePathComparer
+{
+	[TestMethod]
+	// (path1, path2, expected equality)
+	[DataRow(@"C:\folder", @"C:\folder", true, DisplayName = "Same path")]
+	[DataRow(@"C:\FOLDER", @"c:\folder", true, DisplayName = "Same path, different case")]
+	[DataRow(@"C:\FOLDER\sub-folder\file.ABC", @"c:/folder/sub-folder/file.abc", true, DisplayName = "Same path, different separator + case")]
+	[DataRow(@"C:\folder1", @"C:\folder2", false, DisplayName = "Different path")]
+	[DataRow(@"C:\folder", @"D:\folder", false, DisplayName = "Different drive")]
+	[DataRow(@"C:\folder", @"C:\folder\subfolder", false, DisplayName = "Different path length")]
+	[DataRow(@"C:folder", @"C:folder", false, DisplayName = "Invalid path (no slash)")]
+	[DataRow(@".\something", @"something", false, DisplayName = "Relative path (invalid)")]
+	[DataRow(@"\\server\share", @"\\server\share", true, DisplayName = "UNC path")]
+	[DataRow(@"\\server\share", @"/server/share", false, DisplayName = "UNC vs absolute path")]
+	[DataRow(@"\\SERVER\share", @"\\server\Share\sub1\sub2\..\..", true, DisplayName = "UNC path, different case, with 2x'..'")]
+	[DataRow(@"\\server\share\folder", @"\\server\share\Folder", true, DisplayName = "UNC path, folder case difference")]
+	[DataRow(@"\\server\share\folder\..\sub", @"\\server\share\sub", true, DisplayName = "UNC path with '..' (parent folder)")]
+	[DataRow(@"/usr/local/bin", @"/usr/local/bin", true, DisplayName = "Unix path")]
+	[DataRow(@"/usr/local/bin", @"/usr/LOCAL/bin", true, DisplayName = "Unix path, different case")]
+	[DataRow(@"/usr/local/bin", @"/usr/local/lib", false, DisplayName = "Unix path, different")]
+	public void GivenCaseInsensitive_WhenEqualsIsCalled_ThenItReturnsExpectedResult(string? path1, string? path2, bool expected)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.ComparerIgnoreCase; // or new AbsolutePathComparer(true);
+
+		// Act
+		var result = comparer.Equals(path1, path2);
+
+		// Assert
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	[DataRow(null, null, false, DisplayName = "null vs null => false")]
+	[DataRow(null, @"C:\folder", false, DisplayName = "null vs path => false")]
+	[DataRow(@"C:\folder", null, false, DisplayName = "path vs null => false")]
+	[DataRow("", "", false, DisplayName = "empty => not fully qualified => false")]
+	[DataRow("/", "/", false, DisplayName = "Unix root => 0 segment => false")]
+	[DataRow("/../../..", "/../../..", false, DisplayName = "Invalid backtracking => false")]
+	[DataRow(@"C:\folder\", @"C:\folder", true, DisplayName = "ending slash => true")]
+	[DataRow(@"C:\folder\\sub", @"C:\folder\sub", true, DisplayName = "duplicate slashes => true")]
+	[DataRow(@"C:\folder\.", @"C:\folder", true, DisplayName = "'.' ignored => true")]
+	[DataRow(@"C:\.\.\.\./././folder\.", @"C:\folder/././", true, DisplayName = "multiple '.' ignored => true")]
+	[DataRow(@"C:\folder\sub\..", @"C:\folder", true, DisplayName = "'..' => true")]
+	[DataRow(@"C:\folder\sub\..\..", @"C:\", false, DisplayName = "2x '..' => 0 segments => false")]
+	[DataRow(@"C:\folder", @"c:\folder", true, DisplayName = "Different case => true")]
+	public void GivenCaseInsensitive_WhenEqualsIsCalled_WithEdgeCases_ThenItReturnsExpectedResult(string? path1, string? path2, bool expected)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.ComparerIgnoreCase;
+
+		// Act
+		var result = comparer.Equals(path1, path2);
+
+		// Assert
+		Assert.AreEqual(expected, result, $"Expected {expected} for '{path1}' and '{path2}', but got {result}.");
+	}
+
+	[TestMethod]
+	// (path1, path2, expected equality)
+	[DataRow(@"C:\folder", @"C:\folder", true, DisplayName = "Same path (case-sensitive)")]
+	[DataRow(@"C:\folder", @"c:\folder", true, DisplayName = "Same path, different case for drive letter => true")]
+	[DataRow(@"C:\folder", @"C:\FOLDER", false, DisplayName = "Case mismatch => not equal")]
+	[DataRow(@"/usr/local/bin", @"/usr/local/bin", true, DisplayName = "Same Unix path (case-sensitive)")]
+	[DataRow(@"/usr/local/bin", @"/usr/LOCAL/bin", false, DisplayName = "Case mismatch (Unix)")]
+	[DataRow(@"C:folder", @"C:folder", false, DisplayName = "Invalid path, no slash")]
+	public void GivenCaseSensitive_WhenEqualsIsCalled_ThenItReturnsExpectedResult(string? path1, string? path2, bool expected)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.Comparer; // or new AbsolutePathComparer(false);
+
+		// Act
+		var result = comparer.Equals(path1, path2);
+
+		// Assert
+		Assert.AreEqual(expected, result);
+	}
+
+	[TestMethod]
+	[DataRow(@"C:\folder", @"C:\folder", true, DisplayName = "Same path (case-sensitive)")]
+	[DataRow(@"C:\folder", @"c:\folder", true, DisplayName = "Same path, different case => true")]
+	[DataRow(@"C:\folder", @"c:\FOLDER", true, DisplayName = "Same path, different case => true")]
+	[DataRow(@"C:\folder1", @"C:\folder2", false, DisplayName = "Different path")]
+	[DataRow(null, @"C:\folder2", false, DisplayName = "null vs path => false")]
+	[DataRow(@"C:\folder1", null, false, DisplayName = "path vs null => false")]
+	public void GivenAPathCaseInsensitive_WhenGetHashCodeIsCalled_ThenItIsConsistentWithEquals(string? path1, string? path2, bool expectSameHash)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.ComparerIgnoreCase; // or new AbsolutePathComparer(true);
+
+		// Act
+		var hash1 = comparer.GetHashCode(path1);
+		var hash2 = comparer.GetHashCode(path2);
+		var sameHash = (hash1 == hash2);
+
+		// Assert
+		if (expectSameHash)
+		{
+			Assert.IsTrue(sameHash, $"Expected same hash code for '{path1}' and '{path2}', but got {hash1} and {hash2}.");
+		}
+		else
+		{
+			Assert.IsFalse(sameHash, $"Expected different hash code for '{path1}' and '{path2}', but both got {hash1}.");
+		}
+	}
+
+	[TestMethod]
+	[DataRow(@"C:\folder", @"C:\folder", true, DisplayName = "Same path (case-sensitive)")]
+	[DataRow(@"C:\folder", @"C:\FOLDER", false, DisplayName = "Case mismatch => not equal")]
+	[DataRow(@"/usr/local/bin", @"/usr/local/bin", true, DisplayName = "Same Unix path (case-sensitive)")]
+	[DataRow(@"/usr/local/bin", @"/usr/LOCAL/bin", false, DisplayName = "Case mismatch (Unix)")]
+	public void GivenAPathCaseSensitive_WhenGetHashCodeIsCalled_ThenItIsConsistentWithEquals(string? path1, string? path2, bool expectSameHash)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.Comparer; // or new AbsolutePathComparer(false);
+
+		// Act
+		var hash1 = comparer.GetHashCode(path1);
+		var hash2 = comparer.GetHashCode(path2);
+		var sameHash = (hash1 == hash2);
+
+		// Assert
+		if (expectSameHash)
+		{
+			Assert.IsTrue(sameHash,	$"Expected same hash code for '{path1}' and '{path2}', but got {hash1} and {hash2}.");
+		}
+		else
+		{
+			Assert.IsFalse(sameHash, $"Expected different hash code for '{path1}' and '{path2}', but both got {hash1}.");
+		}
+	}
+
+	[TestMethod]
+	// (path1, path2, expectedEquals)
+	// Both are UNC
+	[DataRow(@"\\server\share",    @"\\server\share",   true,  DisplayName = "UNC vs UNC (identical) => true")]
+	[DataRow(@"\\Server\Share",    @"\\server\share",   true,  DisplayName = "UNC vs UNC (case diff) => true (ignoreCase)")]
+	[DataRow(@"\\server\Share\..", @"\\server\",        true,  DisplayName = "UNC path with '..' => same final segments => true")]
+	[DataRow(@"\\server\share",    @"/server/share",    false, DisplayName = "UNC vs Unix => false")]
+
+	// Both are Windows
+	[DataRow(@"C:\folder",         @"C:\folder",        true,  DisplayName = "Windows vs Windows => true")]
+	[DataRow(@"C:\FOLDER",         @"c:\folder",        true,  DisplayName = "Windows drive letter / segment case => true (ignoreCase)")]
+	[DataRow(@"C:\folder\..",      @"C:\",              false, DisplayName = "Windows path with '..' => 0 segments => false (code requires >= 1)")]
+
+	// Both are Unix
+	[DataRow(@"/usr/bin",          @"/usr/bin",         true,  DisplayName = "Unix vs Unix => true")]
+	[DataRow(@"/usr/BIN",          @"/usr/bin",         true,  DisplayName = "Unix vs Unix (case diff) => true (ignoreCase)")]
+	[DataRow(@"/usr/bin/..",       @"/usr",             true, DisplayName = "Unix path with '..' => true")]
+
+	// Relative checks
+	[DataRow(@"folder\sub",       @"folder\sub",       false, DisplayName = "Relative vs Relative => false (no segments)")]
+	[DataRow(@"C:folder",         @"C:\folder",        false, DisplayName = "Relative (C:folder) vs Windows (C:\\folder) => false")]
+	[DataRow(@".\folder",         @"..\folder",        false, DisplayName = "Both relative => still false (code doesn't handle them as fully qualified)")]
+
+	public void WhenComparingPaths_CaseInsensitive_ThenResultIsAsExpected(string? path1, string? path2, bool expectedEquals)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.ComparerIgnoreCase;
+
+		// Act
+		var result = comparer.Equals(path1, path2);
+
+		// Assert
+		Assert.AreEqual(expectedEquals, result,"Case-insensitive: '{path1}' vs '{path2}' should be {expectedEquals}.");
+	}
+
+	[TestMethod]
+	// (path1, path2, expectedEquals)
+	// UNC
+	[DataRow(@"\\server\share",  @"\\server\share",   true,  DisplayName = "UNC vs UNC => true")]
+	[DataRow(@"\\Server\Share",  @"\\server\share",   false, DisplayName = "UNC vs UNC => false if case is different in segments")]
+	[DataRow(@"\\server\share",  @"/server/share",    false, DisplayName = "UNC vs Unix => false")]
+
+	// Windows
+	[DataRow(@"C:\folder",       @"C:\folder",        true,  DisplayName = "Windows vs Windows (exact case) => true")]
+	[DataRow(@"C:\folder",       @"C:\FOLDER",        false, DisplayName = "Windows vs Windows (case diff) => false")]
+	[DataRow(@"C:\folder\..",    @"C:\",              false, DisplayName = "Windows '..' => drive root => false")]
+
+	// Unix
+	[DataRow(@"/usr/bin",        @"/usr/bin",         true,  DisplayName = "Unix vs Unix => true")]
+	[DataRow(@"/usr/BIN",        @"/usr/bin",         false, DisplayName = "Unix vs Unix (case diff) => false")]
+	[DataRow(@"/usr/bin/..",     @"/usr",             true,  DisplayName = "Unix '..' => 1 segment => true")]
+	[DataRow(@"/usr/..",         @"/",                false, DisplayName = "Unix '..' => 0 segments => false")]
+
+	// Relative
+	[DataRow(@"folder\sub",      @"folder\sub",       false, DisplayName = "Relative vs Relative => false (no segments)")]
+	[DataRow(@"C:folder",        @"C:\folder",        false, DisplayName = "Relative vs Windows => false")]
+
+	public void WhenComparingPaths_CaseSensitive_ThenResultIsAsExpected(string? path1, string? path2, bool expectedEquals)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.Comparer;
+
+		// Act
+		var result = comparer.Equals(path1, path2);
+
+		// Assert
+		Assert.AreEqual(expectedEquals, result,"Case-sensitive: '{path1}' vs '{path2}' should be {expectedEquals}.");
+	}
+
+	[TestMethod]
+	// (path1, path2, expectSameHash)
+	[DataRow(@"\\server\share",  @"\\server\share",   true,  DisplayName = "UNC vs UNC => same hash")]
+	[DataRow(@"\\server\share",  @"/server/share",    false, DisplayName = "UNC vs Unix => different hash (types differ)")]
+	[DataRow(@"C:\folder",       @"C:\folder",        true,  DisplayName = "Windows vs Windows => same hash")]
+	[DataRow(@"C:\folder",       @"C:\FOLDER",        true,  DisplayName = "Windows vs Windows (ignoreCase) => same hash if ignoring case")]
+	[DataRow(@"/usr/bin",        @"/usr/bin",         true,  DisplayName = "Unix vs Unix => same hash")]
+	[DataRow(@"folder\sub",      @"folder\sub",       true,  DisplayName = "Relative vs Relative => both parse to no segments => same hash = 0? Actually let's see.")]
+	public void WhenGetHashCode_CaseInsensitive_ThenItMatchesEquality(string? path1, string? path2, bool expectSameHash)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.ComparerIgnoreCase;
+
+		// Act
+		var equalsResult = comparer.Equals(path1, path2);
+		var hash1 = comparer.GetHashCode(path1);
+		var hash2 = comparer.GetHashCode(path2);
+		var sameHash = (hash1 == hash2);
+
+		// Assert
+		if (equalsResult)
+		{
+			Assert.IsTrue(sameHash, $"Paths '{path1}' and '{path2}' are equal, so they should have the same hash code. Got: {hash1}, {hash2}.");
+		}
+		else if (expectSameHash)
+		{
+			Assert.IsTrue(sameHash, $"Expected same hash code for '{path1}' and '{path2}', but got {hash1} vs {hash2}.");
+		}
+		else
+		{
+			// Usually we expect different hash, but collisions are still possible in theory.
+			Assert.IsFalse(sameHash, $"Expected different hash codes for '{path1}' and '{path2}', but both are {hash1}.");
+		}
+	}
+
+	[TestMethod]
+	[DataRow(@"\\server\share",  @"\\server\share",  true,  DisplayName = "UNC vs UNC => same hash (exact)")]
+	[DataRow(@"\\Server\share",  @"\\server\share",  false, DisplayName = "UNC vs UNC (case diff in first segment) => different hash")]
+	[DataRow(@"C:\folder",       @"C:\folder",       true,  DisplayName = "Windows vs Windows => same hash")]
+	[DataRow(@"C:\folder",       @"C:\FOLDER",       false, DisplayName = "Windows vs Windows (case diff) => different hash")]
+	[DataRow(@"/usr/bin",        @"/usr/bin",        true,  DisplayName = "Unix vs Unix => same hash")]
+	[DataRow(@"/usr/bin",        @"/usr/BIN",        false, DisplayName = "Unix vs Unix (case diff) => different hash")]
+	[DataRow(@"folder\sub",      @"folder\sub",      true,  DisplayName = "Relative => parse as no segments => same hash = 0?")]
+	public void WhenGetHashCode_CaseSensitive_ThenItMatchesEquality(string? path1, string? path2, bool expectSameHash)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.Comparer;
+
+		// Act
+		var equalsResult = comparer.Equals(path1, path2);
+		var hash1 = comparer.GetHashCode(path1);
+		var hash2 = comparer.GetHashCode(path2);
+		var sameHash = (hash1 == hash2);
+
+		// Assert
+		if (equalsResult)
+		{
+			Assert.IsTrue(sameHash, $"Paths '{path1}' and '{path2}' are equal, so they should have the same hash code. Got: {hash1}, {hash2}.");
+		}
+		else if (expectSameHash)
+		{
+			Assert.IsTrue(sameHash, $"Expected same hash code for '{path1}' and '{path2}', but got {hash1} vs {hash2}.");
+		}
+		else
+		{
+			// Collisions can happen, but typically we expect different values.
+			Assert.IsFalse(sameHash, $"Expected different hash codes for '{path1}' and '{path2}', but both are {hash1}.");
+		}
+	}
+	
+	[TestMethod]
+	[DataRow(@"C:\folder\🦄", @"C:\folder\🦄", true, DisplayName = "Windows path with emoji")]
+	[DataRow("/usr/local/🦄", "/usr/local/🦄", true, DisplayName = "Unix path with emoji")]
+	[DataRow(@"C:\folder\مرحبا", @"C:\folder\مرحبا", true, DisplayName = "Windows path with Arabic")]
+	[DataRow("/usr/local/你好", "/usr/local/你好", true, DisplayName = "Unix path with Chinese")]
+	public void GivenPaths_WhenComparingWithUnicodeCharacters_ThenItReturnsExpectedResult(string? path1, string? path2, bool expectedEquals)
+	{
+		// Arrange
+		var comparer = AbsolutePathComparer.ComparerIgnoreCase;
+
+		// Act
+		var result = comparer.Equals(path1, path2);
+
+		// Assert
+		Assert.AreEqual(expectedEquals, result, $"Paths '{path1}' and '{path2}' should be {expectedEquals}.");
+	}
+}

--- a/src/Uno.UI.Tests/Uno.UI.Unit.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Unit.Tests.csproj
@@ -68,6 +68,9 @@
 		<Page Include="..\SamplesApp\UITests.Shared\Windows_UI_Xaml\Resources\Test_Dictionary_Linked.xaml" Link="App/Linked/Test_Dictionary_Linked.xaml" />
 	</ItemGroup>
 	<ItemGroup>
+		<Compile Include="..\Uno.UI.RemoteControl.VS\AbsolutePathComparer.cs">
+		  <Link>Helpers\AbsolutePathComparer.cs</Link>
+		</Compile>
 		<Compile Include="..\Uno.UI.RuntimeTests\Helpers\SizeAssertion.cs" Link="Extensions\SizeAssertion.cs" />
 		<Compile Include="..\Uno.UI.RuntimeTests\Tests\Windows_UI_Xaml_Controls\Given_ListViewBase_Items.cs" Link="Windows_UI_XAML_Controls\ListViewBaseTests\Given_ListViewBase_Items.cs" />
 		<Compile Include="..\Uno.UI.RuntimeTests\Tests\Windows_UI_Xaml_Controls\GroupingObservableCollection.cs" Link="Windows_UI_XAML_Controls\ListViewBaseTests\GroupingObservableCollection.cs" />


### PR DESCRIPTION
Closes https://github.com/unoplatform/uno.hotdesign/issues/3351

# Feature
The way Visual Studio is dealing with Hot Reload is by using its _documents_ to compile and ship updated IL to the application. There is no requirement to save the file for _Hot Reload_ to work in this environment.

That means 2 things:
1. The file on disk may not reflect the last changes which only occurs in memory in Visual Studio. The user _may_ save the file, but it's not a requirement for HR.
2. If the file is opened in Visual Studio, a _silent_ change to the file on disk may not be picked up by HR, especially when VS is not focused. THIS IS THE PROBLEM THIS PR IS ADDRESSING. The other one will be addressed afterwards (soon).


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
