### PR TITLE
fix(WebView2): Fix HistoryChanged calling priority on iOS

### DIFF
--- a/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
+++ b/src/SamplesApp/SamplesApp.UITests/Windows_UI_Xaml_Controls/WebViewTests/UnoSamples_Test_NavigateToString.cs
@@ -60,13 +60,13 @@ namespace SamplesApp.UITests.Windows_UI_Xaml_Controls.WebViewTests
 
 			// navigate to anchor
 			_app.FastTap(navigateToAnchorButton);
-			_app.WaitForText(navigationCompletedTextBlock, "https://uno-assets.platform.uno/tests/docs/WebView_NavigateToAnchor.html");
+			_app.WaitForText(navigationCompletedTextBlock, "https://uno-assets.platform.uno/tests/docs/WebView_NavigateToAnchor.html#section-1");
 
 			TakeScreenshot("navigate to anchor");
 
 			// user click in the browser itself
 			_app.FastTap(clickAnchorButton);
-			_app.WaitForText(navigationCompletedTextBlock, "https://uno-assets.platform.uno/tests/docs/WebView_NavigateToAnchor.html");
+			_app.WaitForText(navigationCompletedTextBlock, "https://uno-assets.platform.uno/tests/docs/WebView_NavigateToAnchor.html#page-4");
 
 			TakeScreenshot("click anchor");
 		}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/WebView/WebView_AnchorNavigation.xaml.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using Uno.UI.Samples.Controls;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.Web.WebView2.Core;
 
 namespace Uno.UI.Samples.Content.UITests.WebView
 {
-	[Sample(Description = "This sample tests that anchor navigation raises the proper events. The 2 uris received from the NavigationStarting and NavigationCompleted must NOT update whether you tap the NavigateToAnchor button or tap on anchors from the web content. This matches the behavior of the WinUI WebView2 implementation.")]
+	[Sample(Description = "This sample tests that anchor navigation raises the proper events. The 2 uris received from the NavigationStarting must NOT update whether you tap the NavigateToAnchor button or tap on anchors from the web content. However, the bottom URI should update from after the history has changed. This matches the behavior of the WinUI WebView2 implementation.")]
 	public sealed partial class WebView_AnchorNavigation : UserControl
 	{
 		public WebView_AnchorNavigation()
@@ -13,7 +14,12 @@ namespace Uno.UI.Samples.Content.UITests.WebView
 
 			webView.Navigate(new Uri("https://uno-assets.platform.uno/tests/docs/WebView_NavigateToAnchor.html"));
 			webView.NavigationStarting += WebView_NavigationStarting;
-			webView.NavigationCompleted += WebView_NavigationCompleted;
+			webView.CoreWebView2.HistoryChanged += WebView2_HistoryChanged;
+		}
+
+		private void WebView2_HistoryChanged(CoreWebView2 sender, object args)
+		{
+			NavigationCompletedTextBlock.Text = sender.Source;
 		}
 
 		private void WebView_NavigationStarting(Microsoft.UI.Xaml.Controls.WebView sender, WebViewNavigationStartingEventArgs args)

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/WebViewNavigationDelegate.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/WebViewNavigationDelegate.iOSmacOS.cs
@@ -63,7 +63,15 @@ internal class WebViewNavigationDelegate : WKNavigationDelegate
 				return;
 			}
 
-			// For link activations, always check navigation start
+			 // Check for anchor navigation first, before processing as a regular navigation
+			if (requestUrl != null && GetIsAnchorNavigation(requestUrl))
+			{
+				unoWKWebView.OnAnchorNavigation(requestUrl);
+				decisionHandler(WKNavigationActionPolicy.Allow);
+				return;
+			}
+
+			// For link activations, check navigation start for non-anchor navigations
 			if (navigationAction.NavigationType == WKNavigationType.LinkActivated)
 			{
 				if (unoWKWebView.OnStarted(requestUrl, stopLoadingOnCanceled: true))
@@ -71,14 +79,6 @@ internal class WebViewNavigationDelegate : WKNavigationDelegate
 					decisionHandler(WKNavigationActionPolicy.Cancel);
 					return;
 				}
-			}
-
-			// If this is an anchor navigation, handle it specially
-			if (requestUrl != null && GetIsAnchorNavigation(requestUrl))
-			{
-				unoWKWebView.OnAnchorNavigation(requestUrl);
-				decisionHandler(WKNavigationActionPolicy.Allow);
-				return;
 			}
 
 			// For all other cases, allow the navigation

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/WebViewNavigationDelegate.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/WebViewNavigationDelegate.iOSmacOS.cs
@@ -63,7 +63,7 @@ internal class WebViewNavigationDelegate : WKNavigationDelegate
 				return;
 			}
 
-			 // Check for anchor navigation first, before processing as a regular navigation
+			// Check for anchor navigation first, before processing as a regular navigation
 			if (requestUrl != null && GetIsAnchorNavigation(requestUrl))
 			{
 				unoWKWebView.OnAnchorNavigation(requestUrl);


### PR DESCRIPTION
**GitHub Issue:** closes #20761

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:
- 🐞 Bugfix
<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

- Anchors not working properly on iOS implementation for WebView2.
- `HistoryChanged` event passing the wrong parameters.


## What is the new behavior? 🚀

- Anchor links are properly followed.
- `HistoryChanged` event pass the correct parameters.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [X] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [X] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->