### PR TITLE
feat: Add ability to have multiple direct-manipulation active in parallel

### DIFF
--- a/src/Uno.Foundation.Logging/Logger.cs
+++ b/src/Uno.Foundation.Logging/Logger.cs
@@ -63,6 +63,7 @@ namespace Uno.Foundation.Logging
 
 		public void Critical(string message) => Log(LogLevel.Critical, message);
 		public void Critical(IFormattable formattable) => Log(LogLevel.Critical, formattable.ToString());
+		public void Critical(IFormattable formattable, Exception? ex) => Log(LogLevel.Critical, formattable.ToString(), ex);
 
 		public void LogInfo(string message) => Log(LogLevel.Information, message);
 		public void LogInfo(string message, Exception? ex) => Log(LogLevel.Information, message, ex);

--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -95,10 +95,10 @@ public partial class ContainerVisual : Visual
 	}
 
 	/// <remarks>This does NOT take the clipping into account.</remarks>
-	internal virtual bool HitTest(Point point) => new Rect(0, 0, Size.X, Size.Y).Contains(point);
+	internal virtual bool HitTest(Point relativeLocation) => new Rect(0, 0, Size.X, Size.Y).Contains(relativeLocation);
 
 	/// <returns>true if a ViewBox exists</returns>
-	internal bool GetArrangeClipPathInElementCoordinateSpace(SKPath dst)
+	internal bool GetArrangeClipPathInElementCoordinateSpace(SKPath dst) // TODO: Do not use SKPath here, bad for perf and prevents usage for IDirectManipulationHandler.IsInBoundsForResume
 	{
 		if (LayoutClip is not { isAncestorClip: var isAncestorClip, rect: var rect })
 		{
@@ -122,7 +122,7 @@ public partial class ContainerVisual : Visual
 
 	private static SKPath _sparePrePaintingClippingPath = new SKPath();
 
-	internal override bool GetPrePaintingClipping(SKPath dst)
+	internal override bool GetPrePaintingClipping(SKPath dst) // TODO: Do not use SKPath here, bad for perf and prevents usage for IDirectManipulationHandler.IsInBoundsForResume
 	{
 		var prePaintingClipPath = _sparePrePaintingClippingPath;
 

--- a/src/Uno.UI.Composition/Composition/Visual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/Visual.skia.cs
@@ -379,7 +379,7 @@ public partial class Visual : global::Microsoft.UI.Composition.CompositionObject
 			}
 		}
 
-		static void PaintStep(Visual visual, PaintingSession session)
+		static void PaintStep(Visual visual, in PaintingSession session)
 		{
 			// Rendering shouldn't depend on matrix or clip adjustments happening in a visual's Paint. That should
 			// be specific to that visual and should not affect the rendering of any other visual.

--- a/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/UITestHelper.cs
@@ -454,23 +454,23 @@ public partial class Finger : IInjectedPointer, IDisposable
 	{
 		if (_currentPosition is { } current)
 		{
-			Inject(GetMove(current, position, steps, stepOffsetInMilliseconds));
+			Inject(GetMove(_id, current, position, steps, stepOffsetInMilliseconds));
 			_currentPosition = position;
 		}
 	}
 
 	void IInjectedPointer.MoveBy(double deltaX, double deltaY) => MoveBy(deltaX, deltaY);
-	public void MoveBy(double deltaX, double deltaY, uint steps = _defaultMoveSteps, uint stepOffsetInMilliseconds = _defaultStepOffsetInMilliseconds)
+	public void MoveBy(double x = 0, double y = 0, uint steps = _defaultMoveSteps, uint stepOffsetInMilliseconds = _defaultStepOffsetInMilliseconds)
 	{
 		if (_currentPosition is { } current)
 		{
-			MoveTo(current.Offset(deltaX, deltaY), steps, stepOffsetInMilliseconds);
+			MoveTo(current.Offset(x, y), steps, stepOffsetInMilliseconds);
 		}
 	}
 
 	public void Release(Point position)
 	{
-		Inject(GetRelease(position));
+		Inject(GetRelease(_id, position));
 		_currentPosition = null;
 	}
 
@@ -478,7 +478,7 @@ public partial class Finger : IInjectedPointer, IDisposable
 	{
 		if (_currentPosition is { } current)
 		{
-			Inject(GetRelease(current));
+			Inject(GetRelease(_id, current));
 			_currentPosition = null;
 		}
 	}
@@ -503,7 +503,7 @@ public partial class Finger : IInjectedPointer, IDisposable
 			}
 		};
 
-	public static IEnumerable<InjectedInputTouchInfo> GetMove(Point fromPosition, Point toPosition, uint steps = _defaultMoveSteps, uint stepOffsetInMilliseconds = _defaultStepOffsetInMilliseconds)
+	public static IEnumerable<InjectedInputTouchInfo> GetMove(uint id, Point fromPosition, Point toPosition, uint steps = _defaultMoveSteps, uint stepOffsetInMilliseconds = _defaultStepOffsetInMilliseconds)
 	{
 		steps += 1; // We need to send at least the final location, but steps refers to the number of intermediate points
 
@@ -515,6 +515,7 @@ public partial class Finger : IInjectedPointer, IDisposable
 			{
 				PointerInfo = new()
 				{
+					PointerId = id,
 					TimeOffsetInMilliseconds = stepOffsetInMilliseconds,
 					PixelLocation = At(fromPosition.X + step * stepX, fromPosition.Y + step * stepY),
 					PointerOptions = InjectedInputPointerOptions.Update
@@ -526,11 +527,12 @@ public partial class Finger : IInjectedPointer, IDisposable
 		}
 	}
 
-	public static InjectedInputTouchInfo GetRelease(Point position)
+	public static InjectedInputTouchInfo GetRelease(uint id, Point position)
 		=> new()
 		{
 			PointerInfo = new()
 			{
+				PointerId = id,
 				PixelLocation = At(position),
 				PointerOptions = InjectedInputPointerOptions.FirstButton
 					| InjectedInputPointerOptions.PointerUp

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Xaml_Core/Given_InputManager.cs
@@ -821,6 +821,312 @@ public class Given_InputManager
 #elif !HAS_INPUT_INJECTOR
 	[Ignore("InputInjector is not supported on this platform.")]
 #endif
+	public async Task When_DirectManipulationMultiple_Then_RunsIndependently()
+	{
+		ScrollViewer sv1, sv2;
+		var root = new Grid
+		{
+			Width = 400,
+			Height = 200,
+			ColumnDefinitions = { new ColumnDefinition(), new ColumnDefinition() },
+			Children =
+			{
+				(sv1 = new ScrollViewer
+				{
+					UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous,
+					Background = new SolidColorBrush(Colors.DeepPink),
+					Content = new Border
+					{
+						Background = new SolidColorBrush(Colors.BlueViolet),
+						Margin = new Thickness(10),
+						Width = 800,
+						Height = 80000,
+					}
+				}.Apply(sv => Grid.SetColumn(sv, 0))),
+				(sv2 = new ScrollViewer
+				{
+					UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous,
+					Background = new SolidColorBrush(Colors.Chartreuse),
+					Content = new Border
+					{
+						Background = new SolidColorBrush(Colors.DarkGreen),
+						Margin = new Thickness(10),
+						Width = 800,
+						Height = 80000,
+					}
+				}.Apply(sv => Grid.SetColumn(sv, 1))),
+			}
+		};
+
+		await UITestHelper.Load(root);
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+
+		using var finger1 = injector.GetFinger();
+		finger1.Press(sv1.GetAbsoluteBounds().GetCenter());
+
+		using var finger2 = injector.GetFinger(id: 83);
+		finger2.Press(sv2.GetAbsoluteBounds().GetCenter());
+
+		// Start scrolling on both fingers
+		finger1.MoveBy(y: -200);
+		finger2.MoveBy(y: -100);
+
+		sv1.VerticalOffset.Should().BeApproximately(200, precision: 2, because: "first finger should have scrolled the first ScrollViewer");
+		sv2.VerticalOffset.Should().BeApproximately(100, precision: 2, because: "second finger should have scrolled the second ScrollViewer");
+
+		// Release first finger and validate that first finger is still scrolling
+		finger1.Release();
+		finger2.MoveBy(y: -100);
+		finger2.Release();
+
+		sv1.VerticalOffset.Should().BeApproximately(200, precision: 2, because: "first ScrollViewer should not have been affected by second finger");
+		sv2.VerticalOffset.Should().BeApproximately(200, precision: 2, because: "second finger should still be scrolling the second ScrollViewer after first finger release");
+	}
+
+	[TestMethod]
+#if __WASM__
+	[Ignore("Scrolling is handled by native code and InputInjector is not yet able to inject native pointers.")]
+#elif !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
+	public async Task When_DirectManipulationMultiple_Then_RunsIndependently_2()
+	{
+		ScrollViewer sv1, sv2;
+		var root = new Grid
+		{
+			Width = 400,
+			Height = 200,
+			ColumnDefinitions = { new ColumnDefinition(), new ColumnDefinition() },
+			Children =
+			{
+				(sv1 = new ScrollViewer
+				{
+					UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous,
+					Background = new SolidColorBrush(Colors.DeepPink),
+					Content = new Border
+					{
+						Background = new SolidColorBrush(Colors.BlueViolet),
+						Margin = new Thickness(10),
+						Width = 800,
+						Height = 80000,
+					}
+				}.Apply(sv => Grid.SetColumn(sv, 0))),
+				(sv2 = new ScrollViewer
+				{
+					UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous,
+					Background = new SolidColorBrush(Colors.Chartreuse),
+					Content = new Border
+					{
+						Background = new SolidColorBrush(Colors.DarkGreen),
+						Margin = new Thickness(10),
+						Width = 800,
+						Height = 80000,
+					}
+				}.Apply(sv => Grid.SetColumn(sv, 1))),
+			}
+		};
+
+		await UITestHelper.Load(root);
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+
+		using var finger1 = injector.GetFinger();
+		finger1.Press(sv1.GetAbsoluteBounds().GetCenter());
+
+		using var finger2 = injector.GetFinger(id: 83);
+		finger2.Press(sv2.GetAbsoluteBounds().GetCenter());
+
+		// Start scrolling on both fingers
+		finger1.MoveBy(y: -100);
+		finger2.MoveBy(y: -200);
+
+		sv1.VerticalOffset.Should().BeApproximately(100, precision: 2, because: "first finger should have scrolled the first ScrollViewer");
+		sv2.VerticalOffset.Should().BeApproximately(200, precision: 2, because: "second finger should have scrolled the second ScrollViewer");
+
+		// Release second finger and validate that first finger is still scrolling
+		finger2.Release();
+		finger1.MoveBy(y: -100);
+		finger1.Release();
+
+		sv1.VerticalOffset.Should().BeApproximately(200, precision: 2, because: "first finger should still be scrolling the first ScrollViewer after second finger release");
+		sv2.VerticalOffset.Should().BeApproximately(200, precision: 2, because: "second ScrollViewer should not have been affected by first finger");
+	}
+
+	[TestMethod]
+#if __WASM__
+	[Ignore("Scrolling is handled by native code and InputInjector is not yet able to inject native pointers.")]
+#elif !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
+	public async Task When_DirectManipulationMultipleWithInertia_Then_RunsIndependently()
+	{
+		ScrollViewer sv1, sv2;
+		var root = new Grid
+		{
+			Width = 400,
+			Height = 200,
+			ColumnDefinitions = { new ColumnDefinition(), new ColumnDefinition() },
+			Children =
+			{
+				(sv1 = new ScrollViewer
+				{
+					UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous,
+					IsScrollInertiaEnabled = true,
+					Background = new SolidColorBrush(Colors.DeepPink),
+					Content = new Border
+					{
+						Background = new SolidColorBrush(Colors.BlueViolet),
+						Margin = new Thickness(10),
+						Width = 800,
+						Height = 80000,
+					}
+				}.Apply(sv => Grid.SetColumn(sv, 0))),
+				(sv2 = new ScrollViewer
+				{
+					UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous,
+					IsScrollInertiaEnabled = false,
+					Background = new SolidColorBrush(Colors.Chartreuse),
+					Content = new Border
+					{
+						Background = new SolidColorBrush(Colors.DarkGreen),
+						Margin = new Thickness(10),
+						Width = 800,
+						Height = 80000,
+					}
+				}.Apply(sv => Grid.SetColumn(sv, 1))),
+			}
+		};
+
+		await UITestHelper.Load(root);
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var finger = injector.GetFinger(); // We re-used the same finger ID on all interactions
+
+		// Start inertia on SV1
+		finger.Drag(
+			from: sv1.GetAbsoluteBounds().GetCenter(),
+			to: sv1.GetAbsoluteBounds().GetCenter().Offset(y: -200),
+			steps: 1,
+			stepOffsetInMilliseconds: 20);
+
+		var sv1VOffsetAtEndOfSv1Drag = sv1.VerticalOffset; // Capture the initial offset after the drag
+		sv1VOffsetAtEndOfSv1Drag.Should().BeGreaterOrEqualTo(200);
+
+		// Attempt to scroll SV2
+		finger.Drag(
+			from: sv2.GetAbsoluteBounds().GetCenter(),
+			to: sv2.GetAbsoluteBounds().GetCenter().Offset(y: -200),
+			steps: 1);
+		sv2.VerticalOffset.Should().BeApproximately(200, precision: 2, because: "second finger should have scrolled the second ScrollViewer");
+
+		await Task.Delay(1); // Allow time for the inertia to process at least one frame
+
+		var sv1VOffsetAtEndOfSv2Drag = sv1.VerticalOffset; // Capture the initial offset after the drag
+		sv1VOffsetAtEndOfSv2Drag.Should().BeGreaterThan(sv1VOffsetAtEndOfSv1Drag, because: "Inertia should still be running after SV2 interaction");
+
+		await Task.Delay(10); // Allow time for the inertia to process more frames (to confirm it's still running even after finger2 has been released)
+
+		sv1.VerticalOffset.Should().BeGreaterThan(sv1VOffsetAtEndOfSv2Drag, because: "Inertia should still be running");
+	}
+
+	[TestMethod]
+#if __WASM__
+	[Ignore("Scrolling is handled by native code and InputInjector is not yet able to inject native pointers.")]
+#elif !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
+	public async Task When_DirectManipulationMultipleWithMultipleInertia_Then_RunsIndependently()
+	{
+		ScrollViewer sv1, sv2;
+		var root = new Grid
+		{
+			Width = 400,
+			Height = 200,
+			ColumnDefinitions = { new ColumnDefinition(), new ColumnDefinition() },
+			Children =
+			{
+				(sv1 = new ScrollViewer
+				{
+					UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous,
+					IsScrollInertiaEnabled = true,
+					Background = new SolidColorBrush(Colors.DeepPink),
+					Content = new Border
+					{
+						Background = new SolidColorBrush(Colors.BlueViolet),
+						Margin = new Thickness(10),
+						Width = 800,
+						Height = 80000,
+					}
+				}.Apply(sv => Grid.SetColumn(sv, 0))),
+				(sv2 = new ScrollViewer
+				{
+					UpdatesMode = Uno.UI.Xaml.Controls.ScrollViewerUpdatesMode.Synchronous,
+					IsScrollInertiaEnabled = true,
+					Background = new SolidColorBrush(Colors.Chartreuse),
+					Content = new Border
+					{
+						Background = new SolidColorBrush(Colors.DarkGreen),
+						Margin = new Thickness(10),
+						Width = 800,
+						Height = 80000,
+					}
+				}.Apply(sv => Grid.SetColumn(sv, 1))),
+			}
+		};
+
+		await UITestHelper.Load(root);
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var finger = injector.GetFinger(); // We re-used the same finger ID on all interactions
+
+		// Start inertia on SV1
+		finger.Drag(
+			from: sv1.GetAbsoluteBounds().GetCenter(),
+			to: sv1.GetAbsoluteBounds().GetCenter().Offset(y: -200),
+			steps: 1,
+			stepOffsetInMilliseconds: 20);
+
+		var sv1VOffsetAtEndOfSv1Drag = sv1.VerticalOffset; // Capture the initial offset after the drag
+		sv1VOffsetAtEndOfSv1Drag.Should().BeGreaterOrEqualTo(200);
+
+		// Start inertia on SV2
+		finger.Drag(
+			from: sv2.GetAbsoluteBounds().GetCenter(),
+			to: sv2.GetAbsoluteBounds().GetCenter().Offset(y: -200),
+			steps: 1,
+			stepOffsetInMilliseconds: 20);
+
+		await Task.Delay(1); // Allow time for the inertia to process at least one frame
+
+		var sv1VOffsetAtEndOfSv2Drag = sv1.VerticalOffset; // Capture the initial offset after the drag
+		sv1VOffsetAtEndOfSv2Drag.Should().BeGreaterThan(sv1VOffsetAtEndOfSv1Drag);
+		var sv2VOffsetAtEndOfSv2Drag = sv2.VerticalOffset; // Capture the initial offset after the drag
+		sv2VOffsetAtEndOfSv2Drag.Should().BeGreaterOrEqualTo(200);
+
+		await Task.Delay(10); // Allow time for the inertia to process more frames (to confirm it's still running even after finger2 has been released)
+
+		sv1.VerticalOffset.Should().BeGreaterThan(sv1VOffsetAtEndOfSv1Drag, because: "Inertia should still be running on sv1");
+		sv2.VerticalOffset.Should().BeGreaterThan(sv2VOffsetAtEndOfSv2Drag, because: "Inertia should still be running on sv2");
+
+		// Finally stop scrollers by tapping them
+		finger.Tap(sv2.GetAbsoluteBounds().GetCenter());
+
+		var sv1VOffsetAfterSv2Tap = sv1.VerticalOffset;
+		var sv2VOffsetAfterSv2Tap = sv2.VerticalOffset;
+
+		await Task.Delay(1); // Allow time for the inertia to process at least one frame
+
+		sv1.VerticalOffset.Should().BeGreaterThan(sv1VOffsetAfterSv2Tap, because: "Inertia should still be running on sv1");
+		sv2.VerticalOffset.Should().Be(sv2VOffsetAfterSv2Tap, because: "Inertia should have been stopped on sv2");
+	}
+
+	[TestMethod]
+#if __WASM__
+	[Ignore("Scrolling is handled by native code and InputInjector is not yet able to inject native pointers.")]
+#elif !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
 	public async Task When_DirectManipulationMixedWithUIElementManipulation_Then_TopMostWins()
 	{
 		ScrollViewer sv1, sv2;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input_Preview_Injection/Given_InputInjector.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Input_Preview_Injection/Given_InputInjector.cs
@@ -76,6 +76,7 @@ public class Given_InputInjector
 			{
 				PointerInfo = new()
 				{
+					PointerId = 42,
 					PixelLocation =
 					{
 						PositionX = (int)targetLocation.X + 100 + 2,
@@ -90,6 +91,7 @@ public class Given_InputInjector
 			{
 				PointerInfo = new()
 				{
+					PointerId = 42,
 					PixelLocation =
 					{
 						PositionX = (int)targetLocation.X + 100 + 2,

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Button.cs
@@ -243,7 +243,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			}
 			async Task Release(uint i)
 			{
-				var secondPress = Finger.GetRelease(SUT.GetAbsoluteBounds().GetCenter());
+				var secondPress = Finger.GetRelease(42, SUT.GetAbsoluteBounds().GetCenter());
 				var pointerInfo = secondPress.PointerInfo;
 				pointerInfo.TimeOffsetInMilliseconds = i;
 				secondPress.PointerInfo = pointerInfo;

--- a/src/Uno.UI.RuntimeTests/UITests/_Engine/RuntimeTestsApp.cs
+++ b/src/Uno.UI.RuntimeTests/UITests/_Engine/RuntimeTestsApp.cs
@@ -155,6 +155,7 @@ public partial class RuntimeTestsApp : IApp
 					{
 						PointerInfo = new()
 						{
+							PointerId = 42,
 							PixelLocation =
 							{
 								PositionX = (int)x,
@@ -218,6 +219,7 @@ public partial class RuntimeTestsApp : IApp
 						{
 							PointerInfo = new()
 							{
+								PointerId = 42,
 								PixelLocation = new()
 								{
 									PositionX = (int)(fromX + step * stepX),
@@ -235,6 +237,7 @@ public partial class RuntimeTestsApp : IApp
 					{
 						PointerInfo = new()
 						{
+							PointerId = 42,
 							PixelLocation =
 							{
 								PositionX = (int)toX,
@@ -299,6 +302,7 @@ public partial class RuntimeTestsApp : IApp
 						{
 							PointerInfo = new()
 							{
+								PointerId = 42,
 								PixelLocation = new()
 								{
 									PositionX = (int)(fromX + step * stepX),
@@ -316,6 +320,7 @@ public partial class RuntimeTestsApp : IApp
 					{
 						PointerInfo = new()
 						{
+							PointerId = 42,
 							PixelLocation =
 							{
 								PositionX = (int)toX,

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/SwipeControl/SwipeControl.Uno.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/SwipeControl/SwipeControl.Uno.cs
@@ -37,6 +37,7 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 		private bool _hasRightContent;
 		private bool _hasTopContent;
 		private bool _hasBottomContent;
+		private bool _isReady; // Template applied
 
 		[Conditional("DEBUG")]
 		private static void SWIPECONTROL_TRACE_INFO(SwipeControl that, [CallerLineNumber] int TRACE_MSG_METH = -1, [CallerMemberName] string METH_NAME = null, SwipeControl _ = null)
@@ -52,12 +53,12 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 
 		private void InitializeInteractionTracker()
 		{
-			if (m_content.RenderTransform is null || _transform is null)
+			if (m_content is not null && (m_content.RenderTransform is null || _transform is null))
 			{
 				m_content.RenderTransform = _transform = new TranslateTransform();
 			}
 
-			if (m_swipeContentStackPanel.RenderTransform is null || _swipeStackPaneltransform is null)
+			if (m_swipeContentStackPanel is not null && (m_swipeContentStackPanel.RenderTransform is null || _swipeStackPaneltransform is null))
 			{
 				m_swipeContentStackPanel.RenderTransform = _swipeStackPaneltransform = new TranslateTransform();
 			}
@@ -449,6 +450,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 
 		private void UpdateTransforms()
 		{
+			if (_transform is null || _swipeStackPaneltransform is null)
+			{
+				return;
+			}
+
 			if (m_isHorizontal)
 			{
 				_transform.X = _desiredPosition.X;

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/SwipeControl/SwipeControl.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/SwipeControl/SwipeControl.cs
@@ -67,8 +67,11 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 
 		private void SwipeControl_Unfinalizer()
 		{
-			DetachEventHandlers(); // Do not double subscribe
-			AttachEventHandlers(isUnoUnfinalizer: true);
+			if (_isReady)
+			{
+				DetachEventHandlers(); // Do not double subscribe
+				AttachEventHandlers(isUnoUnfinalizer: true);
+			}
 		}
 
 		private void SwipeControl_Finalizer()
@@ -181,6 +184,8 @@ namespace Microsoft/* UWP don't rename */.UI.Xaml.Controls
 			GetTemplateParts();
 			EnsureClip();
 			AttachEventHandlers();
+
+			_isReady = true;
 		}
 
 		private void OnPropertyChanged(DependencyPropertyChangedEventArgs args)

--- a/src/Uno.UI/UI/Input/GestureRecognizer.Manipulation.InertiaProcessor.cs
+++ b/src/Uno.UI/UI/Input/GestureRecognizer.Manipulation.InertiaProcessor.cs
@@ -75,6 +75,23 @@ public partial class GestureRecognizer
 			public double DesiredExpansion = NaN;
 			public double DesiredExpansionDeceleration = NaN;
 
+			/// <summary>
+			/// Attempts to start the inertia processor for the given manipulation.
+			/// </summary>
+			/// <param name="owner">The manipulation instance that owns this inertia processor.</param>
+			/// <param name="processor">A reference to the inertia processor. If inertia is successfully started, this will be set to a new instance.</param>
+			/// <param name="changeSet">The set of changes that occurred during the manipulation.</param>
+			/// <returns>True if inertia was successfully started; otherwise, false.</returns>
+			/// <remarks>
+			/// Inertia can only be enabled if the following preconditions are met:
+			/// <list type="bullet">
+			/// <item><description>The <paramref name="processor"/> is null.</description></item>
+			/// <item><description>The manipulation is not a drag manipulation (<see cref="Manipulation.IsDragManipulation"/>).</description></item>
+			/// <item><description>The manipulation settings include inertia (<see cref="GestureSettingsHelper.Inertia"/>).</description></item>
+			/// <item><description>The manipulation settings include manipulations (<see cref="GestureSettingsHelper.Manipulations"/>).</description></item>
+			/// </list>
+			/// Additionally, inertia for specific properties (e.g., translation, rotation, expansion) is enabled based on the velocities and thresholds defined in the manipulation settings.
+			/// </remarks>
 			public static bool TryStart(Manipulation owner, [NotNullWhen(true)] ref InertiaProcessor? processor, ManipulationChangeSet changeSet)
 			{
 				if (processor is not null

--- a/src/Uno.UI/UI/Input/GestureRecognizer.cs
+++ b/src/Uno.UI/UI/Input/GestureRecognizer.cs
@@ -36,7 +36,7 @@ namespace Windows.UI.Input
 		internal const long DragWithTouchMinDelayMicroseconds = 300000; // https://docs.microsoft.com/en-us/windows/uwp/design/input/drag-and-drop#open-a-context-menu-on-an-item-you-can-drag-with-touch
 
 		private readonly Logger _log;
-		private IDictionary<uint, Gesture> _gestures = new Dictionary<uint, Gesture>(_defaultGesturesSize);
+		private IDictionary<PointerIdentifier, Gesture> _gestures = new Dictionary<PointerIdentifier, Gesture>(_defaultGesturesSize);
 		private Manipulation _manipulation;
 		private GestureSettings _gestureSettings = GestureSettings.Tap; // On WinUI, Tap is always raised no matter the flag set on the recognizer
 		private bool _isManipulationOrDragEnabled;
@@ -52,6 +52,9 @@ namespace Windows.UI.Input
 		}
 
 		public bool IsActive => _gestures.Count > 0 || _manipulation != null;
+
+		internal bool IsTracking(PointerIdentifier pointer)
+			=> _gestures.ContainsKey(pointer) || _manipulation?.IsActive(pointer) is true;
 
 		/// <summary>
 		/// Defines which suspicious cases should be patched by the gesture recognizer.
@@ -82,7 +85,7 @@ namespace Windows.UI.Input
 		public void ProcessDownEvent(PointerPoint value)
 		{
 			// Sanity validation. This is pretty important as the Gesture now has an internal state for the Holding state.
-			if (_gestures.TryGetValue(value.PointerId, out var previousGesture))
+			if (_gestures.TryGetValue(value.Pointer, out var previousGesture))
 			{
 				if (_log.IsEnabled(LogLevel.Debug))
 				{
@@ -98,12 +101,12 @@ namespace Windows.UI.Input
 				// This usually means that the gesture already detected a double tap
 				if (previousGesture != null)
 				{
-					_gestures.Remove(value.PointerId);
+					_gestures.Remove(value.Pointer);
 				}
 
 				return;
 			}
-			_gestures[value.PointerId] = gesture;
+			_gestures[value.Pointer] = gesture;
 
 			// Create or update a Manipulation responsible to recognize multi-pointer and drag gestures
 			if (_isManipulationOrDragEnabled)
@@ -118,7 +121,7 @@ namespace Windows.UI.Input
 			// and we should considered it for the gesture recognition when processing the up.
 			foreach (var point in value)
 			{
-				if (_gestures.TryGetValue(point.PointerId, out var gesture))
+				if (_gestures.TryGetValue(point.Pointer, out var gesture))
 				{
 					gesture.ProcessMove(point);
 				}
@@ -144,7 +147,7 @@ namespace Windows.UI.Input
 
 		internal void ProcessUpEvent(PointerPoint value, bool isRelevant)
 		{
-			if (_gestures.Remove(value.PointerId, out var gesture))
+			if (_gestures.Remove(value.Pointer, out var gesture))
 			{
 				// Note: At this point we MAY be IsActive == false, which is the expected behavior (same as UWP)
 				//		 even if we will fire some events now.
@@ -179,7 +182,7 @@ namespace Windows.UI.Input
 		{
 			// Capture the list in order to avoid alteration while enumerating
 			var gestures = _gestures;
-			_gestures = new Dictionary<uint, Gesture>(_defaultGesturesSize);
+			_gestures = new Dictionary<PointerIdentifier, Gesture>(_defaultGesturesSize);
 
 			// Note: At this point we are IsActive == false, which is the expected behavior (same as UWP)
 			//		 even if we will fire some events now.
@@ -202,7 +205,7 @@ namespace Windows.UI.Input
 			}
 
 			var ret = GestureSettings.None;
-			if (_gestures.TryGetValue(pointerId.Id, out var gesture))
+			if (_gestures.TryGetValue(pointerId, out var gesture))
 			{
 				gesture.PreventGestures(events);
 				ret |= gesture.Settings;

--- a/src/Uno.UI/UI/Xaml/Internal/DirectManipulation.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/DirectManipulation.cs
@@ -1,0 +1,497 @@
+﻿#if UNO_HAS_MANAGED_POINTERS
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Windows.Devices.Input;
+using Windows.Foundation;
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Uno.Foundation.Logging;
+using _PointerEventArgs = Windows.UI.Core.PointerEventArgs;
+
+namespace Uno.UI.Xaml.Core;
+
+internal sealed class DirectManipulation : InputManager.PointerManager.IGestureRecognizer
+{
+	/*
+			                      "Continuing"            "Resuming"                      
+			                  ┌─────────────────────┐   ┌────────────┐                    
+			                  │                     ▼   ▼            │                    
+			                  │  ┌─────────┐    ┌───────────┐    ┌───┴────┐    ┌─────────┐
+			 Pointer pressed ─┴─►│Preparing├───►│Interacting├───►│Inertial├───►│Completed│
+			                     └───┬─────┘    └─────┬─────┘    └───┬────┘    └─────────┘
+			                         │                │              │              ▲     
+			                         │                │              │              │     
+			                         │                │              │              │     
+			                         │                │              │         ┌────┴────┐
+			                         └────────────────┴──────────────┴────────►│Cancelled│
+			                                                                   └─────────┘
+
+		Note: Cancelled is "cancelled by the user" using the UIElement.CancelDirectManipulation method.
+			  It will only prevent any pointer event processing by the recognizer, except the pt cancel / remove (treated as pt cancel in that case).
+			  It's not like the "aborted" event, which is fired when the manipulation is aborted by the recognizer
+			  (Which is usually because `Settings` configured in the starting event prevents any manipulation detection).
+			  It's neither caused by a pointer cancelled event, which is only completing the current gesture,
+			  just like a pointer released event (but without any possible gesture).
+	 */
+
+#pragma warning disable IDE0055
+	public enum States
+	{	//		can:		Add handler		Add pointer									Scavenge on pt remove
+		Preparing,		//	true			false										true
+		Interacting,	//	false			true (multi-touch, a.k.a. "continuing")		false
+		Inertial,		//	false			true (a.k.a. "resuming")					false
+		Cancelled,		//	false			false										true
+		Completed,		//	false			false										true
+	}
+#pragma warning restore IDE0055
+
+	private static readonly Logger _log = LogExtensionPoint.Log(typeof(InputManager.PointerManager));
+	private static readonly Action<string>? Trace = _log.IsEnabled(LogLevel.Trace) ? _log.Trace : null;
+
+	private readonly InputManager.PointerManager _pointerManager;
+	private readonly DirectManipulationCollection _collection;
+	private readonly GestureRecognizer _recognizer;
+
+	private bool _isResuming;
+	private GestureSettings _settings;
+	private Windows.UI.Core.PointerEventArgs? _currentPointerArgs;
+
+	private States _state = States.Preparing;
+
+	// The handler for inertial manipulations, if any.
+	// Note: once inertia as started we support only one handler!
+	// Note 2: In case of resume, that handler might change!
+	private IDirectManipulationHandler? _inertiaHandler;
+
+	public List<IDirectManipulationHandler> Handlers { get; } = new();
+
+	public DirectManipulation(InputManager.PointerManager pointerManager, DirectManipulationCollection collection)
+	{
+		_pointerManager = pointerManager;
+		_collection = collection;
+
+		_recognizer = new GestureRecognizer(this)
+		{
+			GestureSettings = GestureSettingsHelper.Manipulations,
+			PatchCases = WinRTFeatureConfiguration.GestureRecognizer.PatchCasesForDirectManipulation
+		};
+		_recognizer.ManipulationStarting += _onDirectManipulationStarting;
+		_recognizer.ManipulationStarted += _onDirectManipulationStarted;
+		_recognizer.ManipulationUpdated += _onDirectManipulationUpdated;
+		_recognizer.ManipulationInertiaStarting += _onDirectManipulationInertiaStarting;
+		_recognizer.ManipulationCompleted += _onDirectManipulationCompleted;
+		_recognizer.ManipulationAborted += _onDirectManipulationAborted;
+	}
+
+	/// <summary>
+	/// Indicates that the manipulation has started and all pointer events now has to be forwarded to this manipulation instead of being propagated to the visual tree.
+	/// </summary>
+	/// <remarks>Once true, will remain true forever! Complete will NOT set this back to false.</remarks>
+	public bool HasStarted { get; private set; }
+
+	public bool IsCompleted => _state is States.Completed;
+
+	public bool IsPointerType(Windows.Devices.Input.PointerDeviceType type)
+		=> _recognizer.PendingManipulation is { PointerDeviceType: var currentType } && currentType == (Microsoft.UI.Input.PointerDeviceType)type;
+
+	/// <summary>
+	/// Gets a boolean indicating that this manipulation is currently tracking the given pointer.
+	/// "Tracking" means that the manipulation is interested in all updates of the pointer (i.e. not inertial).
+	/// (This does NOT mean "interacting" !!)
+	/// </summary>
+	public bool IsTracking(PointerIdentifier pointer)
+		=> _state is not States.Inertial && _recognizer.PendingManipulation?.IsActive(pointer) is true;
+
+	public bool Cancel()
+	{
+		// Note: When cancelled, the GestureRecognizer is no longer updated until the pointer up / cancel.
+		var wasActive = _state is States.Interacting or States.Inertial;
+		_state = States.Cancelled;
+		return wasActive;
+	}
+
+	#region Pointers input (direct-manip specific try-redirect methods [pre dispatch] + IGestureRecognizer [post dispatch])
+	public bool TryProcessEnter(_PointerEventArgs args)
+	{
+		// WARNING: Unlike others TryProcess*** methods, this method is called for all pointers of same type, not only those that was considered as IsInteracting.
+
+		Debug.Assert(_state is not States.Completed, "Inactive manipulation should have been scavenged prior trying to continue/resume.");
+
+		// Note: We can resume an inertial manip ONLY if the inertial handler accepts it ... usually it will be when the pressed pointer is again on the target element.
+		if (_inertiaHandler?.CanAddPointerAt(args.CurrentPoint.Position) ?? false)
+		{
+			Debug.Assert(_state is States.Inertial);
+
+			// We don't need to do anything here, we wait for the down to .
+
+			return true;
+		}
+		// "continue" multi-touch: else if(lastActiveHandler.IsInBoundsForResume())
+		else
+		{
+			// Pointer is out-of-range, let continue normal processing (and potentially start another direct-manipulation).
+
+			return false;
+		}
+	}
+
+	public bool TryProcessDown(_PointerEventArgs args)
+	{
+		// WARNING: Unlike others TryProcess*** methods, this method is called for all pointers of same type, not only those that was considered as IsInteracting.
+
+		Debug.Assert(_state is not States.Completed, "Inactive manipulation should have been scavenged prior trying to continue/resume.");
+
+		// There are 2 cases where a manipulation can process a down event:
+		//		* Single touch: inertial
+		//		* Multi touch: multiples pinches (to zoom) with the release of only one pointer **NOT SUPPORTED**
+
+		// Note: We can resume an inertial manip ONLY if the inertial handler accepts it ... usually it will be when the pressed pointer is again on the target element.
+		if (_inertiaHandler?.CanAddPointerAt(args.CurrentPoint.Position) ?? false)
+		{
+			Debug.Assert(_state is States.Inertial);
+
+			// Pointer is again above the element which currently handles the inertia, we can resume the direct manipulation.
+			_isResuming = true;
+			try
+			{
+				// For now we do not support multi-touch direct-manipulations, so we complete the previous manipulation and start a new one.
+				// This has be changed to support pinch to zoom.
+				using var _ = WithCurrent(args);
+				_recognizer.CompleteGesture();
+				_recognizer.ProcessDownEvent(args.CurrentPoint); // Starts a new manipulation (in starting state for now).
+			}
+			finally
+			{
+				_isResuming = false;
+			}
+
+			return true;
+		}
+		// "continue" multi-touch: else if(lastActiveHandler.IsInBoundsForResume())
+		else
+		{
+			// Pointer is out-of-range, let continue normal processing (and potentially start another direct-manipulation).
+
+			return false;
+		}
+	}
+
+	/// <inheritdoc />
+	public void ProcessDown(_PointerEventArgs args)
+	{
+		if (_state is States.Preparing) // If resuming, we would have already processed the down event in TryProcessDown.
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Adding pointer --POST DISPATCH-- (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+
+			using var _ = WithCurrent(args);
+			_recognizer.ProcessDownEvent(args.CurrentPoint);
+		}
+	}
+
+	public bool TryProcessMove(_PointerEventArgs args)
+	{
+		Debug.Assert(_state is States.Preparing or States.Interacting or States.Cancelled);
+
+		if (_state is States.Interacting)
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Handling PRE move (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+
+			using var _ = WithCurrent(args);
+			_recognizer.ProcessMoveEvents([args.CurrentPoint]);
+		}
+
+		return HasStarted;
+	}
+
+	/// <inheritdoc />
+	public void ProcessMove(_PointerEventArgs args)
+	{
+		Debug.Assert(_state is States.Preparing or States.Cancelled, "In all other states we should it should have gone to the TryProcessMove and prevented dispatch to visual tree)");
+
+		if (_state is not States.Cancelled)
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Handling POST move (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+
+			using var _ = WithCurrent(args);
+			_recognizer.ProcessMoveEvents([args.CurrentPoint]);
+		}
+	}
+
+	public bool TryProcessRelease(_PointerEventArgs args)
+	{
+		Debug.Assert(_state is States.Preparing or States.Interacting or States.Cancelled);
+
+		if (_state is States.Interacting)
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Releasing pointer (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+
+			using var _ = WithCurrent(args);
+			_recognizer.ProcessUpEvent(args.CurrentPoint); // Will move **single-touch** manipulation to completed state
+		}
+		else if (_state is not States.Completed)
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Releasing -abort- pointer (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+
+			using var _ = WithCurrent(args);
+			// Note: This is **not** multi-touch safe! We need to wait for the last pointer to be released/cancelled before completing the manipulation.
+			_recognizer.CompleteGesture(); // Will move **single-touch** manipulation to completed state
+		}
+
+		return HasStarted;
+	}
+
+	/// <inheritdoc />
+	public void ProcessUp(_PointerEventArgs args)
+	{
+		Debug.Assert(_state is not States.Interacting, "Interacting should have been processed by TryProcessRelease (and prevented dispatch to visual tree)");
+
+		if (_state is not States.Completed)
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Releasing pointer of an non-started manip (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+
+			using var _ = WithCurrent(args);
+			// Note: This is **not** multi-touch safe! We need to wait for the last pointer to be released/cancelled before completing the manipulation.
+			_recognizer.CompleteGesture(); // Will move to completed state and scavenge this direct-manipulation
+		}
+	}
+
+	public bool TryProcessCancel(_PointerEventArgs args)
+	{
+		Debug.Assert(_state is States.Preparing or States.Interacting or States.Cancelled);
+
+		if (_state is not States.Completed)
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Cancelling pointer (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+
+			using var _ = WithCurrent(args);
+			// Note: This is **not** multi-touch safe! We need to wait for the last pointer to be released/cancelled before completing the manipulation.
+			_recognizer.CompleteGesture(); // Will move to completed state and scavenge this direct-manipulation 
+		}
+
+		return HasStarted;
+	}
+
+	/// <inheritdoc />
+	public void ProcessCancel(_PointerEventArgs args)
+	{
+		Debug.Assert(_state is not States.Interacting, "Interacting should have been processed by TryProcessCancel (and prevented dispatch to visual tree)");
+
+		if (_state is not States.Completed)
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Cancelling pointer of an non-started manip (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
+
+			using var _ = WithCurrent(args);
+			// Note: This is **not** multi-touch safe! We need to wait for the last pointer to be released/cancelled before completing the manipulation.
+			_recognizer.CompleteGesture(); // Will move to completed state and scavenge this direct-manipulation 
+		}
+	}
+	#endregion
+
+	#region Manipulation event handlers
+	private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartingEventArgs> _onDirectManipulationStarting = static (sender, args) => ((DirectManipulation)sender.Owner).OnDirectManipulationStarting(sender, args);
+	private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> _onDirectManipulationStarted = static (sender, args) => ((DirectManipulation)sender.Owner).OnDirectManipulationStarted(sender, args);
+	private static readonly TypedEventHandler<GestureRecognizer, ManipulationUpdatedEventArgs> _onDirectManipulationUpdated = static (sender, args) => ((DirectManipulation)sender.Owner).OnDirectManipulationUpdated(sender, args);
+	private static readonly TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> _onDirectManipulationInertiaStarting = static (sender, args) => ((DirectManipulation)sender.Owner).OnDirectManipulationInertiaStarting(sender, args);
+	private static readonly TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> _onDirectManipulationCompleted = static (sender, args) => ((DirectManipulation)sender.Owner).OnDirectManipulationCompleted(sender, args);
+	private static readonly TypedEventHandler<GestureRecognizer, GestureRecognizer.Manipulation> _onDirectManipulationAborted = static (sender, manip) => ((DirectManipulation)sender.Owner).OnDirectManipulationAborted(sender, manip);
+
+	private void OnDirectManipulationStarting(GestureRecognizer sender, ManipulationStartingEventArgs args)
+	{
+		if (_state is States.Cancelled)
+		{
+			return;
+		}
+
+		// Note: We MUST NOT use the PointerRoutedEventArgs.LastPointerEvent in this handler as it might be raised directly from a PointerEventArgs (NOT routed).
+		if (_currentPointerArgs is null)
+		{
+			Debug.Fail("_currentPointerArgs must be set before requesting to the gesture recognizer to process that event!");
+			return;
+		}
+
+		// TODO: Make sure ManipulationStarting is fired on UIElement.
+
+		if (_state is not States.Preparing)
+		{
+			Trace?.Invoke($"[DirectManipulation] **RESUMING** Starting. ==> Restoring mode {_settings}.");
+
+			args.Settings = _settings;
+
+			// Resuming (from inertia), we clear the previous inertial handler
+			_inertiaHandler = null;
+
+			// When we resume a manipulation, we don't wait for the started to go in interacting mode.
+			_state = States.Interacting; // Forcefully set as interacting without waiting for the recognizer to effectively (re-)start the manipulation
+
+			// If pointer is able to give over info, we might have let them pass through before the pressed, if so make sure to clear them.
+			_pointerManager.CancelPointer(_currentPointerArgs, isDirectManipulation: true, isDirectManipulationResume: true);
+		}
+		else if (PointerCapture.TryGet(args.Pointer, out var capture) && capture.Options.HasFlag(PointerCaptureOptions.PreventDirectManipulation))
+		{
+			Trace?.Invoke("[DirectManipulation] Ignored ==> An element in the tree prevented direct-manipulation.");
+
+			// If a control has captured the pointer with our internal PreventDirectManipulation patch flag,
+			// it means that it does not want to be redirected to direct manipulation.
+			_settings = args.Settings = GestureSettings.None;
+		}
+		else
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.Pointer}] Starting");
+
+			var supportedMode = ManipulationModes.None;
+			foreach (var handler in Handlers)
+			{
+				supportedMode |= handler.OnStarting(sender, args);
+			}
+
+			_settings = args.Settings = supportedMode.ToGestureSettings();
+
+			Trace?.Invoke($"[DirectManipulation] [{args.Pointer}] Starting ==> Final configured mode is {supportedMode}.");
+		}
+	}
+
+	private void OnDirectManipulationStarted(GestureRecognizer sender, ManipulationStartedEventArgs args)
+	{
+		if (_state is States.Cancelled)
+		{
+			return;
+		}
+
+		// Note: We MUST NOT use the PointerRoutedEventArgs.LastPointerEvent in this handler as it might be raised directly from a PointerEventArgs (NOT routed).
+		if (_currentPointerArgs is null)
+		{
+			Debug.Fail("_currentPointerArgs must be set before requesting to the gesture recognizer to process that event!");
+			return;
+		}
+
+		HasStarted = true;
+
+		if (_state is States.Preparing)
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.Pointers[0]}] Started @={args.Position.ToDebugString()}");
+
+			_state = States.Interacting;
+
+			// Stealing the pointer! Starting from here, no other element in the visual tree will receive pointer events for this pointer,
+			// and we will receive them only through the TryProcess*** methods.
+			_pointerManager.CancelPointer(_currentPointerArgs, isDirectManipulation: true);
+
+			foreach (var handler in Handlers)
+			{
+				handler.OnStarted(sender, args, isResuming: false);
+			}
+		}
+		else
+		{
+			Trace?.Invoke($"[DirectManipulation] [{args.Pointers[0]}] **RESUMING** Started @={args.Position.ToDebugString()}");
+
+			// Note: No needs to _state = States.Interacting, this has been done by the Starting
+
+			foreach (var handler in Handlers)
+			{
+				handler.OnStarted(sender, args, isResuming: true);
+			}
+		}
+	}
+
+	private void OnDirectManipulationUpdated(GestureRecognizer sender, ManipulationUpdatedEventArgs args)
+	{
+		if (_state is States.Cancelled)
+		{
+			return;
+		}
+
+		Trace?.Invoke($"[DirectManipulation] [{args.Pointers[0]}] Update @={args.Position.ToDebugString()} | Δ=({args.Delta} | v={args.Velocities}){(args.IsInertial ? " *inertial*" : "")}");
+
+		Debug.Assert(!args.IsInertial || _inertiaHandler is not null);
+
+		var unhandledDelta = args.Delta;
+		if (args.IsInertial && _inertiaHandler is { } inertialHandler)
+		{
+			inertialHandler.OnUpdated(sender, args, ref unhandledDelta);
+		}
+		else
+		{
+			foreach (var handler in Handlers)
+			{
+				handler.OnUpdated(sender, args, ref unhandledDelta);
+			}
+		}
+	}
+
+	private void OnDirectManipulationInertiaStarting(GestureRecognizer sender, ManipulationInertiaStartingEventArgs args)
+	{
+		if (_state is States.Cancelled)
+		{
+			return;
+		}
+
+		Trace?.Invoke($"[DirectManipulation] [{args.Pointers[0]}] Inertia starting @={args.Position.ToDebugString()} | Δ=({args.Delta}) | v=({args.Velocities})");
+
+		args.UseCompositionTimer = WinRTFeatureConfiguration.GestureRecognizer.UseCompositionTimerForDirectManipulation;
+
+		_state = States.Inertial;
+
+		var isHandled = false;
+		foreach (var handler in Handlers)
+		{
+			if (handler.OnInertiaStarting(sender, args, isHandled))
+			{
+				_inertiaHandler ??= handler; // We assume that only one handler will handle the inertia.
+				isHandled = true;
+			}
+		}
+	}
+
+	private void OnDirectManipulationCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs args)
+	{
+		if (_isResuming) // Possible only when cancelled during inertia, cf. TryProcessDown
+		{
+			return;
+		}
+
+		Trace?.Invoke($"[DirectManipulation] [{args.Pointers[0]}] Completed @={args.Position.ToDebugString()}");
+
+		_state = States.Completed;
+
+		// Even if cancelled we still want to notify the handlers that the manipulation has completed to avoid leaking state.
+		foreach (var handler in Handlers)
+		{
+			handler.OnCompleted(recognizer, args);
+		}
+	}
+
+	private void OnDirectManipulationAborted(GestureRecognizer recognizer, GestureRecognizer.Manipulation manip)
+	{
+		Trace?.Invoke("[DirectManipulation] Aborted");
+
+		_state = States.Completed;
+
+		// Even if cancelled we still want to notify the handlers that the manipulation has completed to avoid leaking state.
+		foreach (var handler in Handlers)
+		{
+			handler.OnCompleted(recognizer, null);
+		}
+	}
+	#endregion
+
+	private readonly struct CurrentArgSubscription(DirectManipulation manipulation) : IDisposable
+	{
+		/// <inheritdoc />
+		public void Dispose()
+			=> manipulation._currentPointerArgs = null;
+	}
+
+	private CurrentArgSubscription WithCurrent(Windows.UI.Core.PointerEventArgs args)
+	{
+		Debug.Assert(_currentPointerArgs is null);
+		_currentPointerArgs = args;
+		return new CurrentArgSubscription(this);
+	}
+
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Internal/DirectManipulationCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/DirectManipulationCollection.cs
@@ -1,0 +1,44 @@
+﻿#if UNO_HAS_MANAGED_POINTERS
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Windows.Devices.Input;
+
+namespace Uno.UI.Xaml.Core;
+
+internal sealed class DirectManipulationCollection : IEnumerable<DirectManipulation>
+{
+	// Note: We should optimize this collection to track manipulation per active PointerIdentifier.
+	//		 This would involve to add an event to the GestureRecognizer when it starts to handle a pointer.
+	//		 We will also have to consider that a manipulation might be associated to 0 (inertial), 1 or more PointerIdentifiers!
+	//		 It's also possible to have multiple manipulation (in different states, e.g. one interacting and one inertial) for the same PointerIdentifier!
+
+	private readonly List<DirectManipulation> _instances = new();
+
+	public void Scavenge()
+		=> _instances.RemoveAll(static manip => manip.IsCompleted);
+
+	public IEnumerable<DirectManipulation> OfType(PointerDeviceType type)
+	{
+		return _instances.Where(manip => manip.IsPointerType(type));
+	}
+
+	public DirectManipulation? Get(PointerIdentifier identifier)
+		=> _instances.FirstOrDefault(manip => manip.IsTracking(identifier));
+
+	public void Add(DirectManipulation manipulation)
+		=> _instances.Add(manipulation);
+
+	public void Remove(DirectManipulation manipulation)
+		=> _instances.Remove(manipulation);
+
+	/// <inheritdoc />
+	public IEnumerator<DirectManipulation> GetEnumerator()
+		=> _instances.GetEnumerator();
+
+	IEnumerator IEnumerable.GetEnumerator()
+		=> GetEnumerator();
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Internal/DirectManipulationCollection.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/DirectManipulationCollection.cs
@@ -40,5 +40,8 @@ internal sealed class DirectManipulationCollection : IEnumerable<DirectManipulat
 
 	IEnumerator IEnumerable.GetEnumerator()
 		=> GetEnumerator();
+
+	public void ClearForFatalError()
+		=> _instances.Clear();
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Internal/IDirectManipulationHandler.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/IDirectManipulationHandler.cs
@@ -1,0 +1,58 @@
+﻿#if UNO_HAS_MANAGED_POINTERS
+#nullable enable
+using System;
+using System.Linq;
+using Windows.Foundation;
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml.Input;
+
+namespace Uno.UI.Xaml.Core;
+
+/// <remarks>
+/// Unlike manipulations on a UIElement, we can "resume" it, so the sequence can be:
+/// Starting{1} ──► Started{1} ──► Updated{1-*} ───────────────────────────────────────────────────► Completed{1}
+///                                  ▲   │                                                               ▲
+///                                  │   └────► InertiaStarting{1} ──► Updated(isInertial=true){1-*} ────┤
+///                                  │                                                                   │
+///                                  └─────────────────── Started(isResuming=true){1} ◄──────────────────┘
+/// 
+/// While on UIElement it could be only
+/// Starting{1} ──► Started{1} ──► Updated{1-*} ───────────────────────────────────────────────────► Completed{1}
+///                                      │                                                               ▲
+///                                      └────► InertiaStarting{1} ──► Updated(isInertial=true){1-*} ────┘
+/// </remarks>
+internal interface IDirectManipulationHandler
+{
+	object? Owner { get; }
+
+	ManipulationModes OnStarting(GestureRecognizer recognizer, ManipulationStartingEventArgs args);
+
+	/// <summary>
+	/// Determines if a pointer point is in handler's bounds, so a new pointer can be added to the current direct-manipulation.
+	/// </summary>
+	bool CanAddPointerAt(in Point absoluteLocation)
+		=> false;
+
+	/// <summary>
+	/// Invoked when the manipulation has started.
+	/// Starting from here, other elements in the tree will no longer receive pointer events (get PointerCaptureLost)
+	/// </summary>
+	/// <param name="recognizer">The associated gesture recognizer.</param>
+	/// <param name="args"></param>
+	/// <param name="isResuming">
+	/// Indicates if this start is resuming a previous manipulation (e.g. touch again while in an inertial translation).
+	/// WARNING: Args.Cumulative will be reset starting from here. If using it in OnUpdated or any other handlers, make sure to aggregate them!
+	/// </param>
+	void OnStarted(GestureRecognizer recognizer, ManipulationStartedEventArgs args, bool isResuming) { }
+
+	void OnUpdated(GestureRecognizer recognizer, ManipulationUpdatedEventArgs args, ref ManipulationDelta unhandledDelta) { }
+
+	/// <remarks>
+	/// Be aware that unlike manipulations on a UIElement, we can "resume" it, so this can be invoked more than once.
+	/// </remarks>
+	bool OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args, bool isHandled)
+		=> false;
+
+	void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs? args) { }
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.Managed.cs
@@ -82,13 +82,107 @@ internal partial class InputManager
 
 			CoreWindow.GetForCurrentThreadSafe()?.SetPointerInputSource(_source);
 
-			_source.PointerMoved += (c, e) => OnPointerMoved(e);
-			_source.PointerEntered += (c, e) => OnPointerEntered(e);
-			_source.PointerExited += (c, e) => OnPointerExited(e);
-			_source.PointerPressed += (c, e) => OnPointerPressed(e);
-			_source.PointerReleased += (c, e) => OnPointerReleased(e);
-			_source.PointerWheelChanged += (c, e) => OnPointerWheelChanged(e);
-			_source.PointerCancelled += (c, e) => OnPointerCancelled(e);
+			_source.PointerMoved += (c, e) =>
+			{
+				try
+				{
+					OnPointerMoved(e);
+				}
+				catch (Exception error)
+				{
+					OnTopLevelFatalError(nameof(OnPointerMoved), error);
+				}
+			};
+			_source.PointerEntered += (c, e) =>
+			{
+				try
+				{
+					OnPointerEntered(e);
+				}
+				catch (Exception error)
+				{
+					OnTopLevelFatalError(nameof(OnPointerEntered), error);
+				}
+			};
+			_source.PointerExited += (c, e) =>
+			{
+				try
+				{
+					OnPointerExited(e);
+				}
+				catch (Exception error)
+				{
+					OnTopLevelFatalError(nameof(OnPointerExited), error);
+				}
+			};
+			_source.PointerPressed += (c, e) =>
+			{
+				try
+				{
+					OnPointerPressed(e);
+				}
+				catch (Exception error)
+				{
+					OnTopLevelFatalError(nameof(OnPointerPressed), error);
+				}
+			};
+			_source.PointerReleased += (c, e) =>
+			{
+				try
+				{
+					OnPointerReleased(e);
+				}
+				catch (Exception error)
+				{
+					OnTopLevelFatalError(nameof(OnPointerReleased), error);
+				}
+			};
+			_source.PointerWheelChanged += (c, e) =>
+			{
+				try
+				{
+					OnPointerWheelChanged(e);
+				}
+				catch (Exception error)
+				{
+					OnTopLevelFatalError(nameof(OnPointerWheelChanged), error);
+				}
+			};
+			_source.PointerCancelled += (c, e) =>
+			{
+				try
+				{
+					OnPointerCancelled(e);
+				}
+				catch (Exception error)
+				{
+					OnTopLevelFatalError(nameof(OnPointerCancelled), error);
+				}
+			};
+		}
+
+		private void OnTopLevelFatalError(string evt, Exception error)
+		{
+			if (this.Log().IsEnabled(LogLevel.Critical))
+			{
+				this.Log().Critical($"""
+					Critical error while handling pointer event '{evt}'.
+					This is a top level error handler to prevent application crash, but error is not recoverable and pointers are expected to work erratically starting from now.
+					Application restart is required to continue.
+					Please report issue to the team.
+					""",
+					error);
+			}
+
+			// Attempt to recover by clearing all states that can prevent normal pointer event dispatching.
+			try
+			{
+				_directManipulations.ClearForFatalError();
+				_gestureRecognizers.ClearForFataError();
+				PointerCapture.ClearForFatalError();
+				_reRouted = null;
+			}
+			catch { }
 		}
 
 		#region Current event dispatching transaction

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -70,7 +70,7 @@ partial class InputManager
 			var manipulation = _directManipulations.Get(pointer);
 			if (manipulation is null)
 			{
-				manipulation = new DirectManipulation(this, _directManipulations);
+				manipulation = new DirectManipulation(this, _directManipulations, pointer);
 
 				_directManipulations.Add(manipulation);
 				RegisterGestureRecognizerCore(pointer, manipulation);

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -411,6 +411,15 @@ partial class InputManager
 			/// <inheritdoc />
 			IEnumerator IEnumerable.GetEnumerator()
 				=> GetEnumerator();
+
+			public void ClearForFataError()
+			{
+				for (var i = 0; i < _length; i++)
+				{
+					_hasValues[i] = false;
+					_values[i] = default!;
+				}
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -15,7 +15,6 @@ using Windows.Foundation;
 using Windows.UI.Core;
 using Windows.UI.Input.Preview.Injection;
 using Microsoft.UI.Xaml.Controls;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Windows.Devices.Input;
@@ -36,48 +35,7 @@ partial class InputManager
 {
 	partial class PointerManager
 	{
-		/// <remarks>
-		/// Unlike manipulations on a UIElement, we can "resume" it, so the sequence can be:
-		/// Starting{1} ──► Started{1} ──► Updated{1-*} ───────────────────────────────────────────────────► Completed{1}
-		///                                  ▲   │                                                               ▲
-		///                                  │   └────► InertiaStarting{1} ──► Updated(isInertial=true){1-*} ────┤
-		///                                  │                                                                   │
-		///                                  └─────────────────── Started(isResuming=true){1} ◄──────────────────┘
-		/// 
-		/// While on UIElement it could be only
-		/// Starting{1} ──► Started{1} ──► Updated{1-*} ───────────────────────────────────────────────────► Completed{1}
-		///                                      │                                                               ▲
-		///                                      └────► InertiaStarting{1} ──► Updated(isInertial=true){1-*} ────┘
-		/// </remarks>
-		internal interface IDirectManipulationHandler
-		{
-			object? Owner { get; }
-
-			ManipulationModes OnStarting(GestureRecognizer recognizer, ManipulationStartingEventArgs args);
-
-			/// <summary>
-			/// Invoked when the manipulation has started.
-			/// Starting from here, other elements in the tree will no longer receive pointer events (get PointerCaptureLost)
-			/// </summary>
-			/// <param name="recognizer">The associated gesture recognizer.</param>
-			/// <param name="args"></param>
-			/// <param name="isResuming">
-			/// Indicates if this start is resuming a previous manipulation (e.g. touch again while in an inertial translation).
-			/// WARNING: Args.Cumulative will be reset starting from here. If using it in OnUpdated or any other handlers, make sure to aggregate them!
-			/// </param>
-			void OnStarted(GestureRecognizer recognizer, ManipulationStartedEventArgs args, bool isResuming) { }
-
-			void OnUpdated(GestureRecognizer recognizer, ManipulationUpdatedEventArgs args, ref ManipulationDelta unhandledDelta) { }
-
-			/// <remarks>
-			/// Be aware that unlike manipulations on a UIElement, we can "resume" it, so this can be invoked more than once.
-			/// </remarks>
-			void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args, ref bool isHandled) { }
-
-			void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs? args) { }
-		}
-
-		private interface IGestureRecognizer
+		internal interface IGestureRecognizer
 		{
 			void ProcessDown(Windows.UI.Core.PointerEventArgs args);
 
@@ -88,7 +46,12 @@ partial class InputManager
 			void ProcessCancel(Windows.UI.Core.PointerEventArgs args);
 		}
 
-		private readonly PointerTypePseudoDictionary<DirectManipulation> _directManipulations = new();
+		// The direct manipulations, i.e. the manipulation that "stole" the pointer to send events only to its handlers
+		// Could be either composition-based (e.g. InteractionTracker) or UIElement-based (e.g. ScrollViewer).
+		private readonly DirectManipulationCollection _directManipulations = new();
+
+		// All the gesture recognizer currently active in the visual tree, including both direct-manipulation and plain UIElement recognizers (for manipulation events, not ScrollViewer).
+		// This unified ordered list is required to make sure, in case of conflicting manipulations kinds, it's the top most recognizer that is able to start first.
 		private readonly PointerTypePseudoDictionary<Queue<IGestureRecognizer>> _gestureRecognizers = new();
 
 		internal void RegisterDirectManipulationHandler(PointerIdentifier pointer, IDirectManipulationHandler handler)
@@ -99,22 +62,33 @@ partial class InputManager
 
 		private void RegisterDirectManipulationHandlerCore(PointerIdentifier pointer, IDirectManipulationHandler handler)
 		{
-			if (!_directManipulations.TryGetValue(pointer.Type, out var manip))
-			{
-				manip = _directManipulations[pointer.Type] = new(this);
-				RegisterGestureRecognizerCore(pointer, manip);
-			}
-
-			manip.Handlers.Add(handler);
-
 			if (_trace)
 			{
 				Trace($"[DirectManipulation] [{pointer}] Redirection requested to {handler.GetDebugName()}");
 			}
+
+			var manipulation = _directManipulations.Get(pointer);
+			if (manipulation is null)
+			{
+				manipulation = new DirectManipulation(this, _directManipulations);
+
+				_directManipulations.Add(manipulation);
+				RegisterGestureRecognizerCore(pointer, manipulation);
+			}
+
+			manipulation.Handlers.Add(handler);
 		}
 
+		/// <summary>
+		/// When a gesture recognizers on a UIElement is STARTING
+		/// </summary>
 		internal void RegisterUiElementManipulationRecognizer(PointerIdentifier pointer, UIElement element, GestureRecognizer recognizer)
 			=> RegisterGestureRecognizerCore(pointer, new UIElementRecognizer(element, recognizer));
+
+		/// <summary>
+		/// When a gesture recognizers on a UIElement completes
+		/// </summary>
+		internal void UnregisterUiElementManipulationRecognizer(PointerIdentifier[] pointers, GestureRecognizer recognizer) { }
 
 		private void RegisterGestureRecognizerCore(PointerIdentifier pointer, IGestureRecognizer recognizer)
 		{
@@ -139,11 +113,7 @@ partial class InputManager
 			var cancelled = false;
 			foreach (var pointer in identifiers)
 			{
-				if (_directManipulations.TryGetValue(pointer.Type, out var manip))
-				{
-					cancelled |= manip.IsActive;
-					manip.Cancel();
-				}
+				cancelled |= _directManipulations.Get(pointer)?.Cancel() is true;
 			}
 
 			return cancelled;
@@ -155,12 +125,11 @@ partial class InputManager
 		internal bool CancelDirectManipulations(UIElement requestingElement)
 		{
 			var cancelled = false;
-			foreach (var (_, manip) in _directManipulations)
+			foreach (var manipulation in _directManipulations)
 			{
-				if (manip.Handlers.Any(handler => handler.Owner == requestingElement))
+				if (manipulation.Handlers.Any(handler => handler.Owner == requestingElement))
 				{
-					cancelled |= manip.IsActive;
-					manip.Cancel();
+					cancelled |= manipulation.Cancel();
 				}
 			}
 
@@ -168,61 +137,56 @@ partial class InputManager
 		}
 
 		private bool IsRedirectedToManipulations(PointerIdentifier pointerId)
-			=> _directManipulations.ContainsKey(pointerId.Type);
+			=> _directManipulations.Get(pointerId)?.HasStarted is true;
 
-		private bool BeforePressTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
+		private bool BeforeEnterTryRedirectToManipulation(Windows.UI.Core.PointerEventArgs args)
 		{
-			// Currently we do not support to redirect pointer before the press event (e.g. in pointer hover move).
-			// This is theoretically possible using composition APIs, but currently never the case in current source code (as of 2025-03-24),
-			// and is also most probably refused by WinUI.
-			// So we cancel all gesture recognizer, except the one that is for the same kind of pointer (to allow multi-touch manipulation).
+			// First we scavenge all manipulations that are no longer active
+			_directManipulations.Scavenge();
 
-			var currentPointer = args.CurrentPoint.Pointer;
-			var redirected = false;
-			foreach ((var pointer, var manipulation) in _directManipulations)
+			// Search for the first direct-manipulation that is able to handle this new pointer
+			foreach (var manipulation in _directManipulations.OfType(args.CurrentPoint.PointerDeviceType))
 			{
-				if (pointer == currentPointer.Type && manipulation.IsActive)
-				{
-					// The pointer is of the same type of the pending manipulation:
-					//		* Single touch: inertial
-					//		* Multi touch: multiples pinches (to zoom) with the release of only one pointer **NOT SUPPORTED**
-
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{pointer}] Resuming previous manipulation (as we have a down for {currentPointer}).");
-					}
-
-					using var _ = manipulation.Resuming();
-					using var __ = manipulation.WithCurrent(args);
-
-					manipulation.Recognizer.CompleteGesture();
-					manipulation.Recognizer.ProcessDownEvent(args.CurrentPoint); // Starts a new manipulation
-
-					redirected = true;
-				}
-				else
+				if (manipulation.TryProcessEnter(args))
 				{
 					if (_trace)
 					{
-						Trace($"[DirectManipulation] [{pointer}] Completing previous manipulation (as we have a down for {currentPointer}).");
+						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Enter for a resuming/continuing manipulation.");
 					}
 
-					if (manipulation.IsActive)
-					{
-						manipulation.Recognizer.CompleteGesture();
-					}
-
-					_directManipulations.Remove(pointer); // Using the PointerTypePseudoDictionary we can safely remove while enumerating
+					return true; // We was abled to find a direct-manipulation for the given args, we can stop here and prevent args to be dispatched to the visual tree.
 				}
 			}
 
-			return redirected;
+			return false;
+		}
+
+		private bool BeforePressTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
+		{
+			// First we scavenge all manipulations that are no longer active
+			_directManipulations.Scavenge();
+
+			// Search for the first direct-manipulation that is able to handle this new pointer
+			foreach (var manipulation in _directManipulations.OfType(args.CurrentPoint.PointerDeviceType))
+			{
+				if (manipulation.TryProcessDown(args))
+				{
+					if (_trace)
+					{
+						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Down which resumed/continued a previous manipulation.");
+					}
+
+					return true; // We was abled to find a direct-manipulation for the given args, we can stop here and prevent args to be dispatched to the visual tree.
+				}
+			}
+
+			return false;
 		}
 
 		private void AfterPressForDirectManipulation(Windows.UI.Core.PointerEventArgs args)
 		{
-			// Direct manip handlers will register them during the PointerPressed event bubbling, then once bubbling is over,
-			// we forward the press event to the gesture recognizer (so we will fire the ManipStarting event)
+			// Direct-manipulation handlers are typically registering them during the PointerPressed event bubbling, then once bubbling is over,
+			// we forward the press event to the gesture recognizers (which will fire the ManipStarting event)
 
 			if (_gestureRecognizers.TryGetValue(args.CurrentPoint.PointerDeviceType, out var recognizers))
 			{
@@ -234,26 +198,7 @@ partial class InputManager
 		}
 
 		private bool BeforeMoveTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
-		{
-			if (_directManipulations.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip)
-				&& manip.HasStarted) // We defer the handle of the move to **AFTER** while the manipulation has not started, so UIElement's manipulation will be able to kick-in before we stole all the pointers.
-			{
-				if (manip.IsActive)
-				{
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Handling move (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
-					}
-
-					using var _ = manip.WithCurrent(args);
-					manip.Recognizer.ProcessMoveEvents([args.CurrentPoint]);
-				}
-
-				return true; // If the manipulation has been cancelled, we still do not want to forward the event to the visual tree until the next release/cancel.
-			}
-
-			return false;
-		}
+			=> _directManipulations.Get(args.CurrentPoint.Pointer)?.TryProcessMove(args) ?? false;
 
 		private void AfterMoveForManipulations(Windows.UI.Core.PointerEventArgs args)
 		{
@@ -268,32 +213,17 @@ partial class InputManager
 
 		private bool BeforeReleaseTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
 		{
-			if (_directManipulations.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip))
+			if (_directManipulations.Get(args.CurrentPoint.Pointer)?.TryProcessRelease(args) is true)
 			{
-				if (manip.IsActive)
-				{
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Releasing pointer (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
-					}
+				// The AfterReleaseForManipulations will **not** be invoked, so make sure to clean-up the recognizers here.
+				_gestureRecognizers.Remove(args.CurrentPoint.Pointer.Type); // This is valid only because currently GestureRecognizer are completing gesture as soon as a pointer is being removed.
 
-					using var _ = manip.WithCurrent(args);
-					manip.Recognizer.ProcessUpEvent(args.CurrentPoint);
-				}
-
-				var redirected = manip.HasStarted;
-				if (redirected)
-				{
-					// If redirected, we won't receive the AfterReleaseForManipulations, make sure to clean-up UIElement recognizers.
-					// Note: We do NOT remove the recognizer from the direct manipulation, it will self-remove when the manipulation is completed (i.e. once inertia is completed!).
-					//		 This is to allow the manipulation to be cancelled if the pointer is re-pressed.
-					_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType);
-				}
-
-				return redirected;
+				return true;
 			}
-
-			return false;
+			else
+			{
+				return false;
+			}
 		}
 
 		private void AfterReleaseForManipulations(Windows.UI.Core.PointerEventArgs args)
@@ -305,37 +235,23 @@ partial class InputManager
 					recognizer.ProcessUp(args);
 				}
 
-				_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType);
+				_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType); // This is valid only because currently GestureRecognizer are completing gesture as soon as a pointer is being removed.
 			}
 		}
 
 		private bool BeforeCancelTryRedirectToManipulations(Windows.UI.Core.PointerEventArgs args)
 		{
-			if (_directManipulations.TryGetValue(args.CurrentPoint.PointerDeviceType, out var manip))
+			if (_directManipulations.Get(args.CurrentPoint.Pointer)?.TryProcessCancel(args) is true)
 			{
-				if (manip.IsActive)
-				{
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Cancelling pointer (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
-					}
+				// The AfterCancelForManipulations will **not** be invoked, so make sure to clean-up the recognizers here.
+				_gestureRecognizers.Remove(args.CurrentPoint.Pointer.Type); // This is valid only because currently GestureRecognizer are completing gesture as soon as a pointer is being removed.
 
-					using var _ = manip.WithCurrent(args);
-					manip.Cancel(); // Makes sure to complete handlers. 
-				}
-
-				var redirected = manip.HasStarted;
-				if (redirected)
-				{
-					// If redirected, we won't receive the AfterReleaseForManipulations, make sure to clean-up UIElement recognizers.
-					// Note: Even if no possible inertia here for direct-manipulation, we follow the same path as for the release and let him self-clean itself in complete.
-					_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType);
-				}
-
-				return redirected;
+				return true;
 			}
-
-			return false;
+			else
+			{
+				return false;
+			}
 		}
 
 		private void AfterCancelForManipulations(Windows.UI.Core.PointerEventArgs args)
@@ -347,7 +263,7 @@ partial class InputManager
 					recognizer.ProcessCancel(args);
 				}
 
-				_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType);
+				_gestureRecognizers.Remove(args.CurrentPoint.PointerDeviceType); // This is valid only because currently GestureRecognizer are completing gesture as soon as a pointer is being removed.
 			}
 		}
 
@@ -357,295 +273,6 @@ partial class InputManager
 			{
 				Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Is redirected, ignore the {caller} (Event is NOT being forwarded to the visual tree).");
 			}
-		}
-
-		private sealed class DirectManipulation : IGestureRecognizer
-		{
-			private readonly PointerManager _pointerManager;
-
-			private bool _isResuming;
-			private bool _isCancelled; // Has been cancelled by an external actor (UIElement.CancelDirectManipulation). Manip cannot be resumed.
-			private bool _isCompleted; // Has been completed by the recognizer. Manip cannot be resumed.
-			private GestureSettings _settings;
-			private Windows.UI.Core.PointerEventArgs? _currentPointerArgs;
-
-			public GestureRecognizer Recognizer { get; }
-
-			public List<IDirectManipulationHandler> Handlers { get; } = new();
-
-			public DirectManipulation(PointerManager pointerManager)
-			{
-				_pointerManager = pointerManager;
-				Recognizer = CreateDirectManipulationGestureRecognizer();
-			}
-
-			/// <summary>
-			/// Indicates that the manipulation has started and all pointer events now has to be forwarded to this manipulation instead of being propagated to the visual tree.
-			/// </summary>
-			/// <remarks>Once true, will remain true forever! Complete will NOT set this back to false.</remarks>
-			public bool HasStarted { get; private set; }
-
-			/// <summary>
-			/// Indicates that the direct manipulation can accept new pointer events.
-			/// </summary>
-			public bool IsActive => !_isCancelled && !_isCompleted;
-
-			public void Cancel()
-			{
-				_isCancelled = true;
-				Recognizer.CompleteGesture(); // This will actually cause `_isCompleted = true` so the `_isCancelled` is useless so far, but we keep it for clarity.
-			}
-
-			private GestureRecognizer CreateDirectManipulationGestureRecognizer()
-			{
-				var recognizer = new GestureRecognizer(this)
-				{
-					GestureSettings = GestureSettingsHelper.Manipulations,
-					PatchCases = WinRTFeatureConfiguration.GestureRecognizer.PatchCasesForDirectManipulation
-				};
-				recognizer.ManipulationStarting += OnDirectManipulationStarting;
-				recognizer.ManipulationStarted += OnDirectManipulationStarted;
-				recognizer.ManipulationUpdated += OnDirectManipulationUpdated;
-				recognizer.ManipulationInertiaStarting += OnDirectManipulationInertiaStarting;
-				recognizer.ManipulationCompleted += OnDirectManipulationCompleted;
-				recognizer.ManipulationAborted += OnDirectManipulationAborted;
-
-				return recognizer;
-			}
-
-			public readonly struct ResumingManipulation(DirectManipulation manipulation) : IDisposable
-			{
-				/// <inheritdoc />
-				public void Dispose()
-					=> manipulation._isResuming = false;
-			}
-
-			public ResumingManipulation Resuming()
-			{
-				_isResuming = true;
-				return new ResumingManipulation(this);
-			}
-
-			public readonly struct CurrentArgSubscription(DirectManipulation manipulation) : IDisposable
-			{
-				/// <inheritdoc />
-				public void Dispose()
-					=> manipulation._currentPointerArgs = null;
-			}
-
-			public CurrentArgSubscription WithCurrent(Windows.UI.Core.PointerEventArgs args)
-			{
-				Debug.Assert(_currentPointerArgs is null);
-				_currentPointerArgs = args;
-				return new CurrentArgSubscription(this);
-			}
-
-			#region Pointers input (IGestureRecognizerRegistration)
-			/// <inheritdoc />
-			public void ProcessDown(PointerEventArgs args)
-			{
-				if (!HasStarted // resuming, no needs to forward pointer again
-					&& IsActive
-					&& Recognizer.PendingManipulation?.IsActive(args.CurrentPoint.Pointer) is not true)
-				{
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Adding pointer --POST DISPATCH-- (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
-					}
-
-					using var _ = WithCurrent(args);
-					Recognizer.ProcessDownEvent(args.CurrentPoint);
-				}
-			}
-
-			/// <inheritdoc />
-			public void ProcessMove(PointerEventArgs args)
-			{
-				if (!HasStarted && IsActive)
-				{
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{args.CurrentPoint.Pointer}] Handling POST move (@{args.CurrentPoint.Position.ToDebugString()} | ts={args.CurrentPoint.Timestamp}).");
-					}
-
-					using var _ = WithCurrent(args);
-					Recognizer.ProcessMoveEvents([args.CurrentPoint]);
-				}
-			}
-
-			/// <inheritdoc />
-			public void ProcessUp(PointerEventArgs args) { }
-
-			/// <inheritdoc />
-			public void ProcessCancel(PointerEventArgs args) { }
-			#endregion
-
-			#region Manipulation event handlers
-			private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartingEventArgs> OnDirectManipulationStarting = (sender, args) =>
-			{
-				// TODO: Make sure ManipulationStarting is fired on UIElement.
-
-				var that = (DirectManipulation)sender.Owner;
-				var supportedMode = ManipulationModes.None;
-
-				if (that.HasStarted)
-				{
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] **RESUMING** Starting. ==> Restoring mode {that._settings}.");
-					}
-
-					args.Settings = that._settings;
-				}
-				else if (PointerCapture.TryGet(args.Pointer, out var capture) && capture.Options.HasFlag(PointerCaptureOptions.PreventDirectManipulation))
-				{
-					if (_trace)
-					{
-						Trace("[DirectManipulation] Ignored ==> An element in the tree prevented direct-manipulation.");
-					}
-
-					// If a control has captured the pointer with our internal PreventDirectManipulation patch flag,
-					// it means that it does not want to be redirected to direct manipulation.
-					that._settings = args.Settings = GestureSettings.None;
-				}
-				else
-				{
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{args.Pointer}] Starting");
-					}
-
-					foreach (var handler in that.Handlers)
-					{
-						supportedMode |= handler.OnStarting(sender, args);
-					}
-
-					that._settings = args.Settings = supportedMode.ToGestureSettings();
-
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{args.Pointer}] Starting ==> Final configured mode is {supportedMode}.");
-					}
-				}
-			};
-
-			private static readonly TypedEventHandler<GestureRecognizer, ManipulationStartedEventArgs> OnDirectManipulationStarted = (sender, args) =>
-			{
-				// Note: We MUST NOT use the PointerRoutedEventArgs.LastPointerEvent in this handler, as it might be raised directly from a PointerEventArgs (NOT routed).
-
-				if (sender.Owner is not DirectManipulation { _currentPointerArgs: { } pointerArgs } that)
-				{
-					return;
-				}
-
-				if (that.HasStarted)
-				{
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{args.Pointers[0]}] **RESUMING** Started @={args.Position.ToDebugString()}");
-					}
-
-					foreach (var handler in that.Handlers)
-					{
-						handler.OnStarted(sender, args, isResuming: true);
-					}
-				}
-				else
-				{
-					if (_trace)
-					{
-						Trace($"[DirectManipulation] [{args.Pointers[0]}] Started @={args.Position.ToDebugString()}");
-					}
-
-					that.HasStarted = true;
-					that._pointerManager.CancelPointer(pointerArgs, isDirectManipulation: true);
-
-					foreach (var handler in that.Handlers)
-					{
-						handler.OnStarted(sender, args, isResuming: false);
-					}
-				}
-			};
-
-			private static readonly TypedEventHandler<GestureRecognizer, ManipulationUpdatedEventArgs> OnDirectManipulationUpdated = (sender, args) =>
-			{
-				var that = (DirectManipulation)sender.Owner;
-
-				if (_trace)
-				{
-					Trace($"[DirectManipulation] [{args.Pointers[0]}] Update @={args.Position.ToDebugString()} | Δ=({args.Delta} | v={args.Velocities}){(args.IsInertial ? " *inertial*" : "")}");
-				}
-
-				var unhandledDelta = args.Delta;
-				foreach (var handler in that.Handlers)
-				{
-					handler.OnUpdated(sender, args, ref unhandledDelta);
-				}
-			};
-
-			private static readonly TypedEventHandler<GestureRecognizer, ManipulationInertiaStartingEventArgs> OnDirectManipulationInertiaStarting = (sender, args) =>
-			{
-				args.UseCompositionTimer = WinRTFeatureConfiguration.GestureRecognizer.UseCompositionTimerForDirectManipulation;
-
-				var that = (DirectManipulation)sender.Owner;
-
-				if (_trace)
-				{
-					Trace($"[DirectManipulation] [{args.Pointers[0]}] Inertia starting @={args.Position.ToDebugString()} | Δ=({args.Delta}) | v=({args.Velocities})");
-				}
-
-				var isHandled = false;
-				foreach (var handler in that.Handlers)
-				{
-					handler.OnInertiaStarting(sender, args, ref isHandled);
-				}
-			};
-
-			private static readonly TypedEventHandler<GestureRecognizer, ManipulationCompletedEventArgs> OnDirectManipulationCompleted = (sender, args) =>
-			{
-				var that = (DirectManipulation)sender.Owner;
-
-				if (that._isResuming) // Possible only when cancelled during inertia, cf. BeforePressTryRedirectToDirectManipulation
-				{
-					return;
-				}
-
-				// We do not self scavenge this manipulation from the _manipluations.
-				// We prefer to wait for the next down so we can keep track of the completion state
-				// (and more specifically the Cancelled state set using the UIElement.CancelDirectManipulation).
-				that._isCompleted = true;
-
-				if (_trace)
-				{
-					Trace($"[DirectManipulation] [{args.Pointers[0]}] Completed @={args.Position.ToDebugString()}");
-				}
-
-				foreach (var handler in that.Handlers)
-				{
-					handler.OnCompleted(sender, args);
-				}
-			};
-
-			private static readonly TypedEventHandler<GestureRecognizer, GestureRecognizer.Manipulation> OnDirectManipulationAborted = (sender, manip) =>
-			{
-				var that = (DirectManipulation)sender.Owner;
-
-				if (_trace)
-				{
-					Trace($"[DirectManipulation] Aborted");
-				}
-
-				// We do not self scavenge this manipulation from the _manipluations.
-				// We prefer to wait for the next down so we can keep track of the completion state
-				// (and more specifically the Cancelled state set using the UIElement.CancelDirectManipulation).
-				that._isCompleted = true;
-
-				foreach (var handler in that.Handlers)
-				{
-					handler.OnCompleted(sender, null);
-				}
-			};
-			#endregion
 		}
 
 		private record InteractionTrackerToDirectManipulationHandler(InteractionTracker Tracker) : IDirectManipulationHandler
@@ -667,8 +294,16 @@ partial class InputManager
 			}
 
 			/// <inheritdoc />
-			public void OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args, ref bool isHandled)
-				=> Tracker.ReceiveInertiaStarting(new Point(args.Velocities.Linear.X * 1000, args.Velocities.Linear.Y * 1000));
+			public bool OnInertiaStarting(GestureRecognizer recognizer, ManipulationInertiaStartingEventArgs args, bool isHandled)
+			{
+				if (isHandled)
+				{
+					return false;
+				}
+
+				Tracker.ReceiveInertiaStarting(new Point(args.Velocities.Linear.X * 1000, args.Velocities.Linear.Y * 1000));
+				return true;
+			}
 
 			/// <inheritdoc />
 			public void OnCompleted(GestureRecognizer recognizer, ManipulationCompletedEventArgs? args)
@@ -733,8 +368,8 @@ partial class InputManager
 				}
 			}
 
-			public bool ContainsKey(PointerDeviceType pointer)
-				=> _hasValues[(int)pointer];
+			//public bool ContainsKey(PointerDeviceType pointer)
+			//	=> _hasValues[(int)pointer];
 
 			public bool TryGetValue(PointerDeviceType pointer, [NotNullWhen(true)] out TValue? value)
 			{

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCapture.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCapture.cs
@@ -58,6 +58,9 @@ internal partial class PointerCapture
 		}
 	}
 
+	public static void ClearForFatalError()
+		=> _actives.Clear();
+
 	private UIElement? _nativeCaptureElement;
 	private readonly Dictionary<UIElement, PointerCaptureTarget> _targets = new(2);
 	private PointerCaptureOptions _currentOptions;

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -357,6 +357,10 @@ namespace Microsoft.UI.Xaml
 #endif
 
 			that.SafeRaiseEvent(ManipulationCompletedEvent, new ManipulationCompletedRoutedEventArgs(src, that, args));
+
+#if UNO_HAS_MANAGED_POINTERS
+			that.XamlRoot?.VisualTree.ContentRoot.InputManager.Pointers.UnregisterUiElementManipulationRecognizer(args.Pointers, sender);
+#endif
 		};
 
 		private static readonly TypedEventHandler<GestureRecognizer, TappedEventArgs> OnRecognizerTapped = (sender, args) =>

--- a/src/Uno.UI/UI/Xaml/UIElement.skia.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.skia.cs
@@ -104,9 +104,9 @@ namespace Microsoft.UI.Xaml
 		internal static Action<UIElement, UIElement, int?> ExternalOnChildAdded { get; set; }
 		internal static Action<UIElement, UIElement> ExternalOnChildRemoved { get; set; }
 
-		/// <param name="point">The point being tested, in element coordinates (i.e. top-left of element is (0,0) if not RTL)</param>
+		/// <param name="relativeLocation">The point being tested, in element coordinates (i.e. top-left of element is (0,0) if not RTL)</param>
 		/// <remarks>This does NOT take the clipping into account.</remarks>
-		internal virtual bool HitTest(Point point) => Visual.HitTest(point);
+		internal virtual bool HitTest(Point relativeLocation) => Visual.HitTest(relativeLocation);
 
 		internal void AddChild(UIElement child, int? index = null)
 		{

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPointerInfo.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputPointerInfo.cs
@@ -84,7 +84,7 @@ public partial struct InjectedInputPointerInfo
 			state.FrameId + (uint)PerformanceCount,
 			timestampInMicroseconds,
 			PointerDevice.For(state.Type),
-			isNew ? PointerId : state.PointerId,
+			PointerId,
 			location,
 			location,
 			PointerOptions.HasFlag(InjectedInputPointerOptions.InContact),

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputState.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InjectedInputState.cs
@@ -21,8 +21,6 @@ internal class InjectedInputState
 
 	public PointerDeviceType Type { get; }
 
-	public uint PointerId { get; set; }
-
 	public uint FrameId { get; set; }
 
 	public ulong Timestamp { get; set; }
@@ -47,7 +45,6 @@ internal class InjectedInputState
 
 	public void Update(PointerEventArgs args)
 	{
-		PointerId = args.CurrentPoint.PointerId;
 		FrameId = args.CurrentPoint.FrameId;
 		Timestamp = args.CurrentPoint.Timestamp;
 		Position = args.CurrentPoint.Position;

--- a/src/Uno.UWP/UI/Input/Preview.Injection/InputInjector.cs
+++ b/src/Uno.UWP/UI/Input/Preview.Injection/InputInjector.cs
@@ -58,7 +58,14 @@ public partial class InputInjector
 	{
 		if (_touch is not null)
 		{
-			var cancel = new InjectedInputTouchInfo { PointerInfo = new() { PointerOptions = InjectedInputPointerOptions.Canceled } };
+			var cancel = new InjectedInputTouchInfo
+			{
+				PointerInfo = new()
+				{
+					PointerId = 42,
+					PointerOptions = InjectedInputPointerOptions.Canceled
+				}
+			};
 
 			_target.InjectPointerRemoved(cancel.ToEventArgs(_touch.Value.state));
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/20594

## Feature
Add ability to have multiple direct-manipulation active in parallel

## What is the current behavior?
Only one direct-manipulation was possible at a time (preventing users to interact with a second `ScrollViewer` while a first one was inertia scrolling)

## What is the new behavior?
We can now have multiple direct-manipulation running in //

## PR Checklist
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
