### PR TITLE
fix(webview): Don't allow for the webview iframe to be selected

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_OuterSelection.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_OuterSelection.xaml
@@ -1,0 +1,29 @@
+﻿<Page x:Class="UITests.Shared.Windows_UI_Xaml.WebView2_OuterSelection"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:unoControls="using:Uno.UI.Samples.Controls"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel HorizontalAlignment="Center"
+				VerticalAlignment="Center">
+
+		<WebView2 Width="640"
+				  Height="480"
+				  Source="https://platform.uno"></WebView2>
+
+		<Slider  Orientation="Horizontal"
+				 AllowDrop="False"
+				 CanDrag="False"
+				 IsThumbToolTipEnabled="False"
+				 IsTrackerEnabled="False"
+				 Minimum="10"
+				 Maximum="140"
+				 Width="140"
+				 ManipulationMode="None"
+				 StepFrequency="10"></Slider>
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_OuterSelection.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_OuterSelection.xaml
@@ -3,6 +3,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:mux="using:Microsoft.UI.Xaml.Controls"
 	xmlns:unoControls="using:Uno.UI.Samples.Controls"
 	mc:Ignorable="d"
 	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -10,7 +11,7 @@
 	<StackPanel HorizontalAlignment="Center"
 				VerticalAlignment="Center">
 
-		<WebView2 Width="640"
+		<mux:WebView2 Width="640"
 				  Height="480"
 				  Source="https://platform.uno"></WebView2>
 

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_OuterSelection.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_OuterSelection.xaml
@@ -13,7 +13,7 @@
 
 		<mux:WebView2 Width="640"
 				  Height="480"
-				  Source="https://platform.uno"></WebView2>
+				  Source="https://platform.uno" />
 
 		<Slider  Orientation="Horizontal"
 				 AllowDrop="False"

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_OuterSelection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_OuterSelection.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+using SamplesApp.Microsoft_UI_Xaml_Controls.WebView2Tests;
+
+namespace UITests.Shared.Windows_UI_Xaml
+{
+	[Sample("WebView",
+		Name = "WebView2_OuterSelection",
+		IsManualTest = true,
+		Description = "When trying to select the slider as if it were text, the WebView should not become selected (blue overlay).")]
+	public sealed partial class WebView2_OuterSelection : Page
+	{
+		public WebView2_OuterSelection()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -474,6 +474,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\WebView2Tests\WebView2_OuterSelection.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Msal\MsalLoginAndGraph.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -5887,6 +5891,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\ExpanderTests\Expander_ScrollView.xaml.cs">
       <DependentUpon>Expander_ScrollView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\WebView2Tests\WebView2_OuterSelection.xaml.cs">
+      <DependentUpon>WebView2_OuterSelection.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Msal\MsalLoginAndGraph.xaml.cs">
       <DependentUpon>MsalLoginAndGraph.xaml</DependentUpon>

--- a/src/Uno.UI/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI/WasmCSS/Uno.UI.css
@@ -301,4 +301,5 @@ input::-ms-clear {
   border: 0px;
   width: 100%;
   height: 100%;
+  user-select: none;
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/19640

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

The WebView2 controls is not selectable as text anymore.