### PR TITLE
chore: exclude .github from LLMs script

### DIFF
--- a/doc/generate-llms-full.ps1
+++ b/doc/generate-llms-full.ps1
@@ -39,7 +39,10 @@ if ($Llmstxt) {
 
 # ── 2) Process all markdown files ───────────────────────────────────────────────
 Get-ChildItem $InputFolder -Recurse -Filter '*.md' |
-    Where-Object { $_.FullName -ne $headerResolved } |   # skip header if in tree
+    Where-Object {
+        $_.FullName -ne $headerResolved -and
+        $_.FullName -notmatch '[\\/]\.github[\\/]'
+    } |  # skip header if in tree + skip .github folder
     Sort-Object FullName |
     ForEach-Object {
         $text = Get-Content $_.FullName -Raw

--- a/doc/generate-llms-full.ps1
+++ b/doc/generate-llms-full.ps1
@@ -42,7 +42,7 @@ Get-ChildItem $InputFolder -Recurse -Filter '*.md' |
     Where-Object {
         $_.FullName -ne $headerResolved -and
         $_.FullName -notmatch '[\\/]\.github[\\/]'
-    } |  # skip header if in tree + skip .github folder
+    } |  # skip header if in tree and skip .github folder
     Sort-Object FullName |
     ForEach-Object {
         $text = Get-Content $_.FullName -Raw


### PR DESCRIPTION
## PR Type:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

The updated script now skips any `.md` files under the `.github` directory when generating the combined markdown file for LLM ingestion.


## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes