### PR TITLE
fix(textblock): invalidate the inner TextVisual whenever the TextBlock changes layout

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4335,6 +4335,54 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(0, SUT.SelectionLength);
 		}
 
+		[TestMethod]
+		[RequiresFullWindow]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20857")]
+		public async Task When_Rearranged_Without_Remeasuring()
+		{
+			var SUT1 = new TextBox { Text = "text", TextAlignment = TextAlignment.End };
+			var btn1 = new Button { Content = "button" };
+			var grid1 = new Grid
+			{
+				ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = GridLengthHelper.OneStar },
+					new ColumnDefinition { Width = GridLengthHelper.Auto }
+				},
+				Children =
+				{
+					SUT1,
+					FluentExtensions.Apply(btn1, btn => Grid.SetColumn(btn, 1))
+				}
+			};
+			await UITestHelper.Load(grid1);
+
+			var screenshot1 = await UITestHelper.ScreenShot(SUT1);
+
+			var SUT2 = new TextBox { Text = "text", TextAlignment = TextAlignment.End };
+			var btn2 = new Button { Content = "button" };
+			btn2.Visibility = Visibility.Collapsed; // difference here
+			var grid2 = new Grid
+			{
+				ColumnDefinitions =
+				{
+					new ColumnDefinition { Width = GridLengthHelper.OneStar },
+					new ColumnDefinition { Width = GridLengthHelper.Auto }
+				},
+				Children =
+				{
+					SUT2,
+					FluentExtensions.Apply(btn2, btn => Grid.SetColumn(btn, 1))
+				}
+			};
+			await UITestHelper.Load(grid2);
+			btn2.Visibility = Visibility.Visible;
+			await UITestHelper.WaitForIdle();
+
+			var screenshot2 = await UITestHelper.ScreenShot(SUT2);
+			await ImageAssert.AreEqualAsync(screenshot1, screenshot2);
+		}
+
 		private static bool HasColorInRectangle(RawBitmap screenshot, Rectangle rect, Color expectedColor)
 		{
 			for (var x = rect.Left; x < rect.Right; x++)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -29,6 +29,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private IDisposable? _selectionHighlightBrushChangedSubscription;
 		private readonly Dictionary<ContextMenuItem, MenuFlyoutItem> _flyoutItems = new();
 		private readonly VirtualKeyModifiers _platformCtrlKey = OperatingSystem.IsMacOS() ? VirtualKeyModifiers.Windows : VirtualKeyModifiers.Control;
+		private Size _lastInlinesArrangeWithPadding;
 
 		private protected override ContainerVisual CreateElementVisual() => new TextVisual(Compositor.GetSharedCompositor(), this);
 
@@ -119,7 +120,8 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			var padding = Padding;
 			var availableSizeWithoutPadding = finalSize.Subtract(padding);
-			Inlines.Arrange(availableSizeWithoutPadding);
+			var arrangedSize = Inlines.Arrange(availableSizeWithoutPadding);
+			_lastInlinesArrangeWithPadding = arrangedSize.Add(padding);
 			ApplyFlowDirection((float)finalSize.Width);
 
 			var result = base.ArrangeOverride(finalSize);
@@ -403,8 +405,8 @@ namespace Microsoft.UI.Xaml.Controls
 		partial void UpdateIsTextTrimmed()
 		{
 			IsTextTrimmed = IsTextTrimmable && (
-				(Visual.Size.X + Padding.Left + Padding.Right) > ActualWidth ||
-				(Visual.Size.Y + Padding.Top + Padding.Bottom) > ActualHeight
+				_lastInlinesArrangeWithPadding.Width > ActualWidth ||
+				_lastInlinesArrangeWithPadding.Height > ActualHeight
 			);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -24,19 +24,17 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	partial class TextBlock : FrameworkElement, IBlock
 	{
-		private readonly TextVisual _textVisual;
 		private Action? _selectionHighlightColorChanged;
 		private MenuFlyout? _contextMenu;
 		private IDisposable? _selectionHighlightBrushChangedSubscription;
 		private readonly Dictionary<ContextMenuItem, MenuFlyoutItem> _flyoutItems = new();
 		private readonly VirtualKeyModifiers _platformCtrlKey = OperatingSystem.IsMacOS() ? VirtualKeyModifiers.Windows : VirtualKeyModifiers.Control;
 
+		private protected override ContainerVisual CreateElementVisual() => new TextVisual(Compositor.GetSharedCompositor(), this);
+
 		public TextBlock()
 		{
 			UpdateLastUsedTheme();
-			_textVisual = new TextVisual(Visual.Compositor, this);
-
-			Visual.Children.InsertAtBottom(_textVisual);
 
 			_hyperlinks.CollectionChanged += HyperlinksOnCollectionChanged;
 
@@ -55,7 +53,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
-			_textVisual.Comment = $"{Visual.Comment}#text";
+			Visual.Comment = $"{Visual.Comment}#text";
 		}
 #endif
 
@@ -112,23 +110,16 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private void ApplyFlowDirection(float width)
 		{
-			if (this.FlowDirection == FlowDirection.RightToLeft)
-			{
-				_textVisual.TransformMatrix = new Matrix4x4(new Matrix3x2(-1.0f, 0.0f, 0.0f, 1.0f, width, 0.0f));
-			}
-			else
-			{
-				_textVisual.TransformMatrix = Matrix4x4.Identity;
-			}
+			Visual.TransformMatrix = FlowDirection == FlowDirection.RightToLeft
+				? new Matrix4x4(new Matrix3x2(-1.0f, 0.0f, 0.0f, 1.0f, width, 0.0f))
+				: Matrix4x4.Identity;
 		}
 
 		protected override Size ArrangeOverride(Size finalSize)
 		{
 			var padding = Padding;
 			var availableSizeWithoutPadding = finalSize.Subtract(padding);
-			var arrangedSizeWithoutPadding = Inlines.Arrange(availableSizeWithoutPadding);
-			_textVisual.Size = new Vector2((float)arrangedSizeWithoutPadding.Width, (float)arrangedSizeWithoutPadding.Height);
-			_textVisual.Offset = new Vector3((float)padding.Left, (float)padding.Top, 0);
+			Inlines.Arrange(availableSizeWithoutPadding);
 			ApplyFlowDirection((float)finalSize.Width);
 
 			var result = base.ArrangeOverride(finalSize);
@@ -178,7 +169,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private void InvalidateInlineAndRequireRepaint()
 		{
 			Inlines.InvalidateMeasure();
-			_textVisual.Compositor.InvalidateRender(_textVisual);
+			Visual.Compositor.InvalidateRender(Visual);
 		}
 
 		partial void InvalidateTextBlockPartial() => InvalidateInlineAndRequireRepaint();
@@ -412,8 +403,8 @@ namespace Microsoft.UI.Xaml.Controls
 		partial void UpdateIsTextTrimmed()
 		{
 			IsTextTrimmed = IsTextTrimmable && (
-				(_textVisual.Size.X + Padding.Left + Padding.Right) > ActualWidth ||
-				(_textVisual.Size.Y + Padding.Top + Padding.Bottom) > ActualHeight
+				(Visual.Size.X + Padding.Left + Padding.Right) > ActualWidth ||
+				(Visual.Size.Y + Padding.Top + Padding.Bottom) > ActualHeight
 			);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextVisual.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextVisual.skia.cs
@@ -18,7 +18,7 @@ using Uno.UI.Composition;
 
 namespace Microsoft.UI.Composition
 {
-	internal class TextVisual : Visual
+	internal class TextVisual : ContainerVisual
 	{
 		private readonly WeakReference<TextBlock> _owner;
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/20857

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->