### PR TITLE
fix: Do not throw when setting RenderPhase property on Skia

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.skia.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.skia.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Windows.Foundation;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Uno;
 using Uno.UI.Xaml;
 
 namespace Microsoft.UI.Xaml
@@ -61,13 +62,21 @@ namespace Microsoft.UI.Xaml
 			return finalSize;
 		}
 
+		[NotImplemented]
 		public int? RenderPhase
 		{
-			get => throw new NotImplementedException();
-			set => throw new NotImplementedException();
+			get
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.FrameworkElement", "RenderPhase");
+				return null;
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.FrameworkElement", "RenderPhase");
+			}
 		}
 
-		public void ApplyBindingPhase(int phase) => throw new NotImplementedException();
+		public void ApplyBindingPhase(int phase) { }
 
 		#region Background DependencyProperty
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.unittests.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.unittests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Windows.Foundation;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Uno;
 using Uno.UI.Xaml;
 
 namespace Microsoft.UI.Xaml
@@ -73,13 +74,21 @@ namespace Microsoft.UI.Xaml
 			return finalSize;
 		}
 
+		[NotImplemented]
 		public int? RenderPhase
 		{
-			get => throw new NotImplementedException();
-			set => throw new NotImplementedException();
+			get
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.FrameworkElement", "RenderPhase");
+				return null;
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.FrameworkElement", "RenderPhase");
+			}
 		}
 
-		public void ApplyBindingPhase(int phase) => throw new NotImplementedException();
+		public void ApplyBindingPhase(int phase) { }
 
 		#region Background DependencyProperty
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Shapes;
 
+using Uno;
 using Uno.Extensions;
 using Uno.UI;
 using Uno.Disposables;
@@ -107,12 +108,20 @@ namespace Microsoft.UI.Xaml
 		}
 		#endregion
 
+		[NotImplemented]
 		public int? RenderPhase
 		{
-			get => throw new NotImplementedException();
-			set => throw new NotImplementedException();
+			get
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.FrameworkElement", "RenderPhase");
+				return null;
+			}
+			set
+			{
+				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Microsoft.UI.Xaml.FrameworkElement", "RenderPhase");
+			}
 		}
 
-		public void ApplyBindingPhase(int phase) => throw new NotImplementedException();
+		public void ApplyBindingPhase(int phase) { }
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** Related to #21244

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

When the x:RenderPhase attribute is set, a NotImplementedException is raised at startup. It is not possible to share DataTemplates between platforms which do support RenderPhase and platform which don't (e.g. Skia).

On WinUI, the x:RenderPhase can be applied to any UI element. But it is only ever used when applied to ListView or GridView ItemTemplate. Applying it to unsupported elements in WinUI does not throw exceptions.


## What is the new behavior? 🚀

Setting x:RenderPhase on unsupported elements or platforms does not throw exceptions anymore. It just does not have any effect. So now DataTemplates can be easily shared between all platforms.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->