### PR TITLE
fix(pointers): Fix inertia scrolling might not being stopped

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -2,10 +2,12 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Microsoft.UI.Xaml.Input;
 using Windows.Foundation;
 using Microsoft.UI.Input;
 using Uno.Disposables;
+using Uno.Foundation.Logging;
 using Uno.UI.Extensions;
 using Uno.UI.Xaml.Core;
 using static Uno.UI.Xaml.Core.InputManager.PointerManager;
@@ -24,6 +26,12 @@ namespace Microsoft.UI.Xaml.Controls
 		, ICustomClippingElement
 #endif
 	{
+#nullable enable
+		private static readonly Action<string>? _trace = typeof(ScrollContentPresenter).Log().IsEnabled(LogLevel.Trace)
+			? typeof(ScrollContentPresenter).Log().Trace
+			: null;
+#nullable restore
+
 		private /*readonly - partial*/ IScrollStrategy _strategy;
 		private ScrollOptions? _touchInertiaOptions;
 
@@ -147,15 +155,19 @@ namespace Microsoft.UI.Xaml.Controls
 			double? verticalOffset = null,
 			float? zoomFactor = null,
 			bool disableAnimation = false,
-			bool isIntermediate = false)
-			=> Set(horizontalOffset, verticalOffset, zoomFactor, options: new(disableAnimation), isIntermediate);
+			bool isIntermediate = false,
+			[CallerMemberName] string callerName = "",
+			[CallerLineNumber] int callerLine = -1)
+			=> Set(horizontalOffset, verticalOffset, zoomFactor, options: new(disableAnimation), isIntermediate, callerName, callerLine);
 
 		private bool Set(
 			double? horizontalOffset = null,
 			double? verticalOffset = null,
 			float? zoomFactor = null,
 			ScrollOptions options = default,
-			bool isIntermediate = false)
+			bool isIntermediate = false,
+			[CallerMemberName] string callerName = "",
+			[CallerLineNumber] int callerLine = -1)
 		{
 			var success = true;
 
@@ -184,6 +196,8 @@ namespace Microsoft.UI.Xaml.Controls
 					VerticalOffset = scrollY;
 				}
 			}
+
+			_trace?.Invoke($"Scroll [{callerName}@{callerLine}] (success: {success} | req: h={horizontalOffset} v={verticalOffset} | actual: h={HorizontalOffset} v={VerticalOffset} | inter: {isIntermediate} | opts: {options})");
 
 			Apply(options, isIntermediate);
 

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -108,6 +108,7 @@ partial class InputManager
 				foreach ((var manipPointer, var manip) in new Dictionary<PointerIdentifier, DirectManipulation>(_directManipulations))
 				{
 					if (manipPointer.Type != currentPointer.Type // Not the same type
+						|| manip.Recognizer.PendingManipulation is { Inertia: not null } // Manipulation is processing inertia, we want to stop it as soon as a new pointer is pressed
 						|| manip.Recognizer.PendingManipulation?.IsActive(currentPointer) is true) // Second press on the same pointer, we cancel the previous one!
 					{
 						if (_trace)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1096

## Bugfix
Inertia scrolling might not being stopped

## What is the current behavior?
If input source provides a different pointer ID for each touch, we do not abort previous inertial scrolling

## What is the new behavior?
Pending direct manipulation is being aborted on pointer pressed if processing inertia

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
