### PR TITLE
fix: Correctly render `CalendarDatePicker` on iOS

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -123,6 +123,53 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public async Task Check_Border_Transparent_Null()
+		{
+			static Border CreateBorder(Color color)
+			{
+				return new Border()
+				{
+					Width = 40,
+					Height = 40,
+					Background = new SolidColorBrush(color),
+				};
+			}
+			var container = new StackPanel() { Spacing = 10 };
+			var transparentParent = CreateBorder(Colors.Green);
+			var transparentBorder = CreateBorder(Colors.Red);
+			transparentBorder.BorderBrush = new SolidColorBrush(Colors.Transparent);
+			transparentBorder.BorderThickness = new Thickness(4);
+			transparentParent.Child = transparentBorder;
+
+			var nullParent = CreateBorder(Colors.Green);
+			var nullBorder = CreateBorder(Colors.Red);
+			nullBorder.BorderBrush = null;
+			nullBorder.BorderThickness = new Thickness(4);
+			nullParent.Child = nullBorder;
+
+			var noParent = CreateBorder(Colors.Green);
+			var noBorder = CreateBorder(Colors.Red);
+			noBorder.BorderThickness = new Thickness(0);
+			noParent.Child = noBorder;
+
+			container.Children.Add(transparentParent);
+			container.Children.Add(nullParent);
+			container.Children.Add(noParent);
+
+			WindowHelper.WindowContent = container;
+			await WindowHelper.WaitForLoaded(container);
+
+			// screenshot of nullBorder should be the same of transparentBorder
+			var transparentBorderScreenshot = await UITestHelper.ScreenShot(transparentParent);
+			var nullBorderScreenshot = await UITestHelper.ScreenShot(nullParent);
+			await ImageAssert.AreEqualAsync(transparentBorderScreenshot, nullBorderScreenshot);
+
+			// screenshot of noBorder should be different
+			var noBorderScreenshot = await UITestHelper.ScreenShot(noParent);
+			await ImageAssert.AreNotEqualAsync(nullBorderScreenshot, noBorderScreenshot);
+		}
+
+		[TestMethod]
 #if __ANDROID__
 		[Ignore("It doesn't yet work properly on Android")]
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -123,7 +123,10 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
-		public async Task Check_Border_Transparent_Null()
+#if !HAS_RENDER_TARGET_BITMAP
+		[Ignore("Cannot take screenshot on this platform.")]
+#endif
+		public async Task When_Non_Empty_Null_Border()
 		{
 			static Border CreateBorder(Color color)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -277,15 +277,8 @@ partial class BorderLayerRenderer
 					GC.KeepAlive(color);
 				};
 
-				if (borderBrush is null)
-				{
-					onInvalidateRender();
-				}
-				else
-				{
-					onInvalidateRender();
-					borderBrush.RegisterInvalidateRender(onInvalidateRender).DisposeWith(disposables);
-				}
+				onInvalidateRender();
+				borderBrush?.RegisterInvalidateRender(onInvalidateRender).DisposeWith(disposables);
 			}
 
 			parent.Mask = new CAShapeLayer()
@@ -412,7 +405,7 @@ partial class BorderLayerRenderer
 					Action onInvalidateRender = () => layer.FillColor = Brush.GetFallbackColor(borderBrush);
 
 					onInvalidateRender();
-					borderBrush.RegisterInvalidateRender(onInvalidateRender).DisposeWith(disposables);
+					borderBrush?.RegisterInvalidateRender(onInvalidateRender).DisposeWith(disposables);
 				}
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/19505

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

NRE in `BorderLayerRenderer`


## What is the new behavior?

No NRE

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.