### PR TITLE
fix: Fix ColorPicker does not prevent scrolling

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/ColorPicker/ColorSpectrum.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/ColorPicker/ColorSpectrum.cs
@@ -18,7 +18,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Shapes;
 using Uno.UI.Core;
-
+using Uno.UI.Xaml.Core;
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;
@@ -928,7 +928,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls.Primitives
 				(PointerDeviceType)args.Pointer.PointerDeviceType == PointerDeviceType.Pen ||
 				(PointerDeviceType)args.Pointer.PointerDeviceType == PointerDeviceType.Touch;
 
-			inputTarget.CapturePointer(args.Pointer);
+			inputTarget.CapturePointer(args.Pointer, /* uno */ options: PointerCaptureOptions.PreventDirectManipulation);
 			UpdateColorFromPoint(args.GetCurrentPoint(inputTarget));
 			UpdateVisualState(useTransitions: true);
 			UpdateEllipse();

--- a/src/Uno.UI/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/GestureRecognizer.Manipulation.cs
@@ -645,6 +645,7 @@ namespace Windows.UI.Input
 				=> _inertia is null
 					&& !IsDragManipulation
 					&& (_settings & GestureSettingsHelper.Inertia) != 0
+					&& (_settings & GestureSettingsHelper.Manipulations) != 0 // On pointer removed, we should not start inertia if all manip are disabled (could happen if configured for drag but IsDragManipulation not yet true)
 					&& velocities.IsAnyAbove(_inertiaThresholds);
 
 			private void DecideTranslateDirection(Point oldPosition, Point newPosition, ref ManipulationDelta cumulative, ref ManipulationDelta delta, ref ManipulationVelocities velocities)

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCaptureOptions.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCaptureOptions.cs
@@ -15,5 +15,5 @@ internal enum PointerCaptureOptions : byte
 	///   * iOS and Android, where we configure the OS to forbid it to steal the pointer when it detects a scroll gesture.
 	///   * Managed pointers (Skia), which prevents the direct manipulation to kick in (cf. InputManager.Pointers).
 	/// </summary>
-	PreventDirectManipulation = 1,
+	PreventDirectManipulation = 1, // Note: We should actually rely on the ManipulationMode.System instead of this!
 }


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/906

## Bugfix
Fix ColorPicker does not prevent scrolling

## What is the current behavior?
ColorPicker does not prevent scrolling

## What is the new behavior?
We use our current internal patch to support this case

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
