### PR TITLE
fix: Fallback from Segoe UI Symbol to configured symbol font

### DIFF
--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/IconSource/IconSourceApiTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/IconSource/IconSourceApiTests.cs
@@ -35,6 +35,11 @@ using System.Threading.Tasks;
 #if !HAS_UNO_WINUI
 using Microsoft.UI.Xaml.Controls;
 #endif
+
+#if HAS_UNO
+using Uno.UI;
+#endif
+
 namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 {
 	[TestClass]
@@ -230,8 +235,14 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 				Verify.AreEqual(FontStyle.Oblique, fontIcon.FontStyle);
 				Verify.AreEqual(250, iconSource.FontWeight.Weight);
 				Verify.AreEqual(250, fontIcon.FontWeight.Weight);
+#if !HAS_UNO
 				Verify.AreEqual("Segoe UI Symbol", iconSource.FontFamily.Source);
 				Verify.AreEqual("Segoe UI Symbol", fontIcon.FontFamily.Source);
+#else
+				// In case of Uno the Source is equal to FeatureConfiguration.Font.SymbolsFont
+				Verify.AreEqual(FeatureConfiguration.Font.SymbolsFont, iconSource.FontFamily.Source);
+				Verify.AreEqual(FeatureConfiguration.Font.SymbolsFont, fontIcon.FontFamily.Source);
+#endif
 				Verify.AreEqual(true, iconSource.IsTextScaleFactorEnabled);
 				Verify.AreEqual(true, fontIcon.IsTextScaleFactorEnabled);
 				Verify.AreEqual(true, iconSource.MirroredWhenRightToLeft);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_FontFamily.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_FontFamily.cs
@@ -52,6 +52,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 			Assert.IsTrue(fontFamily.CssFontName.StartsWith("font"));
 		}
 #endif
+
+#if HAS_UNO
 		[TestMethod]
 		[RunsOnUIThread]
 		public void Symbol_Fonts_Fallback()
@@ -65,5 +67,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 			fontFamily = new FontFamily("Symbols");
 			Assert.AreEqual(FeatureConfiguration.Font.SymbolsFont, fontFamily.Source);
 		}
+#endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_FontFamily.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_FontFamily.cs
@@ -1,5 +1,4 @@
-﻿#if __WASM__
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml.Media;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
@@ -7,6 +6,8 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 	[TestClass]
 	public class Given_FontFamily
 	{
+#if __WASM__
+
 		[TestMethod]
 		public void With_Pure_Name()
 		{
@@ -50,6 +51,19 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 			var fontFamily = new FontFamily(fontFamilyPath);
 			Assert.IsTrue(fontFamily.CssFontName.StartsWith("font"));
 		}
+#endif
+		[TestMethod]
+		[RunsOnUIThread]
+		public void Symbol_Fonts_Fallback()
+		{
+			var fontFamily = new FontFamily("Segoe Fluent Icons");
+			Assert.AreEqual(FeatureConfiguration.Font.SymbolsFont, fontFamily.Source);
+			fontFamily = new FontFamily("Segoe UI Symbol");
+			Assert.AreEqual(FeatureConfiguration.Font.SymbolsFont, fontFamily.Source);
+			fontFamily = new FontFamily("Segoe MDL2 Assets");
+			Assert.AreEqual(FeatureConfiguration.Font.SymbolsFont, fontFamily.Source);
+			fontFamily = new FontFamily("Symbols");
+			Assert.AreEqual(FeatureConfiguration.Font.SymbolsFont, fontFamily.Source);
+		}
 	}
 }
-#endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_FontFamily.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_FontFamily.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml.Media;
+#if HAS_UNO
+using Uno.UI;
+#endif
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 {

--- a/src/Uno.UI/UI/Xaml/FontFamily.cs
+++ b/src/Uno.UI/UI/Xaml/FontFamily.cs
@@ -16,6 +16,7 @@ namespace Microsoft.UI.Xaml.Media
 
 			// A workaround before font fallback is supported. Issue: https://github.com/unoplatform/uno/issues/10148 
 			if (familyName.Contains("Segoe Fluent Icons", StringComparison.InvariantCultureIgnoreCase) ||
+				familyName.Contains("Segoe UI Symbol", StringComparison.InvariantCultureIgnoreCase) ||
 				familyName.Contains("Segoe MDL2 Assets", StringComparison.InvariantCultureIgnoreCase) ||
 				familyName.Equals("Symbols", StringComparison.InvariantCultureIgnoreCase))
 			{


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/4579

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- 
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->