### PR TITLE
fix: Adjust behavior between InteractionTracker and DirectManipulation

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
@@ -123,6 +123,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 			}
 		}
 
+#if HAS_UNO
 		[TestMethod]
 #if __WASM__
 		[Ignore("Scrolling is handled by native code and InputInjector is not yet able to inject native pointers.")]
@@ -322,6 +323,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 
 			Assert.AreNotEqual(-1, lv.SelectedIndex);
 		}
+#endif
 
 		private Task<RawBitmap> TakeScreenshot(FrameworkElement SUT)
 			=> UITestHelper.ScreenShot(SUT);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -111,6 +111,10 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		/// <inheritdoc />
+		internal override bool HitTest(Point point)
+			=> true; // Makes sure to get pointers events, even if no background.
+
 		private void HookScrollEvents(ScrollViewer sv)
 		{
 			UnhookScrollEvents(sv);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -126,8 +126,10 @@ namespace Microsoft.UI.Xaml.Controls
 			sv.PointerWheelChanged += PointerWheelScroll;
 
 			// Touch and pen scroll support
+			// Note: We add handler on this (not SV) in order to make sure to get it first
+			//		 (and especially before the RefreshContainers - which subscribe to the same event on the SV)
 			var handler = new PointerEventHandler(TryEnableDirectManipulation);
-			sv.AddHandler(PointerPressedEvent, handler, handledEventsToo: true);
+			AddHandler(PointerPressedEvent, handler, handledEventsToo: true);
 
 			_eventSubscriptions.Disposable = Disposable.Create(() =>
 			{

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -59,20 +59,9 @@ partial class InputManager
 			=> RegisterDirectManipulationTargetCore(pointer, directManipulationTarget);
 
 		internal void RedirectPointer(Windows.UI.Input.PointerPoint pointer, InteractionTracker tracker)
-		{
-			var manip = RegisterDirectManipulationTargetCore(pointer.Pointer, new InteractionTrackerToDirectManipulationHandler(tracker));
-			if (!manip.HasStarted)
-			{
-				// We consider the manipulation active as soon as we have an interaction tracker.
-				// This is only to ensure compatibility with the current behavior (redirection is probably enabled only when the manipulation has started).
-				// But this could cause a double start threshold (one for the request to redirect and a second for the gesture recignizer to start)
-				// and it should be revisited to determine if we should also forcefully start the GestureRecognizer.
-				manip.HasStarted = true;
-				manip.Recognizer.ProcessDownEvent(pointer);
-			}
-		}
+			=> RegisterDirectManipulationTargetCore(pointer.Pointer, new InteractionTrackerToDirectManipulationHandler(tracker));
 
-		private DirectManipulation RegisterDirectManipulationTargetCore(PointerIdentifier pointer, IDirectManipulationHandler directManipulationTarget)
+		private void RegisterDirectManipulationTargetCore(PointerIdentifier pointer, IDirectManipulationHandler directManipulationTarget)
 		{
 			ref var manip = ref CollectionsMarshal.GetValueRefOrAddDefault(_directManipulations ??= new(), pointer, out var exists);
 			if (exists)
@@ -88,8 +77,6 @@ partial class InputManager
 			{
 				Trace($"[DirectManipulation] [{pointer}] Redirection requested to {directManipulationTarget.GetDebugName()}");
 			}
-
-			return manip;
 		}
 
 		private bool IsRedirectedToDirectManipulation(PointerIdentifier pointerId)

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -335,7 +335,10 @@ partial class InputManager
 
 			/// <inheritdoc />
 			public void OnUpdated(GestureRecognizer recognizer, ManipulationUpdatedEventArgs args, ref ManipulationDelta unhandledDelta)
-				=> Tracker.ReceiveManipulationDelta(args.Delta.Translation);
+			{
+				Tracker.ReceiveManipulationDelta(unhandledDelta.Translation);
+				unhandledDelta = ManipulationDelta.Empty;
+			}
 
 			/// <inheritdoc />
 			public void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/899

## Bugfix
Adjust behavior between InteractionTracker and DirectManipualtion

## What is the current behavior?
`ListView` and `RefreshContainer` are scrolling twice ... and are globally non functional

## What is the new behavior?
Collaborates nicely

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
