### PR TITLE
fix(droid): webview insets

### DIFF
--- a/doc/articles/common-issues-android.md
+++ b/doc/articles/common-issues-android.md
@@ -4,6 +4,30 @@ uid: Uno.UI.CommonIssues.Android
 
 # Issues related to Android projects
 
+## Insets not working when using WebView
+
+There is a known issue on Android with the [Edge-to-Edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) feature, where the bottom Insets do not function correctly when using a WebView. This flaw prevents the inputs from being shifted upward, which results in the keyboard covering them.
+
+> [!IMPORTANT]
+> Edge-to-Edge is enforced on devices running Android 15 with a Target SDK of 35 or higher.
+
+A workaround for this issue is to navigate to the `MainActivity.Android.cs` file in your Uno Platform application, override the `OnCreate` method, and call `WindowCompat.SetDecorFitsSystemWindows()`, setting the second parameter, decorFitsSystemWindows, to true.
+
+Your code should be structured as follows:
+
+```csharp
+public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
+{
+  protected override void OnCreate(Bundle bundle)
+  {
+      base.OnCreate(bundle);
+      WindowCompat.SetDecorFitsSystemWindows(Window, true);
+  }
+}
+```
+
+Learn more about this issue [on Google's issues tracker](https://issuetracker.google.com/issues/311256305?pli=1) website.
+
 ## ADB0020 - The package does not support the CPU architecture of this device
 
 This error may occur when deploying an application to a physical device with ARM architecture. To resolve this issue, you will need to add the following to your csproj anywhere inside the `<PropertyGroup>` tag:

--- a/doc/articles/common-issues-android.md
+++ b/doc/articles/common-issues-android.md
@@ -28,6 +28,9 @@ public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
 
 Learn more about this issue [on Google's issues tracker](https://issuetracker.google.com/issues/311256305?pli=1) website.
 
+> [!IMPORTANT]
+> Using the workaround mentioned above will deactivate some benefits of the Edge-To-Edge feature. For instance, your top navigation bar will no longer be "invisible," which removes the immersive appearance associated with edge-to-edge design.
+
 ## ADB0020 - The package does not support the CPU architecture of this device
 
 This error may occur when deploying an application to a physical device with ARM architecture. To resolve this issue, you will need to add the following to your csproj anywhere inside the `<PropertyGroup>` tag:

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -4226,6 +4226,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Input_Keyboard_Insets.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_InvokeScriptAsync.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -8365,6 +8369,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\UndefinedHeightListView.xaml.cs">
       <DependentUpon>UndefinedHeightListView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\WebView\WebView_Input_Keyboard_Insets.xaml.cs">
+      <DependentUpon>WebView_Input_Keyboard_Insets.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\XamlUICommandTests.xaml.cs">
       <DependentUpon>XamlUICommandTests.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Input_Keyboard_Insets.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Input_Keyboard_Insets.xaml
@@ -1,0 +1,10 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.WebView.WebView_Input_Keyboard_Insets"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.WebView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Input_Keyboard_Insets.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_Input_Keyboard_Insets.xaml.cs
@@ -1,0 +1,225 @@
+﻿using Uno.UI.Samples.Controls;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System.Collections.Generic;
+
+#if __ANDROID__
+using Android.Views;
+using Android.App;
+#endif
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Windows_UI_Xaml_Controls.WebView;
+
+[SampleControlInfo("WebView", "WebView_Input_Keyboard_Insets",
+	isManualTest: true,
+	description: "Android Only. Other platform you will see an empty page. \n" +
+	"When focusing inputs, inset will be properly added preventing keyboard from covering the focused input.")]
+public sealed partial class WebView_Input_Keyboard_Insets : Page
+{
+	public WebView_Input_Keyboard_Insets()
+	{
+		this.InitializeComponent();
+		this.Content = new WebViewContainer();
+	}
+}
+
+public partial class WebViewContainer : Control { }
+
+#if __ANDROID__
+public partial class WebViewContainer
+{
+	public WebViewContainer()
+	{
+		Initialize();
+	}
+
+	private void Initialize()
+	{
+		HandleKeyboard();
+
+		var webView = new Android.Webkit.WebView(this.Context!)
+		{
+			Focusable = true,
+			FocusableInTouchMode = true
+		};
+
+		webView.Settings.JavaScriptEnabled = true;
+		webView.Settings.DomStorageEnabled = true;
+		webView.Settings.JavaScriptCanOpenWindowsAutomatically = true;
+
+		AddView(webView);
+
+		webView.LoadDataWithBaseURL(
+			baseUrl: null,
+			data: html,
+			mimeType: "text/html",
+			encoding: "utf-8",
+			historyUrl: null
+		);
+
+		webView.SetFocusable(ViewFocusability.Focusable);
+	}
+
+	private void HandleKeyboard()
+	{
+		if (this.Context is Activity activity)
+		{
+			activity.Window?.SetSoftInputMode(SoftInput.AdjustResize | SoftInput.StateHidden);
+		}
+		Unloaded += (s, e) =>
+		{
+			if (this.Context is Activity activity)
+			{
+				activity.Window?.SetSoftInputMode(SoftInput.AdjustNothing | SoftInput.StateHidden);
+
+			}
+		};
+	}
+
+	string html = @"
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+  <title>ID Verification</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      font-family: sans-serif;
+      background-color: #f8f8f8;
+    }
+
+    .wrapper {
+      min-height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 24px;
+      box-sizing: border-box;
+    }
+
+    .container {
+      width: 100%;
+      max-width: 400px;
+      background-color: white;
+      padding: 24px;
+      border-radius: 10px;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    }
+
+    .group {
+      margin-bottom: 48px; /* spacing 3배 증가 */
+    }
+
+    label {
+      font-weight: bold;
+      margin-bottom: 4px;
+      display: block;
+    }
+
+    input {
+      width: 100%;
+      padding: 12px;
+      font-size: 16px;
+      margin-top: 35px;
+      box-sizing: border-box;
+    }
+
+    button {
+      padding: 12px;
+      width: 100%;
+      background-color: #4CAF50;
+      color: white;
+      font-size: 16px;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+
+    .hidden {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <div class='wrapper'>
+    <div class='container'>
+      <div class='group'>
+        <label for='name'>Please enter your name</label>
+        <input type='text' id='name' placeholder='Your name' />
+      </div>
+
+      <div class='group' id='confirm-group'>
+        <button id='confirm'>Confirm</button>
+      </div>
+
+      <div class='group' id='birth-group'>
+        <label for='birth'>Please enter your birthdate (YYMMDD)</label>
+        <input type='text' id='birth' maxlength='6' placeholder='e.g. 900101' />
+      </div>
+
+      <div class='group' id='gender-group'>
+        <label for='gender'>Please enter your gender</label>
+        <input type='text' id='gender' maxlength='1' placeholder='e.g. 1' />
+      </div>
+
+      <div class='group' id='phone-group'>
+        <label for='phone'>Please enter your mobile number</label>
+        <input type='tel' id='phone' maxlength='11' placeholder='e.g. 01012345678' />
+      </div>
+
+      <div class='group' id='country-group'>
+        <label for='country'>Please enter Country</label>
+        <input type='text' id='country' placeholder='e.g. Canada' />
+      </div>
+      <div class='group' id='country-group'>
+        <label for='city'>Please enter City</label>
+        <input type='text' id='city' placeholder='e.g. Montreal' />
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const confirmBtn = document.getElementById('confirm');
+    const confirmGroup = document.getElementById('confirm-group');
+    const birthGroup = document.getElementById('birth-group');
+    const genderGroup = document.getElementById('gender-group');
+    const phoneGroup = document.getElementById('phone-group');
+    const birthInput = document.getElementById('birth');
+    const genderInput = document.getElementById('gender');
+
+    confirmBtn.addEventListener('click', () => {
+      confirmGroup.classList.add('hidden');
+      birthGroup.classList.remove('hidden');
+    });
+
+    // Show gender input after birthdate is fully entered
+    birthInput.addEventListener('input', () => {
+      if (birthInput.value.length === 6) {
+        genderGroup.classList.remove('hidden');
+      } else {
+        genderGroup.classList.add('hidden');
+        phoneGroup.classList.add('hidden');
+      }
+    });
+
+    // Show phone input only after both birth and gender are valid + Enter pressed
+    genderInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' &&
+          birthInput.value.length === 6 &&
+          genderInput.value.length >= 1) {
+        phoneGroup.classList.remove('hidden');
+        phoneGroup.scrollIntoView({ behavior: 'smooth' });
+      }
+    });
+  </script>
+</body>
+</html>";
+
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
@@ -9,6 +9,7 @@ using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
 using AndroidX.Activity;
+using AndroidX.Core.View;
 using DirectUI;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
@@ -266,6 +267,8 @@ namespace Microsoft.UI.Xaml
 			{
 				EdgeToEdge.Enable(this);
 			}
+
+			WindowCompat.SetDecorFitsSystemWindows(Window, FeatureConfiguration.AndroidSettings.IsEdgeToEdgeEnabled);
 
 			base.OnCreate(bundle);
 

--- a/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
@@ -9,7 +9,6 @@ using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
 using AndroidX.Activity;
-using AndroidX.Core.View;
 using DirectUI;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
@@ -267,8 +266,6 @@ namespace Microsoft.UI.Xaml
 			{
 				EdgeToEdge.Enable(this);
 			}
-
-			WindowCompat.SetDecorFitsSystemWindows(Window, FeatureConfiguration.AndroidSettings.IsEdgeToEdgeEnabled);
 
 			base.OnCreate(bundle);
 


### PR DESCRIPTION
**GitHub Issue:** closes #19858 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

Android when using WebViews the Insets are not being applied correctly causing the inputs to be covered by the keyboard

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->