### PR TITLE
fix: `MenuFlyout` sub menu sometimes stays open

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/CascadingMenuHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/CascadingMenuHelper.cs
@@ -625,7 +625,7 @@ namespace Microsoft.UI.Xaml.Controls
 			// weak reference contents to a known type that it's guaranteed
 			// to be (if it isn't null), and we then AsOrNull() the ComPtr,
 			// once it's safe to ask about a type that we're not sure of.
-			FrameworkElement subMenuPresenterAsFE = m_wpSubMenuPresenter?.Target as Frame;
+			var subMenuPresenterAsFE = m_wpSubMenuPresenter?.IsAlive == true ? m_wpSubMenuPresenter.Target as FrameworkElement : null;
 
 			IMenuPresenter subMenuPresenter = null;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.hotdesign/issues/3548

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Nested menus sometimes stay open


## What is the new behavior?

They close correctly

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
