### PR TITLE
fix: skia ratingcontrol alignment

### DIFF
--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/RatingControl/RatingControl.mux.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/RatingControl/RatingControl.mux.cs
@@ -27,9 +27,10 @@ namespace Microsoft.UI.Xaml.Controls;
 partial class RatingControl
 {
 #if __SKIA__ // TODO Uno: Expression animation is only supported on Skia
-	private const float c_horizontalScaleAnimationCenterPoint = 0.5f;
+	private const float c_scaleAnimationCenterPoint = 0.5f;
+#else
+	private const float c_scaleAnimationCenterPoint = 0.8f;
 #endif
-	private const float c_verticalScaleAnimationCenterPoint = 0.5f;
 	private readonly Thickness c_focusVisualMargin = new Thickness(-8, -7, -8, 0);
 	private const int c_defaultRatingFontSizeForRendering = 32; // (32 = 2 * [default fontsize] -- because of double size rendering), remove when MSFT #10030063 is done
 	private const int c_defaultItemSpacing = 8;
@@ -135,14 +136,14 @@ partial class RatingControl
 	private void UpdateCaptionMargins()
 	{
 		// We manually set margins to caption text to make it center-aligned with the stars
-		// because star vertical center is 0.8 instead of the normal 0.5.
+		// because star vertical center is rendered as 0.8 on native instead of the normal 0.5.
 		// When text scale changes we need to update top margin to make the text follow start center.
 		var captionTextBlock = m_captionTextBlock;
 		if (captionTextBlock != null)
 		{
 			double textScaleFactor = GetUISettings().TextScaleFactor;
 			Thickness margin = captionTextBlock.Margin;
-			margin.Top = c_defaultCaptionTopMargin - (ActualRatingFontSize() * c_verticalScaleAnimationCenterPoint);
+			margin.Top = c_defaultCaptionTopMargin - (ActualRatingFontSize() * c_scaleAnimationCenterPoint);
 
 			captionTextBlock.Margin(margin);
 		}
@@ -400,7 +401,8 @@ partial class RatingControl
 
 		// Star size = 16. 0.5 is just arbitrary center point chosen in design spec
 		// 32 = star size * 2 because of the rendering at double size we do
-		uiElementVisual.AnchorPoint = new Vector2(c_defaultRatingFontSizeForRendering * c_horizontalScaleAnimationCenterPoint, c_defaultRatingFontSizeForRendering * c_verticalScaleAnimationCenterPoint);
+		var scaledStarSize = c_defaultRatingFontSizeForRendering * c_scaleAnimationCenterPoint;
+		uiElementVisual.AnchorPoint = new Vector2(scaledStarSize);
 #endif
 	}
 

--- a/src/Uno.UI/Microsoft/UI/Xaml/Controls/RatingControl/RatingControl.mux.cs
+++ b/src/Uno.UI/Microsoft/UI/Xaml/Controls/RatingControl/RatingControl.mux.cs
@@ -29,7 +29,7 @@ partial class RatingControl
 #if __SKIA__ // TODO Uno: Expression animation is only supported on Skia
 	private const float c_horizontalScaleAnimationCenterPoint = 0.5f;
 #endif
-	private const float c_verticalScaleAnimationCenterPoint = 0.8f;
+	private const float c_verticalScaleAnimationCenterPoint = 0.5f;
 	private readonly Thickness c_focusVisualMargin = new Thickness(-8, -7, -8, 0);
 	private const int c_defaultRatingFontSizeForRendering = 32; // (32 = 2 * [default fontsize] -- because of double size rendering), remove when MSFT #10030063 is done
 	private const int c_defaultItemSpacing = 8;
@@ -398,9 +398,9 @@ partial class RatingControl
 		uiElementVisual.StartAnimation("Scale.X", ea);
 		uiElementVisual.StartAnimation("Scale.Y", ea);
 
-		// Star size = 16. 0.5 and 0.8 are just arbitrary center point chosen in design spec
+		// Star size = 16. 0.5 is just arbitrary center point chosen in design spec
 		// 32 = star size * 2 because of the rendering at double size we do
-		uiElementVisual.CenterPoint = new Vector3(c_defaultRatingFontSizeForRendering * c_horizontalScaleAnimationCenterPoint, c_defaultRatingFontSizeForRendering * c_verticalScaleAnimationCenterPoint, 0.0f);
+		uiElementVisual.AnchorPoint = new Vector2(c_defaultRatingFontSizeForRendering * c_horizontalScaleAnimationCenterPoint, c_defaultRatingFontSizeForRendering * c_verticalScaleAnimationCenterPoint);
 #endif
 	}
 
@@ -438,7 +438,7 @@ partial class RatingControl
 			if (image != null)
 			{
 				image.Source = GetAppropriateImageSource(type);
-				image.Width = RenderingRatingFontSize(); // 
+				image.Width = RenderingRatingFontSize(); //
 				image.Height = RenderingRatingFontSize(); // MSFT #10030063 Replacing with Rating size DPs
 			}
 		}


### PR DESCRIPTION
**GitHub Issue:** closes #21148 
refs https://github.com/unoplatform/uno.chefs/issues/1668

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Problems:
- On skia the star's vertical height seems to be 5 and not 8 like on native.
- The animation composition visual `CenterPoint` property doesn't seem to do anything in this scenario.

https://github.com/user-attachments/assets/ef8a7502-9eed-46a3-9b28-1c491165d3df

## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

- Changed the star's vertical scale to 0.5 instead of 0.8.
- Use visual `AnchorPoint` instead of `CenterPoint`.

https://github.com/user-attachments/assets/8662a962-9c27-46a5-af04-ef4c95c05c37

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->