### PR TITLE
fix: Increase frame rate for skia backend

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DispatcherAnimator.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DispatcherAnimator.cs
@@ -5,7 +5,7 @@ namespace Microsoft.UI.Xaml.Media.Animation
 {
 	internal abstract class DispatcherAnimator<T> : CPUBoundAnimator<T> where T : struct
 	{
-		public const int DefaultFrameRate = 30;
+		public const int DefaultFrameRate = 60;
 
 		private readonly int _frameRate;
 		private readonly DispatcherTimer _timer;


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1044

## Bugfix
 Increase frame rate for skia backend

## What is the current behavior?
Animations are running at 30 fps on skia backend

## What is the new behavior?
We run them at 60 fps

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
