### PR TITLE
chore(perf): Avoid usage of SKIA structure when not required

### DIFF
--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -125,7 +125,6 @@ public partial class ContainerVisual : Visual
 		return true;
 	}
 
-	/// <returns>true if a ViewBox exists</returns>
 	internal Rect? GetArrangeClipPathInElementCoordinateSpace()
 	{
 		if (LayoutClip is not { isAncestorClip: var isAncestorClip, rect: var rect })

--- a/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
+++ b/src/Uno.UI.Composition/Composition/ContainerVisual.skia.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using SkiaSharp;
 using Windows.Foundation;
+using Uno.Extensions;
 
 namespace Microsoft.UI.Composition;
 
@@ -124,6 +125,27 @@ public partial class ContainerVisual : Visual
 		return true;
 	}
 
+	/// <returns>true if a ViewBox exists</returns>
+	internal Rect? GetArrangeClipPathInElementCoordinateSpace()
+	{
+		if (LayoutClip is not { isAncestorClip: var isAncestorClip, rect: var rect })
+		{
+			return default;
+		}
+
+		if (isAncestorClip)
+		{
+			Matrix4x4.Invert(TotalMatrix, out var totalMatrixInverted);
+			var childToParentTransform = Parent!.TotalMatrix * totalMatrixInverted;
+			if (!childToParentTransform.IsIdentity)
+			{
+				rect = rect.Transform(childToParentTransform.ToMatrix3x2());
+			}
+		}
+
+		return rect;
+	}
+
 	private static SKPath _sparePrePaintingClippingPath = new SKPath();
 
 	internal override bool GetPrePaintingClipping(SKPath dst) // TODO: Do not use SKPath here, bad for perf and prevents usage for IDirectManipulationHandler.IsInBoundsForResume
@@ -134,6 +156,12 @@ public partial class ContainerVisual : Visual
 
 		if (base.GetPrePaintingClipping(dst))
 		{
+			// TODO: SKPath-less
+			//if (GetArrangeClipPathInElementCoordinateSpace() is {} clipping)
+			//{
+			//	dst.AddRect(clipping.ToSKRect());
+			//}
+
 			if (GetArrangeClipPathInElementCoordinateSpace(prePaintingClipPath))
 			{
 				dst.Op(prePaintingClipPath, SKPathOp.Intersect, dst);
@@ -143,6 +171,15 @@ public partial class ContainerVisual : Visual
 		}
 		else
 		{
+			// TODO: SKPath-less
+			//if (GetArrangeClipPathInElementCoordinateSpace() is {} clipping)
+			//{
+			//	dst.Reset();
+			//	dst.AddRect(clipping.ToSKRect());
+
+			//	return true;
+			//}
+
 			if (GetArrangeClipPathInElementCoordinateSpace(prePaintingClipPath))
 			{
 				dst.Reset();


### PR DESCRIPTION
## 🔄 Refactoring (no functional changes, no api changes)
Avoid usage of SKIA structure when not required

## What is the current behavior? 🤔
We are relying in a `SKPath` to perform clipping during hit-testing

## What is the new behavior? 🚀
We rely on a simple 100% managed `Rect`

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
