### PR TITLE
fix(skia): TextBlock RenderTransform and FlowDirection issues

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -16,23 +16,25 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 using Windows.UI.Input.Preview.Injection;
 using FluentAssertions;
-using static Private.Infrastructure.TestServices;
 using System.Collections.Generic;
 using System.Drawing;
 using SamplesApp.UITests;
 using Uno.Disposables;
 using Uno.Extensions;
 using Uno.UI.Extensions;
-using Point = Windows.Foundation.Point;
-using Size = Windows.Foundation.Size;
 using Combinatorial.MSTest;
-
+using Uno.UI.Helpers;
+using Microsoft.UI.Xaml.Markup;
 
 #if __SKIA__
 using Microsoft.UI.Xaml.Data;
 using SkiaSharp;
 using Microsoft.UI.Xaml.Documents.TextFormatting;
 #endif
+
+using Point = Windows.Foundation.Point;
+using Size = Windows.Foundation.Size;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -1658,6 +1660,54 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual(selectedText, sut.SelectedText);
 		}
 		#endregion
+#endif
+
+#if __SKIA__
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/21264")]
+		[DataRow("L")]
+		[DataRow("R")]
+		[DataRow("LL")]
+		[DataRow("LR")]
+		[DataRow("RL")]
+		[DataRow("RR")]
+		[DataRow("LLL")]
+		[DataRow("LLR")]
+		[DataRow("LRL")]
+		[DataRow("LRR")]
+		[DataRow("RLL")]
+		[DataRow("RLR")]
+		[DataRow("RRL")]
+		[DataRow("RRR")]
+		public async Task When_Layered_FlowDirection(string setup)
+		{
+			if (string.IsNullOrEmpty(setup) || setup.Any(c => c is not ('L' or 'R')))
+			{
+				throw new ArgumentException("setup must be a non-empty string containing only 'L' and 'R' characters");
+			}
+
+			FrameworkElement root = null;
+			var textblock = new TextBlock { Text = "Asd" };
+
+			// assign FlowDirection from in-most, and box each layer with border
+			// LLR: Border R > Border L > TextBlock L
+			foreach (var c in setup)
+			{
+				root = root is null ? textblock : new Border { Child = root };
+				root.FlowDirection = Parse(c);
+			}
+
+			await UITestHelper.Load(root);
+
+			Assert.AreEqual(1, textblock.Visual.TotalMatrix.M11);
+
+			FlowDirection Parse(char c) => c switch
+			{
+				'L' => FlowDirection.LeftToRight,
+				'R' => FlowDirection.RightToLeft,
+				_ => throw new InvalidOperationException()
+			};
+		}
 #endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -1021,6 +1021,29 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			ImageAssert.DoesNotHaveColorInRectangle(screenshot, new Rectangle(0, 0, 50, 50), Colors.Red);
 		}
 
+#if __SKIA__
+		[TestMethod]
+		public async Task When_RenderTransform_Rearrange()
+		{
+			var sut = new TextBlock()
+			{
+				Text = "AsdAsd",
+				RenderTransform = new CompositeTransform { ScaleX = 2, ScaleY = 2 },
+			};
+
+			await UITestHelper.Load(sut);
+
+			var a = sut.Visual.TransformMatrix;
+
+			sut.InvalidateArrange();
+			await UITestHelper.WaitForIdle();
+
+			var b = sut.Visual.TransformMatrix;
+
+			Assert.AreEqual(a, b, "Visual.TransformMatrix should remain unchanged after re-arrange.");
+		}
+#endif
+
 #if HAS_UNO // GetMouse is not available on WinUI
 		#region IsTextSelectionEnabled
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.skia.cs
@@ -109,20 +109,12 @@ namespace Microsoft.UI.Xaml.Controls
 			}
 		}
 
-		private void ApplyFlowDirection(float width)
-		{
-			Visual.TransformMatrix = FlowDirection == FlowDirection.RightToLeft
-				? new Matrix4x4(new Matrix3x2(-1.0f, 0.0f, 0.0f, 1.0f, width, 0.0f))
-				: Matrix4x4.Identity;
-		}
-
 		protected override Size ArrangeOverride(Size finalSize)
 		{
 			var padding = Padding;
 			var availableSizeWithoutPadding = finalSize.Subtract(padding);
 			var arrangedSize = Inlines.Arrange(availableSizeWithoutPadding);
 			_lastInlinesArrangeWithPadding = arrangedSize.Add(padding);
-			ApplyFlowDirection((float)finalSize.Width);
 
 			var result = base.ArrangeOverride(finalSize);
 			UpdateIsTextTrimmed();
@@ -152,15 +144,6 @@ namespace Microsoft.UI.Xaml.Controls
 				}
 
 				return font.LineHeight;
-			}
-		}
-
-		internal override void OnPropertyChanged2(DependencyPropertyChangedEventArgs args)
-		{
-			base.OnPropertyChanged2(args);
-			if (args.Property == FlowDirectionProperty)
-			{
-				ApplyFlowDirection((float)this.RenderSize.Width);
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -102,7 +102,14 @@ namespace Microsoft.UI.Xaml
 
 #if SUPPORTS_RTL
 		internal Matrix3x2 GetFlowDirectionTransform()
-			=> ShouldMirrorVisual() ? new Matrix3x2(-1.0f, 0.0f, 0.0f, 1.0f, (float)RenderSize.Width, 0.0f) : Matrix3x2.Identity;
+		{
+			var inMirroredSubtree = ShouldMirrorVisual();
+			var isMirroredTextBlock = this is TextBlock { FlowDirection: FlowDirection.RightToLeft };
+
+			return inMirroredSubtree ^ isMirroredTextBlock
+				? new Matrix3x2(-1.0f, 0.0f, 0.0f, 1.0f, (float)RenderSize.Width, 0.0f)
+				: Matrix3x2.Identity;
+		}
 
 		private bool ShouldMirrorVisual()
 		{


### PR DESCRIPTION
**GitHub Issue:** 
- RenderTransform: closes unoplatform/kahua-private#309, closes unoplatform/Uno.Themes#1557
- FlowDirection: closes #21264

## PR Type:
- 🐞 Bugfix

## What is the current behavior? 🤔
- On re-arrange, the corresponding Visual.TransformMatrix, which TextBlock.RenderTransform maps to, is overwritten an identity matrix...
- TextBlock with FlowDirection=Right2Left are incorrectly v-mirrored

## What is the new behavior? 🚀
^ no more.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
The current/pre-existing implementation for TextBlock FlowDirection is incorrect anyways. It simply applies a vertical mirroring to the entire textblock... If we were actually to apply Right2Left, we would need to apply a vertical mirror on the entire TextBlock, AND a vertical mirror on every single character. Without the 2nd part, the text aren't normally readable...