### PR TITLE
fix: remove privateassets="all" from mauiembedding bits

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Android.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.Android.targets
@@ -36,7 +36,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(_IsExecutable) == 'true' AND $(UnoFeatures.Contains(';skiarenderer;')) AND $(UnoFeatures.Contains(';mauiembedding;'))">
-		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Maui.WinUI.Runtime.Skia" PrivateAssets="all" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Maui.WinUI.Runtime.Skia" ProjectSystem="true" />
 	</ItemGroup>
 
 </Project>

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.MacCatalyst.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.MacCatalyst.targets
@@ -23,6 +23,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(_IsExecutable) == 'true' AND $(UnoFeatures.Contains(';skiarenderer;')) AND $(UnoFeatures.Contains(';mauiembedding;'))">
-		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Maui.WinUI.Runtime.Skia" PrivateAssets="all" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Maui.WinUI.Runtime.Skia" ProjectSystem="true" />
 	</ItemGroup>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.iOS.targets
+++ b/src/Uno.Sdk/targets/Uno.Implicit.Packages.ProjectSystem.iOS.targets
@@ -23,6 +23,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="$(_IsExecutable) == 'true' AND $(UnoFeatures.Contains(';skiarenderer;')) AND $(UnoFeatures.Contains(';mauiembedding;'))">
-		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Maui.WinUI.Runtime.Skia" PrivateAssets="all" ProjectSystem="true" />
+		<_UnoProjectSystemPackageReference Include="Uno.Extensions.Maui.WinUI.Runtime.Skia" ProjectSystem="true" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Avoids error when using MAUI Embedding:
 

System.IO.FileNotFoundException: 'Could not load file or assembly 'Uno.Extensions.Maui.WinUI.Runtime.Skia, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null' or one of its dependencies.'

 

 

