### PR TITLE
fix(XamlRoot): Changed event incorrect Size value on device rotation

### DIFF
--- a/src/Uno.UI/UI/Xaml/Internal/VisualTree.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/VisualTree.cs
@@ -922,6 +922,24 @@ namespace Uno.UI.Xaml.Core
 			}
 		}
 
+		internal event SizeChangedEventHandler SizeChanged
+		{
+			add
+			{
+				if (RootElement is FrameworkElement fe)
+				{
+					fe.SizeChanged += value;
+				}
+			}
+			remove
+			{
+				if (RootElement is FrameworkElement fe)
+				{
+					fe.SizeChanged -= value;
+				}
+			}
+		}
+
 		internal void OnVisibleBoundChanged() => VisibleBoundsChanged?.Invoke(this, EventArgs.Empty);
 
 #if UNO_HAS_ENHANCED_LIFECYCLE

--- a/src/Uno.UI/UI/Xaml/XamlRoot.cs
+++ b/src/Uno.UI/UI/Xaml/XamlRoot.cs
@@ -22,6 +22,7 @@ public sealed partial class XamlRoot
 	internal XamlRoot(VisualTree visualTree)
 	{
 		VisualTree = visualTree;
+		VisualTree.SizeChanged += (s, e) => RaiseChangedEvent();
 	}
 
 	/// <summary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno-private#1267

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
XamlRoot.Changed is fired, before its .Size is updated on device rotation.

## What is the new behavior?
XamlRoot.Size origin updates will now in turn trigger a XamlRoot.Changed.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.