### PR TITLE
fix: Prevent temporary TextBox selection reset on text change

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -1,28 +1,28 @@
 ﻿using System;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Windows.ApplicationModel.DataTransfer;
-using Windows.System;
-using Windows.UI;
-using Windows.UI.Input.Preview.Injection;
+using FluentAssertions;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using FluentAssertions;
 using MUXControlsTestApp.Utilities;
+using SamplesApp.UITests;
 using Uno.Disposables;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
 using Uno.UI.Xaml.Core;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation;
+using Windows.System;
+using Windows.UI;
+using Windows.UI.Input.Preview.Injection;
 using static Private.Infrastructure.TestServices;
 using Color = Windows.UI.Color;
 using Point = Windows.Foundation.Point;
-using System.Runtime.InteropServices;
-using Windows.Foundation;
-using SamplesApp.UITests;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -4127,6 +4127,33 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		public async Task When_First_Second_Tap_Caret_Thumb_Shows()
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text"
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.IsTrue(SUT.CaretMode is TextBox.CaretDisplayMode.ThumblessCaretHidden or TextBox.CaretDisplayMode.ThumblessCaretShowing);
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			Assert.AreEqual(TextBox.CaretDisplayMode.CaretWithThumbsOnlyEndShowing, SUT.CaretMode);
+		}
+
+		[TestMethod]
 		[UnoWorkItem("https://github.com/unoplatform/uno-private/issues/1199")]
 		public async Task When_TextBox_TextChange_Not_Trigger_Selection_Change_To_Start()
 		{
@@ -4161,6 +4188,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await WindowHelper.WaitForIdle();
 			Assert.IsFalse(selectionChangedToStart, "SelectionChanged event should not be triggered when TextBox text is changed.");
 		}
+
 		[TestMethod]
 		[UnoWorkItem("https://github.com/unoplatform/uno/issues/19327")]
 		public async Task When_Setting_Short_Text_And_Previous_Selection_Is_OutOfBounds()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4127,6 +4127,41 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		}
 
 		[TestMethod]
+		[UnoWorkItem("https://github.com/unoplatform/uno-private/issues/1199")]
+		public async Task When_TextBox_TextChange_Not_Trigger_Selection_Change_To_Start()
+		{
+			var SUT = new TextBox
+			{
+				Width = 400,
+				Text = "Some Text"
+			};
+
+			await UITestHelper.Load(SUT);
+
+			var selectionChangedToStart = false;
+
+			var displayBlock = SUT.TextBoxView.DisplayBlock;
+			displayBlock.SelectionChanged += (s, e) =>
+			{
+				if (displayBlock.SelectionStart.Offset == 0)
+				{
+					selectionChangedToStart = true;
+				}
+			};
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			using var finger = injector.GetFinger();
+
+			finger.Press(SUT.GetAbsoluteBoundsRect().GetCenter());
+			finger.Release();
+			await WindowHelper.WaitForIdle();
+
+			SUT.Text = "Some Text 2";
+
+			await WindowHelper.WaitForIdle();
+			Assert.IsFalse(selectionChangedToStart, "SelectionChanged event should not be triggered when TextBox text is changed.");
+		}
+		[TestMethod]
 		[UnoWorkItem("https://github.com/unoplatform/uno/issues/19327")]
 		public async Task When_Setting_Short_Text_And_Previous_Selection_Is_OutOfBounds()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -310,7 +310,7 @@ namespace Microsoft.UI.Xaml.Controls
 			UpdateInlines(newValue);
 
 #if __SKIA__
-			if (GetTemplatedParent() is not TextBox textBox || textBox.TextBoxView?.DisplayBlock != this)
+			if (!IsTextBoxDisplay)
 #endif
 			{
 				// On skia, we don't want to set the selection here in case TextBox is managing the selection.

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -47,6 +47,8 @@ namespace Microsoft.UI.Xaml.Controls
 			LostFocus += (_, _) => UpdateSelectionRendering();
 		}
 
+		internal bool IsTextBoxDisplay { get; set; }
+
 #if DEBUG
 		private protected override void OnLoaded()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -47,7 +47,7 @@ namespace Microsoft.UI.Xaml.Controls
 			LostFocus += (_, _) => UpdateSelectionRendering();
 		}
 
-		internal bool IsTextBoxDisplay { get; set; }
+		internal bool IsTextBoxDisplay { get; init; }
 
 #if DEBUG
 		private protected override void OnLoaded()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -1098,7 +1098,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		partial void OnPointerPressedPartial(PointerRoutedEventArgs args);
 
-		partial void OnPointerReleasedPartial(PointerRoutedEventArgs args);
+		partial void OnPointerReleasedPartial(PointerRoutedEventArgs args, bool wasFocused);
 
 		partial void OnPointerCaptureLostPartial(PointerRoutedEventArgs e);
 
@@ -1107,9 +1107,9 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			base.OnPointerReleased(args);
 
+			bool wasFocused = FocusState != FocusState.Unfocused;
 			if (!ShouldFocusOnPointerPressed(args))
 			{
-				var wasFocused = FocusState != FocusState.Unfocused;
 				Focus(FocusState.Pointer);
 #if __SKIA__
 				if (wasFocused)
@@ -1130,7 +1130,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			args.Handled = true;
 
-			OnPointerReleasedPartial(args);
+			OnPointerReleasedPartial(args, wasFocused);
 		}
 
 		protected override void OnTapped(TappedRoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.pointers.skia.cs
@@ -178,7 +178,7 @@ public partial class TextBox
 		}
 	}
 
-	partial void OnPointerReleasedPartial(PointerRoutedEventArgs args)
+	partial void OnPointerReleasedPartial(PointerRoutedEventArgs args, bool wasFocused)
 	{
 		_mouseMultiTapChunk = null;
 
@@ -197,11 +197,11 @@ public partial class TextBox
 		}
 		else if (!Text.IsNullOrEmpty()) // Touch tap
 		{
-			TouchTap(args.GetCurrentPoint(TextBoxView.DisplayBlock).Position);
+			TouchTap(args.GetCurrentPoint(TextBoxView.DisplayBlock).Position, wasFocused);
 		}
 	}
 
-	private void TouchTap(Point point)
+	private void TouchTap(Point point, bool wasFocused)
 	{
 		var index = Math.Max(0, DisplayBlockInlines.GetIndexAt(point, true, true));
 
@@ -227,7 +227,11 @@ public partial class TextBox
 
 			var closerEnd = Math.Abs(point.X - leftEnd.Left) < Math.Abs(point.X - rightEnd.Right) ? leftEndIndex : rightEndIndex + 1;
 
-			CaretMode = CaretDisplayMode.CaretWithThumbsOnlyEndShowing;
+			if (wasFocused) // If we were not focused before, caret should be initially thumbless.
+			{
+				CaretMode = CaretDisplayMode.CaretWithThumbsOnlyEndShowing;
+			}
+
 			Select(closerEnd, 0);
 		}
 	}
@@ -315,7 +319,7 @@ public partial class TextBox
 		if (IsMultiTapGesture((previous.PointerId, previous.Timestamp, previous.Position), e.GetCurrentPoint(null)))
 		{
 			e.Handled = true;
-			TouchTap(e.GetCurrentPoint(TextBoxView.DisplayBlock).Position);
+			TouchTap(e.GetCurrentPoint(TextBoxView.DisplayBlock).Position, true);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -85,10 +85,10 @@ public partial class TextBox
 
 	internal ContentControl ContentElement => _contentElement;
 
-	private CaretDisplayMode CaretMode
+	internal CaretDisplayMode CaretMode
 	{
 		get => _caretMode;
-		set
+		private set
 		{
 			if (_caretMode != value)
 			{
@@ -1381,7 +1381,7 @@ public partial class TextBox
 	internal override bool IsDelegatingFocusToTemplateChild()
 		=> OperatingSystem.IsBrowser();
 
-	private enum CaretDisplayMode
+	internal enum CaretDisplayMode
 	{
 		ThumblessCaretHidden,
 		ThumblessCaretShowing,

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -35,7 +35,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_textBox = WeakReferencePool.RentWeakReference(this, textBox);
 			IsPasswordBox = textBox is PasswordBox;
 
-			DisplayBlock = new TextBlock { MinWidth = InlineCollection.CaretThickness };
+			DisplayBlock = new TextBlock { MinWidth = InlineCollection.CaretThickness, IsTextBoxDisplay = true };
 			SetFlowDirectionAndTextAlignment();
 
 			if ((!_isSkiaTextBox || _useInvisibleNativeTextView) && !ApiExtensibility.CreateInstance(this, out _textBoxExtension))


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/1199

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
