### PR TITLE
fix: `DrawingFinished` handler timing

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -236,7 +236,15 @@ public partial class TextBox
 						_lastEndCaretRect = null;
 					};
 
-					inlines.DrawingFinished += UpdateFlyoutPosition;
+					inlines.DrawingFinished += () =>
+					{
+						// Only invalidate the carets after drawing is complete
+						// to avoid modifying the children visuals while they are being enumerated.
+						NativeDispatcher.Main.Enqueue(() =>
+						{
+							UpdateFlyoutPosition();
+						}, NativeDispatcherPriority.Normal);
+					};
 
 					inlines.CaretFound += args =>
 					{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/1155

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When the event handler is executed while a render is in progress, it causes a crash when the carets are added or removed

## What is the new behavior?

Modified the `DrawingFinished` event handler to use a lambda function that enqueues the `UpdateFlyoutPosition` method on the main thread after drawing is complete. This change ensures carets are invalidated only after the drawing process, preventing potential issues from modifying visuals during enumeration.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
