### PR TITLE
chore: Avoid nuget dependencies vulnerability check errors in debug

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -250,7 +250,7 @@
 		<WarningsNotAsErrors Condition="'$(Configuration)' == 'Debug'">$(WarningsNotAsErrors);IDE0051;IDE0055</WarningsNotAsErrors>
 		
 		<!-- Disable package checks -->
-		<WarningsNotAsErrors Condition="'$(Configuration)' == 'Debug'">$(WarningsNotAsErrors);NU1202;NU1701;NU1903;NU1604</WarningsNotAsErrors>
+		<WarningsNotAsErrors Condition="'$(Configuration)' == 'Debug'">$(WarningsNotAsErrors);NU1202;NU1701;NU1901;NU1902;NU1903;NU1904;NU1604</WarningsNotAsErrors>
 		
 		<!-- Disable warning about cross platform call sites -->
 		<NoWarn>$(NoWarn);CA1416</NoWarn>


### PR DESCRIPTION
## 🏗️ Build or CI related changes
Avoid nuget dependencies vulnerability check errors in debug

## What is the current behavior? 🤔
DEBUG build fails when a new vulnerability is found

## What is the new behavior? 🚀
An error is reported

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
