### PR TITLE
feat: Add `.desktop.cs` suffix and `__DESKTOP__` constant

### DIFF
--- a/doc/articles/controls/SKCanvasElement.md
+++ b/doc/articles/controls/SKCanvasElement.md
@@ -80,7 +80,7 @@ namespace BlankApp
 ```
 
 ```csharp
-// SKCanvasElementImpl.skia.cs <-- NOTICE the `.skia`
+// SKCanvasElementImpl.desktop.cs <-- NOTICE the `.desktop`
 using System;
 using Windows.Foundation;
 using Microsoft.UI.Xaml;

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -286,6 +286,14 @@ By Default when using the Uno.Sdk you get the added benefit of default includes 
 - `*.Android.cs` (Android)
 - `*.WinAppSDK.cs` (Windows App SDK)
 
+For class libraries we also provide:
+
+- `*.reference.cs` (Reference only)
+- `*.crossruntime.cs` (WebAssembly, Desktop, or Reference)
+
+> [!NOTE]
+> For backwards compatibility, using `.skia.cs` is currently equivalent to `.desktop.cs`. This might change in the future, so we recommend using the suffixes above instead.
+
 As discussed above setting `EnableDefaultUnoItems` to false will disable these includes.
 
 > [!TIP]

--- a/doc/articles/features/using-the-uno-sdk.md
+++ b/doc/articles/features/using-the-uno-sdk.md
@@ -278,11 +278,9 @@ Many Uno projects and libraries make use of a `winappsdk-workaround.targets` fil
 
 By Default when using the Uno.Sdk you get the added benefit of default includes for an easier time building Cross Targeted Applications. The supported file extensions are as shown below:
 
-- `*.crossruntime.cs` (WASM, Skia, or Reference)
 - `*.wasm.cs` (WebAssembly)
-- `*.skia.cs` (Skia)
-- `*.reference.cs` (Reference only)
-- `*.iOS.cs`, `*.iOSmacOS.cs` (iOS)
+- `*.desktop.cs` (Desktop)
+- `*.iOS.cs` (iOS)
 - `*.tvOS.cs`(tvOS)
 - `*.UIKit.cs`, `*.Apple.cs` (iOS & tvOS)
 - `*.Android.cs` (Android)

--- a/doc/articles/platform-specific-csharp.md
+++ b/doc/articles/platform-specific-csharp.md
@@ -112,8 +112,8 @@ Starting from Uno Platform 5.2, in project or class libraries using the `Uno.Sdk
 
 In addition, for class libraries:
 
-- `*.reference.cs` is built only for reference implementation
-- `*.crossruntime.cs` is built for WebAssembly, Desktop, and reference implementation
+* `*.reference.cs` is built only for reference implementation
+* `*.crossruntime.cs` is built for WebAssembly, Desktop, and reference implementation
 
 > [!NOTE]
 > For backwards compatibility, using `.skia.cs` is currently equivalent to `.desktop.cs`. This might change in the future, so we recommend using the suffixes above instead.

--- a/doc/articles/platform-specific-csharp.md
+++ b/doc/articles/platform-specific-csharp.md
@@ -110,6 +110,14 @@ Starting from Uno Platform 5.2, in project or class libraries using the `Uno.Sdk
 * `*.Apple.cs` is built only for `net9.0-ios` and `net9.0-maccatalyst` and `net9.0-tvos`
 * `*.Android.cs` is built only for `net9.0-android`
 
+In addition, for class libraries:
+
+- `*.reference.cs` is built only for reference implementation
+- `*.crossruntime.cs` is built for WebAssembly, Desktop, and reference implementation
+
+> [!NOTE]
+> For backwards compatibility, using `.skia.cs` is currently equivalent to `.desktop.cs`. This might change in the future, so we recommend using the suffixes above instead.
+
 Using file name conventions allows for reducing the use of `#if` compiler directives.
 
 ### A simple example

--- a/doc/articles/platform-specific-csharp.md
+++ b/doc/articles/platform-specific-csharp.md
@@ -60,7 +60,8 @@ The following conditional symbols are predefined for each Uno platform:
 | Catalyst        | `__MACCATALYST__`  | |
 | iOS or tvOS or Catalyst | `__APPLE_UIKIT__` | |
 | WebAssembly     | `__WASM__`         | Only available in the `net9.0-browserwasm` target framework, see [below](xref:Uno.Development.PlatformSpecificCSharp#webassembly-considerations) |
-| Skia            | `__UNO_SKIA__`     | Only available with `SkiaRenderer` feature.) |
+| Desktop         | `__DESKTOP__`      | Only available in the `net9.0-desktop` target framework. |
+| Skia            | `__UNO_SKIA__`     | Only available with `SkiaRenderer` feature. |
 | _Non-Windows_   | `__UNO__`          | To learn about symbols available when `__UNO__` is not present, see [below](xref:Uno.Development.PlatformSpecificCSharp#windows-specific-code) |
 
 > [!TIP]
@@ -102,8 +103,7 @@ Heavy usage of `#if` conditionals in shared code makes it hard to read and compr
 Starting from Uno Platform 5.2, in project or class libraries using the `Uno.Sdk`, a set of implicit file name conventions can be used to target specific platforms:
 
 * `*.wasm.cs` is built only for `net9.0-browserwasm`
-* `*.skia.cs` is built only for `net9.0-desktop`
-* `*.reference.cs` is built only for `net9.0-desktop`
+* `*.desktop.cs` is built only for `net9.0-desktop`
 * `*.iOS.cs` is built only for `net9.0-ios` and `net9.0-maccatalyst`
 * `*.tvOS.cs` is built only for `net9.0-tvos`
 * `*.UIKit.cs` is built only for `net9.0-ios` and `net9.0-maccatalyst` and `net9.0-tvos`

--- a/src/Uno.Sdk/targets/Uno.CrossTargeting.targets
+++ b/src/Uno.Sdk/targets/Uno.CrossTargeting.targets
@@ -15,6 +15,9 @@
 		<None Include="**\*.skia.cs" Exclude="bin\**\*.skia.cs;obj\**\*.skia.cs" Condition="'$(UnoRuntimeIdentifier)'!='Skia'" />
 		<Compile Remove="**\*.skia.cs" Condition="'$(UnoRuntimeIdentifier)'!='Skia'" />
 
+		<None Include="**\*.desktop.cs" Exclude="bin\**\*.desktop.cs;obj\**\*.desktop.cs" Condition="!$(IsDesktop)" />
+		<Compile Remove="**\*.desktop.cs" Condition="!$(IsDesktop)" />
+
 		<None Include="**\*.reference.cs" Exclude="bin\**\*.reference.cs;obj\**\*.reference.cs" Condition="'$(UnoRuntimeIdentifier)'!='Reference'" />
 		<Compile Remove="**\*.reference.cs" Condition="'$(UnoRuntimeIdentifier)'!='Reference'" />
 

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/buildTransitive/Uno.WinUI.Runtime.Skia.Linux.FrameBuffer.targets
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/buildTransitive/Uno.WinUI.Runtime.Skia.Linux.FrameBuffer.targets
@@ -7,7 +7,7 @@
 	<Target Name="_UnoSkiaLinuxFBFeatureDefines" AfterTargets="PrepareForBuild">
 
 		<PropertyGroup>
-			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_LINUX_FB;__UNO_SKIA__;__UNO_SKIA_LINUX_FB__</DefineConstants>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_LINUX_FB;__DESKTOP__;__UNO_SKIA__;__UNO_SKIA_LINUX_FB__</DefineConstants>
 		</PropertyGroup>
 
 	</Target>

--- a/src/Uno.UI.Runtime.Skia.MacOS/buildTransitive/Uno.WinUI.Runtime.Skia.MacOS.targets
+++ b/src/Uno.UI.Runtime.Skia.MacOS/buildTransitive/Uno.WinUI.Runtime.Skia.MacOS.targets
@@ -7,7 +7,7 @@
 	<Target Name="_UnoSkiaMacOSFeatureDefines" AfterTargets="PrepareForBuild">
 
 		<PropertyGroup>
-			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_MACOS;__UNO_SKIA__;__UNO_SKIA_MACOS__</DefineConstants>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_MACOS;__DESKTOP__;__UNO_SKIA__;__UNO_SKIA_MACOS__</DefineConstants>
 		</PropertyGroup>
 
 	</Target>

--- a/src/Uno.UI.Runtime.Skia.Win32/buildTransitive/Uno.WinUI.Runtime.Skia.Win32.targets
+++ b/src/Uno.UI.Runtime.Skia.Win32/buildTransitive/Uno.WinUI.Runtime.Skia.Win32.targets
@@ -7,7 +7,7 @@
 	<Target Name="_UnoSkiaWin32FeatureDefines" AfterTargets="PrepareForBuild">
 
 		<PropertyGroup>
-			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WIN32;__UNO_SKIA__;__UNO_SKIA_WIN32__</DefineConstants>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WIN32;__DESKTOP__;__UNO_SKIA__;__UNO_SKIA_WIN32__</DefineConstants>
 		</PropertyGroup>
 
 	</Target>

--- a/src/Uno.UI.Runtime.Skia.Wpf/buildTransitive/Uno.WinUI.Runtime.Skia.Wpf.targets
+++ b/src/Uno.UI.Runtime.Skia.Wpf/buildTransitive/Uno.WinUI.Runtime.Skia.Wpf.targets
@@ -7,7 +7,7 @@
 	<Target Name="_UnoSkiaWpfFeatureDefines" AfterTargets="PrepareForBuild">
 
 		<PropertyGroup>
-			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WPF;__UNO_SKIA__;__UNO_SKIA_WPF__</DefineConstants>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_WPF;__DESKTOP__;__UNO_SKIA__;__UNO_SKIA_WPF__</DefineConstants>
 		</PropertyGroup>
 
 	</Target>

--- a/src/Uno.UI.Runtime.Skia.X11/buildTransitive/Uno.WinUI.Runtime.Skia.X11.targets
+++ b/src/Uno.UI.Runtime.Skia.X11/buildTransitive/Uno.WinUI.Runtime.Skia.X11.targets
@@ -7,7 +7,7 @@
 	<Target Name="_UnoSkiaX11FeatureDefines" AfterTargets="PrepareForBuild">
 
 		<PropertyGroup>
-			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_X11;__UNO_SKIA__;__UNO_SKIA_X11__</DefineConstants>
+			<DefineConstants>$(DefineConstants);UNO_REFERENCE_API;HAS_UNO_SKIA;HAS_UNO_SKIA_X11;__DESKTOP__;__UNO_SKIA__;__UNO_SKIA_X11__</DefineConstants>
 		</PropertyGroup>
 
 	</Target>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/20344

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

There is no clear way to target desktop-only with `#if` or `.cs`

## What is the new behavior?

- New `__DESKTOP__` target
- New `.desktop.cs` suffix
- **Existing `__SKIA__` and `.skia.cs` still target desktop, but should probably be removed from Sdk in the next major, or should instead target all skia renderer targets**
- **Removed docs mentions of `reference` and `crossruntime` as they are no longer too meaningful for end users**

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.