### PR TITLE
fix(skia): Textbox content inherits textblock styles

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/TextBoxTests/TextBoxTests.cs
@@ -19,6 +19,17 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.TextBoxTests
 	{
 		[Test]
 		[AutoRetry]
+		public void TextBox_Content_DoesNotInheritParentTextBlockStyle()
+		{
+			Run("UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_ImplicitParentTextBlockStyle");
+
+			var sut = _app.Marked("textbox").FirstResult().Rect;
+
+			sut.Height.Should().BeLessThan(100);
+		}
+
+		[Test]
+		[AutoRetry]
 		public void TextBox_NaturalSize_When_Empty_Is_Right_Width()
 		{
 			Run("UITests.Shared.Windows_UI_Xaml_Controls.TextBoxes.TextBox_NaturalSize");

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -85,7 +85,7 @@
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\CommandBarFlyoutTests\TextCommandBarFlyoutPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
-    </Page>            
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\ExpanderTests\ExpanderColorValidationPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1927,6 +1927,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text_Arabic.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_ImplicitParentTextBlockStyle.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -6423,6 +6427,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuFlyoutTests\MenuFlyoutSubItem_Placement.xaml.cs">
       <DependentUpon>MenuFlyoutSubItem_Placement.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_ImplicitParentTextBlockStyle.xaml.cs">
+      <DependentUpon>TextBox_ImplicitParentTextBlockStyle.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_Keyboard_Navigation.xaml.cs">
       <DependentUpon>TextBox_Keyboard_Navigation.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_ImplicitParentTextBlockStyle.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_ImplicitParentTextBlockStyle.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl
+    x:Class="UITests.Windows_UI_Xaml_Controls.TextBox.TextBox_ImplicitParentTextBlockStyle"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.TextBox">
+
+    <StackPanel>
+        <StackPanel.Resources>
+            <Style TargetType="TextBlock">
+                <Setter Property="Margin" Value="0,100,0,0"/>
+            </Style>
+        </StackPanel.Resources>
+
+        <TextBox x:Name="textbox" Text="This text content should not have the TextBlock style's top margin applied."/>
+    </StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_ImplicitParentTextBlockStyle.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_ImplicitParentTextBlockStyle.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+namespace UITests.Windows_UI_Xaml_Controls.TextBox
+{
+	[Sample("TextBox", Description = "TextBox's content should not be affected by parent TextBlock styles")]
+	public sealed partial class TextBox_ImplicitParentTextBlockStyle : UserControl
+	{
+		public TextBox_ImplicitParentTextBlockStyle()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.skia.cs
@@ -35,7 +35,13 @@ namespace Microsoft.UI.Xaml.Controls
 			_textBox = WeakReferencePool.RentWeakReference(this, textBox);
 			IsPasswordBox = textBox is PasswordBox;
 
-			DisplayBlock = new TextBlock { MinWidth = InlineCollection.CaretThickness, IsTextBoxDisplay = true };
+			DisplayBlock = new TextBlock
+			{
+				MinWidth = InlineCollection.CaretThickness,
+				Style = null, // Prevent inheriting TextBlock styles
+				IsTextBoxDisplay = true,
+			};
+
 			SetFlowDirectionAndTextAlignment();
 
 			if ((!_isSkiaTextBox || _useInvisibleNativeTextView) && !ApiExtensibility.CreateInstance(this, out _overlayTextBoxViewExtension))


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/20295

## PR Type:

- 🐞 Bugfix
<!--
Copy the labels that apply to this PR and paste them above:

- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

TextBox content incorrectly inherits parent TextBlock styles.


## What is the new behavior? 🚀

TextBox content does not inherit parent TextBlock styles.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->