### PR TITLE
docs: fixing the logo asset path for the C#/MVVM Counter documentation

### DIFF
--- a/doc/articles/getting-started/counterapp/get-started-counter-csharp-mvvm.md
+++ b/doc/articles/getting-started/counterapp/get-started-counter-csharp-mvvm.md
@@ -151,7 +151,7 @@ Now that we have the **`MainViewModel`** class, we can update the **`MainPage`**
                                 .HorizontalAlignment(HorizontalAlignment.Center)
                                 .Width(150)
                                 .Height(150)
-                                .Source("ms-appx:///Counter/Assets/logo.png"),
+                                .Source("ms-appx:///Assets/logo.png"),
                             new TextBox()
                                 .Margin(12)
                                 .HorizontalAlignment(HorizontalAlignment.Center)


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

The path of the logo asset references a non existent folder in the C#/MVVM Counter documentation.


## What is the new behavior?

The updated path allow the asset to load properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.


## Other information

Was already fixed in the other Counter tutorial variants.

