### PR TITLE
fix: Fix ContentRootType invalid on desktop

### DIFF
--- a/src/Uno.UI/UI/Xaml/Hosting/DesktopWindowXamlSource.cs
+++ b/src/Uno.UI/UI/Xaml/Hosting/DesktopWindowXamlSource.cs
@@ -4,6 +4,7 @@ using System;
 using Uno.UI.Xaml.Islands;
 using Windows.Foundation;
 using Uno.UI.Xaml.Controls;
+using Uno.UI.Xaml.Core;
 using WinUICoreServices = global::Uno.UI.Xaml.Core.CoreServices;
 
 namespace Microsoft.UI.Xaml.Hosting;
@@ -23,7 +24,7 @@ public partial class DesktopWindowXamlSource : IDisposable
 	/// </summary>
 	public DesktopWindowXamlSource()
 	{
-		_xamlIsland = new();
+		_xamlIsland = new(ContentRootType.ShellWindow);
 	}
 
 	/// <summary>

--- a/src/Uno.UI/UI/Xaml/Input/Internal/FocusObserver.cs
+++ b/src/Uno.UI/UI/Xaml/Input/Internal/FocusObserver.cs
@@ -151,6 +151,7 @@ internal class FocusObserver
 		pRoot = _contentRoot.Type switch
 		{
 			ContentRootType.XamlIslandRoot => _contentRoot.VisualTree.RootScrollViewer ?? _contentRoot.VisualTree.ActiveRootVisual,
+			ContentRootType.ShellWindow => _contentRoot.VisualTree.RootScrollViewer ?? _contentRoot.VisualTree.ActiveRootVisual,
 			_ => _contentRoot.VisualTree.ActiveRootVisual,
 		};
 

--- a/src/Uno.UI/UI/Xaml/Internal/ContentRoot.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/ContentRoot.cs
@@ -89,6 +89,7 @@ internal partial class ContentRoot
 				FocusManager.SetFocusObserver(new CoreWindowFocusObserver(this));
 				break;
 			case ContentRootType.XamlIslandRoot:
+			case ContentRootType.ShellWindow:
 				FocusAdapter = new FocusManagerXamlIslandAdapter(this);
 				FocusManager.SetFocusObserver(new FocusObserver(this));
 				break;
@@ -136,6 +137,7 @@ internal partial class ContentRoot
 		switch (Type)
 		{
 			case ContentRootType.XamlIslandRoot:
+			case ContentRootType.ShellWindow:
 				XamlIslandRoot?.OnStateChanged();
 				break;
 			case ContentRootType.CoreWindow:
@@ -150,7 +152,7 @@ internal partial class ContentRoot
 		ContentIsland content,
 		ContentIslandAutomationProviderRequestedEventArgs args)
 	{
-		if (Type == ContentRootType.XamlIslandRoot)
+		if (Type is ContentRootType.XamlIslandRoot or ContentRootType.ShellWindow)
 		{
 			// XamlislandRoot.OnContentAutomationProviderRequested(content, args));
 		}
@@ -278,7 +280,7 @@ internal partial class ContentRoot
 		return Type switch
 		{
 			ContentRootType.CoreWindow => Window.CurrentSafe,
-			ContentRootType.XamlIslandRoot when XamlIslandRoot is not null => XamlIslandRoot.OwnerWindow,
+			ContentRootType.XamlIslandRoot or ContentRootType.ShellWindow when XamlIslandRoot is not null => XamlIslandRoot.OwnerWindow,
 			_ => null
 		};
 	}

--- a/src/Uno.UI/UI/Xaml/Internal/ContentRootType.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/ContentRootType.cs
@@ -6,6 +6,7 @@ namespace Uno.UI.Xaml.Core;
 
 internal enum ContentRootType
 {
-	CoreWindow,
-	XamlIslandRoot
+	CoreWindow, // A window created using the "native UI framework" (e.g. iOS-UIKit / Android-View / Windows-WPF)
+	XamlIslandRoot, // Xaml Island hosted in an application which uses another UI framework (e.g. WPF / WinUI)
+	ShellWindow, // A window created using system OS APIs (e.g. Win32 / X11)
 }

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Keyboard.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Keyboard.skia.cs
@@ -42,7 +42,7 @@ partial class InputManager
 				return;
 			}
 
-			if (_inputManager.ContentRoot.Type == ContentRootType.CoreWindow)
+			if (_inputManager.ContentRoot.Type is ContentRootType.CoreWindow or ContentRootType.ShellWindow)
 			{
 				CoreWindow.GetForCurrentThreadSafe()?.SetKeyboardInputSource(_source);
 			}

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
@@ -80,7 +80,7 @@ internal partial class InputManager
 				return;
 			}
 
-			if (_inputManager.ContentRoot.Type == ContentRootType.CoreWindow)
+			if (_inputManager.ContentRoot.Type is ContentRootType.CoreWindow or ContentRootType.ShellWindow)
 			{
 				CoreWindow.GetForCurrentThreadSafe()?.SetPointerInputSource(_source);
 			}

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.cs
@@ -54,8 +54,9 @@ partial class InputManager
 
 	internal partial class PointerManager
 	{
+#pragma warning disable
 		private static readonly Logger _log = LogExtensionPoint.Log(typeof(PointerManager));
-		private static readonly bool _trace = _log.IsEnabled(LogLevel.Trace);
+		private static readonly bool _trace = true;//_log.IsEnabled(LogLevel.Trace);
 
 		private readonly InputManager _inputManager;
 

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.cs
@@ -54,9 +54,8 @@ partial class InputManager
 
 	internal partial class PointerManager
 	{
-#pragma warning disable
 		private static readonly Logger _log = LogExtensionPoint.Log(typeof(PointerManager));
-		private static readonly bool _trace = true;//_log.IsEnabled(LogLevel.Trace);
+		private static readonly bool _trace = _log.IsEnabled(LogLevel.Trace);
 
 		private readonly InputManager _inputManager;
 

--- a/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.Core.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.Core.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Diagnostics;
 using DirectUI;
 using Microsoft.UI.Content;
 using Microsoft.UI.Xaml;
@@ -21,9 +22,11 @@ internal partial class XamlIslandRoot
 	private bool _isVisible;
 	private Size _previousIslandSize;
 
-	internal void InitializeRoot(WinUICoreServices coreServices)
+	internal void InitializeRoot(WinUICoreServices coreServices, ContentRootType type = ContentRootType.XamlIslandRoot)
 	{
-		_contentRoot = coreServices.ContentRootCoordinator.CreateContentRoot(ContentRootType.XamlIslandRoot, Colors.Transparent, this);
+		Debug.Assert(type is ContentRootType.XamlIslandRoot or ContentRootType.ShellWindow);
+
+		_contentRoot = coreServices.ContentRootCoordinator.CreateContentRoot(type, Colors.Transparent, this);
 		_contentRoot.XamlIslandRoot = this;
 	}
 

--- a/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.cs
@@ -13,13 +13,13 @@ internal partial class XamlIslandRoot : Panel
 {
 	private readonly ContentManager _contentManager;
 
-	public XamlIslandRoot()
+	public XamlIslandRoot(ContentRootType type = ContentRootType.XamlIslandRoot)
 	{
 		_contentManager = new(this, false);
 		// TODO: Uno specific - additional root logic required by Uno.
 		_rootElementLogic = new(this);
 
-		InitializeRoot(WinUICoreServices.Instance);
+		InitializeRoot(WinUICoreServices.Instance, type);
 	}
 
 	internal ContentManager ContentManager => _contentManager;

--- a/src/Uno.UI/UI/Xaml/Internal/VisualTree.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/VisualTree.cs
@@ -81,12 +81,12 @@ namespace Uno.UI.Xaml.Core
 				RootElement = RootVisual;
 			}
 
-			if (ContentRoot.Type == ContentRootType.CoreWindow)
+			if (ContentRoot.Type is ContentRootType.CoreWindow)
 			{
 				var config = RootScaleConfig.ParentApply; //XamlOneCoreTransforms.IsEnabled ? RootScaleConfig::ParentApply : RootScaleConfig::ParentInvert;
 				RootScale = new CoreWindowRootScale(config, coreServices, this);
 			}
-			else if (ContentRoot.Type == ContentRootType.XamlIslandRoot)
+			else if (ContentRoot.Type is ContentRootType.XamlIslandRoot or ContentRootType.ShellWindow)
 			{
 				RootScale = new XamlIslandRootScale(coreServices, this);
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/20490

## Bugfix
Fix ContentRootType invalid on desktop

## What is the current behavior?
Configured as "Xaml Island"

## What is the new behavior?
Created a new type `ShellWindow` 

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
