### PR TITLE
refactor: `AllowUnsafeBlocks` in `Directory.Build.props`

### DIFF
--- a/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.Wasm.csproj
+++ b/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.Wasm.csproj
@@ -6,7 +6,6 @@
 	<Import Project="../../targetframework-override.props" />
 
 	<PropertyGroup>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Deterministic>true</Deterministic>
 
 		<AssemblyName>Uno.UI.Lottie</AssemblyName>

--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Wasm.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Wasm.csproj
@@ -6,7 +6,6 @@
 	<Import Project="../../targetframework-override.props"/>
 
 	<PropertyGroup>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Deterministic>true</Deterministic>
 		<AssemblyName>Uno.UI.MSAL</AssemblyName>
 		<RootNamespace>Uno.UI.MSAL</RootNamespace>

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.Win32/Uno.UI.MediaPlayer.Skia.Win32.csproj
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.Win32/Uno.UI.MediaPlayer.Skia.Win32.csproj
@@ -21,7 +21,6 @@
 
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.X11/Uno.UI.MediaPlayer.Skia.X11.csproj
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.X11/Uno.UI.MediaPlayer.Skia.X11.csproj
@@ -21,7 +21,6 @@
 
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/Uno.UI.MediaPlayer.WebAssembly.csproj
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/Uno.UI.MediaPlayer.WebAssembly.csproj
@@ -10,7 +10,6 @@
 		<Deterministic>true</Deterministic>
 		<AssemblyName>Uno.UI.MediaPlayer.WebAssembly</AssemblyName>
 		<RootNamespace>Uno.UI.Media</RootNamespace>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
 		<PackageId Condition="'$(UNO_UWP_BUILD)'=='false'">Uno.WinUI.MediaPlayer.WebAssembly</PackageId>
 		<Description>This package provides support for MediaPlayerElement for WebAssembly</Description>

--- a/src/AddIns/Uno.UI.WebView.Skia.X11/Uno.UI.WebView.Skia.X11.csproj
+++ b/src/AddIns/Uno.UI.WebView.Skia.X11/Uno.UI.WebView.Skia.X11.csproj
@@ -19,7 +19,6 @@
 
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/AddIns/Uno.WinUI.Graphics3DGL/Uno.WinUI.Graphics3DGL.csproj
+++ b/src/AddIns/Uno.WinUI.Graphics3DGL/Uno.WinUI.Graphics3DGL.csproj
@@ -7,7 +7,6 @@
 		<GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
 
 		<Nullable>enable</Nullable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		
 		<!-- Required as the project name does not end with `.Skia` when building for netcoremobile targets -->
 		<UnoDisableTargetFrameworkPlatformOverride Condition="!$(UnoTargetFrameworkOverride.Contains('windows10'))">true</UnoDisableTargetFrameworkPlatformOverride>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -53,9 +53,8 @@
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 
 		<RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
-	
-		<!-- Don't install GTK in CI, let the workflow do it to prevent concurrency issues -->
-		<SkipGtkInstall Condition=" '$(CI_Build)'!='' OR '$(TF_BUILD)' == 'true' ">true</SkipGtkInstall>
+
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj
@@ -2,7 +2,6 @@
 	<PropertyGroup>
 		<TargetFrameworks>$(NetSkiaPreviousAndCurrent)</TargetFrameworks>
 		<RollForward>Major</RollForward>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<Import Project="../../targetframework-override-noplatform.props" />

--- a/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
+++ b/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>$(NetPrevious)</TargetFrameworks>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<Import Project="../../targetframework-override.props" />
@@ -10,8 +9,6 @@
 		<DefineConstants>$(DefineConstants);__SKIA__;HAS_UNO;UNO_REFERENCE_API</DefineConstants>
 		<IsUnoHead>true</IsUnoHead>
 		<UnoRuntimeIdentifier>Skia</UnoRuntimeIdentifier>
-
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
 		<!-- In external apps, this will flow from NuGet package props -->
 		<SupportsFontManifest>true</SupportsFontManifest>

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -15,7 +15,6 @@
 		<UseUnoXamlParser>true</UseUnoXamlParser>
 		<UnoRuntimeIdentifier>WebAssembly</UnoRuntimeIdentifier>
 		<WasmShellIncludeWindowsCompatibility>false</WasmShellIncludeWindowsCompatibility>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		
 		<!-- Required for net9 workloads -->
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -11,7 +11,6 @@
 		<UseWinUI>true</UseWinUI>
 		<EnableMsixTooling>true</EnableMsixTooling>
 		<DefineConstants>$(DefineConstants);WINAPPSDK</DefineConstants>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		
 		<!-- Disabled because of https://github.com/dotnet/sdk/issues/43680#issuecomment-2401193028 -->
 		<CsWinRTAotOptimizerEnabled>false</CsWinRTAotOptimizerEnabled>

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia/UnoIslandsSamplesApp.Skia.csproj
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia/UnoIslandsSamplesApp.Skia.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>$(NetSkiaPreviousAndCurrent)</TargetFrameworks>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<Import Project="../../targetframework-override.props" />
@@ -10,7 +9,6 @@
 		<DefineConstants>$(DefineConstants);__SKIA__;HAS_UNO;UNO_REFERENCE_API;UNO_ISLANDS</DefineConstants>
 		<IsUnoHead>true</IsUnoHead>
 		<UnoRuntimeIdentifier>Skia</UnoRuntimeIdentifier>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/SourceGenerators/System.Xaml.Tests.MS/System.Xaml.Tests.MS.csproj
+++ b/src/SourceGenerators/System.Xaml.Tests.MS/System.Xaml.Tests.MS.csproj
@@ -3,7 +3,6 @@
 		<TargetFramework>net461</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<DefineConstants>$(DefineConstants);NET_4_0;NET_4_5;NET_4_6;MONO;WIN_PLATFORM;MULTIPLEX_OS</DefineConstants>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<EnableAutomaticXamlPageInclusion>false</EnableAutomaticXamlPageInclusion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/SourceGenerators/System.Xaml.Tests/Uno.Xaml.Tests.csproj
+++ b/src/SourceGenerators/System.Xaml.Tests/Uno.Xaml.Tests.csproj
@@ -3,7 +3,6 @@
 		<TargetFramework>net462</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<DefineConstants>$(DefineConstants);NET_4_0;NET_4_5;NET_4_6;MONO;WIN_PLATFORM;MULTIPLEX_OS</DefineConstants>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<DebugType>full</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 		<NoWarn>$(NoWarn);CS3003;CS0219;CS0162;CS0642;CS0067;CS0649;CS7033</NoWarn>

--- a/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
+++ b/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
@@ -12,7 +12,6 @@
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
 		<NoWarn>$(NoWarn);IDE0051</NoWarn>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
 	</PropertyGroup>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -5,7 +5,6 @@
 		<AssemblyName>Uno.UI.SourceGenerators</AssemblyName>
 		<AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
 		<!-- We need all the intermediate assemblies -->
 		<DisablePrivateProjectReference>true</DisablePrivateProjectReference>

--- a/src/Uno.Foundation.Runtime.WebAssembly/Uno.Foundation.Runtime.WebAssembly.csproj
+++ b/src/Uno.Foundation.Runtime.WebAssembly/Uno.Foundation.Runtime.WebAssembly.csproj
@@ -11,7 +11,6 @@
 
 	<PropertyGroup>
 		<NoWarn>$(NoWarn);NU1701</NoWarn>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<DefineConstants>$(DefineConstants);IS_UNO_FOUNDATION_RUNTIME_WEBASSEMBLY_PROJECT</DefineConstants>
 
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>

--- a/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.props
+++ b/src/Uno.Foundation/Uno.Core.Extensions/Uno.Core.Extensions.props
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
-  <PropertyGroup>
-	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
   <ItemGroup>
 	<Compile Remove="$(MSBuildThisFileDirectory)**\*.cs" />
 	<!-- Remove everything because of the inclusion in source generators -->

--- a/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.WinAppSdk.targets
@@ -15,9 +15,6 @@
 		<RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)'==''">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
 
 		<IsMSALSupported>true</IsMSALSupported>
-
-		<!-- net9 requires the use of unsafe blocks -->
-		<AllowUnsafeBlocks Condition=" '$(AllowUnsafeBlocks)' == '' ">true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" $(_IsExecutable) == 'true' ">

--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.netcoremobile.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.netcoremobile.csproj
@@ -2,7 +2,6 @@
 	<PropertyGroup>
 		<TargetFrameworks>$(NetAndroidPreviousAndCurrent)</TargetFrameworks>
 
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<NoWarn>1701;1702;1705;109</NoWarn>
 
 		<!-- generated\src\Java.Interop.__TypeRegistrations.cs(16,6): Error CA1825: Avoid unnecessary zero-length array allocations. -->

--- a/src/Uno.UI.Composition/Uno.UI.Composition.Skia.csproj
+++ b/src/Uno.UI.Composition/Uno.UI.Composition.Skia.csproj
@@ -6,7 +6,6 @@
 	<Import Project="../targetframework-override.props" />
 
 	<PropertyGroup>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>Uno.UI.Composition</AssemblyName>
 		<DefineConstants>$(DefineConstants);IS_UNO_COMPOSITION</DefineConstants>
 	</PropertyGroup>

--- a/src/Uno.UI.Dispatching/Uno.UI.Dispatching.Skia.csproj
+++ b/src/Uno.UI.Dispatching/Uno.UI.Dispatching.Skia.csproj
@@ -6,7 +6,6 @@
 	<Import Project="../targetframework-override.props" />
 
 	<PropertyGroup>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>Uno.UI.Dispatching</AssemblyName>
 		<DefineConstants>$(DefineConstants);IS_UNO_UI_DISPATCHING_PROJECT</DefineConstants>
 	</PropertyGroup>

--- a/src/Uno.UI.Dispatching/Uno.UI.Dispatching.Wasm.csproj
+++ b/src/Uno.UI.Dispatching/Uno.UI.Dispatching.Wasm.csproj
@@ -7,7 +7,6 @@
 	<Import Project="../targetframework-override.props" />
 
 	<PropertyGroup>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>Uno.UI.Dispatching</AssemblyName>
 		<RootNamespace>Uno.UI.Dispatching</RootNamespace>
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO;IS_UNO_UI_DISPATCHING_PROJECT</DefineConstants>

--- a/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
+++ b/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
@@ -22,8 +22,6 @@
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<DefineConstants>$(DefineConstants);ANDROID_SKIA</DefineConstants>
-
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/Uno.UI.Runtime.Skia.AppleUIKit.csproj
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/Uno.UI.Runtime.Skia.AppleUIKit.csproj
@@ -22,8 +22,6 @@
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<DefineConstants>$(DefineConstants);UIKIT_SKIA</DefineConstants>
-		
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Uno.UI.Runtime.Skia.Linux.FrameBuffer.csproj
+++ b/src/Uno.UI.Runtime.Skia.Linux.FrameBuffer/Uno.UI.Runtime.Skia.Linux.FrameBuffer.csproj
@@ -16,8 +16,6 @@
 		<RootNamespace>Uno.WinUI.Runtime.Skia.Linux.FrameBuffer</RootNamespace>
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.MacOS/Uno.UI.Runtime.Skia.MacOS.csproj
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Uno.UI.Runtime.Skia.MacOS.csproj
@@ -18,8 +18,6 @@
 		<RootNamespace>Uno.UI.Runtime.Skia.MacOS</RootNamespace>
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Uno.UI.Runtime.Skia.WebAssembly.Browser.csproj
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Uno.UI.Runtime.Skia.WebAssembly.Browser.csproj
@@ -25,8 +25,6 @@
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<DefineConstants>$(DefineConstants);WASM_SKIA</DefineConstants>
-
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Runtime.Skia.X11/Uno.UI.Runtime.Skia.X11.csproj
+++ b/src/Uno.UI.Runtime.Skia.X11/Uno.UI.Runtime.Skia.X11.csproj
@@ -15,8 +15,6 @@
 		<RootNamespace>Uno.WinUI.Runtime.Skia.X11</RootNamespace>
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Runtime.Skia/Uno.UI.Runtime.Skia.csproj
+++ b/src/Uno.UI.Runtime.Skia/Uno.UI.Runtime.Skia.csproj
@@ -15,8 +15,6 @@
 		<RootNamespace>Uno.UI.Runtime.Skia</RootNamespace>
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Windows.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.Windows.csproj
@@ -78,7 +78,6 @@
 
 	<PropertyGroup>
 		<PageExclusions>$(MSBuildThisFileDirectory)MUX\Microsoft_UI_XAML_Controls\**\*.xaml</PageExclusions>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Tests/Uno.UI.Unit.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Unit.Tests.csproj
@@ -6,7 +6,6 @@
 		<OutputPath>bin\$(Platform)\$(Configuration)</OutputPath>
 		<UseUnoXamlParser>true</UseUnoXamlParser>
 		<ImportFrameworkWinFXTargets>false</ImportFrameworkWinFXTargets>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<UnoForceHotReloadCodeGen>true</UnoForceHotReloadCodeGen>
 		<AssemblyName>Uno.UI.Tests</AssemblyName>
 		<RootNamespace>Uno.UI.Tests</RootNamespace>

--- a/src/Uno.UI.Wasm.Tests/Uno.UI.Wasm.Tests.csproj
+++ b/src/Uno.UI.Wasm.Tests/Uno.UI.Wasm.Tests.csproj
@@ -6,8 +6,6 @@
 		<TSBindingsPath>$(MSBuildThisFileDirectory)tsbindings</TSBindingsPath>
 		<DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
 
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
 		<EnableDefaultTypeScriptItems>false</EnableDefaultTypeScriptItems>
 	</PropertyGroup>
 

--- a/src/Uno.UI.XamlHost/Uno.UI.XamlHost.Skia.csproj
+++ b/src/Uno.UI.XamlHost/Uno.UI.XamlHost.Skia.csproj
@@ -6,7 +6,6 @@
 	<Import Project="../targetframework-override.props" />
 
 	<PropertyGroup>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>Uno.UI.XamlHost</AssemblyName>
 		<DefineConstants>$(DefineConstants);IS_UNO_UI_XamlHost_PROJECT</DefineConstants>
 	</PropertyGroup>

--- a/src/Uno.UI/Uno.UI.Reference.csproj
+++ b/src/Uno.UI/Uno.UI.Reference.csproj
@@ -11,7 +11,6 @@
 		<AssemblyName>Uno.UI</AssemblyName>
 		<RootNamespace>Uno.UI</RootNamespace>
 		<DefineConstants>$(DefineConstants);IS_UNO;IS_UNO_UI_PROJECT</DefineConstants>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<BuildForLiveUnitTesting>false</BuildForLiveUnitTesting>
 		<NoWarn>$(NoWarn);NU1701;1572;1587;419;1574;1711;1734;CS0105</NoWarn>
 

--- a/src/Uno.UI/Uno.UI.Skia.csproj
+++ b/src/Uno.UI/Uno.UI.Skia.csproj
@@ -9,7 +9,6 @@
 	<PropertyGroup>
 		<NoWarn>$(NoWarn);NU1701</NoWarn>
 		<DefineConstants>$(DefineConstants);IS_UNO;IS_UNO_UI_PROJECT</DefineConstants>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>

--- a/src/Uno.UI/Uno.UI.Tests.csproj
+++ b/src/Uno.UI/Uno.UI.Tests.csproj
@@ -11,7 +11,6 @@
 		<AssemblyName>Uno.UI</AssemblyName>
 		<RootNamespace>Uno.UI</RootNamespace>
 		<DefineConstants>$(DefineConstants);IS_UNO;IS_UNO_UI_PROJECT</DefineConstants>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<BuildForLiveUnitTesting>false</BuildForLiveUnitTesting>
 		<NoWarn>$(NoWarn);NU1701;1572;1587;419;1574;1711;1734;CS0105</NoWarn>
 

--- a/src/Uno.UI/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI/Uno.UI.Wasm.csproj
@@ -14,7 +14,6 @@
 		<Deterministic>true</Deterministic>
 		<RootNamespace>Uno.UI</RootNamespace>
 		<AssemblyName>Uno.UI</AssemblyName>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
 		<TSBindingsPath>$(MSBuildThisFileDirectory)tsBindings</TSBindingsPath>
 		<TSBindingAssemblySource>Uno;Uno.UI</TSBindingAssemblySource>

--- a/src/Uno.UI/Uno.UI.netcoremobile.csproj
+++ b/src/Uno.UI/Uno.UI.netcoremobile.csproj
@@ -11,7 +11,6 @@
 		<AssemblyName>Uno.UI</AssemblyName>
 		<RootNamespace>Uno.UI</RootNamespace>
 		<DefineConstants>$(DefineConstants);IS_UNO;IS_UNO_UI_PROJECT</DefineConstants>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<BuildForLiveUnitTesting>false</BuildForLiveUnitTesting>
 		<NoWarn>$(NoWarn);NU1701;1572;1587;419;1574;1711;1734;CS0105</NoWarn>
 

--- a/src/Uno.UWP/Uno.Reference.csproj
+++ b/src/Uno.UWP/Uno.Reference.csproj
@@ -15,8 +15,6 @@
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
 
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
 		<UnoRuntimeIdentifier>Reference</UnoRuntimeIdentifier>
 		
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>

--- a/src/Uno.UWP/Uno.Skia.csproj
+++ b/src/Uno.UWP/Uno.Skia.csproj
@@ -6,10 +6,6 @@
 	<Import Project="../targetframework-override.props" />
 
 	<PropertyGroup>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	</PropertyGroup>
-
-	<PropertyGroup>
 		<AssemblyName>Uno</AssemblyName>
 		<RootNamespace>Windows</RootNamespace>
 		<DefineConstants>$(DefineConstants);XAMARIN;IS_UNO;HAS_UMBRELLA_UI;HAS_UMBRELLA_BINDING;HAS_CRIPPLEDREFLECTION</DefineConstants>

--- a/src/Uno.UWP/Uno.Tests.csproj
+++ b/src/Uno.UWP/Uno.Tests.csproj
@@ -14,8 +14,6 @@
 
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
-
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UWP/Uno.Wasm.csproj
+++ b/src/Uno.UWP/Uno.Wasm.csproj
@@ -18,8 +18,6 @@
 
 		<UnoRuntimeIdentifier>WebAssembly</UnoRuntimeIdentifier>
 		<PlatformItemsBasePath>.\</PlatformItemsBasePath>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<CommonOverridePackageId>uno.winrt</CommonOverridePackageId>
 

--- a/src/Uno.UWP/Uno.netcoremobile.csproj
+++ b/src/Uno.UWP/Uno.netcoremobile.csproj
@@ -24,7 +24,6 @@
 		assembly, for non-fully qualified types in System and Windows.System
 		-->
 		<AndroidResgenNamespace>Uno.UWP</AndroidResgenNamespace>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<CommonOverridePackageId>uno.winrt</CommonOverridePackageId>


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/20774

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🔄 Refactoring (no functional changes, no api changes)

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

Unsafe blocks are enabled in each project individually.

## What is the new behavior? 🚀

`<AllowUnsafeBlocks>` in `Directory.Build.props`

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes