### PR TITLE
Add DPI awareness

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
+++ b/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
@@ -193,6 +193,7 @@ SetCursor
 SetLayeredWindowAttributes
 SetParent
 SetPixelFormat
+SetProcessDpiAwarenessContext
 SetThreadDpiAwarenessContext
 SetWindowLong
 SetWindowPos

--- a/src/Uno.UI.Runtime.Skia.Win32/DpiBootstrap.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/DpiBootstrap.cs
@@ -1,0 +1,36 @@
+﻿using System.Runtime.CompilerServices;
+using Windows.Win32;
+using Windows.Win32.UI.HiDpi;
+
+#pragma warning disable CA2255
+
+internal static class DpiBootstrap
+{
+	[ModuleInitializer]
+	internal static void Init()
+	{
+		// This call ensures that the application is properly marked as per-monitor DPI aware (PerMonitorV2).
+		// When launched via `dotnet.exe` (e.g., `dotnet MyApp.dll` or `dotnet run`), the host process is the .NET CLI runtime,
+		// which does NOT contain a DPI-awareness declaration in its embedded application manifest (RT_MANIFEST).
+		// Consequently, Windows assumes the process is DPI-unaware, applies bitmap scaling, and reports a logical DPI of 96,
+		// leading to incorrect pointer coordinates, layout glitches, and drag-and-drop offsets.
+		//
+		// In contrast, when launching a native application executable (e.g., `MyApp.exe`), the process inherits the
+		// DPI-awareness setting defined in the manifest block:
+		//
+		// <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+		//   <asmv3:application>
+		//     <asmv3:windowsSettings>
+		//       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+		//     </asmv3:windowsSettings>
+		//   </asmv3:application>
+		// </assembly>
+		//
+		// More details on DPI Awareness contexts and behaviors:
+		// - https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process
+		//
+		// This call must be made BEFORE any window is initialized.
+
+		PInvoke.SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Win32Host.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Win32Host.cs
@@ -12,6 +12,7 @@ using Windows.UI.ViewManagement;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.GdiPlus;
+using Windows.Win32.UI.HiDpi;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -121,12 +122,50 @@ public class Win32Host : SkiaHost, ISkiaApplicationHost
 
 	protected override void Initialize()
 	{
+		SetProcessDpiAwareness();
+
 		CoreDispatcher.DispatchOverride = Win32EventLoop.Schedule;
 		CoreDispatcher.HasThreadAccessOverride = () => _isDispatcherThread;
 
 		// We do not have a display timer on this target, we can use
 		// a constant timer.
 		CompositionTargetTimer.Start();
+	}
+
+	private void SetProcessDpiAwareness()
+	{
+		// This call ensures that the application is properly marked as per-monitor DPI aware (PerMonitorV2).
+		// When launched via `dotnet.exe` (e.g., `dotnet MyApp.dll` or `dotnet run`), the host process is the .NET CLI runtime,
+		// which does NOT contain a DPI-awareness declaration in its embedded application manifest (RT_MANIFEST).
+		// Consequently, Windows assumes the process is DPI-unaware, applies bitmap scaling, and reports a logical DPI of 96,
+		// leading to incorrect pointer coordinates, layout glitches, and drag-and-drop offsets.
+		//
+		// In contrast, when launching a native application executable (e.g., `MyApp.exe`), the process inherits the
+		// DPI-awareness setting defined in the manifest block:
+		//
+		// <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+		//   <asmv3:application>
+		//     <asmv3:windowsSettings>
+		//       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+		//     </asmv3:windowsSettings>
+		//   </asmv3:application>
+		// </assembly>
+		//
+		// Important: Calling SetThreadDpiAwarenessContext() affects only the DPI behavior of user32/GDI calls **on that thread**,
+		// but it does NOT update the global DPI-awareness context of the process, nor does it affect how the OS scales
+		// the window or reports DPI-related metrics to frameworks like Skia or WinUI. To enable proper DPI scaling and
+		// accurate coordinate transformation, the process DPI-awareness must be set at launch or via SetProcessDpiAwarenessContext().
+		//
+		// NOTE: DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 (-4) provides the most accurate and modern DPI behavior available
+		// on Windows 10+ with improved scaling, child-window consistency, and multi-monitor support.
+		//
+		// More details on DPI Awareness contexts and behaviors:
+		// - https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process
+		//
+		// This call must be made BEFORE any window is initialized.
+
+		var success = PInvoke.SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) != 0;
+		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.SetProcessDpiAwarenessContext)} failed: {Win32Helper.GetErrorMessage()}"); }
 	}
 
 	protected override Task RunLoop()


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.hotdesign/issues/4139

# Bugfix

## What is the new behavior?

- Introduced `SetProcessDpiAwareness()` to address DPI scaling issues when not defined in the process manifest (when started from `dotnet run`)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [X] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [X] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
