### PR TITLE
fix: Fix support on mixed UIElement manipulations and direct manipulations

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/UIElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/UIElement.cs
@@ -944,13 +944,7 @@ namespace Microsoft.UI.Xaml
 		}
 #endif
 		// Skipping already declared method Microsoft.UI.Xaml.UIElement.UpdateLayout()
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
-		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
-		public bool CancelDirectManipulations()
-		{
-			throw new global::System.NotImplementedException("The member bool UIElement.CancelDirectManipulations() is not implemented. For more information, visit https://aka.platform.uno/notimplemented#m=bool%20UIElement.CancelDirectManipulations%28%29");
-		}
-#endif
+		// Skipping already declared method Microsoft.UI.Xaml.UIElement.CancelDirectManipulations()
 		// Forced skipping of method Microsoft.UI.Xaml.UIElement.StartDragAsync(Microsoft.UI.Input.PointerPoint)
 		// Skipping already declared method Microsoft.UI.Xaml.UIElement.StartBringIntoView()
 		// Skipping already declared method Microsoft.UI.Xaml.UIElement.StartBringIntoView(Microsoft.UI.Xaml.BringIntoViewOptions)

--- a/src/Uno.UI/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UI/UI/Input/GestureRecognizer.cs
@@ -112,9 +112,7 @@ namespace Windows.UI.Input
 			}
 		}
 
-		public void ProcessMoveEvents(IList<PointerPoint> value) => ProcessMoveEvents(value, true);
-
-		internal void ProcessMoveEvents(IList<PointerPoint> value, bool isRelevant)
+		public void ProcessMoveEvents(IList<PointerPoint> value)
 		{
 			// Even if the pointer was considered as irrelevant, we still buffer it as it is part of the user interaction
 			// and we should considered it for the gesture recognition when processing the up.

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Managed.cs
@@ -284,8 +284,10 @@ namespace Microsoft.UI.Xaml.Controls
 				return;
 			}
 
-			XamlRoot?.VisualTree.ContentRoot.InputManager.Pointers.RegisterDirectManipulationTarget(args.Pointer.UniqueId, this);
+			XamlRoot?.VisualTree.ContentRoot.InputManager.Pointers.RegisterDirectManipulationHandler(args.Pointer.UniqueId, this);
 		}
+
+		object? IDirectManipulationHandler.Owner => ScrollOwner;
 
 		/// <inheritdoc />
 		ManipulationModes IDirectManipulationHandler.OnStarting(GestureRecognizer _, ManipulationStartingEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
@@ -67,6 +67,7 @@ namespace Microsoft.UI.Xaml.Input
 		/// This is a GestureSettings, but we're actually only interested in a few gesture event-related
 		/// flags like Tapped and Hold.
 		/// </summary>
+		/// <remarks>For UNO_HAS_MANAGED_POINTERS, we should move this to the aggregated manipulation support in the InputManager.</remarks>
 		internal GestureSettings GestureEventsAlreadyRaised { get; set; }
 
 		public VirtualKeyModifiers KeyModifiers { get; }

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
@@ -194,9 +194,9 @@ internal partial class InputManager
 
 		private void OnPointerWheelChanged(Windows.UI.Core.PointerEventArgs args, bool isInjected = false)
 		{
-			if (IsRedirectedToDirectManipulation(args.CurrentPoint.Pointer))
+			if (IsRedirectedToManipulations(args.CurrentPoint.Pointer))
 			{
-				TraceIgnoredForDirectManipulation(args);
+				TraceIgnoredForManipulations(args);
 				return;
 			}
 
@@ -247,9 +247,9 @@ internal partial class InputManager
 
 		private void OnPointerEntered(Windows.UI.Core.PointerEventArgs args, bool isInjected = false)
 		{
-			if (IsRedirectedToDirectManipulation(args.CurrentPoint.Pointer))
+			if (IsRedirectedToManipulations(args.CurrentPoint.Pointer))
 			{
-				TraceIgnoredForDirectManipulation(args);
+				TraceIgnoredForManipulations(args);
 				return;
 			}
 
@@ -270,9 +270,9 @@ internal partial class InputManager
 
 		private void OnPointerExited(Windows.UI.Core.PointerEventArgs args, bool isInjected = false)
 		{
-			if (IsRedirectedToDirectManipulation(args.CurrentPoint.Pointer))
+			if (IsRedirectedToManipulations(args.CurrentPoint.Pointer))
 			{
-				TraceIgnoredForDirectManipulation(args);
+				TraceIgnoredForManipulations(args);
 				return;
 			}
 
@@ -311,9 +311,9 @@ internal partial class InputManager
 				return;
 			}
 
-			if (TryRedirectPressToDirectManipulation(args))
+			if (BeforePressTryRedirectToManipulations(args))
 			{
-				TraceIgnoredForDirectManipulation(args);
+				TraceIgnoredForManipulations(args);
 				return;
 			}
 
@@ -336,7 +336,7 @@ internal partial class InputManager
 			_pressedElements[routedArgs.Pointer] = originalSource;
 			result += Raise(Pressed, originalSource, routedArgs);
 
-			EndPressForDirectManipulation(args);
+			AfterPressForDirectManipulation(args);
 
 			args.DispatchResult = result;
 		}
@@ -351,9 +351,9 @@ internal partial class InputManager
 				return;
 			}
 
-			if (TryRedirectReleaseToDirectManipulation(args))
+			if (BeforeReleaseTryRedirectToManipulations(args))
 			{
-				TraceIgnoredForDirectManipulation(args);
+				TraceIgnoredForManipulations(args);
 				return;
 			}
 
@@ -409,16 +409,16 @@ internal partial class InputManager
 					break;
 			}
 
-			TryClearDirectManipulationRedirection(args.CurrentPoint.Pointer);
+			AfterReleaseForManipulations(args);
 
 			args.DispatchResult = result;
 		}
 
 		private void OnPointerMoved(Windows.UI.Core.PointerEventArgs args, bool isInjected = false)
 		{
-			if (TryRedirectMoveToDirectManipulation(args))
+			if (BeforeMoveTryRedirectToManipulations(args))
 			{
-				TraceIgnoredForDirectManipulation(args);
+				TraceIgnoredForManipulations(args);
 				return;
 			}
 
@@ -439,18 +439,22 @@ internal partial class InputManager
 			// Finally raise the event, either on the OriginalSource or on the capture owners if any
 			result += RaiseUsingCaptures(Move, originalSource, routedArgs, setCursor: true);
 
+			AfterMoveForManipulations(args);
+
 			args.DispatchResult = result;
 		}
 
 		private void OnPointerCancelled(PointerEventArgs args, bool isInjected = false)
 		{
-			if (TryClearDirectManipulationRedirection(args.CurrentPoint.Pointer))
+			if (BeforeCancelTryRedirectToManipulations(args))
 			{
-				TraceIgnoredForDirectManipulation(args);
+				TraceIgnoredForManipulations(args);
 				return;
 			}
 
 			CancelPointer(args, isInjected: isInjected);
+
+			AfterCancelForManipulations(args);
 		}
 
 		private void CancelPointer(PointerEventArgs args, bool isInjected = false, bool isDirectManipulation = false)

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -704,7 +704,7 @@ partial class InputManager
 			private PointerPoint GetRelativePoint(PointerEventArgs args)
 			{
 				var absolutePoint = args.CurrentPoint;
-				var relativePosition = UIElement.GetTransform(element, null).Transform(args.CurrentPoint.Position);
+				var relativePosition = UIElement.GetTransform(element, null).Inverse().Transform(args.CurrentPoint.Position);
 
 				return absolutePoint.At(relativePosition);
 			}

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -2,6 +2,7 @@
 
 #if UNO_HAS_MANAGED_POINTERS
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -15,11 +16,15 @@ using Windows.UI.Core;
 using Windows.UI.Input.Preview.Injection;
 using Microsoft.UI.Xaml.Controls;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Windows.Devices.Input;
 using Uno.UI.Extensions;
 using System.Runtime.CompilerServices;
 using PointerDeviceType = Windows.Devices.Input.PointerDeviceType;
+using System.Reflection;
+using Uno.Extensions;
+using PointerEventArgs = Windows.UI.Core.PointerEventArgs;
 
 #if !HAS_UNO_WINUI
 using Windows.UI.Input;
@@ -31,21 +36,23 @@ partial class InputManager
 {
 	partial class PointerManager
 	{
-		/// <remarks>>
+		/// <remarks>
 		/// Unlike manipulations on a UIElement, we can "resume" it, so the sequence can be:
-		/// Starting{1} ──► Started{1} ──► Updated{1-*} ────────────────────────────────────────────────► Completed{1}
-		///                                  ▲   │                                                            ▲
-		///                                  │   └────► InertiaStarting ──► Updated(isInertial=true){1-*} ────┤
-		///                                  │                                                                │
-		///                                  └─────────────────── Started(isResuming=true){1} ◄───────────────┘
+		/// Starting{1} ──► Started{1} ──► Updated{1-*} ───────────────────────────────────────────────────► Completed{1}
+		///                                  ▲   │                                                               ▲
+		///                                  │   └────► InertiaStarting{1} ──► Updated(isInertial=true){1-*} ────┤
+		///                                  │                                                                   │
+		///                                  └─────────────────── Started(isResuming=true){1} ◄──────────────────┘
 		/// 
 		/// While on UIElement it could be only
 		/// Starting{1} ──► Started{1} ──► Updated{1-*} ───────────────────────────────────────────────────► Completed{1}
 		///                                      │                                                               ▲
 		///                                      └────► InertiaStarting{1} ──► Updated(isInertial=true){1-*} ────┘
-		/// </remarks>>
+		/// </remarks>
 		internal interface IDirectManipulationHandler
 		{
+			object? Owner { get; }
+
 			ManipulationModes OnStarting(GestureRecognizer recognizer, ManipulationStartingEventArgs args);
 
 			/// <summary>
@@ -64,162 +71,287 @@ partial class InputManager
 
 			/// <remarks>
 			/// Be aware that unlike manipulations on a UIElement, we can "resume" it, so this can be invoked more than once.
-			/// </remarks>>
+			/// </remarks>
 			void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args, ref bool isHandled) { }
 
 			void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs? args) { }
 		}
 
-		// TODO: Consider using https://github.com/dotnet/roslyn/blob/d9272a3f01928b1c3614a942bdbbfeb0fb17a43b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
-		// This dictionary is not going to be large, so SmallDictionary might be more efficient.
-		private Dictionary<PointerDeviceType, DirectManipulation>? _directManipulations;
-		private Windows.UI.Core.PointerEventArgs? _directManipulationsCurrentPointerArgs;
-
-		private CurrentArgSubscription AsCurrentForDirectManipulation(Windows.UI.Core.PointerEventArgs args)
+		private interface IGestureRecognizer
 		{
-			Debug.Assert(_directManipulationsCurrentPointerArgs is null);
-			_directManipulationsCurrentPointerArgs = args;
-			return new CurrentArgSubscription(this);
+			void ProcessDown(Windows.UI.Core.PointerEventArgs args);
+
+			void ProcessMove(Windows.UI.Core.PointerEventArgs args);
+
+			void ProcessUp(Windows.UI.Core.PointerEventArgs args);
+
+			void ProcessCancel(Windows.UI.Core.PointerEventArgs args);
 		}
 
-		internal void RegisterDirectManipulationTarget(PointerIdentifier pointer, IDirectManipulationHandler directManipulationTarget)
-			=> RegisterDirectManipulationTargetCore(pointer, directManipulationTarget);
+		private readonly PointerTypePseudoDictionary<DirectManipulation> _directManipulations = new();
+		private readonly PointerTypePseudoDictionary<Queue<IGestureRecognizer>> _gestureRecognizers = new();
+
+		internal void RegisterDirectManipulationHandler(PointerIdentifier pointer, IDirectManipulationHandler handler)
+			=> RegisterDirectManipulationHandlerCore(pointer, handler);
 
 		internal void RedirectPointer(Windows.UI.Input.PointerPoint pointer, InteractionTracker tracker)
-			=> RegisterDirectManipulationTargetCore(pointer.Pointer, new InteractionTrackerToDirectManipulationHandler(tracker));
+			=> RegisterDirectManipulationHandlerCore(pointer.Pointer, new InteractionTrackerToDirectManipulationHandler(tracker));
 
-		private void RegisterDirectManipulationTargetCore(PointerIdentifier pointer, IDirectManipulationHandler directManipulationTarget)
+		private void RegisterDirectManipulationHandlerCore(PointerIdentifier pointer, IDirectManipulationHandler handler)
 		{
-			ref var manip = ref CollectionsMarshal.GetValueRefOrAddDefault(_directManipulations ??= new(), pointer.Type, out var exists);
-			if (exists)
+			if (!_directManipulations.TryGetValue(pointer.Type, out var manip))
 			{
-				manip!.Handlers.Add(directManipulationTarget);
+				manip = _directManipulations[pointer.Type] = new(this);
+				RegisterGestureRecognizerCore(pointer, manip);
 			}
-			else
-			{
-				manip = new DirectManipulation(this) { Handlers = { directManipulationTarget } };
-			}
+
+			manip.Handlers.Add(handler);
 
 			if (_trace)
 			{
-				Trace($"[DirectManipulation] [{pointer}] Redirection requested to {directManipulationTarget.GetDebugName()}");
+				Trace($"[DirectManipulation] [{pointer}] Redirection requested to {handler.GetDebugName()}");
 			}
 		}
 
-		private bool IsRedirectedToDirectManipulation(PointerIdentifier pointerId)
-			=> _directManipulations?.ContainsKey(pointerId.Type) == true;
+		internal void RegisterUiElementManipulationRecognizer(PointerIdentifier pointer, UIElement element, GestureRecognizer recognizer)
+			=> RegisterGestureRecognizerCore(pointer, new UIElementRecognizer(element, recognizer));
 
-		private bool TryRedirectPressToDirectManipulation(Windows.UI.Core.PointerEventArgs args)
+		private void RegisterGestureRecognizerCore(PointerIdentifier pointer, IGestureRecognizer recognizer)
 		{
-			if (_directManipulations is not null)
+			if (!_gestureRecognizers.TryGetValue(pointer.Type, out var recognizers))
 			{
-				// Currently we do not support to redirect pointer before the press event (e.g. in pointer hover move).
-				// This is theoretically possible using composition APIs, but currently never the case in current source code (as of 2025-03-24),
-				// and is also most probably refused by WinUI.
+				recognizers = _gestureRecognizers[pointer.Type] = new();
+			}
 
-				// So we cancel all gesture recognizer, except the one that is for the same kind of pointer (to allow multi-touch manipulation).
-				var currentPointer = args.CurrentPoint.Pointer;
-				foreach ((var manipPointerType, var manip) in new Dictionary<PointerDeviceType, DirectManipulation>(_directManipulations))
+			recognizers.Enqueue(recognizer);
+
+			if (_trace)
+			{
+				Trace($"[GestureRecognition] [{pointer}] Recognizer registered {recognizer}");
+			}
+		}
+
+		/// <summary>
+		/// Cancel direct manipulation for the given pointers, no matter their handlers/owner.
+		/// </summary>
+		internal bool CancelAllDirectManipulations(PointerIdentifier[] identifiers)
+		{
+			var cancelled = false;
+			foreach (var pointer in identifiers)
+			{
+				if (_directManipulations.TryGetValue(pointer.Type, out var manip))
 				{
-					if (manipPointerType == currentPointer.Type)
-					{
-						// The pointer is of the same type of the pending manipulation:
-						//		* Single touch: inertial
-						//		* Multi touch: multiples pinches (to zoom) with the release of only one pointer **NOT SUPPORTED**
-
-						if (_trace)
-						{
-							Trace($"[DirectManipulation] [{manipPointerType}] Resuming previous manipulation (as we have a down for {currentPointer}).");
-						}
-
-						using var _ = manip.Resuming();
-						using var __ = AsCurrentForDirectManipulation(args);
-
-						// Note: This will most probably invoke the Completed event, which will remove the manipulation from the dictionary (therefore we use a clone).
-						manip.Recognizer.CompleteGesture();
-						manip.Recognizer.ProcessDownEvent(args.CurrentPoint); // Starts a new manipulation
-
-						return true;
-					}
-					else if (manipPointerType != currentPointer.Type // Not the same type
-						|| manip.Recognizer.PendingManipulation is { Inertia: not null }) // Manipulation is processing inertia, we want to stop it as soon as a new pointer is pressed
-					{
-						if (_trace)
-						{
-							Trace($"[DirectManipulation] [{manipPointerType}] Completing previous manipulation (as we have a down for {currentPointer}).");
-						}
-
-						// Note: This will most probably invoke the Completed event, which will remove the manipulation from the dictionary (therefore we use a clone).
-						manip.Recognizer.CompleteGesture();
-					}
+					cancelled |= manip.IsActive;
+					manip.Cancel();
 				}
 			}
 
-			return false;
+			return cancelled;
 		}
 
-		private void EndPressForDirectManipulation(Windows.UI.Core.PointerEventArgs args)
+		/// <summary>
+		/// Cancel direct manipulation which are handled by the given <paramref name="requestingElement"/>.
+		/// </summary>
+		internal bool CancelDirectManipulations(UIElement requestingElement)
+		{
+			var cancelled = false;
+			foreach (var (_, manip) in _directManipulations)
+			{
+				if (manip.Handlers.Any(handler => handler.Owner == requestingElement))
+				{
+					cancelled |= manip.IsActive;
+					manip.Cancel();
+				}
+			}
+
+			return cancelled;
+		}
+
+		private bool IsRedirectedToManipulations(PointerIdentifier pointerId)
+			=> _directManipulations.ContainsKey(pointerId.Type);
+
+		private bool BeforePressTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
+		{
+			// Currently we do not support to redirect pointer before the press event (e.g. in pointer hover move).
+			// This is theoretically possible using composition APIs, but currently never the case in current source code (as of 2025-03-24),
+			// and is also most probably refused by WinUI.
+			// So we cancel all gesture recognizer, except the one that is for the same kind of pointer (to allow multi-touch manipulation).
+
+			var currentPointer = args.CurrentPoint.Pointer;
+			var redirected = false;
+			foreach ((var pointer, var manipulation) in _directManipulations)
+			{
+				if (pointer == currentPointer.Type && manipulation.IsActive)
+				{
+					// The pointer is of the same type of the pending manipulation:
+					//		* Single touch: inertial
+					//		* Multi touch: multiples pinches (to zoom) with the release of only one pointer **NOT SUPPORTED**
+
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{pointer}] Resuming previous manipulation (as we have a down for {currentPointer}).");
+					}
+
+					using var _ = manipulation.Resuming();
+					using var __ = manipulation.WithCurrent(args);
+
+					manipulation.Recognizer.CompleteGesture();
+					manipulation.Recognizer.ProcessDownEvent(args.CurrentPoint); // Starts a new manipulation
+
+					redirected = true;
+				}
+				else
+				{
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{pointer}] Completing previous manipulation (as we have a down for {currentPointer}).");
+					}
+
+					if (manipulation.IsActive)
+					{
+						manipulation.Recognizer.CompleteGesture();
+					}
+
+					_directManipulations.Remove(pointer); // Using the PointerTypePseudoDictionary we can safely remove while enumerating
+				}
+			}
+
+			return redirected;
+		}
+
+		private void AfterPressForDirectManipulation(Windows.UI.Core.PointerEventArgs args)
 		{
 			// Direct manip handlers will register them during the PointerPressed event bubbling, then once bubbling is over,
 			// we forward the press event to the gesture recognizer (so we will fire the ManipStarting event)
 
-			if (_directManipulations?.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip) is true
-				&& manip.HasStarted is false // resuming, no needs to forward pointer again
-				&& manip.Recognizer.PendingManipulation?.IsActive(args.CurrentPoint.Pointer) is not true)
+			if (_gestureRecognizers.TryGetValue(args.CurrentPoint.PointerDeviceType, out var recognizers))
 			{
-				if (_trace)
+				foreach (var recognizer in recognizers)
 				{
-					Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Adding pointer --POST DISPATCH-- (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+					recognizer.ProcessDown(args);
 				}
-
-				using var _ = AsCurrentForDirectManipulation(args);
-				manip.Recognizer.ProcessDownEvent(args.CurrentPoint);
 			}
 		}
 
-		private bool TryRedirectMoveToDirectManipulation(Windows.UI.Core.PointerEventArgs args)
+		private bool BeforeMoveTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
 		{
-			if (_directManipulations?.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip) is true)
+			if (_directManipulations.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip)
+				&& manip.HasStarted) // We defer the handle of the move to **AFTER** while the manipulation has not started, so UIElement's manipulation will be able to kick-in before we stole all the pointers.
 			{
-				if (_trace)
+				if (manip.IsActive)
 				{
-					Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Handling move (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Handling move (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+					}
+
+					using var _ = manip.WithCurrent(args);
+					manip.Recognizer.ProcessMoveEvents([args.CurrentPoint]);
 				}
 
-				using var _ = AsCurrentForDirectManipulation(args);
-				manip.Recognizer.ProcessMoveEvents([args.CurrentPoint]);
-
-				return manip.HasStarted;
+				return true; // If the manipulation has been cancelled, we still do not want to forward the event to the visual tree until the next release/cancel.
 			}
 
 			return false;
 		}
 
-		private bool TryRedirectReleaseToDirectManipulation(Windows.UI.Core.PointerEventArgs args)
+		private void AfterMoveForManipulations(Windows.UI.Core.PointerEventArgs args)
 		{
-			if (_directManipulations?.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip) is true)
+			if (_gestureRecognizers.TryGetValue(args.CurrentPoint.PointerDeviceType, out var recognizers))
 			{
-				// Note: We do NOT remove the recognizer from the manipulation, it will self-remove when the manipulation is completed (i.e. once inertia is completed!).
-				//		 This is to allow the manipulation to be cancelled if the pointer is re-pressed.
-
-				if (_trace)
+				foreach (var recognizer in recognizers)
 				{
-					Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Releasing pointer (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+					recognizer.ProcessMove(args);
+				}
+			}
+		}
+
+		private bool BeforeReleaseTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
+		{
+			if (_directManipulations.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip))
+			{
+				if (manip.IsActive)
+				{
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Releasing pointer (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+					}
+
+					using var _ = manip.WithCurrent(args);
+					manip.Recognizer.ProcessUpEvent(args.CurrentPoint);
 				}
 
-				using var _ = AsCurrentForDirectManipulation(args);
-				manip.Recognizer.ProcessUpEvent(args.CurrentPoint);
+				var redirected = manip.HasStarted;
+				if (redirected)
+				{
+					// If redirected, we won't receive the AfterReleaseForManipulations, make sure to clean-up UIElement recognizers.
+					// Note: We do NOT remove the recognizer from the direct manipulation, it will self-remove when the manipulation is completed (i.e. once inertia is completed!).
+					//		 This is to allow the manipulation to be cancelled if the pointer is re-pressed.
+					_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType);
+				}
 
-				return manip.HasStarted;
+				return redirected;
 			}
 
 			return false;
 		}
 
-		private bool TryClearDirectManipulationRedirection(PointerIdentifier pointerId)
-			=> _directManipulations?.Remove(pointerId.Type) is true;
+		private void AfterReleaseForManipulations(Windows.UI.Core.PointerEventArgs args)
+		{
+			if (_gestureRecognizers.TryGetValue(args.CurrentPoint.PointerDeviceType, out var recognizers))
+			{
+				foreach (var recognizer in recognizers)
+				{
+					recognizer.ProcessUp(args);
+				}
 
-		private void TraceIgnoredForDirectManipulation(Windows.UI.Core.PointerEventArgs args, [CallerMemberName] string caller = "")
+				_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType);
+			}
+		}
+
+		private bool BeforeCancelTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
+		{
+			if (_directManipulations.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip))
+			{
+				if (manip.IsActive)
+				{
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Cancelling pointer (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+					}
+
+					using var _ = manip.WithCurrent(args);
+					manip.Cancel(); // Makes sure to complete handlers. 
+				}
+
+				var redirected = manip.HasStarted;
+				if (redirected)
+				{
+					// If redirected, we won't receive the AfterReleaseForManipulations, make sure to clean-up UIElement recognizers.
+					// Note: Even if no possible inertia here for direct-manipulation, we follow the same path as for the release and let him self-clean itself in complete.
+					_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType);
+				}
+
+				return redirected;
+			}
+
+			return false;
+		}
+
+		private void AfterCancelForManipulations(Windows.UI.Core.PointerEventArgs args)
+		{
+			if (_gestureRecognizers.TryGetValue(args.CurrentPoint.PointerDeviceType, out var recognizers))
+			{
+				foreach (var recognizer in recognizers)
+				{
+					recognizer.ProcessCancel(args);
+				}
+
+				_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType);
+			}
+		}
+
+		private void TraceIgnoredForManipulations(Windows.UI.Core.PointerEventArgs args, [CallerMemberName] string caller = "")
 		{
 			if (_trace)
 			{
@@ -227,12 +359,15 @@ partial class InputManager
 			}
 		}
 
-		private sealed class DirectManipulation
+		private sealed class DirectManipulation : IGestureRecognizer
 		{
 			private readonly PointerManager _pointerManager;
 
-			private bool _resuming;
+			private bool _isResuming;
+			private bool _isCancelled; // Has been cancelled by an external actor (UIElement.CancelDirectManipulation). Manip cannot be resumed.
+			private bool _isCompleted; // Has been completed by the recognizer. Manip cannot be resumed.
 			private GestureSettings _settings;
+			private Windows.UI.Core.PointerEventArgs? _currentPointerArgs;
 
 			public GestureRecognizer Recognizer { get; }
 
@@ -247,7 +382,19 @@ partial class InputManager
 			/// <summary>
 			/// Indicates that the manipulation has started and all pointer events now has to be forwarded to this manipulation instead of being propagated to the visual tree.
 			/// </summary>
-			public bool HasStarted { get; set; }
+			/// <remarks>Once true, will remain true forever! Complete will NOT set this back to false.</remarks>
+			public bool HasStarted { get; private set; }
+
+			/// <summary>
+			/// Indicates that the direct manipulation can accept new pointer events.
+			/// </summary>
+			public bool IsActive => !_isCancelled && !_isCompleted;
+
+			public void Cancel()
+			{
+				_isCancelled = true;
+				Recognizer.CompleteGesture(); // This will actually cause `_isCompleted = true` so the `_isCancelled` is useless so far, but we keep it for clarity.
+			}
 
 			private GestureRecognizer CreateDirectManipulationGestureRecognizer()
 			{
@@ -266,19 +413,74 @@ partial class InputManager
 				return recognizer;
 			}
 
-			public struct ResumingManipulation(DirectManipulation manip) : IDisposable
+			public readonly struct ResumingManipulation(DirectManipulation manipulation) : IDisposable
 			{
 				/// <inheritdoc />
 				public void Dispose()
-					=> manip._resuming = false;
+					=> manipulation._isResuming = false;
 			}
 
 			public ResumingManipulation Resuming()
 			{
-				_resuming = true;
+				_isResuming = true;
 				return new ResumingManipulation(this);
 			}
 
+			public readonly struct CurrentArgSubscription(DirectManipulation manipulation) : IDisposable
+			{
+				/// <inheritdoc />
+				public void Dispose()
+					=> manipulation._currentPointerArgs = null;
+			}
+
+			public CurrentArgSubscription WithCurrent(Windows.UI.Core.PointerEventArgs args)
+			{
+				Debug.Assert(_currentPointerArgs is null);
+				_currentPointerArgs = args;
+				return new CurrentArgSubscription(this);
+			}
+
+			#region Pointers input (IGestureRecognizerRegistration)
+			/// <inheritdoc />
+			public void ProcessDown(PointerEventArgs args)
+			{
+				if (!HasStarted // resuming, no needs to forward pointer again
+					&& IsActive
+					&& Recognizer.PendingManipulation?.IsActive(args.CurrentPoint.Pointer) is not true)
+				{
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Adding pointer --POST DISPATCH-- (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+					}
+
+					using var _ = WithCurrent(args);
+					Recognizer.ProcessDownEvent(args.CurrentPoint);
+				}
+			}
+
+			/// <inheritdoc />
+			public void ProcessMove(PointerEventArgs args)
+			{
+				if (!HasStarted && IsActive)
+				{
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Handling POST move (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+					}
+
+					using var _ = WithCurrent(args);
+					Recognizer.ProcessMoveEvents([args.CurrentPoint]);
+				}
+			}
+
+			/// <inheritdoc />
+			public void ProcessUp(PointerEventArgs args) { }
+
+			/// <inheritdoc />
+			public void ProcessCancel(PointerEventArgs args) { }
+			#endregion
+
+			#region Manipulation event handlers
 			private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartingEventArgs> OnDirectManipulationStarting = (sender, args) =>
 			{
 				// TODO: Make sure ManipulationStarting is fired on UIElement.
@@ -331,7 +533,7 @@ partial class InputManager
 			{
 				// Note: We MUST NOT use the PointerRoutedEventArgs.LastPointerEvent in this handler, as it might be raised directly from a PointerEventArgs (NOT routed).
 
-				if (sender.Owner is not DirectManipulation { _pointerManager: { _directManipulationsCurrentPointerArgs: { } pointerArgs } manager } that)
+				if (sender.Owner is not DirectManipulation { _currentPointerArgs: { } pointerArgs } that)
 				{
 					return;
 				}
@@ -356,7 +558,7 @@ partial class InputManager
 					}
 
 					that.HasStarted = true;
-					manager.CancelPointer(pointerArgs, isDirectManipulation: true);
+					that._pointerManager.CancelPointer(pointerArgs, isDirectManipulation: true);
 
 					foreach (var handler in that.Handlers)
 					{
@@ -403,12 +605,15 @@ partial class InputManager
 			{
 				var that = (DirectManipulation)sender.Owner;
 
-				if (that._resuming)
+				if (that._isResuming) // Possible only when cancelled during inertia, cf. BeforePressTryRedirectToDirectManipulation
 				{
 					return;
 				}
 
-				that._pointerManager._directManipulations!.Remove((PointerDeviceType)args.PointerDeviceType);
+				// We do not self scavenge this manipulation from the _manipluations.
+				// We prefer to wait for the next down so we can keep track of the completion state
+				// (and more specifically the Cancelled state set using the UIElement.CancelDirectManipulation).
+				that._isCompleted = true;
 
 				if (_trace)
 				{
@@ -425,22 +630,28 @@ partial class InputManager
 			{
 				var that = (DirectManipulation)sender.Owner;
 
-				that._pointerManager._directManipulations!.Remove((PointerDeviceType)manip.PointerDeviceType);
-
 				if (_trace)
 				{
 					Trace($"[DirectManipulation] Aborted");
 				}
+
+				// We do not self scavenge this manipulation from the _manipluations.
+				// We prefer to wait for the next down so we can keep track of the completion state
+				// (and more specifically the Cancelled state set using the UIElement.CancelDirectManipulation).
+				that._isCompleted = true;
 
 				foreach (var handler in that.Handlers)
 				{
 					handler.OnCompleted(sender, null);
 				}
 			};
+			#endregion
 		}
 
 		private record InteractionTrackerToDirectManipulationHandler(InteractionTracker Tracker) : IDirectManipulationHandler
 		{
+			public object? Owner => Tracker;
+
 			/// <inheritdoc />
 			public ManipulationModes OnStarting(GestureRecognizer recognizer, ManipulationStartingEventArgs args)
 			{
@@ -464,11 +675,100 @@ partial class InputManager
 				=> Tracker.CompleteUserManipulation(new Vector3((float)(args?.Velocities.Linear.X * 1000 ?? 0), (float)(args?.Velocities.Linear.Y * 1000 ?? 0), 0));
 		}
 
-		private struct CurrentArgSubscription(PointerManager manager) : IDisposable
+		private class UIElementRecognizer(UIElement element, GestureRecognizer recognizer) : IGestureRecognizer
 		{
 			/// <inheritdoc />
-			public void Dispose()
-				=> manager._directManipulationsCurrentPointerArgs = null;
+			public void ProcessDown(PointerEventArgs args) { } // Currently, to avoid any regression for 6.0 SR1, only the move is processed.
+
+			/// <inheritdoc />
+			public void ProcessMove(PointerEventArgs args)
+			{
+				recognizer.ProcessMoveEvents([GetRelativePoint(args)]);
+				if (recognizer.IsDragging)
+				{
+					XamlRoot.GetCoreDragDropManager(element.XamlRoot).ProcessMoved(new PointerRoutedEventArgs(args, element));
+				}
+			}
+
+			/// <inheritdoc />
+			public void ProcessUp(PointerEventArgs args) { } // Currently, to avoid any regression for 6.0 SR1, only the move is processed.
+
+			/// <inheritdoc />
+			public void ProcessCancel(PointerEventArgs args) { } // Currently, to avoid any regression for 6.0 SR1, only the move is processed.
+
+			/// <summary>
+			/// Get the PointerPoint relative to the location of the element.
+			/// This is to be backward compatible with the current behavior, but we should consider to use only absolute location in the GestureRecognizer
+			/// and then make the position relative to the UIElement only in the conversion from ManipXXXEventArgs to ManipXXX**Routed**EventArgs.
+			/// </summary>
+			private PointerPoint GetRelativePoint(PointerEventArgs args)
+			{
+				var absolutePoint = args.CurrentPoint;
+				var relativePosition = UIElement.GetTransform(element, null).Transform(args.CurrentPoint.Position);
+
+				return absolutePoint.At(relativePosition);
+			}
+
+			/// <inheritdoc />
+			public override string ToString()
+				=> element.GetDebugName();
+		}
+
+		private class PointerTypePseudoDictionary<TValue> : IEnumerable<KeyValuePair<PointerDeviceType, TValue>>
+			where TValue : notnull
+		{
+			private static readonly int _length = Enum.GetValues(typeof(PointerDeviceType)).Length;
+
+			private readonly bool[] _hasValues = new bool[_length];
+			private readonly TValue[] _values = new TValue[_length];
+
+			public TValue? this[PointerDeviceType pointer]
+			{
+				get => _values[(int)pointer];
+				set
+				{
+					var index = (int)pointer;
+					_hasValues[index] = true;
+					_values[index] = value!;
+				}
+			}
+
+			public bool ContainsKey(PointerDeviceType pointer)
+				=> _hasValues[(int)pointer];
+
+			public bool TryGetValue(PointerDeviceType pointer, [NotNullWhen(true)] out TValue? value)
+			{
+				var index = (int)pointer;
+				if (_hasValues[index])
+				{
+					value = _values[index];
+					return true;
+				}
+				else
+				{
+					value = default;
+					return false;
+				}
+			}
+
+			public void Remove(PointerDeviceType pointer)
+				=> _hasValues[(int)pointer] = false;
+
+			/// <inheritdoc />
+			public IEnumerator<KeyValuePair<PointerDeviceType, TValue>> GetEnumerator()
+			{
+				for (var i = 0; i < _length; i++)
+				{
+					if (_hasValues[i])
+					{
+						yield return new KeyValuePair<PointerDeviceType, TValue>((PointerDeviceType)i, _values[i]);
+					}
+				}
+			}
+
+			/// <inheritdoc />
+			IEnumerator IEnumerable.GetEnumerator()
+				=> GetEnumerator();
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Native.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Native.cs
@@ -46,7 +46,7 @@ partial class UIElement
 		if (IsGestureRecognizerCreated)
 		{
 			var gestures = GestureRecognizer;
-			gestures.ProcessMoveEvents(args.GetIntermediatePoints(this), isOverOrCaptured && !ctx.IsCleanup);
+			gestures.ProcessMoveEvents(args.GetIntermediatePoints(this));
 			if (gestures.IsDragging)
 			{
 				XamlRoot.GetCoreDragDropManager(XamlRoot).ProcessMoved(args);

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -309,10 +309,12 @@ namespace Microsoft.UI.Xaml
 			var src = PointerRoutedEventArgs.LastPointerEvent?.OriginalSource as UIElement ?? that;
 
 			that.SafeRaiseEvent(ManipulationStartingEvent, new ManipulationStartingRoutedEventArgs(src, that, args));
+#if UNO_HAS_MANAGED_POINTERS
 			if (args.Settings is not GestureSettings.None)
 			{
 				that.XamlRoot?.VisualTree.ContentRoot.InputManager.Pointers.RegisterUiElementManipulationRecognizer(args.Pointer, that, sender);
 			}
+#endif
 		};
 
 		private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> OnRecognizerManipulationStarted = (sender, args) =>

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -309,6 +309,10 @@ namespace Microsoft.UI.Xaml
 			var src = PointerRoutedEventArgs.LastPointerEvent?.OriginalSource as UIElement ?? that;
 
 			that.SafeRaiseEvent(ManipulationStartingEvent, new ManipulationStartingRoutedEventArgs(src, that, args));
+			if (args.Settings is not GestureSettings.None)
+			{
+				that.XamlRoot?.VisualTree.ContentRoot.InputManager.Pointers.RegisterUiElementManipulationRecognizer(args.Pointer, that, sender);
+			}
 		};
 
 		private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> OnRecognizerManipulationStarted = (sender, args) =>
@@ -316,6 +320,7 @@ namespace Microsoft.UI.Xaml
 			var that = (UIElement)sender.Owner;
 			var src = PointerRoutedEventArgs.LastPointerEvent?.OriginalSource as UIElement ?? that;
 
+			that.CancelAllDirectManipulations(args.Pointers);
 			that.SafeRaiseEvent(ManipulationStartedEvent, new ManipulationStartedRoutedEventArgs(src, that, sender, args));
 		};
 
@@ -387,6 +392,7 @@ namespace Microsoft.UI.Xaml
 		{
 			var that = (UIElement)sender.Owner;
 
+			that.CancelAllDirectManipulations(args.Pointer.Pointer);
 			that.OnDragStarting(args);
 		};
 		#endregion
@@ -505,6 +511,24 @@ namespace Microsoft.UI.Xaml
 				GestureRecognizer.CompleteGesture();
 			}
 			// Note: We do not need to alter the location of the events, on UWP they are always relative to the OriginalSource.
+		}
+
+		private void CancelAllDirectManipulations(params PointerIdentifier[] identifiers)
+		{
+#if UNO_HAS_MANAGED_POINTERS
+			XamlRoot?.VisualTree.ContentRoot.InputManager.Pointers.CancelAllDirectManipulations(identifiers);
+#endif
+		}
+
+		// Not implemented for native pointers (i.e. !UNO_HAS_MANAGED_POINTERS)
+		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__NETSTD_REFERENCE__")]
+		public bool CancelDirectManipulations()
+		{
+#if UNO_HAS_MANAGED_POINTERS
+			return XamlRoot?.VisualTree.ContentRoot.InputManager.Pointers.CancelDirectManipulations(this) ?? false;
+#else
+			return false;
+#endif
 		}
 		#endregion
 
@@ -1007,10 +1031,16 @@ namespace Microsoft.UI.Xaml
 #if !HAS_NATIVE_IMPLICIT_POINTER_CAPTURE
 				if (recognizer.PendingManipulation?.IsActive(point.Pointer) ?? false)
 				{
-					Capture(args.Pointer, PointerCaptureKind.Implicit, PointerCaptureOptions.PreventDirectManipulation, args);
+					Capture(args.Pointer, PointerCaptureKind.Implicit, default, args);
 				}
 #endif
 			}
+
+			// TODO
+			//if (!ManipulationMode.HasFlag(ManipulationModes.System))
+			//{
+			//	Cancel[ALL]DirectManipulation()
+			//}
 
 			return handledInManaged;
 		}
@@ -1030,17 +1060,19 @@ namespace Microsoft.UI.Xaml
 				handledInManaged |= RaisePointerEvent(PointerMovedEvent, args);
 			}
 
+#if !UNO_HAS_MANAGED_POINTERS
 			if (IsGestureRecognizerCreated)
 			{
 				// We need to process only events that were not handled by a child control,
 				// so we should not use them for gesture recognition.
 				var gestures = GestureRecognizer;
-				gestures.ProcessMoveEvents(args.GetIntermediatePoints(this), isOverOrCaptured && !ctx.IsCleanup);
+				gestures.ProcessMoveEvents(args.GetIntermediatePoints(this));
 				if (gestures.IsDragging)
 				{
 					XamlRoot.GetCoreDragDropManager(XamlRoot).ProcessMoved(args);
 				}
 			}
+#endif
 
 			return handledInManaged;
 		}

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -554,15 +554,23 @@ namespace Microsoft.UI.Xaml
 			}
 
 #if __SKIA__
-			Matrix4x4.Invert(to?.Visual.TotalMatrix ?? Matrix4x4.Identity, out var invertedTotalMatrix);
-			var finalTransform = (from.Visual.TotalMatrix * invertedTotalMatrix).ToMatrix3x2();
+			Matrix3x2 from2To;
+			if (to is null)
+			{
+				from2To = from.Visual.TotalMatrix.ToMatrix3x2();
+			}
+			else
+			{
+				Matrix4x4.Invert(to.Visual.TotalMatrix /* root2To */, out var to2Root);
+				from2To = (to2Root * from.Visual.TotalMatrix /* root2from */).ToMatrix3x2();
+			}
 
 			if (from.Log().IsEnabled(LogLevel.Trace))
 			{
-				from.Log().Trace($"{nameof(GetTransform)} SKIA FAST PATH (from: {from.GetDebugName()}, to: {to.GetDebugName()}) = {finalTransform}");
+				from.Log().Trace($"{nameof(GetTransform)} SKIA FAST PATH (from: {from.GetDebugName()}, to: {to.GetDebugName()}) = {from2To}");
 			}
 
-			return finalTransform;
+			return from2To;
 #else
 #if UNO_REFERENCE_API // Depth is defined properly only on WASM and Skia
 			// If possible we try to navigate the tree upward so we have a greater chance

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -562,7 +562,7 @@ namespace Microsoft.UI.Xaml
 			else
 			{
 				Matrix4x4.Invert(to.Visual.TotalMatrix /* root2To */, out var to2Root);
-				from2To = (to2Root * from.Visual.TotalMatrix /* root2from */).ToMatrix3x2();
+				from2To = (from.Visual.TotalMatrix /* root2from */ * to2Root).ToMatrix3x2();
 			}
 
 			if (from.Log().IsEnabled(LogLevel.Trace))

--- a/src/Uno.UWP/Devices/Input/PointerDeviceType.cs
+++ b/src/Uno.UWP/Devices/Input/PointerDeviceType.cs
@@ -7,6 +7,7 @@ namespace Windows.Devices.Input
 	public enum PointerDeviceType
 	{
 		// WARNING: This enum has a corresponding version in TypeScript!
+		// WARNING: This enum is used as index in PointerTypePseudoDictionary, i.e. we are assuming that the values are sequential int starting from 0!
 
 		/// <summary>
 		/// A touch-enabled device


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1266

## Bugfix
Fix support on mixed UIElement manipulations and direct manipulations

## What is the current behavior?
`UIElement`'s manipulation always takes over direct manipulation.

## What is the new behavior?
We are making sure to order recognizer to dispatch events accordingly, allowing the top-most recognizer to react first (and prevent other recognizers)

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
