### PR TITLE
ci: Reduce hangdump timeout

### DIFF
--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -242,7 +242,7 @@ else
 	echo "  Test filters: $UNO_TESTS_FILTER"
 
 	## Run tests
-	dotnet run -c Release -- --results-directory $UNO_ORIGINAL_TEST_RESULTS_DIRECTORY --hangdump --hangdump-timeout 45m --hangdump-filename hang.dump --settings .runsettings --filter "$UNO_TESTS_FILTER" || true
+	dotnet run -c Release -- --results-directory $UNO_ORIGINAL_TEST_RESULTS_DIRECTORY --hangdump --hangdump-timeout 10m --hangdump-filename hang.dump --settings .runsettings --filter "$UNO_TESTS_FILTER" || true
 fi
 
 # export the simulator logs

--- a/build/test-scripts/ios-uitest-run.sh
+++ b/build/test-scripts/ios-uitest-run.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -242,7 +242,7 @@ else
 	echo "  Test filters: $UNO_TESTS_FILTER"
 
 	## Run tests
-	dotnet run -c Release -- --results-directory $UNO_ORIGINAL_TEST_RESULTS_DIRECTORY --hangdump --hangdump-timeout 10m --hangdump-filename hang.dump --settings .runsettings --filter "$UNO_TESTS_FILTER" || true
+	dotnet run -c Release -- --results-directory $UNO_ORIGINAL_TEST_RESULTS_DIRECTORY --hangdump --hangdump-timeout 10m --hangdump-filename hang.dmp --settings .runsettings --filter "$UNO_TESTS_FILTER" || true
 fi
 
 # export the simulator logs


### PR DESCRIPTION
45 minutes looks unnecessarily too high. I wouldn't expect a test to take more than 10 minutes.
Using a lower timeout ensures that there is enough time for producing the dump, before everything is killed by Azure if the job itself times out.
Also, this ensures that the job finishes early and not waste CI machine time when it's likely to never progress further.

Also uses `.dmp` extension for dump file, as `.dmp` is openable by VS.