### PR TITLE
fix: Fix touch scrolling selects text

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/TextBlock.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml.Controls/TextBlock.cs
@@ -146,8 +146,8 @@ namespace Microsoft.UI.Xaml.Controls
 #endif
 		// Skipping already declared property Inlines
 		// Skipping already declared property IsTextTrimmed
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
+#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __NETSTD_REFERENCE__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__NETSTD_REFERENCE__")]
 		public string SelectedText
 		{
 			get
@@ -234,8 +234,8 @@ namespace Microsoft.UI.Xaml.Controls
 			new Microsoft.UI.Xaml.FrameworkPropertyMetadata(default(global::Microsoft.UI.Xaml.OpticalMarginAlignment)));
 #endif
 		// Skipping already declared property PaddingProperty
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
+#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __NETSTD_REFERENCE__
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__NETSTD_REFERENCE__")]
 		public static global::Microsoft.UI.Xaml.DependencyProperty SelectedTextProperty { get; } =
 		Microsoft.UI.Xaml.DependencyProperty.Register(
 			nameof(SelectedText), typeof(string),

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -56,6 +56,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private Run _reusableRun;
 		private bool _skipInlinesChangedTextSetter;
 		private Range _selection;
+		private Range _selectionOnPointerPressed;
 
 		// end can be less than or equal to start when the selection starts ahead and then goes back
 		// see the selection in TextBox.skia.cs for more info
@@ -905,6 +906,14 @@ namespace Microsoft.UI.Xaml.Controls
 		partial void ClearTextPartial();
 
 		#region pointer events
+		// For pen and touch selection, we need to:
+		// * Start selection using a long-press and/or double-tap (platform specific)
+		// * Add visual anchor (platform specific) to edit selection (pointer pressed out of those anchors only scroll, tap would unselect)
+		// * Prevent scrolling to kick-in when editing selection (i.e. disable the DirectManipulation)
+		// * Automatic scroll (platform specific) when pointer is close to the edge of the parent ScrollViewer
+		// * Show a magnifier when finger can hide the text being (un)selected (platform specific)
+		private static bool SupportsSelection(PointerRoutedEventArgs args)
+			=> args.Pointer.PointerDeviceType is PointerDeviceType.Mouse;
 
 		private static readonly PointerEventHandler OnPointerPressed = (object sender, PointerRoutedEventArgs e) =>
 		{
@@ -934,7 +943,7 @@ namespace Microsoft.UI.Xaml.Controls
 				that.CompleteGesture(); // Make sure to mute Tapped
 			}
 #if !__WASM__
-			else if (that.IsTextSelectionEnabled)
+			else if (that.IsTextSelectionEnabled && SupportsSelection(e))
 			{
 				var point = e.GetCurrentPoint(that);
 
@@ -943,6 +952,7 @@ namespace Microsoft.UI.Xaml.Controls
 #else // TODO: add an option to get the closest char to point
 				var index = that.GetCharacterIndexAtPoint(point.Position);
 #endif
+				that._selectionOnPointerPressed = that.Selection;
 				if (index >= 0) // should always be true if above TODO is addressed
 				{
 					that.Selection = new Range(index, index);
@@ -1005,6 +1015,14 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (sender is TextBlock that)
 			{
+#if !__WASM__
+				that._isPressed = false;
+				if (SupportsSelection(e))
+				{
+					that.Selection = that._selectionOnPointerPressed;
+				}
+#endif
+
 				e.Handled = that.AbortHyperlinkCaptures(e.Pointer);
 			}
 		};
@@ -1025,7 +1043,7 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 
 #if !__WASM__
-			if (that._isPressed && that.IsTextSelectionEnabled)
+			if (that._isPressed && that.IsTextSelectionEnabled && SupportsSelection(e))
 			{
 				var point = e.GetCurrentPoint(that);
 #if __SKIA__ // GetCharacterIndexAtPoint returns -1 if point isn't on any char. For pointers, we still want to get the closest char

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -906,6 +906,7 @@ namespace Microsoft.UI.Xaml.Controls
 		partial void ClearTextPartial();
 
 		#region pointer events
+		// https://github.com/unoplatform/uno-private/issues/1238
 		// For pen and touch selection, we need to:
 		// * Start selection using a long-press and/or double-tap (platform specific)
 		// * Add visual anchor (platform specific) to edit selection (pointer pressed out of those anchors only scroll, tap would unselect)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -46,6 +46,7 @@ namespace Microsoft.UI.Xaml.Controls
 #if !__WASM__
 		// Used for text selection which is handled natively
 		private bool _isPressed;
+		private Range _selectionOnPointerPressed;
 #endif
 
 		private Hyperlink _hyperlinkOver;
@@ -56,7 +57,6 @@ namespace Microsoft.UI.Xaml.Controls
 		private Run _reusableRun;
 		private bool _skipInlinesChangedTextSetter;
 		private Range _selection;
-		private Range _selectionOnPointerPressed;
 
 		// end can be less than or equal to start when the selection starts ahead and then goes back
 		// see the selection in TextBox.skia.cs for more info
@@ -906,6 +906,7 @@ namespace Microsoft.UI.Xaml.Controls
 		partial void ClearTextPartial();
 
 		#region pointer events
+#if !__WASM__
 		// https://github.com/unoplatform/uno-private/issues/1238
 		// For pen and touch selection, we need to:
 		// * Start selection using a long-press and/or double-tap (platform specific)
@@ -915,6 +916,7 @@ namespace Microsoft.UI.Xaml.Controls
 		// * Show a magnifier when finger can hide the text being (un)selected (platform specific)
 		private static bool SupportsSelection(PointerRoutedEventArgs args)
 			=> args.Pointer.PointerDeviceType is PointerDeviceType.Mouse;
+#endif
 
 		private static readonly PointerEventHandler OnPointerPressed = (object sender, PointerRoutedEventArgs e) =>
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -385,7 +385,7 @@ namespace Microsoft.UI.Xaml.Controls
 			_selectionHighlightBrushChangedSubscription = Brush.SetupBrushChanged(newBrush, ref _selectionHighlightColorChanged, () => OnSelectionHighlightColorChangedPartial(newBrush));
 		}
 
-		partial void OnSelectionHighlightColorChangedPartial(SolidColorBrush brush); 
+		partial void OnSelectionHighlightColorChangedPartial(SolidColorBrush brush);
 		#endregion
 
 		#region SelectedText (DP - readonly)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -39,10 +39,10 @@ namespace Microsoft.UI.Xaml.Controls
 
 			_hyperlinks.CollectionChanged += HyperlinksOnCollectionChanged;
 
-			Tapped += (s, e) => ((TextBlock)s).OnTapped(e);
-			DoubleTapped += (s, e) => ((TextBlock)s).OnDoubleTapped(e);
-			RightTapped += (s, e) => ((TextBlock)s).OnRightTapped(e);
-			KeyDown += (s, e) => ((TextBlock)s).OnKeyDown(e);
+			Tapped += static (s, e) => ((TextBlock)s).OnTapped(e);
+			DoubleTapped += static (s, e) => ((TextBlock)s).OnDoubleTapped(e);
+			RightTapped += static (s, e) => ((TextBlock)s).OnRightTapped(e);
+			KeyDown += static (s, e) => ((TextBlock)s).OnKeyDown(e);
 
 			GotFocus += (_, _) => UpdateSelectionRendering();
 			LostFocus += (_, _) => UpdateSelectionRendering();
@@ -187,7 +187,13 @@ namespace Microsoft.UI.Xaml.Controls
 		string IBlock.GetText() => Text;
 
 		partial void OnSelectionChanged()
-			=> Inlines.Selection = (Math.Min(Selection.start, Selection.end), Math.Max(Selection.start, Selection.end));
+		{
+			Inlines.Selection = (Math.Min(Selection.start, Selection.end), Math.Max(Selection.start, Selection.end));
+
+			var start = Math.Min(Selection.start, Selection.end);
+			var end = Math.Max(Selection.start, Selection.end);
+			SelectedText = Text[start..end];
+		}
 
 		private static SKPaint _spareSelectionFoundPaint = new SKPaint();
 
@@ -344,9 +350,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (Selection.start != Selection.end)
 			{
-				var start = Math.Min(Selection.start, Selection.end);
-				var end = Math.Max(Selection.start, Selection.end);
-				var text = Text[start..end];
+				var text = SelectedText;
 				var dataPackage = new DataPackage();
 				dataPackage.SetText(text);
 				Clipboard.SetContent(dataPackage);
@@ -356,6 +360,7 @@ namespace Microsoft.UI.Xaml.Controls
 		public void SelectAll() => Selection = new Range(0, Text.Length);
 
 		// TODO: move to TextBlock.cs when we implement SelectionHighlightColor for the other platforms
+		#region SelectionHighlightColor (DP)
 		public SolidColorBrush SelectionHighlightColor
 		{
 			get => (SolidColorBrush)GetValue(SelectionHighlightColorProperty);
@@ -380,7 +385,22 @@ namespace Microsoft.UI.Xaml.Controls
 			_selectionHighlightBrushChangedSubscription = Brush.SetupBrushChanged(newBrush, ref _selectionHighlightColorChanged, () => OnSelectionHighlightColorChangedPartial(newBrush));
 		}
 
-		partial void OnSelectionHighlightColorChangedPartial(SolidColorBrush brush);
+		partial void OnSelectionHighlightColorChangedPartial(SolidColorBrush brush); 
+		#endregion
+
+		#region SelectedText (DP - readonly)
+		public static DependencyProperty SelectedTextProperty { get; } =
+			DependencyProperty.Register(
+				nameof(SelectedText), typeof(string),
+				typeof(TextBlock),
+				new FrameworkPropertyMetadata(default(string)));
+
+		public string SelectedText
+		{
+			get => (string)this.GetValue(SelectedTextProperty);
+			private set => this.SetValue(SelectedTextProperty, value);
+		}
+		#endregion
 
 		partial void UpdateIsTextTrimmed()
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -39,6 +39,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			_hyperlinks.CollectionChanged += HyperlinksOnCollectionChanged;
 
+			Tapped += (s, e) => ((TextBlock)s).OnTapped(e);
 			DoubleTapped += (s, e) => ((TextBlock)s).OnDoubleTapped(e);
 			RightTapped += (s, e) => ((TextBlock)s).OnRightTapped(e);
 			KeyDown += (s, e) => ((TextBlock)s).OnKeyDown(e);
@@ -222,6 +223,14 @@ namespace Microsoft.UI.Xaml.Controls
 					SelectAll();
 					args.Handled = true;
 					break;
+			}
+		}
+
+		private void OnTapped(TappedRoutedEventArgs _)
+		{
+			if (IsTextSelectionEnabled)
+			{
+				Selection = default;
 			}
 		}
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1197

## Bugfix
Fix touch scrolling selects text

## What is the current behavior?
At the beginning of a touch scroll, the text is being selected

## What is the new behavior?
Selection using touch has been disabled

## PR Checklist

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
This mainly disables selection using touch and pen. https://github.com/unoplatform/uno-private/issues/1238 tracks the next steps for this.