### PR TITLE
perf: Fix boxing in the BorderLayerRenderer

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Android.cs
@@ -45,7 +45,7 @@ namespace Uno.UI.Xaml.Controls
 			var newState = new BorderLayerState(drawArea.Size, _borderInfoProvider);
 			var previousLayoutState = _currentState;
 
-			if (newState.Equals(previousLayoutState) && !forceUpdate)
+			if (newState.Equals((BorderLayerState)previousLayoutState) && !forceUpdate)
 			{
 				return;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Apple.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.Apple.cs
@@ -64,7 +64,7 @@ partial class BorderLayerRenderer
 			_borderInfoProvider.BorderBrush,
 			_borderInfoProvider.BorderThickness,
 			_borderInfoProvider.CornerRadius);
-		if (!newState.Equals(_currentState) || forceUpdate)
+		if (!newState.Equals((BorderLayerState)_currentState) || forceUpdate)
 		{
 			_layerDisposable.Disposable = null;
 			_layerDisposable.Disposable = InnerCreateLayer(_owner, _owner.Layer, newState, out var updatedBoundsPath);

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.wasm.cs
@@ -33,7 +33,7 @@ partial class BorderLayerRenderer
 			_borderInfoProvider.BorderThickness,
 			_borderInfoProvider.CornerRadius);
 		var previousLayoutState = _currentState;
-		if (!newState.Equals(previousLayoutState) || forceUpdate)
+		if (!newState.Equals((BorderLayerState)previousLayoutState) || forceUpdate)
 		{
 			if (previousLayoutState.Background != newState.Background && _owner is FrameworkElement fwElt)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #16107

https://github.com/unoplatform/uno/issues/16107

## PR Type
Performance Fix
What kind of change does this PR introduce?
Bugfix
Refactoring (no functional changes, no api changes)


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Boxing was observed in the border equals function.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
We unfortunately have not been able to figure out quality assurance methods (neither developer mode in Chrome or PerfView). however, we believe this should reduce the amount of boxing that is occurring in the .Equals comparison function found in BorderLayerRenderer UpdatePlatform method. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
