### PR TITLE
fix: Ensure a SynchronizationContext is available for browser events

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1158,6 +1158,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_AsyncFlow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_NativeLayout.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6303,6 +6307,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\Clipping\UIElement_Clip_Update.xaml.cs">
       <DependentUpon>UIElement_Clip_Update.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\FrameworkElement_AsyncFlow.xaml.cs">
+      <DependentUpon>FrameworkElement_AsyncFlow.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\UIElement_Clipping.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\AutoSuggestBox_SoftKeboard.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_AsyncFlow.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_AsyncFlow.xaml
@@ -1,0 +1,15 @@
+﻿<Page x:Class="UITests.Windows_UI_Xaml.FrameworkElementTests.FrameworkElement_AsyncFlow"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:UITests.Windows_UI_Xaml.FrameworkElementTests"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<Button Click="Button_Click"
+				Content="Click me!" />
+		<TextBlock x:Name="results" />
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_AsyncFlow.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/FrameworkElement_AsyncFlow.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using System.Threading.Tasks;
+using System.Threading;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml.FrameworkElementTests;
+
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+[Sample("FrameworkElement", IsManualTest = true, Description = "When pressing the button, the text should not be null and should indicate the active synchronization context")]
+public sealed partial class FrameworkElement_AsyncFlow : Page
+{
+	public FrameworkElement_AsyncFlow()
+	{
+		this.InitializeComponent();
+	}
+
+	public async void Button_Click(object sender, object args)
+	{
+		await Task.Delay(10);
+		results.Text = SynchronizationContext.Current?.ToString() ?? "Invalid";
+	}
+}

--- a/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
+++ b/src/Uno.UI.Dispatching/Native/NativeDispatcher.cs
@@ -71,6 +71,18 @@ namespace Uno.UI.Dispatching
 		}
 
 		/// <summary>
+		/// Gets the synchronizations contexts for the available priorities from <see cref="NativeDispatcherPriority"/>.
+		/// </summary>
+		internal NativeDispatcherSynchronizationContext GetSynchronizationContext(NativeDispatcherPriority priority)
+		{
+			if ((int)priority < 0 || (int)priority > 3)
+			{
+				throw new ArgumentOutOfRangeException(nameof(priority));
+			}
+			return _synchronizationContexts[(int)priority];
+		}
+
+		/// <summary>
 		/// Enforce access on the UI thread.
 		/// </summary>
 		internal static void CheckThreadAccess()

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/BrowserKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/BrowserKeyboardInputSource.cs
@@ -5,6 +5,7 @@ using Windows.System;
 using Windows.UI.Core;
 using Uno.Foundation.Logging;
 using Uno.UI.Xaml;
+using Uno.UI.Dispatching;
 
 namespace Uno.UI.Runtime.Skia;
 
@@ -38,6 +39,10 @@ internal partial class BrowserKeyboardInputSource : IUnoKeyboardInputSource
 		{
 			_log.Debug($"Native Keyboard Event: down={down}, ctrl={ctrl}, shift={shift}, meta={meta}, code={code}, key=${key}");
 		}
+
+		// Ensure that the async context is set properly, since we're raising
+		// events from outside the dispatcher.
+		using var syncContextScope = NativeDispatcher.Main.GetSynchronizationContext(NativeDispatcherPriority.Normal).Apply();
 
 		var args = new KeyEventArgs(
 			"keyboard",

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/BrowserPointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/BrowserPointerInputSource.cs
@@ -12,6 +12,7 @@ using _PointerIdentifierPool = Windows.Devices.Input.PointerIdentifierPool; // i
 using _PointerIdentifier = Windows.Devices.Input.PointerIdentifier; // internal type (should be in Uno namespace)
 using System.Runtime.InteropServices;
 using Windows.System;
+using Uno.UI.Dispatching;
 
 namespace Uno.UI.Runtime.Skia;
 
@@ -75,6 +76,10 @@ internal unsafe partial class BrowserPointerInputSource : IUnoCorePointerInputSo
 		try
 		{
 			_trace?.Invoke($"Pointer evt={(HtmlPointerEvent)@event}|id={pointerId}|x={x}|y={x}|ctrl={ctrl}|shift={shift}|bts={buttons}|btUpdate={buttonUpdate}|type={(PointerDeviceType)deviceType}|ts={timestamp}|pres={pressure}|wheelX={wheelDeltaX}|wheelY={wheelDeltaY}|relTarget={hasRelatedTarget}");
+
+			// Ensure that the async context is set properly, since we're raising
+			// events from outside the dispatcher.
+			using var syncContextScope = NativeDispatcher.Main.GetSynchronizationContext(NativeDispatcherPriority.Normal).Apply();
 
 			var that = (BrowserPointerInputSource)inputSource;
 			var evt = (HtmlPointerEvent)@event;

--- a/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
+++ b/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
@@ -1,21 +1,21 @@
 ﻿#nullable enable
 
 using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.JavaScript;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.Foundation.Logging;
+using Uno.UI.Dispatching;
 using Windows.Devices.Input;
 using Windows.Foundation;
+using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Input;
-using Microsoft.UI.Xaml.Controls;
 using static Windows.UI.Input.PointerUpdateKind;
-using Uno.Foundation.Logging;
-using System.Runtime.InteropServices.JavaScript;
-
-using _PointerIdentifierPool = Windows.Devices.Input.PointerIdentifierPool; // internal type (should be in Uno namespace)
-using _PointerIdentifier = Windows.Devices.Input.PointerIdentifier; // internal type (should be in Uno namespace)
 using _NativeMethods = __Windows.UI.Core.CoreWindow.NativeMethods;
-using System.Runtime.InteropServices;
-using Windows.System;
-using Microsoft.UI.Xaml;
+using _PointerIdentifier = Windows.Devices.Input.PointerIdentifier; // internal type (should be in Uno namespace)
+using _PointerIdentifierPool = Windows.Devices.Input.PointerIdentifierPool; // internal type (should be in Uno namespace)
 
 namespace Uno.UI.Runtime;
 
@@ -99,6 +99,10 @@ internal partial class BrowserPointerInputSource : IUnoCorePointerInputSource
 		try
 		{
 			_logTrace?.Trace($"Pointer evt={(HtmlPointerEvent)@event}|id={pointerId}|x={x}|y={x}|ctrl={ctrl}|shift={shift}|bts={buttons}|btUpdate={buttonUpdate}|type={(PointerDeviceType)deviceType}|ts={timestamp}|pres={pressure}|wheelX={wheelDeltaX}|wheelY={wheelDeltaY}|relTarget={hasRelatedTarget}");
+
+			// Ensure that the async context is set properly, since we're raising
+			// events from outside the dispatcher.
+			using var syncContextScope = NativeDispatcher.Main.GetSynchronizationContext(NativeDispatcherPriority.Normal).Apply();
 
 			var that = (BrowserPointerInputSource)inputSource;
 			var evt = (HtmlPointerEvent)@event;

--- a/src/Uno.UI/UI/Xaml/UIElement.EventRegistration.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.EventRegistration.wasm.cs
@@ -6,12 +6,12 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.JavaScript;
 using System.Runtime.Serialization;
-
+using Microsoft.UI.Xaml.Controls;
 using Uno;
 using Uno.Extensions;
 using Uno.Foundation.Logging;
+using Uno.UI.Dispatching;
 using Uno.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 
 
 namespace Microsoft.UI.Xaml
@@ -250,6 +250,10 @@ namespace Microsoft.UI.Xaml
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private HtmlEventDispatchResult InternalInnerDispatchEvent(EventArgs eventArgs, string nativeEventPayload, string n, bool onCapturePhase = false)
 		{
+			// Ensure that the async context is set properly, since we're raising
+			// events from outside the dispatcher.
+			using var syncContextScope = NativeDispatcher.Main.GetSynchronizationContext(NativeDispatcherPriority.Normal).Apply();
+
 			if (_eventHandlers.TryGetValue((n, onCapturePhase), out var registration))
 			{
 				return registration.Dispatch(eventArgs, nativeEventPayload);


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/19749

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Properly set the `SynchronizationContext` for browser input raised events, which do not go through the dispatcher.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
