### PR TITLE
chore: check is path is not empty (instead of null)

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/RootViewController.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/RootViewController.cs
@@ -140,7 +140,7 @@ internal class RootViewController : UINavigationController, IAppleUIKitXamlRootH
 				int width = (int)View!.Frame.Width;
 				int height = (int)View!.Frame.Height;
 				var path = SkiaRenderHelper.RenderRootVisualAndReturnNegativePath(width, height, rootVisual, surface.Canvas);
-				if (path is { })
+				if (!path.IsEmpty)
 				{
 					var svgPath = path.ToSvgPathData();
 					if (svgPath != _lastSvgClipPath)

--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
@@ -86,7 +86,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 				int width = (int)nativeWidth;
 				int height = (int)nativeHeight;
 				var path = SkiaRenderHelper.RenderRootVisualAndReturnNegativePath(width, height, rootVisual, surface.Canvas);
-				if (path is { })
+				if (!path.IsEmpty)
 				{
 					NativeUno.uno_window_clip_svg(_nativeWindow.Handle, path.ToSvgPathData());
 				}


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

The newer `SkiaRenderHelper.RenderRootVisualAndReturnNegativePath` API returns an empty path, not `null`, if there's not clipping required.

This means we're doing extra work (and allocations) that are not needed.

## What is the new behavior?

If the path is empty we do not execute any clipping code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
