### PR TITLE
chore: crosstargeting_override.props.sample misc fix

### DIFF
--- a/src/crosstargeting_override.props.sample
+++ b/src/crosstargeting_override.props.sample
@@ -30,12 +30,12 @@
         ├──────────────────────────────────────────────────────────┼──────────────────────────────┼───────────────────────────────────────────────┤
         │ net8.0-windows10.0.19041.0 or net9.0-windows10.0.19041.0 │ Windows                      │ Uno.UI-Windows-only.slnf                      │
         │ net8.0 or net9.0                                         │ WebAssembly, Skia            │ Uno.UI-Wasm-only.slnf, Uno.UI-Skia-only.slnf  │
+        │ net8.0-android or net9.0-android                         │ .NET 8/9 Android             │ Uno.UI-netcore-mobile-only.slnf               │
+        │ net8.0-android or net9.0-android                         │ .NET 8/9 Android Skia        │ Uno.UI-Skia-only.slnf                         │
         │ net8.0-ios or net9.0-ios                                 │ .NET 8/9 iOS                 │ Uno.UI-netcore-mobile-only.slnf               │
-        │ net8.0-ios or net9.0-ios                                 │ .NET 8/9 iOS  Skia           │ Uno.UI-netcore-mobile-only.slnf               │
+        │ net8.0-ios or net9.0-ios                                 │ .NET 8/9 iOS Skia            │ Uno.UI-Skia-only.slnf                         │
         │ net8.0-tvos or net9.0-tvos                               │ .NET 8/9 tvOS                │ Uno.UI-netcore-mobile-only.slnf               │
         │ net8.0-tvos or net9.0-tvos                               │ .NET 8/9 tvOS Skia           │ Uno.UI-Skia-only.slnf                         │
-        │ net8.0-android or net9.0-android                         │ .NET 8/9 Android             │ Uno.UI-netcore-mobile-only.slnf               │
-        │ net8.0-android or net9.0-android                         │ .NET 8/9 Android Skia        │ Uno.UI-netcore-mobile-only.slnf               │
         │ net8.0-maccatalyst or net9.0-maccatalyst                 │ .NET 8/9 macOS Catalyst      │ Uno.UI-netcore-mobile-only.slnf               │
         │ net8.0-maccatalyst or net9.0-maccatalyst                 │ .NET 8/9 macOS Catalyst Skia │ Uno.UI-Skia-only.slnf                         │
         │ net8.0 or net9.0                                         │ Wasm+Skia Reference API      │ Uno.UI-Reference-only.slnf                    │


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix
- Documentation content changes

## What is the current behavior?
documentation instructing skia targets to build with `Uno.UI-netcore-mobile-only.slnf`

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->