### PR TITLE
fix(pointers): Attempt to fix scrolling glitches on Android

### DIFF
--- a/src/Uno.UI/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UI/UI/Input/GestureRecognizer.cs
@@ -2,6 +2,7 @@
 #if HAS_UNO_WINUI || !IS_UNO_UI_PROJECT
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Windows.Devices.Input;
 using Windows.Foundation;
@@ -12,6 +13,7 @@ using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno;
 using Windows.Devices.Haptics;
+using Uno.UI.Input;
 
 #if HAS_UNO_WINUI && IS_UNO_UI_PROJECT
 namespace Microsoft.UI.Input
@@ -50,6 +52,13 @@ namespace Windows.UI.Input
 		}
 
 		public bool IsActive => _gestures.Count > 0 || _manipulation != null;
+
+		/// <summary>
+		/// Defines which suspicious cases should be patched by the gesture recognizer.
+		/// </summary>
+		[UnoOnly]
+		[EditorBrowsable(EditorBrowsableState.Advanced)]
+		public GestureRecognizerSuspiciousCases PatchCases { get; set; } = WinRTFeatureConfiguration.GestureRecognizer._defaultPatchSuspiciousCases;
 
 		internal bool IsDragging => _manipulation?.IsDragManipulation ?? false;
 

--- a/src/Uno.UI/UI/Input/ManipulationVelocities.cs
+++ b/src/Uno.UI/UI/Input/ManipulationVelocities.cs
@@ -38,6 +38,9 @@ namespace Windows.UI.Input
 				|| Math.Abs(Angular) > thresholds.Rotate
 				|| Math.Abs(Expansion) > thresholds.Expansion;
 
+		internal Point Apply(Point point, double δTimeMs)
+			=> new(point.X + Linear.X * δTimeMs, point.Y + Linear.Y * δTimeMs);
+
 		/// <inheritdoc />
 		public override string ToString()
 			=> $"x:{Linear.X:F2};y:{Linear.Y:F2};θ:{Angular};e:{Expansion:F2}";

--- a/src/Uno.UI/UI/Input/PointerPoint.cs
+++ b/src/Uno.UI/UI/Input/PointerPoint.cs
@@ -99,7 +99,7 @@ namespace Windows.UI.Input
 #nullable restore
 
 		internal PointerPoint At(Point position)
-			=> new PointerPoint(
+			=> new(
 				FrameId,
 				Timestamp,
 				PointerDevice,
@@ -109,7 +109,18 @@ namespace Windows.UI.Input
 				IsInContact,
 				Properties);
 
-		internal PointerIdentifier Pointer => new PointerIdentifier(PointerDevice.PointerDeviceType, PointerId);
+		internal PointerPoint At(Point rawPosition, Point position)
+			=> new(
+				FrameId,
+				Timestamp,
+				PointerDevice,
+				PointerId,
+				rawPosition: rawPosition,
+				position: position,
+				IsInContact,
+				Properties);
+
+		internal PointerIdentifier Pointer => new(PointerDevice.PointerDeviceType, PointerId);
 
 		public uint FrameId { get; }
 

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -134,7 +134,7 @@ partial class InputManager
 			{
 				if (_trace)
 				{
-					Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Adding pointer --POST DISPATCH-- (@{args.CurrentPoint.Position.ToDebugString()}).");
+					Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Adding pointer --POST DISPATCH-- (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
 				}
 
 				using var _ = AsCurrentForDirectManipulation(args);
@@ -148,7 +148,7 @@ partial class InputManager
 			{
 				if (_trace)
 				{
-					Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Handling move (@{args.CurrentPoint.Position.ToDebugString()}).");
+					Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Handling move (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
 				}
 
 				using var _ = AsCurrentForDirectManipulation(args);
@@ -169,7 +169,7 @@ partial class InputManager
 
 				if (_trace)
 				{
-					Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Releasing pointer (@{args.CurrentPoint.Position.ToDebugString()}).");
+					Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Releasing pointer (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
 				}
 
 				using var _ = AsCurrentForDirectManipulation(args);
@@ -215,7 +215,8 @@ partial class InputManager
 			{
 				var recognizer = new GestureRecognizer(this)
 				{
-					GestureSettings = GestureSettingsHelper.Manipulations
+					GestureSettings = GestureSettingsHelper.Manipulations,
+					PatchCases = WinRTFeatureConfiguration.GestureRecognizer.PatchCasesForDirectManipulation
 				};
 				recognizer.ManipulationStarting += OnDirectManipulationStarting;
 				recognizer.ManipulationStarted += OnDirectManipulationStarted;

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -16,7 +16,7 @@ using Windows.UI.Core;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Imaging;
-
+using Uno;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
 using Uno.UI;
@@ -391,7 +391,10 @@ namespace Microsoft.UI.Xaml
 
 		private GestureRecognizer CreateGestureRecognizer()
 		{
-			var recognizer = new GestureRecognizer(this);
+			var recognizer = new GestureRecognizer(this)
+			{
+				PatchCases = WinRTFeatureConfiguration.GestureRecognizer.PatchCasesForUiElement
+			};
 
 			// Allow partial parts to subscribe to pointer events (WASM)
 			// or to subscribe to events for platform specific needs (iOS)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1087

## Bugfix
Attempt to fix scrolling glitches on Android

## What is the current behavior?
We get an invalid pointer release from the OS

## What is the new behavior?
We patch it to an expected location interpolated from previous pointer location and velocity

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
