### PR TITLE
fix(reg): Fix support of the inertial direct manipulation completion / resuming

### DIFF
--- a/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerInteractingState.cs
+++ b/src/Uno.UI.Composition/Composition/InteractionTracker/InteractionTrackerInteractingState.cs
@@ -29,15 +29,7 @@ internal sealed class InteractionTrackerInteractingState : InteractionTrackerSta
 
 	internal override void CompleteUserManipulation(Vector3 linearVelocity)
 	{
-		// Can this happen?
-		// Should we always get ReceiveInertiaStarting first?
-		// Anyway, it's likely still safe to go to inertia state here as interacting state can only transition to inertia.
-		if (this.Log().IsEnabled(LogLevel.Error))
-		{
-			this.Log().Error("Unexpected CompleteUserManipulation while in interacting state");
-		}
-
-		_interactionTracker.ChangeState(new InteractionTrackerInertiaState(_interactionTracker, linearVelocity, requestId: 0, isFromPointerWheel: false));
+		_interactionTracker.ChangeState(new InteractionTrackerIdleState(_interactionTracker, requestId: 0));
 	}
 
 	internal override void ReceiveManipulationDelta(Point translationDelta)

--- a/src/Uno.UI.RuntimeTests/Extensions/UIElementExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Extensions/UIElementExtensions.cs
@@ -1,0 +1,50 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Uno.UI.Extensions;
+
+namespace Uno.UI.RuntimeTests.Extensions;
+
+internal static class UIElementExtensions
+{
+	public static List<string> SubscribeToPointerEvents(this UIElement elt, List<string>? pointerEvents = null, [CallerArgumentExpression(nameof(elt))] string? name = null)
+	{
+		pointerEvents ??= new();
+		if (elt is FrameworkElement { Name: { Length: > 0 } fwEltName })
+		{
+			name = fwEltName;
+		}
+		name ??= elt.GetDebugName();
+
+		// Raw pointers
+		elt.PointerEntered += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.PointerEntered));
+		elt.PointerExited += (snd, e) => pointerEvents.Add(name + "." + name + "." + nameof(UIElement.PointerExited));
+		elt.PointerPressed += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.PointerPressed));
+		elt.PointerReleased += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.PointerReleased));
+		elt.PointerMoved += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.PointerMoved));
+		elt.PointerCaptureLost += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.PointerCaptureLost));
+		elt.PointerCanceled += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.PointerCanceled));
+		elt.PointerWheelChanged += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.PointerWheelChanged));
+
+		// Gestures
+		elt.Tapped += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.Tapped));
+		elt.DoubleTapped += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.DoubleTapped));
+		elt.RightTapped += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.RightTapped));
+		elt.Holding += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.Holding));
+
+		// Manipulation
+		elt.ManipulationStarting += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.ManipulationStarting));
+		elt.ManipulationStarted += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.ManipulationStarted));
+		elt.ManipulationDelta += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.ManipulationDelta));
+		elt.ManipulationInertiaStarting += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.ManipulationInertiaStarting));
+		elt.ManipulationCompleted += (snd, e) => pointerEvents.Add(name + "." + nameof(UIElement.ManipulationCompleted));
+
+		return pointerEvents;
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
@@ -413,6 +413,12 @@ public static class InjectedPointerExtensions
 		pointer.MoveTo(to, steps, stepOffsetInMilliseconds);
 		pointer.Release();
 	}
+
+	public static void Tap(this IInjectedPointer pointer, Point location)
+	{
+		pointer.Press(location);
+		pointer.Release();
+	}
 }
 
 public partial class Finger : IInjectedPointer, IDisposable

--- a/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
@@ -392,10 +392,10 @@ public static class FrameworkElementExtensions
 
 public static class PointExtensions
 {
-	public static Point Offset(this Point point, double xAndY)
+	public static Point OffsetLinear(this Point point, double xAndY)
 		=> new(point.X + xAndY, point.Y + xAndY);
 
-	public static Point Offset(this Point point, double x, double y)
+	public static Point Offset(this Point point, double x = 0, double y = 0)
 		=> new(point.X + x, point.Y + y);
 }
 

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
@@ -275,7 +275,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 				from: rect.GetCenter(),
 				to: new(rect.GetCenter().X, rect.GetCenter().Y - 100),
 				steps: 5,
-				stepOffsetInMilliseconds: 100);
+				stepOffsetInMilliseconds: 300);
 
 			await UITestHelper.WaitForIdle();
 
@@ -288,7 +288,8 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 
 			await UITestHelper.WaitForIdle();
 
-			var pixel = (await UITestHelper.ScreenShot(sut))[50, 1];
+			var result = await UITestHelper.ScreenShot(sut);
+			var pixel = result[50, 1];
 			Assert.IsTrue(pixel != Colors.Chartreuse && pixel != Colors.DeepPink);
 			Assert.AreEqual(0, requested);
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Composition/Given_InteractionTracker.cs
@@ -251,17 +251,6 @@ public partial class Given_InteractionTracker
 		helper.Advance();
 
 		Assert.AreEqual(
-			TrackerLogsConstructingHelper.GetInertiaStateEntered(
-				trackerPosition: new(-50.0f, 0.0f, 0.0f),
-				requestId: 0,
-				naturalRestingPosition: new(-50.0f, 0.0f, 0.0f),
-				modifiedRestingPosition: new(-50.0f, 0.0f, 0.0f),
-				positionVelocityInPixelsPerSecond: new(-0.0f, -0.0f, -0.0f)),
-			helper.Current);
-
-		helper.Advance();
-
-		Assert.AreEqual(
 			TrackerLogsConstructingHelper.GetIdleStateEntered(
 				trackerPosition: new(-50.0f, 0.0f, 0.0f),
 				requestId: 0),

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_NavigationView.cs
@@ -118,9 +118,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var screenShot = await UITestHelper.ScreenShot(SUT);
 
-			ImageAssert.HasColorAt(screenShot, item9.GetLocation().Offset(5), "#E6E6E6");
-			ImageAssert.HasColorAt(screenShot, item7.GetLocation().Offset(5), "#E6E6E6");
-			ImageAssert.HasColorAt(screenShot, item5.GetLocation().Offset(5), "#E6E6E6");
+			ImageAssert.HasColorAt(screenShot, item9.GetLocation().OffsetLinear(5), "#E6E6E6");
+			ImageAssert.HasColorAt(screenShot, item7.GetLocation().OffsetLinear(5), "#E6E6E6");
+			ImageAssert.HasColorAt(screenShot, item5.GetLocation().OffsetLinear(5), "#E6E6E6");
 
 			async Task OpenPane()
 			{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_VisualTreeHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_VisualTreeHelper.cs
@@ -134,9 +134,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 
 			var position = (await UITestHelper.Load(root)).Location;
 
-			AssertName(VisualTreeHelper.HitTest(position.Offset(256), root.XamlRoot).element!, "Root");
-			AssertName(VisualTreeHelper.HitTest(position.Offset(256 + 65), root.XamlRoot).element!, "Transformed");
-			AssertName(VisualTreeHelper.HitTest(position.Offset(256 + 128), root.XamlRoot).element!, "Nested");
+			AssertName(VisualTreeHelper.HitTest(position.OffsetLinear(256), root.XamlRoot).element!, "Root");
+			AssertName(VisualTreeHelper.HitTest(position.OffsetLinear(256 + 65), root.XamlRoot).element!, "Transformed");
+			AssertName(VisualTreeHelper.HitTest(position.OffsetLinear(256 + 128), root.XamlRoot).element!, "Nested");
 		}
 
 		[TestMethod]
@@ -194,9 +194,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 
 			var position = (await UITestHelper.Load(root)).Location;
 
-			AssertName(VisualTreeHelper.HitTest(position.Offset(128 - 5), root.XamlRoot).element!, "Root");
-			AssertName(VisualTreeHelper.HitTest(position.Offset(128 + 5), root.XamlRoot).element!, "Transformed");
-			AssertName(VisualTreeHelper.HitTest(position.Offset(256 - 60), root.XamlRoot).element!, "Nested");
+			AssertName(VisualTreeHelper.HitTest(position.OffsetLinear(128 - 5), root.XamlRoot).element!, "Root");
+			AssertName(VisualTreeHelper.HitTest(position.OffsetLinear(128 + 5), root.XamlRoot).element!, "Transformed");
+			AssertName(VisualTreeHelper.HitTest(position.OffsetLinear(256 - 60), root.XamlRoot).element!, "Nested");
 		}
 
 		private static void AssertName(UIElement element, string expectedName)

--- a/src/Uno.UI/UI/Input/GestureRecognizer.Manipulation.cs
+++ b/src/Uno.UI/UI/Input/GestureRecognizer.Manipulation.cs
@@ -79,6 +79,11 @@ namespace Windows.UI.Input
 			private InertiaProcessor? _inertia;
 
 			/// <summary>
+			/// Type of the pointers handled by this manipulation.
+			/// </summary>
+			public PointerDeviceType PointerDeviceType => _deviceType;
+
+			/// <summary>
 			/// Indicates that this manipulation **has started** and is for drag-and-drop.
 			/// (i.e. raises Drag event instead of Manipulation&lt;Started Delta Completed&gt; events).
 			/// </summary>
@@ -180,6 +185,11 @@ namespace Windows.UI.Input
 				StartDragTimer();
 			}
 
+			/// <summary>
+			/// Gets a boolean indicating if the given pointer is still active in the manipulation.
+			/// Active means that manipulation is not completed and pointer has been used at least at some point in the manipulation.
+			/// </summary>
+			/// <param name="pointer">Identifier of the pointer to test.</param>
 			public bool IsActive(PointerIdentifier pointer)
 				=> _status != ManipulationStatus.Completed
 					&& _deviceType == (PointerDeviceType)pointer.Type

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -131,6 +131,8 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				UnhookScrollEvents(sv);
 			}
+			_touchInertia?.Complete();
+			_touchInertia = null;
 		}
 
 		/// <inheritdoc />

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -137,6 +137,7 @@ namespace Microsoft.UI.Xaml.Controls
 		internal override bool HitTest(Point point)
 			=> true; // Makes sure to get pointers events, even if no background.
 
+#nullable enable
 		private void HookScrollEvents(ScrollViewer sv)
 		{
 			UnhookScrollEvents(sv);
@@ -273,12 +274,6 @@ namespace Microsoft.UI.Xaml.Controls
 		/// <inheritdoc />
 		ManipulationModes IDirectManipulationHandler.OnStarting(GestureRecognizer _, ManipulationStartingEventArgs args)
 		{
-			if (args.Pointer.Type is not (PointerDeviceType.Pen or PointerDeviceType.Touch)
-				|| (PointerCapture.TryGet(args.Pointer, out var capture) && capture.Options.HasFlag(PointerCaptureOptions.PreventDirectManipulation)))
-			{
-				return ManipulationModes.None;
-			}
-
 			var mode = ManipulationModes.None;
 			var scrollable = GetScrollableOffsets();
 			if (scrollable.Horizontally)
@@ -310,6 +305,12 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 
 			return mode;
+		}
+
+		void IDirectManipulationHandler.OnStarted(GestureRecognizer recognizer, ManipulationStartedEventArgs args, bool isResuming)
+		{
+			Debug.Assert(_touchInertia is null || isResuming, "Inertia should already be null instead if we are resuming from a previous manipulation.");
+			_touchInertia = null;
 		}
 
 		/// <inheritdoc />
@@ -466,14 +467,9 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 		/// <inheritdoc />
-		void IDirectManipulationHandler.OnCompleted(GestureRecognizer _, ManipulationCompletedEventArgs args)
+		void IDirectManipulationHandler.OnCompleted(GestureRecognizer _, ManipulationCompletedEventArgs? args)
 		{
-			if ((PointerDeviceType)args.PointerDeviceType != PointerDeviceType.Touch)
-			{
-				return;
-			}
-
-			if (args.IsInertial && _touchInertia is null)
+			if (args?.IsInertial is true && _touchInertia is null)
 			{
 				// Inertia has been aborted (external ChangeView request?) or was not even allowed, do not try to apply the final value.
 				return;

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -304,7 +304,7 @@ partial class InputManager
 
 					// If a control has captured the pointer with our internal PreventDirectManipulation patch flag,
 					// it means that it does not want to be redirected to direct manipulation.
-					that._settings = GestureSettings.None;
+					that._settings = args.Settings = GestureSettings.None;
 				}
 				else
 				{

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -33,14 +33,14 @@ partial class InputManager
 	{
 		/// <remarks>>
 		/// Unlike manipulations on a UIElement, we can "resume" it, so the sequence can be:
-		/// Starting{1} ──► Started{1} ──► Updated{1-*} ────────────────────────────────────────────────► Completed
+		/// Starting{1} ──► Started{1} ──► Updated{1-*} ────────────────────────────────────────────────► Completed{1}
 		///                                  ▲   │                                                            ▲
 		///                                  │   └────► InertiaStarting ──► Updated(isInertial=true){1-*} ────┤
 		///                                  │                                                                │
 		///                                  └─────────────────── Started(isResuming=true){1} ◄───────────────┘
 		/// 
 		/// While on UIElement it could be only
-		/// Starting{1} ──► Started{1} ──► Updated{1-*} ───────────────────────────────────────────────────► Completed
+		/// Starting{1} ──► Started{1} ──► Updated{1-*} ───────────────────────────────────────────────────► Completed{1}
 		///                                      │                                                               ▲
 		///                                      └────► InertiaStarting{1} ──► Updated(isInertial=true){1-*} ────┘
 		/// </remarks>>

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -31,6 +31,19 @@ partial class InputManager
 {
 	partial class PointerManager
 	{
+		/// <remarks>>
+		/// Unlike manipulations on a UIElement, we can "resume" it, so the sequence can be:
+		/// Starting{1} ──► Started{1} ──► Updated{1-*} ────────────────────────────────────────────────► Completed
+		///                                  ▲   │                                                            ▲
+		///                                  │   └────► InertiaStarting ──► Updated(isInertial=true){1-*} ────┤
+		///                                  │                                                                │
+		///                                  └─────────────────── Started(isResuming=true){1} ◄───────────────┘
+		/// 
+		/// While on UIElement it could be only
+		/// Starting{1} ──► Started{1} ──► Updated{1-*} ───────────────────────────────────────────────────► Completed
+		///                                      │                                                               ▲
+		///                                      └────► InertiaStarting{1} ──► Updated(isInertial=true){1-*} ────┘
+		/// </remarks>>
 		internal interface IDirectManipulationHandler
 		{
 			ManipulationModes OnStarting(GestureRecognizer recognizer, ManipulationStartingEventArgs args);
@@ -49,6 +62,9 @@ partial class InputManager
 
 			void OnUpdated(GestureRecognizer recognizer, ManipulationUpdatedEventArgs args, ref ManipulationDelta unhandledDelta) { }
 
+			/// <remarks>
+			/// Be aware that unlike manipulations on a UIElement, we can "resume" it, so this can be invoked more than once.
+			/// </remarks>>
 			void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args, ref bool isHandled) { }
 
 			void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs? args) { }

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -19,6 +19,7 @@ using System.Runtime.InteropServices;
 using Windows.Devices.Input;
 using Uno.UI.Extensions;
 using System.Runtime.CompilerServices;
+using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
 
 #if !HAS_UNO_WINUI
 using Windows.UI.Input;
@@ -34,18 +35,28 @@ partial class InputManager
 		{
 			ManipulationModes OnStarting(GestureRecognizer recognizer, ManipulationStartingEventArgs args);
 
-			void OnStarted(GestureRecognizer recognizer, ManipulationStartedEventArgs args) { }
+			/// <summary>
+			/// Invoked when the manipulation has started.
+			/// Starting from here, other elements in the tree will no longer receive pointer events (get PointerCaptureLost)
+			/// </summary>
+			/// <param name="recognizer">The associated gesture recognizer.</param>
+			/// <param name="args"></param>
+			/// <param name="isResuming">
+			/// Indicates if this start is resuming a previous manipulation (e.g. touch again while in an inertial translation).
+			/// WARNING: Args.Cumulative will be reset starting from here. If using it in OnUpdated or any other handlers, make sure to aggregate them!
+			/// </param>
+			void OnStarted(GestureRecognizer recognizer, ManipulationStartedEventArgs args, bool isResuming) { }
 
 			void OnUpdated(GestureRecognizer recognizer, ManipulationUpdatedEventArgs args, ref ManipulationDelta unhandledDelta) { }
 
 			void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args, ref bool isHandled) { }
 
-			void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs args) { }
+			void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs? args) { }
 		}
 
 		// TODO: Consider using https://github.com/dotnet/roslyn/blob/d9272a3f01928b1c3614a942bdbbfeb0fb17a43b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
 		// This dictionary is not going to be large, so SmallDictionary might be more efficient.
-		private Dictionary<PointerIdentifier, DirectManipulation>? _directManipulations;
+		private Dictionary<PointerDeviceType, DirectManipulation>? _directManipulations;
 		private Windows.UI.Core.PointerEventArgs? _directManipulationsCurrentPointerArgs;
 
 		private CurrentArgSubscription AsCurrentForDirectManipulation(Windows.UI.Core.PointerEventArgs args)
@@ -63,7 +74,7 @@ partial class InputManager
 
 		private void RegisterDirectManipulationTargetCore(PointerIdentifier pointer, IDirectManipulationHandler directManipulationTarget)
 		{
-			ref var manip = ref CollectionsMarshal.GetValueRefOrAddDefault(_directManipulations ??= new(), pointer, out var exists);
+			ref var manip = ref CollectionsMarshal.GetValueRefOrAddDefault(_directManipulations ??= new(), pointer.Type, out var exists);
 			if (exists)
 			{
 				manip!.Handlers.Add(directManipulationTarget);
@@ -80,7 +91,7 @@ partial class InputManager
 		}
 
 		private bool IsRedirectedToDirectManipulation(PointerIdentifier pointerId)
-			=> _directManipulations?.ContainsKey(pointerId) == true;
+			=> _directManipulations?.ContainsKey(pointerId.Type) == true;
 
 		private bool TryRedirectPressToDirectManipulation(Windows.UI.Core.PointerEventArgs args)
 		{
@@ -92,15 +103,34 @@ partial class InputManager
 
 				// So we cancel all gesture recognizer, except the one that is for the same kind of pointer (to allow multi-touch manipulation).
 				var currentPointer = args.CurrentPoint.Pointer;
-				foreach ((var manipPointer, var manip) in new Dictionary<PointerIdentifier, DirectManipulation>(_directManipulations))
+				foreach ((var manipPointerType, var manip) in new Dictionary<PointerDeviceType, DirectManipulation>(_directManipulations))
 				{
-					if (manipPointer.Type != currentPointer.Type // Not the same type
-						|| manip.Recognizer.PendingManipulation is { Inertia: not null } // Manipulation is processing inertia, we want to stop it as soon as a new pointer is pressed
-						|| manip.Recognizer.PendingManipulation?.IsActive(currentPointer) is true) // Second press on the same pointer, we cancel the previous one!
+					if (manipPointerType == currentPointer.Type)
+					{
+						// The pointer is of the same type of the pending manipulation:
+						//		* Single touch: inertial
+						//		* Multi touch: multiples pinches (to zoom) with the release of only one pointer **NOT SUPPORTED**
+
+						if (_trace)
+						{
+							Trace($"[DirectManipulation] [{manipPointerType}] Resuming previous manipulation (as we have a down for {currentPointer}).");
+						}
+
+						using var _ = manip.Resuming();
+						using var __ = AsCurrentForDirectManipulation(args);
+
+						// Note: This will most probably invoke the Completed event, which will remove the manipulation from the dictionary (therefore we use a clone).
+						manip.Recognizer.CompleteGesture();
+						manip.Recognizer.ProcessDownEvent(args.CurrentPoint); // Starts a new manipulation
+
+						return true;
+					}
+					else if (manipPointerType != currentPointer.Type // Not the same type
+						|| manip.Recognizer.PendingManipulation is { Inertia: not null }) // Manipulation is processing inertia, we want to stop it as soon as a new pointer is pressed
 					{
 						if (_trace)
 						{
-							Trace($"[DirectManipulation] [{manipPointer}] Completing previous manipulation (as we have a down for {currentPointer}).");
+							Trace($"[DirectManipulation] [{manipPointerType}] Completing previous manipulation (as we have a down for {currentPointer}).");
 						}
 
 						// Note: This will most probably invoke the Completed event, which will remove the manipulation from the dictionary (therefore we use a clone).
@@ -114,10 +144,11 @@ partial class InputManager
 
 		private void EndPressForDirectManipulation(Windows.UI.Core.PointerEventArgs args)
 		{
-			// SV will register them during the PointerPressed event bubbling, then once bubbling is over,
-			// we forward the press event to the gesture recognizer (so we will fire the ManipStarting event).
+			// Direct manip handlers will register them during the PointerPressed event bubbling, then once bubbling is over,
+			// we forward the press event to the gesture recognizer (so we will fire the ManipStarting event)
 
-			if (_directManipulations?.TryGetValue(args.CurrentPoint.Pointer, out var manip) is true
+			if (_directManipulations?.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip) is true
+				&& manip.HasStarted is false // resuming, no needs to forward pointer again
 				&& manip.Recognizer.PendingManipulation?.IsActive(args.CurrentPoint.Pointer) is not true)
 			{
 				if (_trace)
@@ -132,7 +163,7 @@ partial class InputManager
 
 		private bool TryRedirectMoveToDirectManipulation(Windows.UI.Core.PointerEventArgs args)
 		{
-			if (_directManipulations?.TryGetValue(args.CurrentPoint.Pointer, out var manip) is true)
+			if (_directManipulations?.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip) is true)
 			{
 				if (_trace)
 				{
@@ -150,7 +181,7 @@ partial class InputManager
 
 		private bool TryRedirectReleaseToDirectManipulation(Windows.UI.Core.PointerEventArgs args)
 		{
-			if (_directManipulations?.TryGetValue(args.CurrentPoint.Pointer, out var manip) is true)
+			if (_directManipulations?.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip) is true)
 			{
 				// Note: We do NOT remove the recognizer from the manipulation, it will self-remove when the manipulation is completed (i.e. once inertia is completed!).
 				//		 This is to allow the manipulation to be cancelled if the pointer is re-pressed.
@@ -170,7 +201,7 @@ partial class InputManager
 		}
 
 		private bool TryClearDirectManipulationRedirection(PointerIdentifier pointerId)
-			=> _directManipulations?.Remove(pointerId) is true;
+			=> _directManipulations?.Remove(pointerId.Type) is true;
 
 		private void TraceIgnoredForDirectManipulation(Windows.UI.Core.PointerEventArgs args, [CallerMemberName] string caller = "")
 		{
@@ -183,6 +214,9 @@ partial class InputManager
 		private sealed class DirectManipulation
 		{
 			private readonly PointerManager _pointerManager;
+
+			private bool _resuming;
+			private GestureSettings _settings;
 
 			public GestureRecognizer Recognizer { get; }
 
@@ -211,32 +245,69 @@ partial class InputManager
 				recognizer.ManipulationUpdated += OnDirectManipulationUpdated;
 				recognizer.ManipulationInertiaStarting += OnDirectManipulationInertiaStarting;
 				recognizer.ManipulationCompleted += OnDirectManipulationCompleted;
+				recognizer.ManipulationAborted += OnDirectManipulationAborted;
 
 				return recognizer;
 			}
 
+			public struct ResumingManipulation(DirectManipulation manip) : IDisposable
+			{
+				/// <inheritdoc />
+				public void Dispose()
+					=> manip._resuming = false;
+			}
+
+			public ResumingManipulation Resuming()
+			{
+				_resuming = true;
+				return new ResumingManipulation(this);
+			}
+
 			private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartingEventArgs> OnDirectManipulationStarting = (sender, args) =>
 			{
-				if (_trace)
-				{
-					Trace($"[DirectManipulation] [{args.Pointer}] Starting");
-				}
-
 				// TODO: Make sure ManipulationStarting is fired on UIElement.
 
-				var manipulation = (DirectManipulation)sender.Owner;
+				var that = (DirectManipulation)sender.Owner;
 				var supportedMode = ManipulationModes.None;
 
-				foreach (var handler in manipulation.Handlers)
+				if (that.HasStarted)
 				{
-					supportedMode |= handler.OnStarting(sender, args);
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] **RESUMING** Starting. ==> Restoring mode {that._settings}.");
+					}
+
+					args.Settings = that._settings;
 				}
-
-				args.Settings = supportedMode.ToGestureSettings();
-
-				if (_trace)
+				else if (PointerCapture.TryGet(args.Pointer, out var capture) && capture.Options.HasFlag(PointerCaptureOptions.PreventDirectManipulation))
 				{
-					Trace($"[DirectManipulation] [{args.Pointer}] Starting ==> Final configured mode is {supportedMode}.");
+					if (_trace)
+					{
+						Trace("[DirectManipulation] Ignored ==> An element in the tree prevented direct-manipulation.");
+					}
+
+					// If a control has captured the pointer with our internal PreventDirectManipulation patch flag,
+					// it means that it does not want to be redirected to direct manipulation.
+					that._settings = GestureSettings.None;
+				}
+				else
+				{
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.Pointer}] Starting");
+					}
+
+					foreach (var handler in that.Handlers)
+					{
+						supportedMode |= handler.OnStarting(sender, args);
+					}
+
+					that._settings = args.Settings = supportedMode.ToGestureSettings();
+
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.Pointer}] Starting ==> Final configured mode is {supportedMode}.");
+					}
 				}
 			};
 
@@ -249,17 +320,32 @@ partial class InputManager
 					return;
 				}
 
-				if (_trace)
+				if (that.HasStarted)
 				{
-					Trace($"[DirectManipulation] [{args.Pointers[0]}] Started @={args.Position.ToDebugString()}");
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.Pointers[0]}] **RESUMING** Started @={args.Position.ToDebugString()}");
+					}
+
+					foreach (var handler in that.Handlers)
+					{
+						handler.OnStarted(sender, args, isResuming: true);
+					}
 				}
-
-				that.HasStarted = true;
-				manager.CancelPointer(pointerArgs, isDirectManipulation: true);
-
-				foreach (var handler in that.Handlers)
+				else
 				{
-					handler.OnStarted(sender, args);
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.Pointers[0]}] Started @={args.Position.ToDebugString()}");
+					}
+
+					that.HasStarted = true;
+					manager.CancelPointer(pointerArgs, isDirectManipulation: true);
+
+					foreach (var handler in that.Handlers)
+					{
+						handler.OnStarted(sender, args, isResuming: false);
+					}
 				}
 			};
 
@@ -300,7 +386,13 @@ partial class InputManager
 			private static readonly TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> OnDirectManipulationCompleted = (sender, args) =>
 			{
 				var that = (DirectManipulation)sender.Owner;
-				that._pointerManager._directManipulations!.Remove(args.Pointers[0]);
+
+				if (that._resuming)
+				{
+					return;
+				}
+
+				that._pointerManager._directManipulations!.Remove((PointerDeviceType)args.PointerDeviceType);
 
 				if (_trace)
 				{
@@ -310,6 +402,23 @@ partial class InputManager
 				foreach (var handler in that.Handlers)
 				{
 					handler.OnCompleted(sender, args);
+				}
+			};
+
+			private static readonly TypedEventHandler<GestureRecognizer, GestureRecognizer.Manipulation> OnDirectManipulationAborted = (sender, manip) =>
+			{
+				var that = (DirectManipulation)sender.Owner;
+
+				that._pointerManager._directManipulations!.Remove((PointerDeviceType)manip.PointerDeviceType);
+
+				if (_trace)
+				{
+					Trace($"[DirectManipulation] Aborted");
+				}
+
+				foreach (var handler in that.Handlers)
+				{
+					handler.OnCompleted(sender, null);
 				}
 			};
 		}
@@ -335,8 +444,8 @@ partial class InputManager
 				=> Tracker.ReceiveInertiaStarting(new Point(args.Velocities.Linear.X * 1000, args.Velocities.Linear.Y * 1000));
 
 			/// <inheritdoc />
-			public void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs args)
-				=> Tracker.CompleteUserManipulation(new Vector3((float)(args.Velocities.Linear.X * 1000), (float)(args.Velocities.Linear.Y * 1000), 0));
+			public void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs? args)
+				=> Tracker.CompleteUserManipulation(new Vector3((float)(args?.Velocities.Linear.X * 1000 ?? 0), (float)(args?.Velocities.Linear.Y * 1000 ?? 0), 0));
 		}
 
 		private struct CurrentArgSubscription(PointerManager manager) : IDisposable


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1257

## Bugfix
Fix support of the inertial direct manipulation completion / resuming

## What is the current behavior?
New interaction during inertial direct manipulation allows full interaction

## What is the new behavior?
New interaction can only resume previous manipulation.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
