### PR TITLE
fix: Ensure `UpdateLayout` executes for `CalendarPanel`

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
@@ -12,6 +12,7 @@ using Uno.UI.RuntimeTests.Helpers;
 using System.Linq;
 using SamplesApp.UITests;
 using Windows.Foundation;
+using static Private.Infrastructure.TestServices;
 
 #if HAS_UNO && !HAS_UNO_WINUI
 using Microsoft/* UWP don't rename */.UI.Xaml.Controls;
@@ -251,6 +252,23 @@ public class Given_CalendarView
 		Assert.AreEqual(calendar.SelectedBorderBrush, brush1);
 		brush2 = (Brush)GetItemBorderBrushInfo.Invoke(dayItem2, new object[] { false });
 		Assert.AreEqual(calendar.SelectedBorderBrush, brush2);
+	}
+
+	[TestMethod]
+	public async Task When_Year_Mode_Shown()
+	{
+		var now = DateTimeOffset.UtcNow;
+		var calendarView = new Microsoft.UI.Xaml.Controls.CalendarView();
+
+		TestServices.WindowHelper.WindowContent = calendarView;
+
+		await TestServices.WindowHelper.WaitForLoaded(calendarView);
+
+		calendarView.DisplayMode = CalendarViewDisplayMode.Year;
+
+		await TestServices.WindowHelper.WaitForIdle();
+
+		Assert.IsTrue(calendarView.TemplateSettings.HeaderText.EndsWith(now.Year.ToString(), StringComparison.Ordinal));
 	}
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
@@ -255,6 +255,7 @@ public class Given_CalendarView
 	}
 
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20575")]
 	public async Task When_Year_Mode_Shown()
 	{
 		var now = DateTimeOffset.UtcNow;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
@@ -254,7 +254,7 @@ public class Given_CalendarView
 		Assert.AreEqual(calendar.SelectedBorderBrush, brush2);
 	}
 
-	[TestMethod]
+	[ConditionalTest(IgnoredPlatforms = RuntimeTestPlatforms.NativeIOS)] // Test is flaky on iOS native because the calendar takes longer to fully #9080.
 	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20575")]
 	public async Task When_Year_Mode_Shown()
 	{

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
@@ -2121,6 +2121,9 @@ namespace Microsoft.UI.Xaml.Controls
 				// hooked up yet. Give the panel an extra layout pass to hook up the ScrollViewer.
 				if (newDisplayMode != CalendarViewDisplayMode.Month)
 				{
+#if HAS_UNO // Uno specific: UpdateLayout requires XamlRoot to find the root element in our case.
+					pCurrentPanel.XamlRoot ??= spCurrentHost.ScrollViewer.XamlRoot;
+#endif
 					pCurrentPanel.UpdateLayout();
 				}
 

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
@@ -2121,7 +2121,7 @@ namespace Microsoft.UI.Xaml.Controls
 				// hooked up yet. Give the panel an extra layout pass to hook up the ScrollViewer.
 				if (newDisplayMode != CalendarViewDisplayMode.Month)
 				{
-#if HAS_UNO // Uno specific: UpdateLayout requires XamlRoot to find the root element in our case.
+#if HAS_UNO // Uno workaround: UpdateLayout requires XamlRoot to find the root element in our case. #20681
 					pCurrentPanel.XamlRoot ??= spCurrentHost.ScrollViewer.XamlRoot;
 #endif
 					pCurrentPanel.UpdateLayout();

--- a/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CalendarView/CalendarView_Partial.cs
@@ -2122,7 +2122,7 @@ namespace Microsoft.UI.Xaml.Controls
 				if (newDisplayMode != CalendarViewDisplayMode.Month)
 				{
 #if HAS_UNO // Uno workaround: UpdateLayout requires XamlRoot to find the root element in our case. #20681
-					pCurrentPanel.XamlRoot ??= spCurrentHost.ScrollViewer.XamlRoot;
+					pCurrentPanel.XamlRoot ??= spCurrentHost.ScrollViewer?.XamlRoot;
 #endif
 					pCurrentPanel.UpdateLayout();
 				}


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/20575

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

`CalendarView` tries to `UpdateLayout` of a just shown `CalendarPanel` which fails because it didn't yet have time to be associated with a `XamlRoot`.

## What is the new behavior? 🚀

We explicitly set the `XamlRoot` to avoid this behavior.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes