### PR TITLE
fix: Handled virtual key was not correct

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -570,11 +570,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await KeyboardHelper.Down();
 			await WindowHelper.WaitForIdle();
-			Assert.AreEqual(2, keyDownCount);
+			Assert.AreEqual(3, keyDownCount);
 
 			await KeyboardHelper.Right();
 			await WindowHelper.WaitForIdle();
-			Assert.AreEqual(3, keyDownCount);
+			Assert.AreEqual(4, keyDownCount);
 		}
 #endif
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -500,11 +500,11 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			await KeyboardHelper.PageDown();
 			await WindowHelper.WaitForIdle();
-			Assert.AreEqual(3, keyDownCount);
+			Assert.AreEqual(2, keyDownCount);
 
 			await KeyboardHelper.PressKeySequence("$d$_home#$u$_home");
 			await WindowHelper.WaitForIdle();
-			Assert.AreEqual(3, keyDownCount);
+			Assert.AreEqual(2, keyDownCount);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -202,7 +202,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if !HAS_INPUT_INJECTOR
 		[Ignore("InputInjector is not supported on this platform.")]
 #endif
-		public async Task When_Key_Press_Cant_Scroll()
+		public async Task When_Key_Press_Cannot_Scroll()
 		{
 			var navigationView = new NavigationView
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1669,7 +1669,7 @@ namespace Microsoft.UI.Xaml.Controls
 					args.Handled = !NumericExtensions.AreClose(oldVerticalOffset, Presenter.TargetVerticalOffset);
 				}
 
-				args.Handled |= key is VirtualKey.PageUp or VirtualKey.Down;
+				args.Handled |= key is VirtualKey.PageUp or VirtualKey.PageDown;
 			}
 
 			// This gets the delta that should be applied when arrow keys are pressed as a function of the

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.focus.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.focus.cs
@@ -1,0 +1,168 @@
+﻿#nullable enable
+
+using Microsoft.UI.Xaml.Input;
+using Windows.Foundation;
+using static Microsoft.UI.Xaml.Controls._Tracing;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+partial class ScrollViewer
+{
+	private (bool shouldScroll, bool shouldMoveFocus) HandleKeyDownForXYNavigation(KeyRoutedEventArgs args)
+	{
+		bool shouldScroll = false;
+		bool shouldMoveFocus = false;
+		var originalKey = args.OriginalKey;
+		bool isPageNavigation = FocusHelper.IsGamepadPageNavigationDirection(originalKey);
+		double scrollAmountProportion = isPageNavigation ? 1.0 : 0.5;
+		bool shouldProcessKeyEvent = true;
+		FocusNavigationDirection navigationDirection;
+
+		if (Presenter is null || XamlRoot is null)
+		{
+			return (shouldScroll, shouldMoveFocus);
+		}
+
+		if (isPageNavigation)
+		{
+			navigationDirection = FocusHelper.GetPageNavigationDirection(originalKey);
+		}
+		else
+		{
+			navigationDirection = FocusHelper.GetNavigationDirection(originalKey);
+		}
+
+		if (shouldProcessKeyEvent)
+		{
+			DependencyObject? nextElement = null;
+
+			if (navigationDirection != FocusNavigationDirection.None)
+			{
+				nextElement = GetNextFocusCandidate(navigationDirection, isPageNavigation);
+			}
+
+			if (nextElement is not null && nextElement != FocusManager.GetFocusedElement(XamlRoot))
+			{
+				UIElement nextElementAsUIE = FocusHelper.GetUIElementForFocusCandidate(nextElement);
+				MUX_ASSERT(nextElementAsUIE != null);
+
+				var nextElementAsFe = nextElementAsUIE as FrameworkElement;
+				if (nextElementAsFe is null || nextElementAsUIE is null)
+				{
+					shouldScroll = true;
+					shouldMoveFocus = false;
+					return (shouldScroll, shouldMoveFocus);
+				}
+
+				var rect = new Rect(0, 0, nextElementAsFe.ActualWidth, nextElementAsFe.ActualHeight);
+				var elementBounds = nextElementAsUIE.TransformToVisual(Presenter).TransformBounds(rect);
+				var viewport = new Rect(0, 0, Presenter.ActualWidth, Presenter.ActualHeight);
+
+				// Extend the viewport in the direction we are moving:
+				Rect extendedViewport = viewport;
+				switch (navigationDirection)
+				{
+					case FocusNavigationDirection.Down:
+						extendedViewport.Height += viewport.Height;
+						break;
+					case FocusNavigationDirection.Up:
+						extendedViewport.Y -= viewport.Height;
+						extendedViewport.Height += viewport.Height;
+						break;
+					case FocusNavigationDirection.Left:
+						extendedViewport.X -= viewport.Width;
+						extendedViewport.Width += viewport.Width;
+						break;
+					case FocusNavigationDirection.Right:
+						extendedViewport.Width += viewport.Width;
+						break;
+				}
+
+				bool isElementInExtendedViewport = RectHelper.Intersect(elementBounds, extendedViewport) != RectHelper.Empty;
+				bool isElementFullyInExtendedViewport = RectHelper.Union(elementBounds, extendedViewport) == extendedViewport;
+
+				if (isElementInExtendedViewport)
+				{
+					if (isPageNavigation)
+					{
+						// Always scroll for page navigation
+						shouldScroll = true;
+
+						if (isElementFullyInExtendedViewport)
+						{
+							// Move focus:
+							shouldMoveFocus = true;
+						}
+					}
+					else
+					{
+						// Non-paging scroll allows partial candidates
+						shouldMoveFocus = true;
+					}
+				}
+				else
+				{
+					// Element is outside extended viewport - scroll but don't focus.
+					shouldScroll = true;
+				}
+			}
+			else
+			{
+				// No focus candidate: scroll
+				shouldScroll = true;
+			}
+		}
+
+		return (shouldScroll, shouldMoveFocus);
+	}
+
+	private DependencyObject? GetNextFocusCandidate(FocusNavigationDirection navigationDirection, bool isPageNavigation)
+	{
+		MUX_ASSERT(Presenter is not null);
+		MUX_ASSERT(navigationDirection != FocusNavigationDirection.None);
+		var scrollPresenter = Presenter;
+
+		if (scrollPresenter is null)
+		{
+			return null;
+		}
+
+		FocusNavigationDirection focusDirection = navigationDirection;
+
+		FindNextElementOptions findNextElementOptions = new FindNextElementOptions();
+		findNextElementOptions.SearchRoot = scrollPresenter.Content as DependencyObject;
+
+		if (isPageNavigation)
+		{
+			var localBounds = new Rect(0, 0, scrollPresenter.ActualWidth, scrollPresenter.ActualHeight);
+			var globalBounds = scrollPresenter.TransformToVisual(null).TransformBounds(localBounds);
+			int numPagesLookAhead = 2;
+
+			var hintRect = globalBounds;
+			switch (navigationDirection)
+			{
+				case FocusNavigationDirection.Down:
+					hintRect.Y += globalBounds.Height * numPagesLookAhead;
+					break;
+				case FocusNavigationDirection.Up:
+					hintRect.Y -= globalBounds.Height * numPagesLookAhead;
+					break;
+				case FocusNavigationDirection.Left:
+					hintRect.X -= globalBounds.Width * numPagesLookAhead;
+					break;
+				case FocusNavigationDirection.Right:
+					hintRect.X += globalBounds.Width * numPagesLookAhead;
+					break;
+				default:
+					MUX_ASSERT(false);
+					break;
+			}
+
+			findNextElementOptions.HintRect = hintRect;
+			findNextElementOptions.ExclusionRect = hintRect;
+			focusDirection = FocusHelper.GetOppositeDirection(navigationDirection);
+		}
+
+		return FocusManager.FindNextElement(focusDirection, findNextElementOptions);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.focus.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.focus.cs
@@ -1,5 +1,5 @@
 ﻿#nullable enable
-
+#if UNO_HAS_MANAGED_SCROLL_PRESENTER
 using Microsoft.UI.Xaml.Input;
 using Windows.Foundation;
 using static Microsoft.UI.Xaml.Controls._Tracing;
@@ -118,7 +118,6 @@ partial class ScrollViewer
 
 	private DependencyObject? GetNextFocusCandidate(FocusNavigationDirection navigationDirection, bool isPageNavigation)
 	{
-		MUX_ASSERT(Presenter is not null);
 		MUX_ASSERT(navigationDirection != FocusNavigationDirection.None);
 		var scrollPresenter = Presenter;
 
@@ -166,3 +165,4 @@ partial class ScrollViewer
 		return FocusManager.FindNextElement(focusDirection, findNextElementOptions);
 	}
 }
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.focus.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.focus.cs
@@ -1,5 +1,5 @@
 ﻿#nullable enable
-#if UNO_HAS_MANAGED_SCROLL_PRESENTER
+#if !__ANDROID__ && !__APPLE_UIKIT__ && !__WASM__
 using Microsoft.UI.Xaml.Input;
 using Windows.Foundation;
 using static Microsoft.UI.Xaml.Controls._Tracing;


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/add-private/issues/43

## PR Type: 🐞 Bugfix, ✨ Feature

<!--
Copy the labels that apply to this PR and paste them above:

- 
- 
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

- `Down` key is always handled by `ScrollViewer`, even if scroll did not actually happen
- We always scroll and prevent focus if scrolling is possible in given direction

## What is the new behavior? 🚀

- `Down` key handling corrected
- We only scroll when the next focused item would be out of the viewport

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes