### PR TITLE
fix(codegen): xbind still trigger when the host is unloaded

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/UnoAssemblyHelper.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/UnoAssemblyHelper.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace Uno.UI.SourceGenerators.Tests.Verifiers;
+
+internal static partial class UnoAssemblyHelper
+{
+	public static PortableExecutableReference[] LoadAssemblies() =>
+		LoadAssemblies(GetBinDirectory(
+			[
+				// On CI the test assemblies set must be first, as it contains all dependent assemblies
+				"Uno.UI.Tests",
+				"Uno.UI.Skia",
+				"Uno.UI.Reference",
+			],
+			[TFMPrevious, TFMCurrent]
+		));
+
+	public static PortableExecutableReference[] LoadAndroidAssemblies() =>
+		LoadAssemblies(GetBinDirectory(
+			["Uno.UI.netcoremobile"],
+			[$"{TFMPrevious}-android", $"{TFMCurrent}-android"]
+		));
+
+	private static string GetBinDirectory(string[] targets, string[] tfms)
+	{
+		var tfmSubPaths =
+		(
+			from tfm in tfms
+			from target in targets
+			select Path.Combine(target, CurrentConfiguration, tfm)
+		).ToArray();
+
+		var unoBasePath = Path.Combine(
+			Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+			"..",
+			"..",
+			"..",
+			"..",
+			"..",
+			"Uno.UI",
+			"bin"
+		);
+
+		var directory = tfmSubPaths
+			.Select(x => Path.Combine(unoBasePath, x))
+			.FirstOrDefault(x => File.Exists(Path.Combine(x, "Uno.UI.dll")));
+		if (directory is null)
+		{
+			throw new InvalidOperationException(string.Join("\n", (string[])[
+				"Unable to find Uno.UI.dll in the expected locations.",
+#if DEBUG
+				// on ci, they are ensured by the ci script
+				"note: If you are getting this error locally, make sure to build the Uno.UI project once for any of the target listed below",
+#endif
+				$"unoBasePath: {new Uri(unoBasePath).LocalPath}",
+				$"tfmSubPaths:",
+				..tfmSubPaths.Select(x => $"  - {x}"),
+			]));
+		}
+
+		return directory;
+	}
+
+	private static PortableExecutableReference[] LoadAssemblies(string binDirectory) =>
+		Directory.GetFiles(binDirectory, "*.dll")
+			.Select(x => MetadataReference.CreateFromFile(x))
+			.ToArray();
+}
+
+partial class UnoAssemblyHelper
+{
+	private const string CurrentConfiguration =
+#if DEBUG
+		"Debug";
+#else
+		"Release";
+#endif
+	private const string TFMPrevious = "net8.0";
+	private const string TFMCurrent = "net9.0";
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_GenerateEmbeddedXamlSources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_GenerateEmbeddedXamlSources.cs
@@ -45,7 +45,6 @@ public class Given_GenerateEmbeddedXamlSources
 				}
 			},
 			ReferenceAssemblies = _Dotnet.Current.WithUnoPackage(),
-			DisableBuildReferences = true,
 			GlobalConfigOverride = configOverride,
 		}.AddGeneratedSources();
 
@@ -90,7 +89,6 @@ public class Given_GenerateEmbeddedXamlSources
 				}
 			},
 			ReferenceAssemblies = _Dotnet.Current.WithUnoPackage(),
-			DisableBuildReferences = true,
 			GlobalConfigOverride = configOverride,
 		}.AddGeneratedSources();
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_HotReloadEnabledInBuild.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_HotReloadEnabledInBuild.cs
@@ -55,7 +55,6 @@ public class Given_HotReloadEnabledInBuild
 				}
 			},
 			ReferenceAssemblies = _Dotnet.Current.WithUnoPackage(),
-			DisableBuildReferences = true,
 			GlobalConfigOverride = configOverride,
 		}.AddGeneratedSources();
 
@@ -241,7 +240,6 @@ public class Given_HotReloadEnabledInBuild
 		var test = new Verify.Test(xamlFile)
 		{
 			ReferenceAssemblies = _Dotnet.Current.WithUnoPackage(),
-			DisableBuildReferences = true,
 			GlobalConfigOverride = configOverride,
 		}.AddGeneratedSources();
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_LazyLoading.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_LazyLoading.cs
@@ -56,7 +56,6 @@ public class Given_LazyLoading
 				}
 			},
 			ReferenceAssemblies = _Dotnet.Current.WithUnoPackage(),
-			DisableBuildReferences = true,
 		}.AddGeneratedSources();
 
 		await test.RunAsync();
@@ -115,7 +114,6 @@ public class Given_LazyLoading
 				}
 			},
 			ReferenceAssemblies = _Dotnet.Current.WithUnoPackage(),
-			DisableBuildReferences = true,
 		}.AddGeneratedSources();
 
 		await test.RunAsync();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_NoFuzzyMatching.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_NoFuzzyMatching.cs
@@ -53,7 +53,6 @@ public class Given_NoFuzzyMatching
 				}
 			},
 			ReferenceAssemblies = _Dotnet.CurrentAndroid.WithUnoPackage(),
-			DisableBuildReferences = true,
 		}.AddGeneratedSources();
 
 		await test.RunAsync();
@@ -106,7 +105,6 @@ public class Given_NoFuzzyMatching
 				}
 			},
 			ReferenceAssemblies = _Dotnet.Current.WithUnoPackage(),
-			DisableBuildReferences = true,
 		}.AddGeneratedSources();
 
 		await test.RunAsync();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_Parser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_Parser.cs
@@ -362,7 +362,6 @@ public class Given_Parser
 					"""
 				}
 			},
-			DisableBuildReferences = true,
 			ReferenceAssemblies = _Dotnet.CurrentAndroid.ReferenceAssemblies.AddPackages([new PackageIdentity("SkiaSharp.Views.Uno.WinUI", "3.0.0-preview.3.1")]),
 		}.AddGeneratedSources();
 
@@ -410,7 +409,6 @@ public class Given_Parser
 					"""
 				}
 			},
-			DisableBuildReferences = true,
 			ReferenceAssemblies = _Dotnet.Current.WithUnoPackage("5.3.114"),
 		}.AddGeneratedSources();
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_Xuid.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_Xuid.cs
@@ -52,7 +52,6 @@ public class Given_Xuid
 				}
 			},
 			ReferenceAssemblies = _Dotnet.CurrentAndroid.WithUnoPackage(),
-			DisableBuildReferences = true,
 		}.AddGeneratedSources();
 
 		await test.RunAsync();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/ENQ/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/ENQ/XamlCodeGenerator_GlobalStaticResources.cs
@@ -24,12 +24,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/ETQ/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/ETQ/XamlCodeGenerator_GlobalStaticResources.cs
@@ -24,12 +24,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_GlobalStaticResources.cs
@@ -25,12 +25,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SBUIIOFFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -62,48 +62,44 @@ namespace TestRepro
 						FontSize = 30d,
 						// Source 0\MainPage.xaml (Line 9:4)
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_0					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_0))
 					,
 				}
 			}
-			.GenericApply(__that, __nameScope, (ApplyMethod_1			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_1))
 			;
 			
 			this
-			.GenericApply(__that, __nameScope, (ApplyMethod_2			))
-			.GenericApply(__that, __nameScope, (ApplyMethod_3			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_2))
+			.GenericApply(__that, __nameScope, (ApplyMethod_3))
 			;
 			OnInitializeCompleted();
 
 		}
 		partial void OnInitializeCompleted();
-							private void ApplyMethod_0(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 9, 4);
-						__p1.CreationComplete();
-					}
-
-					private void ApplyMethod_1(global::Microsoft.UI.Xaml.Controls.Grid __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				global::Uno.UI.Toolkit.VisibleBoundsPadding.SetPaddingMask(__p1, global::Uno.UI.Toolkit.VisibleBoundsPadding.PaddingMask.Top);
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 8, 3);
-				__p1.CreationComplete();
-			}
-
-					private void ApplyMethod_2(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				// Source 0\MainPage.xaml (Line 1:2)
-				
-				// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
-			}
-
-					private void ApplyMethod_3(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				// Class TestRepro.MainPage
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
-				__p1.CreationComplete();
-			}
-
+		private void ApplyMethod_0(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 9, 4);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_1(global::Microsoft.UI.Xaml.Controls.Grid __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Toolkit.VisibleBoundsPadding.SetPaddingMask(__p1, global::Uno.UI.Toolkit.VisibleBoundsPadding.PaddingMask.Top);
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 8, 3);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_2(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			// Source 0\MainPage.xaml (Line 1:2)
+			
+			// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
+		}
+		private void ApplyMethod_3(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			// Class TestRepro.MainPage
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
+			__p1.CreationComplete();
+		}
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
@@ -149,6 +145,7 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFDOTAFE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -67,7 +67,7 @@ namespace TestRepro
 							,
 						}
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_1					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_1))
 				;
 			}
 			)
@@ -93,7 +93,7 @@ namespace TestRepro
 							,
 						}
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_4					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_4))
 				;
 			}
 			)
@@ -105,7 +105,7 @@ namespace TestRepro
 			{
 				return 
 					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.SC0().Build(__owner)
-					)					.GenericApply(__that, __nameScope, (ApplyMethod_6					))
+					)					.GenericApply(__that, __nameScope, (ApplyMethod_6))
 				;
 			}
 			)
@@ -117,16 +117,16 @@ namespace TestRepro
 				IsParsing = true,
 				Name = "TheListView",
 				HeaderTemplate = 				new global::Microsoft.UI.Xaml.DataTemplate(this, (__owner) => 				new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.SC1().Build(__owner)
-				)				.GenericApply(__that, __nameScope, (ApplyMethod_7				))
+				)				.GenericApply(__that, __nameScope, (ApplyMethod_7))
 				,
 				// Source 0\MainPage.xaml (Line 40:4)
 			}
-			.GenericApply(__that, __nameScope, (ApplyMethod_8			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_8))
 			;
 			
 			this
-			.GenericApply(__that, __nameScope, (ApplyMethod_9			))
-			.GenericApply(__that, __nameScope, (ApplyMethod_10			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_9))
+			.GenericApply(__that, __nameScope, (ApplyMethod_10))
 			;
 			OnInitializeCompleted();
 
@@ -138,154 +138,143 @@ namespace TestRepro
 		{
 			this.Bindings.UpdateResources();
 		}
-							private void ApplyMethod_1(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L7:6");
-					}
-
-							private void ApplyMethod_4(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L10:6");
-					}
-
-							private void ApplyMethod_6(global::System.Object __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L13:6");
-					}
-
-						private void ApplyMethod_7(global::System.Object __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-				{
-					global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L42:8");
-				}
-
-					private void ApplyMethod_8(global::Microsoft.UI.Xaml.Controls.ListView __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		private void ApplyMethod_1(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L7:6");
+		}
+		private void ApplyMethod_4(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L10:6");
+		}
+		private void ApplyMethod_6(global::System.Object __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L13:6");
+		}
+		private void ApplyMethod_7(global::System.Object __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L42:8");
+		}
+		private void ApplyMethod_8(global::Microsoft.UI.Xaml.Controls.ListView __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			/* _isTopLevelDictionary:False */
+			__that._component_0 = __p1;
+			__nameScope.RegisterName("TheListView", __p1);
+			__that.TheListView = __p1;
+			global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.ListView.ItemTemplateProperty, "MyItemTemplate", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 40, 4);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_9(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			// Source 0\MainPage.xaml (Line 1:2)
+			
+			// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
+		}
+		private void ApplyMethod_11(global::Microsoft.UI.Xaml.AdaptiveTrigger __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L24:12");
+		}
+		private void ApplyMethod_12(global::Microsoft.UI.Xaml.VisualState __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			__nameScope.RegisterName("WideState", __p1);
+			__that.WideState = __p1;
+			global::Uno.UI.Helpers.MarkupHelper.SetVisualStateLazy(__p1, () => 
 			{
-				/* _isTopLevelDictionary:False */
-				__that._component_0 = __p1;
-				__nameScope.RegisterName("TheListView", __p1);
-				__that.TheListView = __p1;
-				global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.ListView.ItemTemplateProperty, "MyItemTemplate", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 40, 4);
-				__p1.CreationComplete();
-			}
-
-					private void ApplyMethod_9(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				// Source 0\MainPage.xaml (Line 1:2)
-				
-				// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
-			}
-
-											private void ApplyMethod_11(global::Microsoft.UI.Xaml.AdaptiveTrigger __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-									{
-										global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L24:12");
-									}
-
-									private void ApplyMethod_12(global::Microsoft.UI.Xaml.VisualState __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-							{
-								__nameScope.RegisterName("WideState", __p1);
-								__that.WideState = __p1;
-								global::Uno.UI.Helpers.MarkupHelper.SetVisualStateLazy(__p1, () => 
-								{
-									__p1.Name = "WideState";
-									__p1.Setters.Add(
-										new global::Microsoft.UI.Xaml.Setter
-										{
-											Target = new global::Microsoft.UI.Xaml.TargetPropertyPath(this._TheListViewSubject, "Background"),
-											Value = @"Red",
-											// Source 0\MainPage.xaml (Line 27:12)
-										}
-									);
-									;
-								}
-								);
-								global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L22:8");
-							}
-
-											private void ApplyMethod_14(global::Microsoft.UI.Xaml.AdaptiveTrigger __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-									{
-										global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L32:12");
-									}
-
-									private void ApplyMethod_15(global::Microsoft.UI.Xaml.VisualState __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-							{
-								__nameScope.RegisterName("NarrowState", __p1);
-								__that.NarrowState = __p1;
-								global::Uno.UI.Helpers.MarkupHelper.SetVisualStateLazy(__p1, () => 
-								{
-									__p1.Name = "NarrowState";
-									__p1.Setters.Add(
-										new global::Microsoft.UI.Xaml.Setter
-										{
-											Target = new global::Microsoft.UI.Xaml.TargetPropertyPath(this._TheListViewSubject, "Background"),
-											Value = @"Green",
-											// Source 0\MainPage.xaml (Line 35:12)
-										}
-									);
-									;
-								}
-								);
-								global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L30:8");
-							}
-
-					private void ApplyMethod_10(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				/* _isTopLevelDictionary:False */
-				__that._component_1 = __p1;
-				// Class TestRepro.MainPage
-				global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-				global::Microsoft.UI.Xaml.VisualStateManager.SetVisualStateGroups(__p1, 
-				new[]
-				{
-					new global::Microsoft.UI.Xaml.VisualStateGroup
+				__p1.Name = "WideState";
+				__p1.Setters.Add(
+					new global::Microsoft.UI.Xaml.Setter
 					{
-						// Source 0\MainPage.xaml (Line 21:6)
-						States = 
-						{
-							new global::Microsoft.UI.Xaml.VisualState
-							{
-								Name = "WideState",
-								StateTriggers = 
-								{
-									new global::Microsoft.UI.Xaml.AdaptiveTrigger
-									{
-										MinWindowWidth = 641d,
-										// Source 0\MainPage.xaml (Line 24:12)
-									}
-									.GenericApply(__that, __nameScope, (ApplyMethod_11									))
-									,
-								}
-								,
-								// Source 0\MainPage.xaml (Line 22:8)
-							}
-							.GenericApply(__that, __nameScope, (ApplyMethod_12							))
-							,
-							new global::Microsoft.UI.Xaml.VisualState
-							{
-								Name = "NarrowState",
-								StateTriggers = 
-								{
-									new global::Microsoft.UI.Xaml.AdaptiveTrigger
-									{
-										MinWindowWidth = 0d,
-										// Source 0\MainPage.xaml (Line 32:12)
-									}
-									.GenericApply(__that, __nameScope, (ApplyMethod_14									))
-									,
-								}
-								,
-								// Source 0\MainPage.xaml (Line 30:8)
-							}
-							.GenericApply(__that, __nameScope, (ApplyMethod_15							))
-							,
-						}
+						Target = new global::Microsoft.UI.Xaml.TargetPropertyPath(this._TheListViewSubject, "Background"),
+						Value = @"Red",
+						// Source 0\MainPage.xaml (Line 27:12)
 					}
-					,				}
 				);
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
-				__p1.CreationComplete();
+				;
 			}
-
+			);
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L22:8");
+		}
+		private void ApplyMethod_14(global::Microsoft.UI.Xaml.AdaptiveTrigger __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L32:12");
+		}
+		private void ApplyMethod_15(global::Microsoft.UI.Xaml.VisualState __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			__nameScope.RegisterName("NarrowState", __p1);
+			__that.NarrowState = __p1;
+			global::Uno.UI.Helpers.MarkupHelper.SetVisualStateLazy(__p1, () => 
+			{
+				__p1.Name = "NarrowState";
+				__p1.Setters.Add(
+					new global::Microsoft.UI.Xaml.Setter
+					{
+						Target = new global::Microsoft.UI.Xaml.TargetPropertyPath(this._TheListViewSubject, "Background"),
+						Value = @"Green",
+						// Source 0\MainPage.xaml (Line 35:12)
+					}
+				);
+				;
+			}
+			);
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L30:8");
+		}
+		private void ApplyMethod_10(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			/* _isTopLevelDictionary:False */
+			__that._component_1 = __p1;
+			// Class TestRepro.MainPage
+			global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+			global::Microsoft.UI.Xaml.VisualStateManager.SetVisualStateGroups(__p1, 
+			new[]
+			{
+				new global::Microsoft.UI.Xaml.VisualStateGroup
+				{
+					// Source 0\MainPage.xaml (Line 21:6)
+					States = 
+					{
+						new global::Microsoft.UI.Xaml.VisualState
+						{
+							Name = "WideState",
+							StateTriggers = 
+							{
+								new global::Microsoft.UI.Xaml.AdaptiveTrigger
+								{
+									MinWindowWidth = 641d,
+									// Source 0\MainPage.xaml (Line 24:12)
+								}
+								.GenericApply(__that, __nameScope, (ApplyMethod_11))
+								,
+							}
+							,
+							// Source 0\MainPage.xaml (Line 22:8)
+						}
+						.GenericApply(__that, __nameScope, (ApplyMethod_12))
+						,
+						new global::Microsoft.UI.Xaml.VisualState
+						{
+							Name = "NarrowState",
+							StateTriggers = 
+							{
+								new global::Microsoft.UI.Xaml.AdaptiveTrigger
+								{
+									MinWindowWidth = 0d,
+									// Source 0\MainPage.xaml (Line 32:12)
+								}
+								.GenericApply(__that, __nameScope, (ApplyMethod_14))
+								,
+							}
+							,
+							// Source 0\MainPage.xaml (Line 30:8)
+						}
+						.GenericApply(__that, __nameScope, (ApplyMethod_15))
+						,
+					}
+				}
+				,	}
+			);
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
+			__p1.CreationComplete();
+		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _NarrowStateSubject { get; set; } = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		private global::Microsoft.UI.Xaml.VisualState NarrowState
 		{
@@ -354,7 +343,7 @@ namespace TestRepro
 								IsParsing = true,
 								// Source 0\MainPage.xaml (Line 15:10)
 							}
-							.GenericApply(__that, __nameScope, (ApplyMethod_17							))
+							.GenericApply(__that, __nameScope, (ApplyMethod_17))
 							,
 							new global::Microsoft.UI.Xaml.Controls.Button
 							{
@@ -362,15 +351,16 @@ namespace TestRepro
 								Content = @"DoSomething",
 								// Source 0\MainPage.xaml (Line 16:10)
 							}
-							.GenericApply(__that, __nameScope, (ApplyMethod_18							))
+							.GenericApply(__that, __nameScope, (ApplyMethod_18))
 							,
 						}
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_19					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_19))
 					;
 					if (__rootInstance is FrameworkElement __fe)
 					{
 						__fe.Loading += __UpdateBindingsAndResources;
+						__fe.Unloaded += __StopTracking;
 					}
 					if (__rootInstance is DependencyObject d)
 					{
@@ -397,37 +387,36 @@ namespace TestRepro
 				}
 				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 				{
-					var owner = this;
 					_component_0.UpdateResourceBindings();
 				}
-											private void ApplyMethod_17(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-							{
-								__p1.SetBinding(
-									global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
-									new Microsoft.UI.Xaml.Data.Binding()
-									{
-										Path = @"",
-									}
-								);
-								global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 15, 10);
-								__p1.CreationComplete();
-							}
-
-											private void ApplyMethod_18(global::Microsoft.UI.Xaml.Controls.Button __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-							{
-								/* _isTopLevelDictionary:False */
-								__that._component_0 = __p1;
-								global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Button.StyleProperty, "MyCustomButtonStyle", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-								global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 16, 10);
-								__p1.CreationComplete();
-							}
-
-									private void ApplyMethod_19(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
-						__p1.CreationComplete();
-					}
-
+				private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+				{
+				}
+				private void ApplyMethod_17(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+				{
+					__p1.SetBinding(
+						global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
+						new Microsoft.UI.Xaml.Data.Binding()
+						{
+							Path = @"",
+						}
+					);
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 15, 10);
+					__p1.CreationComplete();
+				}
+				private void ApplyMethod_18(global::Microsoft.UI.Xaml.Controls.Button __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+				{
+					/* _isTopLevelDictionary:False */
+					__that._component_0 = __p1;
+					global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Button.StyleProperty, "MyCustomButtonStyle", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 16, 10);
+					__p1.CreationComplete();
+				}
+				private void ApplyMethod_19(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+				{
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
+					__p1.CreationComplete();
+				}
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 				private class __MainPage_d6cd66944958ced0c513e0a04797b51d_MyProject__ResourcesSC0_TestReproMainPage
@@ -457,7 +446,7 @@ namespace TestRepro
 						Text = "Header",
 						// Source 0\MainPage.xaml (Line 43:10)
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_20					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_20))
 					;
 					if (__rootInstance is DependencyObject d)
 					{
@@ -470,12 +459,11 @@ namespace TestRepro
 					}
 					return __rootInstance;
 				}
-									private void ApplyMethod_20(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, SC1 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 43, 10);
-						__p1.CreationComplete();
-					}
-
+				private void ApplyMethod_20(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, SC1 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+				{
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 43, 10);
+					__p1.CreationComplete();
+				}
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 				private class __MainPage_d6cd66944958ced0c513e0a04797b51d_MyProject__ResourcesSC1_TestReproMainPage
@@ -549,6 +537,7 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFEDT/XamlCodeGenerator_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIIOFEDT/XamlCodeGenerator_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706.cs
@@ -52,7 +52,7 @@ namespace TestRepro
 			new global::Uno.UI.Xaml.WeakResourceInitializer(this, __ResourceOwner_1 => 
 			{
 				return 
-					new global::Microsoft.UI.Xaml.DataTemplate(					)					.GenericApply(__that, __nameScope, (ApplyMethod_0					))
+					new global::Microsoft.UI.Xaml.DataTemplate(					)					.GenericApply(__that, __nameScope, (ApplyMethod_0))
 				;
 			}
 			)
@@ -70,26 +70,26 @@ namespace TestRepro
 						IsParsing = true,
 						// Source 0\EmptyDataTemplatePage.xaml (Line 12:4)
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_1					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_1))
 					,
 					new global::Microsoft.UI.Xaml.Controls.Button
 					{
 						IsParsing = true,
 						Name = "ButtonWithEmptyDataTemplate",
-						ContentTemplate = 						new global::Microsoft.UI.Xaml.DataTemplate(						)						.GenericApply(__that, __nameScope, (ApplyMethod_2						))
+						ContentTemplate = 						new global::Microsoft.UI.Xaml.DataTemplate(						)						.GenericApply(__that, __nameScope, (ApplyMethod_2))
 						,
 						// Source 0\EmptyDataTemplatePage.xaml (Line 13:4)
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_3					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_3))
 					,
 				}
 			}
-			.GenericApply(__that, __nameScope, (ApplyMethod_4			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_4))
 			;
 			
 			this
-			.GenericApply(__that, __nameScope, (ApplyMethod_5			))
-			.GenericApply(__that, __nameScope, (ApplyMethod_6			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_5))
+			.GenericApply(__that, __nameScope, (ApplyMethod_6))
 			;
 			OnInitializeCompleted();
 
@@ -101,56 +101,49 @@ namespace TestRepro
 		{
 			this.Bindings.UpdateResources();
 		}
-							private void ApplyMethod_0(global::System.Object __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/EmptyDataTemplatePage.xaml#L7:4");
-					}
-
-							private void ApplyMethod_1(global::Microsoft.UI.Xaml.Controls.ListView __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						/* _isTopLevelDictionary:False */
-						__that._component_0 = __p1;
-						global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.ListView.ItemTemplateProperty, "MyItemTemplate", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706, "file:///C:/Project/0/EmptyDataTemplatePage.xaml", 12, 4);
-						__p1.CreationComplete();
-					}
-
-								private void ApplyMethod_2(global::System.Object __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-						{
-							global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/EmptyDataTemplatePage.xaml#L15:6");
-						}
-
-							private void ApplyMethod_3(global::Microsoft.UI.Xaml.Controls.Button __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						__nameScope.RegisterName("ButtonWithEmptyDataTemplate", __p1);
-						__that.ButtonWithEmptyDataTemplate = __p1;
-						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706, "file:///C:/Project/0/EmptyDataTemplatePage.xaml", 13, 4);
-						__p1.CreationComplete();
-					}
-
-					private void ApplyMethod_4(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706, "file:///C:/Project/0/EmptyDataTemplatePage.xaml", 11, 3);
-				__p1.CreationComplete();
-			}
-
-					private void ApplyMethod_5(global::Microsoft.UI.Xaml.Controls.Page __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				// Source 0\EmptyDataTemplatePage.xaml (Line 1:3)
-				
-				// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
-			}
-
-					private void ApplyMethod_6(global::Microsoft.UI.Xaml.Controls.Page __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				/* _isTopLevelDictionary:False */
-				__that._component_1 = __p1;
-				// Class TestRepro.EmptyDataTemplatePage
-				global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706, "file:///C:/Project/0/EmptyDataTemplatePage.xaml", 1, 3);
-				__p1.CreationComplete();
-			}
-
+		private void ApplyMethod_0(global::System.Object __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/EmptyDataTemplatePage.xaml#L7:4");
+		}
+		private void ApplyMethod_1(global::Microsoft.UI.Xaml.Controls.ListView __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			/* _isTopLevelDictionary:False */
+			__that._component_0 = __p1;
+			global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.ListView.ItemTemplateProperty, "MyItemTemplate", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706, "file:///C:/Project/0/EmptyDataTemplatePage.xaml", 12, 4);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_2(global::System.Object __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/EmptyDataTemplatePage.xaml#L15:6");
+		}
+		private void ApplyMethod_3(global::Microsoft.UI.Xaml.Controls.Button __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			__nameScope.RegisterName("ButtonWithEmptyDataTemplate", __p1);
+			__that.ButtonWithEmptyDataTemplate = __p1;
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706, "file:///C:/Project/0/EmptyDataTemplatePage.xaml", 13, 4);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_4(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706, "file:///C:/Project/0/EmptyDataTemplatePage.xaml", 11, 3);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_5(global::Microsoft.UI.Xaml.Controls.Page __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			// Source 0\EmptyDataTemplatePage.xaml (Line 1:3)
+			
+			// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
+		}
+		private void ApplyMethod_6(global::Microsoft.UI.Xaml.Controls.Page __p1, EmptyDataTemplatePage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			/* _isTopLevelDictionary:False */
+			__that._component_1 = __p1;
+			// Class TestRepro.EmptyDataTemplatePage
+			global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_EmptyDataTemplatePage_0f836ad6c048ef5ac0e673406e3c3706, "file:///C:/Project/0/EmptyDataTemplatePage.xaml", 1, 3);
+			__p1.CreationComplete();
+		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _ButtonWithEmptyDataTemplateSubject { get; set; } = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		private global::Microsoft.UI.Xaml.Controls.Button ButtonWithEmptyDataTemplate
 		{
@@ -234,6 +227,7 @@ namespace TestRepro
 			}
 			void IEmptyDataTemplatePage_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLR/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLR/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -67,7 +67,7 @@ namespace TestRepro
 							,
 						}
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_1					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_1))
 				;
 			}
 			)
@@ -93,7 +93,7 @@ namespace TestRepro
 							,
 						}
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_4					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_4))
 				;
 			}
 			)
@@ -105,7 +105,7 @@ namespace TestRepro
 			{
 				return 
 					new global::Microsoft.UI.Xaml.DataTemplate(__ResourceOwner_1, (__owner) => 					new __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage.SC0().Build(__owner)
-					)					.GenericApply(__that, __nameScope, (ApplyMethod_6					))
+					)					.GenericApply(__that, __nameScope, (ApplyMethod_6))
 				;
 			}
 			)
@@ -117,12 +117,12 @@ namespace TestRepro
 				IsParsing = true,
 				// Source 0\MainPage.xaml (Line 20:4)
 			}
-			.GenericApply(__that, __nameScope, (ApplyMethod_7			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_7))
 			;
 			
 			this
-			.GenericApply(__that, __nameScope, (ApplyMethod_8			))
-			.GenericApply(__that, __nameScope, (ApplyMethod_9			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_8))
+			.GenericApply(__that, __nameScope, (ApplyMethod_9))
 			;
 			OnInitializeCompleted();
 
@@ -134,44 +134,38 @@ namespace TestRepro
 		{
 			this.Bindings.UpdateResources();
 		}
-							private void ApplyMethod_1(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L7:6");
-					}
-
-							private void ApplyMethod_4(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L10:6");
-					}
-
-							private void ApplyMethod_6(global::System.Object __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L13:6");
-					}
-
-					private void ApplyMethod_7(global::Microsoft.UI.Xaml.Controls.ListView __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 20, 4);
-				__p1.CreationComplete();
-			}
-
-					private void ApplyMethod_8(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				// Source 0\MainPage.xaml (Line 1:2)
-				
-				// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
-			}
-
-					private void ApplyMethod_9(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				/* _isTopLevelDictionary:False */
-				__that._component_0 = __p1;
-				// Class TestRepro.MainPage
-				global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
-				__p1.CreationComplete();
-			}
-
+		private void ApplyMethod_1(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L7:6");
+		}
+		private void ApplyMethod_4(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L10:6");
+		}
+		private void ApplyMethod_6(global::System.Object __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L13:6");
+		}
+		private void ApplyMethod_7(global::Microsoft.UI.Xaml.Controls.ListView __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 20, 4);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_8(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			// Source 0\MainPage.xaml (Line 1:2)
+			
+			// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
+		}
+		private void ApplyMethod_9(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			/* _isTopLevelDictionary:False */
+			__that._component_0 = __p1;
+			// Class TestRepro.MainPage
+			global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
+			__p1.CreationComplete();
+		}
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
@@ -204,7 +198,7 @@ namespace TestRepro
 								IsParsing = true,
 								// Source 0\MainPage.xaml (Line 15:10)
 							}
-							.GenericApply(__that, __nameScope, (ApplyMethod_10							))
+							.GenericApply(__that, __nameScope, (ApplyMethod_10))
 							,
 							new global::Microsoft.UI.Xaml.Controls.Button
 							{
@@ -212,15 +206,16 @@ namespace TestRepro
 								Content = @"DoSomething",
 								// Source 0\MainPage.xaml (Line 16:10)
 							}
-							.GenericApply(__that, __nameScope, (ApplyMethod_11							))
+							.GenericApply(__that, __nameScope, (ApplyMethod_11))
 							,
 						}
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_12					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_12))
 					;
 					if (__rootInstance is FrameworkElement __fe)
 					{
 						__fe.Loading += __UpdateBindingsAndResources;
+						__fe.Unloaded += __StopTracking;
 					}
 					if (__rootInstance is DependencyObject d)
 					{
@@ -247,37 +242,36 @@ namespace TestRepro
 				}
 				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 				{
-					var owner = this;
 					_component_0.UpdateResourceBindings();
 				}
-											private void ApplyMethod_10(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-							{
-								__p1.SetBinding(
-									global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
-									new Microsoft.UI.Xaml.Data.Binding()
-									{
-										Path = @"",
-									}
-								);
-								global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 15, 10);
-								__p1.CreationComplete();
-							}
-
-											private void ApplyMethod_11(global::Microsoft.UI.Xaml.Controls.Button __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-							{
-								/* _isTopLevelDictionary:False */
-								__that._component_0 = __p1;
-								global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Button.StyleProperty, "MyCustomButtonStyle", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-								global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 16, 10);
-								__p1.CreationComplete();
-							}
-
-									private void ApplyMethod_12(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
-						__p1.CreationComplete();
-					}
-
+				private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+				{
+				}
+				private void ApplyMethod_10(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+				{
+					__p1.SetBinding(
+						global::Microsoft.UI.Xaml.Controls.TextBlock.TextProperty,
+						new Microsoft.UI.Xaml.Data.Binding()
+						{
+							Path = @"",
+						}
+					);
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 15, 10);
+					__p1.CreationComplete();
+				}
+				private void ApplyMethod_11(global::Microsoft.UI.Xaml.Controls.Button __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+				{
+					/* _isTopLevelDictionary:False */
+					__that._component_0 = __p1;
+					global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Button.StyleProperty, "MyCustomButtonStyle", isThemeResourceExtension: false, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 16, 10);
+					__p1.CreationComplete();
+				}
+				private void ApplyMethod_12(global::Microsoft.UI.Xaml.Controls.StackPanel __p1, SC0 __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+				{
+					global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 8);
+					__p1.CreationComplete();
+				}
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 				private class __MainPage_d6cd66944958ced0c513e0a04797b51d_MyProject__ResourcesSC0_TestReproMainPage
@@ -338,6 +332,7 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLS/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFPLS/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -67,7 +67,7 @@ namespace TestRepro
 							,
 						}
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_1					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_1))
 				;
 			}
 			)
@@ -93,7 +93,7 @@ namespace TestRepro
 							,
 						}
 					}
-					.GenericApply(__that, __nameScope, (ApplyMethod_4					))
+					.GenericApply(__that, __nameScope, (ApplyMethod_4))
 				;
 			}
 			)
@@ -105,12 +105,12 @@ namespace TestRepro
 				IsParsing = true,
 				// Source 0\MainPage.xaml (Line 14:4)
 			}
-			.GenericApply(__that, __nameScope, (ApplyMethod_6			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_6))
 			;
 			
 			this
-			.GenericApply(__that, __nameScope, (ApplyMethod_7			))
-			.GenericApply(__that, __nameScope, (ApplyMethod_8			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_7))
+			.GenericApply(__that, __nameScope, (ApplyMethod_8))
 			;
 			OnInitializeCompleted();
 
@@ -122,39 +122,34 @@ namespace TestRepro
 		{
 			this.Bindings.UpdateResources();
 		}
-							private void ApplyMethod_1(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L7:6");
-					}
-
-							private void ApplyMethod_4(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-					{
-						global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L10:6");
-					}
-
-					private void ApplyMethod_6(global::Microsoft.UI.Xaml.Controls.ListView __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 4);
-				__p1.CreationComplete();
-			}
-
-					private void ApplyMethod_7(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				// Source 0\MainPage.xaml (Line 1:2)
-				
-				// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
-			}
-
-					private void ApplyMethod_8(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				/* _isTopLevelDictionary:False */
-				__that._component_0 = __p1;
-				// Class TestRepro.MainPage
-				global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
-				__p1.CreationComplete();
-			}
-
+		private void ApplyMethod_1(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L7:6");
+		}
+		private void ApplyMethod_4(global::Microsoft.UI.Xaml.Style __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.Helpers.MarkupHelper.SetElementProperty(__p1, "OriginalSourceLocation", "file:///C:/Project/0/MainPage.xaml#L10:6");
+		}
+		private void ApplyMethod_6(global::Microsoft.UI.Xaml.Controls.ListView __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 14, 4);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_7(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			// Source 0\MainPage.xaml (Line 1:2)
+			
+			// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
+		}
+		private void ApplyMethod_8(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			/* _isTopLevelDictionary:False */
+			__that._component_0 = __p1;
+			// Class TestRepro.MainPage
+			global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
+			__p1.CreationComplete();
+		}
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
@@ -213,6 +208,7 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFRT/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFRT/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -65,7 +65,7 @@ namespace TestRepro
 				Text = "use me",
 				// Source 0\MainPage.xaml (Line 9:3)
 			}
-			.GenericApply(__that, __nameScope, (ApplyMethod_0			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_0))
 			;
 			// Source 0\MainPage.xaml (Line 1:2)
 			base.Content = 
@@ -75,12 +75,12 @@ namespace TestRepro
 				Text = "Some content",
 				// Source 0\MainPage.xaml (Line 11:4)
 			}
-			.GenericApply(__that, __nameScope, (ApplyMethod_1			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_1))
 			;
 			
 			this
-			.GenericApply(__that, __nameScope, (ApplyMethod_2			))
-			.GenericApply(__that, __nameScope, (ApplyMethod_3			))
+			.GenericApply(__that, __nameScope, (ApplyMethod_2))
+			.GenericApply(__that, __nameScope, (ApplyMethod_3))
 			;
 			OnInitializeCompleted();
 
@@ -92,35 +92,31 @@ namespace TestRepro
 		{
 			this.Bindings.UpdateResources();
 		}
-					private void ApplyMethod_0(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 9, 3);
-				__p1.CreationComplete();
-			}
-
-					private void ApplyMethod_1(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 11, 4);
-				__p1.CreationComplete();
-			}
-
-					private void ApplyMethod_2(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				// Source 0\MainPage.xaml (Line 1:2)
-				
-				// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
-			}
-
-					private void ApplyMethod_3(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
-			{
-				/* _isTopLevelDictionary:False */
-				__that._component_0 = __p1;
-				// Class TestRepro.MainPage
-				global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
-				global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
-				__p1.CreationComplete();
-			}
-
+		private void ApplyMethod_0(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 9, 3);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_1(global::Microsoft.UI.Xaml.Controls.TextBlock __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 11, 4);
+			__p1.CreationComplete();
+		}
+		private void ApplyMethod_2(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			// Source 0\MainPage.xaml (Line 1:2)
+			
+			// WARNING Property __p1.base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page, the namespace is http://www.w3.org/XML/1998/namespace. This error was considered irrelevant by the XamlFileGenerator
+		}
+		private void ApplyMethod_3(global::Microsoft.UI.Xaml.Controls.Page __p1, MainPage __that, global::Microsoft.UI.Xaml.NameScope __nameScope)
+		{
+			/* _isTopLevelDictionary:False */
+			__that._component_0 = __p1;
+			// Class TestRepro.MainPage
+			global::Uno.UI.ResourceResolverSingleton.Instance.ApplyResource(__p1, global::Microsoft.UI.Xaml.Controls.Page.BackgroundProperty, "ApplicationPageBackgroundThemeBrush", isThemeResourceExtension: true, isHotReloadSupported: true, context: global::MyProject.GlobalStaticResources.__ParseContext_);
+			global::Uno.UI.FrameworkElementHelper.SetBaseUri(__p1, __baseUri_MainPage_d6cd66944958ced0c513e0a04797b51d, "file:///C:/Project/0/MainPage.xaml", 1, 2);
+			__p1.CreationComplete();
+		}
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
 		private class __MainPage_d6cd66944958ced0c513e0a04797b51d_TestReproMainPage
@@ -179,6 +175,7 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFTLRD/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/SOSLIOFTLRD/XamlCodeGenerator_GlobalStaticResources.cs
@@ -25,12 +25,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TAA/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TAA/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -109,12 +109,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
@@ -183,6 +188,8 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
 			}
 		}
 		private static bool TryGetInstance_xBind_1(global::TestRepro.MainPage ___tctx, out object o)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TBTNSICB/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TBTNSICB/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -177,6 +177,7 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TDBMIDTIRD/XamlCodeGenerator_MyResourceDictionary_92716e07ff456818f6d4125e055d4d57.cs
@@ -104,6 +104,7 @@ namespace TestRepro
 					if (__rootInstance is FrameworkElement __fe)
 					{
 						__fe.Loading += __UpdateBindingsAndResources;
+						__fe.Unloaded += __StopTracking;
 					}
 					if (__rootInstance is DependencyObject d)
 					{
@@ -142,9 +143,12 @@ namespace TestRepro
 				}
 				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 				{
-					var owner = this;
 					_component_0.UpdateResourceBindings();
 					_component_0.ApplyXBind();
+				}
+				private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+				{
+					_component_0.SuspendXBind();
 				}
 				private static bool TryGetInstance_xBind_1(global::TestRepro.MyModel ___tctx, out object o)
 				{
@@ -288,6 +292,7 @@ namespace MyProject.__Resources
 				if (__rootInstance is FrameworkElement __fe)
 				{
 					__fe.Loading += __UpdateBindingsAndResources;
+					__fe.Unloaded += __StopTracking;
 				}
 				if (__rootInstance is DependencyObject d)
 				{
@@ -326,9 +331,12 @@ namespace MyProject.__Resources
 			}
 			private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 			{
-				var owner = this;
 				_component_0.UpdateResourceBindings();
 				_component_0.ApplyXBind();
+			}
+			private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+			{
+				_component_0.SuspendXBind();
 			}
 			private static bool TryGetInstance_xBind_2(global::TestRepro.MyModel ___tctx, out object o)
 			{
@@ -382,6 +390,7 @@ namespace MyProject.__Resources
 				if (__rootInstance is FrameworkElement __fe)
 				{
 					__fe.Loading += __UpdateBindingsAndResources;
+					__fe.Unloaded += __StopTracking;
 				}
 				if (__rootInstance is DependencyObject d)
 				{
@@ -420,9 +429,12 @@ namespace MyProject.__Resources
 			}
 			private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 			{
-				var owner = this;
 				_component_0.UpdateResourceBindings();
 				_component_0.ApplyXBind();
+			}
+			private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+			{
+				_component_0.SuspendXBind();
 			}
 			private static bool TryGetInstance_xBind_3(global::TestRepro.MyModel ___tctx, out object o)
 			{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIDFA/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIDFA/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -106,12 +106,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.TextBox _component_0
@@ -167,6 +172,8 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIM/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TIM/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -129,6 +129,7 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 			[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
@@ -195,6 +196,10 @@ namespace TestRepro
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]
@@ -307,17 +312,8 @@ namespace TestRepro
 			{
 				var owner = Owner;
 				owner._component_0.ApplyXBind();
-				owner.__ApplyMethod_0_Click_Initialize(true);
-				owner.__ApplyMethod_1_Click_Initialize(true);
-				owner.__ApplyMethod_2_Click_Initialize(true);
 				owner._component_1.ApplyXBind();
-				owner.__ApplyMethod_0_Click_Initialize(true);
-				owner.__ApplyMethod_1_Click_Initialize(true);
-				owner.__ApplyMethod_2_Click_Initialize(true);
 				owner._component_2.ApplyXBind();
-				owner.__ApplyMethod_0_Click_Initialize(true);
-				owner.__ApplyMethod_1_Click_Initialize(true);
-				owner.__ApplyMethod_2_Click_Initialize(true);
 				owner.__ApplyMethod_0_Click_Initialize(true);
 				owner.__ApplyMethod_1_Click_Initialize(true);
 				owner.__ApplyMethod_2_Click_Initialize(true);
@@ -332,6 +328,10 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
+				owner._component_1.SuspendXBind();
+				owner._component_2.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TMEWSFEL/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TMEWSFEL/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -131,6 +131,7 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TMEWSWA/XamlCodeGenerator_MainWindow_c93db19a7202d9eb84ddc41d72fcb89b.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TMEWSWA/XamlCodeGenerator_MainWindow_c93db19a7202d9eb84ddc41d72fcb89b.cs
@@ -143,6 +143,7 @@ namespace TestRepro
 			}
 			void IMainWindow_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TPXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TPXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -204,12 +204,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _LoadElementSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		public global::Microsoft.UI.Xaml.Controls.Primitives.ToggleButton LoadElement
@@ -332,6 +337,10 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
+				owner._component_1.SuspendXBind();
+				owner._component_2.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TRDAAPSSTP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TRDAAPSSTP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -178,6 +178,7 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTIXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -241,12 +241,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _inner1Subject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		private global::Microsoft.UI.Xaml.Controls.StackPanel inner1
@@ -482,6 +487,9 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
+				owner._component_1.SuspendXBind();
 			}
 		}
 		private static bool TryGetInstance_xBind_1(global::TestRepro.MainPage ___tctx, out object o)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTPWXS/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTPWXS/XamlCodeGenerator_GlobalStaticResources.cs
@@ -24,12 +24,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTW/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TTW/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -109,12 +109,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
@@ -183,6 +188,8 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
 			}
 		}
 		private static bool TryGetInstance_xBind_1(global::TestRepro.MainPage ___tctx, out object o)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TVBP/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TVBP/XamlCodeGenerator_GlobalStaticResources.cs
@@ -24,12 +24,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/TXBRXLE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -205,12 +205,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _LoadElementSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		public global::Microsoft.UI.Xaml.Controls.Primitives.ToggleButton LoadElement
@@ -334,6 +339,10 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
+				owner._component_1.SuspendXBind();
+				owner._component_2.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBENIT/XamlCodeGenerator_Binding_ElementName_In_Template_66bf0a54f1801c397a6fa4930a237eca.cs
@@ -164,6 +164,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 					if (__rootInstance is FrameworkElement __fe)
 					{
 						__fe.Loading += __UpdateBindingsAndResources;
+						__fe.Unloaded += __StopTracking;
 					}
 					if (__rootInstance is DependencyObject d)
 					{
@@ -203,8 +204,10 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 				private global::Microsoft.UI.Xaml.Data.ElementNameSubject _topLevelSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject(isRuntimeBound: true, name: "topLevel");
 				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 				{
-					var owner = this;
 					_component_0.UpdateResourceBindings();
+				}
+				private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+				{
 				}
 			}
 		}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBOP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WBOP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -108,12 +108,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.ToggleSwitch _component_0
@@ -169,6 +174,8 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WDLSNVS/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WDLSNVS/XamlCodeGenerator_GlobalStaticResources.cs
@@ -24,12 +24,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WEOTLNDO/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WEOTLNDO/XamlCodeGenerator_GlobalStaticResources.cs
@@ -24,12 +24,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WLCHB/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WLCHB/XamlCodeGenerator_GlobalStaticResources.cs
@@ -24,12 +24,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WLCHB/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WLCHB/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -150,12 +150,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Data.ElementNameSubject _innerTextBlockSubject = new global::Microsoft.UI.Xaml.Data.ElementNameSubject();
 		public global::Microsoft.UI.Xaml.Controls.TextBlock innerTextBlock
@@ -248,6 +253,8 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
 			}
 		}
 		private static bool TryGetInstance_xBind_1(global::TestRepro.MainPage ___tctx, out object o)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNBOP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNBOP/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -108,12 +108,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.ToggleSwitch _component_0
@@ -169,6 +174,8 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WNWSRAE/XamlCodeGenerator_ResourceDictionary_When_Nested_With_Sibling_Ref_And_Event_6d62c5ee15120ed189e095faf6d37e20.cs
@@ -162,6 +162,7 @@ namespace Uno.UI.Tests.Given_ResourceDictionary
 					if (__rootInstance is FrameworkElement __fe)
 					{
 						__fe.Loading += __UpdateBindingsAndResources;
+						__fe.Unloaded += __StopTracking;
 					}
 					if (__rootInstance is DependencyObject d)
 					{
@@ -200,8 +201,10 @@ namespace Uno.UI.Tests.Given_ResourceDictionary
 				}
 				private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 				{
-					var owner = this;
-					_component_0.UpdateResourceBindings();
+					_component_0.UpdateResourceBindings(resourceContextProvider: _component_1);
+				}
+				private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+				{
 				}
 				[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 				[global::System.Runtime.CompilerServices.CreateNewOnMetadataUpdate]

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPADNE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPADNE/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -150,12 +150,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
@@ -239,6 +244,10 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
+				owner._component_1.SuspendXBind();
+				owner._component_2.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE__name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE__name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -150,12 +150,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
@@ -239,6 +244,10 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
+				owner._component_1.SuspendXBind();
+				owner._component_2.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE_m_name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE_m_name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -150,12 +150,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
@@ -239,6 +244,10 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
+				owner._component_1.SuspendXBind();
+				owner._component_2.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE_name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WOPAE_name/XamlCodeGenerator_MainPage_d6cd66944958ced0c513e0a04797b51d.cs
@@ -150,12 +150,17 @@ namespace TestRepro
 
 			Bindings = new MainPage_Bindings(this);
 			((global::Microsoft.UI.Xaml.FrameworkElement)this).Loading += __UpdateBindingsAndResources;
+			((global::Microsoft.UI.Xaml.FrameworkElement)this).Unloaded += __StopTracking;
 		}
 		partial void OnInitializeCompleted();
 		private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)
 		{
 			this.Bindings.Update();
 			this.Bindings.UpdateResources();
+		}
+		private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			this.Bindings.StopTracking();
 		}
 		private global::Microsoft.UI.Xaml.Markup.ComponentHolder _component_0_Holder = new global::Microsoft.UI.Xaml.Markup.ComponentHolder(isWeak: true);
 		private global::Microsoft.UI.Xaml.Controls.TextBlock _component_0
@@ -239,6 +244,10 @@ namespace TestRepro
 			}
 			void IMainPage_Bindings.StopTracking()
 			{
+				var owner = Owner;
+				owner._component_0.SuspendXBind();
+				owner._component_1.SuspendXBind();
+				owner._component_2.SuspendXBind();
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WSXN/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WSXN/XamlCodeGenerator_GlobalStaticResources.cs
@@ -24,15 +24,15 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
 				global::SkiaSharp.Views.Windows.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
 				global::SkiaSharp.Views.Windows.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
 				global::SkiaSharp.Views.Windows.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WXB/XamlCodeGenerator_GlobalStaticResources.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WXB/XamlCodeGenerator_GlobalStaticResources.cs
@@ -24,12 +24,12 @@ namespace MyProject
 			if (!_initialized)
 			{
 				_initialized = true;
-				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.Initialize();
-				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
+				global::Uno.UI.GlobalStaticResources.Initialize();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterDefaultStyles();
-				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterDefaultStyles();
 				global::Uno.UI.Toolkit.GlobalStaticResources.RegisterResourceDictionariesBySource();
+				global::Uno.UI.GlobalStaticResources.RegisterResourceDictionariesBySource();
 			}
 		}
 		public static void RegisterDefaultStyles()

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WXOWCP/XamlCodeGenerator_Binding_Xaml_Object_With_Common_Properties_4891310bc693a433ba9a8e9f5113f94f.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WXOWCP/XamlCodeGenerator_Binding_Xaml_Object_With_Common_Properties_4891310bc693a433ba9a8e9f5113f94f.cs
@@ -199,6 +199,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 			}
 			void IBinding_Xaml_Object_With_Common_Properties_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WXOWXOP/XamlCodeGenerator_Binding_Xaml_Object_With_Xaml_Object_Properties_5147419e44d1bc3e3f86860ad528476f.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Out/WXOWXOP/XamlCodeGenerator_Binding_Xaml_Object_With_Xaml_Object_Properties_5147419e44d1bc3e3f86860ad528476f.cs
@@ -191,6 +191,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.BindingTests.Controls
 			}
 			void IBinding_Xaml_Object_With_Xaml_Object_Properties_Bindings.StopTracking()
 			{
+				var owner = Owner;
 			}
 		}
 	}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
@@ -94,7 +94,6 @@ namespace Uno.UI.SourceGenerators.Tests.Verifiers
 			private readonly ResourceFile[] _resourceFiles;
 
 			public bool EnableFuzzyMatching { get; set; } = true;
-			public bool DisableBuildReferences { get; set; }
 			public Dictionary<string, string>? GlobalConfigOverride { get; set; }
 
 			protected TestBase(XamlFile xamlFile, [CallerFilePath] string testFilePath = "", [CallerMemberName] string testMethodName = "")
@@ -216,10 +215,8 @@ build_metadata.AdditionalFiles.SourceItemGroup = PRIResource
 
 			protected override Project ApplyCompilationOptions(Project project)
 			{
-				if (!DisableBuildReferences)
-				{
-					project = project.AddMetadataReferences(BuildUnoReferences());
-				}
+				project = project
+					.AddMetadataReferences(BuildUnoReferences());
 
 				return base.ApplyCompilationOptions(project);
 			}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Verifiers/CSGenerator.cs
@@ -216,7 +216,7 @@ build_metadata.AdditionalFiles.SourceItemGroup = PRIResource
 			protected override Project ApplyCompilationOptions(Project project)
 			{
 				project = project
-					.AddMetadataReferences(BuildUnoReferences());
+					.AddMetadataReferences(UnoAssemblyHelper.LoadAssemblies());
 
 				return base.ApplyCompilationOptions(project);
 			}
@@ -305,52 +305,6 @@ build_metadata.AdditionalFiles.SourceItemGroup = PRIResource
 				Directory.CreateDirectory(resourceDirectory);
 				File.WriteAllText(filePath, tree.GetText().ToString(), tree.Encoding);
 			}
-
-			private static MetadataReference[] BuildUnoReferences()
-			{
-				const string configuration =
-#if DEBUG
-					"Debug";
-#else
-					"Release";
-#endif
-
-				var availableTargets = new[] {
-					// On CI the test assemblies set must be first, as it contains all
-					// dependent assemblies, which the other platforms don't (see DisablePrivateProjectReference).
-					Path.Combine("Uno.UI.Tests", configuration, "net8.0"),
-					Path.Combine("Uno.UI.Skia", configuration, "net8.0"),
-					Path.Combine("Uno.UI.Reference", configuration, "net8.0"),
-					Path.Combine("Uno.UI.Tests", configuration, "net9.0"),
-					Path.Combine("Uno.UI.Skia", configuration, "net9.0"),
-					Path.Combine("Uno.UI.Reference", configuration, "net9.0"),
-				};
-
-				var unoUIBase = Path.Combine(
-					Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
-					"..",
-					"..",
-					"..",
-					"..",
-					"..",
-					"Uno.UI",
-					"bin"
-					);
-
-				var unoTarget = availableTargets
-					.Select(t => Path.Combine(unoUIBase, t, "Uno.UI.dll"))
-					.FirstOrDefault(File.Exists);
-
-				if (unoTarget is null)
-				{
-					throw new InvalidOperationException($"Unable to find Uno.UI.dll in {string.Join(",", availableTargets)}");
-				}
-
-				return Directory.GetFiles(Path.GetDirectoryName(unoTarget)!, "*.dll")
-							.Select(f => MetadataReference.CreateFromFile(Path.GetFullPath(f)))
-							.ToArray();
-			}
-
 		}
 	}
 }

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1090,16 +1090,22 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				using (writer.BlockInvariant($"if (__rootInstance is FrameworkElement __fe)"))
 				{
 					writer.AppendLineIndented("__fe.Loading += __UpdateBindingsAndResources;");
+					writer.AppendLineIndented("__fe.Unloaded += __StopTracking;");
 
 					CurrentScope.CallbackMethods.Add(eventWriter =>
 					{
 						using (writer.BlockInvariant("private void __UpdateBindingsAndResources(global::Microsoft.UI.Xaml.FrameworkElement s, object e)"))
 						{
-							eventWriter.AppendLineIndented("var owner = this;");
-
-							BuildComponentResouceBindingUpdates(eventWriter);
+							BuildComponentResourceBindingUpdates(eventWriter);
 							BuildXBindApply(eventWriter);
 							BuildxBindEventHandlerInitializers(eventWriter, CurrentScope.xBindEventsHandlers);
+						}
+					});
+					CurrentScope.CallbackMethods.Add(eventWriter =>
+					{
+						using (writer.BlockInvariant("private void __StopTracking(object s, global::Microsoft.UI.Xaml.RoutedEventArgs e)"))
+						{
+							BuildXBindSuspend(eventWriter);
 						}
 					});
 				}
@@ -1122,7 +1128,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 		}
 
-		private void BuildComponentResouceBindingUpdates(IIndentedStringBuilder writer)
+		private void BuildComponentResourceBindingUpdates(IIndentedStringBuilder writer, string prefix = "")
 		{
 			for (var i = 0; i < CurrentScope.Components.Count; i++)
 			{
@@ -1130,20 +1136,43 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				if (HasMarkupExtensionNeedingComponent(component.XamlObject) && IsDependencyObject(component.XamlObject))
 				{
-					writer.AppendLineIndented($"{component.MemberName}.UpdateResourceBindings();");
+					var contextProvider = component.ResourceContext is { } context
+						? $"resourceContextProvider: {prefix}{context.MemberName}"
+						: "";
+
+					writer.AppendLineIndented($"{prefix}{component.MemberName}.UpdateResourceBindings({contextProvider});");
 				}
 			}
 		}
 
-		private void BuildXBindApply(IIndentedStringBuilder writer)
+		private void BuildXBindApply(IIndentedStringBuilder writer, string prefix = "")
 		{
 			for (var i = 0; i < CurrentScope.Components.Count; i++)
 			{
 				var component = CurrentScope.Components[i];
 
-				if (HasXBindMarkupExtension(component.XamlObject) && IsDependencyObject(component.XamlObject))
+				if (HasXBindMarkupExtension(component.XamlObject))
 				{
-					writer.AppendLineIndented($"{component.MemberName}.ApplyXBind();");
+					var isDO = IsDependencyObject(component.XamlObject);
+					var wrap = !isDO ? ".GetDependencyObjectForXBind()" : "";
+
+					writer.AppendLineIndented($"{prefix}{component.MemberName}{wrap}.ApplyXBind();");
+				}
+			}
+		}
+
+		private void BuildXBindSuspend(IIndentedStringBuilder writer, string prefix = "")
+		{
+			for (var i = 0; i < CurrentScope.Components.Count; i++)
+			{
+				var component = CurrentScope.Components[i];
+
+				if (HasXBindMarkupExtension(component.XamlObject))
+				{
+					var isDO = IsDependencyObject(component.XamlObject);
+					var wrap = !isDO ? ".GetDependencyObjectForXBind()" : "";
+
+					writer.AppendLineIndented($"{prefix}{component.MemberName}{wrap}.SuspendXBind();");
 				}
 			}
 		}
@@ -1281,53 +1310,20 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					{
 						writer.AppendLineIndented($"var owner = Owner;");
 
-						for (var i = 0; i < CurrentScope.Components.Count; i++)
-						{
-							var component = CurrentScope.Components[i];
-
-							if (HasXBindMarkupExtension(component.XamlObject))
-							{
-								var isDependencyObject = IsDependencyObject(component.XamlObject);
-
-								var wrapInstance = isDependencyObject ? "" : ".GetDependencyObjectForXBind()";
-
-								writer.AppendLineIndented($"owner.{component.MemberName}{wrapInstance}.ApplyXBind();");
-							}
-
-							BuildxBindEventHandlerInitializers(writer, CurrentScope.xBindEventsHandlers, "owner.");
-						}
+						BuildXBindApply(writer, "owner.");
+						BuildxBindEventHandlerInitializers(writer, CurrentScope.xBindEventsHandlers, "owner.");
 					}
 					using (writer.BlockInvariant($"void {bindingsInterfaceName}.UpdateResources()"))
 					{
 						writer.AppendLineIndented($"var owner = Owner;");
 
-						for (var i = 0; i < CurrentScope.Components.Count; i++)
-						{
-							var component = CurrentScope.Components[i];
-
-							if (HasMarkupExtensionNeedingComponent(component.XamlObject) && IsDependencyObject(component.XamlObject))
-							{
-								writer.AppendLineIndented($"owner.{component.MemberName}.UpdateResourceBindings({(component.ResourceContext is { } ctx ? $"resourceContextProvider: owner.{ctx.MemberName}" : "")});");
-							}
-						}
+						BuildComponentResourceBindingUpdates(writer, "owner.");
 					}
 					using (writer.BlockInvariant($"void {bindingsInterfaceName}.StopTracking()"))
 					{
 						writer.AppendLineIndented($"var owner = Owner;");
 
-						for (var i = 0; i < CurrentScope.Components.Count; i++)
-						{
-							var component = CurrentScope.Components[i];
-
-							if (HasXBindMarkupExtension(component.XamlObject))
-							{
-								var isDependencyObject = IsDependencyObject(component.XamlObject);
-
-								var wrapInstance = isDependencyObject ? "" : ".GetDependencyObjectForXBind()";
-
-								writer.AppendLineIndented($"owner.{component.MemberName}{wrapInstance}.SuspendXBind();");
-							}
-						}
+						BuildXBindSuspend(writer, "owner.");
 					}
 				}
 			}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -813,7 +813,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			TryAnnotateWithGeneratorSource(writer);
 			foreach (var applyMethod in CurrentScope.ExplicitApplyMethods)
 			{
-				writer.AppendLineIndented(applyMethod);
+				writer.AppendMultiLineIndented(applyMethod);
 			}
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlLazyApplyBlockIIndentedStringBuilder.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlLazyApplyBlockIIndentedStringBuilder.cs
@@ -60,14 +60,13 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				_applyOpened = true;
 
-				_inner.Indent(_source.CurrentLevel);
-
 				IDisposable? blockDisposable;
 
 				var delegateString = !_delegateType.IsNullOrEmpty() ? "(" + _delegateType + ")" : "";
 
 				if (_applyPrefix != null)
 				{
+					_inner.Indent(_source.CurrentLevel);
 					blockDisposable = _source.BlockInvariant(".{0}_XamlApply({2}({1} => ", _applyPrefix, _closureName, delegateString);
 				}
 				else if (_exposeContext)
@@ -79,6 +78,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 				else
 				{
+					_inner.Indent(_source.CurrentLevel);
 					blockDisposable = _source.BlockInvariant(".GenericApply({1}(({0}) => ", _closureName, delegateString);
 				}
 
@@ -86,16 +86,24 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					if (_applyPrefix != null || !_exposeContext)
 					{
+						// lambda block
 						_source.Append(_inner.ToString());
 						blockDisposable.Dispose();
+						_source.AppendLineIndented("))");
 					}
 					else if (_exposeContext)
 					{
+						// named method
+						_source.Append("))");
+						_source.AppendLine();
+
 						blockDisposable.Dispose();
 						_onRegisterApplyMethodBody(_inner.ToString());
 					}
-
-					_source.AppendLineIndented("))");
+					else
+					{
+						_source.AppendLineIndented("))");
+					}
 				});
 			}
 		}

--- a/src/SourceGenerators/XamlGenerationTests/TestSetup_SingleXBind.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/TestSetup_SingleXBind.xaml
@@ -1,0 +1,10 @@
+﻿<Page x:Class="XamlGenerationTests.TestSetup_SingleXBind"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:XamlGenerationTests"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d">
+
+	<TextBox Text="{x:Bind VM.Asd, Mode=TwoWay}" />
+</Page>

--- a/src/SourceGenerators/XamlGenerationTests/TestSetup_SingleXBind.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/TestSetup_SingleXBind.xaml
@@ -6,5 +6,20 @@
 	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	  mc:Ignorable="d">
 
-	<TextBox Text="{x:Bind VM.Asd, Mode=TwoWay}" />
+	<Page.Resources>
+		<ControlTemplate x:Key="AsdButtonTemplate" TargetType="Button">
+			<ContentPresenter Tag="{x:Bind Content, Mode=TwoWay}" />
+		</ControlTemplate>
+	</Page.Resources>
+
+	<StackPanel>
+
+		<TextBox Text="{x:Bind VM.Asd, Mode=TwoWay}" />
+
+		<ContentControl x:Name="LazyLoadedHost" x:Load="false">
+			<TextBox Text="{x:Bind VM.Asd, Mode=TwoWay}" />
+		</ContentControl>
+
+	</StackPanel>
+
 </Page>

--- a/src/SourceGenerators/XamlGenerationTests/TestSetup_SingleXBind.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/TestSetup_SingleXBind.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace XamlGenerationTests;
+
+public sealed partial class TestSetup_SingleXBind : Page
+{
+	public TestSetup_SingleXBind()
+	{
+		this.InitializeComponent();
+	}
+
+	public TestSetup_SingleXBind_Data VM { get; set; }
+
+	public class TestSetup_SingleXBind_Data
+	{
+		public string Asd { get; set; }
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindTeardown_Setup.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindTeardown_Setup.xaml
@@ -1,0 +1,7 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.XBindTeardown_Setup"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<TextBox Text="{x:Bind VM.Text, Mode=TwoWay}" />
+
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindTeardown_Setup.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBindTeardown_Setup.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.ComponentModel;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests;
+
+public sealed partial class XBindTeardown_Setup : Page
+{
+	public static event RoutedEventHandler VMAccessDetected;
+
+	public XBindTeardown_Setup()
+	{
+		this.InitializeComponent();
+	}
+
+	public XBindTeardown_Setup_Data VM
+	{
+		get
+		{
+			if (DataContext is { })
+			{
+			}
+			else
+			{
+			}
+
+			VMAccessDetected?.Invoke(this, new());
+			return ((XBindTeardown_Setup_Data_Wrapper)DataContext).Data;
+		}
+	}
+
+	public record XBindTeardown_Setup_Data_Wrapper(XBindTeardown_Setup_Data Data);
+	public class XBindTeardown_Setup_Data : INotifyPropertyChanged
+	{
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		private string _text;
+		public string Text
+		{
+			get => _text;
+			set
+			{
+				if (_text != value)
+				{
+					_text = value;
+					PropertyChanged?.Invoke(this, new(nameof(Text)));
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -434,6 +434,13 @@ namespace Microsoft.UI.Xaml.Data
 				ApplyBinding();
 			}
 		}
+		internal void SuspendCompiledSource()
+		{
+			if (_isCompiledSource && ExplicitSource != null)
+			{
+				SuspendBinding();
+			}
+		}
 
 		internal void ApplyTemplateBindingParent()
 		{
@@ -615,6 +622,8 @@ namespace Microsoft.UI.Xaml.Data
 
 				_subscription.Disposable = null;
 			}
+
+			_isBindingSuspended = false;
 		}
 
 		internal void OnValueChanged(object o)

--- a/src/Uno.UI/UI/Xaml/Data/BindingHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Data/BindingHelper.cs
@@ -40,6 +40,16 @@ namespace Uno.UI.Xaml
 		public static void ApplyXBind(this DependencyObject instance)
 			=> (instance as IDependencyObjectStoreProvider)?.Store.ApplyCompiledBindings();
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static void SuspendXBind(this DependencyObject instance)
+		{
+			// DependencyObjectStore, DependencyPropertyDetailsCollection, and BindingExpression
+			// all keeps track of the binding suspension state. Since we only care about x:Bind here,
+			// it would be easier to skip straight to the BindingExpression, ignoring the first two.
+			(instance as IDependencyObjectStoreProvider)?.Store.SuspendCompiledBindings();
+		}
+
+
 		public static void UpdateResourceBindings(this DependencyObject instance) => UpdateResourceBindings(instance, resourceContextProvider: null);
 		public static void UpdateResourceBindings(this DependencyObject instance, FrameworkElement? resourceContextProvider)
 		{

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.Binder.cs
@@ -153,6 +153,10 @@ namespace Microsoft.UI.Xaml
 		public void ApplyCompiledBindings()
 			=> _properties.ApplyCompiledBindings();
 
+		public void SuspendCompiledBindings()
+			// ignoring local _bindingsSuspended flag, since this operation is applied on the BindingExpression level.
+			=> _properties.SuspendCompiledBindings();
+
 		/// <summary>
 		/// Apply load-time binding updates. Processes the x:Bind markup for the current FrameworkElement, applies load-time ElementName bindings, and updates ResourceBindings.
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.Bindings.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDetailsCollection.Bindings.cs
@@ -48,6 +48,17 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 
+		internal void SuspendCompiledBindings()
+		{
+			// ignoring local _bindingsSuspended flag, since this operation is applied on the BindingExpression level.
+			var bindings = _bindings.Data;
+
+			for (int i = 0; i < bindings.Length; i++)
+			{
+				bindings[i].SuspendCompiledSource();
+			}
+		}
+
 		/// <summary>
 		/// Applies the <see cref="Binding"/> instances which contain an ElementName property
 		/// </summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #19641

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
x:Bind can still trigger when its host is unloaded

## What is the new behavior?
x:Bind will be suspended when its host is unloaded, and resumed on reload.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.