### PR TITLE
test: Disable flaky ValidateDynamicOverflowOrderBasic() test on Android (#9080, #19585)

### DIFF
--- a/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/dxaml/controls/commandbar/CommandBarIntegrationTests.cs
@@ -3043,6 +3043,9 @@ namespace Windows.UI.Tests.Enterprise
 		[TestMethod]
 
 		[Description("Validates the dynamic overflow moving order.")]
+#if __ANDROID__
+		[Ignore("Test is flaky on Android https://github.com/unoplatform/uno/issues/19585")]
+#endif
 		public async Task ValidateDynamicOverflowOrderBasic()
 		{
 			TestCleanupWrapper cleanup;


### PR DESCRIPTION
Related issues: #9080, #19585

## PR Type

What kind of change does this PR introduce?

- Disable flaky test

## What is the current behavior?

`ValidateDynamicOverflowOrderBasic()` test is very flaky on Android  (cf. #9080, #19585)

![image](https://github.com/user-attachments/assets/f8ad42f3-59e8-440f-9964-8c7a9ca5a422)

## What is the new behavior?

Disable the flaky `ValidateDynamicOverflowOrderBasic()` test on Android

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

