### PR TITLE
feat(macOS): Expose UseMetalOnMacOS feature

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacSkiaHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacSkiaHost.cs
@@ -105,7 +105,7 @@ public class MacSkiaHost : SkiaHost, ISkiaApplicationHost
 		try
 		{
 			// Initialize with Metal unless software rendering is requested
-			var metal = FeatureConfiguration.Rendering.UseMetalOnMacOS != false;
+			var metal = FeatureConfiguration.Rendering.UseMetalOnMacOS ?? true;
 
 			// Create the native NSApplication and a main window
 			var result = NativeUno.uno_app_initialize(ref metal);

--- a/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacSkiaHost.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Hosting/MacSkiaHost.cs
@@ -105,23 +105,24 @@ public class MacSkiaHost : SkiaHost, ISkiaApplicationHost
 		try
 		{
 			// Initialize with Metal unless software rendering is requested
-			var metal = RenderSurfaceType != RenderSurfaceType.Software;
+			var metal = FeatureConfiguration.Rendering.UseMetalOnMacOS != false;
 
 			// Create the native NSApplication and a main window
 			var result = NativeUno.uno_app_initialize(ref metal);
 
-			switch (RenderSurfaceType)
+			switch (FeatureConfiguration.Rendering.UseMetalOnMacOS)
 			{
-				case RenderSurfaceType.Auto:
+				case null:
 					RenderSurfaceType = metal ? RenderSurfaceType.Metal : RenderSurfaceType.Software;
 					break;
-				case RenderSurfaceType.Metal:
+				case true:
 					if (!metal)
 					{
 						throw new NotSupportedException("Metal is not supported on this hardware or configuration. Try enabling the software-based renderer. See https://aka.platform.uno/skia-macos");
 					}
+					RenderSurfaceType = RenderSurfaceType.Metal;
 					break;
-				case RenderSurfaceType.Software:
+				case false:
 					if (metal)
 					{
 						if (this.Log().IsEnabled(LogLevel.Warning))
@@ -129,6 +130,7 @@ public class MacSkiaHost : SkiaHost, ISkiaApplicationHost
 							this.Log().Warn("Metal is supported on this hardware but software rendering was requested.");
 						}
 					}
+					RenderSurfaceType = RenderSurfaceType.Software;
 					break;
 			}
 			return result;

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOSoftView.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOSoftView.m
@@ -50,6 +50,8 @@
 #endif
 
     CGRect rect = CGRectMake(0, 0, width, height);
+    CGSize content = [self.window contentRectForFrameRect: rect].size;
+    rect = CGRectMake(0, content.height - rect.size.height, rect.size.width, rect.size.height);
     CGContextDrawImage(NSGraphicsContext.currentContext.CGContext, rect, image);
 
     CGImageRelease(image);

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -921,6 +921,12 @@ namespace Uno.UI
 				set { }
 #endif
 			}
+
+			/// <summary>
+			/// Force the use of Metal (true) or Software (false) rendering on macOS.
+			/// If null (default) use Metal if available, otherwise fallback to Software rendering.
+			/// </summary>
+			public static bool? UseMetalOnMacOS { get; set; }
 		}
 
 		public static class DependencyProperty


### PR DESCRIPTION
**GitHub Issue:** closes #

## PR Type:

- ✨ Feature

## What is the current behavior? 🤔

Software rendering on macOS is automatic, when Metal is not available.
This makes it hard to test it properly.

## What is the new behavior? 🚀

Setting `UseMetalOnMacOS` to a specific value will use the chosen renderer.

```cs
// software
FeatureConfiguration.Rendering.UseMetalOnMacOS = false;
```

```cs
// metal
FeatureConfiguration.Rendering.UseMetalOnMacOS = true;
```

The default is `null` which remains the automatic detection of Metal availability.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->