### PR TITLE
Ensure `TabView` selection behaves correctly when selected tab is closed

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2093,6 +2093,9 @@
 		</Events>
 
 		<Fields>
+			<!-- BEGIN ListViewBase selection changes -->
+			<Member fullName="Windows.Foundation.Collections.IVectorChangedEventArgs Microsoft.UI.Xaml.Controls.ItemsControl::_inProgressVectorChange" reason="Not public in WinUI" />
+			<!-- END ListViewBase selection changes -->
 		</Fields>
 
 		<Properties>
@@ -2111,6 +2114,9 @@
 			<Member fullName="Microsoft.UI.Xaml.DependencyProperty Microsoft.UI.Xaml.Controls.AppBarToggleButton.get_TemplateSettingsProperty()" reason="Not public in WinUI" />
 			<Member fullName="System.Void Microsoft.UI.Xaml.Controls.CommandBar.FindParentCommandBarForElement(Microsoft.UI.Xaml.Controls.ICommandBarElement element, Microsoft.UI.Xaml.Controls.CommandBar&amp; parentCmdBar)" reason="Not public in WinUI" />
 			<!-- END AppBarButton-->
+			<!-- BEGIN ListViewBase selection changes -->
+			<Member fullName="System.Int32 Microsoft.UI.Xaml.Controls.ItemsControl.GetInProgressAdjustedIndex(System.Int32 index)" reason="Not public in WinUI" />
+			<!-- END ListViewBase selection changes -->
 		</Methods>
 	</IgnoreSet>
 	<![CDATA[

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TabView/TabViewTests.Uno.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TabView/TabViewTests.Uno.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
+using Uno.UI.RuntimeTests;
 using Uno.UI.RuntimeTests.Helpers;
 
 namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
@@ -51,5 +52,65 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 			});
 		}
 #endif
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20976")]
+		public async Task When_First_Tab_Selected_And_Closed() => await When_Tab_Selected_And_Closed(0, 1);
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20976")]
+		public async Task When_Middle_Tab_Selected_And_Closed() => await When_Tab_Selected_And_Closed(1, 2);
+
+		[TestMethod]
+		[RunsOnUIThread]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20976")]
+		public async Task When_Last_Tab_Selected_And_Closed() => await When_Tab_Selected_And_Closed(2, 1);
+
+		private async Task When_Tab_Selected_And_Closed(int tabToClose, int expectedSelectedTab)
+		{
+			var tabView = new TabView();
+			tabView.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+			tabView.VerticalContentAlignment = VerticalAlignment.Stretch;
+			tabView.HorizontalAlignment = HorizontalAlignment.Stretch;
+			tabView.VerticalAlignment = VerticalAlignment.Stretch;
+			tabView.Height = 300;
+
+			var tabItem1 = CreateTabViewItem("Item 1");
+			tabItem1.Content = new Border() { Background = new SolidColorBrush(Colors.Blue) };
+			var tabItem2 = CreateTabViewItem("Item 2");
+			tabItem2.Content = new Border() { Background = new SolidColorBrush(Colors.Green) };
+			var tabItem3 = CreateTabViewItem("Item 3");
+			tabItem3.Content = new Border() { Background = new SolidColorBrush(Colors.Red) };
+
+			tabView.TabItems.Add(tabItem1);
+			tabView.TabItems.Add(tabItem2);
+			tabView.TabItems.Add(tabItem3);
+
+			var tabToSelectAndClose = tabView.TabItems[tabToClose];
+			var expectedSelectedTabAfterClose = (TabViewItem)tabView.TabItems[expectedSelectedTab];
+			var expectedColor = ((SolidColorBrush)((Border)expectedSelectedTabAfterClose.Content).Background).Color;
+
+			TestServices.WindowHelper.WindowContent = tabView;
+			await TestServices.WindowHelper.WaitForLoaded(tabView);
+
+			// Select the tab that will be closed
+			tabView.SelectedItem = tabToSelectAndClose;
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Close the tab
+			tabView.TabItems.Remove(tabToSelectAndClose);
+			await TestServices.WindowHelper.WaitForIdle();
+
+			// Verify that the last tab is closed and the second last tab is selected
+			Assert.IsFalse(tabView.TabItems.Contains(tabToSelectAndClose), "Expected the last tab to be removed from the TabItems collection.");
+			Assert.AreEqual(expectedSelectedTabAfterClose, tabView.SelectedItem, "Expected the second last tab to be selected after closing the last tab.");
+
+#if HAS_RENDER_TARGET_BITMAP
+			var contentScreenshot = await UITestHelper.ScreenShot(tabView);
+			ImageAssert.HasColorAt(contentScreenshot, contentScreenshot.Width / 2, contentScreenshot.Height / 2, expectedColor);
+#endif
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TabView/TabViewTests.Uno.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TabView/TabViewTests.Uno.cs
@@ -104,8 +104,8 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 			await TestServices.WindowHelper.WaitForIdle();
 
 			// Verify that the last tab is closed and the second last tab is selected
-			Assert.IsFalse(tabView.TabItems.Contains(tabToSelectAndClose), "Expected the last tab to be removed from the TabItems collection.");
-			Assert.AreEqual(expectedSelectedTabAfterClose, tabView.SelectedItem, "Expected the second last tab to be selected after closing the last tab.");
+			Assert.IsFalse(tabView.TabItems.Contains(tabToSelectAndClose), "Expected the tab to be removed from the TabItems collection.");
+			Assert.AreEqual(expectedSelectedTabAfterClose, tabView.SelectedItem, "Expected different tab to be selected after closing the selected tab.");
 
 #if HAS_RENDER_TARGET_BITMAP
 			var contentScreenshot = await UITestHelper.ScreenShot(tabView);

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TabView/TabViewTests.Uno.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/TabView/TabViewTests.Uno.cs
@@ -7,6 +7,8 @@ using MUXControlsTestApp.Utilities;
 using Private.Infrastructure;
 using Uno.UI.RuntimeTests;
 using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.Extensions;
+using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 {
@@ -106,10 +108,11 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 			// Verify that the last tab is closed and the second last tab is selected
 			Assert.IsFalse(tabView.TabItems.Contains(tabToSelectAndClose), "Expected the tab to be removed from the TabItems collection.");
 			Assert.AreEqual(expectedSelectedTabAfterClose, tabView.SelectedItem, "Expected different tab to be selected after closing the selected tab.");
+			Assert.IsTrue(expectedSelectedTabAfterClose.IsSelected, "Expected tab is not selected.");
 
-#if HAS_RENDER_TARGET_BITMAP
-			var contentScreenshot = await UITestHelper.ScreenShot(tabView);
-			ImageAssert.HasColorAt(contentScreenshot, contentScreenshot.Width / 2, contentScreenshot.Height / 2, expectedColor);
+#if HAS_UNO
+			var presenter = tabView.FindFirstDescendant<ContentPresenter>("TabContentPresenter");
+			Assert.AreEqual(presenter.Content, expectedSelectedTabAfterClose.Content);
 #endif
 		}
 	}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
@@ -201,11 +201,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			itemsSource.RemoveAt(2);
 
-#if __ANDROID__
 			await WindowHelper.WaitForResultEqual(0, () => flipView.SelectedIndex);
-#else
-			await WindowHelper.WaitForResultEqual(-1, () => flipView.SelectedIndex);
-#endif
+
 			itemsSource.Clear();
 
 			await WindowHelper.WaitForResultEqual(-1, () => flipView.SelectedIndex);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -2825,21 +2825,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Assert.AreEqual(items[0], list.ItemFromContainer(container0));
 				Assert.AreEqual(0, list.IndexFromContainer(container0));
 
-				// Test old container/index/item
+				// Test old container for old item
 				Assert.IsNull(list.ContainerFromItem(oldItem));
-				Assert.IsNull(list.ItemFromContainer(oldContainer));
-				Assert.AreEqual(-1, list.IndexFromContainer(oldContainer));
 
-#if HAS_UNO
-				// Test new container/index/item
-				// In UWP the container for the new item is returned, but its
-				// content is not yet set.
-				// We match the situation with Reset and return nulls.
+				// Container for new item should abe available
 				var container1 = (ListViewItem)list.ContainerFromItem(items[1]);
-				Assert.IsNull(container1);
+				Assert.IsNotNull(container1);
 				var containerIndex1 = list.ContainerFromIndex(1);
-				Assert.IsNull(containerIndex1);
-#endif
+				Assert.IsNotNull(containerIndex1);
 
 				// Test container/index/item right after changed
 				var container2 = (ListViewItem)list.ContainerFromItem(items[2]);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ListViewBase.cs
@@ -2552,7 +2552,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			// Item change
 			var oldItem = items[1];
-			var newItem = new ListViewItem();
+			var newItem = new ListViewItem() { Content = "New" };
 
 			list.ItemsChangedAction = () =>
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -106,6 +106,7 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				_inProgressVectorChange = null;
 			}
+			//OnItemsSourceSingleCollectionChanged(this, e.ToNotifyCollectionChangedEventArgs(), 0);
 		}
 
 		partial void InitializePartial();
@@ -1469,43 +1470,6 @@ namespace Microsoft.UI.Xaml.Controls
 				return Items.IndexOf(container);
 			}
 
-			if (_inProgressVectorChange != null)
-			{
-				if (_inProgressVectorChange.CollectionChange == CollectionChange.ItemRemoved)
-				{
-					if (index == _inProgressVectorChange.Index)
-					{
-						// Removed item no longer exists.
-						return -1;
-					}
-					else if (index > _inProgressVectorChange.Index)
-					{
-						// All items after the removed item have a lower new index.
-						return index - 1;
-					}
-				}
-				else if (_inProgressVectorChange.CollectionChange == CollectionChange.ItemInserted)
-				{
-					if (index >= _inProgressVectorChange.Index)
-					{
-						// All items after the added item have a higher new index.
-						return index + 1;
-					}
-				}
-				else if (
-					(_inProgressVectorChange.CollectionChange == CollectionChange.ItemChanged && _inProgressVectorChange.Index == index) ||
-					_inProgressVectorChange.CollectionChange == CollectionChange.Reset)
-				{
-					// In these cases, we return the index only if the item is its own container
-					// and the container is in fact the new item, not the old one
-					var item = ItemFromIndex(index);
-					if (IsItemItsOwnContainer(item) && Equals(item, container))
-					{
-						return index;
-					}
-					return -1;
-				}
-			}
 			return index;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -11,6 +11,7 @@ using Uno.Disposables;
 using Uno.Extensions;
 using Uno.Extensions.Specialized;
 using Uno.Foundation.Logging;
+using Uno.UI;
 using Uno.UI.DataBinding;
 using Uno.UI.Extensions;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -99,14 +99,13 @@ namespace Microsoft.UI.Xaml.Controls
 			try
 			{
 				_inProgressVectorChange = e;
+				OnItemsSourceSingleCollectionChanged(this, e.ToNotifyCollectionChangedEventArgs(), 0);
 				OnItemsChanged(e);
 			}
 			finally
 			{
 				_inProgressVectorChange = null;
 			}
-
-			OnItemsSourceSingleCollectionChanged(this, e.ToNotifyCollectionChangedEventArgs(), 0);
 		}
 
 		partial void InitializePartial();

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -15,8 +15,6 @@ using Uno.UI.DataBinding;
 using Uno.UI.Extensions;
 using System.Diagnostics.CodeAnalysis;
 
-
-
 #if __ANDROID__
 using _View = Android.Views.View;
 using _ViewGroup = Android.Views.ViewGroup;
@@ -1410,7 +1408,11 @@ namespace Microsoft.UI.Xaml.Controls
 			if (index > -1)
 			{
 				var item = ItemFromIndex(index);
-				return item;
+				if (!IsItemItsOwnContainer(item) ||
+					Equals(item, container))
+				{
+					return item;
+				}
 			}
 			else
 			{
@@ -1454,8 +1456,17 @@ namespace Microsoft.UI.Xaml.Controls
 				// If the container is actually an item, we can return its index
 				return Items.IndexOf(container);
 			}
+			else
+			{
+				var item = ItemFromIndex(index);
+				if (!IsItemItsOwnContainer(item) ||
+					Equals(container, item))
+				{
+					return index;
+				}
+			}
 
-			return index;
+			return -1;
 		}
 
 		internal virtual int IndexFromContainerInner(DependencyObject container)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -1112,8 +1112,8 @@ namespace Microsoft.UI.Xaml.Controls
 				var container = ContainerFromIndex(flatIndex);
 				if (container != null)
 				{
-					var item = GetDisplayItemFromIndexPath(unoIndexPath);
 #if __APPLE_UIKIT__ || __ANDROID__ // TODO: The managed ListView should similarly go through the recycling to use the proper container matching the new template
+					var item = GetDisplayItemFromIndexPath(unoIndexPath);
 					if (HasTemplateChanged(((FrameworkElement)container).DataContext, item))
 					{
 						// If items are using different templates, we should go through the native replace operation, to use a container


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/20976

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

Incorrect method call order in `ItemsControl` causes invalid selection changes.

## What is the new behavior? 🚀

Adjusted

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes