### PR TITLE
fix: avoid race to call some API before NSApplication is running

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/Native/NativeUno.cs
@@ -201,6 +201,9 @@ internal static partial class NativeUno
 	internal static partial uint uno_get_system_theme();
 
 	[LibraryImport("libUnoNativeMac.dylib")]
+	internal static unsafe partial void uno_set_application_start_callback(delegate* unmanaged[Cdecl]<void> callback);
+
+	[LibraryImport("libUnoNativeMac.dylib")]
 	internal static unsafe partial void uno_set_application_can_exit_callback(delegate* unmanaged[Cdecl]<int> callback);
 
 	[LibraryImport("libUnoNativeMac.dylib")]

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.h
@@ -23,6 +23,9 @@ bool uno_application_open_url(const char *url);
 bool uno_application_query_url_support(const char *url);
 bool uno_application_is_bundled(void);
 
+typedef void (*application_start_fn_ptr)(void);
+application_start_fn_ptr uno_get_application_start_callback(void);
+
 typedef bool (*application_can_exit_fn_ptr)(void);
 application_can_exit_fn_ptr uno_get_application_can_exit_callback(void);
 void uno_set_application_can_exit_callback(application_can_exit_fn_ptr p);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOApplication.m
@@ -93,6 +93,21 @@ void uno_set_application_can_exit_callback(application_can_exit_fn_ptr p)
     application_can_exit = p;
 }
 
+static application_start_fn_ptr application_start;
+
+inline application_start_fn_ptr uno_get_application_start_callback(void)
+{
+    return application_start;
+}
+
+void uno_set_application_start_callback(application_start_fn_ptr p)
+{
+    application_start = p;
+}
+
+typedef void (*application_start_fn_ptr)(void);
+application_start_fn_ptr uno_get_application_start_callback(void);
+
 bool uno_application_is_bundled(void)
 {
     return NSRunningApplication.currentApplication.bundleIdentifier != nil;
@@ -116,6 +131,8 @@ void uno_application_quit(void)
     NSLog(@"UNOApplicationDelegate.applicationDidFinishLaunching notification %@ win %@", notification, win);
 #endif
     // creating the window will call `makeKeyWindow` and `orderFrontRegardless`
+
+    uno_get_application_start_callback()();
 }
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/20742

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

There's a race where we can call some `NSApplication` API before `NSApplicationMain`. In such case the returned value is incorrect.

This replaces the workaround https://github.com/unoplatform/uno/pull/21124 made for the 6.1 branch.

## What is the new behavior? 🚀

The `StartApp` code is invoked, from native code, when `NSApplication` is ready.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->