### PR TITLE
fix: Ensure `IsEnabled` visual states are properly reflected in `TextBox`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.cs
@@ -151,6 +151,42 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			await ImageAssert.AreEqualAsync(opacityZero, borderThicknessZero);
 		}
 
+		[TestMethod]
+#if !HAS_RENDER_TARGET_BITMAP
+		[Ignore("Cannot take screenshot on this platform.")]
+#endif
+		public async Task When_IsEnabled_With_Text_Changes()
+		{
+			var grid = new Grid
+			{
+				Background = new SolidColorBrush(Colors.Yellow)
+			};
+
+			var textBox = new TextBox
+			{
+				Text = "Hello!",
+				Background = new SolidColorBrush(Colors.Transparent),
+				BorderThickness = new Thickness(0),
+				BorderBrush = new SolidColorBrush(Colors.Transparent),
+				Padding = new Thickness(100),
+			};
+
+			grid.Children.Add(textBox);
+
+			await UITestHelper.Load(grid);
+
+			// Get element marked "ContentElement" from template of textBox
+			var contentElement = textBox.FindFirstChild<ScrollViewer>(tb => tb.Name == "ContentElement");
+
+			var enabledScreenshot = await UITestHelper.ScreenShot(contentElement);
+
+			textBox.IsEnabled = false;
+
+			var disabledScreenshot = await UITestHelper.ScreenShot(contentElement);
+
+			await ImageAssert.AreNotEqualAsync(enabledScreenshot, disabledScreenshot);
+		}
+
 #if __ANDROID__
 		[TestMethod]
 		public void When_InputScope_Null_And_ImeOptions()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -217,14 +217,6 @@ namespace Microsoft.UI.Xaml.Controls
 			return Disposable.Create(() => _textBoxView.ShowSoftInputOnFocus = before);
 		}
 
-		partial void OnForegroundColorChangedPartial(Brush newValue)
-		{
-			if (_textBoxView != null)
-			{
-				_textBoxView.Foreground = newValue;
-			}
-		}
-
 		partial void OnInputScopeChangedPartial(InputScope newValue)
 		{
 			this.CoerceValue(ImeOptionsProperty);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.wasm.cs
@@ -66,11 +66,6 @@ namespace Microsoft.UI.Xaml.Controls
 			FocusTextView();
 		}
 
-		partial void OnForegroundColorChangedPartial(Brush newValue)
-		{
-			_textBoxView?.SetForeground(newValue);
-		}
-
 		partial void UpdateFontPartial()
 		{
 			if (_textBoxView == null)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -107,11 +107,7 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		internal void OnForegroundChanged(Brush brush)
-		{
-			DisplayBlock.Foreground = brush;
-			_overlayTextBoxViewExtension?.UpdateProperties();
-		}
+		internal void OnForegroundChanged(Brush brush) => _overlayTextBoxViewExtension?.UpdateProperties();
 
 		internal void OnSelectionHighlightColorChanged(SolidColorBrush brush)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -107,6 +107,10 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
+		/// <remarks>
+		/// Note that we are intentionally *not* setting the Foreground of DisplayBlock here, as it is inherited from
+		/// ContentElement in TextBox template. If it was set explicitly, the inheritance would no longer apply.
+		/// </remarks>
 		internal void OnForegroundChanged(Brush brush) => _overlayTextBoxViewExtension?.UpdateProperties();
 
 		internal void OnSelectionHighlightColorChanged(SolidColorBrush brush)


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/20519, closes https://github.com/unoplatform/uno/issues/13985

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

`IsEnabled=false` is not reflected in case `Text` property is non-empty

## What is the new behavior?

The `Foreground` is properly inherited

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.