### PR TITLE
fix: Make SplitButton click and tap behave the same

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests_InteractionTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/SplitButton/SplitButtonTests_InteractionTests.cs
@@ -154,17 +154,19 @@ namespace Windows.UI.Xaml.Tests.MUXControls.InteractionTests
 			Verify.AreEqual("0", clickCountTextBlock.Text);
 			Verify.AreEqual("0", flyoutOpenedCountTextBlock.Text);
 
-			Log.Comment("Click primary button to open flyout in touch mode");
+			Log.Comment("Click primary button in touch mode");
 			// ClickPrimaryButton(splitButton);
 			await ClickPrimaryButton(splitButton, finger);
 			await WindowHelper.WaitForIdle();
 
-			// Uno TODO: the test outputs 1 and 0 instead of 1 and 0
-			// This works correctly when manually testing by hand, but fails in the runtime tests.
-			// Verify.AreEqual("0", clickCountTextBlock.Text);
-			// Verify.AreEqual("1", flyoutOpenedCountTextBlock.Text);
 			Verify.AreEqual("1", clickCountTextBlock.Text);
 			Verify.AreEqual("0", flyoutOpenedCountTextBlock.Text);
+
+			Log.Comment("Click secondary button in touch mode");
+			await ClickSecondaryButton(splitButton, finger);
+
+			Verify.AreEqual("1", clickCountTextBlock.Text);
+			Verify.AreEqual("1", flyoutOpenedCountTextBlock.Text);
 
 			Log.Comment("Close flyout by clicking over the button");
 			// splitButton.Click();

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/SplitButton/SplitButton.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/SplitButton/SplitButton.cs
@@ -209,7 +209,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		internal void UpdateVisualStates(bool useTransitions = true)
 		{
 			// place the secondary button
-			if (m_lastPointerDeviceType == PointerDeviceType.Touch || m_isKeyDown)
+			if (m_isKeyDown)
 			{
 				VisualStateManager.GoToState(this, "SecondaryButtonSpan", useTransitions);
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one or more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
When tapping (touchscreen) the flyout would open even if you don't click the chevron.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
Tapping (touchscreen) now behaves like `Click` that only opens the flyout if the chevron is clicked.
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
Based on Microsoft changes: https://github.com/microsoft/microsoft-ui-xaml/commit/69097129a853c65a16447aade4c82576d4724b1a#diff-26435cd7d5a1b50dca1fba8a84c5432c4941c8be555ba8d4ff8e34d99987fb9a

SplitButton.cs
https://github.com/microsoft/microsoft-ui-xaml/blob/69097129a853c65a16447aade4c82576d4724b1a/src/controls/dev/SplitButton/SplitButton.cpp#L121

SplitButtonTests_InteractionTests.cs
https://github.com/microsoft/microsoft-ui-xaml/blob/69097129a853c65a16447aade4c82576d4724b1a/src/controls/dev/SplitButton/InteractionTests/SplitButtonTests.cs#L110-L144
<!-- Please provide any additional information if necessary -->