### PR TITLE
fix(vs): don't reload the profile observer on initial solution open

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
+++ b/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
@@ -34,6 +34,8 @@ internal class ProfilesObserver : IDisposable
 	private readonly Func<string?, string, Task> _onDebugFrameworkChanged;
 	private readonly Func<string?, string, Task> _onDebugProfileChanged;
 	private Func<Task> _onStartupProjectChanged;
+	private object[] _existingStartupProjects = [];
+
 
 	private string? _lastActiveDebugProfile;
 	private string? _lastActiveDebugFramework;
@@ -82,9 +84,6 @@ internal class ProfilesObserver : IDisposable
 		_ = ObserveStartupProjectAsync();
 	}
 
-	object[]? _existingStartupProjects = [];
-
-
 	private async Task ObserveStartupProjectAsync()
 	{
 		while (!_isDisposed)
@@ -99,7 +98,12 @@ internal class ProfilesObserver : IDisposable
 	{
 		if (_dte.Solution.SolutionBuild.StartupProjects is object[] newStartupProjects)
 		{
-			if (!newStartupProjects.SequenceEqual(_existingStartupProjects))
+			if (_existingStartupProjects is { Length: 0 })
+			{
+				// We're starting up, no need to re-create the observer
+				_existingStartupProjects = newStartupProjects;
+			}
+			else if (!newStartupProjects.SequenceEqual(_existingStartupProjects))
 			{
 				_debugLog("Startup projects have changed, reloading observer");
 

--- a/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
+++ b/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
@@ -118,6 +118,15 @@ internal class ProfilesObserver : IDisposable
 				_ = ObserveProfilesAsync();
 			}
 		}
+		else
+		{
+			if (_existingStartupProjects.Length > 0)
+			{
+				_ = _onStartupProjectChanged();
+			}
+
+			_existingStartupProjects = [];
+		}
 	}
 
 	public async Task ObserveProfilesAsync()

--- a/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
+++ b/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
@@ -98,7 +98,7 @@ internal class ProfilesObserver : IDisposable
 	{
 		if (_dte.Solution.SolutionBuild.StartupProjects is object[] newStartupProjects)
 		{
-			if (_existingStartupProjects is { Length: 0 })
+			if (_existingStartupProjects.Length == 0)
 			{
 				// We're starting up, no need to re-create the observer
 				_existingStartupProjects = newStartupProjects;

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
@@ -321,6 +321,12 @@ public partial class EntryPoint : IDisposable
 
 	private async Task OnStartupProjectChangedAsync()
 	{
+		if (_dte.Solution.SolutionBuild.StartupProjects is null)
+		{
+			// The user unloaded all projects, we need to reset the state
+			_isFirstProfileTfmChange = true;
+		}
+
 		if (!await EnsureProjectUserSettingsAsync() && _debuggerObserver is not null)
 		{
 			_debugAction?.Invoke($"The user setting is not yet initialized, aligning framework and profile");


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/private/issues/619

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type
- Bugfix

## What is the new behavior?

The first TFM/profile change is not ignored when the startup project list is asynchronously initialized.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
