### PR TITLE
fix: block FE::EffectiveViewportChanged early procs with invalid values

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -110,9 +110,7 @@ namespace Microsoft.UI.Xaml
 		/// </summary>
 		private SpecializedResourceDictionary.ResourceKey? _themeLastUsed;
 
-#if UNO_HAS_ENHANCED_LIFECYCLE
 		internal bool IsDisposed => _isDisposed;
-#endif
 
 		private InheritedPropertiesDisposable? InheritedProperties
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.EffectiveViewport.cs
@@ -14,13 +14,16 @@ using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Windows.Foundation;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Uno;
 using Uno.Disposables;
 using Uno.UI;
 using Uno.UI.Extensions;
+using Uno.UI.Xaml.Core;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using _This = Microsoft.UI.Xaml.FrameworkElement;
+using ItemsRepeater = Microsoft/* UWP don't rename */.UI.Xaml.Controls.ItemsRepeater;
 
 #if __IOS__
 using UIKit;
@@ -42,7 +45,10 @@ namespace Microsoft.UI.Xaml
 		private static readonly RoutedEventHandler ReconfigureViewportPropagationOnLoad = (snd, e) => ((_This)snd).ReconfigureViewportPropagation();
 		private static readonly RoutedEventHandler ReconfigureViewportPropagationOnUnload = (snd, e) => ((_This)snd).ReconfigureViewportPropagation();
 #endif
-
+#if !UNO_HAS_ENHANCED_LIFECYCLE
+		private static readonly ICustomEventManager<_This, EffectiveViewportChangedEventArgs> _evpChangedManager =
+			new CustomKeepLastEventManager<_This, EffectiveViewportChangedEventArgs>(static () => _evpChangedManager!.OnTick(), (s, e) => s.RaiseEffectiveViewportChanged(e));
+#endif
 		private event TypedEventHandler<_This, EffectiveViewportChangedEventArgs>? _effectiveViewportChanged;
 		private List<IFrameworkElement_EffectiveViewport>? _childrenInterestedInViewportUpdates;
 		private bool _isEnumeratingChildrenInterestedInViewportUpdates;
@@ -387,7 +393,19 @@ namespace Microsoft.UI.Xaml
 #if UNO_HAS_ENHANCED_LIFECYCLE
 				this.GetContext().EventManager.EnqueueForEffectiveViewportChanged(this, new EffectiveViewportChangedEventArgs(parentViewport.Effective));
 #else
-				_effectiveViewportChanged?.Invoke(this, new EffectiveViewportChangedEventArgs(parentViewport.Effective));
+#if !IS_NATIVE_ELEMENT
+				if (this is ItemsRepeater)
+				{
+					// ItemsRepeater's measure depends on EVPChanged, re-dispatching this event can cause invalid first measure.
+					_effectiveViewportChanged?.Invoke(this, new EffectiveViewportChangedEventArgs(parentViewport.Effective));
+				}
+				else
+#endif
+				{
+					// re-dispatching the events on the ui-thread with a keep-last (keyed by the sender) strategy
+					// to filter out the first few invalid events.
+					_evpChangedManager.Enqueue(this, new EffectiveViewportChangedEventArgs(parentViewport.Effective));
+				}
 #endif
 			}
 

--- a/src/Uno.UI/UI/Xaml/Internal/CustomEventManager.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/CustomEventManager.cs
@@ -1,0 +1,83 @@
+﻿#if !UNO_HAS_ENHANCED_LIFECYCLE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Uno.UI.Dispatching;
+
+namespace Uno.UI.Xaml.Core;
+
+// partial implementation of EventManager
+internal interface ICustomEventManager<T, TEventArgs>
+	where T : class
+	where TEventArgs : class
+{
+	void Enqueue(T sender, TEventArgs args);
+
+	/// <remarks>
+	/// Do not call directly.
+	/// </remarks>
+	void OnTick();
+}
+
+internal sealed class CustomKeepLastEventManager<T, TEventArgs> : ICustomEventManager<T, TEventArgs>
+	where T : class
+	where TEventArgs : class
+{
+	private readonly ConditionalWeakTable<T, TEventArgs> _buffers = new();
+	private readonly NativeDispatcherPriority _priority;
+	private Action<T, TEventArgs> _dispatch;
+	private Action _invokeOnTick;
+	private int _isAdditionalFrameRequested;
+
+	/// <summary>
+	/// </summary>
+	/// <param name="onTick">indirect lambda call to <see cref="OnTick"/> without any capture</param>
+	/// <param name="dispatch">dispatch callback</param>
+	/// <param name="priority"></param>
+	public CustomKeepLastEventManager(Action onTick, Action<T, TEventArgs> dispatch, NativeDispatcherPriority priority = NativeDispatcherPriority.Normal)
+	{
+		this._invokeOnTick = onTick;
+		this._dispatch = dispatch;
+
+		this._priority = priority;
+	}
+
+	public void Enqueue(T sender, TEventArgs args)
+	{
+		_buffers.AddOrUpdate(sender, args);
+
+		RequestAdditionalFrame();
+	}
+
+	private void RequestAdditionalFrame()
+	{
+		if (Interlocked.CompareExchange(ref _isAdditionalFrameRequested, 1, 0) == 0)
+		{
+			NativeDispatcher.Main.Enqueue(_invokeOnTick, _priority);
+		}
+	}
+
+	public void OnTick()
+	{
+		_isAdditionalFrameRequested = 0;
+
+		foreach (var item in _buffers)
+		{
+			if (((IDependencyObjectStoreProvider)item.Key).Store.IsDisposed)
+			{
+				continue;
+			}
+
+			_dispatch(item.Key, item.Value);
+		}
+	}
+}
+
+#endif

--- a/src/Uno.UI/UI/Xaml/Internal/EventManager.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/EventManager.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Uno.Extensions;
+using Uno.Extensions.Specialized;
 using Uno.UI.Dispatching;
 
 namespace Uno.UI.Xaml.Core;
@@ -26,7 +28,9 @@ internal sealed partial class EventManager
 
 	internal void EnqueueForEffectiveViewportChanged(FrameworkElement element, EffectiveViewportChangedEventArgs args)
 	{
+		_effectiveViewportChangedQueue.RemoveAll(x => x.Element == element);
 		_effectiveViewportChangedQueue.Add((element, args));
+
 		CoreServices.RequestAdditionalFrame();
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #19751, closes unoplatform/kahua-private#276

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
FE::EffectiveViewportChanged has extra calls with invalid EffectiveViewport values.

## What is the new behavior?
Those invalid calls are now blocked.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
