### PR TITLE
fix(scrollViewer): Fix invalid event unsubscribe causing handler to be invoked multiple times

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -138,7 +138,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_eventSubscriptions.Disposable = Disposable.Create(() =>
 			{
 				sv.PointerWheelChanged -= PointerWheelScroll;
-				sv.RemoveHandler(PointerPressedEvent, handler);
+				RemoveHandler(PointerPressedEvent, handler);
 			});
 		}
 


### PR DESCRIPTION
linked to https://github.com/unoplatform/uno-private/issues/1212

## Bugfix
Fix invalid event unsubscribe causing handler to be invoked multiple times

## What is the current behavior?
Unsubscribe event from an invalid source

## What is the new behavior?
🙃

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
Duplicated change with https://github.com/unoplatform/uno/pull/20141 but in a separated PR to ensure faster merge.