### PR TITLE
fix(skia): MediaPlayerElement rendering

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
@@ -36,14 +36,11 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 			else
 			{
-#if __APPLE_UIKIT__
 				// There are situations where between measurements scaledDimension and naturalDimension
 				// have a small difference in value (a few pixels) causing the measurement to go into an infinite loop.
 				// Related to: https://github.com/unoplatform/uno/issues/15254
 				var ratio = (float)Math.Round(scaledOneDimension / naturalOneDimension, 1);
-#else
-				var ratio = scaledOneDimension / naturalOneDimension;
-#endif
+
 				return naturalOtherDimension * ratio;
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerPresenter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using Windows.Foundation;
 using Windows.Media.Playback;
 using Windows.UI.Core;
@@ -9,11 +10,11 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class MediaPlayerPresenter : Border
 	{
-		private WeakReference<MediaPlayerElement> wrOwner;
+		private WeakReference<MediaPlayerElement>? _wrOwner;
 
 		internal void SetOwner(MediaPlayerElement owner)
 		{
-			wrOwner = new WeakReference<MediaPlayerElement>(owner);
+			_wrOwner = new WeakReference<MediaPlayerElement>(owner);
 		}
 
 		private float GetScaledOtherDimension(
@@ -178,6 +179,7 @@ namespace Microsoft.UI.Xaml.Controls
 				Visibility = Visibility.Collapsed;
 			});
 		}
+
 		private void OnSourceChanged(global::Windows.Media.Playback.MediaPlayer sender, object args)
 		{
 			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
@@ -188,7 +190,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		internal FrameworkElement GetLayoutOwner()
 		{
-			if (wrOwner?.TryGetTarget(out var owner) == true && owner is not null && !IsFullWindow)
+			if (_wrOwner?.TryGetTarget(out var owner) == true && owner is not null && !IsFullWindow)
 			{
 				return owner;
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/1051

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
A bug is noticeable when rendering the MediaPlayer on Skia where we see the Control bouncing on the screen.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
