### PR TITLE
fix: Don't fail on treeview node keypress

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TreeView.cs
@@ -17,6 +17,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Uno.UI;
 using MUXControlsTestApp.Utilities;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
 
 #if HAS_UNO && !HAS_UNO_WINUI
 using Microsoft/* UWP don't rename */.UI.Xaml.Controls;
@@ -124,6 +126,40 @@ public class Given_TreeView
 
 		Assert.AreEqual(child2, child2NodeAfter.DataContext);
 	}
+
+#if __SKIA__
+	[TestMethod]
+	public async Task When_Delete_Node_With_MenuFlyout()
+	{
+		var SUT = new When_Delete_Node_With_MenuFlyout();
+		TestServices.WindowHelper.WindowContent = SUT;
+
+		var root = new MyNode();
+		root.Name = "root";
+		var child1 = new MyNode { Name = "Child 1" };
+		var child2 = new MyNode { Name = "Child 2" };
+		root.Children.Add(child1);
+		root.Children.Add(child2);
+
+		SUT.myTree.ItemsSource = new[] { root };
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var rootCt = SUT.myTree.ContainerFromItem(root) as TreeViewItem;
+		rootCt.IsExpanded = true;
+
+		rootCt.Focus(FocusState.Programmatic);
+
+		await TestServices.WindowHelper.WaitForIdle();
+
+		var child1Ct = SUT.myTree.ContainerFromItem(child1) as TreeViewItem;
+		child1Ct.Focus(FocusState.Programmatic);
+
+		await TestServices.WindowHelper.WaitForIdle();
+
+		// Pressing delete or any other key should not fail when a MenuFlyout
+		child1Ct.RaiseEvent(UIElement.KeyDownEvent, new KeyRoutedEventArgs(SUT, VirtualKey.Delete, VirtualKeyModifiers.None));
+	}
+#endif
 
 #if __ANDROID__
 	[Ignore("Test is not operational on Android, items are not returned properly https://github.com/unoplatform/uno/issues/9080")]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Delete_Node_With_MenuFlyout.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Delete_Node_With_MenuFlyout.xaml
@@ -1,0 +1,31 @@
+﻿<Grid x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests.When_Delete_Node_With_MenuFlyout"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests"
+	  xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  mc:Ignorable="d"
+	  Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<muxc:TreeView x:Name="myTree" x:FieldModifier="public" SelectionMode="Multiple"
+				   ItemsSource="{Binding Children}">
+		<muxc:TreeView.ItemTemplate>
+			<DataTemplate>
+				<muxc:TreeViewItem ItemsSource="{Binding Children}"
+								   Content="{Binding Name}"
+								   Name="{Binding Name}">
+					<muxc:TreeViewItem.ContextFlyout>
+						<MenuFlyout>
+							<!-- Don't delete, we need at least one to get the Style -->
+							<MenuFlyoutItem Text="Fake"
+											Visibility="Collapsed" />
+							<MenuFlyoutSubItem Text="FakeSub"
+											   Visibility="Collapsed" />
+						</MenuFlyout>
+					</muxc:TreeViewItem.ContextFlyout>
+				</muxc:TreeViewItem>
+			</DataTemplate>
+		</muxc:TreeView.ItemTemplate>
+	</muxc:TreeView>
+</Grid>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Delete_Node_With_MenuFlyout.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/TreeViewTests/When_Delete_Node_With_MenuFlyout.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls.TreeViewTests;
+
+public sealed partial class When_Delete_Node_With_MenuFlyout : Grid
+{
+	public When_Delete_Node_With_MenuFlyout()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -678,11 +678,18 @@ namespace Microsoft.UI.Xaml
 			ref bool handled,
 			ref bool handledShouldNotImpedeTextInput)
 		{
+			var contentRoot = VisualTree.GetContentRootForElement(pElement)!;
+
+			if (contentRoot is null)
+			{
+				return;
+			}
+
 			//Try to process accelerators on current CUIElement.
 			KeyboardAcceleratorUtility.ProcessKeyboardAccelerators(
 				key,
 				keyModifiers,
-				VisualTree.GetContentRootForElement(pElement)!.GetAllLiveKeyboardAccelerators(),
+				contentRoot.GetAllLiveKeyboardAccelerators(),
 				pElement,
 				out handled,
 				out handledShouldNotImpedeTextInput,

--- a/src/Uno.UI/UI/Xaml/UIElement.mux.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.mux.cs
@@ -678,7 +678,7 @@ namespace Microsoft.UI.Xaml
 			ref bool handled,
 			ref bool handledShouldNotImpedeTextInput)
 		{
-			var contentRoot = VisualTree.GetContentRootForElement(pElement)!;
+			var contentRoot = VisualTree.GetContentRootForElement(pElement);
 
 			if (contentRoot is null)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/20306

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Don't fail on non-attached element keyboard event processing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
