### PR TITLE
fix(droid): TextBox default foreground not applied

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -771,6 +771,26 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			Assert.AreEqual("Something", textBox.TextBoxView.Text);
 		}
+
+		[TestMethod]
+		[DataRow(false)]
+		[DataRow(true)]
+		public async Task When_Default_Foreground_TextBoxView(bool useDarkTheme)
+		{
+			using var _ = useDarkTheme ? ThemeHelper.UseDarkTheme() : default;
+
+			var SUT = new TextBox { Text = "Asd" };
+
+			await UITestHelper.Load(SUT);
+			var expected = GetBrushColor(SUT.Foreground);
+			var forwarded = GetBrushColor(SUT.TextBoxView.Foreground);
+			var native = new Color((uint)SUT.TextBoxView.CurrentTextColor);
+
+			Assert.AreEqual(expected, forwarded);
+			Assert.AreEqual(expected, native);
+
+			Color? GetBrushColor(Brush brush) => (brush as SolidColorBrush)?.Color;
+		}
 #endif
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -214,6 +214,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 		partial void OnForegroundColorChangedPartial(Brush newValue)
 		{
+			if (_textBoxView != null)
+			{
+				_textBoxView.Foreground = newValue;
+			}
 		}
 
 		partial void OnInputScopeChangedPartial(InputScope newValue)


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/ziidms-private#82

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
AutoSuggestionBox default Foreground is not inherited by its TextBoxView. (note: explicit or late set value aren't imparted.)

## What is the new behavior?
AutoSuggestionBox default Foreground is applied.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.