### PR TITLE
fix: Fail more explicitly when `BrowserHtmlElement` APIs are used with an invalid id

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserNativeElementHostingExtension.ts
@@ -82,19 +82,19 @@ namespace Uno.UI.NativeElementHosting {
 		}
 
 		public static attachNativeElement(content: string) {
-			let element = document.getElementById(content);
+			let element = this.getElementOrThrow(content);
 			element.remove(); // remove from the store
 			this.getNativeElementHost().appendChild(element); // add to the native host
 		}
 
 		public static detachNativeElement(content: string) {
-			let element = document.getElementById(content);
+			let element = this.getElementOrThrow(content);
 			element.remove(); // remove from the native host
 			this.getNativeElementStore().appendChild(element); // add to the native host
 		}
 
 		public static arrangeNativeElement(content: string, x: number, y: number, width: number, height: number) {
-			let element = document.getElementById(content);
+			let element = this.getElementOrThrow(content);
 			element.style.position = "absolute"
 			element.style.left = `${x}px`;
 			element.style.top = `${y}px`;
@@ -103,7 +103,7 @@ namespace Uno.UI.NativeElementHosting {
 		}
 
 		public static changeNativeElementOpacity(content: string, opacity: number) {
-			let element = document.getElementById(content);
+			let element = this.getElementOrThrow(content);
 			element.style.opacity = opacity.toString();
 		}
 
@@ -114,15 +114,15 @@ namespace Uno.UI.NativeElementHosting {
 		}
 
 		public static addToStore(id: string) {
-			this.getNativeElementStore().appendChild(document.getElementById(id));
+			this.getNativeElementStore().appendChild(this.getElementOrThrow(id));
 		}
 
 		public static disposeHtmlElement(id: string) {
-			document.getElementById(id).remove();
+			this.getElementOrThrow(id).remove();
 		}
 
 		public static createSampleComponent(parentId: string, text: string) {
-			let element = document.getElementById(parentId);
+			let element = this.getElementOrThrow(parentId);
 
 			let btn = document.createElement("button");
 			btn.textContent = text;
@@ -137,13 +137,13 @@ namespace Uno.UI.NativeElementHosting {
 		}
 
 		public static setStyleString(elementId: string, name: string, value: string) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			element.style.setProperty(name, value);
 		}
 
 		public static resetStyle(elementId: string, names: string[]) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			for (const name of names) {
 				element.style.setProperty(name, "");
@@ -151,7 +151,7 @@ namespace Uno.UI.NativeElementHosting {
 		}
 
 		public static setClasses(elementId: string, cssClassesList: string[], classIndex: number) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			for (let i = 0; i < cssClassesList.length; i++) {
 				if (i === classIndex) {
@@ -163,7 +163,7 @@ namespace Uno.UI.NativeElementHosting {
 		}
 
 		public static setUnsetCssClasses(elementId: string, classesToUnset: string[]) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			classesToUnset.forEach(c => {
 				element.classList.remove(c);
@@ -171,31 +171,31 @@ namespace Uno.UI.NativeElementHosting {
 		}
 
 		public static setAttribute(elementId: string, name: string, value: string) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			element.setAttribute(name, value);
 		}
 
 		public static getAttribute(elementId: string, name: string) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			return element.getAttribute(name);
 		}
 
 		public static removeAttribute(elementId: string, name: string) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			element.removeAttribute(name);
 		}
 
 		public static setContentHtml(elementId: string, html: string) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			element.innerHTML = html;
 		}
 
 		public static registerNativeHtmlEvent(owner: any, elementId: string, eventName: string, managedHandler: string) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			if (!BrowserHtmlElement.dispatchEventNativeElementMethod) {
 				throw `BrowserHtmlElement: The initialize method has not been called`;
@@ -213,7 +213,7 @@ namespace Uno.UI.NativeElementHosting {
 		}
 
 		public static unregisterNativeHtmlEvent(elementId: string, eventName: string, managedHandler: any) {
-			const element = document.getElementById(elementId);
+			const element = this.getElementOrThrow(elementId);
 
 			if (!BrowserHtmlElement.dispatchEventNativeElementMethod) {
 				throw `BrowserHtmlElement: The initialize method has not been called`;
@@ -238,6 +238,17 @@ namespace Uno.UI.NativeElementHosting {
 
 			return String(result || "");
 
+		}
+
+		/**
+		 * Returns the element with the given id, or throws an error if not found.
+		 */
+		private static getElementOrThrow(id: string): HTMLElement {
+			const element = document.getElementById(id);
+			if (!element) {
+				throw new Error(`BrowserHtmlElement: Element with id '${id}' not found.`);
+			}
+			return element as HTMLElement;
 		}
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/300

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the new behavior? 🚀

Fail with a verbose message when the ID is incorrect.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->