### PR TITLE
fix: SplitView.OpenPaneLength having no effect

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SplitView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SplitView.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Extensions;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+[TestClass]
+public class Given_SplitView
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task Update_OpenPaneLength()
+	{
+		// This test asserts changes to the OpenPaneLength property are reflected in to the column definition's width.
+		// We assume here that the control-template is setup with: SplitView\Grid\@ColumnDefinition[0].Width bound to TemplateSettings.OpenPaneLength
+		// Should the template change, this test will need to be updated accordingly or voided.
+
+		var sut = new SplitView()
+		{
+			OpenPaneLength = 100,
+			CompactPaneLength = 50
+		};
+		await UITestHelper.Load(sut, x => x.IsLoaded);
+
+		var rootGrid = sut.FindFirstDescendant<Grid>() ?? throw new InvalidOperationException("failed to find root grid.");
+		var columnDefinition = rootGrid.ColumnDefinitions.ElementAtOrDefault(0) ?? throw new InvalidOperationException("root grid doesnt contains any column definition");
+
+		Assert.AreEqual(sut.OpenPaneLength, columnDefinition.Width.Value, "ColumnDefinition Width should be equal to OpenPaneLength");
+
+		sut.OpenPaneLength = 105;
+		await UITestHelper.WaitForIdle();
+
+		Assert.AreEqual(sut.OpenPaneLength, columnDefinition.Width.Value, "ColumnDefinition Width should be equal to OpenPaneLength after update");
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitViewTemplateSettings.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitViewTemplateSettings.cs
@@ -4,34 +4,199 @@ using System.Text;
 using Windows.Foundation;
 using Microsoft.UI.Xaml.Media;
 
-namespace Microsoft.UI.Xaml.Controls.Primitives
+// With temporary workaround for #20623: updating SplitView.OpenPaneLength has no effect at runtime
+// that happens because we are using neither INotifyPropertyChanged or DependencyObject::SetValue here.
+// For now, we are turning auto-properties and get-only calculated properties into
+// DependencyProperties with handlers that updates its dependants.
+
+// When eventually updating this file, in accordance with WinUI,
+// these should all be DependencyProperties that are updated by the SplitView.
+
+namespace Microsoft.UI.Xaml.Controls.Primitives;
+
+public sealed partial class SplitViewTemplateSettings : DependencyObject
 {
-	public sealed partial class SplitViewTemplateSettings : DependencyObject
+	private const double DefaultOpenPaneLength = 320;
+	private const double DefaultCompactPaneLength = 48;
+	private const double DefaultViewHeight = 2000;
+
+	public SplitViewTemplateSettings(SplitView splitView)
 	{
-		public SplitViewTemplateSettings(SplitView splitView)
-		{
-			InitializeBinder();
+		InitializeBinder();
 
-			CompactPaneLength = splitView.CompactPaneLength;
-			OpenPaneLength = splitView.OpenPaneLength;
-		}
+		CompactPaneLength = splitView.CompactPaneLength;
+		OpenPaneLength = splitView.OpenPaneLength;
 
-		public GridLength CompactPaneGridLength { get { return new GridLength((float)CompactPaneLength, GridUnitType.Pixel); } }
-		public GridLength OpenPaneGridLength { get { return new GridLength((float)OpenPaneLength, GridUnitType.Pixel); } }
-		public double NegativeOpenPaneLength { get { return -OpenPaneLength; } }
-		public double NegativeOpenPaneLengthMinusCompactLength { get { return NegativeOpenPaneLength - CompactPaneLength; } }
-		public double OpenPaneLengthMinusCompactLength { get { return OpenPaneLength - CompactPaneLength; } }
+		UpdateCalculatedProperties();
+	}
 
-		public double OpenPaneLength { get; internal set; }
-		public double CompactPaneLength { get; internal set; }
+	#region DependencyProperty: OpenPaneLength
 
-		/// <summary>
-		/// These properties were added to facilitate clipping while RectangleGeometry.Transform is not supported
-		/// TODO: Remove and use NegativeOpenPaneLengthMinusCompactLength and OpenPaneLengthMinusCompactLength instead
-		/// </summary>
-		public RectangleGeometry LeftClip { get { return new RectangleGeometry { Rect = new Rect(0, 0, CompactPaneLength, ViewHeight) }; } }
-		public RectangleGeometry RightClip { get { return new RectangleGeometry { Rect = new Rect(OpenPaneLengthMinusCompactLength, 0, CompactPaneLength, ViewHeight) }; } }
+	public static DependencyProperty OpenPaneLengthProperty { get; } = DependencyProperty.Register(
+		nameof(OpenPaneLength),
+		typeof(double),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(DefaultOpenPaneLength, OnPropertyChanged));
 
-		public double ViewHeight { get; internal set; } = 2000;
+	public double OpenPaneLength
+	{
+		get => (double)GetValue(OpenPaneLengthProperty);
+		internal set => SetValue(OpenPaneLengthProperty, value);
+	}
+
+	#endregion
+	#region DependencyProperty: CompactPaneLength
+
+	public static DependencyProperty CompactPaneLengthProperty { get; } = DependencyProperty.Register(
+		nameof(CompactPaneLength),
+		typeof(double),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(DefaultCompactPaneLength, OnPropertyChanged));
+
+	public double CompactPaneLength
+	{
+		get => (double)GetValue(CompactPaneLengthProperty);
+		internal set => SetValue(CompactPaneLengthProperty, value);
+	}
+
+	#endregion
+	#region DependencyProperty: ViewHeight
+
+	public static DependencyProperty ViewHeightProperty { get; } = DependencyProperty.Register(
+		nameof(ViewHeight),
+		typeof(double),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(DefaultViewHeight, OnPropertyChanged));
+
+	public double ViewHeight
+	{
+		get => (double)GetValue(ViewHeightProperty);
+		internal set => SetValue(ViewHeightProperty, value);
+	}
+
+	#endregion
+	#region DependencyProperty: CompactPaneGridLength
+
+	public static DependencyProperty CompactPaneGridLengthProperty { get; } = DependencyProperty.Register(
+		nameof(CompactPaneGridLength),
+		typeof(GridLength),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(default(GridLength)));
+
+	public GridLength CompactPaneGridLength
+	{
+		get => (GridLength)GetValue(CompactPaneGridLengthProperty);
+		internal set => SetValue(CompactPaneGridLengthProperty, value);
+	}
+
+	#endregion
+	#region DependencyProperty: OpenPaneGridLength
+
+	public static DependencyProperty OpenPaneGridLengthProperty { get; } = DependencyProperty.Register(
+		nameof(OpenPaneGridLength),
+		typeof(GridLength),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(default(GridLength)));
+
+	public GridLength OpenPaneGridLength
+	{
+		get => (GridLength)GetValue(OpenPaneGridLengthProperty);
+		internal set => SetValue(OpenPaneGridLengthProperty, value);
+	}
+
+	#endregion
+	#region DependencyProperty: NegativeOpenPaneLength
+
+	public static DependencyProperty NegativeOpenPaneLengthProperty { get; } = DependencyProperty.Register(
+		nameof(NegativeOpenPaneLength),
+		typeof(double),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(default(double)));
+
+	public double NegativeOpenPaneLength
+	{
+		get => (double)GetValue(NegativeOpenPaneLengthProperty);
+		internal set => SetValue(NegativeOpenPaneLengthProperty, value);
+	}
+
+	#endregion
+	#region DependencyProperty: NegativeOpenPaneLengthMinusCompactLength
+
+	public static DependencyProperty NegativeOpenPaneLengthMinusCompactLengthProperty { get; } = DependencyProperty.Register(
+		nameof(NegativeOpenPaneLengthMinusCompactLength),
+		typeof(double),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(default(double)));
+
+	public double NegativeOpenPaneLengthMinusCompactLength
+	{
+		get => (double)GetValue(NegativeOpenPaneLengthMinusCompactLengthProperty);
+		internal set => SetValue(NegativeOpenPaneLengthMinusCompactLengthProperty, value);
+	}
+
+	#endregion
+	#region DependencyProperty: OpenPaneLengthMinusCompactLength
+
+	public static DependencyProperty OpenPaneLengthMinusCompactLengthProperty { get; } = DependencyProperty.Register(
+		nameof(OpenPaneLengthMinusCompactLength),
+		typeof(double),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(default(double)));
+
+	public double OpenPaneLengthMinusCompactLength
+	{
+		get => (double)GetValue(OpenPaneLengthMinusCompactLengthProperty);
+		internal set => SetValue(OpenPaneLengthMinusCompactLengthProperty, value);
+	}
+
+	#endregion
+	#region DependencyProperty: LeftClip
+
+	public static DependencyProperty LeftClipProperty { get; } = DependencyProperty.Register(
+		nameof(LeftClip),
+		typeof(RectangleGeometry),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(default(RectangleGeometry)));
+
+	public RectangleGeometry LeftClip
+	{
+		get => (RectangleGeometry)GetValue(LeftClipProperty);
+		internal set => SetValue(LeftClipProperty, value);
+	}
+
+	#endregion
+	#region DependencyProperty: RightClip
+
+	public static DependencyProperty RightClipProperty { get; } = DependencyProperty.Register(
+		nameof(RightClip),
+		typeof(RectangleGeometry),
+		typeof(SplitViewTemplateSettings),
+		new FrameworkPropertyMetadata(default(RectangleGeometry)));
+
+	public RectangleGeometry RightClip
+	{
+		get => (RectangleGeometry)GetValue(RightClipProperty);
+		internal set => SetValue(RightClipProperty, value);
+	}
+
+	#endregion
+
+	private static void OnPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+	{
+		(sender as SplitViewTemplateSettings)?.UpdateCalculatedProperties();
+	}
+
+	private void UpdateCalculatedProperties()
+	{
+		CompactPaneGridLength = new GridLength(CompactPaneLength, GridUnitType.Pixel);
+		OpenPaneGridLength = new GridLength(OpenPaneLength, GridUnitType.Pixel);
+		NegativeOpenPaneLength = -OpenPaneLength;
+		NegativeOpenPaneLengthMinusCompactLength = NegativeOpenPaneLength - CompactPaneLength;
+		OpenPaneLengthMinusCompactLength = OpenPaneLength - CompactPaneLength;
+
+		// These properties were added to facilitate clipping while RectangleGeometry.Transform is not supported
+		// TODO: Remove and use NegativeOpenPaneLengthMinusCompactLength and OpenPaneLengthMinusCompactLength instead
+		LeftClip = new RectangleGeometry { Rect = new Rect(0, 0, CompactPaneLength, ViewHeight) };
+		RightClip = new RectangleGeometry { Rect = new Rect(OpenPaneLengthMinusCompactLength, 0, CompactPaneLength, ViewHeight) };
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #20623

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
updating SplitView::OpenPaneLength has no effect during runtime.

## What is the new behavior?
updating SplitView::OpenPaneLength now causes the layout to update.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

## Other information
SplitViewTemplateSettings is using auto-property and get-only "calculated" property, instead of using DependencyObject::SetValue that actually notify when there is a change.
