### PR TITLE
Add runtime DataTemplate updates and auto-refresh for presenters (DEV TOOLING)

### DIFF
--- a/build/nuget/uno.winui.common.targets
+++ b/build/nuget/uno.winui.common.targets
@@ -11,11 +11,16 @@
 	<!-- Feature configuration -->
 	<PropertyGroup>
 		<UnoDragDropExternalSupport Condition="'$(UnoDragDropExternalSupport)'==''">true</UnoDragDropExternalSupport>
+		<UnoEnableDynamicDataTemplateUpdate Condition="'$(UnoEnableDynamicDataTemplateUpdate)'==''">false</UnoEnableDynamicDataTemplateUpdate>
 	</PropertyGroup>
 	<ItemGroup>
 		
 		<RuntimeHostConfigurationOption Include="Windows.ApplicationModel.DataTransfer.DragDrop.ExternalSupport"
 										Value="$(UnoDragDropExternalSupport)"
+										Trim="true" />
+
+		<RuntimeHostConfigurationOption Include="Uno.UI.EnableDynamicDataTemplateUpdate"
+										Value="$(UnoEnableDynamicDataTemplateUpdate)"
 										Trim="true" />
 	</ItemGroup>
 

--- a/build/nuget/uno.winui.common.targets
+++ b/build/nuget/uno.winui.common.targets
@@ -11,7 +11,7 @@
 	<!-- Feature configuration -->
 	<PropertyGroup>
 		<UnoDragDropExternalSupport Condition="'$(UnoDragDropExternalSupport)'==''">true</UnoDragDropExternalSupport>
-		<UnoEnableDynamicDataTemplateUpdate Condition="'$(UnoEnableDynamicDataTemplateUpdate)'==''">false</UnoEnableDynamicDataTemplateUpdate>
+		<UnoEnableDynamicDataTemplateUpdate Condition="'$(UnoEnableDynamicDataTemplateUpdate)'==''">true</UnoEnableDynamicDataTemplateUpdate>
 	</PropertyGroup>
 	<ItemGroup>
 		

--- a/build/nuget/uno.winui.common.targets
+++ b/build/nuget/uno.winui.common.targets
@@ -11,7 +11,8 @@
 	<!-- Feature configuration -->
 	<PropertyGroup>
 		<UnoDragDropExternalSupport Condition="'$(UnoDragDropExternalSupport)'==''">true</UnoDragDropExternalSupport>
-		<UnoEnableDynamicDataTemplateUpdate Condition="'$(UnoEnableDynamicDataTemplateUpdate)'==''">true</UnoEnableDynamicDataTemplateUpdate>
+		<UnoEnableDynamicDataTemplateUpdate Condition="'$(UnoEnableDynamicDataTemplateUpdate)'=='' AND '$(Optimize)' == 'true'">false</UnoEnableDynamicDataTemplateUpdate>
+		<UnoEnableDynamicDataTemplateUpdate Condition="'$(UnoEnableDynamicDataTemplateUpdate)'=='' AND '$(Optimize)' != 'true'">true</UnoEnableDynamicDataTemplateUpdate>
 	</PropertyGroup>
 	<ItemGroup>
 		

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -550,6 +550,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Uno_Templates\DataTemplate_Update_Sample.xaml" />
     <Page Include="$(MSBuildThisFileDirectory)Uno_Web\Http\CookieManagerTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6059,6 +6060,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Toolkit\VisibleBoundsPadding_Modal_Test.xaml.cs">
       <DependentUpon>VisibleBoundsPadding_Modal_Test.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Uno_Templates\DataTemplate_Update_Sample.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Uno_Web\Http\CookieManagerTests.xaml.cs">
       <DependentUpon>CookieManagerTests.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
@@ -15,7 +15,11 @@
 
 	<ScrollViewer>
 		<StackPanel Spacing="12" Padding="12">
-			<TextBlock x:Name="unavailable" Text="This feature is unavailable on WinAppSDK. It does nothing." />
+			<TextBlock x:Name="unavailable"
+			           Foreground="Red"
+			           FontWeight="Bold"
+			           Text="This feature is unavailable on WinAppSDK. It does nothing."
+			           Visibility="Collapsed" />
 
 			<TextBlock Text="DataTemplate Update Sample" FontSize="20"/>
 			<TextBlock Text="All presenters below share the same DataTemplate (x:Name=SharedTemplate)."/>

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
@@ -1,0 +1,69 @@
+<Page
+	x:Class="Uno.UI.Samples.UITests.Templates.DataTemplate_Update_Sample"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.Samples.UITests.Templates">
+
+	<Page.Resources>
+		<!-- Define a shared DataTemplate with a name and key so we can reference it in code and XAML -->
+		<DataTemplate x:Key="SharedTemplate">
+			<Grid>
+				<TextBlock Text="Initial template"/>
+			</Grid>
+		</DataTemplate>
+	</Page.Resources>
+
+	<ScrollViewer>
+		<StackPanel Spacing="12" Padding="12">
+			<TextBlock Text="DataTemplate Update Sample" FontSize="20"/>
+			<TextBlock Text="All presenters below share the same DataTemplate (x:Name=SharedTemplate)."/>
+
+			<StackPanel Orientation="Horizontal" Spacing="8">
+				<Button Content="Red" Click="OnRedClick"/>
+				<Button Content="Blue" Click="OnBlueClick"/>
+			</StackPanel>
+
+			<!-- Multiple ContentPresenters/ContentControls using the same template -->
+			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+				<StackPanel Spacing="8">
+					<TextBlock Text="ContentPresenter #1"/>
+					<ContentPresenter Content="item-a" ContentTemplate="{StaticResource SharedTemplate}"/>
+				</StackPanel>
+			</Border>
+
+			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+				<StackPanel Spacing="8">
+					<TextBlock Text="ContentPresenter #2"/>
+					<ContentPresenter Content="item-b" ContentTemplate="{StaticResource SharedTemplate}"/>
+				</StackPanel>
+			</Border>
+
+			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+				<StackPanel Spacing="8">
+					<TextBlock Text="ContentControl"/>
+					<ContentControl Content="item-c" ContentTemplate="{StaticResource SharedTemplate}"/>
+				</StackPanel>
+			</Border>
+
+			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+				<StackPanel Spacing="8">
+					<TextBlock Text="ItemsControl"/>
+					<ItemsControl ItemTemplate="{StaticResource SharedTemplate}">
+						<ItemsControl.Items>
+							<x:String>1</x:String>
+							<x:String>2</x:String>
+							<x:String>3</x:String>
+							<x:String>4</x:String>
+							<x:String>5</x:String>
+						</ItemsControl.Items>
+						<ItemsControl.ItemsPanel>
+							<ItemsPanelTemplate>
+								<StackPanel Orientation="Horizontal" Spacing="20" />
+							</ItemsPanelTemplate>
+						</ItemsControl.ItemsPanel>
+					</ItemsControl>
+				</StackPanel>
+			</Border>
+		</StackPanel>
+	</ScrollViewer>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
@@ -88,14 +88,8 @@
 			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
 				<StackPanel Spacing="8">
 					<TextBlock Text="ItemsRepeater"/>
-					<ItemsRepeater ItemTemplate="{StaticResource SharedTemplate}">
-						<ItemsRepeater.ItemsSource>
-							<x:String>A</x:String>
-							<x:String>B</x:String>
-							<x:String>C</x:String>
-							<x:String>D</x:String>
-							<x:String>E</x:String>
-						</ItemsRepeater.ItemsSource>
+					<ItemsRepeater ItemTemplate="{StaticResource SharedTemplate}"
+					               ItemsSource="{x:Bind itms.Items}">
 						<ItemsRepeater.Layout>
 							<StackLayout Orientation="Horizontal" Spacing="20" />
 						</ItemsRepeater.Layout>
@@ -105,7 +99,7 @@
 
 			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
 				<StackPanel Spacing="8">
-					<TextBlock Text="ItemsRepeater - BINDING TEST"/>
+					<TextBlock Text="ItemsRepeater2"/>
 					<ItemsRepeater ItemTemplate="{StaticResource SharedTemplate}"
 					               ItemsSource="{x:Bind itms.Items}">
 						<ItemsRepeater.Layout>

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
@@ -67,6 +67,26 @@
 
 			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
 				<StackPanel Spacing="8">
+					<TextBlock Text="ListView"/>
+					<ListView ItemTemplate="{StaticResource SharedTemplate}" Height="100">
+						<ListView.Items>
+							<x:String>LV1</x:String>
+							<x:String>LV2</x:String>
+							<x:String>LV3</x:String>
+							<x:String>LV4</x:String>
+							<x:String>LV5</x:String>
+						</ListView.Items>
+						<ListView.ItemsPanel>
+							<ItemsPanelTemplate>
+								<StackPanel Orientation="Horizontal" Spacing="15" />
+							</ItemsPanelTemplate>
+						</ListView.ItemsPanel>
+					</ListView>
+				</StackPanel>
+			</Border>
+
+			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+				<StackPanel Spacing="8">
 					<TextBlock Text="ItemsRepeater"/>
 					<ItemsRepeater ItemTemplate="{StaticResource SharedTemplate}">
 						<ItemsRepeater.ItemsSource>

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
@@ -15,6 +15,8 @@
 
 	<ScrollViewer>
 		<StackPanel Spacing="12" Padding="12">
+			<TextBlock x:Name="unavailable" Text="This feature is unavailable on WinAppSDK. It does nothing." />
+
 			<TextBlock Text="DataTemplate Update Sample" FontSize="20"/>
 			<TextBlock Text="All presenters below share the same DataTemplate (x:Name=SharedTemplate)."/>
 

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml
@@ -48,7 +48,7 @@
 			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
 				<StackPanel Spacing="8">
 					<TextBlock Text="ItemsControl"/>
-					<ItemsControl ItemTemplate="{StaticResource SharedTemplate}">
+					<ItemsControl ItemTemplate="{StaticResource SharedTemplate}" x:Name="itms">
 						<ItemsControl.Items>
 							<x:String>1</x:String>
 							<x:String>2</x:String>
@@ -62,6 +62,36 @@
 							</ItemsPanelTemplate>
 						</ItemsControl.ItemsPanel>
 					</ItemsControl>
+				</StackPanel>
+			</Border>
+
+			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+				<StackPanel Spacing="8">
+					<TextBlock Text="ItemsRepeater"/>
+					<ItemsRepeater ItemTemplate="{StaticResource SharedTemplate}">
+						<ItemsRepeater.ItemsSource>
+							<x:String>A</x:String>
+							<x:String>B</x:String>
+							<x:String>C</x:String>
+							<x:String>D</x:String>
+							<x:String>E</x:String>
+						</ItemsRepeater.ItemsSource>
+						<ItemsRepeater.Layout>
+							<StackLayout Orientation="Horizontal" Spacing="20" />
+						</ItemsRepeater.Layout>
+					</ItemsRepeater>
+				</StackPanel>
+			</Border>
+
+			<Border BorderBrush="Gray" BorderThickness="1" Padding="8">
+				<StackPanel Spacing="8">
+					<TextBlock Text="ItemsRepeater - BINDING TEST"/>
+					<ItemsRepeater ItemTemplate="{StaticResource SharedTemplate}"
+					               ItemsSource="{x:Bind itms.Items}">
+						<ItemsRepeater.Layout>
+							<StackLayout Orientation="Horizontal" Spacing="20" />
+						</ItemsRepeater.Layout>
+					</ItemsRepeater>
 				</StackPanel>
 			</Border>
 		</StackPanel>

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
@@ -20,6 +20,7 @@ namespace Uno.UI.Samples.UITests.Templates
 
 		private void OnRedClick(object sender, RoutedEventArgs e)
 		{
+#if !WINAPPSDK
 			if (Resources["SharedTemplate"] is DataTemplate dt)
 			{
 				Uno.DataTemplateHelper.UpdateDataTemplate(dt, () =>
@@ -35,10 +36,12 @@ namespace Uno.UI.Samples.UITests.Templates
 					return grid;
 				});
 			}
+#endif
 		}
 
 		private void OnBlueClick(object sender, RoutedEventArgs e)
 		{
+#if !WINAPPSDK
 			if (Resources["SharedTemplate"] is DataTemplate dt)
 			{
 				Uno.DataTemplateHelper.UpdateDataTemplate(dt, () =>
@@ -55,5 +58,6 @@ namespace Uno.UI.Samples.UITests.Templates
 				});
 			}
 		}
+#endif
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
@@ -57,7 +57,7 @@ namespace Uno.UI.Samples.UITests.Templates
 					return grid;
 				});
 			}
-		}
 #endif
+		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
@@ -13,8 +13,11 @@ namespace Uno.UI.Samples.UITests.Templates
 	{
 		public DataTemplate_Update_Sample()
 		{
+#if !WINAPPSDK
 			Uno.UI.TemplateManager.EnableUpdateSubscriptions();
-
+#else
+			unavailable.Visiblity = Visibility.Visible;
+#endif
 			this.InitializeComponent();
 		}
 

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
@@ -13,7 +13,7 @@ namespace Uno.UI.Samples.UITests.Templates
 	{
 		public DataTemplate_Update_Sample()
 		{
-			Uno.DataTemplateHelper.EnableUpdateSubscriptions();
+			Uno.TemplateManager.EnableUpdateSubscriptions();
 
 			this.InitializeComponent();
 		}
@@ -23,7 +23,7 @@ namespace Uno.UI.Samples.UITests.Templates
 #if !WINAPPSDK
 			if (Resources["SharedTemplate"] is DataTemplate dt)
 			{
-				Uno.DataTemplateHelper.UpdateDataTemplate(dt, () =>
+				Uno.TemplateManager.UpdateDataTemplate(dt, () =>
 				{
 					var rect = new Rectangle
 					{
@@ -44,7 +44,7 @@ namespace Uno.UI.Samples.UITests.Templates
 #if !WINAPPSDK
 			if (Resources["SharedTemplate"] is DataTemplate dt)
 			{
-				Uno.DataTemplateHelper.UpdateDataTemplate(dt, () =>
+				Uno.TemplateManager.UpdateDataTemplate(dt, () =>
 				{
 					var rect = new Rectangle
 					{

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
@@ -13,7 +13,7 @@ namespace Uno.UI.Samples.UITests.Templates
 	{
 		public DataTemplate_Update_Sample()
 		{
-			Uno.TemplateManager.EnableUpdateSubscriptions();
+			Uno.UI.TemplateManager.EnableUpdateSubscriptions();
 
 			this.InitializeComponent();
 		}
@@ -23,7 +23,7 @@ namespace Uno.UI.Samples.UITests.Templates
 #if !WINAPPSDK
 			if (Resources["SharedTemplate"] is DataTemplate dt)
 			{
-				Uno.TemplateManager.UpdateDataTemplate(dt, () =>
+				Uno.UI.TemplateManager.UpdateDataTemplate(dt, () =>
 				{
 					var rect = new Rectangle
 					{
@@ -44,7 +44,7 @@ namespace Uno.UI.Samples.UITests.Templates
 #if !WINAPPSDK
 			if (Resources["SharedTemplate"] is DataTemplate dt)
 			{
-				Uno.TemplateManager.UpdateDataTemplate(dt, () =>
+				Uno.UI.TemplateManager.UpdateDataTemplate(dt, () =>
 				{
 					var rect = new Rectangle
 					{

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
@@ -16,7 +16,7 @@ namespace Uno.UI.Samples.UITests.Templates
 #if !WINAPPSDK
 			Uno.UI.TemplateManager.EnableUpdateSubscriptions();
 #else
-			unavailable.Visiblity = Visibility.Visible;
+			unavailable.Visibility = Visibility.Visible;
 #endif
 			this.InitializeComponent();
 		}

--- a/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Uno_Templates/DataTemplate_Update_Sample.xaml.cs
@@ -1,0 +1,59 @@
+using System;
+using Uno.UI.Samples.Controls;
+using Uno;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Shapes;
+
+namespace Uno.UI.Samples.UITests.Templates
+{
+	[Sample("Templates", Description = "Demonstrates updating a shared DataTemplate factory at runtime and auto-refresh of multiple presenters.")]
+	public sealed partial class DataTemplate_Update_Sample : Page
+	{
+		public DataTemplate_Update_Sample()
+		{
+			Uno.DataTemplateHelper.EnableUpdateSubscriptions();
+
+			this.InitializeComponent();
+		}
+
+		private void OnRedClick(object sender, RoutedEventArgs e)
+		{
+			if (Resources["SharedTemplate"] is DataTemplate dt)
+			{
+				Uno.DataTemplateHelper.UpdateDataTemplate(dt, () =>
+				{
+					var rect = new Rectangle
+					{
+						Width = 60,
+						Height = 40,
+						Fill = new SolidColorBrush(Windows.UI.Colors.Red)
+					};
+					var grid = new Grid();
+					grid.Children.Add(rect);
+					return grid;
+				});
+			}
+		}
+
+		private void OnBlueClick(object sender, RoutedEventArgs e)
+		{
+			if (Resources["SharedTemplate"] is DataTemplate dt)
+			{
+				Uno.DataTemplateHelper.UpdateDataTemplate(dt, () =>
+				{
+					var rect = new Rectangle
+					{
+						Width = 60,
+						Height = 40,
+						Fill = new SolidColorBrush(Windows.UI.Colors.Blue)
+					};
+					var grid = new Grid();
+					grid.Children.Add(rect);
+					return grid;
+				});
+			}
+		}
+	}
+}

--- a/src/Uno.UI/AssemblyInfo.cs
+++ b/src/Uno.UI/AssemblyInfo.cs
@@ -33,6 +33,8 @@ using Uno.Foundation.Diagnostics.CodeAnalysis;
 [assembly: InternalsVisibleTo("Uno.UI.MediaPlayer.WebAssembly")]
 [assembly: InternalsVisibleTo("Uno.UI.WebView.Skia.X11")]
 
+[assembly: InternalsVisibleTo("Uno.UI.HotDesign.Client")]
+
 [assembly: InternalsVisibleTo("Uno.WinUI.Graphics3DGL")]
 [assembly: InternalsVisibleTo("Uno.WinUI.Graphics2DSK")]
 

--- a/src/Uno.UI/LinkerSubstitution.Wasm.xml
+++ b/src/Uno.UI/LinkerSubstitution.Wasm.xml
@@ -1,13 +1,20 @@
 ﻿<linker>
 	<assembly fullname="Uno.UI">
 		<type fullname="Windows.ApplicationModel.DataTransfer.DragDrop.Core.DragDropExtension">
-
 			<method signature="System.Boolean get_IsExternalDragAndDropSupported()"
 					feature="Windows.ApplicationModel.DataTransfer.DragDrop.ExternalSupport"
 					body="stub"
 					value="false"
 					featurevalue="false" />
 
+		</type>
+
+		<type fullname="Uno.UI.TemplateManager">
+			<method signature="System.Boolean get_IsDataTemplateDynamicUpdateEnabled()"
+					feature="Uno.UI.EnableDynamicDataTemplateUpdate"
+					body="stub"
+					value="false"
+					featurevalue="false" />
 		</type>
 	</assembly>
 </linker>

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -340,7 +340,6 @@ namespace Microsoft.UI.Xaml.Controls
 			//ContentTemplate/ContentTemplateSelector will only be applied to a control with no Template, normally the innermost element
 			if (IsContentPresenterBypassEnabled)
 			{
-
 				var dataTemplate = this.ResolveContentTemplate();
 
 				// Template reload system: ensure we listen for updates on the effective template (when enabled)
@@ -351,7 +350,7 @@ namespace Microsoft.UI.Xaml.Controls
 					SetUpdateTemplate();
 				}
 
-				var templateCanBeUpdated = TemplateUpdateSubscription.Attach(dataTemplate, ref _templateUpdatedSubscription, OnCurrentTemplateUpdated);
+				var templateCanBeUpdated = Uno.UI.TemplateUpdateSubscription.Attach(dataTemplate, ref _templateUpdatedSubscription, OnCurrentTemplateUpdated);
 
 				//Only apply template if it has changed
 				if (!object.Equals(dataTemplate, _dataTemplateUsedLastUpdate) || templateCanBeUpdated)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -347,7 +347,12 @@ namespace Microsoft.UI.Xaml.Controls
 					SetUpdateTemplate();
 				}
 
-				var templateCanBeUpdated = Uno.UI.TemplateUpdateSubscription.Attach(this, dataTemplate, OnCurrentTemplateUpdated);
+				var templateCanBeUpdated = false;
+
+				if (TemplateManager.IsDataTemplateDynamicUpdateEnabled)
+				{
+					templateCanBeUpdated = Uno.UI.TemplateUpdateSubscription.Attach(this, dataTemplate, OnCurrentTemplateUpdated);
+				}
 
 				//Only apply template if it has changed
 				if (!object.Equals(dataTemplate, _dataTemplateUsedLastUpdate) || templateCanBeUpdated)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -49,9 +49,6 @@ namespace Microsoft.UI.Xaml.Controls
 		/// </summary>
 		private bool _localContentDataContextOverride;
 
-		// Template reload system: subscription to DataTemplate updates (when enabled)
-		private IDisposable? _templateUpdatedSubscription;
-
 		protected override bool CanCreateTemplateWithoutParent { get { return _canCreateTemplateWithoutParent; } }
 
 #nullable disable // Public members should stay nullable-oblivious for now to stay consistent with WinUI
@@ -350,7 +347,7 @@ namespace Microsoft.UI.Xaml.Controls
 					SetUpdateTemplate();
 				}
 
-				var templateCanBeUpdated = Uno.UI.TemplateUpdateSubscription.Attach(dataTemplate, ref _templateUpdatedSubscription, OnCurrentTemplateUpdated);
+				var templateCanBeUpdated = Uno.UI.TemplateUpdateSubscription.Attach(this, dataTemplate, OnCurrentTemplateUpdated);
 
 				//Only apply template if it has changed
 				if (!object.Equals(dataTemplate, _dataTemplateUsedLastUpdate) || templateCanBeUpdated)

--- a/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentControl/ContentControl.cs
@@ -347,15 +347,13 @@ namespace Microsoft.UI.Xaml.Controls
 					SetUpdateTemplate();
 				}
 
-				var templateCanBeUpdated = false;
-
 				if (TemplateManager.IsDataTemplateDynamicUpdateEnabled)
 				{
-					templateCanBeUpdated = Uno.UI.TemplateUpdateSubscription.Attach(this, dataTemplate, OnCurrentTemplateUpdated);
+					TemplateUpdateSubscription.Attach(this, dataTemplate, OnCurrentTemplateUpdated);
 				}
 
-				//Only apply template if it has changed
-				if (!object.Equals(dataTemplate, _dataTemplateUsedLastUpdate) || templateCanBeUpdated)
+				// Only apply template if it has changed
+				if (!object.Equals(dataTemplate, _dataTemplateUsedLastUpdate))
 				{
 					_dataTemplateUsedLastUpdate = dataTemplate;
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -1045,7 +1045,7 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 		}
 
 		// Subscribe to template updates so presenter can refresh when factory changes (when feature is activated)
-		Uno.TemplateUpdateSubscription.Attach(dataTemplate, ref _templateUpdatedSubscription, OnCurrentTemplateUpdated);
+		Uno.UI.TemplateUpdateSubscription.Attach(dataTemplate, ref _templateUpdatedSubscription, OnCurrentTemplateUpdated);
 
 		// Only apply the template if it has changed
 		if (!object.Equals(dataTemplate, _dataTemplateUsedLastUpdate))

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -1042,7 +1042,10 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 		}
 
 		// Subscribe to template updates so presenter can refresh when factory changes (when feature is activated)
-		Uno.UI.TemplateUpdateSubscription.Attach(this, dataTemplate, OnCurrentTemplateUpdated);
+		if (TemplateManager.IsDataTemplateDynamicUpdateEnabled)
+		{
+			Uno.UI.TemplateUpdateSubscription.Attach(this, dataTemplate, OnCurrentTemplateUpdated);
+		}
 
 		// Only apply the template if it has changed
 		if (!object.Equals(dataTemplate, _dataTemplateUsedLastUpdate))

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -1034,16 +1034,16 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 		//ContentTemplate/ContentTemplateSelector will only be applied to a control with no Template, normally the innermost element
 		var dataTemplate = this.ResolveContentTemplate();
 
-		void OnCurrentTemplateUpdated()
-		{
-			// Force re-materialization on template update
-			_dataTemplateUsedLastUpdate = null;
-			SetUpdateTemplate();
-		}
-
 		// Subscribe to template updates so presenter can refresh when factory changes (when feature is activated)
 		if (TemplateManager.IsDataTemplateDynamicUpdateEnabled)
 		{
+			void OnCurrentTemplateUpdated()
+			{
+				// Force re-materialization on template update
+				_dataTemplateUsedLastUpdate = null;
+				SetUpdateTemplate();
+			}
+
 			Uno.UI.TemplateUpdateSubscription.Attach(this, dataTemplate, OnCurrentTemplateUpdated);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -61,9 +61,6 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 	private View _contentTemplateRoot;
 	private bool _appliedTemplate;
 
-	// Subscription to DataTemplate updates
-	private IDisposable _templateUpdatedSubscription;
-
 	/// <summary>
 	/// Will be set to either the result of ContentTemplateSelector or to ContentTemplate, depending on which is used
 	/// </summary>
@@ -1045,7 +1042,7 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 		}
 
 		// Subscribe to template updates so presenter can refresh when factory changes (when feature is activated)
-		Uno.UI.TemplateUpdateSubscription.Attach(dataTemplate, ref _templateUpdatedSubscription, OnCurrentTemplateUpdated);
+		Uno.UI.TemplateUpdateSubscription.Attach(this, dataTemplate, OnCurrentTemplateUpdated);
 
 		// Only apply the template if it has changed
 		if (!object.Equals(dataTemplate, _dataTemplateUsedLastUpdate))

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -61,6 +61,9 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 	private View _contentTemplateRoot;
 	private bool _appliedTemplate;
 
+	// Subscription to DataTemplate updates
+	private IDisposable _templateUpdatedSubscription;
+
 	/// <summary>
 	/// Will be set to either the result of ContentTemplateSelector or to ContentTemplate, depending on which is used
 	/// </summary>
@@ -1034,7 +1037,17 @@ public partial class ContentPresenter : FrameworkElement, IFrameworkTemplatePool
 		//ContentTemplate/ContentTemplateSelector will only be applied to a control with no Template, normally the innermost element
 		var dataTemplate = this.ResolveContentTemplate();
 
-		//Only apply template if it has changed
+		void OnCurrentTemplateUpdated()
+		{
+			// Force re-materialization on template update
+			_dataTemplateUsedLastUpdate = null;
+			SetUpdateTemplate();
+		}
+
+		// Subscribe to template updates so presenter can refresh when factory changes (when feature is activated)
+		Uno.TemplateUpdateSubscription.Attach(dataTemplate, ref _templateUpdatedSubscription, OnCurrentTemplateUpdated);
+
+		// Only apply the template if it has changed
 		if (!object.Equals(dataTemplate, _dataTemplateUsedLastUpdate))
 		{
 			_dataTemplateUsedLastUpdate = dataTemplate;

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -949,15 +949,15 @@ namespace Microsoft.UI.Xaml.Controls
 			_isTemplateApplied = true;
 
 			// Uno-specific: ensure subscription is active when template is applied
-			void OnCurrentItemTemplateUpdated()
-			{
-				// Recreate item containers and refresh items
-				Refresh();
-				UpdateItems(null);
-			}
-
 			if (TemplateManager.IsDataTemplateDynamicUpdateEnabled)
 			{
+				void OnCurrentItemTemplateUpdated()
+				{
+					// Recreate item containers and refresh items
+					Refresh();
+					UpdateItems(null);
+				}
+
 				Uno.UI.TemplateUpdateSubscription.Attach(this, ItemTemplate, OnCurrentItemTemplateUpdated);
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -193,7 +193,10 @@ namespace Microsoft.UI.Xaml.Controls
 				UpdateItems(null);
 			}
 
-			Uno.UI.TemplateUpdateSubscription.Attach(this, newItemTemplate, OnCurrentItemTemplateUpdated);
+			if (TemplateManager.IsDataTemplateDynamicUpdateEnabled)
+			{
+				Uno.UI.TemplateUpdateSubscription.Attach(this, newItemTemplate, OnCurrentItemTemplateUpdated);
+			}
 
 			OnCurrentItemTemplateUpdated();
 		}
@@ -953,7 +956,10 @@ namespace Microsoft.UI.Xaml.Controls
 				UpdateItems(null);
 			}
 
-			Uno.UI.TemplateUpdateSubscription.Attach(this, ItemTemplate, OnCurrentItemTemplateUpdated);
+			if (TemplateManager.IsDataTemplateDynamicUpdateEnabled)
+			{
+				Uno.UI.TemplateUpdateSubscription.Attach(this, ItemTemplate, OnCurrentItemTemplateUpdated);
+			}
 		}
 
 		private protected override void OnUnloaded()

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -196,7 +196,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UpdateItems(null);
 			}
 
-			Uno.TemplateUpdateSubscription.Attach(newItemTemplate, ref _itemTemplateUpdatedSubscription, OnCurrentItemTemplateUpdated);
+			Uno.UI.TemplateUpdateSubscription.Attach(newItemTemplate, ref _itemTemplateUpdatedSubscription, OnCurrentItemTemplateUpdated);
 
 			OnCurrentItemTemplateUpdated();
 		}
@@ -956,7 +956,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UpdateItems(null);
 			}
 
-			Uno.TemplateUpdateSubscription.Attach(ItemTemplate, ref _itemTemplateUpdatedSubscription, OnCurrentItemTemplateUpdated);
+			Uno.UI.TemplateUpdateSubscription.Attach(ItemTemplate, ref _itemTemplateUpdatedSubscription, OnCurrentItemTemplateUpdated);
 		}
 
 		private protected override void OnUnloaded()

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -41,9 +41,6 @@ namespace Microsoft.UI.Xaml.Controls
 		private ItemCollection _items = new ItemCollection();
 		private (object Source, IEnumerable Snapshot)? _cachedItemsSource;
 
-		// Uno-specific: subscription to ItemTemplate updates
-		private IDisposable _itemTemplateUpdatedSubscription;
-
 		// This gets prepended to MaterializedContainers to ensure it's being considered
 		// even if it might not yet have be added to the ItemsPanel (e.eg., NativeListViewBase).
 		private DependencyObject _containerBeingPrepared;
@@ -196,7 +193,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UpdateItems(null);
 			}
 
-			Uno.UI.TemplateUpdateSubscription.Attach(newItemTemplate, ref _itemTemplateUpdatedSubscription, OnCurrentItemTemplateUpdated);
+			Uno.UI.TemplateUpdateSubscription.Attach(this, newItemTemplate, OnCurrentItemTemplateUpdated);
 
 			OnCurrentItemTemplateUpdated();
 		}
@@ -956,7 +953,7 @@ namespace Microsoft.UI.Xaml.Controls
 				UpdateItems(null);
 			}
 
-			Uno.UI.TemplateUpdateSubscription.Attach(ItemTemplate, ref _itemTemplateUpdatedSubscription, OnCurrentItemTemplateUpdated);
+			Uno.UI.TemplateUpdateSubscription.Attach(this, ItemTemplate, OnCurrentItemTemplateUpdated);
 		}
 
 		private protected override void OnUnloaded()

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.Templates.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.Templates.cs
@@ -83,11 +83,14 @@ partial class ItemsRepeater
 			// During layout, we only set up subscriptions but prevent the original behavior
 			// to avoid the "ItemTemplate cannot be changed during layout" exception
 
-			// Subscribe to template updates for the new template (if applicable)
-			if (newValue is DataTemplate layoutDataTemplate)
+			if (Uno.UI.TemplateManager.IsDataTemplateDynamicUpdateEnabled)
 			{
-				// Only subscribe if the dynamic template update feature is enabled
-				Uno.UI.TemplateUpdateSubscription.Attach(this, layoutDataTemplate, RefreshAllItemsForTemplateUpdate);
+				// Subscribe to template updates for the new template (if applicable)
+				if (newValue is DataTemplate layoutDataTemplate)
+				{
+					// Only subscribe if the dynamic template update feature is enabled
+					Uno.UI.TemplateUpdateSubscription.Attach(this, layoutDataTemplate, RefreshAllItemsForTemplateUpdate);
+				}
 			}
 
 			// CRITICAL: Update m_itemTemplateWrapper even during layout

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.Templates.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.Templates.cs
@@ -1,0 +1,337 @@
+﻿using System;
+using System.Collections.Specialized;
+using Uno.Disposables;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.UI.Xaml.Controls;
+
+// **************************************************************************
+// PARTIAL FILE: ItemsRepeater.Templates.cs
+// 
+// PURPOSE: Contains Uno-specific dynamic template update functionality for ItemsRepeater.
+// This file implements runtime DataTemplate updates while maintaining layout safety.
+//
+// ARCHITECTURE DECISION: Partial file approach
+// - Keeps WinUI-imported code (ItemsRepeater.cs) minimal and unchanged (4-5 lines)
+// - Isolates all Uno-specific functionality in this separate file
+// - Facilitates easier upstream merging and maintenance
+//
+// CODE DUPLICATION NOTE:
+// This file contains intentional duplication of wrapper update logic from OnItemTemplateChanged.
+// This is architecturally necessary to bypass layout constraints while maintaining ViewManager
+// compatibility. See UpdateItemTemplateWrapper() documentation for detailed justification.
+//
+// RELATED GITHUB PR: https://github.com/unoplatform/uno/pull/[PR_NUMBER]
+// The working GitHub PR modifies OnItemTemplateChanged directly. Our partial file approach
+// achieves the same functionality through controlled duplication.
+// **************************************************************************
+
+// Partial class file containing dynamic template update functionality for ItemsRepeater.
+partial class ItemsRepeater
+{
+	// =====================
+	// DATA TEMPLATE UPDATES
+	// =====================
+	// 
+	// -- FLOW --
+	//
+	// Template Change Request (from Uno.UI.TemplateManager helper)
+	//     ↓
+	// HandleDynamicTemplateUpdate()
+	//     ├─→ Always: UpdateItemTemplateWrapper() (ViewManager requirement) ✅
+	//     ├─→ Layout Active? YES: Defer reset with DispatcherQueue ⏱️
+	//     └─→ Layout Active? NO: Proceed with dynamic reset ✅
+	//         ↓
+	//     Callback Triggered (RefreshAllItemsForTemplateUpdate)
+	//         ↓
+	//     m_isLayoutInProgress Check
+	//         ├─→ YES: Defer callback execution ⏱️
+	//         └─→ NO: Execute reset ✅
+	//             ↓
+	//         SafeTemplateReset()
+	//             ↓
+	//         Final Layout Check
+	//             ├─→ YES: Defer reset operation ⏱️
+	//             └─→ NO: Execute TriggerTemplateReset() safely ✅
+
+	private IDisposable _itemTemplateUpdatedSubscription;
+
+	/// <summary>
+	/// Flag to prevent reentrancy during template reset operations.
+	/// When true, all template change operations are blocked to prevent
+	/// cascading updates that could violate layout constraints.
+	/// </summary>
+	private bool m_isResettingTemplate;
+
+	/// <summary>
+	/// Handles dynamic template updates when enabled.
+	/// This consolidates only the NEW behavior logic for dynamic template updates.
+	/// </summary>
+	/// <returns>True if dynamic update was handled, false if original behavior should execute</returns>
+	private bool HandleDynamicTemplateUpdate(object oldValue, object newValue)
+	{
+		// CRITICAL: Block all template changes during reset operations
+		// This prevents cascading updates from OnItemsChangedCore
+		if (m_isResettingTemplate)
+		{
+			return false; // Let original behavior handle it (will likely queue for later)
+		}
+
+		// If layout is in progress, we need special handling
+		// The ViewManager might try to set a default template, which would trigger the constraint violation
+		if (m_isLayoutInProgress)
+		{
+			// During layout, we only set up subscriptions but prevent the original behavior
+			// to avoid the "ItemTemplate cannot be changed during layout" exception
+
+			// Clean up old subscription (safe during layout)
+			_itemTemplateUpdatedSubscription?.Dispose();
+			_itemTemplateUpdatedSubscription = null;
+
+			// Subscribe to template updates for the new template (if applicable)
+			if (newValue is DataTemplate layoutDataTemplate)
+			{
+				// Only subscribe if the dynamic template update feature is enabled
+				Uno.UI.TemplateUpdateSubscription.Attach(layoutDataTemplate,
+					ref _itemTemplateUpdatedSubscription, RefreshAllItemsForTemplateUpdate);
+			}
+
+			// CRITICAL: Update m_itemTemplateWrapper even during layout
+			// ViewManager REQUIRES this to be valid for element creation
+			UpdateItemTemplateWrapper(newValue);
+
+			// CRITICAL: Return TRUE to prevent original behavior during layout
+			// This bypasses the "ItemTemplate cannot be changed during layout" exception
+			// The template assignment will be deferred until layout is complete
+			_ = DispatcherQueue.TryEnqueue(() =>
+			{
+				if (!m_isLayoutInProgress)
+				{
+					// Retry the template assignment when layout is complete
+					ItemTemplate = newValue;
+				}
+			});
+
+			return true; // Block original behavior to prevent constraint violation
+		}
+
+		// Clear previous subscription
+		_itemTemplateUpdatedSubscription?.Dispose();
+		_itemTemplateUpdatedSubscription = null;
+
+		var templateCanBeUpdated = false;
+
+		// Subscribe to template updates for the new template
+		if (newValue is DataTemplate newDataTemplate)
+		{
+			// Only subscribe if the dynamic template update feature is enabled
+			templateCanBeUpdated = Uno.UI.TemplateUpdateSubscription.Attach(newDataTemplate,
+				ref _itemTemplateUpdatedSubscription, RefreshAllItemsForTemplateUpdate);
+		}
+
+		// Execute dynamic template reset only if feature is enabled
+		if (templateCanBeUpdated)
+		{
+			// Update wrapper first before resetting
+			UpdateItemTemplateWrapper(newValue);
+			
+			// Safe to reset immediately since we verified layout is not in progress
+			SafeTemplateReset(oldValue ?? newValue);
+			return true; // Indicate that dynamic update was handled
+		}
+
+		return false; // Indicate that original behavior should execute
+	}
+
+	/// <summary>
+	/// Triggers a reset of all items when template changes.
+	/// </summary>
+	/// <param name="templateForLayoutNotification">The template to pass to layout for reset notification (oldTemplate for template change, current template for dynamic update)</param>
+	/// <param name="clearRecyclePool">Whether to clear the recycle pool after reset</param>
+	private void TriggerTemplateReset(object templateForLayoutNotification, bool clearRecyclePool = false)
+	{
+		// Additional safety: Don't reset if ItemTemplate is null or if we don't have a valid template to notify
+		if (ItemTemplate == null)
+		{
+			return;
+		}
+
+		// Use current template if templateForLayoutNotification is null
+		templateForLayoutNotification ??= ItemTemplate;
+
+		// Since the ItemTemplate has changed, we need to re-evaluate all the items that
+		// have already been created and are now in the tree. The easiest way to do that
+		// would be to do a reset.. Note that this has to be done before we change the template
+		// so that the cleared elements go back into the old template.
+		var layout = Layout;
+		if (layout != null)
+		{
+			var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
+			using var processingChange = Disposable.Create(() => m_processingItemsSourceChange = null);
+			m_processingItemsSourceChange = args;
+
+			if (layout is VirtualizingLayout virtualLayout)
+			{
+				virtualLayout.OnItemsChangedCore(GetLayoutContext(), templateForLayoutNotification, args);
+			}
+			else if (layout is NonVirtualizingLayout nonVirtualLayout)
+			{
+				// Walk through all the elements and make sure they are cleared for
+				// non-virtualizing layouts.
+				foreach (var element in Children)
+				{
+					if (GetVirtualizationInfo(element).IsRealized)
+					{
+						ClearElementImpl(element);
+					}
+				}
+			}
+		}
+
+		// Clear the RecyclePool after layout has processed the reset (for dynamic updates)
+		if (clearRecyclePool && ItemTemplate is DataTemplate template)
+		{
+			var recyclePool = RecyclePool.GetPoolInstance(template);
+			recyclePool?.Clear();
+		}
+
+		InvalidateMeasure();
+	}
+
+	/// <summary>
+	/// Called when a template is dynamically updated. Handles layout reentrancy safely.
+	/// This method is only called when dynamic template updates are enabled.
+	/// </summary>
+	private void RefreshAllItemsForTemplateUpdate()
+	{
+		// CRITICAL: Block if already in reset operation to prevent cascading updates
+		if (m_isResettingTemplate)
+		{
+			return; // Ignore cascading update requests
+		}
+
+		// CRITICAL: Never trigger any template changes during layout
+		// This would violate the original constraint and cause crashes
+		if (m_isLayoutInProgress)
+		{
+			// Defer the refresh until layout is completely finished
+			_ = DispatcherQueue.TryEnqueue(() =>
+			{
+				if (!m_isLayoutInProgress)
+				{
+					RefreshAllItemsForTemplateUpdate();
+				}
+			});
+			return;
+		}
+
+		// Only proceed if we're definitely not in a layout operation
+		SafeTemplateReset(ItemTemplate, clearRecyclePool: true);
+	}
+
+	/// <summary>
+	/// Safely triggers a template reset with reentrancy protection.
+	/// </summary>
+	/// <param name="templateForLayoutNotification">The template to pass to layout for reset notification</param>
+	/// <param name="clearRecyclePool">Whether to clear the recycle pool after reset</param>
+	private void SafeTemplateReset(object templateForLayoutNotification, bool clearRecyclePool = false)
+	{
+		// CRITICAL: Prevent reentrancy - block cascading resets
+		if (m_isResettingTemplate)
+		{
+			return; // Already resetting, ignore this request
+		}
+
+		// CRITICAL: Never perform any reset operations during layout
+		// This is a hard constraint that must be respected to avoid crashes
+		if (m_isLayoutInProgress)
+		{
+			// Defer the reset until layout is completely finished
+			_ = DispatcherQueue.TryEnqueue(() =>
+			{
+				if (!m_isLayoutInProgress)
+				{
+					SafeTemplateReset(templateForLayoutNotification, clearRecyclePool);
+				}
+			});
+			return;
+		}
+
+		// Set flag to block any template changes during reset operation
+		m_isResettingTemplate = true;
+		try
+		{
+			TriggerTemplateReset(templateForLayoutNotification, clearRecyclePool);
+		}
+		finally
+		{
+			m_isResettingTemplate = false;
+		}
+	}
+
+	/// <summary>
+	/// Updates the ItemTemplateWrapper which is critical for ViewManager element creation.
+	/// This must be kept in sync even during layout operations.
+	/// 
+	/// IMPORTANT: This method duplicates logic from OnItemTemplateChanged (lines 795-825 in the original WinUI code).
+	/// This duplication is ARCHITECTURALLY NECESSARY because:
+	/// 
+	/// 1. PARTIAL FILE ARCHITECTURE: We use partial files to separate Uno-specific functionality
+	///    from the original WinUI code, maintaining clean separation and easier upstream merging.
+	/// 
+	/// 2. LAYOUT CONSTRAINT BYPASS: The original OnItemTemplateChanged throws during layout.
+	///    We need the wrapper update logic WITHOUT the layout constraint check.
+	/// 
+	/// 3. VIEWMANAGER DEPENDENCY: ViewManager.GetElement() requires m_itemTemplateWrapper to be
+	///    valid immediately, even during layout operations, or it crashes with NullReferenceException.
+	/// 
+	/// 4. GITHUB PR COMPARISON: The working GitHub PR modifies OnItemTemplateChanged directly.
+	///    Our partial file approach requires this controlled duplication to achieve the same result.
+	/// 
+	/// FUTURE: When this functionality is integrated upstream, this duplication will be eliminated
+	/// by merging both approaches into the main OnItemTemplateChanged method.
+	/// </summary>
+	/// <param name="newValue">The new template value</param>
+	private void UpdateItemTemplateWrapper(object newValue)
+	{
+		// Clear flag for bug #776
+		m_isItemTemplateEmpty = false;
+		m_itemTemplateWrapper = newValue as IElementFactoryShim;
+		
+		if (m_itemTemplateWrapper == null)
+		{
+			// ItemTemplate set does not implement IElementFactoryShim. We also 
+			// want to support DataTemplate and DataTemplateSelectors automagically.
+			if (newValue is DataTemplate dataTemplate) // Implements IElementFactory but not IElementFactoryShim
+			{
+				m_itemTemplateWrapper = new ItemTemplateWrapper(dataTemplate);
+				if (dataTemplate.LoadContent() is FrameworkElement content)
+				{
+					// Due to bug https://github.com/microsoft/microsoft-ui-xaml/issues/3057, we need to get the framework
+					// to take ownership of the extra implicit ref that was returned by LoadContent. The simplest way to do
+					// this is to add it to a Children collection and immediately remove it.						
+					var children = Children;
+					children.Add(content);
+					children.RemoveAt(children.Count - 1);
+				}
+				else
+				{
+					// We have a DataTemplate which is empty, so we need to set it to true
+					m_isItemTemplateEmpty = true;
+				}
+			}
+			else if (newValue is DataTemplateSelector selector) // Implements IElementFactory but not IElementFactoryShim
+			{
+				m_itemTemplateWrapper = new ItemTemplateWrapper(selector);
+			}
+			else if (newValue != null)
+			{
+				throw new ArgumentException("ItemTemplate", "ItemTemplate");
+			}
+		}
+
+		// Bug in framework's reference tracking causes crash during
+		// UIAffinityQueue cleanup. To avoid that bug, take a strong ref
+		m_itemTemplate = newValue as IElementFactory; // DataTemplate of DataTemplateSelector
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.Templates.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.Templates.cs
@@ -20,9 +20,6 @@ namespace Microsoft.UI.Xaml.Controls;
 // This is architecturally necessary to bypass layout constraints while maintaining ViewManager
 // compatibility. See UpdateItemTemplateWrapper() documentation for detailed justification.
 //
-// RELATED GITHUB PR: https://github.com/unoplatform/uno/pull/[PR_NUMBER]
-// The working GitHub PR modifies OnItemTemplateChanged directly. Our partial file approach
-// achieves the same functionality through controlled duplication.
 // **************************************************************************
 
 // Partial class file containing dynamic template update functionality for ItemsRepeater.
@@ -245,31 +242,22 @@ partial class ItemsRepeater
 			}
 		}
 
-		// <summary>
 		// Updates the ItemTemplateWrapper which is critical for ViewManager element creation.
 		// This must be kept in sync even during layout operations.
-		// 
-		// IMPORTANT: This method duplicates logic from OnItemTemplateChanged (lines 795-825 in the original WinUI code).
-		// This duplication is ARCHITECTURALLY NECESSARY because:
-		// 
-		// 1. PARTIAL FILE ARCHITECTURE: We use partial files to separate Uno-specific functionality
-		//    from the original WinUI code, maintaining clean separation and easier upstream merging.
-		// 
-		// 2. LAYOUT CONSTRAINT BYPASS: The original OnItemTemplateChanged throws during layout.
-		//    We need the wrapper update logic WITHOUT the layout constraint check.
-		// 
-		// 3. VIEWMANAGER DEPENDENCY: ViewManager.GetElement() requires m_itemTemplateWrapper to be
-		//    valid immediately, even during layout operations, or it crashes with NullReferenceException.
-		// 
-		// 4. GITHUB PR COMPARISON: The working GitHub PR modifies OnItemTemplateChanged directly.
-		//    Our partial file approach requires this controlled duplication to achieve the same result.
-		// 
-		// FUTURE: When this functionality is integrated upstream, this duplication will be eliminated
-		// by merging both approaches into the main OnItemTemplateChanged method.
-		// </summary>
-		// <param name="newValue">The new template value</param>
 		void UpdateItemTemplateWrapper(object newValue)
 		{
+			// IMPORTANT: This method duplicates logic from OnItemTemplateChanged (lines 795-825 in the original WinUI code).
+			// This duplication is ARCHITECTURALLY NECESSARY because:
+			// 
+			// 1. PARTIAL FILE ARCHITECTURE: We use partial files to separate Uno-specific functionality
+			//    from the original WinUI code, maintaining clean separation and easier upstream merging.
+			// 
+			// 2. LAYOUT CONSTRAINT BYPASS: The original OnItemTemplateChanged throws during layout.
+			//    We need the wrapper update logic WITHOUT the layout constraint check.
+			// 
+			// 3. VIEWMANAGER DEPENDENCY: ViewManager.GetElement() requires m_itemTemplateWrapper to be
+			//    valid immediately, even during layout operations, or it crashes with NullReferenceException.
+
 			// Clear flag for bug #776
 			m_isItemTemplateEmpty = false;
 			m_itemTemplateWrapper = newValue as IElementFactoryShim;

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
@@ -771,7 +771,6 @@ namespace Microsoft.UI.Xaml.Controls
 			var layout = Layout;
 			if (layout != null)
 			{
-
 				var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
 				using var processingChange = Disposable.Create(() => m_processingItemsSourceChange = null);
 				m_processingItemsSourceChange = args;

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/ItemsRepeater.cs
@@ -747,16 +747,17 @@ namespace Microsoft.UI.Xaml.Controls
 
 		void OnItemTemplateChanged(object oldValue, object newValue)
 		{
-#if HAS_UNO
-			// ARCHITECTURE NOTE: Dynamic template update handling
-			// This delegates to ItemsRepeater.Templates.cs (partial file) which contains
-			// intentionally duplicated wrapper update logic to bypass layout constraints.
-			// See ItemsRepeater.Templates.cs header for detailed architecture explanation.
-			if (HandleDynamicTemplateUpdate(oldValue, newValue))
+			if (Uno.UI.TemplateManager.IsDataTemplateDynamicUpdateEnabled)
 			{
-				return;
+				// ARCHITECTURE NOTE: Dynamic template update handling
+				// This delegates to ItemsRepeater.Templates.cs (partial file) which contains
+				// intentionally duplicated wrapper update logic to bypass layout constraints.
+				// See ItemsRepeater.Templates.cs header for detailed architecture explanation.
+				if (HandleDynamicTemplateUpdate(oldValue, newValue))
+				{
+					return;
+				}
 			}
-#endif
 
 			if (m_isLayoutInProgress && oldValue != null)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePool.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePool.cs
@@ -36,10 +36,13 @@ namespace Microsoft.UI.Xaml.Controls
 		public UIElement TryGetElement(string key, UIElement owner)
 			=> TryGetElementCore(key, owner);
 
+#if HAS_UNO
+		// Uno specific: Helper used by template updater
 		internal void Clear()
 		{
 			m_elements.Clear();
 		}
+#endif
 
 		protected virtual void PutElementCore(UIElement element, string key, UIElement owner)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePool.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Repeater/RecyclePool.cs
@@ -36,6 +36,11 @@ namespace Microsoft.UI.Xaml.Controls
 		public UIElement TryGetElement(string key, UIElement owner)
 			=> TryGetElementCore(key, owner);
 
+		internal void Clear()
+		{
+			m_elements.Clear();
+		}
+
 		protected virtual void PutElementCore(UIElement element, string key, UIElement owner)
 		{
 			var winrtKey = key;

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
@@ -34,7 +34,7 @@ namespace Microsoft.UI.Xaml
 		private readonly ManagedWeakReference? _ownerRef;
 		private readonly bool _isLegacyTemplate = true; // Tests fails if set to false, so we keep it true for now.
 
-		internal NewFrameworkTemplateBuilder? _viewFactory; // Updateable when a special mode is enabled un Uno.DataTemplateHelper
+		internal NewFrameworkTemplateBuilder? _viewFactory; // Updateable when a special mode is enabled in Uno.TemplateManager
 
 		/// <summary>
 		/// The scope at the time of the template's creataion, which will be used when its contents are materialized.
@@ -206,15 +206,13 @@ namespace Microsoft.UI.Xaml
 				(h, s, a) => (h as Action)?.Invoke()
 			);
 
-		internal bool UpdateFactory(Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?> factory)
-		{
-			// Special case to update the factory without creating a new instance.
-			// A special mode is required for it to work and is activated directly in the Uno.DataTemplateHelper.
+	internal bool UpdateFactory(Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?> factory)
+	{
+		// Special case to update the factory without creating a new instance.
+		// A special mode is required for it to work and is activated directly in the Uno.TemplateManager.
 
-			var previous = _viewFactory;
-			var newFactory = factory?.Invoke(previous);
-
-			if (newFactory != previous)
+		var previous = _viewFactory;
+		var newFactory = factory?.Invoke(previous);			if (newFactory != previous)
 			{
 				_viewFactory = newFactory;
 

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
@@ -34,7 +34,8 @@ namespace Microsoft.UI.Xaml
 		private readonly ManagedWeakReference? _ownerRef;
 		private readonly bool _isLegacyTemplate = true; // Tests fails if set to false, so we keep it true for now.
 
-		internal NewFrameworkTemplateBuilder? _viewFactory; // Updateable when a special mode is enabled in Uno.TemplateManager
+		internal NewFrameworkTemplateBuilder?
+			_viewFactory; // Updateable when a special mode is enabled in Uno.TemplateManager
 
 		/// <summary>
 		/// The scope at the time of the template's creataion, which will be used when its contents are materialized.
@@ -96,7 +97,8 @@ namespace Microsoft.UI.Xaml
 		/// instance that has been detached from its parent may be reused at any time.
 		/// If a control needs to be the owner of a created instance, it needs to use <see cref="LoadContent"/>.
 		/// </remarks>
-		internal protected View? LoadContentCachedCore(DependencyObject? templatedParent) => FrameworkTemplatePool.Instance.DequeueTemplate(this, templatedParent);
+		internal protected View? LoadContentCachedCore(DependencyObject? templatedParent) =>
+			FrameworkTemplatePool.Instance.DequeueTemplate(this, templatedParent);
 
 		/// <summary>
 		/// Manually return an unused template root created by <see cref="LoadContentCached"/> to the pool.
@@ -104,7 +106,8 @@ namespace Microsoft.UI.Xaml
 		/// <remarks>
 		/// This is only used in specialized contexts. Normally the template reuse will be automatically handled by the pool.
 		/// </remarks>
-		internal void ReleaseTemplateRoot(View templateRoot) => FrameworkTemplatePool.Instance.ReleaseTemplateRoot(templateRoot, this);
+		internal void ReleaseTemplateRoot(View templateRoot) =>
+			FrameworkTemplatePool.Instance.ReleaseTemplateRoot(templateRoot, this);
 
 		/// <summary>
 		/// Creates a new instance of the current template.
@@ -191,7 +194,7 @@ namespace Microsoft.UI.Xaml
 				|| (
 					ReferenceEquals(left?._viewFactory?.Target, right?._viewFactory?.Target)
 					&& left?._viewFactory?.Method == right?._viewFactory?.Method
-					);
+				);
 
 			public int GetHashCode(FrameworkTemplate obj) => obj._hashCode;
 		}
@@ -206,13 +209,15 @@ namespace Microsoft.UI.Xaml
 				(h, s, a) => (h as Action)?.Invoke()
 			);
 
-	internal bool UpdateFactory(Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?> factory)
-	{
-		// Special case to update the factory without creating a new instance.
-		// A special mode is required for it to work and is activated directly in the Uno.TemplateManager.
+		internal bool UpdateFactory(Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?> factory)
+		{
+			// Special case to update the factory without creating a new instance.
+			// A special mode is required for it to work and is activated directly in the Uno.TemplateManager.
 
-		var previous = _viewFactory;
-		var newFactory = factory?.Invoke(previous);			if (newFactory != previous)
+			var previous = _viewFactory;
+			var newFactory = factory?.Invoke(previous);
+
+			if (newFactory != previous)
 			{
 				_viewFactory = newFactory;
 

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
@@ -215,7 +215,7 @@ namespace Microsoft.UI.Xaml
 		}
 
 		// --- Uno extension points for template factory injection and update notifications ---
-		
+
 		// Use weak attached field to avoid adding a field to every FrameworkTemplate instance
 		// when the dynamic template update feature is not used
 		private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<FrameworkTemplate, global::Windows.UI.Core.WeakEventHelper.WeakEventCollection> _templateUpdatedHandlers = new();

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
@@ -35,7 +35,7 @@ namespace Microsoft.UI.Xaml
 		private readonly bool _isLegacyTemplate = true; // Tests fails if set to false, so we keep it true for now.
 
 		internal NewFrameworkTemplateBuilder?
-			_viewFactory; // Updateable when a special mode is enabled in Uno.TemplateManager
+			_viewFactory; // Updateable when a special mode is enabled in Uno.UI.TemplateManager
 
 		/// <summary>
 		/// The scope at the time of the template's creataion, which will be used when its contents are materialized.
@@ -212,11 +212,10 @@ namespace Microsoft.UI.Xaml
 		internal bool UpdateFactory(Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?> factory)
 		{
 			// Special case to update the factory without creating a new instance.
-			// A special mode is required for it to work and is activated directly in the Uno.TemplateManager.
+			// A special mode is required for it to work and is activated directly in the Uno.UI.TemplateManager.
 
 			var previous = _viewFactory;
 			var newFactory = factory?.Invoke(previous);
-
 			if (newFactory != previous)
 			{
 				_viewFactory = newFactory;

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
@@ -34,8 +34,14 @@ namespace Microsoft.UI.Xaml
 		private readonly ManagedWeakReference? _ownerRef;
 		private readonly bool _isLegacyTemplate = true; // Tests fails if set to false, so we keep it true for now.
 
-		internal NewFrameworkTemplateBuilder?
-			_viewFactory; // Updateable when a special mode is enabled in Uno.UI.TemplateManager
+		/// <summary>
+		/// The template builder factory. This field is mutable and may be updated at runtime
+		/// only when Uno.UI.TemplateManager enables "template materialization override mode".
+		/// In this mode, the factory can be replaced to support dynamic template materialization
+		/// scenarios (e.g., hot reload, design-time updates). Outside of this mode, the field
+		/// should remain unchanged. See Uno.UI.TemplateManager for details.
+		/// </summary>
+		internal NewFrameworkTemplateBuilder? _viewFactory;
 
 		/// <summary>
 		/// The scope at the time of the template's creataion, which will be used when its contents are materialized.

--- a/src/Uno.UI/Uno/DataTemplateHelper.cs
+++ b/src/Uno.UI/Uno/DataTemplateHelper.cs
@@ -1,0 +1,58 @@
+#nullable enable
+
+using System;
+using Microsoft.UI.Xaml;
+
+#if __ANDROID__
+using View = Android.Views.View;
+#elif __APPLE_UIKIT__
+using View = UIKit.UIView;
+#else
+using View = Microsoft.UI.Xaml.UIElement;
+#endif
+
+namespace Uno
+{
+	/// <summary>
+	/// Helper to update an existing DataTemplate factory and notify interested controls.
+	/// Also exposes a global flag to enable template-update subscriptions in controls.
+	/// </summary>
+	public static class DataTemplateHelper
+	{
+		/// <summary>
+		/// When true, controls will subscribe to DataTemplate update notifications and refresh their materialized content.
+		/// Default is false to opt-in explicitly.
+		/// </summary>
+		public static bool IsUpdateSubscriptionsEnabled { get; private set; }
+
+		/// <summary>
+		/// Enables the DataTemplate update subscriptions.
+		/// </summary>
+		/// <remarks>
+		/// This should be called at application startup, before any DataTemplate is created or used.
+		/// DEBUGGER TOOL: SHOULD NOT BE USED IN PRODUCTION APPLICATION CODE.
+		/// </remarks>
+		public static void EnableUpdateSubscriptions() => IsUpdateSubscriptionsEnabled = true;
+
+		/// <summary>
+		/// Updates the factory of the provided <see cref="Microsoft.UI.Xaml.DataTemplate"/> and raises an update notification.
+		/// Returns the previous factory so callers can reuse it if needed for special cases.
+		/// </summary>
+		public static bool UpdateDataTemplate(DataTemplate currentTemplate, Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?> factoryUpdater)
+		{
+			ArgumentNullException.ThrowIfNull(currentTemplate);
+			ArgumentNullException.ThrowIfNull(factoryUpdater);
+
+			// Update and notify
+			return currentTemplate.UpdateFactory(factoryUpdater);
+		}
+
+		public static bool UpdateDataTemplate(DataTemplate currentTemplate, Func<View?> newViewfactory)
+		{
+			ArgumentNullException.ThrowIfNull(currentTemplate);
+			ArgumentNullException.ThrowIfNull(newViewfactory);
+
+			return currentTemplate.UpdateFactory(_ => (NewFrameworkTemplateBuilder)((_, _) => newViewfactory()));
+		}
+	}
+}

--- a/src/Uno.UI/Uno/TemplateManager.cs
+++ b/src/Uno.UI/Uno/TemplateManager.cs
@@ -11,7 +11,7 @@ using View = UIKit.UIView;
 using View = Microsoft.UI.Xaml.UIElement;
 #endif
 
-namespace Uno
+namespace Uno.UI
 {
 	/// <summary>
 	/// Manager for runtime DataTemplate updates and notification system.
@@ -50,7 +50,7 @@ namespace Uno
 			ref IDisposable? subscription,
 			Action onUpdated)
 		{
-			return TemplateUpdateSubscription.Attach(template, ref subscription, onUpdated);
+			return Uno.UI.TemplateUpdateSubscription.Attach(template, ref subscription, onUpdated);
 		}
 
 		/// <summary>

--- a/src/Uno.UI/Uno/TemplateManager.cs
+++ b/src/Uno.UI/Uno/TemplateManager.cs
@@ -17,7 +17,7 @@ namespace Uno.UI
 	/// Manager for runtime DataTemplate updates and notification system.
 	/// Also exposes a global flag to enable template-update subscriptions in controls.
 	/// </summary>
-	public static class TemplateManager
+	internal static class TemplateManager
 	{
 		/// <summary>
 		/// If true, DataTemplate update can be activated.

--- a/src/Uno.UI/Uno/TemplateManager.cs
+++ b/src/Uno.UI/Uno/TemplateManager.cs
@@ -60,6 +60,8 @@ namespace Uno.UI
 			{
 				return TemplateUpdateSubscription.Attach(owner, template, onUpdated);
 			}
+
+			return false;
 		}
 
 		/// <summary>
@@ -75,6 +77,8 @@ namespace Uno.UI
 			{
 				return TemplateUpdateSubscription.Attach(owner, slotKey, template, onUpdated);
 			}
+
+			return false;
 		}
 
 

--- a/src/Uno.UI/Uno/TemplateManager.cs
+++ b/src/Uno.UI/Uno/TemplateManager.cs
@@ -26,19 +26,49 @@ namespace Uno
 		public static bool IsUpdateSubscriptionsEnabled { get; private set; }
 
 		/// <summary>
-		/// Enables the DataTemplate update subscriptions.
+		/// [DEV TOOLING] Enables the DataTemplate update subscriptions.
 		/// </summary>
 		/// <remarks>
 		/// This should be called at application startup, before any DataTemplate is created or used.
-		/// DEBUGGER TOOL: SHOULD NOT BE USED IN PRODUCTION APPLICATION CODE.
+		/// DEV TOOLING: SHOULD NOT BE USED IN PRODUCTION APPLICATION CODE.
 		/// </remarks>
 		public static void EnableUpdateSubscriptions() => IsUpdateSubscriptionsEnabled = true;
+
+		/// <summary>
+		/// Subscribe to dynamic updates for the specified DataTemplate
+		/// </summary>
+		/// <param name="template">The DataTemplate to monitor for updates</param>
+		/// <param name="subscription">Reference to store the subscription (will be disposed/replaced as needed)</param>
+		/// <param name="onUpdated">Callback to invoke when the template is updated</param>
+		/// <returns>True if the subscription was created (when dynamic updates are enabled)</returns>
+		/// <remarks>
+		/// Use this method in custom controls that materialize DataTemplate content and want to 
+		/// automatically refresh when the template is updated at runtime
+		/// </remarks>
+		public static bool SubscribeToTemplate(
+			DataTemplate? template,
+			ref IDisposable? subscription,
+			Action onUpdated)
+		{
+			return TemplateUpdateSubscription.Attach(template, ref subscription, onUpdated);
+		}
+
+		/// <summary>
+		/// Unsubscribe from DataTemplate updates
+		/// </summary>
+		/// <param name="subscription">The subscription to dispose</param>
+		public static void UnsubscribeFromTemplate(ref IDisposable? subscription)
+		{
+			subscription?.Dispose();
+			subscription = null;
+		}
 
 		/// <summary>
 		/// Updates the factory of the provided <see cref="Microsoft.UI.Xaml.DataTemplate"/> and raises an update notification.
 		/// Returns the previous factory so callers can reuse it if needed for special cases.
 		/// </summary>
-		public static bool UpdateDataTemplate(DataTemplate currentTemplate, Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?> factoryUpdater)
+		public static bool UpdateDataTemplate(DataTemplate currentTemplate,
+			Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?> factoryUpdater)
 		{
 			ArgumentNullException.ThrowIfNull(currentTemplate);
 			ArgumentNullException.ThrowIfNull(factoryUpdater);

--- a/src/Uno.UI/Uno/TemplateManager.cs
+++ b/src/Uno.UI/Uno/TemplateManager.cs
@@ -20,6 +20,14 @@ namespace Uno.UI
 	public static class TemplateManager
 	{
 		/// <summary>
+		/// If true, DataTemplate update can be activated.
+		/// </summary>
+		/// <remarks>
+		/// Turned to false by the linker in `Release` build.
+		/// </remarks>
+		public static bool IsDataTemplateDynamicUpdateEnabled { get; } = true;
+
+		/// <summary>
 		/// When true, controls will subscribe to DataTemplate update notifications and refresh their materialized content.
 		/// Default is false to opt-in explicitly.
 		/// </summary>
@@ -32,7 +40,13 @@ namespace Uno.UI
 		/// This should be called at application startup, before any DataTemplate is created or used.
 		/// DEV TOOLING: SHOULD NOT BE USED IN PRODUCTION APPLICATION CODE.
 		/// </remarks>
-		public static void EnableUpdateSubscriptions() => IsUpdateSubscriptionsEnabled = true;
+		public static void EnableUpdateSubscriptions()
+		{
+			if (IsDataTemplateDynamicUpdateEnabled)
+			{
+				IsUpdateSubscriptionsEnabled = true;
+			}
+		}
 
 		/// <summary>
 		/// Subscribe to dynamic updates for the specified DataTemplate and associate the subscription with an owner control.
@@ -42,7 +56,10 @@ namespace Uno.UI
 			DataTemplate? template,
 			Action onUpdated)
 		{
-			return TemplateUpdateSubscription.Attach(owner, template, onUpdated);
+			if (IsDataTemplateDynamicUpdateEnabled)
+			{
+				return TemplateUpdateSubscription.Attach(owner, template, onUpdated);
+			}
 		}
 
 		/// <summary>
@@ -54,7 +71,10 @@ namespace Uno.UI
 			DataTemplate? template,
 			Action onUpdated)
 		{
-			return TemplateUpdateSubscription.Attach(owner, slotKey, template, onUpdated);
+			if (IsDataTemplateDynamicUpdateEnabled)
+			{
+				return TemplateUpdateSubscription.Attach(owner, slotKey, template, onUpdated);
+			}
 		}
 
 
@@ -63,7 +83,10 @@ namespace Uno.UI
 		/// </summary>
 		public static void UnsubscribeFromTemplate(DependencyObject owner)
 		{
-			TemplateUpdateSubscription.Detach(owner);
+			if (IsDataTemplateDynamicUpdateEnabled)
+			{
+				TemplateUpdateSubscription.Detach(owner);
+			}
 		}
 
 		/// <summary>
@@ -71,7 +94,10 @@ namespace Uno.UI
 		/// </summary>
 		public static void UnsubscribeFromTemplate(DependencyObject owner, string slotKey)
 		{
-			TemplateUpdateSubscription.Detach(owner, slotKey);
+			if (IsDataTemplateDynamicUpdateEnabled)
+			{
+				TemplateUpdateSubscription.Detach(owner, slotKey);
+			}
 		}
 
 		/// <summary>
@@ -83,11 +109,16 @@ namespace Uno.UI
 		public static bool UpdateDataTemplate(DataTemplate currentTemplate,
 			Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?> factoryUpdater)
 		{
-			ArgumentNullException.ThrowIfNull(currentTemplate);
-			ArgumentNullException.ThrowIfNull(factoryUpdater);
+			if (IsDataTemplateDynamicUpdateEnabled)
+			{
+				ArgumentNullException.ThrowIfNull(currentTemplate);
+				ArgumentNullException.ThrowIfNull(factoryUpdater);
 
-			// Update and notify
-			return currentTemplate.UpdateFactory(factoryUpdater);
+				// Update and notify
+				return currentTemplate.UpdateFactory(factoryUpdater);
+			}
+
+			return false;
 		}
 
 		/// <summary>
@@ -98,10 +129,15 @@ namespace Uno.UI
 		/// </returns>
 		public static bool UpdateDataTemplate(DataTemplate currentTemplate, Func<View?> newViewfactory)
 		{
-			ArgumentNullException.ThrowIfNull(currentTemplate);
-			ArgumentNullException.ThrowIfNull(newViewfactory);
+			if (IsDataTemplateDynamicUpdateEnabled)
+			{
+				ArgumentNullException.ThrowIfNull(currentTemplate);
+				ArgumentNullException.ThrowIfNull(newViewfactory);
 
-			return currentTemplate.UpdateFactory(_ => (NewFrameworkTemplateBuilder)((_, _) => newViewfactory()));
+				return currentTemplate.UpdateFactory(_ => (NewFrameworkTemplateBuilder)((_, _) => newViewfactory()));
+			}
+
+			return false;
 		}
 	}
 }

--- a/src/Uno.UI/Uno/TemplateManager.cs
+++ b/src/Uno.UI/Uno/TemplateManager.cs
@@ -14,10 +14,10 @@ using View = Microsoft.UI.Xaml.UIElement;
 namespace Uno
 {
 	/// <summary>
-	/// Helper to update an existing DataTemplate factory and notify interested controls.
+	/// Manager for runtime DataTemplate updates and notification system.
 	/// Also exposes a global flag to enable template-update subscriptions in controls.
 	/// </summary>
-	public static class DataTemplateHelper
+	public static class TemplateManager
 	{
 		/// <summary>
 		/// When true, controls will subscribe to DataTemplate update notifications and refresh their materialized content.

--- a/src/Uno.UI/Uno/TemplateManager.md
+++ b/src/Uno.UI/Uno/TemplateManager.md
@@ -28,6 +28,67 @@
 Uno.UI.TemplateManager.EnableUpdateSubscriptions();
 ```
 
+### Production Release Configuration (Not Recommended)
+
+⚠️ **WARNING**: The dynamic template update system is designed as a development/debugging tool. However, if you absolutely need to enable it in a production release build, you must configure both the MSBuild property and runtime activation:
+
+#### Step 1: Enable MSBuild Feature Flag
+
+Add this to your application's `.csproj` file:
+
+```xml
+<PropertyGroup>
+  <!-- DANGER: Only enable this if you absolutely need dynamic templates in production -->
+  <!-- This ensures the code survives compilation and linking -->
+  <UnoEnableDynamicDataTemplateUpdate>true</UnoEnableDynamicDataTemplateUpdate>
+</PropertyGroup>
+```
+
+#### Step 2: Runtime Activation
+
+Even with the MSBuild flag enabled, you still need to explicitly activate the system at application startup:
+
+```csharp
+public partial class App : Application
+{
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        // DANGER: Only call this if you absolutely need dynamic templates in production
+        // This has performance implications and should only be used for debugging
+        Uno.UI.TemplateManager.EnableUpdateSubscriptions();
+        
+        // Rest of your application initialization...
+    }
+}
+```
+
+#### Why Both Steps Are Required
+
+1. **MSBuild Flag (`UnoEnableDynamicDataTemplateUpdate`)**: 
+   - Defaults to `false` to exclude the feature code from release builds
+   - When `false`, the linker removes all dynamic template update code
+   - Must be `true` to include the necessary infrastructure
+
+2. **Runtime Activation (`EnableUpdateSubscriptions()`)**: 
+   - Even when the code is included, the system remains disabled by default
+   - Must be explicitly enabled to avoid any performance overhead
+   - Allows you to conditionally enable the feature based on runtime conditions
+
+#### Production Considerations
+
+- **Performance Impact**: The subscription system adds overhead to template operations
+- **Memory Usage**: Template subscriptions consume additional memory
+- **Security**: Dynamic code execution capabilities may not be suitable for all environments
+- **Debugging Only**: This feature is primarily intended for development scenarios
+
+**Recommended Alternative**: Instead of enabling this in production, consider using conditional compilation symbols to enable it only in debug builds:
+
+```csharp
+#if DEBUG
+Uno.UI.TemplateManager.EnableUpdateSubscriptions();
+#endif
+```
+
 ### Update a DataTemplate
 
 ```csharp

--- a/src/Uno.UI/Uno/TemplateManager.md
+++ b/src/Uno.UI/Uno/TemplateManager.md
@@ -25,7 +25,7 @@
 ```csharp
 // Enable the dynamic template update system
 // WARNING: This is a debugging tool - do not use in production
-Uno.TemplateManager.EnableUpdateSubscriptions();
+Uno.UI.TemplateManager.EnableUpdateSubscriptions();
 ```
 
 ### Update a DataTemplate
@@ -34,7 +34,7 @@ Uno.TemplateManager.EnableUpdateSubscriptions();
 // Update a template's factory function (simple view factory)
 if (Resources["MyTemplate"] is DataTemplate template)
 {
-    Uno.TemplateManager.UpdateDataTemplate(template, () =>
+    Uno.UI.TemplateManager.UpdateDataTemplate(template, () =>
     {
         // Return new UI element - must be compatible with View type
         return new TextBlock { Text = "Updated Content" };
@@ -44,7 +44,7 @@ if (Resources["MyTemplate"] is DataTemplate template)
 // Alternative: Update using factory updater (advanced)
 if (Resources["MyTemplate"] is DataTemplate template)
 {
-    Uno.TemplateManager.UpdateDataTemplate(template, oldFactory =>
+    Uno.UI.TemplateManager.UpdateDataTemplate(template, oldFactory =>
     {
         // Return a new factory that creates different content
         return (NewFrameworkTemplateBuilder)((_, _) => new TextBlock { Text = "Advanced Update" });
@@ -80,7 +80,7 @@ public class MyCustomControl : FrameworkElement
         {
             // Subscribe to template updates using the public API
             // This automatically disposes previous subscription
-            Uno.TemplateManager.SubscribeToTemplate(
+            Uno.UI.TemplateManager.SubscribeToTemplate(
                 (DataTemplate) e.NewValue,
                 ref c._templateSubscription,
                 () => c.RefreshContent());
@@ -142,7 +142,7 @@ public class MyControl : FrameworkElement
     {
         if (d is MyControl c)
         {
-            Uno.TemplateManager.SubscribeToTemplate(
+            Uno.UI.TemplateManager.SubscribeToTemplate(
                 (DataTemplate)e.NewValue, 
                 ref c._templateSubscription, 
                 () => c.RefreshContent());
@@ -154,7 +154,7 @@ public class MyControl : FrameworkElement
     {
         if (disposing)
         {
-            Uno.TemplateManager.UnsubscribeFromTemplate(ref _templateSubscription);
+            Uno.UI.TemplateManager.UnsubscribeFromTemplate(ref _templateSubscription);
         }
         base.Dispose(disposing);
     }
@@ -194,7 +194,7 @@ private static void OnItemTemplateChanged(DependencyObject d, DependencyProperty
 {
     if (d is MyControl c)
     {
-        Uno.TemplateManager.SubscribeToTemplate(
+        Uno.UI.TemplateManager.SubscribeToTemplate(
             (DataTemplate)e.NewValue, 
             ref c._templateSubscription, 
             () => c.RefreshContent());
@@ -235,7 +235,7 @@ public class TemplateHotReloader
 {
     public void Initialize()
     {
-        Uno.TemplateManager.EnableUpdateSubscriptions();
+        Uno.UI.TemplateManager.EnableUpdateSubscriptions();
         
         // Watch for XAML file changes (pseudo-code)
         FileWatcher.OnFileChanged += (file) =>
@@ -246,7 +246,7 @@ public class TemplateHotReloader
                 if (template != null)
                 {
                     // Use the simple view factory overload
-                    Uno.TemplateManager.UpdateDataTemplate(template, () =>
+                    Uno.UI.TemplateManager.UpdateDataTemplate(template, () =>
                     {
                         var updatedElement = LoadUpdatedTemplate(file);
                         return updatedElement; // Must return View? type

--- a/src/Uno.UI/Uno/TemplateManager.md
+++ b/src/Uno.UI/Uno/TemplateManager.md
@@ -171,11 +171,10 @@ public class MyCustomControl : FrameworkElement
 
 The following Uno Platform controls already support dynamic template updates when the feature is enabled:
 
+- `ContentPresenter` and `ContentControl` are fully supported
 - `ItemsRepeater` - Full support with comprehensive reentrancy protection
 - `ItemsControl` - Basic support using internal `TemplateUpdateSubscription.Attach`
 - `ListView` and `GridView` (through inheritance from `ItemsControl`)
-
-**Note**: `ContentPresenter` and `ContentControl` have the infrastructure but may not have dynamic template updates fully implemented yet.
 
 ## Important Notes
 

--- a/src/Uno.UI/Uno/TemplateManager.md
+++ b/src/Uno.UI/Uno/TemplateManager.md
@@ -1,0 +1,213 @@
+# TemplateManager - Dynamic DataTemplate Updates
+
+## Overview
+
+`TemplateManager` is a development tooling feature that enables runtime updates of `DataTemplate` instances and automatic refresh of controls that use them. This is primarily designed for debugging and development scenarios where you need to modify templates dynamically without restarting the application.
+
+## Key Features
+
+- **Runtime Template Updates**: Modify the factory function of existing `DataTemplate` instances
+- **Automatic Control Refresh**: Controls that subscribe to template updates automatically refresh their content
+- **Opt-in System**: Disabled by default to avoid any performance impact in production
+- **Cross-platform Support**: Works on all Uno Platform targets
+
+## How It Works
+
+1. **Enable the System**: Call `TemplateManager.EnableUpdateSubscriptions()` at application startup
+2. **Subscribe Controls**: Controls use `TemplateUpdateSubscription.Attach()` to listen for template changes
+3. **Update Templates**: Use `TemplateManager.UpdateDataTemplate()` to modify template factories
+4. **Automatic Refresh**: Subscribed controls automatically refresh their materialized content
+
+## Usage
+
+### Enable Dynamic Updates (Application Startup)
+
+```csharp
+// Enable the dynamic template update system
+// WARNING: This is a debugging tool - do not use in production
+Uno.TemplateManager.EnableUpdateSubscriptions();
+```
+
+### Update a DataTemplate
+
+```csharp
+// Update a template's factory function
+if (Resources["MyTemplate"] is DataTemplate template)
+{
+    Uno.TemplateManager.UpdateDataTemplate(template, () =>
+    {
+        // Return new UI element
+        return new TextBlock { Text = "Updated Content" };
+    });
+}
+```
+
+### Subscribe to Template Updates (Custom Controls)
+
+If you're developing a custom control that uses `DataTemplate.LoadContent()` and want it to react to template changes:
+
+```csharp
+public class MyCustomControl : FrameworkElement
+{
+    private IDisposable _templateSubscription;
+    private DataTemplate _currentTemplate;
+
+    public DataTemplate ItemTemplate
+    {
+        get => _currentTemplate;
+        set
+        {
+            if (_currentTemplate != value)
+            {
+                _currentTemplate = value;
+                
+                // Subscribe to template updates using the public API
+                Uno.TemplateManager.SubscribeToTemplate(
+                    _currentTemplate, 
+                    ref _templateSubscription, 
+                    OnTemplateUpdated
+                );
+                
+                RefreshContent();
+            }
+        }
+    }
+
+    private void OnTemplateUpdated()
+    {
+        // Template was updated - refresh the materialized content
+        RefreshContent();
+    }
+
+    private void RefreshContent()
+    {
+        if (_currentTemplate != null)
+        {
+            // Clear existing content
+            Children.Clear();
+            
+            // Materialize new content
+            var content = _currentTemplate.LoadContent() as UIElement;
+            if (content != null)
+            {
+                Children.Add(content);
+            }
+        }
+    }
+
+    protected override void OnUnloaded()
+    {
+        // Clean up subscription to avoid memory leaks
+        Uno.TemplateManager.UnsubscribeFromTemplate(ref _templateSubscription);
+        base.OnUnloaded();
+    }
+}
+```
+
+### Understanding the `ref IDisposable` Pattern
+
+The subscription methods use `ref IDisposable?` to automatically manage subscription lifecycle:
+
+```csharp
+private IDisposable _subscription;
+
+// When subscribing to a new template:
+// - If _subscription already exists, it will be automatically disposed
+// - A new subscription will be created and stored in _subscription
+// - The method returns true if dynamic updates are enabled
+bool subscribed = TemplateManager.SubscribeToTemplate(
+    myTemplate, 
+    ref _subscription,  // Note: ref keyword is required
+    () => RefreshUI()
+);
+
+// When changing templates:
+TemplateManager.SubscribeToTemplate(
+    newTemplate, 
+    ref _subscription,  // Automatically disposes previous subscription
+    () => RefreshUI()
+);
+
+// When cleaning up:
+TemplateManager.UnsubscribeFromTemplate(ref _subscription);
+// After this call, _subscription will be null
+```
+
+## Built-in Support
+
+The following Uno Platform controls already support dynamic template updates when the feature is enabled:
+
+- `ItemsRepeater`
+- `ListView` / `GridView`
+- `ItemsControl`
+- `ContentPresenter`
+- `ContentControl`
+
+## Important Notes
+
+### Development Tool Only
+
+This feature is intended **exclusively for development and debugging scenarios**. It should not be enabled in production applications as it:
+
+- Has memory overhead for template subscriptions
+- Can cause unexpected UI refreshes
+- Is not optimized for performance
+
+### Memory Management
+
+Always dispose of template subscriptions in your custom controls to avoid memory leaks:
+
+```csharp
+// In OnUnloaded or Dispose
+Uno.TemplateManager.UnsubscribeFromTemplate(ref _templateSubscription);
+```
+
+### Thread Safety
+
+Template updates should be performed on the UI thread. The system does not provide automatic thread marshaling.
+
+## API Reference
+
+### TemplateManager
+
+- `EnableUpdateSubscriptions()`: Enables the dynamic template update system
+- `IsUpdateSubscriptionsEnabled`: Gets whether the system is enabled
+- `UpdateDataTemplate(DataTemplate, Func<View>)`: Updates a template with a new factory function
+- `SubscribeToTemplate(DataTemplate, ref IDisposable, Action)`: Subscribe to template update notifications
+- `UnsubscribeFromTemplate(ref IDisposable)`: Unsubscribe from template updates
+
+### TemplateUpdateSubscription (Internal)
+
+- `Attach(DataTemplate, ref IDisposable, Action)`: Internal subscription method (use `TemplateManager.SubscribeToTemplate` instead)
+- Returns `true` if subscriptions are enabled and the subscription was created
+
+## Example: Hot-Reload Scenario
+
+```csharp
+// Development tool that updates templates based on file changes
+public class TemplateHotReloader
+{
+    public void Initialize()
+    {
+        Uno.TemplateManager.EnableUpdateSubscriptions();
+        
+        // Watch for XAML file changes (pseudo-code)
+        FileWatcher.OnFileChanged += (file) =>
+        {
+            if (file.EndsWith(".xaml"))
+            {
+                var template = FindTemplateForFile(file);
+                if (template != null)
+                {
+                    Uno.TemplateManager.UpdateDataTemplate(template, () =>
+                    {
+                        return LoadUpdatedTemplate(file);
+                    });
+                }
+            }
+        };
+    }
+}
+```
+
+This enables scenarios like XAML hot-reload where template changes can be reflected immediately in the running application without restart.

--- a/src/Uno.UI/Uno/TemplateManager.md
+++ b/src/Uno.UI/Uno/TemplateManager.md
@@ -14,7 +14,7 @@
 ## How It Works
 
 1. **Enable the System**: Call `TemplateManager.EnableUpdateSubscriptions()` at application startup
-2. **Subscribe Controls**: Controls use `TemplateUpdateSubscription.Attach()` to listen for template changes
+2. **Subscribe Controls**: Controls use `TemplateManager.SubscribeToTemplate()` to listen for template changes
 3. **Update Templates**: Use `TemplateManager.UpdateDataTemplate()` to modify template factories
 4. **Automatic Refresh**: Subscribed controls automatically refresh their materialized content
 
@@ -31,13 +31,23 @@ Uno.TemplateManager.EnableUpdateSubscriptions();
 ### Update a DataTemplate
 
 ```csharp
-// Update a template's factory function
+// Update a template's factory function (simple view factory)
 if (Resources["MyTemplate"] is DataTemplate template)
 {
     Uno.TemplateManager.UpdateDataTemplate(template, () =>
     {
-        // Return new UI element
+        // Return new UI element - must be compatible with View type
         return new TextBlock { Text = "Updated Content" };
+    });
+}
+
+// Alternative: Update using factory updater (advanced)
+if (Resources["MyTemplate"] is DataTemplate template)
+{
+    Uno.TemplateManager.UpdateDataTemplate(template, oldFactory =>
+    {
+        // Return a new factory that creates different content
+        return (NewFrameworkTemplateBuilder)((_, _) => new TextBlock { Text = "Advanced Update" });
     });
 }
 ```
@@ -50,87 +60,52 @@ If you're developing a custom control that uses `DataTemplate.LoadContent()` and
 public class MyCustomControl : FrameworkElement
 {
     private IDisposable _templateSubscription;
-    private DataTemplate _currentTemplate;
+
+    public static readonly DependencyProperty ItemTemplateProperty =
+        DependencyProperty.Register(
+            nameof(ItemTemplate),
+            typeof(DataTemplate),
+            typeof(MyCustomControl),
+            new PropertyMetadata(null, OnItemTemplateChanged));
 
     public DataTemplate ItemTemplate
     {
-        get => _currentTemplate;
-        set
-        {
-            if (_currentTemplate != value)
-            {
-                _currentTemplate = value;
-                
-                // Subscribe to template updates using the public API
-                Uno.TemplateManager.SubscribeToTemplate(
-                    _currentTemplate, 
-                    ref _templateSubscription, 
-                    OnTemplateUpdated
-                );
-                
-                RefreshContent();
-            }
-        }
+        get => (DataTemplate)GetValue(ItemTemplateProperty);
+        set => SetValue(ItemTemplateProperty, value);
     }
 
-    private void OnTemplateUpdated()
+    private static void OnItemTemplateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        // Template was updated - refresh the materialized content
-        RefreshContent();
+        if (d is MyCustomControl c)
+        {
+            // Subscribe to template updates using the public API
+            // This automatically disposes previous subscription
+            Uno.TemplateManager.SubscribeToTemplate(
+                (DataTemplate) e.NewValue,
+                ref c._templateSubscription,
+                () => c.RefreshContent());
+        
+            c.RefreshContent();
+        }
     }
 
     private void RefreshContent()
     {
-        if (_currentTemplate != null)
+        var currentTemplate = ItemTemplate;
+        if (currentTemplate != null)
         {
             // Clear existing content
             Children.Clear();
             
             // Materialize new content
-            var content = _currentTemplate.LoadContent() as UIElement;
+            var content = currentTemplate.LoadContent() as UIElement;
             if (content != null)
             {
                 Children.Add(content);
             }
         }
     }
-
-    protected override void OnUnloaded()
-    {
-        // Clean up subscription to avoid memory leaks
-        Uno.TemplateManager.UnsubscribeFromTemplate(ref _templateSubscription);
-        base.OnUnloaded();
-    }
 }
-```
-
-### Understanding the `ref IDisposable` Pattern
-
-The subscription methods use `ref IDisposable?` to automatically manage subscription lifecycle:
-
-```csharp
-private IDisposable _subscription;
-
-// When subscribing to a new template:
-// - If _subscription already exists, it will be automatically disposed
-// - A new subscription will be created and stored in _subscription
-// - The method returns true if dynamic updates are enabled
-bool subscribed = TemplateManager.SubscribeToTemplate(
-    myTemplate, 
-    ref _subscription,  // Note: ref keyword is required
-    () => RefreshUI()
-);
-
-// When changing templates:
-TemplateManager.SubscribeToTemplate(
-    newTemplate, 
-    ref _subscription,  // Automatically disposes previous subscription
-    () => RefreshUI()
-);
-
-// When cleaning up:
-TemplateManager.UnsubscribeFromTemplate(ref _subscription);
-// After this call, _subscription will be null
 ```
 
 ## Built-in Support
@@ -138,14 +113,14 @@ TemplateManager.UnsubscribeFromTemplate(ref _subscription);
 The following Uno Platform controls already support dynamic template updates when the feature is enabled:
 
 - `ItemsRepeater`
-- `ListView` / `GridView`
 - `ItemsControl`
+- `ListView` and `GridView` (through inheritance from `ItemsControl`)
 - `ContentPresenter`
 - `ContentControl`
 
 ## Important Notes
 
-### Development Tool Only
+### Development Tooling Only
 
 This feature is intended **exclusively for development and debugging scenarios**. It should not be enabled in production applications as it:
 
@@ -155,16 +130,83 @@ This feature is intended **exclusively for development and debugging scenarios**
 
 ### Memory Management
 
-Always dispose of template subscriptions in your custom controls to avoid memory leaks:
+**Important**: Template subscriptions should NOT be disposed in `OnUnloaded` as this would prevent them from working when the control is loaded again. Instead:
 
 ```csharp
-// In OnUnloaded or Dispose
-Uno.TemplateManager.UnsubscribeFromTemplate(ref _templateSubscription);
+public class MyControl : FrameworkElement
+{
+    private IDisposable _templateSubscription;
+
+    // ✅ CORRECT: Subscribe in DependencyProperty callback
+    private static void OnItemTemplateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is MyControl c)
+        {
+            Uno.TemplateManager.SubscribeToTemplate(
+                (DataTemplate)e.NewValue, 
+                ref c._templateSubscription, 
+                () => c.RefreshContent());
+        }
+    }
+
+    // ✅ CORRECT: Clean up only on final disposal (optional)
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Uno.TemplateManager.UnsubscribeFromTemplate(ref _templateSubscription);
+        }
+        base.Dispose(disposing);
+    }
+
+    // ❌ INCORRECT: Don't unsubscribe in OnUnloaded
+    // protected override void OnUnloaded()
+    // {
+    //     Uno.TemplateManager.UnsubscribeFromTemplate(ref _templateSubscription); // DON'T DO THIS
+    // }
+}
 ```
 
 ### Thread Safety
 
-Template updates should be performed on the UI thread. The system does not provide automatic thread marshaling.
+Everything is happening in the UI Thread, so no need to shield against concurrent access.
+
+### Limitations
+
+- **Performance**: Each subscription has memory overhead - use sparingly
+- **Template Identity**: Subscriptions are based on DataTemplate reference equality
+
+### Best Practices
+
+1. **Enable Once**: Call `EnableUpdateSubscriptions()` only once at app startup
+2. **Minimal Subscriptions**: Only subscribe for templates that actually need dynamic updates
+3. **Proper Disposal**: Let the automatic disposal handle cleanup, avoid manual unsubscribe in OnUnloaded
+4. **UI Thread**: Always call `UpdateDataTemplate()` from the UI thread
+5. **Testing**: Verify behavior works correctly across Unload/Load cycles
+
+### DependencyProperty Integration
+
+For custom controls, the subscription should be managed in the DependencyProperty change callback:
+
+```csharp
+// ✅ CORRECT: Subscribe in DependencyProperty callback
+private static void OnItemTemplateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+{
+    if (d is MyControl c)
+    {
+        Uno.TemplateManager.SubscribeToTemplate(
+            (DataTemplate)e.NewValue, 
+            ref c._templateSubscription, 
+            () => c.RefreshContent());
+    }
+}
+
+// ❌ INCORRECT: Don't subscribe in Loaded event
+// protected override void OnLoaded()
+// {
+//     TemplateManager.SubscribeToTemplate(...); // Wrong place
+// }
+```
 
 ## API Reference
 
@@ -172,14 +214,18 @@ Template updates should be performed on the UI thread. The system does not provi
 
 - `EnableUpdateSubscriptions()`: Enables the dynamic template update system
 - `IsUpdateSubscriptionsEnabled`: Gets whether the system is enabled
-- `UpdateDataTemplate(DataTemplate, Func<View>)`: Updates a template with a new factory function
-- `SubscribeToTemplate(DataTemplate, ref IDisposable, Action)`: Subscribe to template update notifications
-- `UnsubscribeFromTemplate(ref IDisposable)`: Unsubscribe from template updates
+- `UpdateDataTemplate(DataTemplate, Func<NewFrameworkTemplateBuilder?, NewFrameworkTemplateBuilder?>)`: Updates a template with a factory updater function
+- `UpdateDataTemplate(DataTemplate, Func<View?>)`: Updates a template with a simple view factory function
+- `SubscribeToTemplate(DataTemplate?, ref IDisposable?, Action)`: Subscribe to template update notifications
+- `UnsubscribeFromTemplate(ref IDisposable?)`: Unsubscribe from template updates
 
 ### TemplateUpdateSubscription (Internal)
 
-- `Attach(DataTemplate, ref IDisposable, Action)`: Internal subscription method (use `TemplateManager.SubscribeToTemplate` instead)
+- `Attach(DataTemplate, ref IDisposable, Action)`: Internal subscription method
+- **Use `TemplateManager.SubscribeToTemplate` instead** - this is the public API
 - Returns `true` if subscriptions are enabled and the subscription was created
+
+**Note**: Built-in Uno Platform controls currently use the internal `TemplateUpdateSubscription.Attach()` method directly for performance reasons. User code should use the public `TemplateManager.SubscribeToTemplate()` API.
 
 ## Example: Hot-Reload Scenario
 
@@ -199,13 +245,28 @@ public class TemplateHotReloader
                 var template = FindTemplateForFile(file);
                 if (template != null)
                 {
+                    // Use the simple view factory overload
                     Uno.TemplateManager.UpdateDataTemplate(template, () =>
                     {
-                        return LoadUpdatedTemplate(file);
+                        var updatedElement = LoadUpdatedTemplate(file);
+                        return updatedElement; // Must return View? type
                     });
                 }
             }
         };
+    }
+    
+    private View? LoadUpdatedTemplate(string filePath)
+    {
+        // Implementation to load and parse XAML file
+        // Returns the root UI element
+        return null; // Implementation specific
+    }
+    
+    private DataTemplate? FindTemplateForFile(string filePath)
+    {
+        // Implementation to find the DataTemplate associated with the file
+        return null; // Implementation specific
     }
 }
 ```

--- a/src/Uno.UI/Uno/TemplateManager.md
+++ b/src/Uno.UI/Uno/TemplateManager.md
@@ -278,7 +278,6 @@ private static void OnItemTemplateChanged(DependencyObject d, DependencyProperty
 - `SubscribeToTemplate(DependencyObject owner, string slotKey, DataTemplate? template, Action onUpdated)`: Owner-based subscription with a named slot for multiple subscriptions per control; returns `bool` indicating success
 - `UnsubscribeFromTemplate(DependencyObject owner)`: Unsubscribes all owner-associated subscriptions
 - `UnsubscribeFromTemplate(DependencyObject owner, string slotKey)`: Unsubscribes the specified slot subscription for the owner
-- `UnsubscribeFromTemplate(DependencyObject owner, string slotKey)`: Unsubscribes the specified slot subscription for the owner
 
 ### TemplateUpdateSubscription (Internal)
 

--- a/src/Uno.UI/Uno/TemplateUpdateSubscription.cs
+++ b/src/Uno.UI/Uno/TemplateUpdateSubscription.cs
@@ -30,7 +30,7 @@ namespace Uno
 			ref IDisposable? subscription,
 			Action onUpdated)
 		{
-			if (!DataTemplateHelper.IsUpdateSubscriptionsEnabled)
+			if (!TemplateManager.IsUpdateSubscriptionsEnabled)
 			{
 				return false;
 			}

--- a/src/Uno.UI/Uno/TemplateUpdateSubscription.cs
+++ b/src/Uno.UI/Uno/TemplateUpdateSubscription.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace Uno
+namespace Uno.UI
 {
 	/// <summary>
 	/// Internal helper to manage weak template-updated subscriptions consistently across controls.
@@ -30,7 +30,7 @@ namespace Uno
 			ref IDisposable? subscription,
 			Action onUpdated)
 		{
-			if (!TemplateManager.IsUpdateSubscriptionsEnabled)
+			if (!Uno.UI.TemplateManager.IsUpdateSubscriptionsEnabled)
 			{
 				return false;
 			}

--- a/src/Uno.UI/Uno/TemplateUpdateSubscription.cs
+++ b/src/Uno.UI/Uno/TemplateUpdateSubscription.cs
@@ -1,0 +1,61 @@
+#nullable enable
+
+using System;
+
+namespace Uno
+{
+	/// <summary>
+	/// Internal helper to manage weak template-updated subscriptions consistently across controls.
+	/// Must remain in Uno namespace to keep public surface stable.
+	/// </summary>
+	internal static class TemplateUpdateSubscription
+	{
+		private sealed class Subscription : IDisposable
+		{
+			public Microsoft.UI.Xaml.DataTemplate? Template { get; }
+			private readonly IDisposable? _inner;
+			public Subscription(Microsoft.UI.Xaml.DataTemplate? template, IDisposable? inner)
+			{
+				Template = template;
+				_inner = inner;
+			}
+			public void Dispose() => _inner?.Dispose();
+		}
+
+		/// <summary>
+		/// Ensure a subscription is set to the given template; returns true if the global update mode is enabled.
+		/// </summary>
+		public static bool Attach(
+			Microsoft.UI.Xaml.DataTemplate? template,
+			ref IDisposable? subscription,
+			Action onUpdated)
+		{
+			if (!DataTemplateHelper.IsUpdateSubscriptionsEnabled)
+			{
+				return false;
+			}
+
+			var current = subscription as Subscription;
+
+			if (!ReferenceEquals(template, current?.Template))
+			{
+				subscription?.Dispose();
+				subscription = null;
+
+				if (template is not null)
+				{
+					var inner = template.RegisterTemplateUpdated(onUpdated);
+					subscription = new Subscription(template, inner);
+				}
+			}
+
+			return true;
+		}
+
+		public static void Detach(ref IDisposable? subscription)
+		{
+			subscription?.Dispose();
+			subscription = null;
+		}
+	}
+}

--- a/src/Uno.UWP/UI/Core/WeakEventHelper.cs
+++ b/src/Uno.UWP/UI/Core/WeakEventHelper.cs
@@ -66,6 +66,12 @@ namespace Windows.UI.Core
 			private List<WeakHandler> _handlers = [];
 			private readonly ITrimProvider _provider;
 
+			// Explicit parameterless constructor to allow Activator.CreateInstance to
+			// dynamically create an instance of WeakEventCollection via reflection.
+			public WeakEventCollection() : this(null)
+			{
+			}
+
 			public WeakEventCollection(ITrimProvider? provider = null)
 			{
 				_provider = provider ?? new DefaultTrimProvider();


### PR DESCRIPTION
This PR introduces a runtime DataTemplate update system for the Uno Platform that enables dynamic modification of DataTemplate factories and automatic refresh of controls using those templates. This is designed as a development/debugging tool to support scenarios like hot reload.

- Adds `TemplateManager` with methods to enable subscriptions and update DataTemplate factories
- Implements a subscription system allowing controls to listen for template updates and refresh automatically
- Updates built-in controls (ContentPresenter, ContentControl, ItemsControl, ItemsRepeater) to support dynamic template updates
- Includes linker optimizations to exclude the feature from production builds by default (in applications using Uno)

# Feature

## What is the new behavior? 🚀
This PR introduces runtime DataTemplate factory updates with auto-refresh capability for controls, designed as a debugging tool. The system allows modifying DataTemplate factories at runtime and automatically notifies subscribed controls to refresh their content.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [X] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes
