### PR TITLE
docs: Add details about codesign issue with iCloud drive

### DIFF
--- a/doc/articles/uno-build-error-codes.md
+++ b/doc/articles/uno-build-error-codes.md
@@ -155,6 +155,14 @@ When the `SkiaRenderer` feature is enabled, the `Uno.WinUI.Runtime.WebAssembly` 
 
 This is generally a package authoring error, make sure to open an issue in the Uno Platform repository to report the problem.
 
+### UNOB0018: Code signing cannot be applied on files with extended attributes (e.g. iCloud)
+
+On macOS code signing will fail if the project's output is located inside a directory that is backed up using [iCloud](https://www.icloud.com). This is because iCloud adds some extended attributes to files and directories while `codesign` will refuse to sign such files.
+
+ref: https://developer.apple.com/library/archive/qa/qa1940/_index.html
+
+Solution: Move your Uno solution/project(s) to a different location, one that is not backed up by iCloud.
+
 ## Compiler Errors
 
 ### UNO0001


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.sdk.extras/issues/58

## PR Type

What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

On macOS `codesign` fails when trying to sign a file with extended attributes. This is most common when files are located inside an iCloud Drive. However the error message from `codesign` is not helpful to solve the problem.

## What is the new behavior?

Describe why this happens and how to solve it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

@jeromelaban @agneszitte could you create https://aka.platform.uno/UNOB0018 to point to this new doc ? thanks!