### PR TITLE
chore: Update settings app in private SDK

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -88,7 +88,7 @@
 	},
 	{
 		"group": "settings",
-		"version": "1.3.8",
+		"version": "1.6.0-dev.15",
 		"packages": [
 			"Uno.Settings.DevServer"
 		]


### PR DESCRIPTION
closes https://github.com/unoplatform/uno.studio/issues/902

## 🐞 Bugfix
Update settings app in private SDK

## What is the current behavior? 🤔
Dev-server crashes at startup when using Uno.Sdk,Private due to a breaking changes in the telemetry package

## What is the new behavior? 🚀
🙃

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
