### PR TITLE
chore: fix ContentPresenter_NativeEmbedding_Android_FillType

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_NativeEmbedding_Android_FillType.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_NativeEmbedding_Android_FillType.xaml
@@ -12,6 +12,6 @@
 			 d:DesignWidth="400">
 	<Grid>
 		<WebView2 Source="https://google.com" />
-		<Ellipse Height="30" VerticalAlignment="Center" Fill="Orange" />
+		<Rectangle Height="30" Width="30" VerticalAlignment="Center" Fill="Orange" />
 	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_NativeEmbedding_Android_FillType.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ContentPresenter/ContentPresenter_NativeEmbedding_Android_FillType.xaml.cs
@@ -5,7 +5,7 @@ using Uno.UI.Samples.Controls;
 
 namespace Uno.UI.Samples.Content.UITests.ContentPresenter
 {
-	[Sample("ContentPresenter", IsManualTest = true, Description = "You should see an orange ellipse on top of a WebView showing Google's homepage. Specifically, the issue reported in https://github.com/unoplatform/uno/issues/21312 should not reproduce.")]
+	[Sample("ContentPresenter", IsManualTest = true, Description = "You should see an orange rectangle on top of a WebView showing Google's homepage. Specifically, the issue reported in https://github.com/unoplatform/uno/issues/21312 should not reproduce.")]
 	public sealed partial class ContentPresenter_NativeEmbedding_Android_FillType : UserControl
 	{
 		public ContentPresenter_NativeEmbedding_Android_FillType()


### PR DESCRIPTION
I accidentally put https://github.com/unoplatform/uno/pull/21329 on auto-merge before finalizing the manual test.