### PR TITLE
fix(wasm): svg with clippath on first render

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/BrowserNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/BrowserNativeElementHostingExtension.cs
@@ -11,7 +11,7 @@ namespace Uno.UI.Runtime.Skia;
 internal partial class BrowserNativeElementHostingExtension : ContentPresenter.INativeElementHostingExtension
 {
 	private readonly ContentPresenter _presenter;
-	private static string _lastSvgClipPath = "";
+	private static string? _lastSvgClipPath;
 
 	public BrowserNativeElementHostingExtension(ContentPresenter contentPresenter)
 	{


### PR DESCRIPTION
**GitHub Issue:** closes #20799 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:
- 🐞 Bugfix


## What is the current behavior? 🤔
WebView is not respecting the boundaries of its parent, this is related to a SVG file with the ClipPath information not being loaded on the first render.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->