### PR TITLE
fix(wasm): Ensure proper dependents execution after 9.0.102

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/uno.ui.tasks.assets.targets
@@ -281,12 +281,25 @@
 		</UnoGenerateAssetsManifestDependsOn>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<UnoGenerateAssetsManifestDependsOn>
+			$(UnoGenerateAssetsManifestDependsOn);
+			_UnoAssetsGetCopyToPublishDirectoryItems
+		</UnoGenerateAssetsManifestDependsOn>
+
+		<_UnoAssetsGetCopyToPublishDirectoryItemsDependsOn>
+			$(_UnoAssetsGetCopyToPublishDirectoryItemsDependsOn);
+			_UnoGetCopyToOutputItems;
+			GenerateUnoWasmAssets; <!-- Required for 9.0.102 and later to get WasmShellOutputPackagePath -->
+		</_UnoAssetsGetCopyToPublishDirectoryItemsDependsOn>
+	</PropertyGroup>
+
 	<!--
 	Ensure that project transitive references are copied to the publish directory, as well
 	as nuget packages content.
 	-->
 	<Target Name="_UnoAssetsGetCopyToPublishDirectoryItems"
-			DependsOnTargets="_UnoGetCopyToOutputItems"
+			DependsOnTargets="$(_UnoAssetsGetCopyToPublishDirectoryItemsDependsOn)"
 			Condition=" '$(UsingMicrosoftNETSdkWebAssembly)' == 'true' ">
 
 		<ItemGroup Condition=" @(UnoAllCopyToOutputItems->Count()) > 0">


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Wasm Transitive assets may not be created properly after 9.0.102.

## What is the new behavior?

Transitive assets are available.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
