### PR TITLE
fix: Fix possible re-use of an already used port

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -656,11 +656,11 @@ public partial class EntryPoint : IDisposable
 					.GetActiveTcpListeners()
 					.All(ep => ep.Port != p))
 				{
-					// Note: The check bellow should be sufficient to check the port number, but with Windows 26100.4351 and dotnet 9.0.300
-					//		 it will **NOT** throw an exception as we would have expected. We keep this (second) check only for safety.
-					tcp = new TcpListener(IPAddress.Any, port) { ExclusiveAddressUse = true };
-				tcp.Start();
-				tcp.Stop();
+					// As a safety, we also try to open a socket just like how kestrell does.
+					// Note : We do NOT use a TCPListener here, as it will not throw an exception if the port is already in use **by Kestrell**.
+					var so = new Socket(IPAddress.Any.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+					so.Bind(new IPEndPoint(IPAddress.Any, port));
+					so.Close();
 
 				return false;
 			}

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -649,7 +649,7 @@ public partial class EntryPoint : IDisposable
 			// (and we prevent a rebuild of the application).
 			try
 			{
-				tcp = new TcpListener(IPAddress.Loopback, port);
+				tcp = new TcpListener(IPAddress.Any, port);
 				tcp.Start();
 				tcp.Stop();
 
@@ -661,7 +661,7 @@ public partial class EntryPoint : IDisposable
 			}
 		}
 
-		tcp = new TcpListener(IPAddress.Loopback, 0);
+		tcp = new TcpListener(IPAddress.Any, 0);
 		tcp.Start();
 		port = ((IPEndPoint)tcp.LocalEndpoint).Port;
 		tcp.Stop();

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -662,8 +662,8 @@ public partial class EntryPoint : IDisposable
 					so.Bind(new IPEndPoint(IPAddress.Any, port));
 					so.Close();
 
-				return false;
-			}
+					return false;
+				}
 			}
 			catch
 			{


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/20835

## 🐞 Bugfix
Fix possible re-use of an already used port


## What is the current behavior? 🤔
We validate if port is being used, but only on loopback address

## What is the new behavior? 🚀
We validate on any address of the system

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
Draft: not tested yet!