### PR TITLE
ci: Adjust condition for the "Publish to Uno Dev Feed" step

### DIFF
--- a/build/ci/templates/nuget-publish-dev.yml
+++ b/build/ci/templates/nuget-publish-dev.yml
@@ -1,7 +1,7 @@
 steps:
   - task: NuGetCommand@2
     displayName: 'Publish to Uno Dev Feed'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), not(eq(variables['build.reason'], 'PullRequest')))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/stable/')), not(eq(variables['build.reason'], 'PullRequest')))
     inputs:
       command: 'push'
       packagesToPush: '$(Pipeline.Workspace)/Nuget_Packages/**/*.nupkg'


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- Build or CI related changes

## Description

Updated condition to allow publishing for both `master` and `release/stable/*` branches for the Uno Internal Dev Feed, while continuing to skip pull request builds. As manual release review check is done before this step for `release/stable/*` branches anyway: 
https://github.com/unoplatform/uno/blob/acd096ea1c5d26efa6462ea2a24cc83ff289e7bb/build/ci/publish/.azure-devops-publish-nuget-prod-dev.yml#L4

