### PR TITLE
fix: Improve `When_Source_Changes` test reliability

### DIFF
--- a/src/Uno.UI.Composition/Composition/RedirectVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/RedirectVisual.skia.cs
@@ -18,6 +18,6 @@ namespace Microsoft.UI.Composition
 		}
 
 		internal override bool CanPaint() => Source?.CanPaint() ?? false;
-		internal override bool RequiresRepaintOnEveryFrame => Source?.RequiresRepaintOnEveryFrame ?? false;
+		internal override bool RequiresRepaintOnEveryFrame => true;
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_RedirectVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_RedirectVisual.cs
@@ -16,7 +16,7 @@ using System.Diagnostics;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
 
-[TestClass]
+[ConditionalTestClass(IgnoredPlatforms = RuntimeTestPlatforms.Native)] // RedirectVisual requires composition
 public class Given_RedirectVisual
 {
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_RedirectVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_RedirectVisual.cs
@@ -13,7 +13,6 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using System.Diagnostics;
-using Uno.UI.Xaml;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_RedirectVisual.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_RedirectVisual.cs
@@ -19,6 +19,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Composition;
 [ConditionalTestClass(IgnoredPlatforms = RuntimeTestPlatforms.Native)] // RedirectVisual requires composition
 public class Given_RedirectVisual
 {
+#if HAS_UNO
 	[TestMethod]
 	[RunsOnUIThread]
 	public async Task When_Source_Changes()
@@ -66,4 +67,5 @@ public class Given_RedirectVisual
 
 		await ImageAssert.AreEqualAsync(actualScreenshot, expectedScreenshot);
 	}
+#endif
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #19866

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Test should only execute on Skia

## What is the new behavior?

Executes only on Skia

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.