### PR TITLE
chore: ios skia rendering perf validation

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SKCanvasElement.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SKCanvasElement.skia.cs
@@ -84,11 +84,12 @@ public class Given_SKCanvasElement
 	}
 
 	[TestMethod]
-	public async Task When_Loading_Not_Rendereing_Unnecessarily()
+	[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/1380")]
+	public async Task When_Loading_Not_Rendering_Unnecessarily()
 	{
 		var renderInvalidatedCount = 0;
 
-		var SUT = new RedFillSKCanvasElement
+		var SUT = new InvalidateOnRenderSKCanvasElement
 		{
 			Height = 400,
 			Width = 400
@@ -122,9 +123,10 @@ public class Given_SKCanvasElement
 
 
 	[TestMethod]
+	[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/1380")]
 	public async Task When_Invalidate_Called_MultipleTimes_DoesNot_Crash()
 	{
-		var SUT = new RedFillSKCanvasElement
+		var SUT = new InvalidateOnRenderSKCanvasElement
 		{
 			Height = 200,
 			Width = 400
@@ -146,16 +148,9 @@ public class Given_SKCanvasElement
 		stack.Children.Add(SUT);
 		stack.Children.Add(blueCanvas);
 
-		var border = new Border
-		{
-			BorderBrush = Microsoft.UI.Colors.Green,
-			Height = 500,
-			Child = stack
-		};
+		await UITestHelper.Load(stack);
 
-		await UITestHelper.Load(border);
-
-		var bitmap = await UITestHelper.ScreenShot(border);
+		var bitmap = await UITestHelper.ScreenShot(stack);
 
 		ImageAssert.HasColorInRectangle(bitmap, new Rectangle(0, 0, 200, 200), Microsoft.UI.Colors.Red);
 		ImageAssert.HasColorInRectangle(bitmap, new Rectangle(0, 200, 200, 200), Microsoft.UI.Colors.Blue);
@@ -204,7 +199,7 @@ public class Given_SKCanvasElement
 		}
 	}
 
-	private class RedFillSKCanvasElement : SKCanvasElement
+	private class InvalidateOnRenderSKCanvasElement : SKCanvasElement
 	{
 		protected override void RenderOverride(SKCanvas canvas, Size area)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SKCanvasElement.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_SKCanvasElement.skia.cs
@@ -84,6 +84,44 @@ public class Given_SKCanvasElement
 	}
 
 	[TestMethod]
+	public async Task When_Loading_Not_Rendereing_Unnecessarily()
+	{
+		var renderInvalidatedCount = 0;
+
+		var SUT = new RedFillSKCanvasElement
+		{
+			Height = 400,
+			Width = 400
+		};
+
+		var border = new Border
+		{
+			BorderBrush = Microsoft.UI.Colors.Green,
+			Height = 400,
+			Child = new ScrollViewer
+			{
+				VerticalAlignment = VerticalAlignment.Top,
+				Height = 400,
+				Background = Microsoft.UI.Colors.Red,
+				Content = SUT
+			}
+		};
+
+		await UITestHelper.Load(border);
+
+		SUT.XamlRoot.RenderInvalidated += () =>
+		{
+			renderInvalidatedCount++;
+		};
+
+		// Wait a short time to ensure no extra invalidations occur
+		await Task.Delay(6000);
+
+		Assert.IsTrue(renderInvalidatedCount < 4, "RenderInvalidated should not be executed indefinitely.");
+	}
+
+
+	[TestMethod]
 	public async Task When_Invalidate_Called_MultipleTimes_DoesNot_Crash()
 	{
 		var SUT = new RedFillSKCanvasElement


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno-private/issues/1380

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 💬 Other... (Please describe)

## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior? 🚀

This PR adds a set of runtime test to validate the performance implications on iOS. The idea behind this change is to capture performance issues related to rendering, such as rendering more than required or rendering when the application is in an idle state.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->