### PR TITLE
fix: Fix pointer and keyboard events not raised on CoreWindow

### DIFF
--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Keyboard.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Keyboard.skia.cs
@@ -42,10 +42,7 @@ partial class InputManager
 				return;
 			}
 
-			if (_inputManager.ContentRoot.Type == ContentRootType.CoreWindow)
-			{
-				CoreWindow.GetForCurrentThreadSafe()?.SetKeyboardInputSource(_source);
-			}
+			CoreWindow.GetForCurrentThreadSafe()?.SetKeyboardInputSource(_source);
 
 			_source.KeyDown += (_, e) => OnKey(e, true);
 			_source.KeyUp += (_, e) => OnKey(e, false);

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
@@ -80,10 +80,7 @@ internal partial class InputManager
 				return;
 			}
 
-			if (_inputManager.ContentRoot.Type == ContentRootType.CoreWindow)
-			{
-				CoreWindow.GetForCurrentThreadSafe()?.SetPointerInputSource(_source);
-			}
+			CoreWindow.GetForCurrentThreadSafe()?.SetPointerInputSource(_source);
 
 			_source.PointerMoved += (c, e) => OnPointerMoved(e);
 			_source.PointerEntered += (c, e) => OnPointerEntered(e);


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/20350

## Bugfix
Fix pointer and keyboard events not raised on CoreWindow

## What is the current behavior?
Pointer and keyboard input source are not set on the `CoreWindow` on desktop target as it reports as "Xaml Island"(as expected, cf. https://github.com/unoplatform/uno/pull/20491)

## What is the new behavior?
We ignore the content root type and set the sources as long as we have a `CoreWindow` instance.

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
