### PR TITLE
fix: Correcting DebugParseContext for replaced elements after HR

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -432,6 +432,11 @@ partial class ClientHotReloadProcessor
 				var oldStore = ((IDependencyObjectStoreProvider)instanceFE).Store;
 				var newStore = ((IDependencyObjectStoreProvider)newInstanceFE).Store;
 				oldStore.ClonePropertiesToAnotherStoreForHotReload(newStore);
+
+				if (instanceFE.DebugParseContext is { } debugParseContext)
+				{
+					newInstanceFE.SetBaseUri(instanceFE.BaseUri.OriginalString, debugParseContext.LocalFileUri, debugParseContext.LineNumber, debugParseContext.LinePosition);
+				}
 #endif
 
 				foreach (var handler in handlers)

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_UserControl.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_UserControl.cs
@@ -42,6 +42,62 @@ public class Given_UserControl : BaseTestClass
 
 		// Validate that the page has been returned to the original text
 		await frame.ValidateTextOnChildTextBlock(UserControl1TextBlockOriginalText, 2);
+
+		await Task.Yield();
+	}
+
+
+	/// <summary>
+	/// Change the Text of a TextBlock inside a UserControl and validate the
+	/// DebugParseContext is still correct
+	/// </summary>
+	[TestMethod]
+	public async Task Check_Change_UserControl_DebugPareContext()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+
+		var frame = new Microsoft.UI.Xaml.Controls.Frame();
+		UnitTestsUIContentHelper.Content = frame;
+
+		frame.Navigate(typeof(HR_Frame_Pages_Page1));
+
+		FrameworkElement.DebugParseContextDetails? existingContext = default;
+
+		// Retrieve the existing DebugParseContext
+		await frame.ValidateChildElement<HR_Frame_Pages_UC1>(
+			async uc =>
+			{
+				existingContext = uc.DebugParseContext;
+				Assert.IsNotNull(existingContext);
+				await Task.CompletedTask;
+			},
+			0
+		);
+
+		// Check the updated text of the TextBlock
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_UC1>(
+			UserControl1TextBlockOriginalText,
+			UserControl1TextBlockChangedText,
+			() => frame.ValidateTextOnChildTextBlock(UserControl1TextBlockChangedText, 2),
+			ct);
+
+		// Validate that the DebugParseContext is still correct
+		await frame.ValidateChildElement<HR_Frame_Pages_UC1>(
+			async uc =>
+			{
+				var updatedContext = uc.DebugParseContext;
+				Assert.IsNotNull(updatedContext);
+				if (existingContext is { } && updatedContext is { })
+				{
+					Assert.AreEqual(existingContext.LocalFileUri, updatedContext.LocalFileUri, "DebugParseContext: LocalFileUri should match");
+					Assert.AreEqual(existingContext.LineNumber, updatedContext.LineNumber, "DebugParseContext: LineNumber should match");
+					Assert.AreEqual(existingContext.LinePosition, updatedContext.LinePosition, "DebugParseContext: LinePosition should match");
+				}
+				await Task.CompletedTask;
+			},
+			0
+		);
+
 		await Task.Yield();
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

When elements are replaced during HR they get a DebugParseContext based on the source code for the control (since it's manually created in code). 

## What is the new behavior?

The DebugParseContext of the replacement element is set to be the same as the element it's replacing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
