### PR TITLE
chore: fix diag-overlay crashing on windows

### DIFF
--- a/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
+++ b/src/Uno.UI.Toolkit/Diagnostics/DiagnosticsOverlay.cs
@@ -20,6 +20,11 @@ namespace Uno.Diagnostics.UI;
 /// <summary>
 /// An overlay layer used to inject analytics and diagnostics indicators into the UI.
 /// </summary>
+// https://github.com/microsoft/microsoft-ui-xaml/issues/7206
+// Required, because WinUI will trim class not used in xaml and without this attribute, causing the XamlReader to throw:
+// > Microsoft.UI.Xaml.Markup.XamlParseException: 'The text associated with this error code could not be found.
+// > Failed to create a 'System.Type' from the text 'local:DiagnosticsOverlay'. [Line: 9 Position: 3]'
+[Microsoft.UI.Xaml.Data.Bindable]
 [TemplatePart(Name = ToolbarPartName, Type = typeof(FrameworkElement))]
 [TemplatePart(Name = ElementsPanelPartName, Type = typeof(Panel))]
 [TemplatePart(Name = AnchorPartName, Type = typeof(UIElement))]
@@ -81,14 +86,6 @@ public sealed partial class DiagnosticsOverlay : Control
 				overlay.Value.EnqueueUpdate();
 			}
 		};
-	}
-
-	public DiagnosticsOverlay()
-	{
-		// This constructor is added here because the WinAppSDK XamlReader requires a parameterless constructor for any TargetType.
-		// > Failed to create a 'System.Type' from the text 'local:DiagnosticsOverlay'. [Line: 9 Position: 3]"
-
-		throw new Exception("This constructor should not be used, use DiagnosticsOverlay.Get(XamlRoot) instead.");
 	}
 
 	private DiagnosticsOverlay(XamlRoot root)


### PR DESCRIPTION
**GitHub Issue:** closes #19746

## PR Type:
- 🐞 Bugfix

## What is the current behavior? 🤔
Calling DiagnosticsOverlay.Get(XamlRoot) would crash on WinAppSDK with:
> Microsoft.UI.Xaml.Markup.XamlParseException: 'The text associated with this error code could not be found.
> Failed to create a 'System.Type' from the text 'local:DiagnosticsOverlay'. [Line: 9 Position: 3]'

## What is the new behavior? 🚀
^ no more.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
n/a