### PR TITLE
fix: Avoid focusing `AutoSuggestBox` when switching tabs in Samples app

### DIFF
--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserControl.xaml
@@ -313,11 +313,32 @@
 						VerticalAlignment="Center"
 						HorizontalAlignment="Right"
 						Command="{Binding RecordAllTestsCommand}">
-						<u:PathControl Style="{StaticResource Icon_RunAll}"
-									   Margin="5,0" />
+						<u:PathControl Style="{StaticResource Icon_RunAll}" Margin="5,0" />
 					</Button>
 				</Grid>
 
+				<!-- Search -->
+				<StackPanel IsTabStop="True" Grid.Row="1" Spacing="4" Padding="4" BorderThickness="0,0,0,1"
+BorderBrush="{StaticResource Color05Brush}">
+					<AutoSuggestBox PlaceholderText="Search..."
+						TextChanged="SearchBox_TextChanged"
+						TextMemberPath="ControlName"
+						QueryIcon="Find"
+						ItemsSource="{Binding FilteredSamples}"
+						HorizontalAlignment="Stretch"
+						QuerySubmitted="SearchBox_QuerySubmitted"
+						SuggestionChosen="SearchBox_SuggestionChosen">
+						<AutoSuggestBox.ItemTemplate>
+							<DataTemplate x:DataType="entities:SampleChooserContent">
+								<TextBlock Text="{x:Bind ControlName}" />
+							</DataTemplate>
+						</AutoSuggestBox.ItemTemplate>
+					</AutoSuggestBox>
+
+
+					<CheckBox Grid.Row="1" Grid.ColumnSpan="5" HorizontalAlignment="Center" 
+							  IsChecked="{Binding ManualTestsOnly, Mode=TwoWay}" Content="Manual tests only" />
+				</StackPanel>
 
 				<ContentControl ContentTemplate="{StaticResource CategoriesList}"
 								Grid.Row="2"
@@ -365,29 +386,6 @@
 								Grid.Row="2"
 								Visibility="{Binding RecentsVisibility, Converter={StaticResource TrueToVisible}}"
 								ContentTemplate="{StaticResource RecentSamplesList}" />
-
-				<StackPanel Grid.Row="1" Spacing="4" Padding="4" BorderThickness="0,0,0,1"
-BorderBrush="{StaticResource Color05Brush}">
-					<!-- Search -->
-					<AutoSuggestBox PlaceholderText="Search..."
-						TextChanged="SearchBox_TextChanged"
-						TextMemberPath="ControlName"
-						QueryIcon="Find"
-						ItemsSource="{Binding FilteredSamples}"
-						HorizontalAlignment="Stretch"
-						QuerySubmitted="SearchBox_QuerySubmitted"
-						SuggestionChosen="SearchBox_SuggestionChosen">
-						<AutoSuggestBox.ItemTemplate>
-							<DataTemplate x:DataType="entities:SampleChooserContent">
-								<TextBlock Text="{x:Bind ControlName}" />
-							</DataTemplate>
-						</AutoSuggestBox.ItemTemplate>
-					</AutoSuggestBox>
-
-
-					<CheckBox Grid.Row="1" Grid.ColumnSpan="5" HorizontalAlignment="Center" 
-							  IsChecked="{Binding ManualTestsOnly, Mode=TwoWay}" Content="Manual tests only" />
-				</StackPanel>
 
 				<!--NAVIGATION BUTTONS-->
 				<Border Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
