### PR TITLE
fix: add phone state permission to sample app

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/Android/AssemblyInfo.Android.cs
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/Android/AssemblyInfo.Android.cs
@@ -17,4 +17,5 @@ using Android.App;
 [assembly: UsesPermission("android.permission.READ_MEDIA_IMAGES")]
 [assembly: UsesPermission("android.permission.READ_MEDIA_VIDEO")]
 [assembly: UsesPermission("android.permission.READ_MEDIA_AUDIO")]
+[assembly: UsesPermission("android.permission.READ_PHONE_STATE")]
 [assembly: UsesPermission("android.permission.MANAGE_EXTERNAL_STORAGE")]

--- a/src/SamplesApp/SamplesApp.netcoremobile/Android/AssemblyInfo.Android.cs
+++ b/src/SamplesApp/SamplesApp.netcoremobile/Android/AssemblyInfo.Android.cs
@@ -17,5 +17,6 @@ using Android.App;
 [assembly: UsesPermission("android.permission.READ_MEDIA_IMAGES")]
 [assembly: UsesPermission("android.permission.READ_MEDIA_VIDEO")]
 [assembly: UsesPermission("android.permission.READ_MEDIA_AUDIO")]
+[assembly: UsesPermission("android.permission.READ_PHONE_STATE")]
 [assembly: UsesPermission("android.permission.MANAGE_EXTERNAL_STORAGE")]
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #19908 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Adds permission to SampleApp

PermissionsHelper couldn't find the READ_PHONE_STATE permission, resulting in a crash when the permission request was to be prompted to the user.
