### PR TITLE
fix: Avoid white borders on WASM for HDPI screens

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/WasmCSS/uno.css
@@ -71,6 +71,8 @@ input::-ms-clear {
 
 #uno-canvas {
     position: fixed;
+    width: 100%;
+    height: 100%;
 }
 
 /* Uno has its own HR indicator: hide default dotnet indicator. */

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserRenderer.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserRenderer.ts
@@ -32,8 +32,9 @@ namespace Uno.UI.Runtime.Skia {
 
 		private setCanvasSize() {
 			var scale = window.devicePixelRatio || 1;
-			var width = document.documentElement.clientWidth;
-			var height = document.documentElement.clientHeight
+			var rect = document.documentElement.getBoundingClientRect();
+			var width = rect.width;
+			var height = rect.height;
 			var w = width * scale
 			var h = height * scale;
 
@@ -41,9 +42,6 @@ namespace Uno.UI.Runtime.Skia {
 				this.canvas.width = w;
 			if (this.canvas.height !== h)
 				this.canvas.height = h;
-
-			this.canvas.style.width = `${width}px`;
-			this.canvas.style.height = `${height}px`;
 
 			// We request to repaint on the next frame. Without this, the first frame after resizing the window will be
 			// blank and will cause a flickering effect when you drag the window's border to resize.


### PR DESCRIPTION
Previously we were explicitly setting the canvas height/width to the clientHeight/clientWidth, which are rounded. Instead we now use getBoundingClientRect which is providing the accurate values.

**GitHub Issue:** closes https://github.com/unoplatform/uno-private/issues/1279

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

We were using `clientHeight` and `clientWidth` which are rounded numbers and hence not accurate, which caused white borders to show up on the right and bottom side of the browser viewport, especially on HDPI devices


## What is the new behavior? 🚀

- Using accurate values
- Stretching canvas to 100%

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->