### PR TITLE
ci: Adjust publish for release/stable/6.1 branch

### DIFF
--- a/build/ci/templates/nuget-publish-dev.yml
+++ b/build/ci/templates/nuget-publish-dev.yml
@@ -1,22 +1,10 @@
 steps:
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), not(eq(variables['build.reason'], 'PullRequest')))
     inputs:
       command: 'push'
       packagesToPush: '$(Pipeline.Workspace)/Nuget_Packages/**/*.nupkg'
       nuGetFeedType: 'internal'
       publishVstsFeed: '1dd81cbd-cb35-41de-a570-b0df3571a196/e7ce08df-613a-41a3-8449-d42784dd45ce'
-      allowPackageConflicts: true
-      verbosityPush: 'Normal'
-
-  - task: NuGetCommand@2
-    displayName: 'Publish to Uno Feature Feed'
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/feature'), not(eq(variables['build.reason'], 'PullRequest')))
-    inputs:
-      command: 'push'
-      packagesToPush: '$(Pipeline.Workspace)/Nuget_Packages/**/*.nupkg'
-      nuGetFeedType: 'internal'
-      publishVstsFeed: '1dd81cbd-cb35-41de-a570-b0df3571a196/d26abad4-c545-4e56-9ac7-fe42c6311c28'
       allowPackageConflicts: true
       verbosityPush: 'Normal'


### PR DESCRIPTION
Similar to what @jeromelaban did here https://github.com/unoplatform/uno/commit/0d2afefa87cb23e09195dbed9575785c0cc565e6 for the previous **release/stable/6.0** branch