### PR TITLE
fix: Change MediaPlayer volume range to 0.0-1.0

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2138,7 +2138,6 @@
 	<IgnoreSet baseVersion="6.2">
 	  <Types>
 		  <Member fullName="Uno.Media.Playback.IMediaPlayerEventsExtension" reason="Does not exist in WinUI" />
-		  <Member fullName="Uno.Media.Playback.IMediaPlayerExtension" reason="Does not exist in WinUI" />
 		  <Member fullName="Uno.UI.MediaPlayer.Skia.X11.SharedMediaPlayerExtension" reason="Does not exist in WinUI" />
 		  <Member fullName="Uno.UI.MediaPlayer.Skia.Win32.SharedMediaPlayerExtension" reason="Does not exist in WinUI" />
 	  </Types>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2135,7 +2135,7 @@
 			<!-- END ListViewBase selection changes -->
 		</Methods>
 	</IgnoreSet>
-	<IgnoreSet baseVersion="6.2">
+	<IgnoreSet baseVersion="6.4">
 	  <Types>
 		  <Member fullName="Uno.Media.Playback.IMediaPlayerExtension" reason="Does not exist in WinUI" />
 		  <Member fullName="Uno.Media.Playback.IMediaPlayerEventsExtension" reason="Does not exist in WinUI" />

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2137,6 +2137,7 @@
 	</IgnoreSet>
 	<IgnoreSet baseVersion="6.2">
 	  <Types>
+		  <Member fullName="Uno.Media.Playback.IMediaPlayerExtension" reason="Does not exist in WinUI" />
 		  <Member fullName="Uno.Media.Playback.IMediaPlayerEventsExtension" reason="Does not exist in WinUI" />
 		  <Member fullName="Uno.UI.MediaPlayer.Skia.X11.SharedMediaPlayerExtension" reason="Does not exist in WinUI" />
 		  <Member fullName="Uno.UI.MediaPlayer.Skia.Win32.SharedMediaPlayerExtension" reason="Does not exist in WinUI" />

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -2135,6 +2135,14 @@
 			<!-- END ListViewBase selection changes -->
 		</Methods>
 	</IgnoreSet>
+	<IgnoreSet baseVersion="6.2">
+	  <Types>
+		  <Member fullName="Uno.Media.Playback.IMediaPlayerEventsExtension" reason="Does not exist in WinUI" />
+		  <Member fullName="Uno.Media.Playback.IMediaPlayerExtension" reason="Does not exist in WinUI" />
+		  <Member fullName="Uno.UI.MediaPlayer.Skia.X11.SharedMediaPlayerExtension" reason="Does not exist in WinUI" />
+		  <Member fullName="Uno.UI.MediaPlayer.Skia.Win32.SharedMediaPlayerExtension" reason="Does not exist in WinUI" />
+	  </Types>
+	</IgnoreSet>
 	<![CDATA[
 		The 'baseVersion' should be the current latest stable version published on nuget, 
 		NOT what will be published by the PR in progress.

--- a/src/AddIns/Uno.UI.MediaPlayer.Skia.X11/SharedMediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.Skia.X11/SharedMediaPlayerExtension.cs
@@ -28,7 +28,7 @@ namespace Uno.UI.MediaPlayer.Skia.Win32;
 namespace Uno.UI.MediaPlayer.Skia.X11;
 #endif
 
-public class SharedMediaPlayerExtension : IMediaPlayerExtension
+internal class SharedMediaPlayerExtension : IMediaPlayerExtension
 {
 	private static int _vlcInitialized;
 	private static LibVLC _vlc = null!;

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -21,7 +21,7 @@ using Uno.Helpers;
 
 namespace Uno.UI.Media;
 
-public partial class MediaPlayerExtension : IMediaPlayerExtension
+internal partial class MediaPlayerExtension : IMediaPlayerExtension
 {
 	private static Dictionary<MediaPlayer, MediaPlayerExtension> _instances = new();
 

--- a/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
+++ b/src/AddIns/Uno.UI.MediaPlayer.WebAssembly/MediaPlayerExtension.cs
@@ -21,7 +21,7 @@ using Uno.Helpers;
 
 namespace Uno.UI.Media;
 
-internal partial class MediaPlayerExtension : IMediaPlayerExtension
+public partial class MediaPlayerExtension : IMediaPlayerExtension
 {
 	private static Dictionary<MediaPlayer, MediaPlayerExtension> _instances = new();
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/MediaPlayerElement/MacOSMediaPlayerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UI/Xaml/Controls/MediaPlayerElement/MacOSMediaPlayerExtension.cs
@@ -256,7 +256,7 @@ internal class MacOSMediaPlayerExtension : IMediaPlayerExtension
 
 	public void OnVolumeChanged()
 	{
-		NativeUno.uno_mediaplayer_set_volume(_nativePlayer, (float)(_player.Volume / 100));
+		NativeUno.uno_mediaplayer_set_volume(_nativePlayer, (float)_player.Volume);
 	}
 
 	public void Pause()

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Controls/MediaPlayerElement/BrowserMediaPlayerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/UI/Xaml/Controls/MediaPlayerElement/BrowserMediaPlayerExtension.cs
@@ -243,7 +243,7 @@ internal partial class BrowserMediaPlayerExtension : IMediaPlayerExtension
 
 	public void ToggleMute() => NativeMethods.SetMuted(HtmlElement.ElementId, _player.IsMuted);
 
-	public void OnVolumeChanged() => NativeMethods.SetVolume(HtmlElement.ElementId, _player.Volume / 100);
+	public void OnVolumeChanged() => NativeMethods.SetVolume(HtmlElement.ElementId, _player.Volume);
 
 	public void OnOptionChanged(string name, object value) { }
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
@@ -462,7 +462,11 @@ namespace Microsoft.UI.Xaml.Controls
 		{
 			if (_mediaPlayer is not null)
 			{
-				_mediaPlayer.Volume = e.NewValue / 100.0;
+				var volume = e.NewValue / 100.0;
+				if (Math.Abs(_mediaPlayer.Volume - volume) > 0.001)
+				{
+					_mediaPlayer.Volume = volume;
+				}
 			}
 
 			UpdateVolumeMuteStates();
@@ -471,14 +475,11 @@ namespace Microsoft.UI.Xaml.Controls
 
 		private void OnPlayerVolumeChanged(_MediaPlayer sender, object e)
 		{
-			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+			var percent = Math.Round(sender.Volume * 100);
+			if (m_tpTHVolumeSlider != null && Math.Abs(m_tpTHVolumeSlider.Value - percent) > 0.1)
 			{
-				var percent = Math.Round(sender.Volume * 100);
-				if (m_tpTHVolumeSlider != null && Math.Abs(m_tpTHVolumeSlider.Value - percent) > 0.1)
-				{
-					m_tpTHVolumeSlider.Value = percent;
-				}
-			});
+				m_tpTHVolumeSlider.Value = percent;
+			}
 		}
 
 		private void ToggleMute(object sender, RoutedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
@@ -469,7 +469,7 @@ namespace Microsoft.UI.Xaml.Controls
 			ResetControlsVisibilityTimer();
 		}
 
-		private void OnPlayerVolumeChanged(MediaPlayer sender, object e)
+		private void OnPlayerVolumeChanged(_MediaPlayer sender, object e)
 		{
 			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.MediaPlayer.cs
@@ -458,7 +458,7 @@ namespace Microsoft.UI.Xaml.Controls
 				_mediaPlayer.PlaybackSession.UpdateTimePositionRate * 2;
 		}
 
-		private void OnVolumeChanged(object sender, RangeBaseValueChangedEventArgs e)
+		private void OnVolumeSliderVolumeChanged(object sender, RangeBaseValueChangedEventArgs e)
 		{
 			if (_mediaPlayer is not null)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayerElement/MediaTransportControls.cs
@@ -313,7 +313,7 @@ namespace Microsoft.UI.Xaml.Controls
 			// Flyout nested:
 			BindFlyout(m_tpVolumeFlyout, OnFlyoutOpened, OnFlyoutClosed);
 			BindButtonClick(m_tpMuteButton, ToggleMute);
-			Bind(m_tpTHVolumeSlider, x => x.ValueChanged += OnVolumeChanged, x => x.ValueChanged -= OnVolumeChanged);
+			Bind(m_tpTHVolumeSlider, x => x.ValueChanged += OnVolumeSliderVolumeChanged, x => x.ValueChanged -= OnVolumeSliderVolumeChanged);
 			BindFlyout(_playbackRateFlyout, OnFlyoutOpened, OnFlyoutClosed);
 			Bind(_playbackRateListView, x => x.SelectionChanged += PlaybackRateListView_SelectionChanged, x => x.SelectionChanged -= PlaybackRateListView_SelectionChanged);
 

--- a/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
@@ -22,13 +22,10 @@ namespace Uno.Media.Playback
 
 		/// <summary>
 		///	Raises the <see cref="MediaPlayer.VolumeChanged"/> event
+		///	Optionally, updates the <see cref="MediaPlayer.Volume"/> property
 		/// </summary>
-		void RaiseVolumeChanged();
-
-		/// <summary>
-		///	Raises the <see cref="MediaPlayer.VolumeChanged"/> event
-		/// </summary>
-		void RaiseExternalVolumeChanged(double newVolume);
+		/// <param name="newVolume">The new volume, in case an external volume changed was detected.</param>
+		void RaiseVolumeChanged(double? newVolume = null);
 
 		/// <summary>
 		///	Raises the <see cref="MediaPlayer.MediaEnded"/> event

--- a/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
@@ -8,7 +8,7 @@ namespace Uno.Media.Playback
 	/// <summary>
 	/// Extension interface for <see cref="MediaPlayer"/> events
 	/// </summary>
-	internal interface IMediaPlayerEventsExtension
+	public interface IMediaPlayerEventsExtension
 	{
 		/// <summary>
 		/// Raises the <see cref="MediaPlayer.SourceChanged"/> event

--- a/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
@@ -26,6 +26,11 @@ namespace Uno.Media.Playback
 		void RaiseVolumeChanged();
 
 		/// <summary>
+		///	Raises the <see cref="MediaPlayer.VolumeChanged"/> event
+		/// </summary>
+		void RaiseExternalVolumeChanged(double newVolume);
+
+		/// <summary>
 		///	Raises the <see cref="MediaPlayer.MediaEnded"/> event
 		/// </summary>
 		void RaiseMediaEnded();

--- a/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlayerEventsExtension.cs
@@ -8,7 +8,7 @@ namespace Uno.Media.Playback
 	/// <summary>
 	/// Extension interface for <see cref="MediaPlayer"/> events
 	/// </summary>
-	public interface IMediaPlayerEventsExtension
+	internal interface IMediaPlayerEventsExtension
 	{
 		/// <summary>
 		/// Raises the <see cref="MediaPlayer.SourceChanged"/> event

--- a/src/Uno.UWP/Media/Playback/IMediaPlayerExtension.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlayerExtension.cs
@@ -12,7 +12,7 @@ namespace Uno.Media.Playback
 	/// <summary>
 	/// Extension definition for the <see cref="MediaPlayer"/> class
 	/// </summary>
-	public interface IMediaPlayerExtension : IDisposable
+	internal interface IMediaPlayerExtension : IDisposable
 	{
 		/// <summary>
 		/// Provides access to the ability to raise MediaPlayer events

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -358,14 +358,14 @@ namespace Windows.Media.Playback
 			}
 			else
 			{
-				var volume = (float)Volume / 100;
+				var volume = (float)Volume;
 				_player?.SetVolume(volume, volume);
 			}
 		}
 
 		private void OnVolumeChanged()
 		{
-			var volume = (float)Volume / 100;
+			var volume = (float)Volume;
 			_player?.SetVolume(volume, volume);
 		}
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Apple.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Apple.cs
@@ -499,7 +499,7 @@ namespace Windows.Media.Playback
 		{
 			if (_player != null)
 			{
-				_player.Volume = (float)Volume / 100;
+				_player.Volume = (float)Volume;
 			}
 		}
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Events.others.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Events.others.cs
@@ -55,12 +55,12 @@ namespace Windows.Media.Playback
 		void RaiseNaturalVideoDimensionChanged()
 			=> NaturalVideoDimensionChanged?.Invoke(this, null);
 
-		void RaiseVolumeChanged()
-			=> VolumeChanged?.Invoke(this, null);
-
-		void RaiseExternalVolumeChanged(double newVolume)
+		void RaiseVolumeChanged(double? newVolume = null)
 		{
-			_volume = Math.Clamp(newVolume, 0.0, 1.0);
+			if (newVolume != null)
+			{
+				_volume = Math.Clamp(newVolume.Value, 0.0, 1.0);
+			}
 			VolumeChanged?.Invoke(this, null);
 		}
 
@@ -121,11 +121,8 @@ namespace Windows.Media.Playback
 			void IMediaPlayerEventsExtension.RaiseNaturalVideoDimensionChanged()
 				=> _owner.RaiseNaturalVideoDimensionChanged();
 
-			void IMediaPlayerEventsExtension.RaiseVolumeChanged()
-				=> _owner.RaiseVolumeChanged();
-
-			void IMediaPlayerEventsExtension.RaiseExternalVolumeChanged(double newVolume)
-				=> _owner.RaiseExternalVolumeChanged(newVolume);
+			void IMediaPlayerEventsExtension.RaiseVolumeChanged(double? newVolume)
+				=> _owner.RaiseVolumeChanged(newVolume);
 
 			public void RaisePositionChanged()
 				=> _owner.RaisePositionChanged();

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Events.others.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Events.others.cs
@@ -58,6 +58,12 @@ namespace Windows.Media.Playback
 		void RaiseVolumeChanged()
 			=> VolumeChanged?.Invoke(this, null);
 
+		void RaiseExternalVolumeChanged(double newVolume)
+		{
+			_volume = Math.Clamp(newVolume, 0.0, 1.0);
+			VolumeChanged?.Invoke(this, null);
+		}
+
 		void RaisePositionChanged()
 			=> PlaybackSession.Position = _extension?.Position ?? TimeSpan.Zero;
 
@@ -117,6 +123,9 @@ namespace Windows.Media.Playback
 
 			void IMediaPlayerEventsExtension.RaiseVolumeChanged()
 				=> _owner.RaiseVolumeChanged();
+
+			void IMediaPlayerEventsExtension.RaiseExternalVolumeChanged(double newVolume)
+				=> _owner.RaiseExternalVolumeChanged(newVolume);
 
 			public void RaisePositionChanged()
 				=> _owner.RaisePositionChanged();

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.cs
@@ -58,9 +58,12 @@ namespace Windows.Media.Playback
 			get => _volume;
 			set
 			{
-				_volume = value;
-				OnVolumeChanged();
-				VolumeChanged?.Invoke(this, _volume);
+				if (value >= 0.0 && value <= 1.0)
+				{
+					_volume = value;
+					OnVolumeChanged();
+					VolumeChanged?.Invoke(this, _volume);
+				}
 			}
 		}
 


### PR DESCRIPTION
**GitHub Issue:** closes #21128

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

Although the Volume of MediaPlayer is defined as range 0.0-1.0, the Uno implementation incorrectly assumes it to be 0.0-100.0. When using standard conform volume on MediaPlayer, sound is inaudible.

Additionally, on the Windows platform, LibVLC uses a per-process volume control, displayed in the Windows volume mixer. So all LibVLC instances in one process share the same volume and volume changes done on one instance apply to all instances. Also, volume changes in the Windows volume mixer apply to all instances. But the "VolumeChanged" event from LibVLC was not handled, so instances reported wrong (old) volume, if the volume was changed in the mixer or in a different instance.


## What is the new behavior? 🚀

Fixed up the Uno implementation to use the correct 0.0-1.0 volume range on all platforms.

Additionally, the VolumeChanged event from LibVLC is handled to allow propagation of extenal volume changes (though windows volume mixer or other LibVLC instance), so the Volume property always reports the actual volume.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->