### PR TITLE
Ensure `XamlIslandRoot.GetSize()` is always up to date

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1406,6 +1406,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\XamlRoot\XamlRoot_Sizing.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\NoPhaseBinding_Large.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6628,6 +6632,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\XamlRoot\XamlRoot_Properties.xaml.cs">
       <DependentUpon>XamlRoot_Properties.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\XamlRoot\XamlRoot_Sizing.xaml.cs">
+      <DependentUpon>XamlRoot_Sizing.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\xBindTests\NoPhaseBinding_Large.xaml.cs">
       <DependentUpon>NoPhaseBinding_Large.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml
@@ -19,7 +19,6 @@
 		<StackPanel Grid.Row="0">
 		</StackPanel>
 		<StackPanel Grid.Row="1">
-			<TextBlock>Responsive: <Run Text="{utu:Responsive Narrow=Narrow, Wide=Wide}"/></TextBlock>
 			<TextBlock>PageSize: <Run x:Name="PageSize"/></TextBlock>
 			<TextBlock>XamlRootSize: <Run x:Name="XamlRootSize"/></TextBlock>
 			<TextBlock>XamlRootChangeCount: <Run x:Name="XamlRootChangeCount"/></TextBlock>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml
@@ -1,0 +1,29 @@
+﻿<UserControl
+	x:Class="UITests.Windows_UI_Xaml.XamlRoot.XamlRoot_Sizing"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Windows_UI_Xaml.XamlRoot"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid Padding="50">
+
+		<Grid.RowDefinitions>
+			<RowDefinition/>
+			<RowDefinition Height="Auto"/>
+		</Grid.RowDefinitions>
+
+		<StackPanel Grid.Row="0">
+		</StackPanel>
+		<StackPanel Grid.Row="1">
+			<TextBlock>Responsive: <Run Text="{utu:Responsive Narrow=Narrow, Wide=Wide}"/></TextBlock>
+			<TextBlock>PageSize: <Run x:Name="PageSize"/></TextBlock>
+			<TextBlock>XamlRootSize: <Run x:Name="XamlRootSize"/></TextBlock>
+			<TextBlock>XamlRootChangeCount: <Run x:Name="XamlRootChangeCount"/></TextBlock>
+		</StackPanel>
+
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml.cs
@@ -2,7 +2,6 @@
 using System.Collections.ObjectModel;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Silk.NET.Core.Native;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml.XamlRoot;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Silk.NET.Core.Native;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml.XamlRoot;
@@ -20,33 +21,33 @@ public sealed partial class XamlRoot_Sizing : UserControl
 
 		Loaded += (s, e) =>
 		{
-			UpdateProperties();
 			XamlRoot.Changed += OnXamlRootChanged;
+			(XamlRoot.Content as FrameworkElement).SizeChanged += OnSizeChanged;
 		};
 
 		Unloaded += (s, e) =>
 		{
 			XamlRoot.Changed -= OnXamlRootChanged;
+			(XamlRoot.Content as FrameworkElement).SizeChanged -= OnSizeChanged;
 		};
-
-		SizeChanged += OnSizeChanged;
 	}
 
 	public ObservableCollection<string> ChangeLog { get; } = new();
 
 	private void OnSizeChanged(object sender, SizeChangedEventArgs args)
 	{
-		Debug.WriteLine($"MainPage::OnSizeChanged: NewSize={PrettyPrint.FormatSize(args.NewSize)}, PreviousSize={PrettyPrint.FormatSize(args.PreviousSize)}");
-		PageSize.Text = PrettyPrint.FormatSize(args.NewSize);
+		PageSize.Text = "X: " + args.NewSize.Width + ", Y: " + args.NewSize.Height;
+		var previousSizeString = "X: " + args.PreviousSize.Width + ", Y: " + args.PreviousSize.Height;
+		System.Diagnostics.Debug.WriteLine($"MainPage::OnSizeChanged: NewSize={PageSize.Text}, PreviousSize={previousSizeString}");
 	}
 
 	private int _count;
-	private void OnXamlRootChanged(XamlRoot sender, XamlRootChangedEventArgs args)
+	private void OnXamlRootChanged(Microsoft.UI.Xaml.XamlRoot sender, XamlRootChangedEventArgs args)
 	{
 		_count++;
 		XamlRootChangeCount.Text = _count.ToString();
-		XamlRootSize.Text = PrettyPrint.FormatSize(sender.Size);
+		XamlRootSize.Text = "X: " + sender.Size.Width + ", Y: " + sender.Size.Height;
 
-		Debug.WriteLine($"MainPage::OnXamlRootChanged: size={PrettyPrint.FormatSize(sender.Size)}");
+		System.Diagnostics.Debug.WriteLine($"MainPage::OnXamlRootChanged: size={XamlRootSize.Text}");
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/XamlRoot/XamlRoot_Sizing.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml.XamlRoot;
+
+[Sample(
+	"Windowing",
+	Description =
+		"Try to change the size of the window, or rotate the device on mobile. Both size values should stay in sync.",
+	IsManualTest = true,
+	IgnoreInSnapshotTests = true)]
+public sealed partial class XamlRoot_Sizing : UserControl
+{
+	public XamlRoot_Sizing()
+	{
+		this.InitializeComponent();
+
+		Loaded += (s, e) =>
+		{
+			UpdateProperties();
+			XamlRoot.Changed += OnXamlRootChanged;
+		};
+
+		Unloaded += (s, e) =>
+		{
+			XamlRoot.Changed -= OnXamlRootChanged;
+		};
+
+		SizeChanged += OnSizeChanged;
+	}
+
+	public ObservableCollection<string> ChangeLog { get; } = new();
+
+	private void OnSizeChanged(object sender, SizeChangedEventArgs args)
+	{
+		Debug.WriteLine($"MainPage::OnSizeChanged: NewSize={PrettyPrint.FormatSize(args.NewSize)}, PreviousSize={PrettyPrint.FormatSize(args.PreviousSize)}");
+		PageSize.Text = PrettyPrint.FormatSize(args.NewSize);
+	}
+
+	private int _count;
+	private void OnXamlRootChanged(XamlRoot sender, XamlRootChangedEventArgs args)
+	{
+		_count++;
+		XamlRootChangeCount.Text = _count.ToString();
+		XamlRootSize.Text = PrettyPrint.FormatSize(sender.Size);
+
+		Debug.WriteLine($"MainPage::OnXamlRootChanged: size={PrettyPrint.FormatSize(sender.Size)}");
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.Core.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.Core.cs
@@ -104,7 +104,11 @@ internal partial class XamlIslandRoot
 		return finalSize;
 	}
 
-	public Size GetSize() => new Size(ActualWidth, ActualHeight);
+	/// <remarks>
+	/// The Width and Height are set in DesktopWindow.cs immediately after native window
+	/// size changes.
+	/// </remarks>
+	public Size GetSize() => new Size(Width, Height);
 
 	public new bool IsVisible() => _isVisible;
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno-private/issues/1267

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Not up to date

## What is the new behavior?

Up to date

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [x] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
