### PR TITLE
fix: Adding check that Desktop folder exists

### DIFF
--- a/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
+++ b/src/Uno.Sdk/targets/Uno.SingleProject.Desktop.targets
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(PlatformsProjectFolder) != '' and Exists($(PlatformsProjectFolder))">
-		<_TargetPlatformFiles Include="$(DesktopProjectFolder)/**/*" />
+		<_TargetPlatformFiles Include="$(DesktopProjectFolder)/**/*" Condition="Exists('$(DesktopProjectFolder)')"/>
 		<_AllPlatformFiles Include="$(PlatformsProjectFolder)/**/*" />
 		<_IgnorePlatformFiles Include="@(_AllPlatformFiles)" Exclude="@(_TargetPlatformFiles)" />
 		<Compile Remove="@(_IgnorePlatformFiles)" />


### PR DESCRIPTION
**GitHub Issue:** closes #(private)

## PR Type:

- 🐞 Bugfix


## What is the current behavior? 🤔

If project is targeting desktop (eg includes net9.0-desktop) but there's no Platforms/Desktop folder, there's a warning as there is an include in the props that will include all files on the computer

## What is the new behavior? 🚀

The include is only relevant if the Platforms/Desktop folder exits

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->