### PR TITLE
feat: Add support for ManipulationMode=None

### DIFF
--- a/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/InputManager.Pointers.ManagedDirectManip.cs
@@ -129,13 +129,16 @@ partial class InputManager
 			var cancelled = false;
 			foreach (var manipulation in _directManipulations)
 			{
-				if (manipulation.Handlers.Any(handler => handler.Owner == requestingElement))
+				if (manipulation.Handlers.Any(IsForParentOfRequestingElement))
 				{
 					cancelled |= manipulation.Cancel();
 				}
 			}
 
 			return cancelled;
+
+			bool IsForParentOfRequestingElement(IDirectManipulationHandler handler)
+				=> handler.Owner is DependencyObject owner && requestingElement.GetAllParents(includeCurrent: true).Contains(owner);
 		}
 
 		private bool IsRedirectedToManipulations(PointerIdentifier pointerId)

--- a/src/Uno.UI/UI/Xaml/Internal/PointerCaptureOptions.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/PointerCaptureOptions.cs
@@ -10,6 +10,8 @@ internal enum PointerCaptureOptions : byte
 	None = 0,
 
 	/// <summary>
+	/// DEPRECATED: Setting ManipulationMode=None is equivalent to setting this option.
+	/// 
 	/// Indicates that the pointer capture should prevent the "direct manipulation" (a.k.a. OS steal) which would takes over the capture (mainly for scrolling using touch and pen).
 	/// This applies for:
 	///   * iOS and Android, where we configure the OS to forbid it to steal the pointer when it detects a scroll gesture.

--- a/src/Uno.UI/UI/Xaml/UIElement.FocusMixins.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.FocusMixins.cs
@@ -7,10 +7,9 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.UI.Xaml
 {
-	/// <summary>
-	/// This contains focus-related mixins that belong either in UIElement or in Control depending whether
-	/// targeting UWP or WinUI. When WinUI becomes the "standard", we can move this in UIElement directly.
-	/// </summary>
+	// This file contains focus-related mixins that belong either in UIElement or in Control depending whether
+	// targeting UWP or WinUI. When WinUI becomes the "standard", we can move this in UIElement directly.
+
 	public partial class UIElement
 	{
 		public FocusState FocusState

--- a/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Pointers.cs
@@ -1042,11 +1042,10 @@ namespace Microsoft.UI.Xaml
 #endif
 			}
 
-			// TODO
-			//if (!ManipulationMode.HasFlag(ManipulationModes.System))
-			//{
-			//	Cancel[ALL]DirectManipulation()
-			//}
+			if (!ManipulationMode.HasFlag(ManipulationModes.System))
+			{
+				CancelDirectManipulations();
+			}
 
 			return handledInManaged;
 		}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/21306

## 🐞 Bugfix
Add support for `ManipulationMode=None`

## What is the current behavior? 🤔
Only internal code of uno can prevent touch scroll

## What is the new behavior? 🚀
Touch scroll can be prevented by setting the `ManipulationMode=None` (or anything else than `System`) or by calling the `CancelDirectManipulation()`

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

