### PR TITLE
chore: .NET10 + Android + CS0246 fixes

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.Diagnostics.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.Diagnostics.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using Microsoft.CodeAnalysis;
 
 namespace Uno.UI.SourceGenerators.DependencyObject;
+
 public partial class DependencyObjectGenerator
 {
 	private static readonly DiagnosticDescriptor _descriptor = new(

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -6,6 +6,7 @@ using Android.Content.PM;
 using Android.Content.Res;
 using Android.Graphics;
 using Android.OS;
+using Android.Runtime;
 using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
@@ -54,7 +55,7 @@ namespace Microsoft.UI.Xaml
 
 		internal ClippedRelativeLayout? NativeLayerHost => _nativeLayerHost;
 
-		public ApplicationActivity(IntPtr ptr, Android.Runtime.JniHandleOwnership owner) : base(ptr, owner)
+		public ApplicationActivity(IntPtr ptr, JniHandleOwnership owner) : base(ptr, owner)
 		{
 			Initialize();
 		}

--- a/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/NativePage.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/UI/Xaml/Controls/NativePage.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Android.App;
 using Android.OS;
+using Android.Runtime;
 using Android.Views;
 using Uno.UI;
 using Uno.UI.Xaml.Controls;
@@ -10,7 +12,7 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public abstract class NativePage : BaseActivity
 	{
-		public NativePage(IntPtr ptr, Android.Runtime.JniHandleOwnership owner) : base(ptr, owner)
+		public NativePage(IntPtr ptr, JniHandleOwnership owner) : base(ptr, owner)
 		{
 		}
 
@@ -24,7 +26,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			InitializeComponent();
 
-			var decorView = (ContextHelper.Current as Android.App.Activity)!.Window!.DecorView;
+			var decorView = (ContextHelper.Current as Activity)!.Window!.DecorView;
 
 #pragma warning disable 618
 #pragma warning disable CA1422 // Validate platform compatibility

--- a/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
+++ b/src/Uno.UI.Runtime.Skia.Android/Uno.UI.Runtime.Skia.Android.csproj
@@ -28,6 +28,7 @@
 		<None Include="..\Common\uno.png" Pack="true" PackagePath="\" />
 		<Compile Include="..\Uno.UI\ActivityHelper.Android.cs" Link="Helpers\ActivityHelper.Android.cs" />
 		<Compile Include="..\Uno.UI\Extensions\PermissionsHelper.Android.cs" Link="Helpers\PermissionsHelper.Android.cs" />
+		<Compile Include="..\Uno.UI\GlobalUsings.cs" Link="Helpers\GlobalUsings.cs" />
 		<Compile Include="..\Uno.UI\UI\Xaml\Controls\DatePicker\NativeDatePickerFlyout.Android.cs" Link="UI\Xaml\Controls\DatePicker\NativeDatePickerFlyout.Android.cs" />
 		<Compile Include="..\Uno.UI\UI\Xaml\Controls\TextBox\InputReturnTypeExtensions.Android.cs" Link="UI\Xaml\Controls\TextBox\InputReturnTypeExtensions.Android.cs" />
 		<Compile Include="..\Uno.UI\UI\Xaml\Controls\TimePicker\NativeTimePickerFlyout.Android.cs" Link="UI\Xaml\Controls\TimePicker\NativeTimePickerFlyout.Android.cs" />

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/XBind_ResourceDictionary.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Controls/XBind_ResourceDictionary.xaml.cs
@@ -14,6 +14,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Controls;
+
 public sealed partial class XBind_ResourceDictionary : ResourceDictionary
 {
 	public XBind_ResourceDictionary()

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_AttachedDP_Markup_Setup.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_AttachedDP_Markup_Setup.xaml.cs
@@ -16,6 +16,7 @@ using Microsoft.UI.Xaml.Navigation;
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls;
+
 public sealed partial class When_AttachedDP_Markup_Setup : UserControl
 {
 	public When_AttachedDP_Markup_Setup()

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_DP_Markup_Setup.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/MarkupExtensionTests/Controls/When_DP_Markup_Setup.xaml.cs
@@ -16,6 +16,7 @@ using Microsoft.UI.Xaml.Navigation;
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.MarkupExtensionTests.Controls;
+
 public sealed partial class When_DP_Markup_Setup : UserControl
 {
 	public When_DP_Markup_Setup()

--- a/src/Uno.UI/Controls/CommandBar/CommandBarNavigationItemRenderer.UIKit.cs
+++ b/src/Uno.UI/Controls/CommandBar/CommandBarNavigationItemRenderer.UIKit.cs
@@ -119,7 +119,7 @@ namespace Uno.UI.Controls
 			// CommandBarExtensions.BackButtonText
 			if (element.GetValue(BackButtonTitleProperty) is string backButtonText)
 			{
-				native.BackBarButtonItem = new UIBarButtonItem(backButtonText, UIBarButtonItemStyle.Plain, null);
+				native.BackBarButtonItem = new UIBarButtonItem(backButtonText, UIBarButtonItemStyle.Plain, delegate { });
 			}
 			else
 			{

--- a/src/Uno.UI/Controls/CommandBar/NativeCommandBarPresenter.UIKit.cs
+++ b/src/Uno.UI/Controls/CommandBar/NativeCommandBarPresenter.UIKit.cs
@@ -96,7 +96,7 @@ namespace Uno.UI.Controls
 			void OnStatusBarChanged(StatusBar sender, object args)
 			{
 				nativeBar.SetNeedsLayout();
-				nativeBar.Superview.SetNeedsLayout();
+				nativeBar.Superview?.SetNeedsLayout();
 			}
 		}
 

--- a/src/Uno.UI/Extensions/TextAlignmentExtensions.cs
+++ b/src/Uno.UI/Extensions/TextAlignmentExtensions.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.UI.Xaml;
 
+#if __ANDROID__
+using Android.Views;
+#endif  // __ANDROID__
+
 namespace Microsoft.UI.Xaml
 {
 	internal static class TextAlignmentExtensions
@@ -27,19 +31,19 @@ namespace Microsoft.UI.Xaml
 
 #elif __ANDROID__
 
-		internal static Android.Views.GravityFlags ToGravity(this TextAlignment textAlignment)
+		internal static GravityFlags ToGravity(this TextAlignment textAlignment)
 		{
 			switch (textAlignment)
 			{
 				case TextAlignment.Center:
-					return Android.Views.GravityFlags.Center;
+					return GravityFlags.Center;
 				case TextAlignment.Right:
-					return Android.Views.GravityFlags.Right;
+					return GravityFlags.Right;
 				case TextAlignment.Justify:
-					return Android.Views.GravityFlags.FillHorizontal;
+					return GravityFlags.FillHorizontal;
 				case TextAlignment.Left:
 				default:
-					return Android.Views.GravityFlags.Left;
+					return GravityFlags.Left;
 			}
 		}
 

--- a/src/Uno.UI/GlobalUsings.cs
+++ b/src/Uno.UI/GlobalUsings.cs
@@ -1,0 +1,28 @@
+#if __ANDROID__
+
+global using AApplication = Android.App.Application;
+global using ABitmap = Android.Graphics.Bitmap;
+global using ABitmapDrawable = Android.Graphics.Drawables.BitmapDrawable;
+global using ABuild = Android.OS.Build;
+global using ABuildVersionCodes = Android.OS.BuildVersionCodes;
+global using AButton = Android.Widget.Button;
+global using ACanvas = Android.Graphics.Canvas;
+global using AColor = Android.Graphics.Color;
+global using AContext = Android.Content.Context;
+global using ADisplayMetrics = Android.Util.DisplayMetrics;
+global using ADescendantFocusability = Android.Views.DescendantFocusability;
+global using ALayout = Android.Text.Layout;
+global using ALayoutAlignment = Android.Text.Layout.Alignment;
+global using AMatrix = Android.Graphics.Matrix;
+global using APath = Android.Graphics.Path;
+global using ARect = Android.Graphics.Rect;
+global using AResource = Android.Resource;
+global using ATimePicker = Android.Widget.TimePicker;
+global using ATypeface = Android.Graphics.Typeface;
+global using AUri = Android.Net.Uri;
+global using AView = Android.Views.View;
+global using AViewGroup = Android.Views.ViewGroup;
+global using AWebView = Android.Webkit.WebView;
+global using AWindow = Android.Views.Window;
+
+#endif  // __ANDROID__

--- a/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
@@ -5,6 +5,7 @@ using Android.Content.PM;
 using Android.Content.Res;
 using Android.Graphics;
 using Android.OS;
+using Android.Runtime;
 using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
@@ -29,7 +30,6 @@ using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
 
-
 namespace Microsoft.UI.Xaml
 {
 	[Activity(ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode, WindowSoftInputMode = SoftInput.AdjustPan | SoftInput.StateHidden)]
@@ -48,9 +48,9 @@ namespace Microsoft.UI.Xaml
 
 		private InputPane _inputPane;
 		private View _content;
-		private Android.Views.Window _window;
+		private AWindow _window;
 
-		public ApplicationActivity(IntPtr ptr, Android.Runtime.JniHandleOwnership owner) : base(ptr, owner)
+		public ApplicationActivity(IntPtr ptr, JniHandleOwnership owner) : base(ptr, owner)
 		{
 			Initialize();
 		}
@@ -70,7 +70,7 @@ namespace Microsoft.UI.Xaml
 		}
 
 		View Uno.UI.Composition.ICompositionRoot.Content => _content;
-		Android.Views.Window Uno.UI.Composition.ICompositionRoot.Window => _window ??= base.Window;
+		AWindow Uno.UI.Composition.ICompositionRoot.Window => _window ??= base.Window;
 
 		internal void EnsureContentView()
 		{

--- a/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/AutomationProperties.cs
@@ -145,7 +145,7 @@ namespace Microsoft.UI.Xaml.Automation
 				view.AccessibilityIdentifier = (string)args.NewValue;
 			}
 #elif __ANDROID__
-			if (FrameworkElementHelper.IsUiAutomationMappingEnabled && dependencyObject is Android.Views.View view)
+			if (FrameworkElementHelper.IsUiAutomationMappingEnabled && dependencyObject is AView view)
 			{
 				view.ContentDescription = (string)args.NewValue;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.Android.cs
@@ -19,7 +19,7 @@ namespace Microsoft.UI.Xaml.Controls;
 
 partial class Border
 {
-	protected override void OnDraw(Android.Graphics.Canvas canvas) => AdjustCornerRadius(canvas, CornerRadius);
+	protected override void OnDraw(ACanvas canvas) => AdjustCornerRadius(canvas, CornerRadius);
 
 	bool ICustomClippingElement.AllowClippingToLayoutSlot => !(Child is UIElement ue) || ue.RenderTransform == null;
 	bool ICustomClippingElement.ForceClippingToLayoutSlot => CornerRadius != CornerRadius.None;

--- a/src/Uno.UI/UI/Xaml/Controls/Button/BindableButtonEx.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Button/BindableButtonEx.Android.cs
@@ -41,7 +41,7 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			get
 			{
-				return new Android.Graphics.Color(this.TextColors.DefaultColor);
+				return new AColor(this.TextColors.DefaultColor);
 			}
 			set
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.partial.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.partial.mux.cs
@@ -946,7 +946,7 @@ partial class ComboBox
 #if HAS_UNO // Force load children
 			// This method will load the itempresenter children
 #if __ANDROID__
-			SetItemsPresenter((m_tpPopupPart.Child as Android.Views.ViewGroup).FindFirstChild<ItemsPresenter>()!);
+			SetItemsPresenter((m_tpPopupPart.Child as AViewGroup).FindFirstChild<ItemsPresenter>()!);
 #elif __APPLE_UIKIT__
 			SetItemsPresenter(m_tpPopupPart.Child.FindFirstChild<ItemsPresenter>()!);
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/SpinnerEx.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/SpinnerEx.Android.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
+using Android.Widget;
+
 namespace Microsoft.UI.Xaml.Controls
 {
-	public partial class SpinnerEx : Android.Widget.Spinner
+	public partial class SpinnerEx : Spinner
 	{
 		public event EventHandler<int> IndexClicked;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.Android.cs
@@ -42,7 +42,7 @@ partial class ContentPresenter
 
 	partial void UnregisterContentTemplateRoot() => this.RemoveViewAndDispose(ContentTemplateRoot);
 
-	protected override void OnDraw(Android.Graphics.Canvas canvas)
+	protected override void OnDraw(ACanvas canvas)
 	{
 		AdjustCornerRadius(canvas, CornerRadius);
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.Android.cs
@@ -14,7 +14,7 @@ namespace Microsoft.UI.Xaml.Controls
 			// Because Controls don't have backgrounds (the background element is part of their template),
 			// we cast elevation shadows using their rectangular bounds.
 			// Note that because it uses the rectangular bounds of the Control, it won't consider rounded corners.
-			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Lollipop)
+			if (ABuild.VERSION.SdkInt >= ABuildVersionCodes.Lollipop)
 			{
 				OutlineProvider = ViewOutlineProvider.Bounds;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.Android.cs
@@ -501,7 +501,7 @@ namespace Microsoft.UI.Xaml.Controls
 			var translateX = ViewHelper.LogicalToPhysicalPixels(sourceRect.X);
 			var translateY = ViewHelper.LogicalToPhysicalPixels(sourceRect.Y);
 
-			var matrix = new Android.Graphics.Matrix();
+			var matrix = new AMatrix();
 			matrix.PostScale((float)scaleX, (float)scaleY);
 			matrix.PostTranslate(translateX, translateY);
 			_nativeImageView.ImageMatrix = matrix;

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
@@ -468,7 +468,7 @@ namespace Microsoft.UI.Xaml.Controls
 #if __ANDROID__
 			// Images on UWP are always clipped to the control's boundaries.
 			var physicalSize = finalSize.LogicalToPhysicalPixels();
-			ClipBounds = new Android.Graphics.Rect(0, 0, (int)physicalSize.Width, (int)physicalSize.Height);
+			ClipBounds = new ARect(0, 0, (int)physicalSize.Width, (int)physicalSize.Height);
 
 			_lastLayoutSize = finalSize;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Image/NativeImageView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/NativeImageView.Android.cs
@@ -159,8 +159,8 @@ namespace Microsoft.UI.Xaml.Controls
 				int targetColor = sourceColor;
 				if (sourceColor != 0)
 				{
-					int sourceAlpha = Android.Graphics.Color.GetAlphaComponent(sourceColor);
-					targetColor = new Android.Graphics.Color(targetR, targetG, targetB, sourceAlpha);
+					int sourceAlpha = AColor.GetAlphaComponent(sourceColor);
+					targetColor = new AColor(targetR, targetG, targetB, sourceAlpha);
 				}
 				targetPixels[i] = targetColor;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.Android.cs
@@ -76,7 +76,7 @@ namespace Microsoft.UI.Xaml.Controls
 	{
 		public static IEnumerable<View> GetChildren(this Layouter layouter)
 		{
-			return (layouter.Panel as Android.Views.ViewGroup).GetChildren();
+			return (layouter.Panel as AViewGroup).GetChildren();
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.Android.cs
@@ -70,7 +70,7 @@ namespace Microsoft.UI.Xaml.Controls
 				InitializeSnapHelper();
 			}
 
-			_shouldRecalibrateFlingVelocity = (int)Android.OS.Build.VERSION.SdkInt >= 28; // Android.OS.BuildVersionCodes.P
+			_shouldRecalibrateFlingVelocity = (int)ABuild.VERSION.SdkInt >= 28; // Android.OS.BuildVersionCodes.P
 
 			// // This is required for animations not to be cut off by transformed ancestor views. (#1333)
 			SetClipChildren(false);
@@ -81,7 +81,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private void InitializeScrollbars()
 		{
 			// Force scrollbars to initialize since we're not inflating from xml
-			if (Android.OS.Build.VERSION.SdkInt <= Android.OS.BuildVersionCodes.Kitkat)
+			if (ABuild.VERSION.SdkInt <= ABuildVersionCodes.Kitkat)
 			{
 				var styledAttributes = Context.Theme.ObtainStyledAttributes(Resource.Styleable.View);
 				InitializeScrollbars(styledAttributes);

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -2762,7 +2762,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			// The time (in ms) it should take for each pixel. For instance, if returned value is 2 ms,
 			// it means scrolling 1000 pixels with LinearInterpolation should take 2 seconds.
-			protected override float CalculateSpeedPerPixel(Android.Util.DisplayMetrics displayMetrics)
+			protected override float CalculateSpeedPerPixel(ADisplayMetrics displayMetrics)
 			{
 				var scrollLength = _layout.ScrollOrientation == Orientation.Horizontal
 					? _layout.ComputeHorizontalScrollRange(_state)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.cs
@@ -291,7 +291,7 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 
 #if __ANDROID__
-			protected override void MeasureChild(Android.Views.View view, int widthSpec, int heightSpec)
+			protected override void MeasureChild(AView view, int widthSpec, int heightSpec)
 			{
 				view.Measure(widthSpec, heightSpec);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElementExtensions.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaPlayerElementExtensions.wasm.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 
 namespace Microsoft.UI.Xaml.Controls;
+
 public static class MediaPlayerElementExtensions
 {
 	public static DependencyProperty AnonymousCORSProperty { get; } =

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.Android.cs
@@ -88,7 +88,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private View GetActualTarget()
 		{
 			if (Target is AppBarButton appBarButton
-			&& ((Android.Views.View)Target).Parent == null // View.Parent (IViewParent) is the visual parent (hidden using `new` modifier).
+			&& ((AView)Target).Parent == null // View.Parent (IViewParent) is the visual parent (hidden using `new` modifier).
 			&& Target.Parent is CommandBar commandBar // FrameworkElement.Parent (DependencyObject) is the logical parent.
 			&& commandBar.FindViewById(appBarButton.GetHashCode()) is View actionMenuItemView)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/Page/NativePage.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Page/NativePage.Android.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Android.App;
 using Android.OS;
+using Android.Runtime;
 using Android.Views;
 using Uno.UI;
 using Uno.UI.Xaml.Controls;
@@ -10,7 +12,7 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public abstract class NativePage : BaseActivity
 	{
-		public NativePage(IntPtr ptr, Android.Runtime.JniHandleOwnership owner) : base(ptr, owner)
+		public NativePage(IntPtr ptr, JniHandleOwnership owner) : base(ptr, owner)
 		{
 		}
 
@@ -24,7 +26,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			InitializeComponent();
 
-			var decorView = (ContextHelper.Current as Android.App.Activity).Window.DecorView;
+			var decorView = (ContextHelper.Current as Activity).Window.DecorView;
 
 #pragma warning disable 618
 #pragma warning disable CA1422 // Validate platform compatibility

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.Android.cs
@@ -51,7 +51,7 @@ partial class Panel : IEnumerable
 		base.OnChildViewAdded(child);
 	}
 
-	protected override void OnDraw(Android.Graphics.Canvas canvas)
+	protected override void OnDraw(ACanvas canvas)
 	{
 		AdjustCornerRadius(canvas, CornerRadiusInternal);
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Pivot/ExtendedViewPager.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Pivot/ExtendedViewPager.Android.cs
@@ -15,14 +15,14 @@ namespace Microsoft.UI.Xaml.Controls
 	{
 		public bool SwipeEnabled { get; set; }
 
-		public ExtendedViewPager(Android.Content.Context context)
+		public ExtendedViewPager(Context context)
 			: base(context)
 		{
 			Initialize();
 		}
 
 		[Register(".ctor", "(Landroid/content/Context;Landroid/util/AttributeSet;)V", "")]
-		public ExtendedViewPager(Android.Content.Context context, IAttributeSet attrs)
+		public ExtendedViewPager(Context context, IAttributeSet attrs)
 			: base(context, attrs)
 		{
 			Initialize();

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/NativePopup.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/NativePopup.Android.cs
@@ -7,6 +7,7 @@ using Uno.Foundation.Logging;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Android.Views;
+using Android.Widget;
 using Uno.UI;
 
 namespace Microsoft.UI.Xaml.Controls.Primitives;
@@ -14,11 +15,11 @@ namespace Microsoft.UI.Xaml.Controls.Primitives;
 [ContentProperty(Name = "Child")]
 public partial class NativePopup : NativePopupBase
 {
-	private Android.Widget.PopupWindow _popupWindow;
+	private PopupWindow _popupWindow;
 
 	public NativePopup()
 	{
-		_popupWindow = new Android.Widget.PopupWindow();
+		_popupWindow = new PopupWindow();
 		_popupWindow.Focusable = true;
 		_popupWindow.Touchable = true;
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -137,7 +137,7 @@ internal partial class PopupPanel : Panel
 			// for android, the above line returns the absolute coordinates of anchor on the screen
 			// because the parent view of this PopupPanel is a PopupWindow and GetLocationInWindow will be (0,0)
 			// therefore, we need to make the relative adjustment
-			if (this.NativeVisualParent is Android.Views.View view)
+			if (this.NativeVisualParent is AView view)
 			{
 				var windowLocation = Point.From(view.GetLocationInWindow);
 				var screenLocation = Point.From(view.GetLocationOnScreen);

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.Android.cs
@@ -46,8 +46,8 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 
 			View uiControl = GetUIControl();
 
-			var nativeButton = uiControl as Android.Widget.Button;
-			if (nativeButton is Android.Widget.Button)
+			var nativeButton = uiControl as AButton;
+			if (nativeButton is AButton)
 			{
 				_isEnabledSubscription.Disposable =
 					DependencyObjectExtensions.RegisterDisposablePropertyChangedCallback(

--- a/src/Uno.UI/UI/Xaml/Controls/ProgressBar/ProgressBar.Header.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ProgressBar/ProgressBar.Header.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Shapes;
 using MUXC = Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml.Controls;
+
 public partial class ProgressBar
 {
 	private MUXC.Grid m_layoutRoot;

--- a/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/Native/RefreshContainer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PullToRefresh/Native/RefreshContainer.Android.cs
@@ -77,7 +77,7 @@ public partial class RefreshContainer : ContentControl
 
 		if (_refreshControl != null)
 		{
-			_refreshControl.Content = Content as Android.Views.View;
+			_refreshControl.Content = Content as AView;
 		}
 	}
 
@@ -115,14 +115,14 @@ public partial class RefreshContainer : ContentControl
 
 		if (visualizer.Foreground is SolidColorBrush foregroundBrush)
 		{
-			var androidIndicatorColor = (int)(Android.Graphics.Color)foregroundBrush.ColorWithOpacity;
+			var androidIndicatorColor = (int)(AColor)foregroundBrush.ColorWithOpacity;
 			var indicatorColorScheme = new[] { androidIndicatorColor };
 			_refreshControl.SetColorSchemeColors(indicatorColorScheme);
 		}
 
 		if (visualizer.Background is SolidColorBrush backgroundBrush)
 		{
-			var androidBackgroundColor = (int)(Android.Graphics.Color)backgroundBrush.ColorWithOpacity;
+			var androidBackgroundColor = (int)(AColor)backgroundBrush.ColorWithOpacity;
 			_refreshControl.SetProgressBackgroundColorSchemeColor(androidBackgroundColor);
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.UIKit.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.UIKit.cs
@@ -1,6 +1,7 @@
 using UIKit;
 
 namespace Microsoft.UI.Xaml.Controls;
+
 public partial class ItemsRepeater
 {
 	public override void AddSubview(UIView view)

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/NativeScrollContentPresenter.Android.cs
@@ -71,7 +71,7 @@ namespace Microsoft.UI.Xaml.Controls
 		private void InitializeScrollbars()
 		{
 			// Force scrollbars to initialize since we're not inflating from xml
-			if (Android.OS.Build.VERSION.SdkInt <= Android.OS.BuildVersionCodes.Kitkat)
+			if (ABuild.VERSION.SdkInt <= ABuildVersionCodes.Kitkat)
 			{
 				var styledAttributes = Context.Theme.ObtainStyledAttributes(Uno.UI.Resource.Styleable.View);
 				InitializeScrollbars(styledAttributes);

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollView/IScrollView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollView/IScrollView.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Controls.Primitives;
 using Windows.Foundation;
 
 namespace Microsoft.UI.Xaml.Controls;
+
 internal interface IScrollView
 {
 	Visibility ComputedHorizontalScrollBarVisibility { get; }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Linq;
 using System.Collections.ObjectModel;
 using Microsoft.UI.Xaml.Documents;
+using Android.OS;
 using Android.Text;
 using Android.Text.Style;
 using Android.Widget;
@@ -54,9 +55,9 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private readonly static TextUtils.TruncateAt TruncateEnd = TextUtils.TruncateAt.End;
 
-		private readonly static Android.Text.Layout.Alignment LayoutAlignCenter = Android.Text.Layout.Alignment.AlignCenter;
-		private readonly static Android.Text.Layout.Alignment LayoutAlignOpposite = Android.Text.Layout.Alignment.AlignOpposite;
-		private readonly static Android.Text.Layout.Alignment LayoutAlignNormal = Android.Text.Layout.Alignment.AlignNormal;
+		private readonly static ALayoutAlignment LayoutAlignCenter = ALayoutAlignment.AlignCenter;
+		private readonly static ALayoutAlignment LayoutAlignOpposite = ALayoutAlignment.AlignOpposite;
+		private readonly static ALayoutAlignment LayoutAlignNormal = ALayoutAlignment.AlignNormal;
 
 		private readonly static Java.Lang.String EmptyString = new Java.Lang.String();
 		private static Java.Lang.Reflect.Constructor _maxLinedStaticLayout;
@@ -66,7 +67,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		static TextBlock()
 		{
-			if ((int)Android.OS.Build.VERSION.SdkInt < 28)
+			if ((int)ABuild.VERSION.SdkInt < 28)
 			{
 				InitializeStaticLayoutInterop();
 			}
@@ -92,7 +93,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			if (_textDirectionHeuristics == null)
 			{
-				if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Kitkat)
+				if (ABuild.VERSION.SdkInt >= BuildVersionCodes.Kitkat)
 				{
 					_textDirectionHeuristics = (Java.Lang.Object)TextDirectionHeuristics.FirststrongLtr;
 				}
@@ -121,13 +122,13 @@ namespace Microsoft.UI.Xaml.Controls
 		private Java.Lang.ICharSequence _textFormatted;
 		private TextPaint _paint;
 		private TextUtils.TruncateAt _ellipsize;
-		private Android.Text.Layout.Alignment _layoutAlignment;
+		private ALayoutAlignment _layoutAlignment;
 		private JustificationMode _justificationMode;
 
 		/// <summary>
 		/// Used by unit tests to verify that the displayed color matches the nominal managed color.
 		/// </summary>
-		internal Android.Graphics.Color? NativeArrangedColor => _arrangeLayout?.Layout.Paint?.Color;
+		internal AColor? NativeArrangedColor => _arrangeLayout?.Layout.Paint?.Color;
 
 		private void InitializePartial()
 		{
@@ -394,7 +395,7 @@ namespace Microsoft.UI.Xaml.Controls
 				//If the measure height is the arrange height.
 				isSameHeight = isSameHeight || isSameMeasuredHeight || isSameUnboundHeight;
 
-				if (!isTextConstrained && isSameWidth && isSameHeight && _layoutAlignment == Android.Text.Layout.Alignment.AlignNormal)
+				if (!isTextConstrained && isSameWidth && isSameHeight && _layoutAlignment == ALayoutAlignment.AlignNormal)
 				{
 					// We can reuse the measure layout as the arrange layout, since it
 					// renders as the same visible surface.
@@ -507,7 +508,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 			private readonly Java.Lang.ICharSequence _textFormatted;
 			private readonly TextUtils.TruncateAt _ellipsize;
-			private readonly Android.Text.Layout.Alignment _layoutAlignment;
+			private readonly ALayoutAlignment _layoutAlignment;
 			private readonly JustificationMode _justificationMode;
 			private readonly TextWrapping _textWrapping;
 			private readonly int _maxLines;
@@ -529,7 +530,7 @@ namespace Microsoft.UI.Xaml.Controls
 			/// <summary>
 			/// The layout to be drawn
 			/// </summary>
-			public Android.Text.Layout Layout { get; private set; }
+			public ALayout Layout { get; private set; }
 
 			/// <summary>
 			/// Builds a new layout with the specified parameters.
@@ -538,7 +539,7 @@ namespace Microsoft.UI.Xaml.Controls
 				Java.Lang.ICharSequence textFormatted,
 				TextPaint paint,
 				TextUtils.TruncateAt ellipsize,
-				Android.Text.Layout.Alignment layoutAlignment,
+				ALayoutAlignment layoutAlignment,
 				JustificationMode isJustifiedText,
 				TextWrapping textWrapping,
 				int maxLines,
@@ -626,7 +627,7 @@ namespace Microsoft.UI.Xaml.Controls
 						// use the measured width of the text.
 						desiredWidth = Math.Min(
 							maxWidth.Value,
-							(int)Math.Ceiling(Android.Text.Layout.GetDesiredWidth(_textFormatted, _paint))
+							(int)Math.Ceiling(ALayout.GetDesiredWidth(_textFormatted, _paint))
 						);
 					}
 					else
@@ -634,7 +635,7 @@ namespace Microsoft.UI.Xaml.Controls
 						// We need to return the size of the text, no matter what
 						// the available size it: the layout engine will automatically
 						// apply clipping when required.
-						desiredWidth = (int)Math.Ceiling(Android.Text.Layout.GetDesiredWidth(_textFormatted, _paint));
+						desiredWidth = (int)Math.Ceiling(ALayout.GetDesiredWidth(_textFormatted, _paint));
 					}
 
 					MakeLayout(
@@ -645,7 +646,7 @@ namespace Microsoft.UI.Xaml.Controls
 				else
 				{
 					// No constraint, this is going to be a text on a single line.
-					desiredWidth = (int)Math.Ceiling(Android.Text.Layout.GetDesiredWidth(_textFormatted, _paint));
+					desiredWidth = (int)Math.Ceiling(ALayout.GetDesiredWidth(_textFormatted, _paint));
 
 					MakeLayout(desiredWidth);
 				}
@@ -676,7 +677,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 					if (lineAtHeight == 1)
 					{
-						desiredWidth = (int)Math.Ceiling(Android.Text.Layout.GetDesiredWidth(_textFormatted, _paint));
+						desiredWidth = (int)Math.Ceiling(ALayout.GetDesiredWidth(_textFormatted, _paint));
 					}
 
 					MakeLayout(
@@ -770,7 +771,7 @@ namespace Microsoft.UI.Xaml.Controls
 					}
 				}
 
-				if ((int)Android.OS.Build.VERSION.SdkInt < 28)
+				if ((int)ABuild.VERSION.SdkInt < 28)
 				{
 					Layout = UnoStaticLayoutBuilder.Build(
 						/*source:*/ _textFormatted,
@@ -796,7 +797,7 @@ namespace Microsoft.UI.Xaml.Controls
 						.SetIncludePad(true);
 
 					// JustificationMode was introduced in Android 8.
-					if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.O)
+					if (ABuild.VERSION.SdkInt >= BuildVersionCodes.O)
 					{
 						builder.SetJustificationMode(_justificationMode);
 					}
@@ -826,7 +827,7 @@ namespace Microsoft.UI.Xaml.Controls
 			var physicalPoint = point.LogicalToPhysicalPixels();
 
 			var layout = _arrangeLayout.Layout;
-			var rect = new Android.Graphics.Rect(0, 0, layout.Width, layout.Height);
+			var rect = new ARect(0, 0, layout.Width, layout.Height);
 			if (rect.Contains((int)physicalPoint.X, (int)physicalPoint.Y))
 			{
 				int line = layout.GetLineForVertical((int)physicalPoint.Y);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -477,12 +477,12 @@ namespace Microsoft.UI.Xaml.Controls
 							// Don't show keyboard if programmatically focused and PreventKeyboardDisplayOnProgrammaticFocus is true
 							!(FocusState == FocusState.Programmatic && PreventKeyboardDisplayOnProgrammaticFocus);
 
-						var inputManager = activity?.GetSystemService(Android.Content.Context.InputMethodService) as Android.Views.InputMethods.InputMethodManager;
+						var inputManager = activity?.GetSystemService(AContext.InputMethodService) as InputMethodManager;
 
 						//When a TextBox gains focus, we want to show the keyboard
 						if (hasFocus && needsKeyboard)
 						{
-							inputManager?.ShowSoftInput(_textBoxView, Android.Views.InputMethods.ShowFlags.Implicit);
+							inputManager?.ShowSoftInput(_textBoxView, ShowFlags.Implicit);
 						}
 
 						//When a TextBox loses focus, we want to dismiss the keyboard if no other view requiring it is focused
@@ -494,7 +494,7 @@ namespace Microsoft.UI.Xaml.Controls
 							//Seems like CurrentFocus can be null if the previously focused element is not part of the view anymore,
 							//resulting in the keyboard not being closed.
 							//We still try to get the Window token from it and if we fail, we get it from the TextBox we're currently unfocusing.
-							inputManager?.HideSoftInputFromWindow(activity?.CurrentFocus?.WindowToken ?? viewWindowToken, Android.Views.InputMethods.HideSoftInputFlags.None);
+							inputManager?.HideSoftInputFromWindow(activity?.CurrentFocus?.WindowToken ?? viewWindowToken, HideSoftInputFlags.None);
 						}
 
 						if (hasFocus)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.Android.cs
@@ -52,9 +52,9 @@ namespace Microsoft.UI.Xaml.Controls
 			_isInitialized = true;
 
 			// This ensures the TextBoxView gets resized as Text changes
-			LayoutParameters = new Android.Views.ViewGroup.LayoutParams(
-				 Android.Views.ViewGroup.LayoutParams.WrapContent,
-				 Android.Views.ViewGroup.LayoutParams.WrapContent
+			LayoutParameters = new AViewGroup.LayoutParams(
+				 AViewGroup.LayoutParams.WrapContent,
+				 AViewGroup.LayoutParams.WrapContent
 			);
 
 			_inputTypes = (InputType, InputType);
@@ -95,7 +95,7 @@ namespace Microsoft.UI.Xaml.Controls
 
 		public override bool OnTextContextMenuItem(int id)
 		{
-			if (id == Android.Resource.Id.Paste)
+			if (id == AResource.Id.Paste)
 			{
 				var args = new TextControlPasteEventArgs();
 				Owner?.RaisePaste(args);
@@ -217,7 +217,7 @@ namespace Microsoft.UI.Xaml.Controls
 						if (BlendMode.SrcAtop != null)
 						{
 							var colorFilter = BlendModeColorFilterCompat.CreateBlendModeColorFilterCompat(
-								(Android.Graphics.Color)color,
+								(AColor)color,
 								BlendModeCompat.SrcAtop!);
 							drawable?.SetColorFilter(colorFilter);
 						}
@@ -233,7 +233,7 @@ namespace Microsoft.UI.Xaml.Controls
 						var mCursorDrawableRes = _cursorDrawableResField.GetInt(editText);
 						var editor = _editorField.Get(editText);
 
-						var colorFilter = new PorterDuffColorFilter((Android.Graphics.Color)color, PorterDuff.Mode.SrcIn);
+						var colorFilter = new PorterDuffColorFilter((AColor)color, PorterDuff.Mode.SrcIn);
 
 						if ((int)Build.VERSION.SdkInt < 28) // 28 means BuildVersionCodes.P
 						{

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/NativeTimePickerFlyout.Android.cs
@@ -114,13 +114,13 @@ partial class NativeTimePickerFlyout : TimePickerFlyout
 
 	public class OnSetTimeListener : Java.Lang.Object, IOnTimeSetListener
 	{
-		private Action<Android.Widget.TimePicker, int, int> _action;
+		private Action<ATimePicker, int, int> _action;
 
-		public OnSetTimeListener(Action<Android.Widget.TimePicker, int, int> action)
+		public OnSetTimeListener(Action<ATimePicker, int, int> action)
 		{
 			_action = action;
 		}
 
-		public void OnTimeSet(Android.Widget.TimePicker view, int hourOfDay, int minute) => _action(view, hourOfDay, minute);
+		public void OnTimeSet(ATimePicker view, int hourOfDay, int minute) => _action(view, hourOfDay, minute);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.Android.cs
@@ -10,19 +10,19 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class TimePickerSelector : ContentControl
 	{
-		private Android.Widget.TimePicker _picker;
+		private ATimePicker _picker;
 		private TimeSpan _initialTime;
 
 		private protected override void OnLoaded()
 		{
 			base.OnLoaded();
 
-			_picker = this.FindFirstChild<Android.Widget.TimePicker>();
+			_picker = this.FindFirstChild<ATimePicker>();
 
 			if (_picker != null)
 			{
 				//By settings DescendantFocusability to BlockDescendnts it disables the possibility to use the keyboard to modify time which was causing issues in 4.4
-				_picker.DescendantFocusability = Android.Views.DescendantFocusability.BlockDescendants;
+				_picker.DescendantFocusability = ADescendantFocusability.BlockDescendants;
 
 				this.Binding(nameof(Time), nameof(Time), Content, BindingMode.TwoWay);
 				this.Binding(nameof(MinuteIncrement), nameof(MinuteIncrement), Content, BindingMode.TwoWay);

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/UnoTimePickerDialog.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/UnoTimePickerDialog.Android.cs
@@ -18,7 +18,7 @@ public
 #endif
 	class UnoTimePickerDialog : TimePickerDialog
 {
-	private Android.Widget.TimePicker _picker;
+	private ATimePicker _picker;
 	private int _minuteIncrement = 1;
 	private int _hourOfDay;
 	private int _minute;
@@ -65,7 +65,7 @@ public
 
 	public override void SetView(View view)
 	{
-		_picker = (Android.Widget.TimePicker)view;
+		_picker = (ATimePicker)view;
 		base.SetView(_picker);
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2.Android.cs
@@ -29,8 +29,8 @@ public partial class CoreWebView2
 	internal INativeWebView? GetNativeWebViewFromTemplate()
 	{
 		var webView = (_owner as ViewGroup)?
-			.GetChildren(v => v is Android.Webkit.WebView)
-			.FirstOrDefault() as Android.Webkit.WebView;
+			.GetChildren(v => v is AWebView)
+			.FirstOrDefault() as AWebView;
 
 		if (webView is null)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Android/NativeWebView.Android.cs
@@ -3,7 +3,7 @@ using Uno.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml.Controls;
 
-public partial class NativeWebView : Android.Webkit.WebView
+public partial class NativeWebView : AWebView
 {
 	public NativeWebView() : base(ContextHelper.Current)
 	{

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/LocalWKUIDelegate.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/LocalWKUIDelegate.iOSmacOS.cs
@@ -50,6 +50,9 @@ internal class LocalWKUIDelegate : WKUIDelegate
 		_runJavaScriptAlertPanel?.Invoke(webView, message, frame, completionHandler);
 	}
 
+#if MACCATALYST18_4_OR_GREATER || (NET10_0 && IOS18_0_OR_GREATER)
+	[Obsolete("It's not possible to call the completion handler with a null value using this method. Please see https://github.com/dotnet/macios/issues/15728 for a workaround.")]
+#endif  // MACCATALYST18_4_OR_GREATER || (NET10_0 && IOS18_0_OR_GREATER)
 	public override void RunJavaScriptTextInputPanel(WKWebView webView, string prompt, string? defaultText, WKFrameInfo frame, Action<string> completionHandler)
 	{
 		if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/UnoWKWebView.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/iOSmacOS/UnoWKWebView.iOSmacOS.cs
@@ -281,7 +281,7 @@ public
 			if (!cancel)
 			{
 #if __APPLE_UIKIT__
-				if (UIKit.UIApplication.SharedApplication.CanOpenUrl(target))
+				if (UIKit.UIApplication.SharedApplication.CanOpenUrl(target!))
 #else
 				if (target != null && NSWorkspace.SharedWorkspace.UrlForApplication(new NSUrl(target.AbsoluteUri)) != null)
 #endif
@@ -807,7 +807,7 @@ public
 				}
 				else
 				{
-					tcs.TrySetResult(result as NSString);
+					tcs.TrySetResult((result as NSString) ?? "");
 				}
 			});
 

--- a/src/Uno.UI/UI/Xaml/Extensions/FontHelper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Extensions/FontHelper.Android.cs
@@ -79,10 +79,10 @@ namespace Microsoft.UI.Xaml
 				else
 				{
 					var style = TypefaceStyleHelper.GetTypefaceStyle(italic, fontWeight);
-					typeface = Android.Graphics.Typeface.Create(fontFamily.Source, style);
+					typeface = ATypeface.Create(fontFamily.Source, style);
 					if (typeface is not null && typeface.Weight != fontWeight.Weight)
 					{
-						typeface = Android.Graphics.Typeface.Create(typeface, fontWeight.Weight, italic);
+						typeface = ATypeface.Create(typeface, fontWeight.Weight, italic);
 					}
 				}
 
@@ -145,7 +145,7 @@ namespace Microsoft.UI.Xaml
 			string actualAsset = AssetsHelper.FindAssetFile(encodedSource);
 			if (actualAsset != null)
 			{
-				var builder = new Android.Graphics.Typeface.Builder(Android.App.Application.Context.Assets!, actualAsset);
+				var builder = new ATypeface.Builder(AApplication.Context.Assets!, actualAsset);
 				// NOTE: We are unable to use 'ital' axis here. If that axis doesn't exist in the
 				// font file, italic will break badly. However, if it exists, we will render "reasonable" (but not ideal) italic text.
 				builder.SetFontVariationSettings($"'wght' {weight}, 'wdth' {FontStretchToPercentage(stretch)}");

--- a/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElement.cs
@@ -17,10 +17,8 @@ using Uno.Foundation.Logging;
 using Uno.Collections;
 
 #if __ANDROID__
-using View = Android.Views.View;
-using ViewGroup = Android.Views.ViewGroup;
-using Font = Android.Graphics.Typeface;
 using Android.Graphics;
+using Android.Views;
 #pragma warning disable CS8981 // The type name 'nint' only contains lower-cased ascii characters. Such names may become reserved for the language
 using nint = System.Int32;
 using nfloat = System.Double;
@@ -164,7 +162,7 @@ namespace Microsoft.UI.Xaml
 				// and calls the overridden InitializeAccessibilityNodeInfo method.
 				// This could become a performance problem (due to interop) in complex UIs (only if TalkBack is enabled).
 				// A possible optimization could be to set it to ImportantForAccessibility.No if FrameworkElement.CreateAutomationPeer returns null.
-				view.ImportantForAccessibility = Android.Views.ImportantForAccessibility.Yes;
+				view.ImportantForAccessibility = ImportantForAccessibility.Yes;
 			}
 #endif
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -362,7 +362,7 @@ namespace <#= mixin.NamespaceName #>
 
 		protected virtual void OnVisibilityChanged(Visibility oldValue, Visibility newValue)
 		{
-			var newNativeVisibility = newValue == Visibility.Visible ? Android.Views.ViewStates.Visible : Android.Views.ViewStates.Gone;
+			var newNativeVisibility = newValue == Visibility.Visible ? ViewStates.Visible : ViewStates.Gone;
 
 			var bindableView = ((object)this) as Uno.UI.Controls.BindableView;
 

--- a/src/Uno.UI/UI/Xaml/Input/FocusManager.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Input/FocusManager.Android.cs
@@ -20,7 +20,7 @@ namespace Microsoft.UI.Xaml.Input
 			if (element is Control control)
 			{
 				var focusManager = VisualTree.GetFocusManagerForElement(control);
-				if (element is Android.Views.View androidView &&
+				if (element is AView androidView &&
 					androidView.Focusable &&
 					focusManager?.InitialFocus == false) // Do not focus natively on initial focus so the soft keyboard is not opened
 				{

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.Android.cs
@@ -163,7 +163,7 @@ namespace Microsoft.UI.Xaml.Input
 				// We cannot cache the "bootTime" as the "uptimeMillis" is frozen while in deep sleep
 				// (cf. https://developer.android.com/reference/android/os/SystemClock)
 
-				var sleepTime = Android.OS.SystemClock.ElapsedRealtime() - Android.OS.SystemClock.UptimeMillis();
+				var sleepTime = SystemClock.ElapsedRealtime() - SystemClock.UptimeMillis();
 				var realUptime = (ulong)(uptimeMillis + sleepTime);
 				return realUptime * 1000;
 			}

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCapture.Managed.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCapture.Managed.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 
 namespace Uno.UI.Xaml.Core;
+
 internal partial class PointerCapture
 {
 	partial void CaptureNative(UIElement target, Pointer pointer)

--- a/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Rendering.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Rendering.Android.cs
@@ -56,7 +56,7 @@ namespace Microsoft.UI.Xaml.Media
 			{
 				state.BackgroundDrawable = new GradientDrawable();
 				state.BackgroundDrawable.SetShape(ShapeType.Rectangle);
-				Android.Graphics.Color androidColor = Colors.Transparent;
+				AColor androidColor = Colors.Transparent;
 
 				state.BackgroundDrawable.SetColor(androidColor);
 

--- a/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Rendering.Blur.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/AcrylicBrush/Android/AcrylicBrush.Rendering.Blur.Android.cs
@@ -62,7 +62,7 @@ namespace Microsoft.UI.Xaml.Media
 					TintColor.R,
 					TintColor.G,
 					TintColor.B);
-			Android.Graphics.Color tintColor = tintColorWithOpacity;
+			AColor tintColor = tintColorWithOpacity;
 			state.BlurView?.SetOverlayColor(tintColor, invalidate);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
@@ -35,8 +35,8 @@ namespace Microsoft.UI.Xaml.Media.Animation
 		{
 			// TODO: GPU-bound color animations - https://github.com/unoplatform/uno/issues/2947
 
-			var startingColor = (Android.Graphics.Color)(Color)startingValue;
-			var targetColor = (Android.Graphics.Color)(Color)targetValue;
+			var startingColor = (AColor)(Color)startingValue;
+			var targetColor = (AColor)(Color)targetValue;
 			var valueAnimator = ValueAnimator.OfArgb(startingColor, targetColor);
 			return new NativeValueAnimatorAdapter(valueAnimator);
 		}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/NativeValueAnimatorAdapter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/NativeValueAnimatorAdapter.Android.cs
@@ -212,7 +212,7 @@ namespace Microsoft.UI.Xaml.Media.Animation
 		/// <inheritdoc />
 		public void Pause()
 		{
-			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Kitkat)
+			if (ABuild.VERSION.SdkInt >= ABuildVersionCodes.Kitkat)
 			{
 				_adaptee.Pause();
 			}
@@ -225,7 +225,7 @@ namespace Microsoft.UI.Xaml.Media.Animation
 		/// <inheritdoc />
 		public void Resume()
 		{
-			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Kitkat)
+			if (ABuild.VERSION.SdkInt >= ABuildVersionCodes.Kitkat)
 			{
 				_adaptee.Resume();
 			}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/ColorAnimationUsingKeyFrames.cs
@@ -304,7 +304,7 @@ namespace Microsoft.UI.Xaml.Media.Animation
 				var i = index;
 
 #if __ANDROID__
-				if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Kitkat)
+				if (ABuild.VERSION.SdkInt >= ABuildVersionCodes.Kitkat)
 				{
 					animator.AnimationPause += (a, _) => OnFrame((IValueAnimator)a);
 				}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimationUsingKeyFrames.cs
@@ -274,7 +274,7 @@ namespace Microsoft.UI.Xaml.Media.Animation
 				var i = index;
 
 #if __ANDROID__
-				if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Kitkat)
+				if (ABuild.VERSION.SdkInt >= ABuildVersionCodes.Kitkat)
 				{
 					animator.AnimationPause += (a, _) => OnFrame((IValueAnimator)a);
 				}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/PanelTransitionHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/PanelTransitionHelper.cs
@@ -81,7 +81,7 @@ namespace Microsoft.UI.Xaml.Media.Animation
 #if __APPLE_UIKIT__
 			((UIKit.UIView)element).Hidden = true;
 #elif __ANDROID__
-			((Android.Views.View)element).Visibility = Android.Views.ViewStates.Invisible;
+			((AView)element).Visibility = ViewStates.Invisible;
 #endif
 
 			if (_onLoadedisAnimating)
@@ -121,7 +121,7 @@ namespace Microsoft.UI.Xaml.Media.Animation
 #if __APPLE_UIKIT__
 				((UIKit.UIView)child).Hidden = false;
 #elif __ANDROID__
-				((Android.Views.View)child).Visibility = Android.Views.ViewStates.Visible;
+				((AView)child).Visibility = ViewStates.Visible;
 #endif
 
 				if (child.Transitions.Safe().Any() || !_elements.Contains(child))

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.animation.cs
@@ -241,7 +241,7 @@ namespace Microsoft.UI.Xaml.Media.Animation
 				else
 				{
 #if __ANDROID__
-					if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.Kitkat)
+					if (ABuild.VERSION.SdkInt >= ABuildVersionCodes.Kitkat)
 					{
 						_animator.AnimationPause += OnAnimatorAnimationPause;
 					}

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
@@ -135,7 +135,7 @@ namespace Microsoft.UI.Xaml.Media
 			var paint = new Paint();
 
 			//Draw the output bitmap to the screen
-			var rect = new Android.Graphics.Rect(0, 0, (int)drawRect.Width, (int)drawRect.Height);
+			var rect = new ARect(0, 0, (int)drawRect.Width, (int)drawRect.Height);
 			destinationCanvas.DrawBitmap(output, rect, rect, paint);
 		}
 
@@ -177,7 +177,7 @@ namespace Microsoft.UI.Xaml.Media
 				return null;
 			}
 
-			var outputBitmap = Bitmap.CreateBitmap((int)drawRect.Width, (int)drawRect.Height, Android.Graphics.Bitmap.Config.Argb8888);
+			var outputBitmap = Bitmap.CreateBitmap((int)drawRect.Width, (int)drawRect.Height, ABitmap.Config.Argb8888);
 
 			//and a temporary canvas that will draw into the bitmap
 			using (var bitmapCanvas = new Canvas(outputBitmap))
@@ -215,9 +215,9 @@ namespace Microsoft.UI.Xaml.Media
 		/// <param name="drawRect"></param>
 		/// <param name="bitmap"></param>
 		/// <returns></returns>
-		private Android.Graphics.Matrix GenerateMatrix(Rect drawRect, Bitmap bitmap)
+		private AMatrix GenerateMatrix(Rect drawRect, Bitmap bitmap)
 		{
-			var matrix = new Android.Graphics.Matrix();
+			var matrix = new AMatrix();
 
 			// Note that bitmap.Width and bitmap.Height (in physical pixels) are automatically scaled up when loaded from local resources, but aren't when acquired externally.
 			// This means that bitmaps acquired externally might not render the same way on devices with different densities when using Stretch.None.
@@ -225,7 +225,7 @@ namespace Microsoft.UI.Xaml.Media
 			var sourceRect = new Rect(0, 0, bitmap.Width, bitmap.Height);
 			var destinationRect = GetArrangedImageRect(sourceRect.Size, drawRect);
 
-			matrix.SetRectToRect(sourceRect.ToRectF(), destinationRect.ToRectF(), Android.Graphics.Matrix.ScaleToFit.Fill);
+			matrix.SetRectToRect(sourceRect.ToRectF(), destinationRect.ToRectF(), AMatrix.ScaleToFit.Fill);
 
 			RelativeTransform?.ToNativeMatrix(matrix, size: new Size(sourceRect.Width, sourceRect.Height));
 			return matrix;

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
@@ -17,6 +17,7 @@ using Uno.UI.Xaml.Media;
 
 using ExifInterface = Android.Media.ExifInterface;
 using Orientation = Android.Media.Orientation;
+using AImageView = Android.Widget.ImageView;
 
 namespace Microsoft.UI.Xaml.Media
 {
@@ -36,7 +37,7 @@ namespace Microsoft.UI.Xaml.Media
 		/// <param name="uri">The image uri</param>
 		/// <param name="targetSize">An optional target decoding size</param>
 		/// <returns>A Bitmap instance</returns>
-		public delegate Task<Bitmap> ImageLoaderHandler(CancellationToken ct, string uri, Android.Widget.ImageView? imageView, global::System.Drawing.Size? targetSize);
+		public delegate Task<Bitmap> ImageLoaderHandler(CancellationToken ct, string uri, AImageView? imageView, global::System.Drawing.Size? targetSize);
 
 		/// <summary>
 		/// Provides a optional external image loader.
@@ -188,7 +189,7 @@ namespace Microsoft.UI.Xaml.Media
 				return bitmap;
 			}
 
-			var matrix = new Android.Graphics.Matrix();
+			var matrix = new AMatrix();
 			matrix.PostRotate(rotationAngle);
 
 			var createdBitmap = Bitmap.CreateBitmap(bitmap, x: 0, y: 0, width: bitmap.Width, height: bitmap.Height, matrix, true);
@@ -230,7 +231,7 @@ namespace Microsoft.UI.Xaml.Media
 			return RespectExifOrientation(exifInterface, bitmap);
 		}
 
-		internal async Task<ImageData> Open(CancellationToken ct, Android.Widget.ImageView? targetImage, int? targetWidth = null, int? targetHeight = null)
+		internal async Task<ImageData> Open(CancellationToken ct, AImageView? targetImage, int? targetWidth = null, int? targetHeight = null)
 		{
 			if (this.Log().IsEnabled(Uno.Foundation.Logging.LogLevel.Debug))
 			{
@@ -299,7 +300,7 @@ namespace Microsoft.UI.Xaml.Media
 					// The ContactsService returns the contact uri for compatibility with UniversalImageLoader - in order to obtain the corresponding photo we resolve using the service below.
 					if (IsContactUri(AbsoluteUri))
 					{
-						if (ContactsContract.Contacts.OpenContactPhotoInputStream(ContextHelper.Current.ContentResolver, Android.Net.Uri.Parse(AbsoluteUri.OriginalString)) is not { } stream)
+						if (ContactsContract.Contacts.OpenContactPhotoInputStream(ContextHelper.Current.ContentResolver, AUri.Parse(AbsoluteUri.OriginalString)) is not { } stream)
 						{
 							return _imageData = ImageData.Empty;
 						}

--- a/src/Uno.UI/UI/Xaml/Media/ImageSourceConverter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSourceConverter.Android.cs
@@ -8,19 +8,19 @@ namespace Microsoft.UI.Xaml.Media
 	{
 		partial void CanConvertFromPartial(Type sourceType, ref bool canConvert)
 		{
-			canConvert = sourceType == typeof(Android.Graphics.Bitmap)
-				|| sourceType == typeof(Android.Graphics.Drawables.BitmapDrawable);
+			canConvert = sourceType == typeof(ABitmap)
+				|| sourceType == typeof(ABitmapDrawable);
 		}
 		partial void ConvertFromPartial(object value, ref ImageSource result)
 		{
-			if (value is Android.Graphics.Bitmap)
+			if (value is ABitmap)
 			{
-				result = (Android.Graphics.Bitmap)value;
+				result = (ABitmap)value;
 				return;
 			}
-			if (value is Android.Graphics.Drawables.BitmapDrawable)
+			if (value is ABitmapDrawable)
 			{
-				result = (Android.Graphics.Drawables.BitmapDrawable)value;
+				result = (ABitmapDrawable)value;
 				return;
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Imaging/SvgImageSource.Android.cs
@@ -50,7 +50,7 @@ partial class SvgImageSource
 				// The ContactsService returns the contact uri for compatibility with UniversalImageLoader - in order to obtain the corresponding photo we resolve using the service below.
 				if (IsContactUri(AbsoluteUri))
 				{
-					if (ContactsContract.Contacts.OpenContactPhotoInputStream(ContextHelper.Current.ContentResolver, Android.Net.Uri.Parse(AbsoluteUri.OriginalString)) is not { } stream)
+					if (ContactsContract.Contacts.OpenContactPhotoInputStream(ContextHelper.Current.ContentResolver, AUri.Parse(AbsoluteUri.OriginalString)) is not { } stream)
 					{
 						return ImageData.Empty;
 					}

--- a/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/LinearGradientBrush.Android.cs
@@ -16,7 +16,7 @@ namespace Microsoft.UI.Xaml.Media
 				return null;
 			}
 
-			var colors = GradientStops.SelectToList(s => ((Android.Graphics.Color)GetColorWithOpacity(s.Color)).ToArgb());
+			var colors = GradientStops.SelectToList(s => ((AColor)GetColorWithOpacity(s.Color)).ToArgb());
 			var locations = GradientStops.SelectToList(s => (float)s.Offset);
 
 			if (GradientStops.Count == 1)
@@ -30,7 +30,7 @@ namespace Microsoft.UI.Xaml.Media
 			var width = size.Width;
 			var height = size.Height;
 
-			Android.Graphics.Matrix nativeTransformMatrix = null;
+			AMatrix nativeTransformMatrix = null;
 			if (RelativeTransform != null)
 			{
 				var matrix = RelativeTransform.ToMatrix(Point.Zero, new Size(width, height));

--- a/src/Uno.UI/UI/Xaml/Media/RadialGradientBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RadialGradientBrush.Android.cs
@@ -42,7 +42,7 @@ namespace Microsoft.UI.Xaml.Media
 				return null;
 			}
 
-			var colors = GradientStops.SelectToArray(s => ((Android.Graphics.Color)GetColorWithOpacity(s.Color)).ToArgb());
+			var colors = GradientStops.SelectToArray(s => ((AColor)GetColorWithOpacity(s.Color)).ToArgb());
 			var locations = GradientStops.SelectToArray(s => (float)s.Offset);
 
 			var transform = RelativeTransform?.ToNativeMatrix(size: size);

--- a/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RectangleGeometry.cs
@@ -43,7 +43,7 @@ namespace Microsoft.UI.Xaml.Media
 		#region Geometry implementation (not implemented)
 
 #if __ANDROID__
-		public override Android.Graphics.Path ToPath()
+		public override APath ToPath()
 		{
 			throw new NotImplementedException();
 		}

--- a/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
@@ -12,13 +12,13 @@ namespace Microsoft.UI.Xaml.Media
 	{
 		private bool _isAnimating;
 
-		internal Android.Graphics.Matrix ToNativeMatrix(Android.Graphics.Matrix targetMatrix = null, Point origin = new Point(), Size size = new Size())
+		internal AMatrix ToNativeMatrix(AMatrix targetMatrix = null, Point origin = new Point(), Size size = new Size())
 		{
 			var matrix = ToMatrix(origin, size);
 
 			if (targetMatrix == null)
 			{
-				targetMatrix = new Android.Graphics.Matrix();
+				targetMatrix = new AMatrix();
 			}
 
 			targetMatrix.SetValues(new[]

--- a/src/Uno.UI/UI/Xaml/NativeApplication.cs
+++ b/src/Uno.UI/UI/Xaml/NativeApplication.cs
@@ -1,4 +1,5 @@
 ﻿#nullable disable
+#pragma warning disable DNAA0001 // Application class 'NativeApplication' does not have an Activation Constructor (NativeApplication is used by apps, not by itself)
 
 #if __ANDROID__
 using System;
@@ -9,6 +10,8 @@ using Java.Interop;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.StartScreen;
 using Android.Content;
+using Android.OS;
+using Android.Runtime;
 using Uno.Extensions;
 using Windows.Foundation.Metadata;
 using System.ComponentModel;
@@ -19,7 +22,7 @@ using IOnPreDrawListener = Android.Views.ViewTreeObserver.IOnPreDrawListener;
 
 namespace Microsoft.UI.Xaml
 {
-	public class NativeApplication : Android.App.Application
+	public class NativeApplication : AApplication
 	{
 		private Application _app;
 
@@ -37,7 +40,7 @@ namespace Microsoft.UI.Xaml
 		/// Creates an android Application instance
 		/// </summary>
 		/// <param name="appBuilder">A <see cref="AppBuilder"/> delegate that provides an <see cref="Application"/> instance.</param>
-		public NativeApplication(AppBuilder appBuilder, IntPtr javaReference, Android.Runtime.JniHandleOwnership transfer)
+		public NativeApplication(AppBuilder appBuilder, IntPtr javaReference, JniHandleOwnership transfer)
 			: base(javaReference, transfer)
 		{
 			// Register assemblies earlier than Application itself, otherwise
@@ -165,36 +168,36 @@ namespace Microsoft.UI.Xaml
 				_app = app;
 			}
 
-			public void OnActivityCreated(Android.App.Activity activity, Android.OS.Bundle savedInstanceState)
+			public void OnActivityCreated(Activity activity, Bundle savedInstanceState)
 			{
 
 			}
 
-			public void OnActivityDestroyed(Android.App.Activity activity)
+			public void OnActivityDestroyed(Activity activity)
 			{
 
 			}
 
-			public void OnActivityPaused(Android.App.Activity activity)
+			public void OnActivityPaused(Activity activity)
 			{
 
 			}
 
-			public void OnActivityResumed(Android.App.Activity activity)
+			public void OnActivityResumed(Activity activity)
 			{
 			}
 
-			public void OnActivitySaveInstanceState(Android.App.Activity activity, Android.OS.Bundle outState)
+			public void OnActivitySaveInstanceState(Activity activity, Bundle outState)
 			{
 
 			}
 
-			public void OnActivityStarted(Android.App.Activity activity)
+			public void OnActivityStarted(Activity activity)
 			{
 				_app.OnActivityStarted(activity);
 			}
 
-			public void OnActivityStopped(Android.App.Activity activity)
+			public void OnActivityStopped(Activity activity)
 			{
 
 			}

--- a/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Ellipse.Android.cs
@@ -7,6 +7,6 @@ namespace Microsoft.UI.Xaml.Shapes
 	{
 		/// <inheritdoc />
 		protected override Size ArrangeOverride(Size finalSize)
-			=> base.BasicArrangeOverride(finalSize, path => { path.AddOval(_logicalRenderingArea.ToRectF(), Android.Graphics.Path.Direction.Cw); });
+			=> base.BasicArrangeOverride(finalSize, path => { path.AddOval(_logicalRenderingArea.ToRectF(), APath.Direction.Cw); });
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Line.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Line.Android.cs
@@ -15,7 +15,7 @@ namespace Microsoft.UI.Xaml.Shapes
 		protected override Size ArrangeOverride(Size finalSize)
 			=> ArrangeAbsoluteShape(finalSize, GetPath());
 
-		private Android.Graphics.Path GetPath()
+		private APath GetPath()
 		{
 			var output = GetOrCreatePath();
 

--- a/src/Uno.UI/UI/Xaml/Shapes/Path.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Path.Android.cs
@@ -13,7 +13,7 @@ namespace Microsoft.UI.Xaml.Shapes
 		protected override Size ArrangeOverride(Size finalSize)
 			=> ArrangeAbsoluteShape(finalSize, GetPath());
 
-		private Android.Graphics.Path? GetPath()
+		private APath? GetPath()
 		{
 			return Data?.ToStreamGeometry()?.ToPath();
 		}

--- a/src/Uno.UI/UI/Xaml/Shapes/Polygon.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polygon.Android.cs
@@ -13,7 +13,7 @@ namespace Microsoft.UI.Xaml.Shapes
 		protected override Size ArrangeOverride(Size finalSize)
 			=> ArrangeAbsoluteShape(finalSize, GetPath());
 
-		private Android.Graphics.Path GetPath()
+		private APath GetPath()
 		{
 			var coords = Points;
 

--- a/src/Uno.UI/UI/Xaml/Shapes/Polyline.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Polyline.Android.cs
@@ -13,7 +13,7 @@ namespace Microsoft.UI.Xaml.Shapes
 		protected override Size ArrangeOverride(Size finalSize)
 			=> ArrangeAbsoluteShape(finalSize, GetPath());
 
-		private Android.Graphics.Path GetPath()
+		private APath GetPath()
 		{
 			var coords = Points;
 

--- a/src/Uno.UI/UI/Xaml/Shapes/Rectangle.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Rectangle.Android.cs
@@ -11,6 +11,6 @@ namespace Microsoft.UI.Xaml.Shapes
 
 		/// <inheritdoc />
 		protected override Size ArrangeOverride(Size finalSize)
-			=> base.BasicArrangeOverride(finalSize, path => { path.AddRoundRect(_logicalRenderingArea.ToRectF(), (float)RadiusX, (float)RadiusY, Android.Graphics.Path.Direction.Cw); });
+			=> base.BasicArrangeOverride(finalSize, path => { path.AddRoundRect(_logicalRenderingArea.ToRectF(), (float)RadiusX, (float)RadiusY, APath.Direction.Cw); });
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Shapes/Shape.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Shape.Android.cs
@@ -10,7 +10,7 @@ namespace Microsoft.UI.Xaml.Shapes
 {
 	public partial class Shape
 	{
-		private Android.Graphics.Path _path;
+		private APath _path;
 		private global::Windows.Foundation.Rect _drawArea;
 		protected global::Windows.Foundation.Rect _logicalRenderingArea;
 		private static Paint _strokePaint;
@@ -54,7 +54,7 @@ namespace Microsoft.UI.Xaml.Shapes
 		}
 
 		private protected void Render(
-			Android.Graphics.Path path,
+			APath path,
 			global::Windows.Foundation.Size? size = null,
 			double scaleX = 1d,
 			double scaleY = 1d,
@@ -73,7 +73,7 @@ namespace Microsoft.UI.Xaml.Shapes
 			}
 			_path = path;
 
-			var matrix = new Android.Graphics.Matrix();
+			var matrix = new AMatrix();
 
 			matrix.SetScale((float)scaleX * (float)ViewHelper.Scale, (float)scaleY * (float)ViewHelper.Scale);
 			matrix.PostTranslate(ViewHelper.LogicalToPhysicalPixels(renderOriginX), ViewHelper.LogicalToPhysicalPixels(renderOriginY));
@@ -166,7 +166,7 @@ namespace Microsoft.UI.Xaml.Shapes
 			}
 		}
 
-		private global::Windows.Foundation.Rect GetPathBoundingBox(Android.Graphics.Path path)
+		private global::Windows.Foundation.Rect GetPathBoundingBox(APath path)
 		{
 			// This method should return the bounding box, *not including* control points.
 			// On Android, there doesn't seem to be an easy built-in way to do that, since ComputeBounds will include control points.
@@ -215,10 +215,10 @@ namespace Microsoft.UI.Xaml.Shapes
 				height: maxY - minY);
 		}
 
-		protected Android.Graphics.Path GetOrCreatePath()
+		protected APath GetOrCreatePath()
 		{
 			_path?.Reset();
-			return _path ?? new Android.Graphics.Path();
+			return _path ?? new APath();
 		}
 
 		protected global::Windows.Foundation.Rect TransformToLogical(global::Windows.Foundation.Rect renderingArea)
@@ -238,7 +238,7 @@ namespace Microsoft.UI.Xaml.Shapes
 			return logicalRenderingArea;
 		}
 
-		protected global::Windows.Foundation.Size BasicArrangeOverride(global::Windows.Foundation.Size finalSize, Action<Android.Graphics.Path> action)
+		protected global::Windows.Foundation.Size BasicArrangeOverride(global::Windows.Foundation.Size finalSize, Action<APath> action)
 		{
 			var (shapeSize, renderingArea) = ArrangeRelativeShape(finalSize);
 
@@ -249,7 +249,7 @@ namespace Microsoft.UI.Xaml.Shapes
 				if (!_logicalRenderingArea.Equals(logicalRenderingArea))
 				{
 					_logicalRenderingArea = logicalRenderingArea;
-					Android.Graphics.Path path = GetOrCreatePath();
+					APath path = GetOrCreatePath();
 					action(path);
 					Render(path);
 				}

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -211,7 +211,7 @@ namespace Microsoft.UI.Xaml
 		/// This method is called from the OnDraw of elements supporting rounded corners:
 		/// Border, Rectangle, Panel...
 		/// </summary>
-		private protected void AdjustCornerRadius(Android.Graphics.Canvas canvas, CornerRadius cornerRadius)
+		private protected void AdjustCornerRadius(ACanvas canvas, CornerRadius cornerRadius)
 		{
 			if (cornerRadius != CornerRadius.None)
 			{
@@ -345,7 +345,7 @@ namespace Microsoft.UI.Xaml
 
 		partial void OnVisibilityChangedPartial(Visibility oldValue, Visibility newValue)
 		{
-			var newNativeVisibility = newValue == Visibility.Visible ? Android.Views.ViewStates.Visible : Android.Views.ViewStates.Gone;
+			var newNativeVisibility = newValue == Visibility.Visible ? ViewStates.Visible : ViewStates.Gone;
 
 			var bindableView = ((object)this) as Uno.UI.Controls.BindableView;
 

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.Native.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.Native.cs
@@ -10,6 +10,7 @@ using Microsoft.UI.Xaml.Input;
 using static Microsoft.UI.Xaml.UIElement;
 
 namespace Microsoft.UI.Xaml;
+
 partial class UIElement
 {
 	private bool OnNativePointerEnter(PointerRoutedEventArgs args, BubblingContext ctx = default) => OnPointerEnter(args);

--- a/src/Uno.UI/UI/Xaml/UIElement.ThemeShadow.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.ThemeShadow.Android.cs
@@ -15,7 +15,7 @@ public partial class UIElement
 	partial void SetShadow()
 	{
 		AndroidX.Core.View.ViewCompat.SetElevation(this, Uno.UI.ViewHelper.LogicalToPhysicalPixels(Translation.Z) / 1.8f);
-		if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.P)
+		if (ABuild.VERSION.SdkInt >= ABuildVersionCodes.P)
 		{
 			this.SetOutlineSpotShadowColor(Colors.Black.WithOpacity(0.5));
 			this.SetOutlineAmbientShadowColor(Colors.Transparent);

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindow.UIKit.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindow.UIKit.cs
@@ -348,7 +348,7 @@ public partial class Window : UIWindow
 				return;
 			}
 
-			_inputPane.OccludedRect = ((NSValue)e.Notification.UserInfo.ObjectForKey(UIKeyboard.FrameEndUserInfoKey)).CGRectValue;
+			_inputPane.OccludedRect = ((NSValue?)e.Notification.UserInfo.ObjectForKey(UIKeyboard.FrameEndUserInfoKey))?.CGRectValue ?? default;
 		}
 		catch (Exception ex)
 		{

--- a/src/Uno.UWP/ApplicationModel/Core/CoreApplication.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/Core/CoreApplication.wasm.cs
@@ -9,6 +9,7 @@ using static __Windows.ApplicationModel.Core.CoreApplicationNative;
 using System.Diagnostics;
 
 namespace Windows.ApplicationModel.Core;
+
 partial class CoreApplication
 {
 	private static ICoreApplicationExtension? _coreApplicationExtension;

--- a/src/Uno.UWP/Devices/Sensors/SimpleOrientationSensor.unsupported.cs
+++ b/src/Uno.UWP/Devices/Sensors/SimpleOrientationSensor.unsupported.cs
@@ -3,6 +3,7 @@
 #nullable enable
 
 namespace Windows.Devices.Sensors;
+
 public partial class SimpleOrientationSensor
 {
 	private static partial SimpleOrientationSensor? TryCreateInstance() => null;

--- a/src/Uno.UWP/Storage/Pickers/FileOpenPicker.iOS.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileOpenPicker.iOS.cs
@@ -71,7 +71,7 @@ namespace Windows.Storage.Pickers
 						ImagePickerControllerDelegate = new ImageOpenPickerDelegate(completionSource)
 					};
 
-					var mediaTypesFromPhotoLibrary = UIImagePickerController.AvailableMediaTypes(UIImagePickerControllerSourceType.PhotoLibrary);
+					var mediaTypesFromPhotoLibrary = UIImagePickerController.AvailableMediaTypes(UIImagePickerControllerSourceType.PhotoLibrary) ?? [];
 					var types = new List<string>();
 
 					if (FileTypeFilter.Count == 0 || FileTypeFilter.Contains("*"))


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/70bd636b

As part of .NET 10, .NET for Android introduced a new `Microsoft.Android.Runtime` namespace.  This causes lots of CS0234 errors across the uno codebase:

	// Android.Views.Window Window => …
	error CS0234: The type or namespace name 'Views' does not exist in the namespace 'Microsoft.Android' (are you missing an assembly reference?)

While this requires .NET 10 to get the error, it doesn't require .NET 10 to preemptively *fix* the error.  (And preemptively fixing the error reduces the size of .NET 10 PRs…)

The CS0234 error can be fixed in (at least) three ways:

 1. Instead of a full type name such as `Android.Views.Window`, add a top-level `using Android.Views` and then only use `Window`.

    This approach only works if there is no other `Window` type in scope…which is *not* the case `Window`, but may be the case for other types such as `GravityFlags`.

 2. Use `global::`, e.g. `global::Android.Views.Window`. This *works*, but quickly gets verbose and unwieldy.

 3. [C# 10 `global using` directives][0] for `alias`es:

        global using AWindow = Android.Views.Window;

    then use `AWindow` when `Android.Views.Window` is needed.

Add a new `src/Uno.UI/GlobalUsings.cs` file which contains `global using …` statements for the most commonly used types which trigger CS0234 errors -- `AApplication`, `AButton`, `AWindow`, etc. -- and use a complication of (1) and (3) to fix the CS0234 errors.

Aside: Why a `A` prefix? For two reasons: (1) "A is for Android", and (2) the aliases need to be "unique".  "Real" types take precedence over `using` aliases; if we had `using Window = Android.Views.Window`, *it would not matter* within a `Microsoft.UI.Xaml` namespace or sub- namespace, as `Window` will *always* mean `Microsoft.UI.Xaml.Window`.

"While in the area", fix some new-in-.NET 10 IDE0055 warnings; apparently a blank line is now required between a `namespace` declaration and a type declaration.

Also fix some nullability warnings from the .NET 10 iOS bits.

[0]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive#the-global-modifier

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->