### PR TITLE
fix: ios statusbar set when app is active

### DIFF
--- a/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.iOS.cs
+++ b/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.iOS.cs
@@ -7,6 +7,7 @@ using CoreGraphics;
 using Foundation;
 using UIKit;
 using Uno.Foundation.Logging;
+using Uno.UI.Dispatching;
 using Windows.Foundation;
 using Windows.UI;
 using Windows.UI.Core;
@@ -26,13 +27,13 @@ namespace Windows.UI.ViewManagement
 
 		private void InitializeBackgroundColorObserver()
 		{
+			// Dispatch to ensure UI thread is ready, DidBecomeActive may fire before all windows are loaded
 			NSNotificationCenter.DefaultCenter.AddObserver(
 				UIApplication.DidBecomeActiveNotification,
-				async _ =>
-				{
-					await Task.Delay(100);
-					SetStatusBarBackgroundColor(_backgroundColor);
-				}
+				(NSNotification __) =>
+					_ = CoreDispatcher.Main.RunAsync(
+						CoreDispatcherPriority.Normal,
+						() => SetStatusBarBackgroundColor(_backgroundColor))
 			);
 
 			NSNotificationCenter.DefaultCenter.AddObserver(

--- a/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.iOS.cs
+++ b/src/Uno.UWP/UI/ViewManagement/StatusBar/StatusBar.iOS.cs
@@ -28,7 +28,11 @@ namespace Windows.UI.ViewManagement
 		{
 			NSNotificationCenter.DefaultCenter.AddObserver(
 				UIApplication.DidBecomeActiveNotification,
-				_ => SetStatusBarBackgroundColor(_backgroundColor)
+				async _ =>
+				{
+					await Task.Delay(100);
+					SetStatusBarBackgroundColor(_backgroundColor);
+				}
 			);
 
 			NSNotificationCenter.DefaultCenter.AddObserver(


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno.toolkit.ui/issues/1416

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--

- 🐞 Bugfix


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- The UIApplication.DidBecomeActiveNotification event sometimes triggers slightly before the app loads all UIKit active windows.

## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

- We keep using the UIApplication.DidBecomeActiveNotification event, but instead add a slight delay to ensure all UIKit active windows have loaded.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
