### PR TITLE
fix: visual subtree removal not triggering re-render

### DIFF
--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -33,6 +33,8 @@ public partial class ContainerVisual : Visual
 				parent = parent.Parent;
 			}
 
+			InvalidateParentChildrenPicture();
+
 			if (e.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Reset
 				&& e.OldItems is not null)
 			{
@@ -53,6 +55,8 @@ public partial class ContainerVisual : Visual
 	internal IntPtr Handle { get; private set; }
 
 	internal WeakReference? Owner { get; set; }
+
+	internal string? OwnerDebugName => Owner?.Target?.GetType().Name;
 
 	/// <summary>
 	/// Layout clipping is usually applied in the element's coordinate space.


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/uno.hotdesign#4471

## PR Type:
- 🐞 Bugfix

## What is the current behavior? 🤔
Sometimes Element removed from visual tree can still stay rendered, until a re-render is forced through other means.

## What is the new behavior? 🚀
^ should no longer occur.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
The exact scenario is probably related to a race condition, making it difficult to replicated in a test. (One of the workaround was re-scheduling the Panel.Children.Remove on the dispatcher.)