### PR TITLE
chore: fix PackageDiffIgnore.xml merge issue

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1988,8 +1988,8 @@
 			<!-- END DiagnosticsOverlay -->
 		</Methods>
 	</IgnoreSet>
-    
-  	<IgnoreSet baseVersion="5.6">
+
+	<IgnoreSet baseVersion="5.6">
 		<Assemblies>
 		</Assemblies>
 
@@ -2025,26 +2025,7 @@
 			<Member fullName="System.Double Microsoft.UI.Xaml.Controls.ProgressBarTemplateSettings.get_ContainerAnimationEndPosition2()" reason="Change to Container2AnimationEndPosition which aligns the API with WinUI3 and TemplateSettings should only be used internally" />
 			<Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.ProgressBarTemplateSettings.get_ContainerAnimationEndPosition2Property()" reason="Change to Container2AnimationEndPositionProperty which aligns the API with WinUI3 and TemplateSettings should only be used internally" />
 			<Member fullName="System.Void Microsoft.UI.Xaml.Controls.InfoBadge.set_TemplateSettings(Microsoft.UI.Xaml.Controls.InfoBadgeTemplateSettings value)" reason="No setter in MUX" />
-		</Methods>
-	</IgnoreSet>
 
-	<IgnoreSet baseVersion="5.6">
-		<Assemblies>
-		</Assemblies>
-
-		<Types>
-		</Types>
-
-		<Events>
-		</Events>
-
-		<Fields>
-		</Fields>
-
-		<Properties>
-		</Properties>
-
-		<Methods>
 			<Member fullName="System.Void Microsoft.UI.Xaml.Automation.AutomationProperties.SetAccessibilityeView(Microsoft.UI.Xaml.DependencyObject element, Microsoft.UI.Xaml.Automation.Peers.AccessibilityView value)" reason="Typo" />
 			<Member fullName="System.Void Windows.UI.Xaml.Automation.AutomationProperties.SetAccessibilityeView(Windows.UI.Xaml.DependencyObject element, Windows.UI.Xaml.Automation.Peers.AccessibilityView value)" reason="Typo" />
 			<Member fullName="System.Object Uno.UI.Xaml.Media.Imaging.Svg.ISvgProvider::TryGetLoadedDataAsPictureAsync()" reason="Needed internally for ImageBrushes with SVG assets on Skia." />


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
## What is the new behavior?
fix ci compilation error with SetAccessibilityeView:
> EXEC : error : Removed method System.Void Windows.UI.Xaml.Automation.AutomationProperties.SetAccessibilityeView(Windows.UI.Xaml.DependencyObject element, Windows.UI.Xaml.Automation.Peers.AccessibilityView value) not found in ignore set. [C:\a\1\s\Build\Uno.UI.Build.csproj]

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.