### PR TITLE
fix(PhoneCallManager): Ensure launch phone call on ui thread

### DIFF
--- a/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/Calls/PhoneCallManager.iOS.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using CallKit;
 using Foundation;
 using UIKit;
+using Windows.System;
 
 namespace Windows.ApplicationModel.Calls
 {
@@ -38,7 +39,7 @@ namespace Windows.ApplicationModel.Calls
 		internal static void RaiseCallStateChanged() => CallStateChanged?.Invoke(null, null);
 
 		private static void ShowPhoneCallUIImpl(string phoneNumber, string displayName)
-			=> Task.Run(() => UIApplication.SharedApplication.OpenUrlAsync(new NSUrl($"tel:{phoneNumber}"), new UIApplicationOpenUrlOptions()));
+			=> Task.Run(() => Launcher.LaunchUriAsync(new Uri($"tel:{phoneNumber}")));
 
 	}
 }


### PR DESCRIPTION
closes https://github.com/unoplatform/dispatchscience-private/issues/14
closes https://github.com/unoplatform/uno/issues/21135


Launching `tel:` URIs on iOS requires the call to be on the UI Thread. Go through the Launcher call that already checks for UI Thread.