### PR TITLE
fix(macOS): Desktop MPE when player ends

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSMediaPlayerPresenterExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSMediaPlayerPresenterExtension.cs
@@ -19,9 +19,9 @@ namespace Uno.UI.Runtime.Skia.MacOS;
 
 internal class MacOSMediaPlayerPresenterExtension : IMediaPlayerPresenterExtension
 {
-	private MediaPlayerPresenter _presenter;
+	private readonly MediaPlayerPresenter _presenter;
 	private MacOSMediaPlayerExtension? _playerExtension;
-	private nint _nativeView;
+	private readonly nint _nativeView;
 
 	private MacOSMediaPlayerPresenterExtension(object owner)
 	{

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMediaPlayer.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOMediaPlayer.m
@@ -309,6 +309,7 @@ id timeObserver;
 
 - (id)init {
     self.player = [[AVQueuePlayer alloc] init];
+    self.player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
     self.videoLayer = [AVPlayerLayer playerLayerWithPlayer:self.player];
     self.isVideo = NO;
 #if DEBUG_MEDIAPLAYER


### PR DESCRIPTION
GitHub Issue (If applicable): 

related to https://github.com/unoplatform/uno-private/issues/1052

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

When the video player ends, the player will keep the last frame. This will match with the current iOS behaviour.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
