### PR TITLE
style(TabView): use same fill color resources as WinUI for LeftRadiusRenderArc and RadiusRadiusRenderArc Path

### DIFF
--- a/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/TabView.xaml
+++ b/src/Uno.UI.FluentTheme.v2/Resources/Version2/PriorityDefault/TabView.xaml
@@ -640,7 +640,7 @@
 
                         <Path x:Name="LeftRadiusRenderArc"
                             x:Load="False"
-                            Fill="{ThemeResource CardStrokeColorDefault}"
+                            Fill="{ThemeResource TabViewBorderBrush}"
                             VerticalAlignment="Bottom"
                             Visibility="Collapsed"
                             Margin="-4,0,0,0"
@@ -660,7 +660,7 @@
                             x:Load="False"
                             Grid.Column="2"
                             Visibility="Collapsed"
-                            Fill="{ThemeResource CardStrokeColorDefault}"
+                            Fill="{ThemeResource TabViewBorderBrush}"
                             VerticalAlignment="Bottom"
                             Margin="0,0,-4,0"
                             Height="4"


### PR DESCRIPTION
**GitHub Issue**: closes #20865


## PR Type:
🐞 Bugfix

## What is the current behavior? 🤔
Right now, if you try to style the tab view by updating the static resources of "TabViewSelectedItemBorderBrush" or "TabViewBorderBrush" you can't style the tab view borders without overriding the entire template when targeting Skia, however, this approach works as expected when targeting WinAppSDK. 


## What is the new behavior? 🚀

This update brings the Uno TabViewItem xaml styles closer to what is in the winui 1.7 xaml styles, using the same "TabViewBorderBrush" on "LeftRadiusRenderArc" and "RightRadiusRenderArc" as WinUI does.
There is still some divergence between uno and winui styles for this, but this bring its closer:
See WinUI styles: https://github.com/microsoft/microsoft-ui-xaml/blob/fb7a83b668baa612b5cc594678746dd8c1f8d8bd/src/controls/dev/TabView/TabView.xaml#L43

![image](https://github.com/user-attachments/assets/5376408b-99c4-4d7b-83f0-41bfe3b5114f)

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->