### PR TITLE
build: fix android nuget override not copying assemblies files

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
+++ b/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
@@ -57,6 +57,7 @@
 		<ProjectReference Include="..\Uno.Foundation.Logging\Uno.Foundation.Logging.csproj" />
 		<ProjectReference Include="..\Uno.Foundation\Uno.Foundation.netcoremobile.csproj" TreatAsPackageReference="false" PrivateAssets="all" />
 		<ProjectReference Include="..\Uno.UI\Uno.UI.Skia.csproj" />
+		<ProjectReference Include="..\Uno.UI.Runtime.Skia\Uno.UI.Runtime.Skia.csproj" />
 		<ProjectReference Include="..\Uno.UI.Dispatching\Uno.UI.Dispatching.netcoremobile.csproj" TreatAsPackageReference="false" PrivateAssets="all" />
 		<ProjectReference Include="..\Uno.UWP\Uno.netcoremobile.csproj" TreatAsPackageReference="false" PrivateAssets="all" />
 	</ItemGroup>

--- a/src/Uno.UI.sln
+++ b/src/Uno.UI.sln
@@ -301,6 +301,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.UI.Runtime.Skia.MacOS", "Uno.UI.Runtime.Skia.MacOS\Uno.UI.Runtime.Skia.MacOS.csproj", "{7F6D5A92-ADE8-4DC6-BFEE-11A6575373B8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.UI.Runtime.Skia", "Uno.UI.Runtime.Skia\Uno.UI.Runtime.Skia.csproj", "{A8C22BED-2589-48F1-B1D4-0B436A90FC3B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{01AF1FBC-D11D-441D-AD07-5FF2FE295C0D} = {01AF1FBC-D11D-441D-AD07-5FF2FE295C0D}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SamplesApp.Skia.Generic", "SamplesApp\SamplesApp.Skia.Generic\SamplesApp.Skia.Generic.csproj", "{93E6D033-52E2-4C2B-A715-A9FC1F609E3D}"
 EndProject


### PR DESCRIPTION
GitHub Issue (If applicable): closes n/a

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When performing nuget-override for android with skia-renderer, the generated assemblies are not copied to the nuget cache folder.

## What is the new behavior?
^ they are now copied as part of the build process.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.