### PR TITLE
fix: Fix multiple instance of dev-server can be started when re-using VS sinatnce with multiple solutions

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
+++ b/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
@@ -218,6 +218,26 @@ internal class ProfilesObserver : IDisposable
 		_dte.Events.CommandEvents.AfterExecute += _afterExecute;
 	}
 
+	private void UnObserveSolutionEvents()
+	{
+		if (_projectAdded is not null)
+		{
+			_dte.Events.SolutionEvents.ProjectAdded -= _projectAdded;
+		}
+		if (_projectRemoved is not null)
+		{
+			_dte.Events.SolutionEvents.ProjectRemoved -= _projectRemoved; 
+		}
+		if (_projectRenamed is not null)
+		{
+			_dte.Events.SolutionEvents.ProjectRenamed -= _projectRenamed; 
+		}
+		if (_afterExecute is not null)
+		{
+			_dte.Events.CommandEvents.AfterExecute -= _afterExecute; 
+		}
+	}
+
 	private async Task OnUnconfiguredProject_ProjectUnloadingAsync(object? sender, EventArgs args)
 	{
 		await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -412,6 +432,7 @@ internal class ProfilesObserver : IDisposable
 
 	public void Dispose()
 	{
+		UnObserveSolutionEvents();
 		_projectRuleSubscriptionLink?.Dispose();
 		_isDisposed = true;
 	}

--- a/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
+++ b/src/Uno.UI.RemoteControl.VS/DebuggerHelper/ProfilesObserver.cs
@@ -226,15 +226,15 @@ internal class ProfilesObserver : IDisposable
 		}
 		if (_projectRemoved is not null)
 		{
-			_dte.Events.SolutionEvents.ProjectRemoved -= _projectRemoved; 
+			_dte.Events.SolutionEvents.ProjectRemoved -= _projectRemoved;
 		}
 		if (_projectRenamed is not null)
 		{
-			_dte.Events.SolutionEvents.ProjectRenamed -= _projectRenamed; 
+			_dte.Events.SolutionEvents.ProjectRenamed -= _projectRenamed;
 		}
 		if (_afterExecute is not null)
 		{
-			_dte.Events.CommandEvents.AfterExecute -= _afterExecute; 
+			_dte.Events.CommandEvents.AfterExecute -= _afterExecute;
 		}
 	}
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1353

## Bugfix
Fix multiple instance of dev-server can be started when re-using VS sinatnce with multiple solutions

## What is the current behavior?
* Previous instances of `EntryPoint` leaks and also starts dev-server
* Concurrency issue could cause dev-server to be started more than once

## What is the new behavior?
* Make sure to un-subscribe event to avoid duplicated work + safety check before stating the server
* All the logic to start the dev-server is gated

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
