### PR TITLE
fix: Adjust aliased inclusion of WebView2

### DIFF
--- a/doc/articles/controls/WebView.md
+++ b/doc/articles/controls/WebView.md
@@ -28,8 +28,18 @@ Afterward, you can perform actions such as navigating to an HTML string:
 MyWebView.NavigateToString("<html><body><p>Hello world!</p></body></html>");
 ```
 
+### Windows Specifics
+
+For Skia Desktop on Windows, the `.csproj` must contain the following:
+
+```xml
+<ItemGroup Condition=" $([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'desktop' ">
+    <PackageReference Include="Microsoft.Web.WebView2" Aliases="MSWebView" />
+</ItemGroup>
+```
+
 > [!IMPORTANT]
-> For Skia WPF, you should add `<PackageReference Include="Microsoft.Web.WebView2" Aliases="WpfWebView" />` to your csproj.
+> If your project's desktop builder in `Platforms/Desktop/Program.cs` uses `.UseWindows()`, you'll also need to add the `<UnoUseWebView2WPF>true</UnoUseWebView2WPF>` property for the integration to work. However, it is recommended to [migrate to `.UseWin32()`](xref:Uno.Development.MigratingToUno6) for better performance and reliability.
 
 ## WebAssembly support
 

--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -65,4 +65,42 @@
 		</ItemGroup>
 	</Target>
 
+	<!-- 
+		Removes the WebView2 WPF reference by default. When using `.UseWindows()`, 
+		setting `UnoUseWebView2WPF` to true is required by the user
+	-->
+	<Target Name="_UnoWebView2RemoveWpf"
+			BeforeTargets="ResolveAssemblyReferences"
+			Condition=" '$(UnoUseWebView2WPF)' != 'true' and '$(UnoDisableWebView2Workarounds)' != 'true' ">
+		<ItemGroup>
+			<_wpfWebViewReference Include="@(Reference)" Condition="'%(Reference.FileName)' == 'Microsoft.Web.WebView2.Wpf'" />
+		</ItemGroup>
+		
+		<ItemGroup Condition=" '@(_wpfWebViewReference)' != ''">
+			<Reference Remove="@(_wpfWebViewReference)" />
+		</ItemGroup>
+	</Target>
+
+	<!--
+		Workarounds for manual inclusion of WebView2's files which prevent 
+		`PackageReference.Aliases` from being used.
+	-->
+	<Target Name="_UnoWebView2Workaround"
+			AfterTargets="ResolveAssemblyReferences"
+			Condition=" '$(UnoDisableWebView2Workarounds)' != 'true' ">
+		<ItemGroup>
+			<_webView2WithAliases Include="@(PackageReference)" Condition="'%(PackageReference.Aliases)' != ''" />
+		</ItemGroup>
+
+		<PropertyGroup Condition=" '@(_webView2WithAliases)' != ''">
+			<_webViewPackageAliases>%(_webView2WithAliases.Aliases)</_webViewPackageAliases>
+		</PropertyGroup>
+
+		<ItemGroup Condition=" '@(_webView2WithAliases)' != ''">
+			<ReferencePath Update="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Web.WebView2.Core'">
+				<Aliases>$(_webViewPackageAliases)</Aliases>
+			</ReferencePath>
+		</ItemGroup>
+	</Target>
+
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/19748

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Adjust the inclusion of WebView2 in Win32 desktop runtime.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
