### PR TITLE
feat: Added tracing instrumentation into Hot Reload

### DIFF
--- a/src/Uno.UI.RemoteControl.Messaging/EventTracingProvider.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/EventTracingProvider.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics.Tracing;
+
+namespace Uno.UI.RemoteControl.Messaging;
+
+[EventSource(Name = "Uno.HotReload.TracingProvider")]
+internal class EventTracingProvider : EventSource
+{
+	public static EventTracingProvider Instance { get; } = new EventTracingProvider();
+
+	[Event(1, Level = EventLevel.Informational, Message = "Force hot reload start, requestCorrelationId={0}")]
+	public void OnForceHotReloadStart(long requestCorrelationId) => WriteEvent(1, requestCorrelationId);
+
+	[Event(2, Level = EventLevel.Informational, Message = "Force hot reload stop, requestCorrelationId={0}, success={1}")]
+	public void OnForceHotReloadStop(long requestCorrelationId, bool success) => WriteEvent(2, requestCorrelationId, success);
+
+	[Event(3, Level = EventLevel.Informational, Message = "Update file start, requestCorrelationId={0}, requestFileFullName={1}, requestForceSaveOnDisk={2}")]
+	public void OnUpdateFileStart(long requestCorrelationId, string requestFileFullName, bool requestForceSaveOnDisk)
+		=> WriteEvent(3, requestCorrelationId, requestFileFullName, requestForceSaveOnDisk);
+
+	[Event(4, Level = EventLevel.Informational, Message = "Update file stop, requestCorrelationId={0}, success={1}")]
+	public void OnUpdateFileStop(long requestCorrelationId, bool success) => WriteEvent(4, requestCorrelationId, success);
+
+	[Event(5, Level = EventLevel.Informational, Message = "Hot reload event, source={0}, event={1}")]
+	public void OnHotReloadEvent(string source, string @event) => WriteEvent(5, source, @event);
+}

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -17,6 +17,7 @@ using Uno.Disposables;
 using Uno.Extensions;
 using Uno.UI.RemoteControl.HotReload;
 using Uno.UI.RemoteControl.HotReload.Messages;
+using Uno.UI.RemoteControl.Messaging;
 using Uno.UI.RemoteControl.Messaging.HotReload;
 using Uno.UI.RemoteControl.Messaging.IdeChannel;
 
@@ -134,6 +135,11 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 		private async ValueTask Notify(HotReloadEvent evt, HotReloadEventSource source = HotReloadEventSource.DevServer)
 		{
+			if (EventTracingProvider.Instance.IsEnabled())
+			{
+				EventTracingProvider.Instance.OnHotReloadEvent(source.ToString(), evt.ToString());
+			}
+
 			switch (evt)
 			{
 				// Global state events
@@ -164,6 +170,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				case HotReloadEvent.NoChanges:
 					await (await StartOrContinueHotReload()).Complete(HotReloadServerResult.NoChanges);
 					break;
+
 				case HotReloadEvent.Failed:
 					await (await StartOrContinueHotReload()).Complete(HotReloadServerResult.Failed);
 					break;

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -9,6 +9,9 @@
 	<Import Project="../targetframework-override-noplatform.props" />
 
 	<ItemGroup>
+		<Compile Include="..\Uno.UI.RemoteControl.Messaging\EventTracingProvider.cs">
+		  <Link>HotReload\Messages\EventTracingProvider.cs</Link>
+		</Compile>
 		<Compile Include="..\Uno.UI.RemoteControl\HotReload\Messages\**\*.cs" Link="HotReload/Messages/%(Filename)%(Extension)" />
 	</ItemGroup>
 


### PR DESCRIPTION
# Feature

This PR introduces tracing instrumentation into the hot reload workflow, enabling ETW-based event logging to aid performance analysis with PerfView.

* Integrated tracing events into hot reload operations and in the VS add-on.
* Implemented a new EventTracingProvider for ETW event logging under the name `Uno.HotReload.TracingProvider`

> [!NOTE]
> **DRAFT**: Still improving it and needs some docs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
