### PR TITLE
feat(devSrv): Make VS also use csproj.user file for dev-server port config/discovery

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -243,7 +243,11 @@
 		<IsSampleProject>$(MSBuildProjectName.Contains('Sample'))</IsSampleProject>
 		<IsSampleProject Condition="'$(IsSampleProject)'=='false'">$(MSBuildProjectName.Contains('UnoIslands'))</IsSampleProject>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		
 		<WarningsNotAsErrors Condition="'$(Configuration)' == 'Debug'">$(WarningsNotAsErrors);IDE0051;IDE0055</WarningsNotAsErrors>
+		
+		<!-- Disable package checks -->
+		<WarningsNotAsErrors Condition="'$(Configuration)' == 'Debug'">$(WarningsNotAsErrors);NU1202;NU1701;NU1903;NU1604</WarningsNotAsErrors>
 		
 		<!-- Disable warning about cross platform call sites -->
 		<NoWarn>$(NoWarn);CA1416</NoWarn>

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
@@ -419,7 +419,7 @@ public partial class EntryPoint : IDisposable
 
 			if (hierarchy is IVsBuildPropertyStorage propertyStorage)
 			{
-				WriteUserProperty(propertyStorage, UnoSelectedTargetFrameworkProperty, targetFramework);
+				propertyStorage.SetUserProperty(UnoSelectedTargetFrameworkProperty, targetFramework);
 			}
 			else
 			{
@@ -430,15 +430,5 @@ public partial class EntryPoint : IDisposable
 		{
 			_debugAction?.Invoke("Could not write .user file (1)");
 		}
-	}
-
-	private static void WriteUserProperty(IVsBuildPropertyStorage propertyStorage, string propertyName, string propertyValue)
-	{
-		propertyStorage.SetPropertyValue(
-			propertyName,        // Property name
-			null,                 // Configuration name, null applies to all configurations
-			(uint)_PersistStorageType.PST_USER_FILE,  // Specifies that this is a user-specific property
-			propertyValue             // Property value
-		);
 	}
 }

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.ActiveProfileSync.cs
@@ -320,37 +320,7 @@ public partial class EntryPoint : IDisposable
 			: null;
 	}
 
-	private async Task OnStartupProjectChangedAsync()
-	{
-		if (_dte.Solution.SolutionBuild.StartupProjects is null)
-		{
-			// The user unloaded all projects, we need to reset the state
-			_isFirstProfileTfmChange = true;
-		}
 
-		if (!await EnsureProjectUserSettingsAsync() && _debuggerObserver is not null)
-		{
-			_debugAction?.Invoke($"The user setting is not yet initialized, aligning framework and profile");
-
-			// The user settings file is not available, we have created the
-			// file, but we also need to align the profile.
-			string currentActiveDebugFramework = "";
-
-			var hasTargetFramework = _debuggerObserver
-				.UnconfiguredProject
-				?.Services
-				.ActiveConfiguredProjectProvider
-				?.ActiveConfiguredProject
-				?.ProjectConfiguration
-				.Dimensions
-				.TryGetValue("TargetFramework", out currentActiveDebugFramework) ?? false;
-
-			if (hasTargetFramework)
-			{
-				await OnDebugFrameworkChangedAsync(null, currentActiveDebugFramework, true);
-			}
-		}
-	}
 
 	private async Task<bool> EnsureProjectUserSettingsAsync()
 	{

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -296,6 +296,9 @@ public partial class EntryPoint : IDisposable
 		var persistedPort = persistedPorts.FirstOrDefault(p => p > 0);
 
 		var port = _devServer?.port ?? persistedPort;
+		// Determine if the port configuration is incorrect:
+		// - Either no ports or multiple ports are persisted (`persistedPorts is { Length: 0 or > 1 }`).
+		// - Or the currently used port (`port`) does not match the persisted port (`persistedPort`).
 		var portMisConfigured = persistedPorts is { Length: 0 or > 1 } || port != persistedPort;
 
 		if (_devServer is { process.HasExited: false })

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -37,7 +37,6 @@ public partial class EntryPoint : IDisposable
 {
 	private const string UnoPlatformOutputPane = "Uno Platform";
 	private const string RemoteControlServerPortProperty = "UnoRemoteControlPort";
-	private const string UnoRemoteControlConfigCookieProperty = "UnoRemoteControlConfigCookie";
 	private const string UnoVSExtensionLoadedProperty = "_UnoVSExtensionLoaded";
 
 	private readonly CancellationTokenSource _ct = new();
@@ -51,12 +50,10 @@ public partial class EntryPoint : IDisposable
 	private Action<string>? _warningAction;
 	private Action<string>? _errorAction;
 	private int _msBuildLogLevel;
-	private System.Diagnostics.Process? _process;
-	private SemaphoreSlim _processGate = new(1);
+	private (System.Diagnostics.Process process, int port)? _devServer;
+	private SemaphoreSlim _devServerGate = new(1);
 	private IServiceProvider? _visualStudioServiceProvider;
 
-	private int _remoteControlServerPort;
-	private string? _remoteControlConfigCookie;
 	private bool _closing;
 	private bool _isDisposed;
 	private IdeChannelClient? _ideChannelClient;
@@ -139,16 +136,6 @@ public partial class EntryPoint : IDisposable
 			[UnoVSExtensionLoadedProperty] = "true"
 		};
 
-		if (_remoteControlServerPort is not 0)
-		{
-			properties.Add(RemoteControlServerPortProperty, _remoteControlServerPort.ToString(CultureInfo.InvariantCulture));
-		}
-
-		if (_remoteControlConfigCookie is not null)
-		{
-			properties.Add(UnoRemoteControlConfigCookieProperty, _remoteControlConfigCookie);
-		}
-
 		return Task.FromResult(properties);
 	}
 
@@ -173,8 +160,8 @@ public partial class EntryPoint : IDisposable
 		if (owPane == null)
 		{
 			owPane = ow
-			.OutputWindowPanes
-			.Add(UnoPlatformOutputPane);
+				.OutputWindowPanes
+				.Add(UnoPlatformOutputPane);
 		}
 
 		_debugAction = s =>
@@ -252,24 +239,24 @@ public partial class EntryPoint : IDisposable
 		_dte.Events.SolutionEvents.BeforeClosing -= _closeHandler;
 
 		_closing = true;
-		if (_process is not null)
+		if (_devServer is { process: var devServer })
 		{
 			try
 			{
-				_debugAction?.Invoke($"Terminating Remote Control server (pid: {_process.Id})");
-				_process.Kill();
-				_debugAction?.Invoke($"Terminated Remote Control server (pid: {_process.Id})");
+				_debugAction?.Invoke($"Terminating Remote Control server (pid: {devServer.Id})");
+				devServer.Kill();
+				_debugAction?.Invoke($"Terminated Remote Control server (pid: {devServer.Id})");
 
 				_ideChannelClient?.Dispose();
 				_ideChannelClient = null;
 			}
 			catch (Exception e)
 			{
-				_debugAction?.Invoke($"Failed to terminate Remote Control server (pid: {_process.Id}): {e}");
+				_debugAction?.Invoke($"Failed to terminate Remote Control server (pid: {devServer.Id}): {e}");
 			}
 			finally
 			{
-				_process = null;
+				_devServer = null;
 
 				// Invoke Dispose to make sure other event handlers are detached
 				Dispose();
@@ -301,27 +288,45 @@ public partial class EntryPoint : IDisposable
 	{
 		_debugAction?.Invoke($"Starting server (tid:{Environment.CurrentManagedThreadId})");
 
-		if (_process is { HasExited: false })
+		var persistedPortsStr = await _dte.GetProjectUserSettingsAsync(_asyncPackage, RemoteControlServerPortProperty, ProjectAttribute.Application);
+		var persistedPorts = persistedPortsStr
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.Select(str => int.TryParse(str, out var p) ? p : -1)
+			.ToArray();
+		var persistedPort = persistedPorts.FirstOrDefault(p => p > 0);
+
+		var port = _devServer?.port ?? persistedPort;
+		var portMissConfigured = persistedPorts is { Length: 0 or > 1 } || port != persistedPort;
+
+		if (_devServer is { process.HasExited: false })
 		{
-			_debugAction?.Invoke("Server already running");
+			if (portMissConfigured)
+			{
+				_debugAction?.Invoke($"Server already running on port {_devServer?.port}, but port is not configured properly on all projects. Updating it ...");
+
+				// The dev-server is already running, but at least one project is not configured properly
+				// (This can happen when a project is being added to the solution while opened - Reminder: This EnsureServerAsync is invoked each time a project is built)
+				// We make sure to set the current port for **all** projects.
+				await _dte.SetProjectUserSettingsAsync(_asyncPackage, RemoteControlServerPortProperty, port.ToString(CultureInfo.InvariantCulture), ProjectAttribute.Application);
+			}
+			else
+			{
+				_debugAction?.Invoke($"Server already running on port {_devServer?.port}");
+			}
+
 			return;
 		}
 
-		await _processGate.WaitAsync();
+		await _devServerGate.WaitAsync();
 		try
 		{
-
-			if (EnsureTcpPort(ref _remoteControlServerPort))
+			if (EnsureTcpPort(ref port) || portMissConfigured)
 			{
-				// Update the cookie file, so a rebuild will be triggered
-				_remoteControlConfigCookie ??= Path.GetTempFileName();
-				File.WriteAllText(_remoteControlConfigCookie, _remoteControlServerPort.ToString(CultureInfo.InvariantCulture));
-
-				// Push the new port to the project using global properties
-				_ = _globalPropertiesChanged();
+				// The port has changed, or all application projects does not have the same port number (or is not configured), we update port in *all* user files
+				await _dte.SetProjectUserSettingsAsync(_asyncPackage, RemoteControlServerPortProperty, port.ToString(CultureInfo.InvariantCulture), ProjectAttribute.Application);
 			}
 
-			_debugAction?.Invoke($"Using available port {_remoteControlServerPort}");
+			_debugAction?.Invoke($"Using available port {port}");
 
 			var version = GetDotnetMajorVersion();
 			if (version < 7)
@@ -332,7 +337,7 @@ public partial class EntryPoint : IDisposable
 			var pipeGuid = Guid.NewGuid();
 
 			var hostBinPath = Path.Combine(_toolsPath, "host", $"net{version}.0", "Uno.UI.RemoteControl.Host.dll");
-			var arguments = $"\"{hostBinPath}\" --httpPort {_remoteControlServerPort} --ppid {System.Diagnostics.Process.GetCurrentProcess().Id} --ideChannel \"{pipeGuid}\" --solution \"{_dte.Solution.FullName}\"";
+			var arguments = $"\"{hostBinPath}\" --httpPort {port} --ppid {System.Diagnostics.Process.GetCurrentProcess().Id} --ideChannel \"{pipeGuid}\" --solution \"{_dte.Solution.FullName}\"";
 			var pi = new ProcessStartInfo("dotnet", arguments)
 			{
 				UseShellExecute = false,
@@ -345,55 +350,29 @@ public partial class EntryPoint : IDisposable
 				RedirectStandardError = true
 			};
 
-			_process = new System.Diagnostics.Process { EnableRaisingEvents = true };
+			var devServer = new System.Diagnostics.Process { EnableRaisingEvents = true };
+			_devServer = (devServer, port);
 
 			// hookup the event handlers to capture the data that is received
-			_process.OutputDataReceived += (sender, args) => _debugAction?.Invoke(args.Data);
-			_process.ErrorDataReceived += (sender, args) => _errorAction?.Invoke(args.Data);
+			devServer.OutputDataReceived += (sender, args) => _debugAction?.Invoke(args.Data);
+			devServer.ErrorDataReceived += (sender, args) => _errorAction?.Invoke(args.Data);
 
-			_process.StartInfo = pi;
-			_process.Exited += (sender, args) => _ = RestartAsync();
+			devServer.StartInfo = pi;
+			devServer.Exited += (sender, args) => _ = RestartAsync();
 
-			if (_process.Start())
+			if (devServer.Start())
 			{
 				// start our event pumps
-				_process.BeginOutputReadLine();
-				_process.BeginErrorReadLine();
+				devServer.BeginOutputReadLine();
+				devServer.BeginErrorReadLine();
 
 				_ideChannelClient = new IdeChannelClient(pipeGuid, new Logger(this));
 				_ideChannelClient.OnMessageReceived += OnMessageReceivedAsync;
 				_ideChannelClient.ConnectToHost();
-
-				// Set the port to the projects
-				// This LEGACY as port should be set through the global properties (cf. OnProvideGlobalPropertiesAsync)
-				var portString = _remoteControlServerPort.ToString(CultureInfo.InvariantCulture);
-				await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-				var projects = (await _dte.GetProjectsAsync()).ToArray(); // EnumerateProjects must be called on the UI thread.
-				await TaskScheduler.Default;
-				foreach (var project in projects)
-				{
-					var filename = string.Empty;
-					try
-					{
-						filename = project.FileName;
-					}
-					catch (Exception ex)
-					{
-						_debugAction?.Invoke($"Exception on retrieving {project.UniqueName} details. Err: {ex}.");
-						_warningAction?.Invoke($"Cannot read {project.UniqueName} project details (It may be unloaded).");
-					}
-					if (string.IsNullOrWhiteSpace(filename) == false
-						&& GetMsbuildProject(filename) is Microsoft.Build.Evaluation.Project msbProject
-						&& IsApplication(msbProject))
-					{
-						SetGlobalProperty(filename, RemoteControlServerPortProperty, portString);
-					}
-				}
 			}
 			else
 			{
-				_process = null;
-				_remoteControlServerPort = 0;
+				_devServer = null;
 			}
 		}
 		catch (Exception e)
@@ -402,33 +381,23 @@ public partial class EntryPoint : IDisposable
 		}
 		finally
 		{
-			_processGate.Release();
+			_devServerGate.Release();
 		}
 
 		async Task RestartAsync()
 		{
 			if (_closing || _ct.IsCancellationRequested)
 			{
-				if (_remoteControlConfigCookie is not null)
-				{
-					File.WriteAllText(_remoteControlConfigCookie, "--closed--"); // Make sure VS will re-build on next start
-				}
-
-				_debugAction?.Invoke($"Remote Control server exited ({_process?.ExitCode}) and won't be restarted as solution is closing.");
+				_debugAction?.Invoke($"Remote Control server exited ({_devServer?.process.ExitCode}) and won't be restarted as solution is closing.");
 				return;
 			}
 
-			_debugAction?.Invoke($"Remote Control server exited ({_process?.ExitCode}). It will restart in 5sec.");
+			_debugAction?.Invoke($"Remote Control server exited ({_devServer?.process.ExitCode}). It will restart in 5sec.");
 
 			await Task.Delay(5000, _ct.Token);
 
 			if (_closing || _ct.IsCancellationRequested)
 			{
-				if (_remoteControlConfigCookie is not null)
-				{
-					File.WriteAllText(_remoteControlConfigCookie, "--closed--"); // Make sure VS will re-build on next start
-				}
-
 				_debugAction?.Invoke($"Remote Control server will not be restarted as solution is closing.");
 				return;
 			}
@@ -651,51 +620,6 @@ public partial class EntryPoint : IDisposable
 		tcp.Stop();
 
 		return true; // HasChanged
-	}
-
-	public void SetGlobalProperty(string projectFullName, string propertyName, string propertyValue)
-	{
-		var msbuildProject = GetMsbuildProject(projectFullName);
-		if (msbuildProject == null)
-		{
-			_debugAction?.Invoke($"Failed to find project {projectFullName}, cannot provide listen port to the app.");
-		}
-		else
-		{
-			SetGlobalProperty(msbuildProject, propertyName, propertyValue);
-		}
-	}
-
-	private static Microsoft.Build.Evaluation.Project? GetMsbuildProject(string projectFullName)
-		=> ProjectCollection.GlobalProjectCollection.GetLoadedProjects(projectFullName).FirstOrDefault();
-
-	public void SetGlobalProperties(string projectFullName, IDictionary<string, string> properties)
-	{
-		var msbuildProject = ProjectCollection.GlobalProjectCollection.GetLoadedProjects(projectFullName).FirstOrDefault();
-		if (msbuildProject == null)
-		{
-			_debugAction?.Invoke($"Failed to find project {projectFullName}, cannot provide listen port to the app.");
-		}
-		else
-		{
-			foreach (var property in properties)
-			{
-				SetGlobalProperty(msbuildProject, property.Key, property.Value);
-			}
-		}
-	}
-
-	private void SetGlobalProperty(Microsoft.Build.Evaluation.Project msbuildProject, string propertyName, string propertyValue)
-	{
-		msbuildProject.SetGlobalProperty(propertyName, propertyValue);
-
-	}
-
-	private bool IsApplication(Microsoft.Build.Evaluation.Project project)
-	{
-		var outputType = project.GetPropertyValue("OutputType");
-		return outputType is not null &&
-   				(outputType.Equals("Exe", StringComparison.OrdinalIgnoreCase) || outputType.Equals("WinExe", StringComparison.OrdinalIgnoreCase));
 	}
 
 	public void Dispose()

--- a/src/Uno.UI.RemoteControl.VS/Helpers/DTEHelper.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/DTEHelper.cs
@@ -8,8 +8,28 @@ using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Uno.UI.RemoteControl.VS.Helpers;
+
+[Flags]
+internal enum ProjectAttribute
+{
+	/// <summary>
+	/// Output type is exe or winexe
+	/// </summary>
+	Application = 1 << 0,
+
+	/// <summary>
+	/// Output type is library
+	/// </summary>
+	Library = 1 << 1,
+
+	/// <summary>
+	/// Project is a startup project
+	/// </summary>
+	Startup = 1 << 2,
+}
 
 internal static class DTEHelper
 {
@@ -23,20 +43,124 @@ internal static class DTEHelper
 		return logOutput;
 	}
 
-	public static async Task<IEnumerable<Project>> GetProjectsAsync(this DTE dte)
+	public static bool IsApplication(this EnvDTE.Project project)
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+
+		return project.Properties?.Item("OutputType")?.Value is 0; // for "exe" and "winexe"
+	}
+
+	public static bool IsLibrary(this EnvDTE.Project project)
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+
+		return project.Properties?.Item("OutputType")?.Value is 2;
+	}
+
+	public static async ValueTask<IEnumerable<Project>> GetProjectsAsync(this DTE dte, ProjectAttribute? attributes = null)
+	{
+		var projects = attributes?.HasFlag(ProjectAttribute.Startup) ?? false
+			? await dte.GetStartupProjectsAsync()
+			: await dte.GetProjectsRecursiveAsync();
+
+		projects ??= [];
+
+		if (attributes?.HasFlag(ProjectAttribute.Application) ?? false)
+		{
+			projects = projects.Where(IsApplication);
+		}
+		if (attributes?.HasFlag(ProjectAttribute.Library) ?? false)
+		{
+			projects = projects.Where(IsLibrary);
+		}
+
+		return projects;
+	}
+
+	public static async ValueTask<IEnumerable<string?>> GetProjectUserSettingsAsync(this DTE dte, AsyncPackage asyncPackage, string name, ProjectAttribute? attributes = null)
+	{
+		await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+		if (await asyncPackage.GetServiceAsync(typeof(SVsSolution)) is not IVsSolution solution)
+		{
+			return [];
+		}
+
+		return (await dte.GetProjectsAsync(attributes))
+			.Select(GetHierarchy)
+			.OfType<IVsBuildPropertyStorage>()
+			.Select(propertyStorage => GetUserProperty(propertyStorage, name))
+			.ToArray();
+
+#pragma warning disable VSTHRD010 // False positive rule: we are on the main thread here (including the materialization of the list using the ToArray())
+		IVsHierarchy GetHierarchy(Project project)
+		{
+			solution.GetProjectOfUniqueName(project.UniqueName, out var hierarchy);
+			return hierarchy;
+		}
+#pragma warning restore VSTHRD010
+	}
+
+
+	public static async ValueTask<int> SetProjectUserSettingsAsync(this DTE dte, AsyncPackage asyncPackage, string name, string value, ProjectAttribute? attributes = null)
+	{
+		await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+		if (await asyncPackage.GetServiceAsync(typeof(SVsSolution)) is not IVsSolution solution)
+		{
+			return -1;
+		}
+
+		var updatedProjects = 0;
+		foreach (var project in await dte.GetProjectsAsync(attributes))
+		{
+			// Convert DTE project to IVsHierarchy
+			solution.GetProjectOfUniqueName(project.UniqueName, out var hierarchy);
+			if (hierarchy is IVsBuildPropertyStorage propertyStorage)
+			{
+				propertyStorage.SetUserProperty(name, value);
+				updatedProjects++;
+			}
+		}
+
+		return updatedProjects;
+	}
+
+	public static void SetUserProperty(this IVsBuildPropertyStorage propertyStorage, string propertyName, string propertyValue)
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+
+		propertyStorage.SetPropertyValue(
+			propertyName,        // Property name
+			null,                 // Configuration name, null applies to all configurations
+			(uint)_PersistStorageType.PST_USER_FILE,  // Specifies that this is a user-specific property
+			propertyValue             // Property value
+		);
+	}
+
+	public static string? GetUserProperty(this IVsBuildPropertyStorage propertyStorage, string propertyName)
+	{
+		ThreadHelper.ThrowIfNotOnUIThread();
+
+		propertyStorage.GetPropertyValue(
+			propertyName,        // Property name
+			null,                 // Configuration name, null applies to all configurations
+			(uint)_PersistStorageType.PST_USER_FILE,  // Specifies that this is a user-specific property
+			out var propertyValue             // Property value
+		);
+
+		return propertyValue;
+	}
+
+	private static async Task<IEnumerable<Project>> GetProjectsRecursiveAsync(this DTE dte)
 	{
 		await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
 		var solutionProjectItems = dte.Solution.Projects;
 
-		if (solutionProjectItems != null)
-		{
-			return EnumerateProjects(solutionProjectItems);
-		}
-		else
-		{
-			return Array.Empty<Project>();
-		}
+		return solutionProjectItems is null
+			? []
+			: EnumerateProjects(solutionProjectItems);
 	}
 
 	private static IEnumerable<Project> EnumerateProjects(Projects vsSolution)
@@ -97,19 +221,19 @@ internal static class DTEHelper
 	{
 		await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-		if (dte.Solution.SolutionBuild.StartupProjects is object[] startupProjects
-			&& startupProjects.Length > 0)
+		if (dte.Solution.SolutionBuild.StartupProjects is object[] { Length: > 0 } startupProjects)
 		{
-			var projects = await dte.GetProjectsAsync();
+			var projects = await dte.GetProjectsRecursiveAsync();
 
 			return startupProjects
 				.OfType<string>()
-				.Select(p => projects.FirstOrDefault(p2 =>
+				.Select(startupProjectName => projects.FirstOrDefault(project =>
 				{
 					Microsoft.VisualStudio.Shell.ThreadHelper.ThrowIfNotOnUIThread();
-					return p2.UniqueName == p;
+					return project.UniqueName == startupProjectName;
 				}))
-				.Where(p => p is not null).ToArray();
+				.Where(project => project is not null)
+				.ToArray();
 		}
 
 		return null;

--- a/src/Uno.UI.RemoteControl.VS/Helpers/DTEHelper.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/DTEHelper.cs
@@ -9,6 +9,7 @@ using EnvDTE80;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using VSLangProj110;
 
 namespace Uno.UI.RemoteControl.VS.Helpers;
 
@@ -47,14 +48,14 @@ internal static class DTEHelper
 	{
 		ThreadHelper.ThrowIfNotOnUIThread();
 
-		return project.Properties?.Item("OutputType")?.Value is 0; // for "exe" and "winexe"
+		return project.Properties?.Item("OutputType")?.Value is prjOutputTypeEx.prjOutputTypeEx_Exe or prjOutputTypeEx.prjOutputTypeEx_WinExe or prjOutputTypeEx.prjOutputTypeEx_AppContainerExe;
 	}
 
 	public static bool IsLibrary(this EnvDTE.Project project)
 	{
 		ThreadHelper.ThrowIfNotOnUIThread();
 
-		return project.Properties?.Item("OutputType")?.Value is 2;
+		return project.Properties?.Item("OutputType")?.Value is prjOutputTypeEx.prjOutputTypeEx_Library or prjOutputTypeEx.prjOutputTypeEx_WinMDObj;
 	}
 
 	public static async ValueTask<IEnumerable<Project>> GetProjectsAsync(this DTE dte, ProjectAttribute? attributes = null)


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1303

## Feature
Make VS also use csproj.user file for dev-server port config/discovery

## What is the current behavior?
Port number is injected through the "Global properties" but we observed some case where port was not configured in application.

## What is the new behavior?
Like on VS Code and Rider, we use the `.csproj.user` instead.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
