### PR TITLE
fix: textbox within a flyout hard to focus

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
@@ -14,6 +14,18 @@ namespace Microsoft.UI.Xaml.Controls
 			DefaultStyleKey = typeof(FlyoutPresenter);
 		}
 
+		protected override void OnApplyTemplate()
+		{
+			base.OnApplyTemplate();
+
+			var spInnerScrollViewer = GetTemplateChild<ScrollViewer>("ScrollViewer");
+			if (spInnerScrollViewer is { })
+			{
+				spInnerScrollViewer.m_isFocusableOnFlyoutScrollViewer = true;
+			}
+		}
+
+
 		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
 		{
 			if (args.Property == AllowFocusOnInteractionProperty)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.MuxInternal.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.MuxInternal.cs
@@ -22,6 +22,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 		internal bool m_templatedParentHandlesMouseButton;
 
+		// Allow to set focus on ScrollViewer itself. For example, Flyout inner ScrollViewer.
+		internal bool m_isFocusableOnFlyoutScrollViewer;
+
 		// Indicates whether ScrollViewer should ignore mouse wheel scroll events (not zoom).
 		internal bool ArePointerWheelEventsIgnored { get; set; }
 		internal bool IsInManipulation => IsInDirectManipulation || m_isInConstantVelocityPan;
@@ -135,11 +138,13 @@ namespace Microsoft.UI.Xaml.Controls
 				//}
 				//else
 				{
+					bool isFocusedOnLightDismissPopupOfFlyout = false;
+
 					// Set focus on the Flyout inner ScrollViewer to dismiss IHM.
-					//if (m_isFocusableOnFlyoutScrollViewer)
-					//{
-					var isFocusedOnLightDismissPopupOfFlyout = ScrollContentControl_SetFocusOnFlyoutLightDismissPopupByPointer(this);
-					//}
+					if (m_isFocusableOnFlyoutScrollViewer)
+					{
+						isFocusedOnLightDismissPopupOfFlyout = ScrollContentControl_SetFocusOnFlyoutLightDismissPopupByPointer(this);
+					}
 					if (isFocusedOnLightDismissPopupOfFlyout)
 					{
 						args.Handled = true;


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/uno.chefs#1667

## PR Type:
- 🐞 Bugfix

## What is the current behavior? 🤔
When placed within a flyout, TextBox cannot be focused by clicking on the area where text/placeholder-text is, as the focus will be shifted to the containing Popup instead...

## What is the new behavior? 🚀
^ no more.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
ScrollContentControl_SetFocusOnFlyoutLightDismissPopupByPointer should not be called without a guard (where the ScrollViewer has to be a template member of a FlyoutPresenter).

ref:
https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/1.7.3/src/dxaml/xcp/dxaml/lib/FlyoutPresenter_partial.cpp#L80-L83
https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/1.7.3/src/dxaml/xcp/dxaml/lib/ScrollViewer_Partial.cpp#L2533