### PR TITLE
fix: Improve error reporting from the XamlReader

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj
@@ -21,7 +21,7 @@
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 
 		<!-- Keep full exception strings in release -->
-		<UseSystemResourceKeys>true</UseSystemResourceKeys>
+		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.Generic/SamplesApp.Skia.Generic.csproj
@@ -19,6 +19,9 @@
 		<RollForward>Major</RollForward>
 		
 		<ApplicationManifest>app.manifest</ApplicationManifest>
+
+		<!-- Keep full exception strings in release -->
+		<UseSystemResourceKeys>true</UseSystemResourceKeys>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SamplesApp/SamplesApp.Skia.WebAssembly.Browser/SamplesApp.Skia.WebAssembly.Browser.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.WebAssembly.Browser/SamplesApp.Skia.WebAssembly.Browser.csproj
@@ -32,6 +32,9 @@
 
 		<WasmShellEnableIDBFS>true</WasmShellEnableIDBFS>
 		<WasmBuildNative>true</WasmBuildNative>
+		
+		<!-- Keep full exception strings in release -->
+		<UseSystemResourceKeys>true</UseSystemResourceKeys>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SamplesApp/SamplesApp.Skia.WebAssembly.Browser/SamplesApp.Skia.WebAssembly.Browser.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.WebAssembly.Browser/SamplesApp.Skia.WebAssembly.Browser.csproj
@@ -32,9 +32,9 @@
 
 		<WasmShellEnableIDBFS>true</WasmShellEnableIDBFS>
 		<WasmBuildNative>true</WasmBuildNative>
-		
+
 		<!-- Keep full exception strings in release -->
-		<UseSystemResourceKeys>true</UseSystemResourceKeys>
+		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
@@ -46,6 +46,9 @@
 
 		<IsUIKit Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='maccatalyst' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='tvos'">true</IsUIKit>
 
+		<!-- Keep full exception strings in release -->
+		<UseSystemResourceKeys>true</UseSystemResourceKeys>
+
 		<!-- Required when not building inside VS to avoid dependency issues -->
 		<PreBuildUnoUITasks Condition="'$(BuildingInsideVisualStudio)'==''">true</PreBuildUnoUITasks>
 	</PropertyGroup>

--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
@@ -47,7 +47,7 @@
 		<IsUIKit Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='maccatalyst' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='tvos'">true</IsUIKit>
 
 		<!-- Keep full exception strings in release -->
-		<UseSystemResourceKeys>true</UseSystemResourceKeys>
+		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 
 		<!-- Required when not building inside VS to avoid dependency issues -->
 		<PreBuildUnoUITasks Condition="'$(BuildingInsideVisualStudio)'==''">true</PreBuildUnoUITasks>

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -41,6 +41,9 @@
 		When building in Release, see https://platform.uno/docs/articles/features/using-il-linker-webassembly.html
 		-->
 		<WasmShellILLinkerEnabled>false</WasmShellILLinkerEnabled>
+
+		<!-- Keep full exception strings in release -->
+		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.netcoremobile/SamplesApp.netcoremobile.csproj
@@ -44,6 +44,9 @@
 
 		<!-- We need all the intermediate assemblies -->
 		<DisablePrivateProjectReference>true</DisablePrivateProjectReference>
+
+		<!-- Keep full exception strings in release -->
+		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/UnoIslandsSamplesApp.Skia.Wpf.csproj
+++ b/src/SamplesApp/UnoIslandsSamplesApp.Skia.Wpf/UnoIslandsSamplesApp.Skia.Wpf.csproj
@@ -11,6 +11,9 @@
 		<!-- Required in CI to avoid dependency issues -->
 		<PreBuildUnoUITasks>true</PreBuildUnoUITasks>
 		<NoWarn>$(NoWarn);NU1701</NoWarn>
+
+		<!-- Keep full exception strings in release -->
+		<UseSystemResourceKeys>false</UseSystemResourceKeys>
 	</PropertyGroup>
 
 	<Import Project="../../targetframework-override-windows.props" />

--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlException.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlException.cs
@@ -42,7 +42,7 @@ namespace Uno.Xaml
 		}
 
 		public XamlException (string message, Exception innerException)
-			: this (message, null, 0, 0)
+			: this (message, innerException, 0, 0)
 		{
 		}
 

--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlException.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlException.cs
@@ -51,8 +51,8 @@ namespace Uno.Xaml
 			if (lineNumber <= 0)
 				return message;
 			if (linePosition <= 0)
-				return String.Format (CultureInfo.InvariantCulture, "{0} at line {1}", message, lineNumber);
-			return String.Format (CultureInfo.InvariantCulture, "{0} at line {1}, position {2}", message, lineNumber, linePosition);
+				return String.Format (CultureInfo.InvariantCulture, "{0} [Line: {1}]", message, lineNumber);
+			return String.Format (CultureInfo.InvariantCulture, "{0} [Line: {1} Position {2}]", message, lineNumber, linePosition);
 		}
 
 		public XamlException (string message, Exception innerException, int lineNumber, int linePosition)

--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlException.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlException.cs
@@ -52,7 +52,7 @@ namespace Uno.Xaml
 				return message;
 			if (linePosition <= 0)
 				return String.Format (CultureInfo.InvariantCulture, "{0} [Line: {1}]", message, lineNumber);
-			return String.Format (CultureInfo.InvariantCulture, "{0} [Line: {1} Position {2}]", message, lineNumber, linePosition);
+			return String.Format (CultureInfo.InvariantCulture, "{0} [Line: {1} Position: {2}]", message, lineNumber, linePosition);
 		}
 
 		public XamlException (string message, Exception innerException, int lineNumber, int linePosition)

--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlParseException.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlParseException.cs
@@ -40,8 +40,13 @@ namespace Uno.Xaml
 		{
 		}
 
-		public XamlParseException (string message, Exception innerException)
-			: base (message, innerException)
+		public XamlParseException(string message, Exception innerException)
+			: base(message, innerException)
+		{
+		}
+
+		public XamlParseException(string message, Exception innerException, int lineNumber, int linePosition)
+			: base(message, innerException, lineNumber, linePosition)
 		{
 		}
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_Parser.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/XamlCodeGeneratorTests/Given_Parser.cs
@@ -66,7 +66,7 @@ public class Given_Parser
 		test.ExpectedDiagnostics.AddRange(
 			new[] {
 				// /0/MainPage.xaml(13,5): error UXAML0001: Member 'PaneTitle' cannot have properties at line 13, position 5
-				DiagnosticResult.CompilerError("UXAML0001").WithSpan("C:/Project/0/MainPage.xaml", 13, 5, 13, 5).WithArguments("Member 'PaneTitle' cannot have properties at line 13, position 5"),
+				DiagnosticResult.CompilerError("UXAML0001").WithSpan("C:/Project/0/MainPage.xaml", 13, 5, 13, 5).WithArguments("Member 'PaneTitle' cannot have properties [Line: 13 Position: 5]"),
 				// /0/Test0.cs(9,9): error CS1061: 'MainPage' does not contain a definition for 'InitializeComponent' and no accessible extension method 'InitializeComponent' accepting a first argument of type 'MainPage' could be found (are you missing a using directive or an assembly reference?)
 				DiagnosticResult.CompilerError("CS1061").WithSpan(9, 9, 9, 28).WithArguments("TestRepro.MainPage", "InitializeComponent")
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
@@ -681,9 +681,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 
 			var aggregateException = (AggregateException)ex.InnerException;
 			Assert.AreEqual(5, (aggregateException.InnerExceptions[0] as XamlParseException).LineNumber);
-			Assert.AreEqual("Requested value 'Invalid' was not found. at line 5, position 6", (aggregateException.InnerExceptions[0] as XamlParseException).Message);
+			Assert.AreEqual("Requested value 'Invalid' was not found. [Line: 5 Position: 6]", (aggregateException.InnerExceptions[0] as XamlParseException).Message);
 			Assert.AreEqual(11, (aggregateException.InnerExceptions[1] as XamlParseException).LineNumber);
-			Assert.AreEqual("Requested value 'Invalid2' was not found. at line 11, position 9", (aggregateException.InnerExceptions[1] as XamlParseException).Message);
+			Assert.AreEqual("Requested value 'Invalid2' was not found. [Line: 11 Position: 9]", (aggregateException.InnerExceptions[1] as XamlParseException).Message);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -22,6 +22,7 @@ using SwipeControl = Microsoft.UI.Xaml.Controls.SwipeControl;
 using SwipeMode = Microsoft.UI.Xaml.Controls.SwipeMode;
 using Uno.UI.Tests.Helpers;
 using System.Numerics;
+using Uno.Xaml;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 {
@@ -841,7 +842,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		[TestMethod]
 		public void When_ImplicitStyle_WithoutKey()
 		{
-			Assert.ThrowsExactly<InvalidOperationException>(() =>
+			Assert.ThrowsExactly<XamlParseException>(() =>
 			{
 				var s = GetContent(nameof(When_ImplicitStyle_WithoutKey));
 				var r = Microsoft.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
@@ -1137,7 +1138,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		{
 			var xaml = "<CreateFromStringInvalidReturnTypeOwner Test=\"1\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
 			// TODO: This should throw XamlParseException too
-			Assert.ThrowsExactly<ArgumentException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
+			Assert.ThrowsExactly<XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Markup/XamlReaderTests/Given_XamlReader.cs
@@ -22,7 +22,6 @@ using SwipeControl = Microsoft.UI.Xaml.Controls.SwipeControl;
 using SwipeMode = Microsoft.UI.Xaml.Controls.SwipeMode;
 using Uno.UI.Tests.Helpers;
 using System.Numerics;
-using Uno.Xaml;
 
 namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 {
@@ -842,7 +841,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		[TestMethod]
 		public void When_ImplicitStyle_WithoutKey()
 		{
-			Assert.ThrowsExactly<XamlParseException>(() =>
+			Assert.ThrowsExactly<Uno.Xaml.XamlParseException>(() =>
 			{
 				var s = GetContent(nameof(When_ImplicitStyle_WithoutKey));
 				var r = Microsoft.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
@@ -1138,7 +1137,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests
 		{
 			var xaml = "<CreateFromStringInvalidReturnTypeOwner Test=\"1\" xmlns=\"using:Uno.UI.Tests.Windows_UI_Xaml_Markup.XamlReaderTests\" />";
 			// TODO: This should throw XamlParseException too
-			Assert.ThrowsExactly<XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
+			Assert.ThrowsExactly<Uno.Xaml.XamlParseException>(() => Microsoft.UI.Xaml.Markup.XamlReader.Load(xaml));
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -777,6 +777,15 @@ namespace Uno.UI
 			public static bool ForceHotReloadDisabled { get; set; }
 		}
 
+		public static class XamlReader
+		{
+			/// <summary>
+			/// When set to true, the XamlReader will throw an exception if it encounters properties in
+			/// the XAML that do not map to a property on the target object.
+			/// </summary>
+			public static bool FailOnUnknownProperties { get; set; }
+		}
+
 		public static class DatePicker
 		{
 #if __APPLE_UIKIT__

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -1526,7 +1526,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				var type = TypeResolver.FindType(xamlObjectDefinition.Type);
 				if (type == null)
 				{
-					AddXamlParseException($"The type {xamlObjectDefinition.Type} was not found.", xamlObjectDefinition);
+					AddXamlParseException($"The type '{xamlObjectDefinition.Type}' was not found.", xamlObjectDefinition);
 					return;
 				}
 
@@ -1586,7 +1586,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 								}
 								else if (member.Objects.Count > 0 && !TypeResolver.IsCollectionOrListType(dp.Type) && member.Objects.Count > 1)
 								{
-									AddXamlParseException($"The attachable property `{member.Member.Name}` on type `{type}` does not support multiple values.", xamlObjectDefinition);
+									AddXamlParseException($"The attachable property '{member.Member.Name}' on type '{type}' does not support multiple values.", xamlObjectDefinition);
 								}
 							}
 						}
@@ -1597,7 +1597,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						}
 						else if (FeatureConfiguration.XamlReader.FailOnUnknownProperties && propertyInfo == null && eventInfo == null && !IsNestedChildNode(member) && !IsBlankBaseMember(member))
 						{
-							AddXamlParseException($"The type `{type}` does not contain a property or event named '{member.Member.Name}'.", xamlObjectDefinition);
+							AddXamlParseException($"The type '{type}' does not contain a property or event named '{member.Member.Name}'.", xamlObjectDefinition);
 						}
 						else
 						{

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -698,7 +698,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						throw new XamlParseException(value is Inline
 							? $"Failed to assign to property '{typeof(TextBlock).FullName}.{nameof(TextBlock.Inlines)}' because the type '{value.GetType().FullName}' cannot be assigned to the type '{typeof(InlineCollection).FullName}'."
 							: $"Failed to assign to property '{typeof(TextBlock).FullName}.{nameof(TextBlock.Inlines)}'."
-						);
+						, null, control.LineNumber, control.LinePosition);
 					}
 					if (value is Inline inline)
 					{
@@ -851,7 +851,11 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 					}
 					else
 					{
-						throw new XamlParseException($"This Member '{propertyInfo.DeclaringType}.{propertyInfo.Name}' has more than one item, use the Items property");
+						throw new XamlParseException(
+							$"This Member '{propertyInfo.DeclaringType}.{propertyInfo.Name}' has more than one item, use the Items property"
+							, null
+							, member.LineNumber
+							, member.LinePosition);
 					}
 
 					static bool IsFrameworkElementResources(PropertyInfo propertyInfo) =>
@@ -1528,7 +1532,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				var type = TypeResolver.FindType(xamlObjectDefinition.Type);
 				if (type == null)
 				{
-					AddParseException(new XamlParseException($"The type {xamlObjectDefinition.Type} was not found. (Line {xamlObjectDefinition.LineNumber}:{xamlObjectDefinition.LinePosition})"));
+					AddParseException(new XamlParseException($"The type {xamlObjectDefinition.Type} was not found.", null, xamlObjectDefinition.LineNumber, xamlObjectDefinition.LinePosition));
 					return;
 				}
 
@@ -1541,7 +1545,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				{
 					if (xamlObjectDefinition.Members.Any(m => IsNestedChildNode(m)))
 					{
-						AddParseException(new XamlParseException($"The type '{type}' does not support direct content. (Line {xamlObjectDefinition.LineNumber}:{xamlObjectDefinition.LinePosition})"));
+						AddParseException(new XamlParseException($"The type '{type}' does not support direct content.", null, xamlObjectDefinition.LineNumber, xamlObjectDefinition.LinePosition));
 					}
 				}
 
@@ -1571,7 +1575,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 
 							if (dp is null)
 							{
-								AddParseException(new XamlParseException($"The attachable property '{member.Member.Name}' was not found in type '{type}'. (Line {member.LineNumber}:{member.LinePosition})"));
+								AddParseException(new XamlParseException($"The attachable property '{member.Member.Name}' was not found in type '{type}'.", null, xamlObjectDefinition.LineNumber, xamlObjectDefinition.LinePosition));
 							}
 							else
 							{
@@ -1588,7 +1592,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 								}
 								else if (member.Objects.Count > 0 && !TypeResolver.IsCollectionOrListType(dp.Type) && member.Objects.Count > 1)
 								{
-									AddParseException(new XamlParseException($"The attachable property `{member.Member.Name}` on type `{type}` does not support multiple values. (Line {member.LineNumber}:{member.LinePosition})"));
+									AddParseException(new XamlParseException($"The attachable property `{member.Member.Name}` on type `{type}` does not support multiple values.", null, xamlObjectDefinition.LineNumber, xamlObjectDefinition.LinePosition));
 								}
 							}
 						}
@@ -1599,7 +1603,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						}
 						else if (FeatureConfiguration.XamlReader.FailOnUnknownProperties && propertyInfo == null && eventInfo == null && !IsNestedChildNode(member) && !IsBlankBaseMember(member))
 						{
-							AddParseException(new XamlParseException($"The type `{type}` does not contain a property or event named '{member.Member.Name}'. (Line {member.LineNumber}:{member.LinePosition})"));
+							AddParseException(new XamlParseException($"The type `{type}` does not contain a property or event named '{member.Member.Name}'.", null, xamlObjectDefinition.LineNumber, xamlObjectDefinition.LinePosition));
 						}
 						else
 						{

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -1525,7 +1525,6 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				if (
 					xamlObjectDefinition.Type.Name == "ThemeResource"
 					|| xamlObjectDefinition.Type.Name == "StaticResource"
-					|| xamlObjectDefinition.Type.Name == "ThemeResource"
 				)
 				{
 					// Skip types that are not having explicit representations.
@@ -1603,11 +1602,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						else if (member.Member.PreferredXamlNamespace == XamlConstants.XamlXmlNamespace
 							&& (member.Member.Name == "Key" || member.Member.Name == "Name"))
 						{
-
-						}
-						else if (member.Member.Name == XamlConstants.XamlXmlNamespace && member.Member.Name == "Key")
-						{
-
+							// Skip, no validation needed
 						}
 						else if (FeatureConfiguration.XamlReader.FailOnUnknownProperties && propertyInfo == null && eventInfo == null && !IsNestedChildNode(member) && !IsBlankBaseMember(member))
 						{

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -22,10 +22,7 @@ using Uno.UI.Xaml.Markup;
 using Uno.Xaml;
 
 using Color = Windows.UI.Color;
-using Windows.Media.Playback;
 using System.Text;
-
-
 
 #if __ANDROID__
 using _View = Android.Views.View;


### PR DESCRIPTION
## PR Type:

- ✨ Feature

## What is the new behavior? 🚀

- Ensures that multiple parsing errors can be reported
- Ensures that parse errors in templates are reported immediately
- Fix XamlParseException and XamlException overloads

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->