### PR TITLE
fix: reset native clipping on macOS

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
@@ -95,8 +95,12 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 				var clip = path.IsEmpty ? null : path.ToSvgPathData();
 				if (clip != _lastSvgClipPath)
 				{
-					NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip);
-					_lastSvgClipPath = clip;
+					// if too early it's possible that the native element has not been arranged yet
+					// so the position and dimension of the element are not yet correct (0,0,0,0)
+					if (NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip))
+					{
+						_lastSvgClipPath = clip;
+					}
 				}
 			}
 		}

--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowHost.cs
@@ -35,6 +35,7 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 	private SKSurface? _surface;
 	private int _rowBytes;
 	private bool _initializationCompleted;
+	private string? _lastSvgClipPath;
 
 	private static XamlRootMap<IXamlRootHost> XamlRootMap { get; } = new();
 
@@ -91,9 +92,11 @@ internal class MacOSWindowHost : IXamlRootHost, IUnoKeyboardInputSource, IUnoCor
 				int width = (int)nativeWidth;
 				int height = (int)nativeHeight;
 				var path = SkiaRenderHelper.RenderRootVisualAndReturnNegativePath(width, height, rootVisual, surface.Canvas);
-				if (!path.IsEmpty)
+				var clip = path.IsEmpty ? null : path.ToSvgPathData();
+				if (clip != _lastSvgClipPath)
 				{
-					NativeUno.uno_window_clip_svg(_nativeWindow.Handle, path.ToSvgPathData());
+					NativeUno.uno_window_clip_svg(_nativeWindow.Handle, clip);
+					_lastSvgClipPath = clip;
 				}
 			}
 		}

--- a/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/NativeUno.cs
@@ -288,7 +288,8 @@ internal static partial class NativeUno
 	internal static partial void uno_window_set_min_size(nint window, double width, double height);
 
 	[LibraryImport("libUnoNativeMac.dylib", StringMarshalling = StringMarshalling.Utf8)]
-	internal static partial void uno_window_clip_svg(nint window, string? svg);
+	[return: MarshalAs(UnmanagedType.I1)]
+	internal static partial bool uno_window_clip_svg(nint window, string? svg);
 
 	[LibraryImport("libUnoNativeMac.dylib", StringMarshalling = StringMarshalling.Utf8)]
 	internal static partial string? /* const char* _Nullable */ uno_pick_single_folder(string? prompt, string? identifier, int suggestedStartLocation);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -62,7 +62,7 @@ void uno_window_exit_full_screen(NSWindow *window);
 void uno_window_minimize(NSWindow *window, bool activateWindow);
 void uno_window_restore(NSWindow *window, bool activateWindow);
 
-void uno_window_clip_svg(UNOWindow* window, const char* svg);
+bool uno_window_clip_svg(UNOWindow* window, const char* svg);
 
 typedef NS_ENUM(sint32, OverlappedPresenterState) {
     OverlappedPresenterStateMaximized,

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -671,7 +671,7 @@ CGFloat readNextCoord(const char *svg, int *position, long length)
     return result;
 }
 
-void uno_window_clip_svg(UNOWindow* window, const char* svg)
+bool uno_window_clip_svg(UNOWindow* window, const char* svg)
 {
     if (svg) {
         CGFloat scale = window.screen.backingScaleFactor;
@@ -681,8 +681,13 @@ void uno_window_clip_svg(UNOWindow* window, const char* svg)
         NSArray<__kindof NSView *> *subviews = window.contentViewController.view.subviews;
         for (int i = 0; i < subviews.count; i++) {
             NSView* view = subviews[i];
-            CGFloat vx = view.frame.origin.x;
-            CGFloat vy = view.frame.origin.y;
+            NSRect frame = view.frame;
+            // if called too early the element might not have been arranged and it's values cannot be used yet
+            if (NSIsEmptyRect(frame))
+                return false;
+
+            CGFloat vx = frame.origin.x;
+            CGFloat vy = frame.origin.y;
 #if DEBUG
             NSLog(@"uno_window_clip_svg subview %d %@ layer %@ mask %@", i, view, view.layer, view.layer.mask);
 #endif
@@ -781,6 +786,7 @@ void uno_window_clip_svg(UNOWindow* window, const char* svg)
             }
         }
     }
+    return true;
 }
 
 @implementation UNOWindow : NSWindow

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -760,8 +760,25 @@ void uno_window_clip_svg(UNOWindow* window, const char* svg)
                 view.layer.mask = mask = [[CAShapeLayer alloc] init];
             }
             mask.fillColor = NSColor.blueColor.CGColor; // anything but clearColor
-            mask.path = path;
             mask.fillRule = kCAFillRuleEvenOdd;
+            mask.path = path;
+        }
+    } else {
+#if DEBUG
+        NSLog(@"uno_window_clip_svg %@ %@ reset", window, window.contentView.layer.description);
+#endif
+        NSArray<__kindof NSView *> *subviews = window.contentViewController.view.subviews;
+        for (int i = 0; i < subviews.count; i++) {
+            NSView* view = subviews[i];
+#if DEBUG
+            NSLog(@"uno_window_clip_svg reset subview %d %@ layer %@ mask %@", i, view, view.layer, view.layer.mask);
+#endif
+            CAShapeLayer* mask = view.layer.mask;
+            if (mask != nil) {
+                mask.fillColor = NSColor.clearColor.CGColor;
+                mask.fillRule = kCAFillRuleEvenOdd;
+                mask.path = nil;
+            }
         }
     }
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/private/issues/719

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Resetting the clip was not propagated to the native code.

## What is the new behavior?

* Reset clipping when it's removed.
* Only call (native) clip when the clipping path has changed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Processing the subviews should not be needed, IOW only apply the clip on the parent view but it does not work ([like it does on iOS](https://github.com/unoplatform/uno/pull/20087)). This might be due to differences in `CALayer`, e.g. `NSViewBackingLayer` is used on macOS.