### PR TITLE
fix(scrollViewer): Fix inertia not behaving properly on nested scroll viewers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
 		<NetSkiaPreviousAndCurrent>$(NetPrevious);$(NetCurrent)</NetSkiaPreviousAndCurrent>
 		<NetReferencePreviousAndCurrent>$(NetPrevious);$(NetCurrent)</NetReferencePreviousAndCurrent>
 		<NetWinAppSDKPreviousAndCurrent>$(NetPreviousWinAppSDK);$(NetCurrentWinAppSDK)</NetWinAppSDKPreviousAndCurrent>
-		<NetUnitTests>$(NetPrevious)</NetUnitTests>
+		<NetUnitTests>$(NetCurrent)</NetUnitTests>
 
 		<NetUWPOrWinUI>uap10.0.19041</NetUWPOrWinUI>
 		<NetUWPOrWinUI Condition="'$(UNO_UWP_BUILD)'!='true'">$(NetPrevious)-windows10.0.19041.0</NetUWPOrWinUI>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
 		<NetSkiaPreviousAndCurrent>$(NetPrevious);$(NetCurrent)</NetSkiaPreviousAndCurrent>
 		<NetReferencePreviousAndCurrent>$(NetPrevious);$(NetCurrent)</NetReferencePreviousAndCurrent>
 		<NetWinAppSDKPreviousAndCurrent>$(NetPreviousWinAppSDK);$(NetCurrentWinAppSDK)</NetWinAppSDKPreviousAndCurrent>
-		<NetUnitTests>$(NetCurrent)</NetUnitTests>
+		<NetUnitTests>$(NetPrevious)</NetUnitTests>
 
 		<NetUWPOrWinUI>uap10.0.19041</NetUWPOrWinUI>
 		<NetUWPOrWinUI Condition="'$(UNO_UWP_BUILD)'!='true'">$(NetPrevious)-windows10.0.19041.0</NetUWPOrWinUI>

--- a/src/Uno.UI.Composition/Composition/Compositor.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Compositor.skia.cs
@@ -30,6 +30,8 @@ public partial class Compositor
 
 	internal bool? IsSoftwareRenderer { get; set; }
 
+	internal bool IsAnimating => _runningAnimations.Count > 0;
+
 	internal void RegisterAnimation(CompositionAnimation animation, CompositionObject visual)
 	{
 		if (animation.IsTrackedByCompositor)

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -20,7 +20,6 @@ using Windows.UI;
 using Windows.UI.Input.Preview.Injection;
 using Windows.UI.ViewManagement;
 using Uno.UI.Toolkit.Extensions;
-using Uno.UI.Xaml.Controls;
 using static Private.Infrastructure.TestServices;
 using Disposable = Uno.Disposables.Disposable;
 using ScrollContentPresenter = Microsoft.UI.Xaml.Controls.ScrollContentPresenter;
@@ -1596,7 +1595,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Width = 100,
 				Height = 250,
 				IsScrollInertiaEnabled = true,
-				UpdatesMode = ScrollViewerUpdatesMode.Synchronous, // Make sure to get the VerticalOffset updated immediately while dragging
+				UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous, // Make sure to get the VerticalOffset updated immediately while dragging
 				Content = child = new ScrollViewer
 				{
 					Height = 500,

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -38,7 +38,7 @@ partial class InputManager
 
 			void OnUpdated(GestureRecognizer recognizer, ManipulationUpdatedEventArgs args, ref ManipulationDelta unhandledDelta) { }
 
-			void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args) { }
+			void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args, ref bool isHandled) { }
 
 			void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs args) { }
 		}
@@ -288,9 +288,10 @@ partial class InputManager
 					Trace($"[DirectManipulation] [{args.Pointers[0]}] Inertia starting @={args.Position.ToDebugString()} | Δ=({args.Delta}) | v=({args.Velocities})");
 				}
 
+				var isHandled = false;
 				foreach (var handler in that.Handlers)
 				{
-					handler.OnInertiaStarting(sender, args);
+					handler.OnInertiaStarting(sender, args, ref isHandled);
 				}
 			};
 
@@ -328,7 +329,7 @@ partial class InputManager
 			}
 
 			/// <inheritdoc />
-			public void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args)
+			public void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args, ref bool isHandled)
 				=> Tracker.ReceiveInertiaStarting(new Point(args.Velocities.Linear.X * 1000, args.Velocities.Linear.Y * 1000));
 
 			/// <inheritdoc />


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1212

## Bugfix
Fix inertia not behaving properly on nested scroll viewers

## What is the current behavior?
SCP are all trying to manage inertia simultaneously

## What is the new behavior?
SCP sync nicely

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
