### PR TITLE
fix: ios statusbar when background is set before all windows are loaded

### DIFF
--- a/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.iOS.cs
+++ b/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.iOS.cs
@@ -28,7 +28,7 @@ namespace Windows.UI.ViewManagement
 				UIApplication.DidBecomeActiveNotification,
 				_ => SetStatusBarBackgroundColor(_backgroundColor)
 			);
-			
+
 			NSNotificationCenter.DefaultCenter.AddObserver(
 				UIApplication.DidChangeStatusBarOrientationNotification,
 				_ => SetStatusBarBackgroundColor(_backgroundColor)

--- a/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.iOS.cs
+++ b/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.iOS.cs
@@ -25,6 +25,11 @@ namespace Windows.UI.ViewManagement
 		partial void InitializePartial()
 		{
 			NSNotificationCenter.DefaultCenter.AddObserver(
+				UIApplication.DidBecomeActiveNotification,
+				_ => SetStatusBarBackgroundColor(_backgroundColor)
+			);
+			
+			NSNotificationCenter.DefaultCenter.AddObserver(
 				UIApplication.DidChangeStatusBarOrientationNotification,
 				_ => SetStatusBarBackgroundColor(_backgroundColor)
 			);


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno.toolkit.ui/issues/1416

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--

- 🐞 Bugfix


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When launching an app with StatusBar Extensions from Toolkit, the initial window would have the correct `utu:StatusBar.Background` color. However, the main window would not have the color since it is a new [`WindowsAndStatusBarFrame`](https://github.com/unoplatform/uno/blob/df246eb5d53680d043ebeb2757e5131b915d60fc/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.iOS.cs#L80).

## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

We listen for when the app is active and can receive focus from the user (meaning the windows have loaded) and set the StatusBar background when that happens. 

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->