### PR TITLE
fix: Do not crash on `CoreWindowContentRoot` on Skia

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/RootViewController.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/RootViewController.cs
@@ -96,14 +96,20 @@ internal class RootViewController : UINavigationController, IAppleUIKitXamlRootH
 #if !__TVOS__
 		// Dismiss on device rotation: this reproduces the windows behavior
 		UIApplication.Notifications
-			.ObserveDidChangeStatusBarOrientation((sender, args) =>
-				VisualTreeHelper.CloseLightDismissPopups(WinUICoreServices.Instance.ContentRootCoordinator!.CoreWindowContentRoot!.XamlRoot));
+			.ObserveDidChangeStatusBarOrientation(DismissPopups);
 #endif
 
 		// Dismiss when the app is entering background
 		UIApplication.Notifications
-			.ObserveWillResignActive((sender, args) =>
-				VisualTreeHelper.CloseLightDismissPopups(WinUICoreServices.Instance.ContentRootCoordinator!.CoreWindowContentRoot!.XamlRoot));
+			.ObserveWillResignActive(DismissPopups);
+	}
+
+	private void DismissPopups(object? sender, object? args)
+	{
+		if (_xamlRoot is not null)
+		{
+			VisualTreeHelper.CloseLightDismissPopups(_xamlRoot);
+		}
 	}
 
 	private void NativeOverlayLayer_SubviewsChanged(object? sender, EventArgs e) => _lastSvgClipPath = null; // Ensure the clip path is invalidated for next render.

--- a/src/Uno.UI/Controls/RootViewController.UIKit.cs
+++ b/src/Uno.UI/Controls/RootViewController.UIKit.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Foundation;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
 using ObjCRuntime;
 using UIKit;
@@ -10,6 +11,8 @@ namespace Uno.UI.Controls
 {
 	public partial class RootViewController : UINavigationController, IRotationAwareViewController
 	{
+		private XamlRoot _xamlRoot;
+
 		internal event Action VisibleBoundsChanged;
 
 		public RootViewController()
@@ -48,14 +51,12 @@ namespace Uno.UI.Controls
 #if !__TVOS__
 			// Dismiss on device rotation: this reproduces the windows behavior
 			UIApplication.Notifications
-				.ObserveDidChangeStatusBarOrientation((sender, args) =>
-					VisualTreeHelper.CloseLightDismissPopups(WinUICoreServices.Instance.ContentRootCoordinator.CoreWindowContentRoot.XamlRoot));
+				.ObserveDidChangeStatusBarOrientation(DismissPopups);
 #endif
 
 			// Dismiss when the app is entering background
 			UIApplication.Notifications
-				.ObserveWillResignActive((sender, args) =>
-					VisualTreeHelper.CloseLightDismissPopups(WinUICoreServices.Instance.ContentRootCoordinator.CoreWindowContentRoot.XamlRoot));
+				.ObserveWillResignActive(DismissPopups);
 
 #if NET9_0_OR_GREATER
 			// iOS 17+ only
@@ -65,6 +66,16 @@ namespace Uno.UI.Controls
 			}
 #endif
 		}
+
+		private void DismissPopups(object sender, object args)
+		{
+			if (_xamlRoot is not null)
+			{
+				VisualTreeHelper.CloseLightDismissPopups(_xamlRoot);
+			}
+		}
+
+		internal void SetXamlRoot(XamlRoot xamlRoot) => _xamlRoot = xamlRoot;
 
 		// This will handle when the status bar is showed / hidden by the system on iPhones
 		public override void ViewSafeAreaInsetsDidChange()

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.UIKit.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapper.UIKit.cs
@@ -32,6 +32,7 @@ internal class NativeWindowWrapper : NativeWindowWrapperBase, INativeWindowWrapp
 		_nativeWindow = new NativeWindow();
 
 		_mainController = MUXWindow.ViewControllerGenerator?.Invoke() ?? new RootViewController();
+		_mainController.SetXamlRoot(xamlRoot);
 		_mainController.View.BackgroundColor = UIColor.Clear;
 		_mainController.NavigationBarHidden = true;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/1104, closes [#1102](https://github.com/unoplatform/uno-private/issues/1102)

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?


- Bugfix

## What is the current behavior?

Crashes

## What is the new behavior?

Does not crash

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
