### PR TITLE
fix: Avoid keeping font manifest stream open forever

### DIFF
--- a/src/Uno.UI/UI/Xaml/Documents/TextFormatting/FontDetailsCache.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/TextFormatting/FontDetailsCache.skia.cs
@@ -41,7 +41,7 @@ internal static class FontDetailsCache
 			if (await StorageFileHelper.ExistsInPackage(path))
 			{
 				var manifestFile = await StorageFile.GetFileFromApplicationUriAsync(manifestUri);
-				var manifestStream = await manifestFile.OpenStreamForReadAsync();
+				using var manifestStream = await manifestFile.OpenStreamForReadAsync();
 				uri = new Uri(FontManifestHelpers.GetFamilyNameFromManifest(manifestStream, weight, style, stretch));
 			}
 		}
@@ -59,7 +59,7 @@ internal static class FontDetailsCache
 		}
 
 		var file = await StorageFile.GetFileFromApplicationUriAsync(uri);
-		var stream = await file.OpenStreamForReadAsync();
+		using var stream = await file.OpenStreamForReadAsync();
 		return stream is null ? null : SKTypeface.FromStream(stream);
 	}
 

--- a/src/Uno.UI/UI/Xaml/FontFamilyHelper.skia.cs
+++ b/src/Uno.UI/UI/Xaml/FontFamilyHelper.skia.cs
@@ -54,8 +54,11 @@ internal static partial class FontFamilyHelper
 		}
 
 		var manifestFile = await StorageFile.GetFileFromApplicationUriAsync(manifestUri);
-		var manifestStream = await manifestFile.OpenStreamForReadAsync();
-		var manifest = FontManifestHelpers.DeserializeManifest(manifestStream);
+		FontManifest? manifest = null;
+		using (var manifestStream = await manifestFile.OpenStreamForReadAsync())
+		{
+			manifest = FontManifestHelpers.DeserializeManifest(manifestStream);
+		}
 
 		if (manifest is null)
 		{

--- a/src/Uno.UI/UI/Xaml/FontFamilyHelper.skia.cs
+++ b/src/Uno.UI/UI/Xaml/FontFamilyHelper.skia.cs
@@ -54,7 +54,7 @@ internal static partial class FontFamilyHelper
 		}
 
 		var manifestFile = await StorageFile.GetFileFromApplicationUriAsync(manifestUri);
-		FontManifest? manifest = null;
+		FontManifest manifest = null;
 		using (var manifestStream = await manifestFile.OpenStreamForReadAsync())
 		{
 			manifest = FontManifestHelpers.DeserializeManifest(manifestStream);


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/1102

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`.manifest` stream is kept open

## What is the new behavior?

In case of iOS this is a problem, as the system does not allow keeping streams outside of some allowed filesystem locations open when the application is backgrounded.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
