### PR TITLE
fix(macOS): fix resizing windows (bottom)

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -984,11 +984,15 @@ bool uno_window_clip_svg(UNOWindow* window, const char* svg)
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
-    CGSize size = self.frame.size;
+    // the UNOMetalViewDelegate has it's own resize callback but we need something for the software fallback
+    if (self.metalViewDelegate == nil) {
+        // consider the title bar height
+        CGSize size = [self contentRectForFrameRect: self.frame].size;
 #if DEBUG
-    NSLog(@"UNOWindow %p windowDidMove %@ x: %g y: %g", self, notification, size.width, size.height);
+        NSLog(@"UNOWindow %p windowDidResize %@ w: %g h: %g", self, notification, size.width, size.height);
 #endif
-    uno_get_window_resize_event_callback()(self, size.width, size.height);
+        uno_get_window_resize_event_callback()(self, size.width, size.height);
+    }
 }
 
 - (bool)windowShouldClose:(NSWindow *)sender

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -191,8 +191,10 @@ bool uno_window_resize(NSWindow *window, double width, double height)
     bool result = false;
     if (window) {
         NSRect frame = window.frame;
-        frame.size = CGSizeMake(width, height);
-        [window setFrame:frame display:true animate:true];
+        // consider the titlebar height when re-sizing the window
+        CGSize content = [window contentRectForFrameRect: frame].size;
+        frame.size = CGSizeMake(width, height + (frame.size.height - content.height));
+        [window setFrame:frame display:true animate:false];
         result = true;
     }
     return result;

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -984,7 +984,7 @@ bool uno_window_clip_svg(UNOWindow* window, const char* svg)
 }
 
 - (void)windowDidResize:(NSNotification *)notification {
-    // the UNOMetalViewDelegate has it's own resize callback but we need something for the software fallback
+    // the UNOMetalViewDelegate has its own resize callback but we need something for the software fallback
     if (self.metalViewDelegate == nil) {
         // consider the title bar height
         CGSize size = [self contentRectForFrameRect: self.frame].size;

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
@@ -158,7 +158,7 @@ public class Given_AppWindow
 			TestServices.WindowHelper.IsXamlIsland ||
 			IsGtk())
 		{
-			Assert.Inconclusive("This test only supported on Windows and Linux apps currently.");
+			Assert.Inconclusive("This test only supported on Windows, macOS and Linux apps currently.");
 		}
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/1201

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

There were two resize events coming from native code. One for Metal and another for the software fallback. However both were called and the one for the software fallback did not consider the window's title bar height (which is something done by default for the Metal one).

## What is the new behavior?

Correctly resize the window so that the bottom is not _cut_ (because we're missing the titlebar's height).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
