### PR TITLE
fix: Fix pointer remains in pressed state when touch scrolling

### DIFF
--- a/src/Uno.UI/Extensions/UIElementExtensions.Debug.cs
+++ b/src/Uno.UI/Extensions/UIElementExtensions.Debug.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Linq;
 using System.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
@@ -213,4 +214,21 @@ static partial class UIElementExtensions
 			_ => 0,
 #endif
 		};
+
+
+	/// <summary>
+	/// Get a display identifier for the tree down to the given element for debug purposes
+	/// </summary>
+	internal static string GetDebugPath(this object elt)
+	{
+		var sb = new StringBuilder();
+		foreach (var parent in elt.GetParents().Reverse())
+		{
+			sb.AppendLine(parent.GetDebugIdentifier());
+		}
+
+		sb.Append(GetDebugIdentifier(elt));
+		
+		return sb.ToString();
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
@@ -552,7 +552,7 @@ internal partial class InputManager
 				// ** OR ** the pointer has been captured by a parent element so we didn't raised to released on the sub elements.
 
 				// Note: The event is propagated silently (public events won't be raised) as it's only to clear internal state
-				var ctx = new BubblingContext { IsInternal = true, IsCleanup = true };
+				var ctx = new BubblingContext { IsInternal = false, IsCleanup = true };
 				result = Raise(Released, pressedLeaf, routedArgs, ctx);
 			}
 
@@ -616,7 +616,7 @@ internal partial class InputManager
 					// This is to make sure to not leave element flagged as IsOver = true.
 					// Note: This means that, public listener of the exit events will **never** be raised for those elements.
 					// Note 2: This will try to also raise the exited event on the capture.ExplicitTarget (if any), but this will have no effect as we already did it!
-					var leaveCtx = new BubblingContext { IsCleanup = true, IsInternal = true, Mode = BubblingMode.Bubble, Root = overStaleBranch.Value.Root };
+					var leaveCtx = new BubblingContext { IsCleanup = true, IsInternal = false, Mode = BubblingMode.Bubble, Root = overStaleBranch.Value.Root };
 					var leaveResult = Raise(Leave, overStaleBranch.Value.Leaf, args, leaveCtx);
 					isOriginalSourceStale |= leaveResult.VisualTreeAltered;
 					result += leaveResult;
@@ -647,10 +647,10 @@ internal partial class InputManager
 					result += enterCaptureResult;
 
 					// Second we make sure to also flag as IsOver true all elements in the branch
-					var enterCtx = new BubblingContext { IsCleanup = true, IsInternal = true, Mode = BubblingMode.Bubble };
+					var enterCtx = new BubblingContext { IsCleanup = true, IsInternal = false, Mode = BubblingMode.Bubble };
 					var enterResult = Raise(Enter, originalSource, args, enterCtx);
 					isOriginalSourceStale |= enterCaptureResult.VisualTreeAltered;
-					result += enterCaptureResult;
+					result += enterResult;
 				}
 			}
 			else

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1046,7 +1046,7 @@ namespace Microsoft.UI.Xaml
 		internal bool OnPointerUp(PointerRoutedEventArgs args, BubblingContext ctx = default)
 		{
 			var handledInManaged = false;
-			var isOverOrCaptured = ValidateAndUpdateCapture(args, out var isOver);
+			var isOverOrCaptured = ValidateAndUpdateCapture(args);
 			if (!isOverOrCaptured)
 			{
 				// We receive this event due to implicit capture, just ignore it locally and let is bubble
@@ -1115,8 +1115,9 @@ namespace Microsoft.UI.Xaml
 
 			// When a pointer is cancelled / swallowed by the system, we don't even receive "Released" nor "Exited"
 			// We update only local state as the Cancel is bubbling itself
-			SetPressed(args, false, ctx: BubblingContext.NoBubbling);
-			SetOver(args, false, ctx: BubblingContext.NoBubbling);
+			// Note: Make sure to keep the IsInternal / IsCleanup flags if set!
+			SetPressed(args, false, ctx.WithMode(BubblingMode.NoBubbling));
+			SetOver(args, false, ctx.WithMode(BubblingMode.NoBubbling));
 
 			if (IsGestureRecognizerCreated)
 			{
@@ -1135,7 +1136,7 @@ namespace Microsoft.UI.Xaml
 			var handledInManaged = false;
 			if (args.CanceledByDirectManipulation)
 			{
-				handledInManaged |= SetNotCaptured(args, forceCaptureLostEvent: true);
+				handledInManaged |= SetNotCaptured(args, forceCaptureLostEvent: !ctx.IsInternal);
 			}
 			else
 			{
@@ -1155,7 +1156,7 @@ namespace Microsoft.UI.Xaml
 		private static (UIElement sender, RoutedEvent @event, PointerRoutedEventArgs args) _pendingRaisedEvent;
 		private bool RaisePointerEvent(RoutedEvent evt, PointerRoutedEventArgs args, BubblingContext ctx = default)
 		{
-			if (ctx.IsInternal || ctx.IsCleanup)
+			if (ctx.IsInternal)
 			{
 				// If the event has been flagged as internal it means that it's bubbling in managed code,
 				// so the RaiseEvent won't do anything. This check only avoids a potentially costly try/finally.
@@ -1456,6 +1457,7 @@ namespace Microsoft.UI.Xaml
 
 		private bool ValidateAndUpdateCapture(PointerRoutedEventArgs args, out bool isOver)
 			=> ValidateAndUpdateCapture(args, isOver = IsOver(args.Pointer));
+
 		// Used by all OnNativeXXX to validate and update the common over/pressed/capture states
 		private bool ValidateAndUpdateCapture(PointerRoutedEventArgs args, bool isOver, bool forceRelease = false)
 		{
@@ -1470,6 +1472,14 @@ namespace Microsoft.UI.Xaml
 			// Note: even if the result of this method is usually named 'isOverOrCaptured', the result of this method will also
 			//		 be "false" if the pointer is over the element BUT the pointer was captured by a parent element.
 
+#if UNO_HAS_MANAGED_POINTERS
+			if (PointerCapture.TryGet(args.Pointer, out var capture))
+			{
+				capture.ValidateAndUpdate(this, args, autoRelease: false); // autoRelease: false: With managed pointers, captures are released by the InputManager
+			}
+
+			return true; // With managed pointers, the pointer is always over the element!
+#else
 			if (PointerCapture.TryGet(args.Pointer, out var capture))
 			{
 				return capture.ValidateAndUpdate(this, args, forceRelease);
@@ -1478,6 +1488,7 @@ namespace Microsoft.UI.Xaml
 			{
 				return isOver;
 			}
+#endif
 		}
 
 		private bool SetNotCaptured(PointerRoutedEventArgs args, bool forceCaptureLostEvent = false)
@@ -1550,7 +1561,7 @@ namespace Microsoft.UI.Xaml
 			return RaisePointerEvent(PointerCaptureLostEvent, relatedArgs);
 #endif
 		}
-		#endregion
+#endregion
 
 		#region Drag state (Updated by the RaiseDrag***, should not be updated externaly)
 		private HashSet<long> _draggingOver;


### PR DESCRIPTION
closes https://github.com/unoplatform/private/issues/591

## Bugfix
Fix pointer remains in pressed state when touch scrolling

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
