### PR TITLE
chore: Sync MPE property defaults with WinUI

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.Properties.cs
@@ -35,7 +35,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsPlaybackRateEnabled),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -52,7 +52,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsFastRewindEnabled),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -69,7 +69,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsFastRewindButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -103,7 +103,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsFastForwardEnabled),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -154,7 +154,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsStopEnabled),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -171,7 +171,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsFastForwardButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -188,7 +188,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsStopButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -239,7 +239,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsPlaybackRateButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -307,7 +307,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsSkipBackwardButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -324,7 +324,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsNextTrackButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -358,7 +358,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsSkipForwardEnabled),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -375,7 +375,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsPreviousTrackButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -392,7 +392,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsSkipForwardButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -409,7 +409,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsSkipBackwardEnabled),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -443,7 +443,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsRepeatButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -460,7 +460,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsRepeatEnabled),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -477,7 +477,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsCompactOverlayEnabled),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 
@@ -494,7 +494,7 @@ namespace Microsoft.UI.Xaml.Controls
 				nameof(IsCompactOverlayButtonVisible),
 				typeof(bool),
 				typeof(MediaTransportControls),
-				new FrameworkPropertyMetadata(true));
+				new FrameworkPropertyMetadata(false));
 
 		#endregion
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/20369

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

All the available properties are enabled which is not the case on the latest WinUI.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

This pull request modifies the default behavior of various `MediaTransportControls` properties in the `MediaPlayerElement` component by changing their `FrameworkPropertyMetadata` default values from `true` to `false`. These changes affect the visibility and enabled state of several media control buttons and features.

Uno
![image](https://github.com/user-attachments/assets/9a450a22-e2d8-4228-8581-606dd5fac63f)

WinUI
![image](https://github.com/user-attachments/assets/1538d6fe-8134-4da8-84a9-dcb78b205137)


<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.