### PR TITLE
chore: Bump manifest to latest

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -33,14 +33,14 @@
 	},
 	{
 		"group": "WasmBootstrap",
-		"version": "9.0.16",
+		"version": "9.0.20",
 		"packages": [
 			"Uno.Wasm.Bootstrap",
 			"Uno.Wasm.Bootstrap.DevServer",
 			"Uno.Wasm.Bootstrap.Server"
 		],
 		"versionOverride": {
-			"net10.0": "9.0.16"
+			"net10.0": "10.0.0-dev.24"
 		}
 	},
 	{
@@ -136,27 +136,27 @@
 	},
 	{
 		"group": "MicrosoftLoggingConsole",
-		"version": "9.0.4",
+		"version": "9.0.8",
 		"packages": [
 			"Microsoft.Extensions.Logging.Console"
 		],
 		"versionOverride": {
-			"net10.0": "9.0.4"
+			"net10.0": "10.0.0-preview.7.25380.108"
 		}
 	},
 	{
 		"group": "WindowsCompatibility",
-		"version": "9.0.4",
+		"version": "9.0.8",
 		"packages": [
 			"Microsoft.Windows.Compatibility"
 		],
 		"versionOverride": {
-			"net10.0": "9.0.4"
+			"net10.0": "10.0.0-preview.7.25380.108"
 		}
 	},
 	{
 		"group": "MsalClient",
-		"version": "4.74.1",
+		"version": "4.76.0",
 		"packages": [
 			"Microsoft.Identity.Client",
 			"Microsoft.Identity.Client.Extensions.Msal"
@@ -180,7 +180,7 @@
 	},
 	{
 		"group": "UnoFonts",
-		"version": "2.7.1",
+		"version": "2.8.0-dev.3",
 		"packages": [
 			"Uno.Fonts.OpenSans",
 			"Uno.Fonts.Fluent",
@@ -189,63 +189,87 @@
 	},
 	{
 		"group": "AndroidMaterial",
-		"version": "1.12.0.2",
+		"version": "1.12.0.4",
 		"packages": [
 			"Xamarin.Google.Android.Material"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "1.12.0.4"
+		}
 	},
 	{
 		"group": "AndroidXLegacySupportV4",
 		"version": "1.0.0.23",
 		"packages": [
 			"Xamarin.AndroidX.Legacy.Support.V4"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "1.0.0.33"
+		}
 	},
 	{
 		"group": "AndroidXSplashScreen",
 		"version": "1.0.1.14",
 		"packages": [
 			"Xamarin.AndroidX.Core.SplashScreen"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "1.0.1.14"
+		}
 	},
 	{
 		"group": "AndroidXAppCompat",
-		"version": "1.7.0.5",
+		"version": "1.7.0.7",
 		"packages": [
 			"Xamarin.AndroidX.AppCompat"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "1.7.0.7"
+		}
 	},
 	{
 		"group": "AndroidXRecyclerView",
-		"version": "1.3.2.10",
+		"version": "1.4.0.2",
 		"packages": [
 			"Xamarin.AndroidX.RecyclerView"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "1.4.0.2"
+		}
 	},
 	{
 		"group": "AndroidXActivity",
-		"version": "1.9.3.2",
+		"version": "1.10.1.2",
 		"packages": [
 			"Xamarin.AndroidX.Activity"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "1.10.1.2"
+		}
 	},
 	{
 		"group": "AndroidXBrowser",
-		"version": "1.8.0.8",
+		"version": "1.8.0.10",
 		"packages": [
 			"Xamarin.AndroidX.Browser"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "1.8.0.10"
+		}
 	},
 	{
 		"group": "AndroidXSwipeRefreshLayout",
-		"version": "1.1.0.24",
+		"version": "1.1.0.28",
 		"packages": [
 			"Xamarin.AndroidX.SwipeRefreshLayout"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "1.1.0.28"
+		}
 	},
 	{
 		"group": "AndroidXNavigation",
-		"version": "2.8.5.1",
+		"version": "2.8.9.2",
 		"packages": [
 			"Xamarin.AndroidX.Navigation.UI",
 			"Xamarin.AndroidX.Navigation.Fragment",
@@ -255,27 +279,30 @@
 	},
 	{
 		"group": "AndroidXCollection",
-		"version": "1.4.5.2",
+		"version": "1.5.0.2",
 		"packages": [
 			"Xamarin.AndroidX.Collection",
 			"Xamarin.AndroidX.Collection.Ktx"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "1.5.0.2"
+		}
 	},
 	{
 		"group": "Maui",
-		"version": "9.0.60",
+		"version": "9.0.100",
 		"packages": [
 			"Microsoft.Maui.Controls",
 			"Microsoft.Maui.Controls.Compatibility",
 			"Microsoft.Maui.Graphics"
 		],
 		"versionOverride": {
-			"net10.0": "9.0.60"
+			"net10.0": "10.0.0-preview.7.25406.3"
 		}
 	},
 	{
 		"group": "CSharpMarkup",
-		"version": "6.2.10",
+		"version": "6.3.0-dev.3",
 		"packages": [
 			"Uno.WinUI.Markup",
 			"Uno.Extensions.Markup.Generators"
@@ -283,7 +310,7 @@
 	},
 	{
 		"group": "Extensions",
-		"version": "6.2.3",
+		"version": "6.3.0-dev.3",
 		"packages": [
 			"Uno.Extensions.Authentication.WinUI",
 			"Uno.Extensions.Authentication.MSAL.WinUI",
@@ -313,7 +340,7 @@
 	},
 	{
 		"group": "Toolkit",
-		"version": "8.1.4",
+		"version": "8.2.0-dev.6",
 		"packages": [
 			"Uno.Toolkit.WinUI",
 			"Uno.Toolkit.WinUI.Cupertino",
@@ -325,7 +352,7 @@
 	},
 	{
 		"group": "Themes",
-		"version": "5.7.3",
+		"version": "5.8.0-dev.2",
 		"packages": [
 			"Uno.Material.WinUI",
 			"Uno.Material.WinUI.Markup",

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -180,7 +180,7 @@
 	},
 	{
 		"group": "UnoFonts",
-		"version": "2.8.0-dev.3",
+		"version": "2.7.1",
 		"packages": [
 			"Uno.Fonts.OpenSans",
 			"Uno.Fonts.Fluent",
@@ -302,7 +302,7 @@
 	},
 	{
 		"group": "CSharpMarkup",
-		"version": "6.3.0-dev.3",
+		"version": "6.2.10",
 		"packages": [
 			"Uno.WinUI.Markup",
 			"Uno.Extensions.Markup.Generators"
@@ -310,7 +310,7 @@
 	},
 	{
 		"group": "Extensions",
-		"version": "6.3.0-dev.3",
+		"version": "6.2.3",
 		"packages": [
 			"Uno.Extensions.Authentication.WinUI",
 			"Uno.Extensions.Authentication.MSAL.WinUI",
@@ -340,7 +340,7 @@
 	},
 	{
 		"group": "Toolkit",
-		"version": "8.2.0-dev.6",
+		"version": "8.1.4",
 		"packages": [
 			"Uno.Toolkit.WinUI",
 			"Uno.Toolkit.WinUI.Cupertino",
@@ -352,7 +352,7 @@
 	},
 	{
 		"group": "Themes",
-		"version": "5.8.0-dev.2",
+		"version": "5.7.3",
 		"packages": [
 			"Uno.Material.WinUI",
 			"Uno.Material.WinUI.Markup",


### PR DESCRIPTION
Update manifest to latest following net10 update of the uno sdk