### PR TITLE
fix(win32): Mutiple FileSavePicker updates

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml
@@ -36,7 +36,9 @@
                 BorderThickness="1"
                 CornerRadius="4">
                 <StackPanel Orientation="Horizontal" Spacing="4">
-                    <TextBox
+					<TextBlock 
+						Text="To add a file type selection group, first enter extension names one at a time, then press 'Add extension'. Once done, select a file choice name, then click Add file type choice." />
+					<TextBox
                         Width="140"
                         Header="File choice name"
                         Text="{x:Bind ViewModel.NewFileTypeChoice.Name, Mode=TwoWay}" />

--- a/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
+++ b/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
@@ -202,6 +202,7 @@ SetWindowLong
 SetWindowPos
 SetWindowRgn
 SetWindowText
+SHCreateItemFromParsingName
 ShowWindow
 SwapBuffers
 TranslateMessage

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
@@ -14,6 +14,8 @@ using Uno.Disposables;
 using Uno.Extensions.Storage.Pickers;
 using Uno.Foundation.Logging;
 using Uno.UI.Helpers.WinUI;
+using Uno.UI.Helpers;
+using System.Runtime.InteropServices;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
@@ -70,6 +72,37 @@ internal class Win32FileSaverExtension(FileSavePicker picker) : IFileSavePickerE
 						pattern.Dispose();
 					}
 				}, fileTypeList);
+
+		if (!string.IsNullOrWhiteSpace(picker.SuggestedFileName))
+		{
+			iFileSaveDialog.Value->SetFileName(picker.SuggestedFileName);
+		}
+
+		if (picker.SuggestedStartLocation != PickerLocationId.Unspecified)
+		{
+			var initialDirectory = PickerHelpers.GetInitialDirectory(picker.SuggestedStartLocation);
+
+			if (!string.IsNullOrEmpty(initialDirectory))
+			{
+				hResult = PInvoke.SHCreateItemFromParsingName(initialDirectory, null, IShellItem.IID_Guid, out var defaultFolderItemRaw);
+				if (hResult.Failed)
+				{
+					this.LogError()?.Error($"{nameof(PInvoke.SHCreateItemFromParsingName)} failed: {Win32Helper.GetErrorMessage(hResult)}");
+					return Task.FromResult<StorageFile?>(null);
+				}
+
+				using ComScope<IShellItem> defaultFolderItem = new((IShellItem*)defaultFolderItemRaw);
+
+				defaultFolderItem.Value->GetDisplayName(SIGDN.SIGDN_FILESYSPATH, out var path);
+
+				hResult = iFileSaveDialog.Value->SetDefaultFolder(defaultFolderItem);
+				if (hResult.Failed)
+				{
+					this.LogError()?.Error($"{nameof(IFileDialog.SetDefaultFolder)} failed: {Win32Helper.GetErrorMessage(hResult)}");
+					return Task.FromResult<StorageFile?>(null);
+				}
+			}
+		}
 
 		if (fileTypeList.Count > 0)
 		{
@@ -133,17 +166,21 @@ internal class Win32FileSaverExtension(FileSavePicker picker) : IFileSavePickerE
 		var ret = new List<(Win32Helper.NativeNulTerminatedUtf16String friendlyName, Win32Helper.NativeNulTerminatedUtf16String pattern)>();
 		foreach (var entry in picker.FileTypeChoices)
 		{
+			List<string> patternList = new();
+
 			foreach (var pattern in entry.Value)
 			{
 				if (pattern.StartsWith('.') && pattern[1..] is var ext && ext.All(char.IsLetterOrDigit))
 				{
-					ret.Add((new Win32Helper.NativeNulTerminatedUtf16String(entry.Key), new Win32Helper.NativeNulTerminatedUtf16String($"*{pattern}")));
+					patternList.Add($"*{pattern}");
 				}
 				else
 				{
 					this.LogError()?.Error($"Skipping invalid file extension pattern '{pattern}' for key {entry.Key}");
 				}
 			}
+
+			ret.Add((new Win32Helper.NativeNulTerminatedUtf16String(entry.Key), new Win32Helper.NativeNulTerminatedUtf16String(string.Join(";", patternList))));
 		}
 
 		return ret;

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
@@ -93,8 +93,6 @@ internal class Win32FileSaverExtension(FileSavePicker picker) : IFileSavePickerE
 
 				using ComScope<IShellItem> defaultFolderItem = new((IShellItem*)defaultFolderItemRaw);
 
-				defaultFolderItem.Value->GetDisplayName(SIGDN.SIGDN_FILESYSPATH, out var path);
-
 				hResult = iFileSaveDialog.Value->SetDefaultFolder(defaultFolderItem);
 				if (hResult.Failed)
 				{


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/21364

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the new behavior? 🚀

- Restore support for SuggestedStartLocation
- Restore support for SuggestedFileName
- Restore support multi-filetype group

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->