### PR TITLE
Adjust error reporting on uno runtime references

### DIFF
--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -89,7 +89,7 @@ $projects =
     # @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f:net9.0-desktop", "-p:SelfContained=true", "-p:PackageFormat=snap"), @("Publish"))
 
     # 5.6 Android/ios/Wasm+Skia nuget package first
-    @(3, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY/src/PackageCache"), @()),
+    @(3, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY/src/PackageCache"), @("CleanNugetTemp")),
 
     # 5.6 Android/ios/Wasm+Skia
     @(3, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @()),
@@ -120,6 +120,7 @@ for($i = 0; $i -lt $projects.Length; $i++)
 
     $buildOptions=$projects[$i][3];
     $usePublish = $buildOptions -contains "Publish"
+    $cleanNugetCache = $buildOptions -contains "CleanNugetTemp"
 
     if ($TestGroup -ne $projectTestGroup)
     {
@@ -153,6 +154,11 @@ for($i = 0; $i -lt $projects.Length; $i++)
     Write-Host "Building Release $projectPath with $projectParameters"
     dotnet $dotnetCommand $release "$projectPath" $projectParameters $extraArgs -bl:binlogs/$projectPath/$i/release.binlog
     Assert-ExitCodeIsZero
+
+    if($cleanNugetCache)
+    {
+        dotnet nuget locals temp -c
+    }
 
     dotnet clean $release "$projectPath"
 }

--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -164,6 +164,9 @@ for($i = 0; $i -lt $projects.Length; $i++)
 
     if(!$NoBuildClean)
     {
+        # Cleaning may also remove generated nuget files, even if
+        # OutputPath has been overriden, causing dependents to not find
+        # the pacage.
         dotnet clean $release "$projectPath"
     }
 }

--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -89,7 +89,7 @@ $projects =
     # @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f:net9.0-desktop", "-p:SelfContained=true", "-p:PackageFormat=snap"), @("Publish"))
 
     # 5.6 Android/ios/Wasm+Skia nuget package first
-    @(3, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY/src/PackageCache"), @("CleanNugetTemp")),
+    @(3, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY/src/PackageCache"), @("CleanNugetTemp","NoBuildClean")),
 
     # 5.6 Android/ios/Wasm+Skia
     @(3, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @()),
@@ -121,6 +121,7 @@ for($i = 0; $i -lt $projects.Length; $i++)
     $buildOptions=$projects[$i][3];
     $usePublish = $buildOptions -contains "Publish"
     $cleanNugetCache = $buildOptions -contains "CleanNugetTemp"
+    $noBuildClead = $buildOptions -contains "NoBuildClean"
 
     if ($TestGroup -ne $projectTestGroup)
     {
@@ -161,5 +162,8 @@ for($i = 0; $i -lt $projects.Length; $i++)
         dotnet nuget locals http-cache -c
     }
 
-    dotnet clean $release "$projectPath"
+    if(!$NoBuildClean)
+    {
+        dotnet clean $release "$projectPath"
+    }
 }

--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -88,6 +88,9 @@ $projects =
     # Disabled for LXD setup issues
     # @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f:net9.0-desktop", "-p:SelfContained=true", "-p:PackageFormat=snap"), @("Publish"))
 
+    # 5.6 Android/ios/Wasm+Skia nuget package first
+    @(3, "unoplatform/uno/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:Build_SourcesDirectory/src/PackageCache"), @()),
+
     # 5.6 Android/ios/Wasm+Skia
     @(3, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @()),
 

--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -89,7 +89,7 @@ $projects =
     # @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f:net9.0-desktop", "-p:SelfContained=true", "-p:PackageFormat=snap"), @("Publish"))
 
     # 5.6 Android/ios/Wasm+Skia nuget package first
-    @(3, "unoplatform/uno/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:Build_SourcesDirectory/src/PackageCache"), @()),
+    @(3, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:Build_SourcesDirectory/src/PackageCache"), @()),
 
     # 5.6 Android/ios/Wasm+Skia
     @(3, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @()),

--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -89,7 +89,7 @@ $projects =
     # @(2, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f:net9.0-desktop", "-p:SelfContained=true", "-p:PackageFormat=snap"), @("Publish"))
 
     # 5.6 Android/ios/Wasm+Skia nuget package first
-    @(3, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:Build_SourcesDirectory/src/PackageCache"), @()),
+    @(3, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY/src/PackageCache"), @()),
 
     # 5.6 Android/ios/Wasm+Skia
     @(3, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @()),

--- a/build/test-scripts/run-net7-template-linux.ps1
+++ b/build/test-scripts/run-net7-template-linux.ps1
@@ -158,6 +158,7 @@ for($i = 0; $i -lt $projects.Length; $i++)
     if($cleanNugetCache)
     {
         dotnet nuget locals temp -c
+        dotnet nuget locals http-cache -c
     }
 
     dotnet clean $release "$projectPath"

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -315,6 +315,9 @@ $projects =
     # Ensure that build can happen even if a RID is specified
     @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-android", "-r", "android-arm64"), @("macOS", "NetCore"))
 
+    # 5.6 Android/ios/Wasm+Skia nuget package (build first before the app)
+    @(4, "unoplatform/uno/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:Build_SourcesDirectory\src\PackageCache"), @("macOS", "NetCore")),
+
     # 5.6 Android/ios/Wasm+Skia
     @(4, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @("macOS", "NetCore")),
 

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -316,7 +316,7 @@ $projects =
     @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-android", "-r", "android-arm64"), @("macOS", "NetCore"))
 
     # 5.6 Android/ios/Wasm+Skia nuget package (build first before the app)
-    @(4, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY\src\PackageCache"), @("macOS", "NetCore")),
+    @(4, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY\src\PackageCache"), @("macOS", "NetCore", "CleanNugetTemp")),
 
     # 5.6 Android/ios/Wasm+Skia
     @(4, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @("macOS", "NetCore")),
@@ -354,6 +354,7 @@ for($i = 0; $i -lt $projects.Length; $i++)
     $runOnlyOnMacOS = $buildOptions -contains "OnlyMacOS"
     $buildWithNetCore = $buildOptions -contains "NetCore"
     $usePublish = $buildOptions -contains "Publish"
+    $cleanNugetCache = $buildOptions -contains "CleanNugetTemp"
 
     if ($TestGroup -ne $projectTestGroup)
     {
@@ -419,5 +420,11 @@ for($i = 0; $i -lt $projects.Length; $i++)
 
             & $msbuild $release /r /t:Clean "$projectPath"
         }
+    }
+
+    if($cleanNugetCache)
+    {
+        # Clean the nuget cache in order to avoid missed lookups when generating test packages
+        dotnet nuget locals temp -c
     }
 }

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -405,6 +405,9 @@ for($i = 0; $i -lt $projects.Length; $i++)
  
         if(!$NoBuildClean)
         {
+            # Cleaning may also remove generated nuget files, even if
+            # OutputPath has been overriden, causing dependents to not find
+            # the pacage.
             dotnet clean $release $projectOptions "$projectPath"
         }
     }

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -316,7 +316,7 @@ $projects =
     @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-android", "-r", "android-arm64"), @("macOS", "NetCore"))
 
     # 5.6 Android/ios/Wasm+Skia nuget package (build first before the app)
-    @(4, "unoplatform/uno/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:Build_SourcesDirectory\src\PackageCache"), @("macOS", "NetCore")),
+    @(4, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:Build_SourcesDirectory\src\PackageCache"), @("macOS", "NetCore")),
 
     # 5.6 Android/ios/Wasm+Skia
     @(4, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @("macOS", "NetCore")),

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -316,7 +316,7 @@ $projects =
     @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-android", "-r", "android-arm64"), @("macOS", "NetCore"))
 
     # 5.6 Android/ios/Wasm+Skia nuget package (build first before the app)
-    @(4, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY\src\PackageCache"), @("macOS", "NetCore", "CleanNugetTemp")),
+    @(4, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY\src\PackageCache"), @("macOS", "NetCore", "CleanNugetTemp","NoBuildClean")),
 
     # 5.6 Android/ios/Wasm+Skia
     @(4, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @("macOS", "NetCore")),
@@ -355,6 +355,7 @@ for($i = 0; $i -lt $projects.Length; $i++)
     $buildWithNetCore = $buildOptions -contains "NetCore"
     $usePublish = $buildOptions -contains "Publish"
     $cleanNugetCache = $buildOptions -contains "CleanNugetTemp"
+    $noBuildClead = $buildOptions -contains "NoBuildClean"
 
     if ($TestGroup -ne $projectTestGroup)
     {
@@ -402,7 +403,10 @@ for($i = 0; $i -lt $projects.Length; $i++)
         dotnet $dotnetCommand $release "$projectPath" $projectOptions $extraArgs -bl:binlogs/$projectPath/$i/release/msbuild.binlog
         Assert-ExitCodeIsZero
  
-        dotnet clean $release $projectOptions "$projectPath"
+        if(!$NoBuildClean)
+        {
+            dotnet clean $release $projectOptions "$projectPath"
+        }
     }
     else
     {

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -355,7 +355,7 @@ for($i = 0; $i -lt $projects.Length; $i++)
     $buildWithNetCore = $buildOptions -contains "NetCore"
     $usePublish = $buildOptions -contains "Publish"
     $cleanNugetCache = $buildOptions -contains "CleanNugetTemp"
-    $noBuildClead = $buildOptions -contains "NoBuildClean"
+    $NoBuildClean = $buildOptions -contains "NoBuildClean"
 
     if ($TestGroup -ne $projectTestGroup)
     {

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -426,5 +426,6 @@ for($i = 0; $i -lt $projects.Length; $i++)
     {
         # Clean the nuget cache in order to avoid missed lookups when generating test packages
         dotnet nuget locals temp -c
+        dotnet nuget locals http-cache -c
     }
 }

--- a/build/test-scripts/run-netcore-mobile-template-tests.ps1
+++ b/build/test-scripts/run-netcore-mobile-template-tests.ps1
@@ -316,7 +316,7 @@ $projects =
     @(4, "5.3/uno53net9blank/uno53net9blank/uno53net9blank.csproj", @("-f", "net9.0-android", "-r", "android-arm64"), @("macOS", "NetCore"))
 
     # 5.6 Android/ios/Wasm+Skia nuget package (build first before the app)
-    @(4, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:Build_SourcesDirectory\src\PackageCache"), @("macOS", "NetCore")),
+    @(4, "5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj", @("-p:PackageOutputPath=$env:BUILD_SOURCESDIRECTORY\src\PackageCache"), @("macOS", "NetCore")),
 
     # 5.6 Android/ios/Wasm+Skia
     @(4, "5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj", @(), @("macOS", "NetCore")),

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/Directory.Build.targets
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/Directory.Build.targets
@@ -2,6 +2,6 @@
   <Target Name="ValidateIsPackable"
           AfterTargets="CoreCompile;Build">
     <Error Text="Expected IsPackable='false', however it actually equals '$(IsPackable)'."
-      Condition="$(IsPackable) == 'true'" />
+      Condition="$(IsPackable) == 'true' AND '$(GeneratePackageOnBuild)' != 'true' " />
   </Target>
 </Project>

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/Directory.Packages.props
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/Directory.Packages.props
@@ -6,5 +6,6 @@
     See https://aka.platform.uno/upgrade-uno-packages for more information.
   -->
   <ItemGroup>
+    <PackageVersion Include="Uno56NugetLibrary" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
@@ -14,7 +14,7 @@
     <UnoDisableValidateWinAppSDK3548>true</UnoDisableValidateWinAppSDK3548>
 
     <!-- We can ignore nuget warnings, since were making a test package-->
-    <NoWarn>$(NoWarn);NU5104</NU5104>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
 
     <!--
       UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Uno.Sdk.Private">
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net9.0-ios;net9.0-maccatalyst;net9.0-android;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop</TargetFrameworks>
+    <UnoSingleProject>true</UnoSingleProject>
+    <OutputType>Library</OutputType>
+    <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+    <!--
+      UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.
+      https://aka.platform.uno/singleproject-features
+    -->
+
+    <UnoFeatures>
+      SkiaRenderer;
+    </UnoFeatures>
+
+  </PropertyGroup>
+
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+    <!--
+    If you encounter this error message:
+
+      error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
+      Please update to a newer .NET SDK in order to reference this assembly.
+
+    This means that the two packages below must be aligned with the "build" version number of
+    the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
+    must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
+    -->
+    <!-- <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.22621.28" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.22621.28" /> -->
+  </ItemGroup>
+</Project>

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
@@ -13,6 +13,9 @@
     <!-- We're running in tests, this particular check does not impact the validation -->
     <UnoDisableValidateWinAppSDK3548>true</UnoDisableValidateWinAppSDK3548>
 
+    <!-- We can ignore nuget warnings, since were making a test package-->
+    <NoWarn>$(NoWarn);NU5104</NU5104>
+
     <!--
       UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.
       https://aka.platform.uno/singleproject-features

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/Uno56NugetLibrary.csproj
@@ -10,6 +10,9 @@
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
+    <!-- We're running in tests, this particular check does not impact the validation -->
+    <UnoDisableValidateWinAppSDK3548>true</UnoDisableValidateWinAppSDK3548>
+
     <!--
       UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.
       https://aka.platform.uno/singleproject-features

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/UserControl2.xaml
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/UserControl2.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl
+    x:Class="UnoLibrary2.UserControl2"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UnoLibrary2"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+  <Grid>
+    <TextBlock Text="hello" />
+
+    <!-- x:Load forces the use of android-native content, which fails to bind with skia runtime -->
+    <TextBlock x:Name="test" x:Load="{x:Bind MyTest}" Text="hello" />
+  </Grid>
+</UserControl>

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/UserControl2.xaml.cs
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/Uno56NugetLibrary/UserControl2.xaml.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UnoLibrary2;
+
+public sealed partial class UserControl2 : UserControl
+{
+    public UserControl2()
+    {
+        this.InitializeComponent();
+    }
+
+    public bool MyTest { get; set; }
+}

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj
@@ -40,6 +40,11 @@
     <Content Include="TestStaticContent.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- nuget package reference validation -->
+    <PackageReference Include="Uno56NugetLibrary" />
+  </ItemGroup>
+
   <Target Name="_UnoValidateSelfAssets" 
           BeforeTargets="AfterBuild" 
           Condition="'$(TargetFramework)'=='net9.0-windows10.0.19041'">

--- a/src/SourceGenerators/Uno.UI.Tasks/RuntimeAssetsValidator/RuntimeAssetsValidatorTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/RuntimeAssetsValidator/RuntimeAssetsValidatorTask.cs
@@ -54,7 +54,7 @@ public class RuntimeAssetsValidatorTask_v0 : Microsoft.Build.Utilities.Task
 					&& (metadata.ConstructorArguments[0].Value?.ToString().Equals("UnoUIRuntimeIdentifier", StringComparison.OrdinalIgnoreCase) ?? false)
 					)
 				{
-					var identifier = metadata.ConstructorArguments[0].Value.ToString();
+					var identifier = metadata.ConstructorArguments[1].Value.ToString();
 
 					if (!string.IsNullOrEmpty(identifier)
 						&& !UnoUIRuntimeIdentifier.Equals(identifier, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/20312

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Properly raise a build error when the uno runtime is incorrect.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
