### PR TITLE
docs: remove initializelogging calls from suggested migration code

### DIFF
--- a/doc/articles/migrating-to-uno-6.md
+++ b/doc/articles/migrating-to-uno-6.md
@@ -94,6 +94,8 @@ To upgrade:
     ```csharp
     public static int Main(string[] args)
     {
+        // code omitted for brevity
+
         Microsoft.UI.Xaml.Application.Start(_ => _app = new App());
 
         return 0;
@@ -109,6 +111,8 @@ To upgrade:
 
     public static async Task Main(string[] args)
     {
+        // code omitted for brevity
+
         var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
             .UseWebAssembly()
@@ -142,6 +146,8 @@ To upgrade:
 
     public static void Main(string[] args)
     {
+        // code omitted for brevity
+
         var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
             .UseAppleUIKit()

--- a/doc/articles/migrating-to-uno-6.md
+++ b/doc/articles/migrating-to-uno-6.md
@@ -94,8 +94,6 @@ To upgrade:
     ```csharp
     public static int Main(string[] args)
     {
-        App.InitializeLogging();
-
         Microsoft.UI.Xaml.Application.Start(_ => _app = new App());
 
         return 0;
@@ -111,8 +109,6 @@ To upgrade:
 
     public static async Task Main(string[] args)
     {
-        App.InitializeLogging();
-
         var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
             .UseWebAssembly()
@@ -146,8 +142,6 @@ To upgrade:
 
     public static void Main(string[] args)
     {
-        App.InitializeLogging();
-
         var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
             .UseAppleUIKit()


### PR DESCRIPTION
We should not include the `App.InitializeLogging()` call in the migration code for Skia rendered app. It is misleading as this method may not always exist in the App.xaml.cs depending on the template used