### PR TITLE
chore: fix diag-overlay crashing on windows

### DIFF
--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -83,6 +83,14 @@ public sealed partial class DiagnosticsOverlay : Control
 		};
 	}
 
+	public DiagnosticsOverlay()
+	{
+		// This constructor is added here because the WinAppSDK XamlReader requires a parameterless constructor for any TargetType.
+		// > Failed to create a 'System.Type' from the text 'local:DiagnosticsOverlay'. [Line: 9 Position: 3]"
+
+		throw new Exception("This constructor should not be used, use DiagnosticsOverlay.Get(XamlRoot) instead.");
+	}
+
 	private DiagnosticsOverlay(XamlRoot root)
 	{
 		_root = root;


### PR DESCRIPTION
**GitHub Issue:** closes #19746
## PR Type:
- 🐞 Bugfix

## What is the current behavior? 🤔
Calling `DiagnosticsOverlay.Get(XamlRoot)` would crash on WinAppSDK.

## What is the new behavior? 🚀
^ no more.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
n/a