### PR TITLE
fix(xbind): no longer trigger on host reload

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_Resurrection.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_Resurrection.xaml
@@ -1,0 +1,8 @@
+﻿<Page x:Class="Uno.UI.RuntimeTests.Tests.XBind_Resurrection"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<TextBlock x:Name="TestBlock"
+			   x:FieldModifier="public"
+			   Tag="{x:Bind ViewModel.MyValue, Mode=OneWay}" />
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_Resurrection.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/BindingTests/XBind_Resurrection.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Uno.UI.RuntimeTests.Tests;
+
+public sealed partial class XBind_Resurrection : Page
+{
+	public VM ViewModel { get; } = new VM();
+
+	public XBind_Resurrection()
+	{
+		this.InitializeComponent();
+	}
+
+	public class VM : INotifyPropertyChanged
+	{
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		private int _myValue;
+		public int MyValue
+		{
+			get => _myValue;
+			set
+			{
+				if (_myValue != value)
+				{
+					_myValue = value;
+					PropertyChanged?.Invoke(this, new(nameof(MyValue)));
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -20,7 +20,7 @@ namespace Microsoft.UI.Xaml.Data
 		private readonly Type _targetOwnerType;
 
 		private ManagedWeakReference _dataContext;
-		private SerialDisposable _subscription = new SerialDisposable();
+		private readonly SerialDisposable _subscription = new SerialDisposable();
 
 		private BindingPath _bindingPath;
 		private bool _disposed;
@@ -297,7 +297,7 @@ namespace Microsoft.UI.Xaml.Data
 			if (!_isBindingSuspended)
 			{
 				_isBindingSuspended = true;
-				_subscription.Dispose();
+				_subscription.Disposable = null;
 			}
 		}
 


### PR DESCRIPTION
**GitHub Issue:** closes #20625

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔
x:Bind suspended from an unloaded view, cannot be restored when the view is reloaded.

## What is the new behavior? 🚀
Suspended x:Bind can be properly resumed when the view is reloaded.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
regression from: #19720