### PR TITLE
perf(macOS): remove some reflection for Skia/Metal

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSMetalRenderer.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSMetalRenderer.cs
@@ -27,23 +27,4 @@ internal static class MacOSMetalRenderer
 		}
 		return context;
 	}
-
-	private static readonly ConstructorInfo? _rt = typeof(GRBackendRenderTarget).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, [typeof(nint), typeof(bool)], null);
-
-	public static unsafe GRBackendRenderTarget? CreateTarget(GRContext context, double nativeWidth, double nativeHeight, nint texture)
-	{
-		// note: size is doubled for retina displays
-		var info = new GRMtlTextureInfoNative() { Texture = texture };
-		var nt = NativeSkia.gr_backendrendertarget_new_metal((int)nativeWidth, (int)nativeHeight, &info);
-		if (nt == IntPtr.Zero)
-		{
-			if (typeof(MacOSMetalRenderer).Log().IsEnabled(LogLevel.Error))
-			{
-				typeof(MacOSMetalRenderer).Log().Error("Failed to initialize Skia with Metal backend.");
-			}
-			return null;
-		}
-		// FIXME: contribute some extra API (e.g. using `nint` or `IntPtr`) to SkiaSharp to avoid reflection
-		return (GRBackendRenderTarget)_rt?.Invoke(new object[] { nt, true })!;
-	}
 }

--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
@@ -119,7 +119,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 		}
 
 		// we can't cache anything since the texture will be different on next calls
-		using var target = MacOSMetalRenderer.CreateTarget(_context!, nativeWidth, nativeHeight, texture);
+		using var target = new GRBackendRenderTarget((int)nativeWidth, (int)nativeHeight, new GRMtlTextureInfo(texture));
 		using var surface = SKSurface.Create(_context, target, GRSurfaceOrigin.TopLeft, SKColorType.Rgba8888);
 
 		surface.Canvas.Scale(scale, scale);

--- a/src/Uno.UI.Runtime.Skia.MacOS/NativeSkia.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/NativeSkia.cs
@@ -7,13 +7,4 @@ internal static partial class NativeSkia
 	[LibraryImport("libSkiaSharp")]
 	[UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
 	internal static partial nint gr_direct_context_make_metal(nint device, nint queue);
-
-	[LibraryImport("libSkiaSharp")]
-	[UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
-	internal static unsafe partial nint gr_backendrendertarget_new_metal(int width, int height, GRMtlTextureInfoNative* mtlInfo);
-}
-
-internal struct GRMtlTextureInfoNative
-{
-	public nint Texture;
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Before Skia 3.x if was not possible to create instance of `GRBackendRenderTarget`, without reflection, when using the `netX.X` TFM.

## What is the new behavior?

`GRBackendRenderTarget` can now be created without the use of reflection.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
