### PR TITLE
fix: `RequestedTheme` behavior

### DIFF
--- a/src/Uno.UI.RuntimeTests/Helpers/ThemeHelper.cs
+++ b/src/Uno.UI.RuntimeTests/Helpers/ThemeHelper.cs
@@ -26,5 +26,15 @@ namespace Uno.UI.RuntimeTests.Helpers
 				root.RequestedTheme = currentTheme == ApplicationTheme.Light ? ElementTheme.Light : ElementTheme.Dark;
 			});
 		}
+
+		public static ElementTheme CurrentTheme
+		{
+			get
+			{
+				var root = TestServices.WindowHelper.XamlRoot.Content as FrameworkElement;
+				Assert.IsNotNull(root);
+				return root.ActualTheme;
+			}
+		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_Window.cs
@@ -236,6 +236,29 @@ public class Given_Window
 
 	[TestMethod]
 	[RunsOnUIThread]
+	public async Task When_RequestedTheme_Set_Explicitly()
+	{
+		AssertSupportsMultipleWindows();
+
+		var darkThemeDisposable = ThemeHelper.UseDarkTheme();
+		try
+		{
+			var sut = new Window();
+			sut.Content = new Border() { Width = 100, Height = 100, RequestedTheme = ElementTheme.Light };
+			sut.Activate();
+			await TestServices.WindowHelper.WaitForLoaded(sut.Content as FrameworkElement);
+
+			Assert.AreEqual(ApplicationTheme.Light, Application.Current.RequestedTheme);
+		}
+		finally
+		{
+			// Reset the theme to avoid affecting other tests
+			darkThemeDisposable.Dispose();
+		}
+	}
+
+	[TestMethod]
+	[RunsOnUIThread]
 	public async Task When_Window_Close_Programmatically_Does_Not_Trigger_AppWindow_Closing()
 	{
 		AssertSupportsMultipleWindows();

--- a/src/Uno.UI/UI/Xaml/Application.cs
+++ b/src/Uno.UI/UI/Xaml/Application.cs
@@ -208,6 +208,24 @@ namespace Microsoft.UI.Xaml
 
 		internal bool IsThemeSetExplicitly { get; private set; }
 
+		internal void SyncRequestedThemeFromXamlRoot(XamlRoot xamlRoot)
+		{
+			if (xamlRoot is null)
+			{
+				throw new ArgumentNullException(nameof(xamlRoot));
+			}
+
+			// Sync the requested theme from the XamlRoot
+			// This is an ultra-naive implementation... but nonetheless enables the common use case of overriding the system theme for
+			// the entire visual tree (since Application.RequestedTheme cannot be set after launch)
+			// This will also explicitly change the Application.Current.RequestedTheme, which does not happen in case of UWP.
+			if (xamlRoot.Content is FrameworkElement fe)
+			{
+				var theme = fe.RequestedTheme;
+				SetExplicitRequestedTheme(Uno.UI.Extensions.ElementThemeExtensions.ToApplicationThemeOrDefault(theme));
+			}
+		}
+
 		internal void SetExplicitRequestedTheme(ApplicationTheme? explicitTheme)
 		{
 			// this flag makes sure the app will not respond to OS events

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -420,6 +420,8 @@ namespace Microsoft.UI.Xaml
 		{
 			this.StoreTryEnableHardReferences();
 
+			SyncRootRequestedTheme();
+
 			// Apply active style and default style when we enter the visual tree, if they haven't been applied already.
 			ApplyStyles();
 
@@ -557,13 +559,7 @@ namespace Microsoft.UI.Xaml
 
 		private void OnRequestedThemeChanged(ElementTheme oldValue, ElementTheme newValue)
 		{
-			if (XamlRoot?.Content == this) // Some elements like TextBox set RequestedTheme in their Focused style, so only listen to changes to root view
-			{
-				// This is an ultra-naive implementation... but nonetheless enables the common use case of overriding the system theme for
-				// the entire visual tree (since Application.RequestedTheme cannot be set after launch)
-				// This will also explicitly change the Application.Current.RequestedTheme, which does not happen in case of UWP.
-				Application.Current.SetExplicitRequestedTheme(Uno.UI.Extensions.ElementThemeExtensions.ToApplicationThemeOrDefault(newValue));
-			}
+			SyncRootRequestedTheme();
 
 			if (ActualThemeChanged != null)
 			{
@@ -577,6 +573,14 @@ namespace Microsoft.UI.Xaml
 				{
 					ActualThemeChanged?.Invoke(this, null);
 				}
+			}
+		}
+
+		private void SyncRootRequestedTheme()
+		{
+			if (XamlRoot?.Content == this) // Some elements like TextBox set RequestedTheme in their Focused style, so only listen to changes to root view
+			{
+				Application.Current.SyncRequestedThemeFromXamlRoot(XamlRoot);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -420,7 +420,10 @@ namespace Microsoft.UI.Xaml
 		{
 			this.StoreTryEnableHardReferences();
 
-			SyncRootRequestedTheme();
+			if (RequestedTheme is not ElementTheme.Default)
+			{
+				SyncRootRequestedTheme();
+			}
 
 			// Apply active style and default style when we enter the visual tree, if they haven't been applied already.
 			ApplyStyles();


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/307

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

When `RequestedTheme` is set on root control before it is loaded, it is not properly applied to the application-level theme.


## What is the new behavior? 🚀

Applied

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes