### PR TITLE
fix(hr): Fix HR not working in Popups

### DIFF
--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -114,7 +114,11 @@ partial class ClientHotReloadProcessor
 
 			UpdateGlobalResources(updatedTypes);
 
+#if HAS_UNO_WINUI
 			var rootElement = window.Content?.XamlRoot?.VisualTree.RootElement;
+#else
+			var rootElement = window.Content?.XamlRoot?.Content;
+#endif
 			if (rootElement is null)
 			{
 				if (_log.IsEnabled(LogLevel.Error))

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs
@@ -100,7 +100,6 @@ partial class ClientHotReloadProcessor
 		using var sequentialUiUpdateLock = await _uiUpdateGate.LockAsync(default);
 
 		var handlerActions = ElementAgent?.ElementHandlerActions;
-
 		var uiUpdating = true;
 		try
 		{
@@ -114,6 +113,17 @@ partial class ClientHotReloadProcessor
 			}
 
 			UpdateGlobalResources(updatedTypes);
+
+			var rootElement = window.Content?.XamlRoot?.VisualTree.RootElement;
+			if (rootElement is null)
+			{
+				if (_log.IsEnabled(LogLevel.Error))
+				{
+					_log.Error("Error doing UI Update - no visual root");
+				}
+
+				return;
+			}
 
 			// Action: BeforeVisualTreeUpdate
 			// This is called before the visual tree is updated
@@ -141,7 +151,7 @@ partial class ClientHotReloadProcessor
 
 			var isCapturingState = true;
 			var treeIterator = EnumerateHotReloadInstances(
-				window.Content,
+				rootElement,
 				async (fe, key) =>
 				{
 					// Get the original type of the element, in case it's been replaced
@@ -222,7 +232,7 @@ partial class ClientHotReloadProcessor
 
 				if (elementMappedType is not null)
 				{
-					if (_log.IsEnabled(LogLevel.Trace))
+					if (_log.IsEnabled(LogLevel.Error))
 					{
 						_log.Error($"Updating element [{element}] to [{elementMappedType}]");
 					}

--- a/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/HotReload/Frame/HRApp/Tests/Given_Popup.cs
@@ -1,0 +1,66 @@
+﻿#nullable disable
+
+using System;
+using System.Formats.Asn1;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft/* UWP don't rename */.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Uno.Disposables;
+using Uno.UI.RemoteControl;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame.Pages;
+using Uno.UI.RuntimeTests.Tests.HotReload;
+using Uno.UI.RuntimeTests.Tests.HotReload.Frame;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.Helpers;
+using Uno.UI.RemoteControl.HotReload;
+
+namespace Uno.UI.RuntimeTests.Tests.HotReload.Frame.HRApp.Tests;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_Popup : BaseTestClass
+{
+	public const string SimpleTextChange = " (changed)";
+
+	public const string FirstPageTextBlockOriginalText = "First page";
+	public const string FirstPageTextBlockChangedText = FirstPageTextBlockOriginalText + SimpleTextChange;
+
+	public const string SecondPageTextBlockOriginalText = "Second page";
+	public const string SecondPageTextBlockChangedText = SecondPageTextBlockOriginalText + SimpleTextChange;
+
+
+	/// <summary>
+	/// Checks that a simple change to a XAML element (change Text on TextBlock) will be applied to
+	/// the currently visible page:
+	/// Open Page1
+	/// Change Page1
+	/// </summary>
+	[TestMethod]
+	public async Task When_Changing_TextBlock_Within_Popup()
+	{
+		var ct = new CancellationTokenSource(TimeSpan.FromSeconds(60)).Token;
+
+		var page = new HR_Frame_Pages_Page1();
+		var popup = new Popup { Child = page };
+		UnitTestsUIContentHelper.Content = new ContentControl { Content = popup };
+
+		await UnitTestsUIContentHelper.WaitForIdle();
+		popup.IsOpen = true;
+
+		await UnitTestsUIContentHelper.WaitForLoaded(page);
+		await UnitTestsUIContentHelper.WaitForIdle();
+
+		// Check the initial text of the TextBlock
+		await page.ValidateTextOnChildTextBlock(FirstPageTextBlockOriginalText);
+
+		// Check the updated text of the TextBlock
+		await HotReloadHelper.UpdateServerFileAndRevert<HR_Frame_Pages_Page1>(
+			FirstPageTextBlockOriginalText,
+			FirstPageTextBlockChangedText,
+			() => page.ValidateTextOnChildTextBlock(FirstPageTextBlockChangedText),
+			ct);
+	}
+}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.hotdesign/issues/3931

## Bugfix
Fix HR not working in Popups

## What is the current behavior?
We update the visual tree only from the `window.Content`

## What is the new behavior?
We start updates from the real content root of the application

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
