### PR TITLE
fix: android PhoneCallManager

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Calls/Internal/CallCallback.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/Internal/CallCallback.Android.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.Runtime;
+using Android.Telephony;
+
+namespace Windows.ApplicationModel.Calls
+{
+	internal class CallCallback : TelephonyCallback, TelephonyCallback.ICallStateListener
+	{
+		public void OnCallStateChanged(int state)
+		{
+			PhoneCallManager.RaiseCallStateChanged();
+		}
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
@@ -33,19 +33,23 @@ namespace Windows.ApplicationModel.Calls
 			}
 			else
 			{
-				TryRegisterTelephonyCallbackAsync();
+				RegisterTelephonyCallbackAsync();
 			}
 #pragma warning restore CA1422 // Validate platform compatibility
 #pragma warning restore CS0618 // TelephonyManager is obsolete in API 31
 		}
 
-		private static async void TryRegisterTelephonyCallbackAsync()
+		private static async void RegisterTelephonyCallbackAsync()
 		{
+#pragma warning disable CS0618 // TelephonyManager is obsolete in API 31
+#pragma warning disable CA1422 // Validate platform compatibility
 			if (await Extensions.PermissionsHelper.CheckPermission(CancellationToken.None, Android.Manifest.Permission.ReadPhoneState) ||
 				await Extensions.PermissionsHelper.TryGetPermission(CancellationToken.None, Android.Manifest.Permission.ReadPhoneState))
 			{
 				_telephonyManager.RegisterTelephonyCallback(ContextHelper.Current.MainExecutor, new CallCallback());
 			}
+#pragma warning restore CA1422 // Validate platform compatibility
+#pragma warning restore CS0618 // TelephonyManager is obsolete in API 31
 		}
 
 		public static event EventHandler<object> CallStateChanged;

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
@@ -20,11 +20,20 @@ namespace Windows.ApplicationModel.Calls
 					"PhoneCallManager was used too early in the application lifetime. " +
 					"Android app context needs to be available.");
 			}
+
 			_telephonyManager = (TelephonyManager)ContextHelper.Current
 				.GetSystemService(Context.TelephonyService);
+
 #pragma warning disable CS0618 // TelephonyManager is obsolete in API 31
 #pragma warning disable CA1422 // Validate platform compatibility
-			_telephonyManager.Listen(new CallStateListener(), PhoneStateListenerFlags.CallState);
+			if (Build.VERSION.SdkInt < BuildVersionCodes.S)
+			{
+				_telephonyManager.Listen(new CallStateListener(), PhoneStateListenerFlags.CallState);
+			}
+			else
+			{
+				_telephonyManager.RegisterTelephonyCallback(ContextHelper.Current.MainExecutor, new CallCallback());
+			}
 #pragma warning restore CA1422 // Validate platform compatibility
 #pragma warning restore CS0618 // TelephonyManager is obsolete in API 31
 		}

--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.Android.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using Android.Content;
 using Android.OS;
 using Android.Telephony;
@@ -32,10 +33,19 @@ namespace Windows.ApplicationModel.Calls
 			}
 			else
 			{
-				_telephonyManager.RegisterTelephonyCallback(ContextHelper.Current.MainExecutor, new CallCallback());
+				TryRegisterTelephonyCallbackAsync();
 			}
 #pragma warning restore CA1422 // Validate platform compatibility
 #pragma warning restore CS0618 // TelephonyManager is obsolete in API 31
+		}
+
+		private static async void TryRegisterTelephonyCallbackAsync()
+		{
+			if (await Extensions.PermissionsHelper.CheckPermission(CancellationToken.None, Android.Manifest.Permission.ReadPhoneState) ||
+				await Extensions.PermissionsHelper.TryGetPermission(CancellationToken.None, Android.Manifest.Permission.ReadPhoneState))
+			{
+				_telephonyManager.RegisterTelephonyCallback(ContextHelper.Current.MainExecutor, new CallCallback());
+			}
 		}
 
 		public static event EventHandler<object> CallStateChanged;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #19633 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Telephony.Listen is deprecated for API >= 31

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Now we use Telephony.Listen if API < 31 and Telephony.RegisterTelephonyCallback if API >= 31

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
