### PR TITLE
fix(macOS): app bundles must uses the Resources folder

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowNative.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacOSWindowNative.cs
@@ -54,10 +54,6 @@ internal class MacOSWindowNative
 
 		NativeWindowReady?.Invoke(this, this);
 
-		if (NativeUno.uno_application_is_bundled())
-		{
-			Windows.Storage.StorageFile.ResourcePathBase = IOPath.Combine(Windows.ApplicationModel.Package.Current.InstalledPath, "..", "Resources");
-		}
 		UpdateWindowPropertiesFromPackage();
 		UpdateWindowPropertiesFromApplicationView();
 	}

--- a/src/Uno.UI.Runtime.Skia.MacOS/MacSkiaHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacSkiaHost.cs
@@ -58,6 +58,12 @@ public class MacSkiaHost : SkiaHost, ISkiaApplicationHost
 			return;
 		}
 
+		// if packaged as an app bundle, set the resource path base to the Resources folder
+		if (NativeUno.uno_application_is_bundled())
+		{
+			Windows.Storage.StorageFile.ResourcePathBase = Path.Combine(Windows.ApplicationModel.Package.Current.InstalledPath, "..", "Resources");
+		}
+
 		InitializeDispatcher();
 	}
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/20742

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

The change to the `Resources` folder is made too late and some fonts are being loaded from the incorrect location, leading to crashes.

## What is the new behavior? 🚀

The logic was moved so it is executed earlier in the macOS host setup.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->