### PR TITLE
fix(nativedispatchersynchronizationcontext): always enqueue on Normal

### DIFF
--- a/src/Uno.UI.Dispatching/Native/NativeDispatcherSynchronizationContext.cs
+++ b/src/Uno.UI.Dispatching/Native/NativeDispatcherSynchronizationContext.cs
@@ -3,22 +3,21 @@
 namespace Uno.UI.Dispatching
 {
 	/// <summary>
-	/// Provides a CoreDispatched Synchronization context, to allow for async methods to keep the dispatcher priority.
+	/// A synchronization context that always schedules on the Normal priority.
 	/// </summary>
 	internal sealed class NativeDispatcherSynchronizationContext : SynchronizationContext
 	{
 		private readonly NativeDispatcher _dispatcher;
-		private readonly NativeDispatcherPriority _priority;
+		private const NativeDispatcherPriority Priority = NativeDispatcherPriority.Normal;
 
-		public NativeDispatcherSynchronizationContext(NativeDispatcher dispatcher, NativeDispatcherPriority priority)
+		public NativeDispatcherSynchronizationContext(NativeDispatcher dispatcher)
 		{
 			_dispatcher = dispatcher;
-			_priority = priority;
 		}
 
 		public override void Post(SendOrPostCallback d, object state)
 		{
-			_dispatcher.Enqueue(() => d(state), _priority);
+			_dispatcher.Enqueue(() => d(state), Priority);
 		}
 
 		public override void Send(SendOrPostCallback d, object state)
@@ -30,7 +29,7 @@ namespace Uno.UI.Dispatching
 			else
 			{
 				_dispatcher
-					.EnqueueAsync(() => d(state), _priority)
+					.EnqueueAsync(() => d(state), Priority)
 					.Wait();
 			}
 		}

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserKeyboardInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserKeyboardInputSource.cs
@@ -42,7 +42,7 @@ internal partial class BrowserKeyboardInputSource : IUnoKeyboardInputSource
 
 		// Ensure that the async context is set properly, since we're raising
 		// events from outside the dispatcher.
-		using var syncContextScope = NativeDispatcher.Main.GetSynchronizationContext(NativeDispatcherPriority.Normal).Apply();
+		using var syncContextScope = NativeDispatcher.Main.SynchronizationContext.Apply();
 
 		var args = new KeyEventArgs(
 			"keyboard",

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/Devices/Input/BrowserPointerInputSource.cs
@@ -80,7 +80,7 @@ internal unsafe partial class BrowserPointerInputSource : IUnoCorePointerInputSo
 
 			// Ensure that the async context is set properly, since we're raising
 			// events from outside the dispatcher.
-			using var syncContextScope = NativeDispatcher.Main.GetSynchronizationContext(NativeDispatcherPriority.Normal).Apply();
+			using var syncContextScope = NativeDispatcher.Main.SynchronizationContext.Apply();
 
 			var that = (BrowserPointerInputSource)inputSource;
 			var evt = (HtmlPointerEvent)@event;

--- a/src/Uno.UI.Runtime.Skia.Wpf/Input/WpfCorePointerInputSource.cs
+++ b/src/Uno.UI.Runtime.Skia.Wpf/Input/WpfCorePointerInputSource.cs
@@ -17,6 +17,7 @@ using Windows.Foundation;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Input;
+using Uno.UI.Dispatching;
 using Uno.UI.Runtime.Skia.Wpf;
 using Uno.UI.Runtime.Skia.Wpf.Hosting;
 using Uno.UI.Runtime.Skia.Wpf.UI.Controls;
@@ -140,10 +141,7 @@ internal sealed class WpfCorePointerInputSource : IUnoCorePointerInputSource
 		try
 		{
 			// Make sure WPF doesn't override our own SynchronizationContext.
-			if (Microsoft.UI.Xaml.Application.ApplicationSynchronizationContext is { } syncContext)
-			{
-				SynchronizationContext.SetSynchronizationContext(syncContext);
-			}
+			SynchronizationContext.SetSynchronizationContext(NativeDispatcher.Main.SynchronizationContext);
 
 			var eventArgs = BuildPointerArgs(args, isReleaseOrCancel);
 			ev?.Invoke(this, eventArgs);

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_DispatcherQueue.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_DispatcherQueue.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.RuntimeTests.Helpers;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_System
 {
@@ -26,5 +27,21 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_System
 			Assert.IsNull(DispatcherQueue.GetForCurrentThread());
 		}
 #endif
+
+		[TestMethod]
+		[RunsOnUIThread]
+		public async Task When_NativeDispatcherSynchronizationContext_Continuation_Scheduling()
+		{
+			var list = new List<int>();
+			DispatcherQueue.GetForCurrentThread().TryEnqueue(DispatcherQueuePriority.High, async () =>
+			{
+				list.Add(1);
+				await Task.Yield();
+				list.Add(2);
+			});
+			DispatcherQueue.GetForCurrentThread().TryEnqueue(DispatcherQueuePriority.Normal, () => list.Add(3));
+			await UITestHelper.WaitForIdle();
+			CollectionAssert.AreEqual(new[] { 1, 3, 2 }, list);
+		}
 	}
 }

--- a/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
+++ b/src/Uno.UI/Runtime/BrowserPointerInputSource.wasm.cs
@@ -102,7 +102,7 @@ internal partial class BrowserPointerInputSource : IUnoCorePointerInputSource
 
 			// Ensure that the async context is set properly, since we're raising
 			// events from outside the dispatcher.
-			using var syncContextScope = NativeDispatcher.Main.GetSynchronizationContext(NativeDispatcherPriority.Normal).Apply();
+			using var syncContextScope = NativeDispatcher.Main.SynchronizationContext.Apply();
 
 			var that = (BrowserPointerInputSource)inputSource;
 			var evt = (HtmlPointerEvent)@event;

--- a/src/Uno.UI/UI/Xaml/Application.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Application.skia.cs
@@ -165,8 +165,6 @@ namespace Microsoft.UI.Xaml
 
 		internal ISkiaApplicationHost? Host { get; set; }
 
-		internal static SynchronizationContext ApplicationSynchronizationContext { get; private set; }
-
 		private void SetCurrentLanguage()
 		{
 			if (CultureInfo.CurrentUICulture.IetfLanguageTag == "" &&
@@ -203,9 +201,7 @@ namespace Microsoft.UI.Xaml
 		{
 			_startInvoked = true;
 
-			SynchronizationContext.SetSynchronizationContext(
-				ApplicationSynchronizationContext = new NativeDispatcherSynchronizationContext(NativeDispatcher.Main, NativeDispatcherPriority.Normal)
-			);
+			SynchronizationContext.SetSynchronizationContext(NativeDispatcher.Main.SynchronizationContext);
 
 			callback(new ApplicationInitializationCallbackParams());
 

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -88,9 +88,7 @@ namespace Microsoft.UI.Xaml
 			{
 				_startInvoked = true;
 
-				SynchronizationContext.SetSynchronizationContext(
-					new NativeDispatcherSynchronizationContext(NativeDispatcher.Main, NativeDispatcherPriority.Normal)
-				);
+				SynchronizationContext.SetSynchronizationContext(NativeDispatcher.Main.SynchronizationContext);
 
 				await WindowManagerInterop.InitAsync();
 

--- a/src/Uno.UI/UI/Xaml/UIElement.EventRegistration.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.EventRegistration.wasm.cs
@@ -252,7 +252,7 @@ namespace Microsoft.UI.Xaml
 		{
 			// Ensure that the async context is set properly, since we're raising
 			// events from outside the dispatcher.
-			using var syncContextScope = NativeDispatcher.Main.GetSynchronizationContext(NativeDispatcherPriority.Normal).Apply();
+			using var syncContextScope = NativeDispatcher.Main.SynchronizationContext.Apply();
 
 			if (_eventHandlers.TryGetValue((n, onCapturePhase), out var registration))
 			{


### PR DESCRIPTION
Our NativeDispatcherSynchronizationContext should always enqueue on Normal. Currently, it enqueues on the same priority as the current dispatcher job. This is publicly visible implications, e.g. if a user `await`s any task on the UI thread, it should always enqueue on Normal. For example, pointer events on X11 are scheduled on `High`, but user code that subscribes to pointer events and awaits a task should still be put on Normal.

Investigated during https://github.com/unoplatform/private/issues/894