### PR TITLE
docs: Adding context about MainViewModel in Counter app MVUX variants…

### DIFF
--- a/doc/articles/getting-started/counterapp/get-started-counter-csharp-mvux.md
+++ b/doc/articles/getting-started/counterapp/get-started-counter-csharp-mvux.md
@@ -89,7 +89,7 @@ Also, for more information on all the template options, see [Using the Uno Platf
 
 ## Data Binding
 
-Now that we have the **`MainModel`** class, we can update the **`MainPage`** to use data binding to connect the UI to the application logic.
+As the application uses MVUX, the `MainModel` class is used to generate a bindable ViewModel, `MainViewModel`. We can update the **`MainPage`** to use data binding to connect the UI to the application logic.
 
 - Let's add the **`DataContext`** to our page. To do so, add `.DataContext(new MainViewModel(), (page, vm) => page` before `.Background(...)`. Remember to close the **`DataContext`** expression with a `)` at the end of the code. It should look similar to the code below:
 

--- a/doc/articles/getting-started/counterapp/get-started-counter-xaml-mvux.md
+++ b/doc/articles/getting-started/counterapp/get-started-counter-xaml-mvux.md
@@ -89,7 +89,7 @@ Also, for more information on all the template options, see [Using the Uno Platf
 
 ## Data Binding
 
-Now that we have the **`MainModel`** class, we can update the **`MainPage`** to use data binding to connect the UI to the application logic.
+As the application uses MVUX, the `MainModel` class is used to generate a bindable ViewModel, `MainViewModel`. We can update the **`MainPage`** to use data binding to connect the UI to the application logic.
 
 - Add a **`DataContext`** element to the **`Page`** element in the **MainPage.xaml** file.
 

--- a/doc/articles/getting-started/counterapp/get-started-counter-xaml-mvvm.md
+++ b/doc/articles/getting-started/counterapp/get-started-counter-xaml-mvvm.md
@@ -119,7 +119,7 @@ Now that we have the **`MainViewModel`** class, we can update the **`MainPage`**
              TextAlignment="Center" />
     ```
 
-- Add a new **`Button`** with a  **`Command`** attribute that is bound to the **`IncrementCommand`** property of the **`MainViewModel`**.
+- Update the **`Button`** by adding a **`Command`** attribute that is bound to the **`IncrementCommand`** property of the **`MainViewModel`**.
 
     ```xml
     <Button Margin="12"


### PR DESCRIPTION
… + typo fix

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

 - In Counter app variants XAML/MVUX and C#/MVUX there's no information about the generation of MainViewModel by MVUX. Users are asked to create MainModel, and immediately afterward the tutorial introduces MainViewModel, which can appear as a typo or inconsistency. The origin of MainViewModel is however clearly explained in the Hot Design variant of the tutorial.
 - The XAML/MVVM variant of the Counter app documentation asks users to add a new button instead of updating the existing one

## What is the new behavior?

 - A sentence from the Hot Design variant explaining the origin of MainViewModel was copied to both MVUX variants to provide context.
 - "Add..." was replaced with "Update..." in the XAML/MVVM variant.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->


