### PR TITLE
fix(macOS): avoid uno_application_is_bundled() due to race

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/MacSkiaHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/MacSkiaHost.cs
@@ -59,9 +59,11 @@ public class MacSkiaHost : SkiaHost, ISkiaApplicationHost
 		}
 
 		// if packaged as an app bundle, set the resource path base to the Resources folder
-		if (NativeUno.uno_application_is_bundled())
+		// NSApplication is not fully initialized at this point, so we cannot use NativeUno.uno_application_is_bundled()
+		var installPath = Windows.ApplicationModel.Package.Current.InstalledPath;
+		if (installPath.EndsWith(".app/Contents", StringComparison.Ordinal))
 		{
-			Windows.Storage.StorageFile.ResourcePathBase = Path.Combine(Windows.ApplicationModel.Package.Current.InstalledPath, "..", "Resources");
+			Windows.Storage.StorageFile.ResourcePathBase = Path.Combine(installPath, "Resources");
 		}
 
 		InitializeDispatcher();


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/pull/20760

## PR Type:

- 🐞 Bugfix


## What is the current behavior? 🤔

There's a race at startup where `uno_application_is_bundled()` can be called before `NSApplicationMain` and will return `false`, even if bundled, for some applications.

## What is the new behavior? 🚀

We avoid calling `uno_application_is_bundled()` and use the `InstalledPath` to detect if the app is inside a bundle (or not).

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

This PR is against `release/stable/6.1` as I get a crash when using `master` while drawing with Metal (it seems something else regressed) so I could not test it.

Also I want to fix the race instead of working around it (so it does not hit us anywhere else in the future) but that will take more time (mostly testing) and I want to unblock customers waiting for this fix ASAP.
