### PR TITLE
feat(udei): Add dev-server component messages in UDEI

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/ConsoleHelper.cs
+++ b/src/Uno.UI.RemoteControl.Host/ConsoleHelper.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uno.UI.RemoteControl.Host;
+
+public static class ConsoleHelper
+{
+	public static CancellationTokenSource CreateCancellationToken()
+	{
+		// Set up graceful shutdown handling
+		var cancellationTokenSource = new CancellationTokenSource();
+		var shutdownRequested = false;
+
+		Console.CancelKeyPress += (sender, e) =>
+		{
+			if (!cancellationTokenSource.IsCancellationRequested)
+			{
+				shutdownRequested = true;
+				e.Cancel = true; // Prevent immediate termination
+				Console.WriteLine("Graceful shutdown requested...");
+				cancellationTokenSource.Cancel();
+			}
+		};
+
+		// Monitor stdin for CTRL-C character (ASCII 3) for graceful shutdown
+		_ = Task.Run(async () =>
+			{
+				try
+				{
+					if (!Console.IsInputRedirected)
+						return;
+
+					using var reader = new StreamReader(Console.OpenStandardInput());
+
+					var buffer = new char[1];
+					while (!cancellationTokenSource.Token.IsCancellationRequested)
+					{
+						var read = await reader.ReadAsync(buffer, 0, 1);
+						if (read == 0)
+						{
+							break; // EOF
+						}
+
+						if (buffer[0] != '\x03') // CTRL-C (ASCII 3)
+						{
+							continue;
+						}
+
+						if (!shutdownRequested)
+						{
+							shutdownRequested = true;
+							Console.WriteLine("Graceful shutdown requested via stdin...");
+							await cancellationTokenSource.CancelAsync();
+						}
+
+						break;
+					}
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine($"Error monitoring stdin: {ex.Message}");
+				}
+			},
+			cancellationTokenSource.Token);
+		return cancellationTokenSource;
+	}
+}

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/AddIns.cs
@@ -104,9 +104,8 @@ public class AddIns
 				_log.Log(LogLevel.Information, $"Didn't find any add-ins for solution '{solutionFile}'.");
 			}
 
-			var noAddInsResult = ImmutableArray<string>.Empty;
-			TrackDiscoveryCompletion(telemetry, startTime, noAddInsResult, "NoAddInsFound");
-			return AddInsDiscoveryResult.Failed("Failed to determine target frameworks");
+			TrackDiscoveryCompletion(telemetry, startTime, ImmutableArray<string>.Empty, "NoAddInsFound");
+			return AddInsDiscoveryResult.Empty();
 		}
 		catch (Exception ex)
 		{

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/AddInsDiscoveryResult.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/AddInsDiscoveryResult.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Immutable;
+
+namespace Uno.UI.RemoteControl.Host.Extensibility;
+
+public record AddInsDiscoveryResult(string? Error, ImmutableList<string> AddIns)
+{
+	public static AddInsDiscoveryResult Success(ImmutableList<string> assemblies) => new(null, assemblies);
+	public static AddInsDiscoveryResult Failed(string error) => new(error, ImmutableList<string>.Empty);
+	public static AddInsDiscoveryResult Empty() => new(null, ImmutableList<string>.Empty);
+}

--- a/src/Uno.UI.RemoteControl.Host/Extensibility/AddInsStatus.cs
+++ b/src/Uno.UI.RemoteControl.Host/Extensibility/AddInsStatus.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Immutable;
+using Uno.UI.RemoteControl.Helpers;
+
+namespace Uno.UI.RemoteControl.Host.Extensibility;
+
+public record AddInsStatus(AddInsDiscoveryResult Discovery, IImmutableList<AssemblyLoadResult> Assemblies)
+{
+	public static AddInsStatus Empty { get; } = new(AddInsDiscoveryResult.Empty(), ImmutableArray<AssemblyLoadResult>.Empty);
+}

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -143,6 +143,9 @@ namespace Uno.UI.RemoteControl.Host
 				host.Services.GetService<IIdeChannel>();
 				_ = host.Services.GetRequiredService<UnoDevEnvironmentService>().StartAsync(ct.Token); // Background services are not supported by WebHostBuilder
 
+				// Display DevServer version banner
+				DisplayVersionBanner();
+
 				// STEP 3: Use global telemetry for server-wide events
 				// Track devserver startup using global telemetry service
 				var startupProperties = new Dictionary<string, string>

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -27,60 +27,7 @@ namespace Uno.UI.RemoteControl.Host
 
 			ITelemetry? telemetry = null;
 
-			// Set up graceful shutdown handling
-			using var cancellationTokenSource = new CancellationTokenSource();
-			var shutdownRequested = false;
-
-			Console.CancelKeyPress += (sender, e) =>
-			{
-				if (!shutdownRequested)
-				{
-					shutdownRequested = true;
-					e.Cancel = true; // Prevent immediate termination
-					Console.WriteLine("Graceful shutdown requested...");
-					cancellationTokenSource.Cancel();
-				}
-			};
-
-			// Monitor stdin for CTRL-C character (ASCII 3) for graceful shutdown
-			_ = Task.Run(async () =>
-			{
-				try
-				{
-					if (!Console.IsInputRedirected)
-						return;
-
-					using var reader = new StreamReader(Console.OpenStandardInput());
-
-					var buffer = new char[1];
-					while (!cancellationTokenSource.Token.IsCancellationRequested)
-					{
-						var read = await reader.ReadAsync(buffer, 0, 1);
-						if (read == 0)
-						{
-							break; // EOF
-						}
-
-						if (buffer[0] != '\x03') // CTRL-C (ASCII 3)
-						{
-							continue;
-						}
-
-						if (!shutdownRequested)
-						{
-							shutdownRequested = true;
-							Console.WriteLine("Graceful shutdown requested via stdin...");
-							await cancellationTokenSource.CancelAsync();
-						}
-
-						break;
-					}
-				}
-				catch (Exception ex)
-				{
-					Console.WriteLine($"Error monitoring stdin: {ex.Message}");
-				}
-			}, cancellationTokenSource.Token);
+			using var ct = ConsoleHelper.CreateCancellationToken();
 
 			try
 			{
@@ -156,11 +103,10 @@ namespace Uno.UI.RemoteControl.Host
 					.UseUrls($"http://*:{httpPort}/")
 					.UseContentRoot(Directory.GetCurrentDirectory())
 					.UseStartup<Startup>()
-					.ConfigureLogging(logging =>
-						logging
-							.ClearProviders()
-							.AddConsole()
-							.SetMinimumLevel(LogLevel.Debug))
+					.ConfigureLogging(logging => logging
+						.ClearProviders()
+						.AddConsole()
+						.SetMinimumLevel(LogLevel.Debug))
 					.ConfigureAppConfiguration((hostingContext, config) =>
 					{
 						config.AddCommandLine(args);
@@ -168,6 +114,7 @@ namespace Uno.UI.RemoteControl.Host
 					.ConfigureServices(services =>
 					{
 						services.AddSingleton<IIdeChannel, IdeChannelServer>();
+						services.AddSingleton<UnoDevEnvironmentService>();
 
 						// Add the global service provider to the DI container
 						services.AddKeyedSingleton<IServiceProvider>("global", globalServiceProvider);
@@ -184,6 +131,7 @@ namespace Uno.UI.RemoteControl.Host
 				else
 				{
 					typeof(Program).Log().Log(LogLevel.Warning, "No solution file specified, add-ins will not be loaded which means that you won't be able to use any of the uno-studio features. Usually this indicates that your version of uno's IDE extension is too old.");
+					builder.ConfigureServices(services => services.AddSingleton(AddInsStatus.Empty));
 				}
 
 				var host = builder.Build();
@@ -191,10 +139,9 @@ namespace Uno.UI.RemoteControl.Host
 				// Once the app has started, we use the logger from the host
 				Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = host.Services.GetRequiredService<ILoggerFactory>();
 
+				// Force resolution of the IDEChannel to enable connection (Note: We should use a BackgroundService instead)
 				host.Services.GetService<IIdeChannel>();
-
-				// Display DevServer version banner
-				DisplayVersionBanner();
+				_ = host.Services.GetRequiredService<UnoDevEnvironmentService>().StartAsync(ct.Token); // Background services are not supported by WebHostBuilder
 
 				// STEP 3: Use global telemetry for server-wide events
 				// Track devserver startup using global telemetry service
@@ -205,19 +152,11 @@ namespace Uno.UI.RemoteControl.Host
 
 				telemetry?.TrackEvent("startup", startupProperties, null);
 
-				_ = ParentProcessObserver.ObserveAsync(
-					parentPID,
-					() =>
-					{
-						shutdownRequested = true;
-						cancellationTokenSource.Cancel();
-					},
-					telemetry,
-					cancellationTokenSource.Token);
+				_ = ParentProcessObserver.ObserveAsync(parentPID, ct.Cancel, telemetry, ct.Token);
 
 				try
 				{
-					await host.RunAsync(cancellationTokenSource.Token);
+					await host.RunAsync(ct.Token);
 				}
 				finally
 				{
@@ -227,7 +166,7 @@ namespace Uno.UI.RemoteControl.Host
 						var uptime = TimeSpan.FromTicks(Stopwatch.GetElapsedTime(startTime).Ticks);
 						var shutdownProperties = new Dictionary<string, string>
 						{
-							["ShutdownType"] = shutdownRequested ? "Graceful" : "Crash",
+							["ShutdownType"] = ct.IsCancellationRequested ? "Graceful" : "Crash",
 						};
 						var shutdownMeasurements = new Dictionary<string, double>
 						{

--- a/src/Uno.UI.RemoteControl.Host/UnoDevEnvironmentService.cs
+++ b/src/Uno.UI.RemoteControl.Host/UnoDevEnvironmentService.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Uno.UI.RemoteControl.Host.Extensibility;
+using Uno.UI.RemoteControl.Messaging.IdeChannel;
+using Uno.UI.RemoteControl.Services;
+
+namespace Uno.UI.RemoteControl.Host;
+
+public class UnoDevEnvironmentService(IIdeChannel ideChannel, AddInsStatus addIns) : BackgroundService
+{
+	/// <inheritdoc />
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		DevelopmentEnvironmentStatusIdeMessage udeiMessage;
+		if (addIns.Discovery is null or { Error.Length: > 0 } or { AddIns: null }) // Count: 0 is considered as a valid result!
+		{
+			udeiMessage = new(
+				DevelopmentEnvironmentComponent.DevServer,
+				DevelopmentEnvironmentStatus.Warning,
+				"Failed to discover add-ins",
+				addIns.Discovery?.Error,
+				null,
+				[Command.OpenBrowser("Details", new Uri("https://aka.platform.uno/?udei-why"))]);
+		}
+		else if (addIns is { Assemblies: null } or { Discovery.AddIns.Count: > 0, Assemblies.Count: 0 }
+				|| addIns.Assemblies.Any(result => result.Error is not null))
+		{
+			udeiMessage = new(
+				DevelopmentEnvironmentComponent.DevServer,
+				DevelopmentEnvironmentStatus.Warning,
+				"Failed to load add-ins",
+				addIns.Discovery?.Error,
+				null,
+				[Command.OpenBrowser("Details", new Uri("https://aka.platform.uno/?udei-why"))]);
+		}
+		else
+		{
+			udeiMessage = new(
+				DevelopmentEnvironmentComponent.DevServer,
+				DevelopmentEnvironmentStatus.Ready,
+				"Dev-server is ready",
+				null,
+				null,
+				[Command.OpenBrowser("Details", new Uri("https://aka.platform.uno/?udei-why"))]);
+		}
+
+		await ideChannel.SendToIdeAsync(udeiMessage, stoppingToken);
+	}
+}

--- a/src/Uno.UI.RemoteControl.Messaging/IDEChannel/DevelopmentEnvironmentStatusIdeMessage.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IDEChannel/DevelopmentEnvironmentStatusIdeMessage.cs
@@ -1,6 +1,4 @@
 ﻿#nullable enable
-using System;
-
 namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
 
 /// <summary>

--- a/src/Uno.UI.RemoteControl.Messaging/IdeChannel/Command.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IdeChannel/Command.cs
@@ -10,4 +10,14 @@ namespace Uno.UI.RemoteControl.Messaging.IdeChannel;
 /// <param name="Text">Text content to display to the user.</param>
 /// <param name="Name">The name/id of the command (e.g. uno.hotreload.open_hotreload_window).</param>
 /// <param name="Parameter">A json serialized parameter to execute the command.</param>
-public record Command(string Text, string Name, string? Parameter = null);
+public record Command(string Text, string Name, string? Parameter = null)
+{
+	/// <summary>
+	/// Creates a command that requests to the IDE to open a link in the browser (internal or external).
+	/// </summary>
+	/// <param name="Text">User-friendly text for the link.</param>
+	/// <param name="Uri">Uri to navigate to.</param>
+	/// <returns></returns>
+	public static Command OpenBrowser(string Text, Uri Uri)
+		=> new(Text, "ide.open_browser", Uri.ToString());
+}

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -52,7 +52,7 @@ public partial class EntryPoint : IDisposable
 	private Action<string>? _warningAction;
 	private Action<string>? _errorAction;
 	private int _msBuildLogLevel;
-	private (System.Diagnostics.Process process, int port, CancellationTokenSource atachedServices)? _devServer;
+	private (System.Diagnostics.Process process, int port, CancellationTokenSource attachedServices)? _devServer;
 	private SemaphoreSlim _devServerGate = new(1);
 	private IServiceProvider? _visualStudioServiceProvider;
 	private bool _closing;
@@ -304,7 +304,7 @@ public partial class EntryPoint : IDisposable
 		_dte.Events.SolutionEvents.BeforeClosing -= _closeHandler;
 
 		_closing = true;
-		if (_devServer is { process: var devServer, atachedServices: var ct })
+		if (_devServer is { process: var devServer, attachedServices: var ct })
 		{
 			try
 			{
@@ -434,8 +434,8 @@ public partial class EntryPoint : IDisposable
 				return;
 			}
 
-			// Safety: Cancel previous services! (Should have alredy been cancelled by the exit handler);
-			_devServer?.atachedServices.Cancel();
+			// Safety: Cancel previous services! (Should have already been cancelled by the exit handler);
+			_devServer?.attachedServices.Cancel();
 
 			devServerCt = CancellationTokenSource.CreateLinkedTokenSource(_ct.Token);
 			if (_udei is not null)

--- a/src/Uno.UI.RemoteControl.VS/IDEChannel/IDEChannelClient.cs
+++ b/src/Uno.UI.RemoteControl.VS/IDEChannel/IDEChannelClient.cs
@@ -22,6 +22,8 @@ internal class IdeChannelClient
 
 	public event AsyncEventHandler<IdeMessage>? OnMessageReceived;
 
+	public long MessagesReceivedCount { get; private set; }
+
 	public IdeChannelClient(Guid pipeGuid, ILogger logger)
 	{
 		_logger = logger;
@@ -84,6 +86,8 @@ internal class IdeChannelClient
 	{
 		try
 		{
+			MessagesReceivedCount++;
+
 			var devServerMessage = IdeMessageSerializer.Deserialize(devServerMessageEnvelope);
 
 			_logger.Verbose($"IDE: IDEChannel message received {devServerMessage}");

--- a/src/Uno.UI.RemoteControl.VS/SimpleServiceProvider.cs
+++ b/src/Uno.UI.RemoteControl.VS/SimpleServiceProvider.cs
@@ -9,10 +9,18 @@ internal class SimpleServiceProvider : IServiceProvider, IDisposable
 	private ImmutableDictionary<Type, object> _services = ImmutableDictionary<Type, object>.Empty;
 
 	public void Register(Type contract, object instance)
-		=> ImmutableInterlocked.AddOrUpdate(ref _services, contract, instance, (_, __) => instance);
+		=> ImmutableInterlocked.AddOrUpdate(
+			ref _services,
+			contract ?? throw new ArgumentNullException(nameof(contract)),
+			instance ?? throw new ArgumentNullException(nameof(instance)),
+			(_, __) => instance);
 
 	public void Register<T>(T instance)
-		=> ImmutableInterlocked.AddOrUpdate(ref _services, typeof(T), instance ?? throw new ArgumentNullException(nameof(instance)), (_, __) => instance);
+		=> ImmutableInterlocked.AddOrUpdate(
+			ref _services,
+			typeof(T),
+			instance ?? throw new ArgumentNullException(nameof(instance)),
+			(_, __) => instance);
 
 	/// <inheritdoc />
 	public virtual object? GetService(Type serviceType)

--- a/src/Uno.UI.RemoteControl.VS/VSIXChannel/IUnoDevelopmentEnvironmentIndicator.cs
+++ b/src/Uno.UI.RemoteControl.VS/VSIXChannel/IUnoDevelopmentEnvironmentIndicator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Uno.UI.RemoteControl.Messaging.IdeChannel;
 

--- a/src/Uno.UI.RemoteControl.VS/VSIXChannel/UnoDevelopmentEnvironmentIndicatorExtensions.cs
+++ b/src/Uno.UI.RemoteControl.VS/VSIXChannel/UnoDevelopmentEnvironmentIndicatorExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.UI.RemoteControl.Messaging.IdeChannel;
+
+namespace Uno.IDE;
+
+internal static class UnoDevelopmentEnvironmentIndicatorExtensions
+{
+	/// <summary>
+	/// Indicates dev-server is starting successfully.
+	/// </summary>
+	public static async ValueTask NotifyDevServerStartingAsync(this IUnoDevelopmentEnvironmentIndicator udei, CancellationToken ct)
+		=> await udei.NotifyAsync(new DevelopmentEnvironmentStatusIdeMessage(DevelopmentEnvironmentComponent.DevServer, DevelopmentEnvironmentStatus.Initializing, "Starting", null, null, [Command.OpenBrowser("Details", new Uri("https://aka.platform.uno/?udei-why"))]), ct);
+
+	/// <summary>
+	/// Indicates dev-server process has been killed (and will not restart by its own).
+	/// </summary>
+	public static async ValueTask NotifyDevServerKilledAsync(this IUnoDevelopmentEnvironmentIndicator udei, CancellationToken ct)
+		=> await udei.NotifyAsync(new DevelopmentEnvironmentStatusIdeMessage(DevelopmentEnvironmentComponent.DevServer, DevelopmentEnvironmentStatus.Error, "Not running", null, null, [Command.OpenBrowser("Details", new Uri("https://aka.platform.uno/?udei-why"))]), ct);
+
+	/// <summary>
+	/// Indicates dev-server is restarting.
+	/// </summary>
+	public static async ValueTask NotifyDevServerRestartAsync(this IUnoDevelopmentEnvironmentIndicator udei, CancellationToken ct)
+		=> await udei.NotifyAsync(new DevelopmentEnvironmentStatusIdeMessage(DevelopmentEnvironmentComponent.DevServer, DevelopmentEnvironmentStatus.Warning, "Restarting", null, null, [Command.OpenBrowser("Details", new Uri("https://aka.platform.uno/?udei-why"))]), ct);
+
+	/// <summary>
+	/// Indicates dev-server is restarting.
+	/// </summary>
+	public static async ValueTask NotifyDevServerTimeoutAsync(this IUnoDevelopmentEnvironmentIndicator udei, CancellationToken ct)
+		=> await udei.NotifyAsync(new DevelopmentEnvironmentStatusIdeMessage(DevelopmentEnvironmentComponent.DevServer, DevelopmentEnvironmentStatus.Error, "Timeout", "Dev-server didn't connected back to IDE in the given delay", null, [Command.OpenBrowser("Details", new Uri("https://aka.platform.uno/?udei-why"))]), ct);
+}


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1490

## ✨ Feature
Add dev-server component messages in UDEI

## What is the current behavior? 🤔
Dev-server is silent for end-user

## What is the new behavior? 🚀
Dev-server status is reported in UDEI

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
