### PR TITLE
fix: skia-droid WindowBounds and VisibleBounds with StatusBar.Background

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_StatusBar.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_ViewManagement/Given_StatusBar.cs
@@ -1,0 +1,73 @@
+﻿using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Uno.UI.Extensions;
+using Uno.UI.Helpers;
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI;
+using Windows.UI.ViewManagement;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_ViewManagement;
+
+[TestClass]
+public class Given_StatusBar
+{
+#if __ANDROID__
+#if false // this test doesnt work on the device from ci
+	[ConditionalTest(IgnoredPlatforms = ~RuntimeTestPlatforms.SkiaAndroid)]
+	[RunsOnUIThread]
+	[RequiresFullWindow]
+	public async Task StatusBar_Background_Value_ShouldDisplaceRenderArea()
+	{
+		if (!FeatureConfiguration.AndroidSettings.IsEdgeToEdgeEnabled)
+		{
+			Assert.Inconclusive("This test is only relevant when Edge2Edge is enabled.");
+		}
+
+		var sb = StatusBar.GetForCurrentView();
+		var av = ApplicationView.GetForCurrentView();
+		if (sb.OccludedRect.Height == 0 || av.IsFullScreenMode)
+		{
+			Assert.Inconclusive("The host device doesn't use a status bar or the app is in full-screen/android-immersive mode.");
+		}
+
+		var color = sb.BackgroundColor;
+		try
+		{
+			// prepare initial state with no background, so we have the entire screen available.
+			sb.BackgroundColor = null;
+
+			var outerGrid = XamlHelper.LoadXaml<Grid>("""
+				<Grid BorderBrush="Red" BorderThickness="5">
+					<Grid toolkit:VisibleBoundsPadding.PaddingMask="All">
+						<Border Background="SkyBlue" />
+					</Grid>
+				</Grid>
+				""");
+			var innerGrid = (Grid)outerGrid.Children[0];
+			await UITestHelper.Load(outerGrid, x => x.IsLoaded);
+
+			//var tree1 = outerGrid.TreeGraph();
+			var snapshot1 = new { outerGrid.ActualHeight, innerGrid.Padding };
+
+			// set a background to push down the "skia-canvas"
+			sb.BackgroundColor = Colors.Pink;
+			await UITestHelper.WaitForIdle();
+
+			//var tree2 = outerGrid.TreeGraph();
+			var snapshot2 = new { outerGrid.ActualHeight, innerGrid.Padding };
+
+			// assumption: the test device SHOULD have a status-bar, and MAY have something at the bottom
+			Assert.IsTrue(snapshot1.ActualHeight > snapshot2.ActualHeight, $"The top-level element actual-height should have decreased: {snapshot1.ActualHeight} -> {snapshot2.ActualHeight}");
+			Assert.IsTrue(
+				snapshot2.Padding.Top == 0 && double.Abs(snapshot2.Padding.Bottom - snapshot1.Padding.Bottom) < 1,
+				$"VisibleBoundsPadding on the inner Grid should lost the top side, and kept the bottom: {PrettyPrint.FormatThickness(snapshot1.Padding)} -> {PrettyPrint.FormatThickness(snapshot2.Padding)}");
+		}
+		finally
+		{
+			sb.BackgroundColor = color;
+		}
+	}
+#endif
+#endif
+}


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/uno.chefs#1659

## PR Type:
- 🐞 Bugfix

## What is the current behavior? 🤔
When setting a non-null value to StatusBar.Background, the skia canvas is partially pushed off-screen.

## What is the new behavior? 🚀
^ no more.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
regression from: #20687