### PR TITLE
fix(combobox): dismissed combo cannot be reopened

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.Graphics.Display;
@@ -67,6 +68,14 @@ public static class UITestHelper
 		}
 		await TestServices.WindowHelper.WaitForIdle();
 	}
+
+	public static Task WaitFor(
+		Func<bool> condition,
+		int timeoutMS = 1000,
+		string? message = null,
+		[CallerMemberName] string? callerMemberName = null,
+		[CallerLineNumber] int lineNumber = 0
+	) => TestServices.WindowHelper.WaitFor(condition, timeoutMS, message, callerMemberName, lineNumber);
 
 	public static Task WaitForIdle() => TestServices.WindowHelper.WaitForIdle();
 

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.custom.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.custom.cs
@@ -109,6 +109,14 @@ public partial class ComboBox : Selector
 			//	border.Child 
 			//}
 
+#if HAS_UNO
+			if (IsLoaded)
+			{
+				popup.Closed -= OnPopupClosed;
+				popup.Closed += OnPopupClosed;
+			}
+#endif
+
 			popup.CustomLayouter = new DropDownLayouter(this, popup);
 
 			popup.IsLightDismissEnabled = true;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #20014

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
An initially collapsed ComboBox stays "open" when light-dismissed, prevent it from being opened again, until the focus is lost from the ComboBox forcing it to finally "close".

## What is the new behavior?
No more of that shenanigans...

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.