### PR TITLE
fix: Do not uncheck the `RadioMenuFlyoutItem` that was just checked

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioMenuFlyoutItem.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioMenuFlyoutItem.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Private.Infrastructure;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
+
+[TestClass]
+[RunsOnUIThread]
+public class Given_RadioMenuFlyoutItem
+{
+	[TestMethod]
+	public async Task When_Check_Sequence()
+	{
+		var item1 = new Microsoft.UI.Xaml.Controls.RadioMenuFlyoutItem { GroupName = "group1", IsChecked = true };
+		var item2 = new Microsoft.UI.Xaml.Controls.RadioMenuFlyoutItem { GroupName = "group1" };
+		var item3 = new Microsoft.UI.Xaml.Controls.RadioMenuFlyoutItem { GroupName = "group1" };
+
+		var menu = new Microsoft.UI.Xaml.Controls.MenuFlyout();
+		menu.Items.Add(item1);
+		menu.Items.Add(item2);
+		menu.Items.Add(item3);
+
+		var button = new Microsoft.UI.Xaml.Controls.Button
+		{
+			Content = "Open Menu",
+			Flyout = menu
+		};
+		TestServices.WindowHelper.WindowContent = button;
+		await TestServices.WindowHelper.WaitForLoaded(button);
+		ButtonAutomationPeer automationPeer = (ButtonAutomationPeer)button.GetAutomationPeer();
+		automationPeer.Invoke();
+		item1.IsChecked = true;
+		Assert.IsTrue(item1.IsChecked);
+		Assert.IsFalse(item2.IsChecked);
+		Assert.IsFalse(item3.IsChecked);
+		item2.IsChecked = true;
+		Assert.IsFalse(item1.IsChecked);
+		Assert.IsTrue(item2.IsChecked);
+		Assert.IsFalse(item3.IsChecked);
+		item3.IsChecked = true;
+		Assert.IsFalse(item1.IsChecked);
+		Assert.IsFalse(item2.IsChecked);
+		Assert.IsTrue(item3.IsChecked);
+		item1.IsChecked = true;
+		Assert.IsTrue(item1.IsChecked);
+		item1.IsChecked = false;
+		Assert.IsFalse(item1.IsChecked);
+		item1.IsChecked = true;
+		Assert.IsTrue(item1.IsChecked);
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioMenuFlyoutItem.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_RadioMenuFlyoutItem.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Private.Infrastructure;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
@@ -26,13 +27,13 @@ public class Given_RadioMenuFlyoutItem
 
 		var button = new Microsoft.UI.Xaml.Controls.Button
 		{
-			Content = "Open Menu",
-			Flyout = menu
+			Content = "Open Menu"
 		};
+		FlyoutBase.SetAttachedFlyout(button, menu);
 		TestServices.WindowHelper.WindowContent = button;
 		await TestServices.WindowHelper.WaitForLoaded(button);
-		ButtonAutomationPeer automationPeer = (ButtonAutomationPeer)button.GetAutomationPeer();
-		automationPeer.Invoke();
+		FlyoutBase.ShowAttachedFlyout(button);
+		await TestServices.WindowHelper.WaitForLoaded(item1);
 		item1.IsChecked = true;
 		Assert.IsTrue(item1.IsChecked);
 		Assert.IsFalse(item2.IsChecked);

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/RadioMenuFlyoutItem/RadioMenuFlyoutItem.cs
@@ -100,8 +100,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 				{
 					if (previousCheckedItemWeak.TryGetTarget(out var previousCheckedItem))
 					{
-						// Uncheck the previously checked item.
-						previousCheckedItem.IsChecked = false;
+						if (previousCheckedItem != this)
+						{
+							// Uncheck the previously checked item.
+							previousCheckedItem.IsChecked = false;
+						}
 					}
 				}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno/issues/20655

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

When an item is checked, unchecked, and re-checked, it auto-unchecks again.


## What is the new behavior?

Should not happen.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
