### PR TITLE
fix(ComboBox): updated selection not scrolled into view

### DIFF
--- a/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
@@ -234,6 +234,19 @@ static partial class ViewExtensions
 		.FirstOrDefault();
 
 	/// <summary>
+	/// Returns the first ancestor of a specified type.
+	/// </summary>
+	/// <typeparam name="T">The type of ancestor to find.</typeparam>
+	/// <param name="reference">Any node of the visual tree</param>
+	/// <remarks>First Counting from the <paramref name="reference"/> and not from the root of tree.</remarks>
+	/// <exception cref="Exception">If the specified node could not be found.</exception>
+	public static T? FindFirstAncestorOrThrow<T>(this _View? reference) => EnumerateAncestors(reference)
+		.OfType<T>()
+		.FirstOrDefault() ??
+		throw new Exception($"Unable to find element: {typeof(T).Name}");
+
+
+	/// <summary>
 	/// Returns the first ancestor of a specified type that satisfies the <paramref name="predicate"/>.
 	/// </summary>
 	/// <typeparam name="T">The type of ancestor to find.</typeparam>

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.custom.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.custom.cs
@@ -485,6 +485,76 @@ public partial class ComboBox : Selector
 		set { SetValue(LightDismissOverlayBackgroundProperty, value); }
 	}
 
+	internal void ScrollIntoView(object item, ScrollIntoViewAlignment alignment = ScrollIntoViewAlignment.Default)
+	{
+		if (ItemsPanelRoot is null)
+		{
+			// Not ready.
+			return;
+		}
+
+		if (ContainerFromItem(item) is UIElement element)
+		{
+			// The container we want to jump to is already materialized, so just jump to it.
+			// This means we're in a non-virtualizing panel or in a virtualizing panel where the container we want is materialized for some reason (e.g. partially in view)
+			ScrollIntoViewFastPath(element, alignment);
+		}
+#if !IS_UNIT_TESTS
+		else if (VirtualizingPanel?.GetLayouter() is { } layouter)
+		{
+#if __APPLE_UIKIT__ || __ANDROID__
+			// TODO
+#else
+			layouter.ScrollIntoView(item, alignment);
+#endif
+		}
+#endif
+	}
+
+	private void ScrollIntoViewFastPath(UIElement element, ScrollIntoViewAlignment alignment)
+	{
+		if (ScrollViewer is { } sv && sv.Presenter is { } presenter)
+		{
+			var offsetXY = element.TransformToVisual(presenter).TransformPoint(
+#if __SKIA__ // Skia correctly doesn't include the offsets in TransformToVisual
+				new Point(presenter.HorizontalOffset, presenter.VerticalOffset)
+#else
+				Point.Zero
+#endif
+				);
+
+			var orientation = ItemsPanelRoot?.PhysicalOrientation ?? Orientation.Vertical;
+
+			var (elementOffset, elementLength, presenterOffset, presenterViewportLength) =
+				orientation is Orientation.Vertical
+					? (offsetXY.Y, element.ActualSize.Y, presenter.VerticalOffset, presenter.ViewportHeight)
+					: (offsetXY.X, element.ActualSize.X, presenter.HorizontalOffset, presenter.ViewportWidth);
+
+			if (presenterOffset <= elementOffset && elementOffset + elementLength <= presenterOffset + presenterViewportLength)
+			{
+				// if the element is within the visible viewport, do nothing.
+				return;
+			}
+
+			// If we use the above offset directly, the item we want to jump to will be the start of the viewport, i.e. leading.
+			// For the default alignment, we move the element to either of the viewport ends (i.e. to the top or the bottom of the
+			// viewport. To move to the bottom, we scroll one "viewport page" less. This brings the element's start right after the
+			// viewport's length ends we then scroll again by elementLength so that the end of the element is the end of the viewport.
+			var newOffset = alignment is ScrollIntoViewAlignment.Default && presenterOffset < elementOffset
+				? elementOffset - presenterViewportLength + elementLength
+				: elementOffset;
+
+			if (orientation is Orientation.Vertical)
+			{
+				sv.ScrollToVerticalOffset(newOffset);
+			}
+			else
+			{
+				sv.ScrollToHorizontalOffset(newOffset);
+			}
+		}
+	}
+
 	internal static DependencyProperty LightDismissOverlayBackgroundProperty { get; } =
 		DependencyProperty.Register("LightDismissOverlayBackground", typeof(Brush), typeof(ComboBox), new FrameworkPropertyMetadata(null));
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/kahua-private#293

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Updates to ComboBox selection does not being the selection into view.

## What is the new behavior?
It will now.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.