### PR TITLE
fix: Fix failed to detect plugin on large solutions

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/DevServer.Custom.Impl.Targets
+++ b/src/Uno.UI.RemoteControl.Host/DevServer.Custom.Impl.Targets
@@ -1,0 +1,9 @@
+<Project>
+	<Target Name="UnoDumpTargetFrameworks">
+		<Message Text="This is not a Uno.SDK project, no TFM to dump." Importance="High" />
+	</Target>
+
+	<Target Name="UnoDumpRemoteControlAddIns">
+		<Message Text="This is not a Uno.SDK project, no add-in to dump." Importance="High" />
+	</Target>
+</Project>

--- a/src/Uno.UI.RemoteControl.Host/DevServer.Custom.Targets
+++ b/src/Uno.UI.RemoteControl.Host/DevServer.Custom.Targets
@@ -1,9 +1,3 @@
 <Project>
-	<Target Name="UnoDumpTargetFrameworks">
-		<Message Text="This is not a Uno.SDK project, no TFM to dump." Importance="High" />
-	</Target>
-
-	<Target Name="UnoDumpRemoteControlAddIns">
-		<Message Text="This is not a Uno.SDK project, no add-in to dump." Importance="High" />
-	</Target>
+	<Import Condition="'$(UsingUnoSdk)'!='true'" Project="$(MSBuildThisFileDirectory)/DevServer.Custom.Impl.Targets" />
 </Project>

--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -70,6 +70,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<None Update="DevServer.Custom.Impl.Targets">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 		<None Update="DevServer.Custom.Targets">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/discussions/20545


## Bugfix
Fix failed to detect plugin on large solutions

## What is the current behavior?
On large solution, the `DevServer.Custom.Targets` might be loaded on `Uno.Sdk` project **after** the Uno.WinUI.DevServer package targets file has been loaded, causing the targets to be overriden.

## What is the new behavior?
The dummy targets are included only if the project is not known to use the `Uno.Sdk`

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
