### PR TITLE
feat(import external docs): allow contributor url for import

### DIFF
--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -68,7 +68,7 @@ function Invoke-ImportExternalDocs {
             $repoBranch = $external_docs[$repoPath]
 
             # if the repository is already cloned, just update it, not clone it again, because git will otherwise fail
-            if (-Not (Test-Path $repoPath -and (Get-Location -Stack).Path -contains (Resolve-Path $repoPath).Path)) {
+            if (-Not (Test-Path $repoPath)) {
                 Write-Output "Cloning $repoPath ($repoUrl@$repoBranch)..."
                 git clone $repoUrl $repoPath
                 Assert-ExitCodeIsZero -ErrorMessage "Failed to clone repository $repoUrl."

--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -98,4 +98,25 @@ git config advice.detachedHead $detachedHeadConfig
 
 Pop-Location
 
-Set-PSDebug -Off
+        if ($hasErrors) {
+            Write-Output "Some external repositories failed to import or update. Check the logs for details."
+        }
+        else {
+            Write-Output "All external repositories are imported and up to date."
+        }
+        Write-Output "All external repositories are imported and up to date."
+    }
+}
+
+function Assert-ExitCodeIsZero {
+    param (
+        [string]$ErrorMessage = "A command failed with a non-zero exit code."
+    )
+    Set-PSDebug -Off
+    if ($LASTEXITCODE -ne 0) {
+        $script:hasErrors = $true
+        # Provide detailed context about the failure
+        Write-Error "$ErrorMessage Exit code: $LASTEXITCODE"
+        throw "Command failed with exit code $LASTEXITCODE."
+    }
+}

--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -44,6 +44,7 @@ function Invoke-ImportExternalDocs {
         $external_docs
 
         $ErrorActionPreference = 'Stop'
+       
         if (-Not (Test-Path articles\external)) {
             mkdir articles\external -ErrorAction Continue
         }
@@ -58,13 +59,13 @@ function Invoke-ImportExternalDocs {
 
         # Heads - Release
         foreach ($repoPath in $external_docs.keys) {
-            if ($branches.Contains($repoPath)) {
+            if ($custom_git_urls -ne $null -and $custom_git_urls.ContainsKey($repoPath)) {
                 $repoUrl = "$custom_git_url$repoPath"
             }
             else {
                 $repoUrl = "$uno_git_url$repoPath"
             }
-
+            Write-Output "Importing $repoPath from $repoUrl..."
             $repoBranch = $external_docs[$repoPath]
 
             # if the repository is already cloned, just update it, not clone it again, because git will otherwise fail

--- a/doc/import_external_docs_test.ps1
+++ b/doc/import_external_docs_test.ps1
@@ -21,15 +21,15 @@ $external_docs = @{
 
 # In case you want to import a specific branch wich is not already committed in the uno-origin Repository, specify custom Git URLs for specific repositories and uncomment the following lines:
 # $contributor_git_urls = @{
-#     "uno.themes" = "https://github.com/contributor-fork/uno.themes"
+#     "uno.themes" = "https://github.com/contributor-fork/"
 # }
 
 # dot import the main script
-./import_external_docs.ps1
+. "$PSScriptRoot\import_external_docs.ps1"
 
 # call the function to import external docs
-Invoke-ImportExternalDocs -branches $external_docs -custom_git_urls $contributor_git_urls
+Invoke-ImportExternalDocs -branches $external_docs # -custom_git_urls $contributor_git_urls
 
-docfx build -Path $PSScriptRoot.Replace('import_external_docs_test.ps1', 'docfx.json')
+docfx build docfx.json
 
-dotnet-serve --open-browser:$PSScriptRoot.Replace('import_external_docs_test.ps1', '_site/articles/intro.html')
+dotnet-serve --open-browser:_site/articles/intro.html

--- a/doc/import_external_docs_test.ps1
+++ b/doc/import_external_docs_test.ps1
@@ -1,7 +1,7 @@
-echo 'Updating docfx tool...'
+Write-Output 'Updating docfx tool...'
 dotnet tool update --global docfx
 
-echo 'Updating dotnet-serve tool...'
+Write-Output 'Updating dotnet-serve tool...'
 dotnet tool update --global dotnet-serve
 
 $external_docs = @{
@@ -19,8 +19,17 @@ $external_docs = @{
     "uno.samples"        = "master"
 }
 
-./import_external_docs $external_docs
+# In case you want to import a specific branch wich is not already committed in the uno-origin Repository, specify custom Git URLs for specific repositories and uncomment the following lines:
+# $contributor_git_urls = @{
+#     "uno.themes" = "https://github.com/contributor-fork/uno.themes"
+# }
 
-docfx
+# dot import the main script
+./import_external_docs.ps1
 
-dotnet-serve --open-browser:_site/articles/intro.html
+# call the function to import external docs
+Invoke-ImportExternalDocs -branches $external_docs -custom_git_urls $contributor_git_urls
+
+docfx build -Path $PSScriptRoot.Replace('import_external_docs_test.ps1', 'docfx.json')
+
+dotnet-serve --open-browser:$PSScriptRoot.Replace('import_external_docs_test.ps1', '_site/articles/intro.html')


### PR DESCRIPTION
GitHub Issue (If applicable): closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix
- Feature

<!-- Please uncomment one or more that apply to this PR

- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Script allows only importing from uno github url, which makes it difficult (for me not possible) for non-team contributors to validate the PR if it includes doc changes that would be best to build locally
- while it takes one simple paramter, its not following current PS v7.5 structure with begin-process-end and the function the current code contains lies mid in the executed code which leaves unclear when its called (at this line or maybe only if called by name?) seperated this below the main function to clear this up.
- using alias instead of Get-... Set-... is not recommended from PSAnalyzer so updated this.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- Added a parameter that extends the script capabilities to use the custom github url and not only (until now) the sha to import.
- Changed the PS to advanced script, not only for brevity than also to future allow Verbose, Debug cmdlet and Testing this script
- Changed alias to current recommended

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes => to be evaluated, but I dont think its a breaking change
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Problem this need a last bit of help with:
after running the main script, when it returns to the known `_Test.ps1` the Script executing path does not match coming from the Location change in the main script for importing the externals.
thats most likly just a quick fix but I do not know.

causing problems for most of my docs PR, e.g.:
- https://github.com/unoplatform/uno.extensions/pull/2734
- https://github.com/unoplatform/uno.extensions/pull/2710
- etc.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
