### PR TITLE
ci: bump to min xcode version for macos-15

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -58,7 +58,7 @@ variables:
   linuxScaledPool: 'Ubuntu2204-20230918'
   macOSVMImage: 'macOS-15'
   macOSVMImage_UITests: 'macOS-14'
-  xCodeRoot: '/Applications/Xcode_16.2.app'
+  xCodeRoot: '/Applications/Xcode_16.3.app'
   xCodeRoot_iOS_UITests: '/Applications/Xcode_15.3.app'
 
   # Offline validation to improve build performance


### PR DESCRIPTION
Bump to Xcode 16.3 to adjust for https://github.com/actions/runner-images/issues/12541