### PR TITLE
fix: Ensure that MarkupExtension search behavior is consistent with winui

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1989,25 +1989,25 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			var ns = GetTrimmedNamespace(xamlType.PreferredXamlNamespace); // No MarkupExtensions are defined in the framework, so we expect a user-defined namespace
 			if (ns == xamlType.PreferredXamlNamespace)
-    		{
-		        // It looks like FindType always returns null in this code path.
+			{
+				// It looks like FindType always returns null in this code path.
 				// So, we avoid the costly call here.
-		        return null;
-		    }
-			
+				return null;
+			}
+
 			// If GetTrimmedNamespace returned a different string, it's a "using:"-prefixed namespace.
 			// In this case, we'll have `baseTypeString` as
 			// the fully qualified type name.
 			// In this case, we go through this code path as it's much more efficient than FindType.
-    		var baseTypeString = $"{ns}.{xamlType.Name}";
-    
-		    // Try finding the type with "Extension" suffix first, then without
-		    return FindMarkupExtensionType(baseTypeString + "Extension") ?? FindMarkupExtensionType(baseTypeString);
+			var baseTypeString = $"{ns}.{xamlType.Name}";
+
+			// Try finding the type with "Extension" suffix first, then without
+			return FindMarkupExtensionType(baseTypeString + "Extension") ?? FindMarkupExtensionType(baseTypeString);
 		}
 
 		private INamedTypeSymbol? FindMarkupExtensionType(string fullTypeName)
 		{
-    		return _metadataHelper.FindTypeByFullName(fullTypeName) is INamedTypeSymbol type && type.Is(Generation.MarkupExtensionSymbol.Value) ? type : null;
+			return _metadataHelper.FindTypeByFullName(fullTypeName) is INamedTypeSymbol type && type.Is(Generation.MarkupExtensionSymbol.Value) ? type : null;
 		}
 
 		private bool IsCustomMarkupExtensionType(XamlType? xamlType) =>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1996,8 +1996,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				// the fully qualified type name.
 				// In this case, we go through this code path as it's much more efficient than FindType.
 				var baseTypeString = $"{ns}.{xamlType.Name}";
-				findType = _metadataHelper.FindTypeByFullName(baseTypeString) as INamedTypeSymbol;
-				findType ??= _metadataHelper.FindTypeByFullName(baseTypeString + "Extension") as INamedTypeSymbol; // Support shortened syntax
+				findType = _metadataHelper.FindTypeByFullName(baseTypeString + "Extension") as INamedTypeSymbol; // Support shortened syntax
+				findType ??= _metadataHelper.FindTypeByFullName(baseTypeString) as INamedTypeSymbol;
 			}
 			else
 			{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1989,29 +1989,26 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 			var ns = GetTrimmedNamespace(xamlType.PreferredXamlNamespace); // No MarkupExtensions are defined in the framework, so we expect a user-defined namespace
 			INamedTypeSymbol? findType;
-			if (ns != xamlType.PreferredXamlNamespace)
-			{
-				// If GetTrimmedNamespace returned a different string, it's a "using:"-prefixed namespace.
-				// In this case, we'll have `baseTypeString` as
-				// the fully qualified type name.
-				// In this case, we go through this code path as it's much more efficient than FindType.
-				var baseTypeString = $"{ns}.{xamlType.Name}";
-				findType = _metadataHelper.FindTypeByFullName(baseTypeString + "Extension") as INamedTypeSymbol; // Support shortened syntax
-				findType ??= _metadataHelper.FindTypeByFullName(baseTypeString) as INamedTypeSymbol;
-			}
-			else
-			{
-				// It looks like FindType always returns null in this code path.
+			if (ns == xamlType.PreferredXamlNamespace)
+    		{
+		        // It looks like FindType always returns null in this code path.
 				// So, we avoid the costly call here.
-				return null;
-			}
+		        return null;
+		    }
+			
+			// If GetTrimmedNamespace returned a different string, it's a "using:"-prefixed namespace.
+			// In this case, we'll have `baseTypeString` as
+			// the fully qualified type name.
+			// In this case, we go through this code path as it's much more efficient than FindType.
+    		var baseTypeString = $"{ns}.{xamlType.Name}";
+    
+		    // Try finding the type with "Extension" suffix first, then without
+		    return FindMarkupExtensionType(baseTypeString + "Extension") ?? FindMarkupExtensionType(baseTypeString);
+		}
 
-			if (findType?.Is(Generation.MarkupExtensionSymbol.Value) ?? false)
-			{
-				return findType;
-			}
-
-			return null;
+		private INamedTypeSymbol? FindMarkupExtensionType(string fullTypeName)
+		{
+    		return _metadataHelper.FindTypeByFullName(fullTypeName) is INamedTypeSymbol type && type.Is(Generation.MarkupExtensionSymbol.Value) ? type : null;
 		}
 
 		private bool IsCustomMarkupExtensionType(XamlType? xamlType) =>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1988,7 +1988,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 
 			var ns = GetTrimmedNamespace(xamlType.PreferredXamlNamespace); // No MarkupExtensions are defined in the framework, so we expect a user-defined namespace
-			INamedTypeSymbol? findType;
 			if (ns == xamlType.PreferredXamlNamespace)
     		{
 		        // It looks like FindType always returns null in this code path.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_MarkupExtension.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_MarkupExtension.cs
@@ -104,6 +104,15 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 			Assert.IsTrue(page.Control.IsChecked, "sanity check failed: Control.IsChecked is not true");
 			Assert.IsNull(page.SUT.IsChecked, "Property value should be set to null by the markup-extension");
 		}
+
+		[TestMethod]
+		public void When_MarkupExtension_FullNameFirst()
+		{
+			var page = new MarkupExtension_FullNameFirst();
+
+			Assert.AreEqual(nameof(FullNameFirstMarkupExtension), (page.FullName as TextBlock).Tag);
+			Assert.AreEqual(nameof(ShortNameMarkup), (page.ShortName as TextBlock).Tag);
+		}
 #endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_FullNameFirst.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_FullNameFirst.xaml
@@ -1,0 +1,9 @@
+<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup.MarkupExtension_FullNameFirst"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup">
+	<StackPanel>
+		<TextBlock x:Name="FullName" x:FieldModifier="Public" Tag="{local:FullNameFirstMarkup}" />
+		<TextBlock x:Name="ShortName" x:FieldModifier="Public" Tag="{local:ShortNameMarkup}" />
+	</StackPanel>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_FullNameFirst.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_FullNameFirst.xaml.cs
@@ -1,0 +1,27 @@
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup;
+
+public sealed partial class MarkupExtension_FullNameFirst : Page
+{
+	public MarkupExtension_FullNameFirst()
+	{
+		this.InitializeComponent();
+	}
+}
+
+public class FullNameFirstMarkupExtension : MarkupExtension
+{
+	protected override object ProvideValue() => nameof(FullNameFirstMarkupExtension);
+}
+
+public class FullNameFirstMarkup : MarkupExtension
+{
+	protected override object ProvideValue() => nameof(FullNameFirstMarkup);
+}
+
+public class ShortNameMarkup : MarkupExtension
+{
+	protected override object ProvideValue() => nameof(ShortNameMarkup);
+}


### PR DESCRIPTION
…inui, and prioritize classes with Extension extensions

GitHub Issue (If applicable): closes #19801

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When I created two classes named ResourcesExtension and Resources in same namespace, ResourcesExtension implemented MarkupExtension and Resource is a static class. It can be parsed to ResourcesExtension normally in winui, but in uno, it will first search for the static class Resources.

## What is the new behavior?
The search behavior is consistent with winui, and classes with Extension extensions are searched first.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->