### PR TITLE
fix: Managed pointer input pass-through native layer on iOS

### DIFF
--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_ManagedOverlay.xaml
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_ManagedOverlay.xaml
@@ -1,0 +1,16 @@
+﻿<Page
+    x:Class="UITests.Microsoft_UI_Xaml_Controls.WebView2Tests.WebView2_ManagedOverlay"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Microsoft_UI_Xaml_Controls.WebView2Tests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+		<controls:WebView2 Source="https://platform.uno"/>
+		<Button HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="30" Click="OnTestClick">Click me</Button>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_ManagedOverlay.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/WebView2Tests/WebView2_ManagedOverlay.xaml.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Microsoft_UI_Xaml_Controls.WebView2Tests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	[Uno.UI.Samples.Controls.Sample(
+		"WebView",
+		IsManualTest = true,
+		Description =
+			"You should be able to interact with the website (click links, scroll), as well as click the button in the center." +
+			"Each click should increment it exactly once. Conversely, clicking the button should not trigger any hyperlink that is currently below it.")]
+	public sealed partial class WebView2_ManagedOverlay : Page
+	{
+		public WebView2_ManagedOverlay()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnTestClick(object sender, RoutedEventArgs e)
+		{
+			var btn = (Button)sender;
+			var text = btn.Content.ToString();
+			if (int.TryParse(text, out var value))
+			{
+				btn.Content = (value + 1).ToString();
+			}
+			else
+			{
+				btn.Content = "0";
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -4318,6 +4318,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\WebView2Tests\WebView2_ManagedOverlay.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\WebView2Tests\WebView2_Folder.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -9665,6 +9669,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\WebView2Tests\WebView2_Basic.xaml.cs">
       <DependentUpon>WebView2_Basic.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\WebView2Tests\WebView2_ManagedOverlay.xaml.cs">
+      <DependentUpon>WebView2_ManagedOverlay.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\WebView2Tests\WebView2_Folder.xaml.cs">
       <DependentUpon>WebView2_Folder.xaml</DependentUpon>

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/Devices/Input/TopViewLayer.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/Devices/Input/TopViewLayer.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using CoreAnimation;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 using Uno.UI.Runtime.Skia.AppleUIKit;

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/Devices/Input/TopViewLayer.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/Devices/Input/TopViewLayer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Foundation;
+using UIKit;
+using Uno.UI.Runtime.Skia.AppleUIKit;
+
+namespace Uno.WinUI.Runtime.Skia.AppleUIKit.UI.Xaml;
+
+/// <summary>
+/// Top layer that receives all touch events and forwards them to the
+/// managed pointer handling. It also contains  <see cref="NativeOverlayLayer" /> which
+/// will only capture input of the native element within.
+/// </summary>
+[Register("InputLayer")]
+internal class TopViewLayer : UIView
+{
+#if __IOS__
+	public TopViewLayer()
+	{
+		MultipleTouchEnabled = true;
+	}
+#endif
+
+	// Note: The pointers are listen here in the NativeOverlayLayer as it's the topmost layer in the view hierarchy.
+	// Note2: This must be in a layer (compared to override RootViewController.TouchesXXX methods) in order to be able to properly get the multitouch events.
+	public override void TouchesBegan(NSSet touches, UIEvent? evt)
+	{
+		AppleUIKitCorePointerInputSource.Instance.TouchesBegan(this, touches, evt);
+		base.TouchesBegan(touches, evt);
+	}
+
+	public override void TouchesMoved(NSSet touches, UIEvent? evt)
+	{
+		AppleUIKitCorePointerInputSource.Instance.TouchesMoved(this, touches, evt);
+		base.TouchesMoved(touches, evt);
+	}
+
+	public override void TouchesEnded(NSSet touches, UIEvent? evt)
+	{
+		AppleUIKitCorePointerInputSource.Instance.TouchesEnded(this, touches, evt);
+		base.TouchesEnded(touches, evt);
+	}
+
+	public override void TouchesCancelled(NSSet touches, UIEvent? evt)
+	{
+		AppleUIKitCorePointerInputSource.Instance.TouchesCancelled(this, touches, evt);
+		base.TouchesCancelled(touches, evt);
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/Devices/Input/TopViewLayer.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/Devices/Input/TopViewLayer.cs
@@ -10,8 +10,10 @@ namespace Uno.WinUI.Runtime.Skia.AppleUIKit.UI.Xaml;
 /// Top layer that receives all touch events and forwards them to the
 /// managed pointer handling. It also contains  <see cref="NativeOverlayLayer" /> which
 /// will only capture input of the native element within.
+/// Input handling must be in a layer (compared to override RootViewController.TouchesXXX methods)
+/// in order to be able to properly get the multitouch events.
 /// </summary>
-[Register("InputLayer")]
+[Register("TopViewLayer")]
 internal class TopViewLayer : UIView
 {
 #if __IOS__
@@ -21,8 +23,6 @@ internal class TopViewLayer : UIView
 	}
 #endif
 
-	// Note: The pointers are listen here in the NativeOverlayLayer as it's the topmost layer in the view hierarchy.
-	// Note2: This must be in a layer (compared to override RootViewController.TouchesXXX methods) in order to be able to properly get the multitouch events.
 	public override void TouchesBegan(NSSet touches, UIEvent? evt)
 	{
 		AppleUIKitCorePointerInputSource.Instance.TouchesBegan(this, touches, evt);

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/Native/NativeOverlayLayer.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/Native/NativeOverlayLayer.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using CoreAnimation;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 using Uno.UI.Runtime.Skia.AppleUIKit;
@@ -12,6 +14,11 @@ namespace Uno.WinUI.Runtime.Skia.AppleUIKit.UI.Xaml;
 [Register("NativeOverlayLayer")]
 internal class NativeOverlayLayer : UIView
 {
+	public NativeOverlayLayer()
+	{
+		UserInteractionEnabled = false;
+	}
+
 	public event EventHandler? SubviewsChanged;
 
 	public override void SubviewAdded(UIView uiview)
@@ -29,6 +36,34 @@ internal class NativeOverlayLayer : UIView
 	public override void LayoutSubviews()
 	{
 		base.LayoutSubviews();
+
+		UserInteractionEnabled = Subviews.Length > 0;
+
 		SubviewsChanged?.Invoke(this, EventArgs.Empty);
+	}
+
+	public override UIView? HitTest(CGPoint point, UIEvent? uiEvent)
+	{
+		// When there are any Subviews, we want to hit test against the native clipping
+		// mask, so we can let input pass-through the "holes" in the mask.
+		if (!Frame.Contains(point) || Subviews.Length == 0)
+		{
+			return null;
+		}
+
+		if (Layer.Mask is CAShapeLayer shape)
+		{
+			if (shape.Path is { } path)
+			{
+				var pointInPath = path.ContainsPoint(point, eoFill: true);
+
+				if (pointInPath)
+				{
+					return base.HitTest(point, uiEvent);
+				}
+			}
+		}
+
+		return null;
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/Native/NativeOverlayLayer.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/Native/NativeOverlayLayer.cs
@@ -12,13 +12,6 @@ namespace Uno.WinUI.Runtime.Skia.AppleUIKit.UI.Xaml;
 [Register("NativeOverlayLayer")]
 internal class NativeOverlayLayer : UIView
 {
-#if __IOS__
-	public NativeOverlayLayer()
-	{
-		MultipleTouchEnabled = true;
-	}
-#endif
-
 	public event EventHandler? SubviewsChanged;
 
 	public override void SubviewAdded(UIView uiview)
@@ -37,31 +30,5 @@ internal class NativeOverlayLayer : UIView
 	{
 		base.LayoutSubviews();
 		SubviewsChanged?.Invoke(this, EventArgs.Empty);
-	}
-
-	// Note: The pointers are listen here in the NativeOverlayLayer as it's the topmost layer in the view hierarchy.
-	// Note2: This must be in a layer (compared to override RootViewController.TouchesXXX methods) in order to be able to properly get the multitouch events.
-	public override void TouchesBegan(NSSet touches, UIEvent? evt)
-	{
-		AppleUIKitCorePointerInputSource.Instance.TouchesBegan(this, touches, evt);
-		base.TouchesBegan(touches, evt);
-	}
-
-	public override void TouchesMoved(NSSet touches, UIEvent? evt)
-	{
-		AppleUIKitCorePointerInputSource.Instance.TouchesMoved(this, touches, evt);
-		base.TouchesMoved(touches, evt);
-	}
-
-	public override void TouchesEnded(NSSet touches, UIEvent? evt)
-	{
-		AppleUIKitCorePointerInputSource.Instance.TouchesEnded(this, touches, evt);
-		base.TouchesEnded(touches, evt);
-	}
-
-	public override void TouchesCancelled(NSSet touches, UIEvent? evt)
-	{
-		AppleUIKitCorePointerInputSource.Instance.TouchesCancelled(this, touches, evt);
-		base.TouchesCancelled(touches, evt);
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
@@ -92,14 +92,16 @@ internal class RootViewController : UINavigationController, IAppleUIKitXamlRootH
 #endif
 		view.AddSubview(_skCanvasView);
 
-		var topViewLayer = new TopViewLayer();
+		_topViewLayer = new TopViewLayer();
+		_topViewLayer.Frame = view.Bounds;
+		_topViewLayer.AutoresizingMask = UIViewAutoresizing.All;
 		var nativeOverlayLayer = new NativeOverlayLayer();
 		nativeOverlayLayer.Frame = view.Bounds;
 		nativeOverlayLayer.AutoresizingMask = UIViewAutoresizing.All;
 		nativeOverlayLayer.SubviewsChanged += NativeOverlayLayer_SubviewsChanged;
 		_nativeOverlayLayer = nativeOverlayLayer;
-		topViewLayer.AddSubview(_nativeOverlayLayer);
-		view.AddSubview(topViewLayer);
+		_topViewLayer.AddSubview(_nativeOverlayLayer);
+		view.AddSubview(_topViewLayer);
 
 		// TODO Uno: When we support multi-window, this should close popups for the appropriate XamlRoot #13847.
 

--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Window/RootViewController.cs
@@ -38,6 +38,7 @@ internal class RootViewController : UINavigationController, IAppleUIKitXamlRootH
 	private SkiaCanvas? _skCanvasView;
 	private XamlRoot? _xamlRoot;
 	private UIView? _textInputLayer;
+	private UIView? _topViewLayer;
 	private UIView? _nativeOverlayLayer;
 	private string? _lastSvgClipPath;
 	private SKPicture? _picture;
@@ -91,12 +92,14 @@ internal class RootViewController : UINavigationController, IAppleUIKitXamlRootH
 #endif
 		view.AddSubview(_skCanvasView);
 
+		var topViewLayer = new TopViewLayer();
 		var nativeOverlayLayer = new NativeOverlayLayer();
 		nativeOverlayLayer.Frame = view.Bounds;
 		nativeOverlayLayer.AutoresizingMask = UIViewAutoresizing.All;
 		nativeOverlayLayer.SubviewsChanged += NativeOverlayLayer_SubviewsChanged;
 		_nativeOverlayLayer = nativeOverlayLayer;
-		view.AddSubview(_nativeOverlayLayer);
+		topViewLayer.AddSubview(_nativeOverlayLayer);
+		view.AddSubview(topViewLayer);
 
 		// TODO Uno: When we support multi-window, this should close popups for the appropriate XamlRoot #13847.
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/328

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

Pointer input is not passing through the native layer due to clipping


## What is the new behavior? 🚀

- Input is captured in a new top level layer which contains the clipped native layer
- Native layer is pass-through unless native elements are inside
- In such case we hit test against the clipping layer and let all "clipped" input pass through to the input layer

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes