### PR TITLE
fix: `Frame` `PageStackEntry` initialization

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Frame.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml.Navigation;
 using Uno.Disposables;
 using Uno.UI.RuntimeTests.Helpers;
 using Combinatorial.MSTest;
+using Microsoft.UI.Xaml.Media.Animation;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls;
 
@@ -491,6 +492,36 @@ public class Given_Frame
 		var exception = Assert.ThrowsExactly<NotSupportedException>(() => SUT.Navigate(typeof(ExceptionInOnNavigatedToPage)));
 		Assert.AreEqual("Crashed", exception.Message);
 		Assert.IsTrue(navigationFailed);
+	}
+
+	[TestMethod]
+	public async Task When_BackStack_Then_Go_Back()
+	{
+		var SUT = new Frame()
+		{
+			Width = 200,
+			Height = 200
+		};
+		var navigated = false;
+
+		SUT.Navigated += (s, e) =>
+		{
+			navigated = true;
+		};
+
+		TestServices.WindowHelper.WindowContent = SUT;
+		await TestServices.WindowHelper.WaitForLoaded(SUT);
+		SUT.Navigate(typeof(FirstPage));
+		await TestServices.WindowHelper.WaitFor(() => navigated);
+		navigated = false;
+
+		Assert.IsInstanceOfType(SUT.Content, typeof(FirstPage));
+
+		SUT.BackStack.Add(new PageStackEntry(typeof(SecondPage), null, new SuppressNavigationTransitionInfo()));
+		SUT.GoBack();
+
+		await TestServices.WindowHelper.WaitFor(() => navigated);
+		Assert.IsInstanceOfType(SUT.Content, typeof(SecondPage));
 	}
 
 #if HAS_UNO

--- a/src/Uno.UI/UI/Xaml/Navigation/NavigationHistory.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Navigation/NavigationHistory.mux.cs
@@ -816,7 +816,7 @@ internal partial class NavigationHistory
 		if (spTransitionInfo is not null)
 		{
 			// Write NavigationTransitionInfo type.
-			NavigationHelpers.WriteHSTRINGToString(spTransitionInfo.GetType().FullName, buffer);
+			NavigationHelpers.WriteHSTRINGToString(spTransitionInfo.GetType().AssemblyQualifiedName, buffer);
 
 			// Write NavigationTransitionInfo.
 			strTransitionInfo = spTransitionInfo.GetNavigationStateCoreInternal();

--- a/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.cs
@@ -29,7 +29,7 @@ public sealed partial class PageStackEntry : DependencyObject
 		InitializeBinder();
 
 		SourcePageType = sourcePageType;
-		SetDescriptor(sourcePageType.FullName);
+		SetDescriptor(sourcePageType.AssemblyQualifiedName);
 
 		Parameter = parameter;
 		NavigationTransitionInfo = navigationTransitionInfo;


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/313

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

Creating `PageStackEntry` manually causes issues.


## What is the new behavior? 🚀

Correctly qualify the page type so that it can be constructed.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->