### PR TITLE
mpe bugfixes

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -144,6 +144,11 @@ namespace Microsoft.UI.Xaml.Controls
 			InitializeTemplateChild(TemplateParts.TimeRemainingElement, UIAKeys.UIA_MEDIA_TIME_REMAINING, out m_tpTimeRemainingElement);
 			if (InitializeTemplateChild(TemplateParts.ProgressSlider, UIAKeys.UIA_MEDIA_SEEK, out m_tpMediaPositionSlider))
 			{
+#if HAS_UNO
+				// removes the "Seek" tooltip completely, which can get stuck sometimes when scrubbing.
+				ToolTipService.SetToolTip(m_tpMediaPositionSlider, null);
+#endif
+
 				if (m_tpMediaPositionSlider.TemplatedRoot is { } || m_tpMediaPositionSlider.ApplyTemplate())
 				{
 					m_tpDownloadProgressIndicator = m_tpMediaPositionSlider.GetTemplateChild<ProgressBar>(TemplateParts.DownloadProgressIndicator);

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.mux.h.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.mux.h.cs
@@ -271,7 +271,6 @@ public partial class MediaTransportControls // Template Parts
 	private Grid? _rootGrid;
 	private Border? _timelineContainer;
 	private Border? _controlPanelBorder;
-	private Thumb? _progressSliderThumb;
 	private Flyout? _playbackRateFlyout;
 	private ListView? _playbackRateListView;
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -379,7 +379,7 @@ namespace Windows.Media.Playback
 			{
 				if (PlaybackSession.PlaybackState != MediaPlaybackState.None)
 				{
-					_player?.SeekTo((int)value.TotalMilliseconds);
+					_player?.SeekTo((int)value.TotalMilliseconds, MediaPlayerSeekMode.Closest);
 				}
 			}
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #20628

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔
- [droid] MediaPlayerElement rewinds back a few seconds when completing seek while the video is playing
- MediaPlayerElement scrubbing (press-hold-drag) the progress slider is very laggy/choppy
- MediaPlayerElement doesn't pause the video while scrubbing if the video was currently playing
- MediaPlayerElement scrubbing somestime leaves a lingering "Seek" tooltip

note: the lag and video not pausing when scrubbing happens specifically when the user initiates it by clicking on the slider, but away from the slider thumb.

## What is the new behavior? 🚀
^ no more.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes