### PR TITLE
fix(listview): setting SelectedItem during list refresh leaves blank in items on wasm/skia

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -2243,35 +2243,52 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var scroll = list.FindFirstDescendant<ScrollViewer>();
 			Assert.IsNotNull(scroll);
-			dataContextChanged.Should().BeLessThan(10, $"dataContextChanged {dataContextChanged}");
 
-			ScrollTo(list, ElementHeight);
+			int expectedMaterialized = 0, expectedDCChanged = 0;
+			int[] previouslyMaterializedItems = [];
+			async Task ScrollAndValidate(string context, double? scrollTo)
+			{
+				if (scrollTo is { } voffset)
+				{
+					ScrollTo(list, voffset);
+				}
+				await WindowHelper.WaitForIdle();
 
-			await WindowHelper.WaitForIdle();
+#if HAS_UNO && !(__IOS__ || __ANDROID__)
+				var evpScaling = (list.ItemsPanelRoot as IVirtualizingPanel).GetLayouter().CacheLength * VirtualizingPanelLayout.ExtendedViewportScaling;
+#else
+				var evpScaling = 0.5;
+#endif
 
-			materialized.Should().BeLessThan(12, $"materialized {materialized}");
-			dataContextChanged.Should().BeLessThan(11, $"dataContextChanged {dataContextChanged}");
+				var offset = scroll.VerticalOffset;
+				var max = scroll.ExtentHeight;
+				var vp = scroll.ViewportHeight;
 
-			ScrollTo(list, ElementHeight * 3);
+				var evpStart = Math.Clamp(offset - vp * evpScaling, 0, max);
+				var evpEnd = Math.Clamp(offset + vp + vp * evpScaling, 0, max);
 
-			await WindowHelper.WaitForIdle();
+				var firstIndex = (int)Math.Round(evpStart / ElementHeight, 0, MidpointRounding.ToNegativeInfinity);
+				var lastIndex = (int)Math.Round(evpEnd / ElementHeight, 0, MidpointRounding.ToPositiveInfinity) - 1;
+				var itemsInEVP = Enumerable.Range(firstIndex, lastIndex - firstIndex + 1).ToArray();
+				var newItemsInEVP = itemsInEVP.Except(previouslyMaterializedItems).ToArray();
 
-			materialized.Should().BeLessThan(14, $"materialized {materialized}");
-			dataContextChanged.Should().BeLessThan(13, $"dataContextChanged {dataContextChanged}");
+				// materialized starts with +1 extra, since we use it to determine whether the DataTemplate itself is a self-container
+				// Math.Max to count the historical highest, since "materialization" doesnt "unhappen" (we dont count tear-down).
+				expectedMaterialized = Math.Max(expectedMaterialized, 1 + itemsInEVP.Length);
+				// dc-changed counts the total items prepared and "re-entrancy"(out of effective-viewport and back in).
+				// we just need to add the new items since last time
+				expectedDCChanged += newItemsInEVP.Length;
+				previouslyMaterializedItems = itemsInEVP;
 
-			ScrollTo(list, scroll.ExtentHeight / 2); // Scroll to middle
+				materialized.Should().BeLessOrEqualTo(expectedMaterialized, $"[{context}] materialized {materialized}");
+				dataContextChanged.Should().BeLessOrEqualTo(expectedDCChanged, $"[{context}] dataContextChanged {dataContextChanged}");
+			}
 
-			await WindowHelper.WaitForIdle();
-
-			materialized.Should().BeLessThan(14, $"materialized {materialized}");
-			dataContextChanged.Should().BeLessThan(25, $"dataContextChanged {dataContextChanged}");
-
-			ScrollTo(list, scroll.ExtentHeight / 4); // Scroll to Quarter
-
-			await WindowHelper.WaitForIdle();
-
-			materialized.Should().BeLessThan(14, $"materialized {materialized}");
-			dataContextChanged.Should().BeLessThan(35, $"dataContextChanged {dataContextChanged}");
+			await ScrollAndValidate("initial state", null);
+			await ScrollAndValidate("scrolled past element#0", ElementHeight);
+			await ScrollAndValidate("scrolled past element#2", ElementHeight * 3);
+			await ScrollAndValidate("scrolled to 1/2", scroll.ExtentHeight / 2);
+			await ScrollAndValidate("scrolled back to 1/4", scroll.ExtentHeight / 4);
 		}
 #endif
 

--- a/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
@@ -152,11 +152,11 @@ static partial class ViewExtensions
 #if true // framework layout properties
 			if (x is FrameworkElement fe)
 			{
-				yield return $"Actual={FormatSize(fe.ActualWidth, fe.ActualHeight)}";
 				if (fe.Parent is FrameworkElement parent)
 				{
 					yield return $"XY={FormatPoint(fe.TransformToVisual(parent).TransformPoint(default))}";
 				}
+				yield return $"Actual={FormatSize(fe.ActualWidth, fe.ActualHeight)}";
 #if HAS_UNO
 				//yield return $"Available={FormatSize(fe.m_previousAvailableSize)}";
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.managed.cs
@@ -165,10 +165,12 @@ namespace Microsoft.UI.Xaml.Controls
 		/// </summary>
 		private double ViewportEnd => ScrollOffset + ViewportExtent;
 
+		internal const double ExtendedViewportScaling = 0.5;
+
 		/// <summary>
 		/// The additional length in pixels for which to create buffered views.
 		/// </summary>
-		private double ViewportExtension => CacheLength * ViewportExtent * 0.5;
+		private double ViewportExtension => CacheLength * ViewportExtent * ExtendedViewportScaling;
 
 		/// <summary>
 		/// The start of the 'extended viewport,' the area of the visible viewport plus the buffer area defined by <see cref="CacheLength"/>.
@@ -459,7 +461,10 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <summary>
 		/// Update the item container layout by removing no-longer-visible views and adding visible views.
 		/// </summary>
-		/// <param name="extentAdjustment">Adjustment to apply when calculating fillable area.</param>
+		/// <param name="extentAdjustment">
+		/// Adjustment to apply when calculating fillable area.
+		/// Used when a viewport change is not yet committed into the <see cref="ScrollOffset"/>.
+		/// </param>
 		private void UpdateLayout(double? extentAdjustment, bool isScroll)
 		{
 			ResetReorderingIndex();
@@ -501,7 +506,10 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <summary>
 		/// Fill in extended viewport with views.
 		/// </summary>
-		/// <param name="extentAdjustment">Adjustment to apply when calculating fillable area.</param>
+		/// <param name="extentAdjustment">
+		/// Adjustment to apply when calculating fillable area.
+		/// Used when a viewport change is not yet committed into the <see cref="ScrollOffset"/>.
+		/// </param>
 		private void FillLayout(double extentAdjustment)
 		{
 			// Don't fill backward if we're doing a light rebuild (since we are starting from nearest previously-visible item)
@@ -512,6 +520,13 @@ namespace Microsoft.UI.Xaml.Controls
 
 			FillForward();
 
+			if (_dynamicSeedStart.HasValue && GetItemsEnd() <= ExtendedViewportEnd + extentAdjustment)
+			{
+				// if the FillForward didnt fully fill the current viewport,
+				// we may still need to a FillBackward, otherwise we risk having a leading blank space
+				FillBackward();
+			}
+
 			// Make sure that the reorder item has been rendered
 			if (GetAndUpdateReorderingIndex() is { } reorderIndex && _materializedLines.None(line => line.Contains(reorderIndex)))
 			{
@@ -520,27 +535,22 @@ namespace Microsoft.UI.Xaml.Controls
 
 			void FillBackward()
 			{
-				if (GetItemsStart() > ExtendedViewportStart + extentAdjustment)
+				while (
+					GetItemsStart() is { } start && start > ExtendedViewportStart + extentAdjustment &&
+					GetNextUnmaterializedItem(Backward, GetFirstMaterializedIndexPath()) is { } nextItem)
 				{
-					var nextItem = GetNextUnmaterializedItem(Backward, GetFirstMaterializedIndexPath());
-					while (nextItem != null && GetItemsStart() > ExtendedViewportStart + extentAdjustment)
-					{
-						AddLine(Backward, nextItem.Value);
-						nextItem = GetNextUnmaterializedItem(Backward, GetFirstMaterializedIndexPath());
-					}
+					AddLine(Backward, nextItem);
 				}
 			}
-
 			void FillForward()
 			{
-				if ((GetItemsEnd() ?? 0) < ExtendedViewportEnd + extentAdjustment)
+				var seed = _dynamicSeedIndex;
+				while (
+					GetItemsEnd() is var end && (end ?? 0) < ExtendedViewportEnd + extentAdjustment &&
+					GetNextUnmaterializedItem(Forward, seed ?? GetLastMaterializedIndexPath()) is { } nextItem)
 				{
-					var nextItem = GetNextUnmaterializedItem(Forward, _dynamicSeedIndex ?? GetLastMaterializedIndexPath());
-					while (nextItem != null && (GetItemsEnd() ?? 0) < ExtendedViewportEnd + extentAdjustment)
-					{
-						AddLine(Forward, nextItem.Value);
-						nextItem = GetNextUnmaterializedItem(Forward, GetLastMaterializedIndexPath());
-					}
+					AddLine(Forward, nextItem);
+					seed = null;
 				}
 			}
 		}
@@ -548,7 +558,10 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <summary>
 		/// Remove views that lie entirely outside extended viewport.
 		/// </summary>
-		/// <param name="extentAdjustment">Adjustment to apply when calculating fillable area.</param>
+		/// <param name="extentAdjustment">
+		/// Adjustment to apply when calculating fillable area.
+		/// Used when a viewport change is not yet committed into the <see cref="ScrollOffset"/>.
+		/// </param>
 		private void UnfillLayout(double extentAdjustment)
 		{
 			UnfillBackward();


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/kahua-private#272

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On Wasm/Skia, when setting ListView::SelectedItem during the list refresh/rebuild will causes any item before the selected one to be render as blank.

## What is the new behavior?
^ not anymore.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.