### PR TITLE
Adjust animations performance

### DIFF
--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/MainWindow.xaml
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/MainWindow.xaml
@@ -5,8 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 		xmlns:xamlHost="clr-namespace:Uno.UI.XamlHost.Skia.Wpf;assembly=Uno.UI.XamlHost.Skia.Wpf"
         mc:Ignorable="d"
-        Title="Uno Islands Sample" Height="768" Width="1024">
-	<Border BorderThickness="20" BorderBrush="Red" Background="White">
+        Title="Uno Islands Sample" Height="1024" Width="1280">
+	<Border BorderThickness="5" BorderBrush="Red" Background="White">
 		<Grid>
 			<ContentControl Grid.Row="1" x:Name="hostContainer" IsTabStop="False">
 				<xamlHost:UnoXamlHost x:Name="xamlHost" InitialTypeName="SamplesApp.MainPage" />

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/UnoSKMetalView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/UnoSKMetalView.cs
@@ -5,7 +5,10 @@ using CoreGraphics;
 using Foundation;
 using Metal;
 using MetalKit;
+using Microsoft.Graphics.Display;
 using SkiaSharp;
+using UIKit;
+using Uno.Foundation.Logging;
 
 namespace Uno.UI.Runtime.Skia.AppleUIKit
 {
@@ -49,6 +52,11 @@ namespace Uno.UI.Runtime.Skia.AppleUIKit
 			ColorPixelFormat = MTLPixelFormat.BGRA8Unorm;
 			DepthStencilPixelFormat = MTLPixelFormat.Depth32Float_Stencil8;
 			SampleCount = 1;
+
+			var fps = UIScreen.MainScreen.MaximumFramesPerSecond;
+			PreferredFramesPerSecond = fps;
+
+			this.LogDebug()?.LogDebug($"UnoSKMetalView: {nameof(PreferredFramesPerSecond)} = {fps}");
 
 			Device = device;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -4682,8 +4682,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// drop onto item#1
 			mouse.MoveTo(SUT.GetAbsoluteBoundsRect().GetCenter() with { Y = SUT.GetAbsoluteBoundsRect().Y + 100 }, 1);
 			await WindowHelper.WaitForIdle();
-			mouse.MoveTo(SUT.GetAbsoluteBoundsRect().GetCenter() with { Y = SUT.GetAbsoluteBoundsRect().Y + 150 }, 1);
-			await WindowHelper.WaitForIdle();
+			mouse.MoveTo(SUT.GetAbsoluteBoundsRect().GetCenter() with { Y = SUT.GetAbsoluteBoundsRect().Y + 200 }, 1);
+			await Task.Delay(1000);
 			mouse.Release();
 			await WindowHelper.WaitForIdle();
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DispatcherAnimator.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DispatcherAnimator.cs
@@ -1,5 +1,8 @@
-﻿using System;
+﻿#if !__SKIA__
+using System;
 using System.Linq;
+using Microsoft.UI.Dispatching;
+using Windows.UI.Core;
 
 namespace Microsoft.UI.Xaml.Media.Animation
 {
@@ -27,3 +30,4 @@ namespace Microsoft.UI.Xaml.Media.Animation
 		protected abstract override T GetUpdatedValue(long frame, T from, T to);
 	}
 }
+#endif

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DispatcherAnimator.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DispatcherAnimator.skia.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Authentication.ExtendedProtection;
+using Microsoft.UI.Dispatching;
+using Windows.UI.Core;
+
+namespace Microsoft.UI.Xaml.Media.Animation
+{
+	internal abstract class DispatcherAnimator<T> : CPUBoundAnimator<T> where T : struct
+	{
+		public const int DefaultFrameRate = 60;
+
+		private Stopwatch _watch = new Stopwatch();
+		private TimeSpan? _delay;
+
+		public DispatcherAnimator(T from, T to, int frameRate = 0)
+			: base(from, to)
+		{
+		}
+
+		protected override void EnableFrameReporting() => CompositionTarget.Rendering += OnTargetFrame;
+		protected override void DisableFrameReporting() => CompositionTarget.Rendering -= OnTargetFrame;
+
+		private void OnTargetFrame(object sender, object args)
+		{
+			if (_delay != null)
+			{
+				if (_watch.Elapsed < _delay)
+				{
+					return;
+				}
+				else
+				{
+					_delay = null;
+					_watch.Stop();
+					_watch.Reset();
+				}
+			}
+
+			OnFrame(sender, args);
+		}
+
+		protected override void SetStartFrameDelay(long delayMs)
+		{
+			_delay = TimeSpan.FromMicroseconds(delayMs);
+			_watch.Restart();
+		}
+
+		protected abstract override T GetUpdatedValue(long frame, T from, T to);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DispatcherAnimator.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/DispatcherAnimator.skia.cs
@@ -11,41 +11,13 @@ namespace Microsoft.UI.Xaml.Media.Animation
 	{
 		public const int DefaultFrameRate = 60;
 
-		private Stopwatch _watch = new Stopwatch();
-		private TimeSpan? _delay;
-
 		public DispatcherAnimator(T from, T to, int frameRate = 0)
 			: base(from, to)
 		{
 		}
 
-		protected override void EnableFrameReporting() => CompositionTarget.Rendering += OnTargetFrame;
-		protected override void DisableFrameReporting() => CompositionTarget.Rendering -= OnTargetFrame;
-
-		private void OnTargetFrame(object sender, object args)
-		{
-			if (_delay != null)
-			{
-				if (_watch.Elapsed < _delay)
-				{
-					return;
-				}
-				else
-				{
-					_delay = null;
-					_watch.Stop();
-					_watch.Reset();
-				}
-			}
-
-			OnFrame(sender, args);
-		}
-
-		protected override void SetStartFrameDelay(long delayMs)
-		{
-			_delay = TimeSpan.FromMicroseconds(delayMs);
-			_watch.Restart();
-		}
+		protected override void EnableFrameReporting() => CompositionTarget.Rendering += base.OnFrame;
+		protected override void DisableFrameReporting() => CompositionTarget.Rendering -= base.OnFrame;
 
 		protected abstract override T GetUpdatedValue(long frame, T from, T to);
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/1097

Edit DR: This also closes https://github.com/unoplatform/uno-private/issues/1092

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Move dispatcher animator to use `CompositionTarget.Rendering`.
Adjust framerate for metal view

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
