### PR TITLE
feat: Allow customizing `UIApplicationDelegate`

### DIFF
--- a/doc/articles/features/customizing-uiapplicationdelegate.md
+++ b/doc/articles/features/customizing-uiapplicationdelegate.md
@@ -1,0 +1,51 @@
+---
+uid: Uno.Features.CustomizingUIApplicationDelegate
+---
+
+# Customizing the `UIApplicationDelegate` on iOS
+
+Uno Platform provides the ability to provide custom behavior for `UIApplicationDelegate` on iOS in case of both native- and Skia-based rendering.
+
+## Skia rendering
+
+In Skia-based apps, the `App` type no longer derives from `UIApplicationDelegate`. Instead, Uno Platform provides `Uno.UI.Runtime.Skia.AppleUIKit.UnoUIApplicationDelegate`. If you decide to implement your own application lifecycle handling, create a new type that derives from it:
+
+```csharp
+public class MyApplicationDelegate : Uno.UI.Runtime.Skia.AppleUIKit.UnoUIApplicationDelegate
+{
+    // Your own code or overrides
+}
+```
+
+You then need to inform Uno Platform to use this custom class instead of the built-in delegate by adjusting the host creation in `Main.iOS.cs`:
+
+```csharp
+var host = new Uno.UI.Runtime.Skia.AppleUIKit.AppleUIKitHost(() => new App());
+// Set the custom application delegate type
+host.SetUIApplicationDelegate<MyApplicationDelegate>();
+host.Run();
+```
+
+> [!IMPORTANT]
+> Make sure to call the `base` methods when you override key application lifecycle methods, so that the internals of Uno Platform are still properly executed.
+
+## Native rendering
+
+You `App` class already derives from `UIApplicationDelegate`. This means you can directly override the UIKit methods this class provides:
+
+```csharp
+public App : Application
+{
+    // Existing code in App.xaml.cs
+
+    public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+    {
+        // Your custom handling
+
+        return base.FinishedLaunching(application, launchOptions);
+    }
+}
+```
+
+> [!IMPORTANT]
+> Make sure to call the `base` methods when you override key application lifecycle methods, so that the internals of Uno Platform are still properly executed.

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -553,6 +553,8 @@
           href: uno-toolchain-telemetry.md
         - name: Composition API
           href: composition.md
+        - name: Customizing the UIApplicationDelegate on iOS
+          href: xref:Uno.Features.CustomizingUIApplicationDelegate
         - name: Dialogs
           href: features/dialogs.md
         - name: Fluent styles

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/AppleUIKitHost.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/AppleUIKitHost.cs
@@ -1,21 +1,15 @@
 using System;
-using System.Threading.Tasks;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using UIKit;
-using Uno.Foundation.Extensibility;
-using Uno.UI.Hosting;
-using Uno.UI.Xaml.Controls;
-using Uno.UI.Xaml.Controls.Extensions;
-using Uno.WinUI.Runtime.Skia.AppleUIKit;
 using Uno.WinUI.Runtime.Skia.AppleUIKit.Extensions;
-using Uno.WinUI.Runtime.Skia.AppleUIKit.UI.Xaml;
-using Windows.UI.Core;
 
 namespace Uno.UI.Runtime.Skia.AppleUIKit;
 
 public class AppleUIKitHost : ISkiaApplicationHost
 {
+	private Type? _uiApplicationDelegateOverride;
+
 	/// <summary>
 	/// Creates a host for an Uno Skia Android application.
 	/// </summary>
@@ -32,6 +26,12 @@ public class AppleUIKitHost : ISkiaApplicationHost
 		};
 	}
 
+	public void SetUIApplicationDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
+		where T : UnoUIApplicationDelegate
+	{
+		_uiApplicationDelegateOverride = typeof(T);
+	}
+
 	internal static ApplicationInitializationCallback? CreateAppAction { get; private set; }
 
 	public void Run()
@@ -40,7 +40,9 @@ public class AppleUIKitHost : ISkiaApplicationHost
 		{
 			ExtensionsRegistrar.Register();
 
-			UIApplication.Main(Environment.GetCommandLineArgs(), null, typeof(UnoSkiaAppDelegate));
+			var delegateType = _uiApplicationDelegateOverride ?? typeof(UnoUIApplicationDelegate);
+
+			UIApplication.Main(Environment.GetCommandLineArgs(), null, delegateType);
 		}
 		catch (Exception e)
 		{

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/AppleUIKitHost.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/AppleUIKitHost.cs
@@ -27,10 +27,8 @@ public class AppleUIKitHost : ISkiaApplicationHost
 	}
 
 	public void SetUIApplicationDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
-		where T : UnoUIApplicationDelegate
-	{
+		where T : UnoUIApplicationDelegate =>
 		_uiApplicationDelegateOverride = typeof(T);
-	}
 
 	internal static ApplicationInitializationCallback? CreateAppAction { get; private set; }
 

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UnoUIApplicationDelegate.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UnoUIApplicationDelegate.cs
@@ -8,10 +8,10 @@ using Windows.UI.Core;
 
 namespace Uno.UI.Runtime.Skia.AppleUIKit;
 
-[Register("UnoSkiaAppDelegate")]
-internal partial class UnoSkiaAppDelegate : UIApplicationDelegate
+[Register("UnoUIApplicationDelegate")]
+public partial class UnoUIApplicationDelegate : UIApplicationDelegate
 {
-	public UnoSkiaAppDelegate()
+	public UnoUIApplicationDelegate()
 	{
 		SubscribeBackgroundNotifications();
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/1182

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

`UIApplicationDelegate` is not customizable

## What is the new behavior?

Can be customized

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.