### PR TITLE
fix: avoid beeps for valid keystrokes on macOS

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
@@ -305,7 +305,8 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 			}
 			var args = CreateArgs(key, mods, scanCode, unicode);
 			keyDown.Invoke(window!, args);
-			return FocusManager.GetFocusedElement() == null ? 0 : 1;
+			var root = window?._xamlRoot;
+			return root is null || FocusManager.GetFocusedElement(root) == null ? 0 : 1;
 		}
 		catch (Exception e)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

With the recent [change](https://github.com/unoplatform/uno/pull/19898/files#diff-e32a31a7bea84a6a58b25e8799bf8283a41248bbf7360d8ff6c4941ea8bf3c7fR75) to `FocusManager.GetFocusedElement` all keystrokes on a Mac will beep (like it's invalid).

## What is the new behavior?

All accepted keys will not beep.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
