### PR TITLE
chore: Bump Uno.DevTools.Telemetry to latest stable

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -14,7 +14,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.0.0-dev.24" />
+		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
To include the latest changes including https://github.com/unoplatform/uno.devtools.telemetry/pull/16