### PR TITLE
fix: Change dragging glyph to align closer to WinUI

### DIFF
--- a/src/Uno.UI/UI/Xaml/DragDrop/DragView.cs
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragView.cs
@@ -180,7 +180,7 @@ namespace Microsoft.UI.Xaml
 			}
 			else // None
 			{
-				return "\uE194";
+				return "\uF140";
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/DragDrop/DragView.xaml
+++ b/src/Uno.UI/UI/Xaml/DragDrop/DragView.xaml
@@ -20,8 +20,16 @@
 		<Setter Property="IsHitTestVisible" Value="False" />
 		<Setter Property="HorizontalAlignment" Value="Left" />
 		<Setter Property="VerticalAlignment" Value="Top" />
-		<Setter Property="Padding" Value="0" />
-		<Setter Property="BorderThickness" Value="0" />
+		<Setter Property="Foreground" Value="{ThemeResource ToolTipForegroundBrush}" />
+		<Setter Property="Background" Value="{ThemeResource ToolTipBackgroundBrush}" />
+		<Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
+		<Setter Property="BorderBrush" Value="{ThemeResource ToolTipBorderBrush}" />
+		<Setter Property="BorderThickness" Value="{ThemeResource ToolTipBorderThemeThickness}" />
+		<Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+		<Setter Property="FontSize" Value="{ThemeResource ToolTipContentThemeFontSize}" />
+		<Setter Property="Padding" Value="{StaticResource ToolTipBorderPadding}" />
+		<Setter Property="MaxWidth" Value="{StaticResource ToolTipMaxWidth}" />
+		<Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="DragView">
@@ -32,20 +40,24 @@
 							</Image.RenderTransform>
 						</Image>
 						<StackPanel
-							HorizontalAlignment="Left"
-							VerticalAlignment="Top"
+							HorizontalAlignment="Center"
+							VerticalAlignment="Center"
 							Orientation="Horizontal"
-							BorderThickness="1"
-							BorderBrush="{StaticResource SystemControlForegroundChromeHighBrush}"
-							Background="{StaticResource SystemControlBackgroundChromeMediumLowBrush}"
-							Padding="2,5"
-							Visibility="{TemplateBinding TooltipVisibility}">
+							BorderThickness="{TemplateBinding BorderThickness}"
+							Background="{TemplateBinding Background}"
+							BackgroundSizing="{TemplateBinding BackgroundSizing}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							MaxWidth="{TemplateBinding MaxWidth}"
+							Padding="{TemplateBinding Padding}"
+							CornerRadius="{TemplateBinding CornerRadius}"
+							Visibility="{TemplateBinding TooltipVisibility}"
+							Spacing="4">
 							<StackPanel.RenderTransform>
 								<!-- The caption is above the pointer -->
 								<TranslateTransform Y="-40" />
 							</StackPanel.RenderTransform>
-							<FontIcon Visibility="{TemplateBinding GlyphVisiblity}" FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{TemplateBinding Glyph}" Margin="3,0" />
-							<TextBlock Visibility="{TemplateBinding CaptionVisiblity}" Text="{TemplateBinding Caption}" Margin="3,0" />
+							<FontIcon Visibility="{TemplateBinding GlyphVisibility}" VerticalAlignment="Center" FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{TemplateBinding Glyph}" />
+							<TextBlock Visibility="{TemplateBinding CaptionVisibility}" VerticalAlignment="Center" Text="{TemplateBinding Caption}" />
 						</StackPanel>
 					</Grid>
 				</ControlTemplate>


### PR DESCRIPTION
**GitHub Issue:** closes #20581, closes #19110

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

The dragging UI is not consistent with Fluent nor WinUI


## What is the new behavior? 🚀

Consistent.

![image](https://github.com/user-attachments/assets/df502564-a1e0-451e-a3bc-aba69dbdafd5)

![image](https://github.com/user-attachments/assets/868cfbf8-612d-421a-a154-b3f28de31aaa)


## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes