### PR TITLE
fix: Do not access element until initialized

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserRenderer.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserRenderer.ts
@@ -36,13 +36,15 @@ namespace Uno.UI.Runtime.Skia {
 			var w = width * scale
 			var h = height * scale;
 
-			if (this.canvas.width !== w)
-				this.canvas.width = w;
-			if (this.canvas.height !== h)
-				this.canvas.height = h;
+			if (this.canvas) {
+				if (this.canvas.width !== w)
+					this.canvas.width = w;
+				if (this.canvas.height !== h)
+					this.canvas.height = h;
 
-			this.canvas.style.width = `${width}px`;
-			this.canvas.style.height = `${height}px`;
+				this.canvas.style.width = `${width}px`;
+				this.canvas.style.height = `${height}px`;
+			}
 
 			// We request to repaint on the next frame. Without this, the first frame after resizing the window will be
 			// blank and will cause a flickering effect when you drag the window's border to resize.


### PR DESCRIPTION
GitHub Issue (If applicable): closes #


## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

We may be accessing the instance too early, while still undefined, causing exceptions

## What is the new behavior?

Waiting until initialized

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
