### PR TITLE
fix(perf): Remove double Idle re-scheduling of composition animations

### DIFF
--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -135,7 +135,7 @@ public partial class Compositor
 
 		if (_runningAnimations.Count > 0)
 		{
-			NativeDispatcher.Main.Enqueue(() => CoreApplication.QueueInvalidateRender(rootVisual.CompositionTarget), NativeDispatcherPriority.Idle);
+			CoreApplication.QueueInvalidateRender(rootVisual.CompositionTarget);
 		}
 	}
 


### PR DESCRIPTION
linked to https://github.com/unoplatform/uno-private/issues/1092

## Bugfix
Remove double Idle re-scheduling of composition animations

## What is the current behavior?
Animations are scheduled twice (on idle dispatcher):
1. https://github.com/unoplatform/uno/blob/5d975dcc2517b9f4bb9ee7e59d7031d44d23b9b5/src/Uno.UI.Composition/Composition/Compositor.skia.cs#L138
2. https://github.com/unoplatform/uno/blob/5d975dcc2517b9f4bb9ee7e59d7031d44d23b9b5/src/Uno.UI/UI/Xaml/XamlRoot.crossruntime.cs#L47

## What is the new behavior?
We keep only the second scheduling.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
