### PR TITLE
fix: Remove Skia Wasm WebView border

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_Basic.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_Basic.xaml.cs
@@ -20,7 +20,7 @@ namespace UITests.Microsoft_UI_Xaml_Controls.WebView2Tests
 	/// <summary>
 	/// An empty page that can be used on its own or navigated to within a Frame.
 	/// </summary>
-	[Uno.UI.Samples.Controls.Sample("WebView")]
+	[Uno.UI.Samples.Controls.Sample("WebView", IsManualTest = true, Description = "The WebView2 should be borderless and the Uno Platform website should be displayed.")]
 	public sealed partial class WebView2_Basic : Page
 	{
 		public WebView2_Basic()

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Wasm/NativeWebView.Interop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Wasm/NativeWebView.Interop.wasm.cs
@@ -20,6 +20,9 @@ internal static partial class NativeWebView
 		[JSImport("globalThis.Microsoft.UI.Xaml.Controls.WebView.buildImports")]
 		internal static partial void BuildImports(string assembly);
 
+		[JSImport("globalThis.Microsoft.UI.Xaml.Controls.WebView.initializeStyling")]
+		internal static partial void InitializeStyling(ElementId htmlId);
+
 		[JSImport("globalThis.Microsoft.UI.Xaml.Controls.WebView.reload")]
 		internal static partial void Reload(ElementId htmlId);
 
@@ -43,9 +46,6 @@ internal static partial class NativeWebView
 
 		[JSImport("globalThis.Microsoft.UI.Xaml.Controls.WebView.setAttribute")]
 		internal static partial void SetAttribute(ElementId htmlId, string attribute, string value);
-
-		[JSImport("globalThis.Microsoft.UI.Xaml.Controls.WebView.setBackground")]
-		internal static partial void SetBackground(ElementId htmlId, string value);
 
 		[JSImport("globalThis.Microsoft.UI.Xaml.Controls.WebView.setupEvents")]
 		internal static partial void SetupEvents(ElementId htmlId);

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Wasm/NativeWebView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Wasm/NativeWebView.wasm.cs
@@ -36,7 +36,7 @@ internal partial class NativeWebView : ICleanableNativeWebView
 		_coreWebView = coreWebView;
 		_elementId = elementId;
 
-		NativeMethods.SetBackground(elementId, "transparent");
+		NativeMethods.InitializeStyling(elementId);
 		NativeMethods.SetupEvents(elementId);
 	}
 

--- a/src/Uno.UI/ts/Windows/UI/Xaml/Controls/WebView.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/Controls/WebView.ts
@@ -44,8 +44,10 @@ namespace Microsoft.UI.Xaml.Controls {
 			return (<HTMLIFrameElement>document.getElementById(htmlId)).getAttribute(name);
 		}
 
-		static setBackground(htmlId: string, color: string) {
-			(<HTMLIFrameElement>document.getElementById(htmlId)).style.backgroundColor = color;
+		static initializeStyling(htmlId: string) {
+			const iframe = document.getElementById(htmlId) as HTMLIFrameElement;
+			iframe.style.backgroundColor = "transparent";
+			iframe.style.border = "0";
 		}
 
 		static setupEvents(htmlId: string) {


### PR DESCRIPTION
GitHub Issue (If applicable): closes #20403, closes #20587 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

This pull request refactors the styling initialization for the `WebView` component in the Uno Platform. The most significant changes include replacing the `SetBackground` method with a new `InitializeStyling` method to streamline and centralize styling setup, and updating related TypeScript and C# code to reflect this change.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.