### PR TITLE
fix: skia flyout placement

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Flyout.cs
@@ -1618,7 +1618,16 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RunsOnUIThread]
-		public async Task When_Unbound_FullFlyout()
+		public Task When_Unbound_FullFlyout_Any() =>
+			When_Unbound_FullFlyout_Impl(skiaFullScreen: false);
+
+		[ConditionalTest(IgnoredPlatforms = ~RuntimeTestPlatforms.SkiaMobile)]
+		[RunsOnUIThread]
+		public Task When_Unbound_FullFlyout_SkiaMobile() =>
+			// canvas for skia mobile is in absolute fullscreen, including area taken by status bar or bottom navigation bar.
+			When_Unbound_FullFlyout_Impl(skiaFullScreen: true);
+
+		private async Task When_Unbound_FullFlyout_Impl(bool skiaFullScreen)
 		{
 			var host = new Button
 			{
@@ -1674,10 +1683,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				await TestServices.WindowHelper.WaitForLoaded(presenter);
 
 				var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
+				var expected = skiaFullScreen
+					? host.XamlRoot.Size
+					: new Size(bounds.Width, bounds.Height);
 
 				Assert.IsTrue(
 					presenter.ActualWidth >= bounds.Width && presenter.ActualHeight >= bounds.Height,
-					$"flyout not taking the full size offered: flyout={presenter.ActualWidth}x{presenter.ActualHeight}, VisibleBounds={bounds.Width}x{bounds.Height}");
+					$"flyout not taking the full size offered: flyout={presenter.ActualWidth}x{presenter.ActualHeight}, {(skiaFullScreen ? "XamlRoot.Bounds" : "VisibleBounds")}={expected.Width}x{expected.Height}");
 			}
 			finally
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs#1438

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On skia-everywhere ios, the full flyout placement doesnt match the space available to the app which extends into the status bar.

## What is the new behavior?
For skia-everywhere, the full flyout placement will match the space available to the app.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.