### PR TITLE
fix(win32x11): setting a full screen presenter does not work immediately after window activation

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Win32WindowWrapper.cs
@@ -16,6 +16,7 @@ using Windows.Win32.Graphics.Dwm;
 using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.UI.HiDpi;
 using Windows.Win32.UI.WindowsAndMessaging;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using SkiaSharp;
 using Uno.Disposables;
@@ -389,7 +390,20 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		if (!success) { this.LogError()?.Error($"{nameof(PInvoke.SetActiveWindow)} failed: {Win32Helper.GetErrorMessage()}"); }
 	}
 
-	protected override void ShowCore() => PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_SHOWDEFAULT);
+	protected override void ShowCore()
+	{
+		if (Window?.AppWindow.Presenter is FullScreenPresenter)
+		{
+			// The window takes a split second to be rerendered with the fullscreen window size but
+			// no fix has been found for this yet.
+			SetWindowStyle(WINDOW_STYLE.WS_DLGFRAME, false);
+			_ = PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_MAXIMIZE);
+		}
+		else
+		{
+			PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_SHOWDEFAULT);
+		}
+	}
 
 	protected override void CloseCore()
 	{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -360,6 +361,26 @@ public class Given_Window
 		window.Close();
 
 		await TestServices.WindowHelper.WaitFor(() => window.ClosedExecuted);
+	}
+
+	[ConditionalTest(IgnoredPlatforms = ~(RuntimeTestPlatforms.SkiaWin32 | RuntimeTestPlatforms.SkiaX11))]
+	[RunsOnUIThread]
+	public async Task When_FullScreen_After_Activate()
+	{
+		var window = new Window();
+		var content = new Border() { Width = 100, Height = 100 };
+		window.Content = content;
+		window.Activate();
+		window.AppWindow.SetPresenter(FullScreenPresenter.Create());
+		await TestServices.WindowHelper.WaitForLoaded(content);
+		try
+		{
+			content.XamlRoot.Bounds.Width.Should().BeGreaterThan(900);
+		}
+		finally
+		{
+			window.Close();
+		}
 	}
 
 	[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
@@ -371,15 +371,24 @@ public class Given_Window
 		var content = new Border() { Width = 100, Height = 100 };
 		window.Content = content;
 		window.Activate();
-		window.AppWindow.SetPresenter(FullScreenPresenter.Create());
 		await TestServices.WindowHelper.WaitForLoaded(content);
+		var bounds1 = window.Bounds;
+		window.Close();
+		var window2 = new Window();
+		window2.Content = content;
+		window2.Activate();
+		window2.AppWindow.SetPresenter(FullScreenPresenter.Create());
+		await TestServices.WindowHelper.WaitForLoaded(content);
+		await Task.Delay(TimeSpan.FromMilliseconds(1000));
 		try
 		{
-			content.XamlRoot.Bounds.Width.Should().BeGreaterThan(900);
+			var bounds2 = window2.Bounds;
+			bounds1.Width.Should().BeLessThan(bounds2.Width);
+			bounds1.Height.Should().BeLessThan(bounds2.Height);
 		}
 		finally
 		{
-			window.Close();
+			window2.Close();
 		}
 	}
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/20807

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->