### PR TITLE
fix: Adjust newline handling on iOS

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/InvisibleTextBoxViewExtension.cs
@@ -196,11 +196,10 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 			_textBoxView = CreateNativeView(textBox);
 			if (_textBoxView is UIView nativeView)
 			{
-				nativeView.UserInteractionEnabled = false;
 				nativeView.Alpha = 0.01f;
 			}
 			UpdateProperties();
-			SetNativeText(inputText ?? string.Empty);
+			SetText(inputText ?? string.Empty);
 		}
 	}
 
@@ -216,25 +215,12 @@ internal class InvisibleTextBoxViewExtension : IOverlayTextBoxViewExtension
 			var updatedText = textBox.ProcessTextInput(text);
 			if (text != updatedText)
 			{
-				SetNativeText(updatedText);
+				SetText(updatedText);
 			}
 		}
 	}
 
 	private string? GetNativeText() => _textBoxView?.Text;
-
-	private void SetNativeText(string text)
-	{
-		if (_textBoxView is null)
-		{
-			return;
-		}
-
-		if (_textBoxView.Text != text)
-		{
-			_textBoxView.SetTextNative(text);
-		}
-	}
 
 	private IInvisibleTextBoxView CreateNativeView(TextBox textBox) => _owner?.TextBox?.AcceptsReturn != true ?
 		new SinglelineInvisibleTextBoxView(this) : new MultilineInvisibleTextBoxView(this);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -1093,8 +1093,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(0, SUT.SelectionLength);
 		}
 
-		// Test is failing on iOS https://github.com/unoplatform/uno-private/issues/767
-		[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.SkiaUIKit)]
+		[TestMethod]
 		public async Task When_Pointer_RightClick_Selection()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
@@ -1997,7 +1996,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		// Clipboard is currently not available on skia-WASM
 		// Newline handling is different on Skia.UIKit targets due to native input sync #788
-		[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.SkiaWasm | RuntimeTestPlatforms.SkiaIOS)]
+		[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.SkiaWasm)]
 		public async Task When_Paste_The_Same_Text()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
@@ -2055,7 +2054,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			SUT.ActualHeight.Should().BeGreaterThan(height * 1.2);
 		}
 
-		[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.SkiaUIKit)] // Newline handling is different on Skia.UIKit targets due to native input sync #788
+		[TestMethod]
 		public async Task When_Multiline_LineFeed()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
@@ -2345,7 +2344,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(0, SUT.SelectionLength);
 		}
 
-		[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.SkiaUIKit)] // Failing in Skia iOS CI - https://github.com/unoplatform/uno-private/issues/807
+		[TestMethod]
 		public async Task When_Multiline_Keyboard_Chunking()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
@@ -2492,7 +2491,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(height, SUT.ActualHeight);
 		}
 
-		[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.SkiaUIKit)] // Newline handling is different on Skia.UIKit targets due to native input sync #788
+		[TestMethod]
 		public async Task When_Text_Changed_Events()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();
@@ -2570,7 +2569,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(SUT.Text.Length - 2, SUT.SelectionLength);
 		}
 
-		[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.SkiaUIKit)] // Fails in Skia UIKit CI - https://github.com/unoplatform/uno-private/issues/808
+		[TestMethod]
 		public async Task When_Multiline_Pointer_Tap()
 		{
 			if (OperatingSystem.IsBrowser())
@@ -2822,8 +2821,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(26, SUT.SelectionLength);
 		}
 
-		// Fails on Skia UIKit - https://github.com/unoplatform/uno-private/issues/802
-		[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.SkiaUIKit)]
+		[TestMethod]
 		public async Task When_Multiline_Pointer_TripleTap_With_Wrapping()
 		{
 			using var _ = new TextBoxFeatureConfigDisposable();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -431,7 +431,7 @@ namespace Microsoft.UI.Xaml.Controls
 					_pendingSelection = (start, end - start);
 				}
 			}
-			else if (_isSkiaTextBox && !DeviceTargetHelper.IsUIKit())
+			else if (_isSkiaTextBox)
 			{
 				// WinUI replaces all \n's and and \r\n's by \r. This is annoying because
 				// the _pendingSelection uses indices before this removal.


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/788, closes https://github.com/unoplatform/uno-private/issues/767, closes https://github.com/unoplatform/uno-private/issues/807, closes https://github.com/unoplatform/uno-private/issues/808

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Input handling is not consistent with other platforms

## What is the new behavior?

Consistent

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
