### PR TITLE
fix: Sharing should provide default options when none are provided

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ExpanderTests/Expander_Bindings_TemplatedControl.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/ExpanderTests/Expander_Bindings_TemplatedControl.xaml.cs
@@ -4,7 +4,6 @@ using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml;
-using Microsoft.Graph.Models;
 using System;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236

--- a/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/DataTransfer/DataTransferManagerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/DataTransfer/DataTransferManagerTests.xaml
@@ -25,6 +25,7 @@
 			<TextBox Header="WebLink" Text="{x:Bind ViewModel.WebLink, Mode=TwoWay}" />
 
 			<Button Command="{x:Bind ViewModel.ShowUICommand}" Content="Show share UI" />
+			<Button Command="{x:Bind ViewModel.ShowUIWithoutOptionsCommand}" Content="Show share UI without options" />
 		</StackPanel>
 		<Grid Grid.Row="1">
 			<Grid.RowDefinitions>

--- a/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/DataTransfer/DataTransferManagerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_ApplicationModel/DataTransfer/DataTransferManagerTests.xaml.cs
@@ -2,13 +2,12 @@
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Microsoft.UI.Xaml.Controls;
+using Private.Infrastructure;
 using Uno.Disposables;
 using Uno.UI.Samples.Controls;
 using Uno.UI.Samples.UITests.Helpers;
 using Windows.ApplicationModel.DataTransfer;
-using Windows.UI.Core;
-using Microsoft.UI.Xaml.Controls;
-using Private.Infrastructure;
 
 namespace UITests.Windows_ApplicationModel.DataTransfer
 {
@@ -56,6 +55,8 @@ namespace UITests.Windows_ApplicationModel.DataTransfer
 		public ObservableCollection<string> EventLog { get; } = new ObservableCollection<string>();
 
 		public ICommand ShowUICommand => GetOrCreateCommand(ShowUI);
+
+		public ICommand ShowUIWithoutOptionsCommand => GetOrCreateCommand(ShowUIWithoutOptions);
 
 		public ICommand ClearEventLogCommand => GetOrCreateCommand(ClearEventLog);
 
@@ -133,6 +134,8 @@ namespace UITests.Windows_ApplicationModel.DataTransfer
 		{
 			Theme = GetTheme()
 		});
+
+		private void ShowUIWithoutOptions() => DataTransferManager.ShowShareUI();
 
 		private ShareUITheme GetTheme()
 		{

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataTransferManager.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataTransferManager.cs
@@ -22,8 +22,9 @@ namespace Windows.ApplicationModel.DataTransfer
 
 		public static void ShowShareUI() => ShowShareUI(new ShareUIOptions());
 
-		public static void ShowShareUI(ShareUIOptions options)
+		public static void ShowShareUI(ShareUIOptions? options)
 		{
+			options ??= new(); // When not provided, use defaults.
 			var dataTransferManager = _instance.Value;
 			var args = new DataRequestedEventArgs((dataRequest) => ContinueShowShareUI(options, dataRequest.Data));
 			dataTransferManager.DataRequested?.Invoke(dataTransferManager, args);


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/911

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

