### PR TITLE
chore: bump Microsoft.Identity.Client to 4.72.1 to fix malicious URL in comment

### DIFF
--- a/build/nuget/Uno.WinUI.MSAL.nuspec
+++ b/build/nuget/Uno.WinUI.MSAL.nuspec
@@ -13,58 +13,58 @@
 		<dependencies>
 			<group targetFramework="net9.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net8.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 
 			<!-- BEGIN UWP-specific
 			<group targetFramework="UAP10.0.19041">
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			END UWP-specific -->
 
 
 			<!-- BEGIN WinUI-specific -->
 			<group targetFramework="net8.0-windows10.0.19041.0">
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<!-- END WinUI-specific -->
 			
 
 			<group targetFramework="net8.0-android30.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net8.0-ios17.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net8.0-tvos17.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net8.0-maccatalyst17.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net9.0-android30.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net9.0-ios18.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net9.0-tvos18.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 			<group targetFramework="net9.0-maccatalyst18.0">
 				<dependency id="Uno.WinUI" version="to-be-set-by-ci" />
-				<dependency id="Microsoft.Identity.Client" version="4.61.3" />
+				<dependency id="Microsoft.Identity.Client" version="4.72.1" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Reference.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Reference.csproj
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Skia.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Skia.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Wasm.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Wasm.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Windows.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.Windows.csproj
@@ -33,7 +33,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 	</ItemGroup>
 
 	<Import Project="..\..\..\build\nuget\uno.winui.cross-runtime.targets"/>

--- a/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.netcoremobile.csproj
+++ b/src/AddIns/Uno.UI.MSAL/Uno.UI.MSAL.netcoremobile.csproj
@@ -42,7 +42,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
@@ -253,7 +253,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 
 		<PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />

--- a/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
+++ b/src/SamplesApp/SamplesApp.Skia/SamplesApp.Skia.csproj
@@ -55,7 +55,7 @@
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />
 		<!-- TODO: Use version 8 when compiling against .NET 8? -->

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -89,7 +89,7 @@
 
 		<PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Graph" Version="5.56.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.7.0" />

--- a/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
+++ b/src/SamplesApp/SamplesApp.Windows/SamplesApp.Windows.csproj
@@ -43,7 +43,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
 		<PackageReference Include="Microsoft.Graph" Version="5.56.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250310001" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />

--- a/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
@@ -219,7 +219,7 @@
 			<Version>5.56.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Identity.Client">
-			<Version>4.61.3</Version>
+			<Version>4.72.1</Version>
 		</PackageReference>
 
 		<PackageReference Include="MSTest.TestFramework" />

--- a/src/SamplesApp/UnoIslands.Skia/UnoIslands.Skia.csproj
+++ b/src/SamplesApp/UnoIslands.Skia/UnoIslands.Skia.csproj
@@ -40,7 +40,7 @@
 		<PackageReference Include="Uno.Fonts.Fluent" />
 		<PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Graph" Version="5.56.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />
 		<!-- TODO: Use version 8 when compiling against .NET 8? -->

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia/UnoIslandsSamplesApp.Skia.csproj
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia/UnoIslandsSamplesApp.Skia.csproj
@@ -48,7 +48,7 @@
 		<PackageReference Include="Uno.Fonts.Fluent" />
 		<PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Graph" Version="5.56.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.72.1" />
 		<PackageReference Include="MSTest.TestFramework" />
 		<PackageReference Include="MSTest.Analyzers" />
 		<!-- TODO: Use version 8 when compiling against .NET 8? -->


### PR DESCRIPTION
## PR Type:

- 💬 Other: Dependency vulnerability


## Description

📦 Microsoft.Identity.Client - Security Version Bump

This update addresses a security concern in earlier versions of `Microsoft.Identity.Client`, where a comment contained a typo in a URL: `hXXps[:]//login[.]microsoftonline[.]com/common`

This malformed URL was flagged as a **ConfirmedMaliciousURL** by multiple security vendors including Avira, Sophos, and Bitdefender.

Affected package: `Uno.WinUI.MSAL 6.1.0-dev.701`

The issue is fixed in version **4.72.1** released on **May 20, 2025**.  
🔗 [Release notes](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases/tag/4.72.1)

### ✅ Action Taken

- Updated to `Microsoft.Identity.Client` stable **4.72.1**

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [X] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes