### PR TITLE
Misc fixes for pointers on skia

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/AppleUIKitPointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/AppleUIKitPointerInputSource.cs
@@ -64,8 +64,6 @@ internal sealed class AppleUIKitCorePointerInputSource : IUnoCorePointerInputSou
 	{
 	}
 
-
-
 	internal void TouchesBegan(UIView source, NSSet touches, UIEvent? evt)
 	{
 		try

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/AppleUIKitPointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/AppleUIKitPointerInputSource.cs
@@ -162,7 +162,11 @@ internal sealed class AppleUIKitCorePointerInputSource : IUnoCorePointerInputSou
 
 	private PointerEventArgs CreatePointerEventArgs(UIView source, UITouch touch)
 	{
+#if __TVOS__
+		var position = touch.LocationInView(source);
+#else
 		var position = touch.GetPreciseLocation(source);
+#endif
 		var pointerDeviceType = touch.Type.ToPointerDeviceType();
 		var isInContact = touch.Phase == UITouchPhase.Began
 			|| touch.Phase == UITouchPhase.Moved
@@ -212,7 +216,11 @@ internal sealed class AppleUIKitCorePointerInputSource : IUnoCorePointerInputSou
 		: null;
 
 	private void TraceStart(UIView source, NSSet touches, [CallerMemberName] string action = "")
+#if __TVOS__
+		=> _trace?.Invoke($"<{action} touches={touches.Count} src={source.GetDebugName()}>");
+#else
 		=> _trace?.Invoke($"<{action} touches={touches.Count} src={source.GetDebugName()} multi={source.MultipleTouchEnabled} exclusive={source.ExclusiveTouch}>");
+#endif
 
 	private void TraceSingle(PointerEventArgs args, [CallerMemberName] string action = "")
 		=> _trace?.Invoke($"{action}: {args}>");
@@ -221,6 +229,6 @@ internal sealed class AppleUIKitCorePointerInputSource : IUnoCorePointerInputSou
 		=> _trace?.Invoke($"</{action}>");
 
 	private void TraceError(Exception error, [CallerMemberName] string action = "")
-		=> _trace?.Invoke($"</{action} error=true>\r\n" + error); 
+		=> _trace?.Invoke($"</{action} error=true>\r\n" + error);
 	#endregion
 }

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/AppleUIKitWindow.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/AppleUIKitWindow.cs
@@ -36,18 +36,6 @@ internal class AppleUIKitWindow : UIWindow
 	internal ICoreWindowEvents? OwnerEvents { get; private set; }
 #endif
 
-	public override void TouchesBegan(NSSet touches, UIEvent? evt) =>
-		AppleUIKitCorePointerInputSource.Instance.TouchesBegan(this, touches, evt);
-
-	public override void TouchesMoved(NSSet touches, UIEvent? evt) =>
-		AppleUIKitCorePointerInputSource.Instance.TouchesMoved(this, touches, evt);
-
-	public override void TouchesEnded(NSSet touches, UIEvent? evt) =>
-		AppleUIKitCorePointerInputSource.Instance.TouchesEnded(this, touches, evt);
-
-	public override void TouchesCancelled(NSSet touches, UIEvent? evt) =>
-		AppleUIKitCorePointerInputSource.Instance.TouchesCancelled(this, touches, evt);
-
 	public override void PressesEnded(NSSet<UIPress> presses, UIPressesEvent evt)
 	{
 		if (!UnoKeyboardInputSource.Instance.TryHandlePresses(presses, evt, this))

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/RootViewController.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/RootViewController.cs
@@ -284,6 +284,30 @@ internal class RootViewController : UINavigationController, IRotationAwareViewCo
 	}
 #endif
 
+	public override void TouchesBegan(NSSet touches, UIEvent? evt)
+	{
+		AppleUIKitCorePointerInputSource.Instance.TouchesBegan(this.View!, touches, evt);
+		base.TouchesBegan(touches, evt);
+	}
+
+	public override void TouchesMoved(NSSet touches, UIEvent? evt)
+	{
+		AppleUIKitCorePointerInputSource.Instance.TouchesMoved(this.View!, touches, evt);
+		base.TouchesMoved(touches, evt);
+	}
+
+	public override void TouchesEnded(NSSet touches, UIEvent? evt)
+	{
+		AppleUIKitCorePointerInputSource.Instance.TouchesEnded(this.View!, touches, evt);
+		base.TouchesEnded(touches, evt);
+	}
+
+	public override void TouchesCancelled(NSSet touches, UIEvent? evt)
+	{
+		AppleUIKitCorePointerInputSource.Instance.TouchesCancelled(this.View!, touches, evt);
+		base.TouchesCancelled(touches, evt);
+	}
+
 	public override void MotionEnded(UIEventSubtype motion, UIEvent? evt)
 	{
 #if !__TVOS__

--- a/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Input/Given_GestureRecognizer.cs
@@ -1005,7 +1005,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			// flick at 2 px/ms
 			sut.ProcessDownEvent(10, 10, ts: 0);
 			sut.ProcessMoveEvent(100, 100, ts: 100 * MicrosecondsPerMillisecond);
-			sut.ProcessUpEvent(102, 102, ts: 101 * MicrosecondsPerMillisecond);
+			sut.ProcessUpEvent(104, 104, ts: 102 * MicrosecondsPerMillisecond);
 
 			sut.RunInertiaSync();
 
@@ -1038,8 +1038,8 @@ namespace Uno.UI.Tests.Windows_UI_Input
 				v => v.Delta().IsInertial(),
 				v => v.Delta().IsInertial(),
 				v => v.Delta().IsInertial(),
-				v => v.Delta().IsInertial().WithCumulative(tX: 1090.40002441406, tY: 1090.40002441406),
-				v => v.End().WithCumulative(tX: 1090.40002441406, tY: 1090.40002441406)
+				v => v.Delta().IsInertial().WithCumulative(tX: 1092.40002441406, tY: 1092.40002441406),
+				v => v.End().WithCumulative(tX: 1092.40002441406, tY: 1092.40002441406)
 			);
 		}
 
@@ -1052,7 +1052,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			// flick at 2 px/ms
 			sut.ProcessDownEvent(10, 10, ts: 0);
 			sut.ProcessMoveEvent(100, 100, ts: 100 * MicrosecondsPerMillisecond);
-			sut.ProcessUpEvent(102, 102, ts: 101 * MicrosecondsPerMillisecond);
+			sut.ProcessUpEvent(104, 104, ts: 102 * MicrosecondsPerMillisecond);
 
 			sut.RunInertiaSync();
 
@@ -1085,8 +1085,8 @@ namespace Uno.UI.Tests.Windows_UI_Input
 				v => v.Delta().IsInertial(),
 				v => v.Delta().IsInertial(),
 				v => v.Delta().IsInertial(),
-				v => v.Delta().IsInertial().WithCumulative(tX: 1090.40002441406, tY: 0),
-				v => v.End().WithCumulative(tX: 1090.40002441406, tY: 0)
+				v => v.Delta().IsInertial().WithCumulative(tX: 1092.40002441406, tY: 0),
+				v => v.End().WithCumulative(tX: 1092.40002441406, tY: 0)
 			);
 		}
 
@@ -1099,7 +1099,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			// flick at 2 px/ms
 			sut.ProcessDownEvent(10, 10, ts: 0);
 			sut.ProcessMoveEvent(100, 100, ts: 100 * MicrosecondsPerMillisecond);
-			sut.ProcessUpEvent(102, 102, ts: 101 * MicrosecondsPerMillisecond);
+			sut.ProcessUpEvent(104, 104, ts: 102 * MicrosecondsPerMillisecond);
 
 			sut.RunInertiaSync();
 
@@ -1132,8 +1132,8 @@ namespace Uno.UI.Tests.Windows_UI_Input
 				v => v.Delta().IsInertial(),
 				v => v.Delta().IsInertial(),
 				v => v.Delta().IsInertial(),
-				v => v.Delta().IsInertial().WithCumulative(tX: 0, tY: 1090.40002441406),
-				v => v.End().WithCumulative(tX: 0, tY: 1090.40002441406)
+				v => v.Delta().IsInertial().WithCumulative(tX: 0, tY: 1092.40002441406),
+				v => v.End().WithCumulative(tX: 0, tY: 1092.40002441406)
 			);
 		}
 
@@ -1146,7 +1146,7 @@ namespace Uno.UI.Tests.Windows_UI_Input
 			// flick at 2 px/ms
 			sut.ProcessDownEvent(10, 10, ts: 0);
 			sut.ProcessMoveEvent(100, 100, ts: 100 * MicrosecondsPerMillisecond);
-			sut.ProcessUpEvent(98, 98, ts: 101 * MicrosecondsPerMillisecond);
+			sut.ProcessUpEvent(96, 96, ts: 102 * MicrosecondsPerMillisecond);
 
 			sut.RunInertiaSync();
 
@@ -1179,8 +1179,8 @@ namespace Uno.UI.Tests.Windows_UI_Input
 				v => v.Delta().IsInertial(),
 				v => v.Delta().IsInertial(),
 				v => v.Delta().IsInertial(),
-				v => v.Delta().IsInertial().WithCumulative(tX: -910.40002441406, tY: -910.40002441406),
-				v => v.End().WithCumulative(tX: -910.40002441406, tY: -910.40002441406)
+				v => v.Delta().IsInertial().WithCumulative(tX: -912.40002441406, tY: -912.40002441406),
+				v => v.End().WithCumulative(tX: -912.40002441406, tY: -912.40002441406)
 			);
 		}
 

--- a/src/Uno.UI/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/GestureRecognizer.Manipulation.cs
@@ -491,42 +491,6 @@ namespace Windows.UI.Input
 				};
 			}
 
-			//private record struct ManipulationUpdate(
-			//	ulong Timestamp,
-			//	ManipulationDelta Cumulative,
-			//	ManipulationDelta Delta,
-			//	ManipulationVelocities Velocities);
-
-			//private ManipulationUpdate GetUpdateSinceLastEvent()
-			//{
-			//	var origins = _origins;
-			//	var currents = _currents;
-			//	var lastEvent = _lastPublishedState;
-
-			//	// The _currents.Timestamp is not updated once inertia as started, we must get the elapsed duration from the inertia processor
-			//	// (and not compare it to PointerPoint.Timestamp in any way, cf. remarks on InertiaProcessor.Elapsed)
-			//	var elapsedMicroseconds = _inertia?.Elapsed.TotalMicroseconds ?? (currents.Timestamp - lastEvent.Timestamp);
-			//	var elapsedMs = elapsedMicroseconds / 1000;
-
-			//	var cumulative = GetCumulative(/* origins, currents*/);
-			//	var delta = GetDelta(lastEvent.SumOfDelta, cumulative);
-
-			//	// With uno a single native event might produce multiple managed pointer events.
-			//	// In that case we would get an empty velocities ... which is often not relevant!
-			//	// When we detect that case, we prefer to replay the last known velocities.
-			//	ManipulationVelocities velocities;
-			//	if (delta.IsEmpty || elapsedMs == 0)
-			//	{
-			//		velocities = _lastRelevantVelocities; // TODO: Merge to LastEvent!
-			//	}
-			//	else
-			//	{
-			//		velocities = GetVelocities(delta, elapsedMs);
-			//	}
-
-			//	return new ManipulationUpdate(currents.Timestamp, cumulative, delta, velocities);
-			//}
-
 			private ManipulationDelta GetDelta(ManipulationDelta cumulative)
 			{
 				var deltaSum = _lastPublishedState.SumOfDelta;

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -280,7 +280,7 @@ partial class InputManager
 
 				if (_trace)
 				{
-					Trace($"[DirectManipulation] [{args.Pointers[0]}] Update @={args.Position.ToDebugString()} | Δ=({args.Delta}){(args.IsInertial ? " *inertial*" : "")}");
+					Trace($"[DirectManipulation] [{args.Pointers[0]}] Update @={args.Position.ToDebugString()} | Δ=({args.Delta} | v={args.Velocities}){(args.IsInertial ? " *inertial*" : "")}");
 				}
 
 				var unhandledDelta = args.Delta;


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1061
closes https://github.com/unoplatform/uno-private/issues/1038

## Bugfix
Misc fixes for pointers on skia

## What is the current behavior?
* All pointers have ID = 0
* Flick gesture on iOS 18 @ 120 fps start inertia with really small speed

## What is the new behavior?
* Pointers have valid IDs
* We ignore the last pointer event (release) to compute velocities values to start inertia

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
