### PR TITLE
docs: Update azure static apps walkthrough

### DIFF
--- a/doc/articles/guides/azure-static-webapps.md
+++ b/doc/articles/guides/azure-static-webapps.md
@@ -22,7 +22,7 @@ Here is how to publish an app from GitHub, using Uno Platform:
     dotnet new unoapp -o MyApp
     ```
 
-- If the `<TargetFramework>` value in the `MyApp.Wasm.csproj` is not `net8.0`, [follow the upgrading steps provided here](../../articles/migrating-to-uno-5.md#migrating-webassembly-from-netstandard2-0-to-net7-0-or-net8-0).
+- If the `<TargetFramework>` value in the `MyApp.Wasm.csproj` is not `net9.0`, [follow the upgrading steps provided here](../../articles/migrating-to-uno-5.md#migrating-webassembly-from-netstandard2-0-to-net7-0-or-net8-0).
 - If in the `MyApp.Wasm\wwwroot`, you find a `web.config` file, delete it. This will enable brotli compression in Azure Static Web Apps.
 - Search for [Static Web Apps](https://portal.azure.com/#create/Microsoft.StaticApp) in the Azure Portal
 - Fill the required fields in the creation form:
@@ -42,9 +42,9 @@ Here is how to publish an app from GitHub, using Uno Platform:
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.100'
+        dotnet-version: '9.0.x'
 
-    - run: |
+    - run: 
         cd src/MyApp.Wasm
         dotnet build -c Release
     ```
@@ -52,7 +52,7 @@ Here is how to publish an app from GitHub, using Uno Platform:
 - In the Deploy step that was automatically added, change the `app_location` parameter to the following:
 
     ```yaml
-    app_location: "src/MyApp.Wasm/bin/Debug/net8.0/dist"
+    app_location: "src/MyApp.Wasm/bin/Debug/net9.0/dist"
     ```
 
 - Once changed, the application will be built and deployed on your Azure Static Web App instance.

--- a/doc/articles/guides/azure-static-webapps.md
+++ b/doc/articles/guides/azure-static-webapps.md
@@ -1,5 +1,5 @@
 ---
-uid: Uno.Tutorials.AzureStaticWepApps
+uid: Uno.Tutorials.AzureStaticWebApps
 ---
 
 # Hosting Uno Platform WebAssembly apps on Azure Static Web Apps
@@ -22,7 +22,8 @@ Here is how to publish an app from GitHub, using Uno Platform:
     dotnet new unoapp -o MyApp
     ```
 
-- If the `<TargetFramework>` value in the `MyApp.Wasm.csproj` is not `net9.0`, [follow the upgrading steps provided here](../../articles/migrating-to-uno-5.md#migrating-webassembly-from-netstandard2-0-to-net7-0-or-net8-0).
+- If the `<TargetFramework>` value in the `MyApp.Wasm.csproj` is not `net9.0`, [make sure to upgrade to latest Uno release by following these steps](xref:Uno.Development.MigratingFromPreviousReleases).
+
 - If in the `MyApp.Wasm\wwwroot`, you find a `web.config` file, delete it. This will enable brotli compression in Azure Static Web Apps.
 - Search for [Static Web Apps](https://portal.azure.com/#create/Microsoft.StaticApp) in the Azure Portal
 - Fill the required fields in the creation form:

--- a/doc/articles/guides/azure-static-webapps.md
+++ b/doc/articles/guides/azure-static-webapps.md
@@ -22,7 +22,7 @@ Here is how to publish an app from GitHub, using Uno Platform:
     dotnet new unoapp -o MyApp
     ```
 
-- If the `<TargetFramework>` value in the `MyApp.Wasm.csproj` is not `net5.0`, [follow the upgrading steps provided here](../../articles/migrating-from-previous-releases.md#migrating-webassembly-projects-to-net-5).
+- If the `<TargetFramework>` value in the `MyApp.Wasm.csproj` is not `net8.0`, [follow the upgrading steps provided here](../../articles/migrating-to-uno-5.md#migrating-webassembly-from-netstandard2-0-to-net7-0-or-net8-0).
 - If in the `MyApp.Wasm\wwwroot`, you find a `web.config` file, delete it. This will enable brotli compression in Azure Static Web Apps.
 - Search for [Static Web Apps](https://portal.azure.com/#create/Microsoft.StaticApp) in the Azure Portal
 - Fill the required fields in the creation form:
@@ -35,14 +35,14 @@ Here is how to publish an app from GitHub, using Uno Platform:
 
     ![visual-studio-installer-web](../Assets/aswa-settings.png)
 
-- The click on **Review+Create** button. Azure will automatically create a new **GitHub Actions Workflow** in your repository. The workflow will automatically be started and will fail for this first run, as some parameters need to be adjusted.
+- Then click on **Review+Create** button. Azure will automatically create a new **GitHub Actions Workflow** in your repository. The workflow will automatically be started and will fail for this first run, as some parameters need to be adjusted.
 - In your repository’s newly added github workflow (in `.github/workflows`), add the following two steps, after the checkout step:
 
     ```yaml
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v1.7.2
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.402'
+        dotnet-version: '8.0.100'
 
     - run: |
         cd src/MyApp.Wasm
@@ -52,7 +52,7 @@ Here is how to publish an app from GitHub, using Uno Platform:
 - In the Deploy step that was automatically added, change the `app_location` parameter to the following:
 
     ```yaml
-    app_location: "src/MyApp.Wasm/bin/Debug/net5.0/dist"
+    app_location: "src/MyApp.Wasm/bin/Debug/net8.0/dist"
     ```
 
 - Once changed, the application will be built and deployed on your Azure Static Web App instance.

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -104,7 +104,7 @@
       - name: Overview
         href: xref:Uno.Tutorials.Intro
       - name: How to deploy a WebAssembly app on Azure Static Web Apps
-        href: xref:Uno.Tutorials.AzureStaticWepApps
+        href: xref:Uno.Tutorials.AzureStaticWebApps
       - name: How to use Windows Community Toolkit
         topicHref: xref:Uno.Development.CommunityToolkit
         items:

--- a/doc/articles/uno-publishing-webassembly.md
+++ b/doc/articles/uno-publishing-webassembly.md
@@ -48,5 +48,5 @@ Once done, you can head over to [publishing section](xref:uno.publishing.webasse
 Publishing your app can be done to different servers and cloud providers.
 
 - [How to host a WebAssembly App](xref:Uno.Development.HostWebAssemblyApp)
-- [Publishing to Azure Static Apps](xref:Uno.Tutorials.AzureStaticWepApps)
+- [Publishing to Azure Static Apps](xref:Uno.Tutorials.AzureStaticWebApps)
 - [Server locally using dotnet-serve](https://github.com/natemcmaster/dotnet-serve)


### PR DESCRIPTION
GitHub Issue: closes #20944

PR Type:
📚 Documentation content changes

What is the current behavior? 🤔
The Azure Static Web Apps hosting guide references .NET 5.0 for Uno WebAssembly deployment steps, which is outdated. The official Uno templates and recommended target framework have moved to .NET 8.0.

What is the new behavior? 🚀
Updated the TargetFramework instructions from net5.0 to net8.0 in:

Azure Static Web Apps publishing guide.

Related fallback route configuration snippet.

Updated links to point to the .NET 8 migration section in migration docs.

Clarified fallback route configuration examples.

PR Checklist ✅
 📝 Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

 📚 Docs updated to match the current Uno platform version recommendations.

 ❗ Contains NO breaking changes

Other information ℹ️
This PR addresses issue feedback requesting an update for .NET 8.0 deployment compatibility and clarity for new contributors referencing outdated net5.0 instructions.