### PR TITLE
feat: Constrain full popup placement by visible bounds

### DIFF
--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -51,7 +51,7 @@ By default, the `ComboBox` popup will not extend under the status bar even if it
 
 ### Constraining by visible bounds
 
-By default we constrain popups by the visible bounds of the application view. This ensures the popup does not flow below the system UI (e.g. mobile device status bar or navigation bar). If you desire this behavior, you can set the `ConstrainByVisibleBounds` property to `false`. Please note that in such a case you are responsible for ensuring the content of your popups has appropriate padding around its content. This can be achieved using the [`SafeArea` control in Uno Toolkit](xref:Toolkit.Controls.SafeArea).
+By default we don't constrain popups by the visible bounds of the application view on Skia renderer targets. This is different from native renderer where popups are automatically padded by the visible bounds, which ensures the popup does not flow below the system UI (e.g. mobile device status bar or navigation bar). The `ConstrainByVisibleBounds` property allows you to control this behavior. Please note that in case the property is set to `false` (which is the default for Skia renderer), you are responsible for ensuring the content of your popups has appropriate padding around its content. This can be achieved using the [`SafeArea` control in Uno Toolkit](xref:Toolkit.Controls.SafeArea).
 
 ### Native popups (Android)
 

--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -49,6 +49,10 @@ By default, the `ComboBox` popup will not extend under the status bar even if it
 
 ## Popups
 
+### Constraining by visible bounds
+
+By default we constrain popups by the visible bounds of the application view. This ensures the popup does not flow below the system UI (e.g. mobile device status bar or navigation bar). If you desire this behavior, you can set the `ConstrainByVisibleBounds` property to `false`. Please note that in such a case you are responsible for ensuring the content of your popups has appropriate padding around its content. This can be achieved using the [`SafeArea` control in Uno Toolkit](xref:Toolkit.Controls.SafeArea).
+
 ### Native popups (Android)
 
 On Android, it is possible to use a native popup implementation, which is integrated into the system for `Popup`- and `Flyout`-derived UI. Prior to Uno Platform 3.5, native popups were used by default. On Uno Platform 3.5 or later, we made the managed implementation the default.

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -216,6 +216,60 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 			popup.IsOpen = false;
 		}
 
+		[TestMethod]
+		[CombinatorialData]
+		public async Task When_ConstrainedByVisibleBounds(bool constrain)
+		{
+			var constrainedPreviously = FeatureConfiguration.Popup.ConstrainByVisibleBounds;
+			var visibleBoundsDisposable = ScreenHelper.OverrideVisibleBounds(new Thickness(100, 100, 100, 100), false);
+			try
+			{
+				FeatureConfiguration.Popup.ConstrainByVisibleBounds = constrain;
+
+				var content = new Border
+				{
+					Background = new SolidColorBrush(Windows.UI.Colors.Red),
+					HorizontalAlignment = HorizontalAlignment.Stretch,
+					VerticalAlignment = VerticalAlignment.Stretch,
+				};
+				var popup = new Popup
+				{
+					Child = content
+				};
+
+				popup.DesiredPlacement = PopupPlacementMode.Auto;
+				popup.PlacementTarget = (FrameworkElement)WindowHelper.XamlRoot.Content;
+				popup.XamlRoot = WindowHelper.XamlRoot;
+
+				popup.IsOpen = true;
+
+				await WindowHelper.WaitForLoaded(content);
+
+				var xamlRoot = WindowHelper.XamlRoot;
+
+
+				if (constrain)
+				{
+					var constrainedHeight = xamlRoot.VisualTree.VisibleBounds.Height;
+					var constrainedWidth = xamlRoot.VisualTree.VisibleBounds.Width;
+					Assert.AreEqual(constrainedHeight, content.ActualHeight);
+					Assert.AreEqual(constrainedWidth, content.ActualWidth);
+				}
+				else
+				{
+					var unconstrainedHeight = xamlRoot.VisualTree.Size.Height;
+					var unconstrainedWidth = xamlRoot.VisualTree.Size.Width;
+					Assert.AreEqual(unconstrainedHeight, content.ActualHeight);
+					Assert.AreEqual(unconstrainedWidth, content.ActualWidth);
+				}
+			}
+			finally
+			{
+				visibleBoundsDisposable?.Dispose();
+				FeatureConfiguration.Popup.ConstrainByVisibleBounds = constrainedPreviously;
+			}
+		}
+
 #if HAS_UNO
 		[TestMethod]
 		public async Task When_Escape_Handled()

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -217,6 +217,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 		}
 
 		[TestMethod]
+		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeIOS)] // On iOS native the flyout sizing is not handled differently, so the results are different.
 		[CombinatorialData]
 		public async Task When_ConstrainedByVisibleBounds(bool constrain)
 		{

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -216,6 +216,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 			popup.IsOpen = false;
 		}
 
+#if HAS_UNO // FeatureConfiguration is Uno-only
 		[TestMethod]
 		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeIOS)] // On iOS native the flyout sizing is not handled differently, so the results are different.
 		[CombinatorialData]
@@ -269,6 +270,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 				FeatureConfiguration.Popup.ConstrainByVisibleBounds = constrainedPreviously;
 			}
 		}
+#endif
 
 #if HAS_UNO
 		[TestMethod]

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls_Primitives/Given_Popup.cs
@@ -247,7 +247,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls_Primitives
 
 				var xamlRoot = WindowHelper.XamlRoot;
 
-
 				if (constrain)
 				{
 					var constrainedHeight = xamlRoot.VisualTree.VisibleBounds.Height;

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -361,6 +361,11 @@ namespace Uno.UI
 			/// This is mainly useful for debugging purposes, we do not recommend using this in production code.
 			/// </summary>
 			public static bool PreventLightDismissOnWindowDeactivated { get; set; }
+
+			/// <summary>
+			/// By default, popups are constrained by the visible bounds.
+			/// </summary>
+			public static bool ConstrainByVisibleBounds { get; set; } = true;
 		}
 
 		public static class ProgressRing

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -363,9 +363,12 @@ namespace Uno.UI
 			public static bool PreventLightDismissOnWindowDeactivated { get; set; }
 
 			/// <summary>
-			/// By default, popups are constrained by the visible bounds.
+			/// By default, popups are constrained by the visible bounds on native renderer, but unconstrained on Skia renderer.
 			/// </summary>
-			public static bool ConstrainByVisibleBounds { get; set; } = true;
+			public static bool ConstrainByVisibleBounds { get; set; }
+#if !__SKIA__
+				= true;
+#endif
 		}
 
 		public static class ProgressRing

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
@@ -202,7 +202,11 @@ partial class PopupPanel
 					{
 						// When ConstrainByVisibleBounds is false, we let the flyout to occupy the entire area available,
 						// as dictated by the root skia-canvas. This extends into the status bar, and bottom bar if present.
+#if __SKIA__
 						childDesiredSize = m_unclippedDesiredSize;
+#else
+						childDesiredSize = DesiredSize;
+#endif
 					}
 
 					finalPosition = new Point(

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
@@ -185,20 +185,26 @@ partial class PopupPanel
 						y: anchorRect.Top + halfAnchorHeight - halfChildHeight + popup.VerticalOffset);
 					break;
 				case FlyoutBase.MajorPlacementMode.Full:
-#if __SKIA__
-					// For skia-ios/droid, we let the flyout to occupy the entire area available,
-					// as dictated by the root skia-canvas. This extends into status bar, and bottom bar if present.
-					childDesiredSize = m_unclippedDesiredSize
-#elif !__APPLE_UIKIT__
-					childDesiredSize = visibleBounds.Size
+					if (FeatureConfiguration.Popup.ConstrainToVisibleBounds)
+					{
+#if !__APPLE_UIKIT__
+						childDesiredSize = visibleBounds.Size;
 #else
-					// The mobile status bar should always remain visible.
-					// On droid, this panel is placed beneath the status bar.
-					// On iOS, this panel will cover the status bar, so we have to substract it out.
-					childDesiredSize = new Size(ActualWidth, ActualHeight)
-						.Subtract(0, visibleBounds.Y)
+						// The mobile status bar should always remain visible.
+						// On droid, this panel is placed beneath the status bar.
+						// On iOS, this panel will cover the status bar, so we have to substract it out.
+						childDesiredSize = new Size(ActualWidth, ActualHeight)
+							.Subtract(0, visibleBounds.Y)
+							.AtMost(maxSize);
 #endif
-						.AtMost(maxSize);
+					}
+					else
+					{
+						// For skia-ios/droid, we let the flyout to occupy the entire area available,
+						// as dictated by the root skia-canvas. This extends into status bar, and bottom bar if present.
+						childDesiredSize = m_unclippedDesiredSize;
+					}
+
 					finalPosition = new Point(
 #if __SKIA__
 						x: FindOptimalOffset(childDesiredSize.Width, visibleBounds.X, visibleBounds.Width, (Parent as FrameworkElement)?.ActualWidth ?? ActualWidth),

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
@@ -200,8 +200,8 @@ partial class PopupPanel
 					}
 					else
 					{
-						// For skia-ios/droid, we let the flyout to occupy the entire area available,
-						// as dictated by the root skia-canvas. This extends into status bar, and bottom bar if present.
+						// When ConstrainByVisibleBounds is false, we let the flyout to occupy the entire area available,
+						// as dictated by the root skia-canvas. This extends into the status bar, and bottom bar if present.
 						childDesiredSize = m_unclippedDesiredSize;
 					}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.Placement.cs
@@ -185,7 +185,7 @@ partial class PopupPanel
 						y: anchorRect.Top + halfAnchorHeight - halfChildHeight + popup.VerticalOffset);
 					break;
 				case FlyoutBase.MajorPlacementMode.Full:
-					if (FeatureConfiguration.Popup.ConstrainToVisibleBounds)
+					if (FeatureConfiguration.Popup.ConstrainByVisibleBounds)
 					{
 #if !__APPLE_UIKIT__
 						childDesiredSize = visibleBounds.Size;

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -158,7 +158,7 @@ internal partial class PopupPanel : Panel
 			// TODO: For now, the layouting logic for managed DatePickerFlyout or TimePickerFlyout does not correctly work
 			// against the placement target approach.
 			var isFlyoutManagedDatePicker =
-					(Popup.AssociatedFlyout is DatePickerFlyout || Popup.AssociatedFlyout is TimePickerFlyout)
+				(Popup.AssociatedFlyout is DatePickerFlyout || Popup.AssociatedFlyout is TimePickerFlyout)
 #if __ANDROID__ || __IOS__
 				&& (Popup.AssociatedFlyout is not NativeDatePickerFlyout && Popup.AssociatedFlyout is not NativeTimePickerFlyout)
 #endif


### PR DESCRIPTION
**GitHub Issue:** closes closes https://github.com/unoplatform/kahua-private/issues/308, closes https://github.com/unoplatform/kahua-private/issues/310, closes https://github.com/unoplatform/kahua-private/issues/306

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: ✨ Feature

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- 
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

On Skia full popups were previously not constrained by visible bounds


## What is the new behavior? 🚀

- Constrained by default
- New feature flag allows to disable this behavior

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes