### PR TITLE
fix(ContentDialog): full-size dialog being cut off at bottom

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ContentDialog.cs
@@ -21,6 +21,7 @@ using Windows.UI.Input.Preview.Injection;
 using Microsoft.UI.Xaml.Automation.Peers;
 using MUXControlsTestApp.Utilities;
 using Combinatorial.MSTest;
+using Uno.UI.Extensions;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -147,6 +148,52 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			finally
 			{
 				SUT.Hide();
+			}
+		}
+
+		[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.SkiaIslands | RuntimeTestPlatforms.Native)]
+		public async Task When_Uncapped_FullSizeDesired()
+		{
+			var SUT = new MyContentDialog(unconstrained: true)
+			{
+				Content = new Grid
+				{
+					BorderBrush = new SolidColorBrush(Colors.Red),
+					BorderThickness = new Thickness(5),
+				},
+				Background = new SolidColorBrush(Colors.SkyBlue),
+				PrimaryButtonText = "YES",
+				SecondaryButtonText = "NO",
+			};
+			SUT.FullSizeDesired = true;
+			SetXamlRootForIslandsOrWinUI(SUT);
+
+			var nativeUnsafeArea = ScreenHelper.GetUnsafeArea();
+
+			using (ScreenHelper.OverrideVisibleBounds(new Thickness(0, 38, 0, 72), skipIfHasNativeUnsafeArea: (nativeUnsafeArea.Top + nativeUnsafeArea.Bottom) > 50))
+			{
+				try
+				{
+					await ShowDialog(SUT);
+
+					var bgeScreenRect = SUT.BackgroundElement.GetOnScreenBounds();
+					var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
+
+					var scale =
+#if HAS_UNO && __SKIA__
+						SUT.BackgroundElement.GetScaleFactorForLayoutRounding();
+#else
+						1;
+#endif
+					var roundingMargin = 0.5 / scale;
+
+					Assert.AreEqual(visibleBounds.Top, bgeScreenRect.Top, roundingMargin * 2);
+					Assert.AreEqual(visibleBounds.Height, bgeScreenRect.Height, roundingMargin * 2);
+				}
+				finally
+				{
+					SUT.Hide();
+				}
 			}
 		}
 
@@ -758,18 +805,34 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 	public partial class MyContentDialog : ContentDialog
 	{
+		private readonly bool unconstrained;
+		public MyContentDialog(bool unconstrained = false)
+		{
+			this.unconstrained = unconstrained;
+		}
+
 		public Button PrimaryButton { get; private set; }
 		public Border BackgroundElement { get; private set; }
+		public Border Container { get; private set; }
 		public Grid LayoutRoot { get; private set; }
 		public ScrollViewer ContentScrollViewer { get; private set; }
+
 		protected override void OnApplyTemplate()
 		{
 			base.OnApplyTemplate();
 
-			PrimaryButton = GetTemplateChild("PrimaryButton") as Button;
-			BackgroundElement = GetTemplateChild("BackgroundElement") as Border;
+			Container = GetTemplateChild("Container") as Border;
 			LayoutRoot = GetTemplateChild("LayoutRoot") as Grid;
+			BackgroundElement = GetTemplateChild("BackgroundElement") as Border;
+
 			ContentScrollViewer = GetTemplateChild("ContentScrollViewer") as ScrollViewer;
+			PrimaryButton = GetTemplateChild("PrimaryButton") as Button;
+
+			if (unconstrained && BackgroundElement is { })
+			{
+				BackgroundElement.MinWidth = BackgroundElement.MinHeight = 0;
+				BackgroundElement.MaxWidth = BackgroundElement.MaxHeight = double.PositiveInfinity;
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.Visuals.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentDialog/ContentDialog.Visuals.cs
@@ -223,7 +223,11 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 			}
 
+#if !HAS_UNO
 			var xamlRootSize = XamlRoot.Size;
+#else
+			var xamlRootSize = XamlRoot.VisualTree.TrueVisibleBounds.Size;
+#endif
 
 			var flowDirection = FlowDirection;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes #20278

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On skia-mobile, the ContentDialog is being cut off at the bottom.

## What is the new behavior?
^ no more.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
The dialog is being forced to be at screen-size, while also placed lower than the status-bar, thus pushing it off the screen.
