### PR TITLE
feat: Make `XamlMerge` priority-based

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -24,9 +24,14 @@
 		<None Remove="**/*.xaml" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(XamlMergeOutputFile)'!=''">
-		<XamlMergeInput Include="@(Page)" Exclude="@(_NonMergedXamlResources)" />
-	</ItemGroup>
+	<Target Name="PrepareXamlMergeInput" BeforeTargets="GenerateMergedXaml" Condition="'$(XamlMergeOutputFile)'!=''">
+		<ItemGroup>
+			<OrderedMergedXamlResources Include="@(Page)" Condition="'%(Page.Priority)' == '1'" />
+			<OrderedMergedXamlResources Include="@(Page)" Exclude="@(_NonMergedXamlResources)" Condition="'%(Page.Priority)' == ''" />
+
+			<XamlMergeInput Include="@(OrderedMergedXamlResources)" />
+		</ItemGroup>
+	</Target>
 
 	<ItemGroup>
 		<UpToDateCheckInput Include="@(Page)" />

--- a/src/Uno.UI/XamlMerge.targets
+++ b/src/Uno.UI/XamlMerge.targets
@@ -18,8 +18,13 @@
 		direct non-overridable resources in other files. See When_Theme_Changed_Animated_Value
 		test for more details.
 	  -->
-	  <_NonMergedXamlResources Include="$(MSBuildProjectDirectory)\UI\Xaml\Style\Generic\SystemResources.xaml" />
-	  <_NonMergedXamlResources Include="$(MSBuildProjectDirectory)\UI\Xaml\Style\Generic\Generic.Native.xaml" />
+	  <_NonMergedXamlResources Include="UI\Xaml\Style\Generic\SystemResources.xaml" />
+	  <_NonMergedXamlResources Include="UI\Xaml\Style\Generic\Generic.Native.xaml" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<Page Remove="Microsoft\UI\Xaml\Styles\Common_themeresources_any.xaml" />
+	<Page Include="Microsoft\UI\Xaml\Styles\Common_themeresources_any.xaml" Priority="1" />
   </ItemGroup>
 
   <Import Project="$(NuGetPackageRoot)\uno.xamlmerge.task\$(_Uno_XamlMerge_Task_Version)\build\Uno.XamlMerge.Task.targets"


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: ✨ Feature

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- 
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

Currently we do not distinguish `.xaml` for merge task by priority

## What is the new behavior? 🚀

We include the `Common` resources first ahead of the rest

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes