### PR TITLE
ci: Set version to '6.4.0-dev.{height}' after 6.3 stable branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.3.0-dev.{height}",
+  "version": "6.4.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
Set version to '6.4.0-dev.{height}' after 6.3 stable branch creation