### PR TITLE
fix: Fix ManipRoutedEvtArg.Position to be relative to the Container

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
@@ -15,6 +15,9 @@ public partial class Given_UIElement
 {
 	[TestMethod]
 	[RunsOnUIThread]
+#if !HAS_INPUT_INJECTOR
+	[Ignore("InputInjector is not supported on this platform.")]
+#endif
 	public async Task When_ManipulationEvents_Then_PositionIsRelative()
 	{
 		var sut = new Border
@@ -35,7 +38,7 @@ public partial class Given_UIElement
 
 		var bounds = await UITestHelper.Load(sut);
 
-		finger.Drag(bounds.Location.Offset(10, 10), bounds.Location.Offset(-100, 10), steps: 2);
+		finger.Drag(bounds.GetLocation().Offset(10, 10), bounds.GetLocation().Offset(-100, 10), steps: 2);
 
 		started.X.Should().BeInRange(-100 - 1, 10 + 1);
 		started.Y.Should().BeApproximately(10, precision: 1);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Media;
 using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.Toolkit.Extensions;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.Manipulations.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.Foundation;
+using Windows.UI.Input.Preview.Injection;
+using FluentAssertions;
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Media;
+using Uno.UI.RuntimeTests.Helpers;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml;
+
+public partial class Given_UIElement
+{
+	[TestMethod]
+	[RunsOnUIThread]
+	public async Task When_ManipulationEvents_Then_PositionIsRelative()
+	{
+		var sut = new Border
+		{
+			Width = 200,
+			Height = 200,
+			ManipulationMode = ManipulationModes.TranslateX | ManipulationModes.TranslateY,
+			Background = new SolidColorBrush(Colors.DeepPink)
+		};
+
+		Point started = default, delta = default, completed = default;
+		sut.ManipulationStarted += (snd, args) => started = args.Position;
+		sut.ManipulationDelta += (snd, args) => delta = args.Position;
+		sut.ManipulationCompleted += (snd, args) => completed = args.Position;
+
+		var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+		using var finger = injector.GetFinger();
+
+		var bounds = await UITestHelper.Load(sut);
+
+		finger.Drag(bounds.Location.Offset(10, 10), bounds.Location.Offset(-100, 10), steps: 2);
+
+		started.X.Should().BeInRange(-100 - 1, 10 + 1);
+		started.Y.Should().BeApproximately(10, precision: 1);
+
+		delta.X.Should().BeInRange(-100 - 1, 10 + 1);
+		delta.Y.Should().BeApproximately(10, precision: 1);
+
+		completed.X.Should().BeApproximately(-100, precision: 1);
+		completed.Y.Should().BeApproximately(10, precision: 1);
+	}
+}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -461,6 +461,16 @@ namespace Uno.UI
 #endif
 		}
 
+		public static class ManipulationRoutedEventArgs
+		{
+			/// <summary>
+			/// In previous versions of uno, the Position property of the Manipulation&gt;Started|Delta|Complete&lt;**Routed**EventArgs
+			/// was in absolute coordinate space instead of being relative to the Container.
+			/// Enabling this flag does restore the previous behavior.
+			/// </summary>
+			public static bool IsAbsolutePositionEnabled { get; set; }
+		}
+
 		public static class SelectorItem
 		{
 			/// <summary>

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationCompletedRoutedEventArgs.cs
@@ -1,4 +1,6 @@
 ﻿using Windows.Foundation;
+using Uno.Extensions;
+using Uno.UI;
 using Uno.UI.Xaml.Input;
 
 #if HAS_UNO_WINUI
@@ -21,7 +23,9 @@ namespace Microsoft.UI.Xaml.Input
 
 			Pointers = args.Pointers;
 			PointerDeviceType = args.PointerDeviceType;
-			Position = args.Position;
+			Position = FeatureConfiguration.ManipulationRoutedEventArgs.IsAbsolutePositionEnabled
+				? args.Position
+				: UIElement.GetTransform(container, null).Inverse().Transform(args.Position);
 			Cumulative = args.Cumulative;
 			Velocities = args.Velocities;
 			IsInertial = args.IsInertial;

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationDeltaRoutedEventArgs.cs
@@ -1,4 +1,7 @@
-﻿using Windows.Foundation;
+﻿using System;
+using Windows.Foundation;
+using Uno.Extensions;
+using Uno.UI;
 using Uno.UI.Xaml.Input;
 
 #if HAS_UNO_WINUI
@@ -26,7 +29,9 @@ namespace Microsoft.UI.Xaml.Input
 
 			Pointers = args.Pointers;
 			PointerDeviceType = args.PointerDeviceType;
-			Position = args.Position;
+			Position = FeatureConfiguration.ManipulationRoutedEventArgs.IsAbsolutePositionEnabled
+				? args.Position
+				: UIElement.GetTransform(container, null).Inverse().Transform(args.Position);
 			Delta = args.Delta;
 			Cumulative = args.Cumulative;
 			Velocities = args.Velocities;
@@ -39,7 +44,7 @@ namespace Microsoft.UI.Xaml.Input
 		/// Gets identifiers of all pointer that has been involved in that manipulation (cf. Remarks).
 		/// </summary>
 		/// <remarks>This collection might contains pointers that has been released.</remarks>
-		/// <remarks>All pointers are expected to have the same <see cref="PointerIdentifier.Type"/>.</remarks>
+		/// <remarks>All pointers are expected to have the same <see cref="Type"/>.</remarks>
 		internal global::Windows.Devices.Input.PointerIdentifier[] Pointers { get; }
 
 		public bool Handled { get; set; }

--- a/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/ManipulationStartedRoutedEventArgs.cs
@@ -1,6 +1,8 @@
 ﻿using Uno.UI.Xaml.Input;
 using Windows.Devices.Input;
 using Windows.Foundation;
+using Uno.Extensions;
+using Uno.UI;
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;
@@ -26,7 +28,9 @@ namespace Microsoft.UI.Xaml.Input
 
 			Pointers = args.Pointers;
 			PointerDeviceType = args.PointerDeviceType;
-			Position = args.Position;
+			Position = FeatureConfiguration.ManipulationRoutedEventArgs.IsAbsolutePositionEnabled
+				? args.Position
+				: UIElement.GetTransform(container, null).Inverse().Transform(args.Position);
 			Cumulative = args.Cumulative;
 		}
 

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -553,7 +553,8 @@ namespace Microsoft.UI.Xaml
 
 		internal AutomationPeer OnCreateAutomationPeerInternal() => OnCreateAutomationPeer();
 
-		internal static Matrix3x2 GetTransform(UIElement from, UIElement to)
+#nullable enable
+		internal static Matrix3x2 GetTransform(UIElement from, UIElement? to)
 		{
 			if (from == to || !from.IsInLiveTree || (to is { IsVisualTreeRoot: false, IsInLiveTree: false }))
 			{
@@ -617,6 +618,7 @@ namespace Microsoft.UI.Xaml
 			return matrix;
 #endif
 		}
+#nullable restore
 
 #if !__SKIA__
 		/// <summary>


### PR DESCRIPTION
**GitHub Issue:** closes: https://github.com/unoplatform/uno/issues/6964

## 🐞 Bugfix
 Fix `Manipulation<Started|Delta|Complete>RoutedEventArgs.Position` to be relative to the `Container`

## What is the current behavior? 🤔
`Position` is absolute

## What is the new behavior? 🚀
`Position` is relative to the `Container`

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
Previous behavior can be restored using a feature flag