### PR TITLE
fix(vs): Adjust for skipped profile/target changes

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
+++ b/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
@@ -161,8 +161,15 @@ internal class ProfilesObserver : IDisposable
 							PropagateCompletion = true
 						};
 
-						var projectBlock = projectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(evaluationLinkOptions, true);
-						var unconfiguredProjectBlock = ProjectDataSources.SyncLinkOptions(unconfiguredProject.Capabilities.SourceBlock);
+						var projectBlock = projectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(
+							evaluationLinkOptions,
+							// Request for the initial values of the source
+							initialDataAsNewForProjectSubscriptionUpdate: true);
+
+						var unconfiguredProjectBlock = ProjectDataSources.SyncLinkOptions(
+							unconfiguredProject.Capabilities.SourceBlock,
+							// Request for the initial values of the source
+							initialDataAsNewForProjectSubscriptionUpdate: true);
 
 						_projectRuleSubscriptionLink = ProjectDataSources.SyncLinkTo(
 							projectBlock,
@@ -215,7 +222,7 @@ internal class ProfilesObserver : IDisposable
 	{
 		await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-		_debugLog($"unconfiguredProject was unloaded");
+		_debugLog($"ProfilesObserver: unconfiguredProject was unloaded");
 
 		UnsubscribeCurrentProject();
 	}
@@ -224,6 +231,8 @@ internal class ProfilesObserver : IDisposable
 	{
 		_currentActiveDebugFramework = null;
 		_currentActiveDebugProfile = null;
+		_lastActiveDebugProfile = null;
+		_lastActiveDebugFramework = null;
 
 		// Force a refresh of reflection calls
 		_projectFrameworkServices = null;

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
@@ -29,7 +29,8 @@ public partial class EntryPoint : IDisposable
 	private const string WasmTargetFrameworkIdentifier = "browserwasm";
 	private const string UnoSelectedTargetFrameworkProperty = "_UnoSelectedTargetFramework";
 	private CancellationTokenSource? _wasmProjectReloadTask;
-	private Stopwatch _lastOperation = new Stopwatch();
+	private Stopwatch _lastProfileOperation = new Stopwatch();
+	private Stopwatch _lastTargetOperation = new Stopwatch();
 	private TimeSpan _profileOrFrameworkDelay = TimeSpan.FromSeconds(1);
 	private bool _pendingRequestedChanged;
 	private bool _isFirstProfileTfmChange = true;
@@ -50,7 +51,7 @@ public partial class EntryPoint : IDisposable
 			// is the right one.
 			await WriteProjectUserSettingsAsync(newFramework);
 
-			if (!_pendingRequestedChanged && _lastOperation.IsRunning && _lastOperation.Elapsed < _profileOrFrameworkDelay)
+			if (!_pendingRequestedChanged && _lastTargetOperation.IsRunning && _lastTargetOperation.Elapsed < _profileOrFrameworkDelay)
 			{
 				// This debouncing needs to happen when VS intermittently changes the active
 				// profile or target framework on project reloading. We skip the change if it
@@ -62,7 +63,7 @@ public partial class EntryPoint : IDisposable
 			}
 
 			_pendingRequestedChanged = false;
-			_lastOperation.Restart();
+			_lastTargetOperation.Restart();
 
 			if (!isFirstProfileTfmChange && !forceReload && string.IsNullOrEmpty(previousFramework))
 			{
@@ -123,7 +124,7 @@ public partial class EntryPoint : IDisposable
 		// In this case, a new TargetFramework was selected. We need to file a matching target framework, if any.
 		_debugAction?.Invoke($"OnDebugProfileChangedAsync({previousProfile},{newProfile}) isFirstProfileTfmChange:{isFirstProfileTfmChange}");
 
-		if (!isFirstProfileTfmChange && !_pendingRequestedChanged && _lastOperation.IsRunning && _lastOperation.Elapsed < _profileOrFrameworkDelay)
+		if (!isFirstProfileTfmChange && !_pendingRequestedChanged && _lastProfileOperation.IsRunning && _lastProfileOperation.Elapsed < _profileOrFrameworkDelay)
 		{
 			// This debouncing needs to happen when VS intermittently changes the active
 			// profile or target framework on project reloading. We skip the change if it
@@ -135,7 +136,7 @@ public partial class EntryPoint : IDisposable
 		}
 
 		_pendingRequestedChanged = false;
-		_lastOperation.Restart();
+		_lastProfileOperation.Restart();
 
 		if (!isFirstProfileTfmChange && string.IsNullOrEmpty(previousProfile))
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/20313

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- Changes to get the initial profile/target values, otherwise, we'd miss the preview/new value pair and skip the updates
- Change to separate debouncing timers for profile and target

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
