### PR TITLE
Fix: FlipView can swipe multiple items at once

### DIFF
--- a/src/Uno.UI.Composition/Composition/CompositionAnimation.cs
+++ b/src/Uno.UI.Composition/Composition/CompositionAnimation.cs
@@ -56,7 +56,7 @@ public partial class CompositionAnimation
 	internal virtual object? Start(ReadOnlySpan<char> propertyName, ReadOnlySpan<char> subPropertyName, CompositionObject compositionObject)
 	{
 #if __SKIA__
-		Compositor.RegisterAnimation(this);
+		Compositor.RegisterAnimation(this, compositionObject);
 #endif
 		return null;
 	}

--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -21,11 +21,15 @@ public partial class Compositor
 
 	internal bool? IsSoftwareRenderer { get; set; }
 
-	internal void RegisterAnimation(CompositionAnimation animation)
+	internal void RegisterAnimation(CompositionAnimation animation, CompositionObject visual)
 	{
 		if (animation.IsTrackedByCompositor)
 		{
 			_runningAnimations.Add(animation);
+			if (visual is Visual { CompositionTarget: { } target })
+			{
+				CoreApplication.QueueInvalidateRender(target);
+			}
 		}
 	}
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1101

## Bugfix
FlipView can swipe multiple items at once

## What is the current behavior?
* FlipView can swipe more than one item at once
* Snapping animation is not running (`ScrollViewer` scroll animation)

## What is the new behavior?
* Coerce the inertial support between nested SV
* Frame is requested as soon as a composition animation is started

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
