### PR TITLE
Add ToString() override to AppWindowPositionAndSizeViewModel

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Windowing/AppWindowPositionAndSize.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Windowing/AppWindowPositionAndSize.xaml.cs
@@ -159,4 +159,9 @@ internal class AppWindowPositionAndSizeViewModel : ViewModelBase
 		contentDialog.PrimaryButtonText = "OK";
 		await contentDialog.ShowAsync();
 	}
+	public override string ToString()
+	{
+		return $"AppWindowPositionAndSizeViewModel(Width={Width}, Height={Height}, X={X}, Y={Y})";
+	}
+
 }


### PR DESCRIPTION
“Hi, I’m exploring contributing to Uno – happy to adapt this if needed.”

This PR adds a `ToString()` override to the `AppWindowPositionAndSizeViewModel` class.

It returns the Width, Height, X and Y values to improve the developer experience while debugging or logging.

Example output:
AppWindowPositionAndSizeViewModel(Width=1024, Height=768, X=100, Y=200)

No functionality is changed. Only improves inspectability of the ViewModel.
