### PR TITLE
chore: Update to .NET 10 RC1

### DIFF
--- a/.vsts-ci-docs.yml
+++ b/.vsts-ci-docs.yml
@@ -22,7 +22,7 @@ variables:
 
   enable_dotnet_cache: true
   enable_emsdk_cache: true
-  GlobalUnoCheckVersion: '1.32.0-dev.45'
+  GlobalUnoCheckVersion: '1.33.0-dev.7'
 
 stages:
 - template: build/ci/.azure-devops-stages-docs.yml

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -69,7 +69,7 @@ variables:
 
   enable_dotnet_cache: true
   enable_emsdk_cache: true
-  GlobalUnoCheckVersion: '1.32.0-dev.45'
+  GlobalUnoCheckVersion: '1.33.0-dev.7'
 
 stages:
 - template: build/ci/.azure-devops-stages.yml

--- a/build/ci/net10/global.json
+++ b/build/ci/net10/global.json
@@ -1,11 +1,11 @@
 {
 	"sdk": {
-		"version": "10.0.100-preview.7.25380.108",
+		"version": "10.0.100-rc.1.25451.107",
 		"allowPrerelease": true,
 		"rollForward": "latestMinor"
 	},
 	"tools": {
-		"dotnet": "10.0.100-preview.7.25380.108"
+		"dotnet": "10.0.100-rc.1.25451.107"
 	},
 	"msbuild-sdks": {
 		"MSBuild.Sdk.Extras": "3.0.44",

--- a/build/ci/templates/dotnet-install.yml
+++ b/build/ci/templates/dotnet-install.yml
@@ -1,5 +1,5 @@
 parameters:
-  defaultDotNetSdkVersion: "10.0.100-preview.7.25380.108"
+  defaultDotNetSdkVersion: "10.0.100-rc.1.25451.107"
   haveCheckout: true
 
 steps:

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -126,7 +126,7 @@
 		<PackageReference Update="harfbuzzsharp.nativeassets.tvos" Version="$(HarfbuzzSharpVersion)" />
 
 		<PackageReference Condition=" '$(TargetFramework)' == '$(NetPrevious)' " Update="Microsoft.Win32.SystemEvents" Version="9.0.0" />
-		<PackageReference Condition=" '$(TargetFramework)' == '$(NetCurrent)' " Update="Microsoft.Win32.SystemEvents" Version="10.0.0-preview.7.25380.108" />
+		<PackageReference Condition=" '$(TargetFramework)' == '$(NetCurrent)' " Update="Microsoft.Win32.SystemEvents" Version="10.0.0-rc.1.25451.107" />
 
 		<PackageReference Update="Svg.Skia" Version="3.0.6" />
 		<PackageReference Update="GtkSharp" Version="3.24.24.38" />

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -301,7 +301,7 @@ namespace SamplesApp
 					$"PreviousState - {e.PreviousExecutionState}, " +
 					$"Uri - {protocolActivatedEventArgs.Uri}",
 					"Application activated via protocol");
-				if (ApiInformation.IsMethodPresent("Windows.UI.Popups.MessageDialog", nameof(MessageDialog.ShowAsync)))
+				if (ApiInformation.IsMethodPresent("Windows.UI.Popups.MessageDialog, Uno", nameof(MessageDialog.ShowAsync)))
 				{
 					await dlg.ShowAsync();
 				}

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RadioMenuFlyoutItemTests/RadioMenuFlyoutItemPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RadioMenuFlyoutItemTests/RadioMenuFlyoutItemPage.xaml.cs
@@ -27,14 +27,14 @@ namespace UITests.Shared.Microsoft_UI_Xaml_Controls.RadioMenuFlyoutItemTests
 
 			itemStates = new Dictionary<string, TextBlock>();
 
-			if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.MenuFlyoutItem", "Icon"))
+			if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.MenuFlyoutItem, Uno.UI", "Icon"))
 			{
 				IconMenuFlyoutItem.Icon = new SymbolIcon(Symbol.Calendar);
 				IconRadioMenuFlyoutItem.Icon = new SymbolIcon(Symbol.Calculator);
 				IconRadioMenuFlyoutItem2.Icon = new SymbolIcon(Symbol.Calculator);
 			}
 
-			if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.Grid", "ColumnSpacing"))
+			if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.Grid, Uno.UI", "ColumnSpacing"))
 			{
 				ItemNames.Spacing = 4;
 				ItemStates.Spacing = 4;

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RatingControlTests/RatingControlPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/RatingControlTests/RatingControlPage.xaml.cs
@@ -84,7 +84,7 @@ namespace UITests.Microsoft_UI_Xaml_Controls.RatingControlTests
 			//FrameDetails.Text = Window.Current.Bounds.ToString() + " " + cb.IsChecked.ToString();
 
 #if !HAS_UNO
-			if (ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Controls.RatingControl"))
+			if (ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Controls.RatingControl, Uno.UI"))
 			{
 				var wuxcRatingControl = new Microsoft.UI.Xaml.Controls.RatingControl();
 				wuxcRatingControl.Name = "WUXC RatingControl";

--- a/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TestAppUtils/FrameExtensions.cs
+++ b/src/SamplesApp/UITests.Shared/Microsoft_UI_Xaml_Controls/TestAppUtils/FrameExtensions.cs
@@ -13,7 +13,7 @@ static class FrameExtensions
 {
 	public static void NavigateWithoutAnimation(this Frame frame, Type sourcePageType)
 	{
-		if (ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Animation.SuppressNavigationTransitionInfo"))
+		if (ApiInformation.IsTypePresent("Windows.UI.Xaml.Media.Animation.SuppressNavigationTransitionInfo, Uno.UI"))
 		{
 			frame.Navigate(sourcePageType, new SuppressNavigationTransitionInfo());
 		}

--- a/src/SamplesApp/UITests.Shared/Windows_Phone/Devices_Notifications_VibrationDevice.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Phone/Devices_Notifications_VibrationDevice.xaml.cs
@@ -28,7 +28,7 @@ namespace UITests.Shared.Windows_Phone
 		public Devices_Notifications_VibrationDevice()
 		{
 			this.InitializeComponent();
-			if (ApiInformation.IsTypePresent("Windows.Phone.Devices.Notification.VibrationDevice"))
+			if (ApiInformation.IsTypePresent("Windows.Phone.Devices.Notification.VibrationDevice, Uno"))
 			{
 				try
 				{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_ViewManagement/IsScreenCaptureEnabledTests.xaml.cs
@@ -24,7 +24,7 @@ namespace UITests.Shared.Windows_UI_ViewManagement
 		public IsScreenCaptureEnabledTests()
 		{
 			this.InitializeComponent();
-			if (ApiInformation.IsPropertyPresent("Windows.UI.ViewManagement.ApplicationView", "IsScreenCaptureEnabled"))
+			if (ApiInformation.IsPropertyPresent("Windows.UI.ViewManagement.ApplicationView, Uno", "IsScreenCaptureEnabled"))
 			{
 				CaptureCheckBox.IsChecked = ApplicationView.GetForCurrentView().IsScreenCaptureEnabled;
 			}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControlPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/SwipeControlTests/SwipeControlPage.xaml.cs
@@ -125,7 +125,7 @@ namespace MUXControlsTestApp
 		//SwipeTestHooks.LastInteractedWithSwipeControlChanged += SwipeTestHooks_LastInteractedWithSwipeControlChanged;
 		//         MaterialHelperTestApiSetup();
 
-		//         if (ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Input.XamlUICommand"))
+		//         if (ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Input.XamlUICommand, Uno.UI"))
 		//         {
 		//             XamlUICommand uiCommand = new XamlUICommand
 		//             {

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/RadialGradientBrushPage.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/GradientBrushTests/RadialGradientBrushPage.xaml.cs
@@ -141,7 +141,7 @@ namespace MUXControlsTestApp
 			var centerColor = GetPixelAtPoint(new Point(rtb.PixelWidth / 2, rtb.PixelHeight / 2), rtb, pixelArray);
 			var outerColor = GetPixelAtPoint(new Point(0, 0), rtb, pixelArray);
 
-			if (ApiInformation.IsTypePresent("Microsoft.UI.Composition.CompositionRadialGradientBrush"))
+			if (ApiInformation.IsTypePresent("Microsoft.UI.Composition.CompositionRadialGradientBrush, Uno.UI.Composition"))
 			{
 				// If CompositionRadialGradientBrush is available then should be rendering a gradient.
 				if (centerColor == Microsoft.UI.Colors.Orange && outerColor == Microsoft.UI.Colors.Green)

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -141,7 +141,7 @@
 			"Microsoft.Extensions.Logging.Console"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.0-preview.7.25380.108"
+			"net10.0": "10.0.100-rc.1.25451.107"
 		}
 	},
 	{
@@ -151,7 +151,7 @@
 			"Microsoft.Windows.Compatibility"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.0-preview.7.25380.108"
+			"net10.0": "10.0.100-rc.1.25451.107"
 		}
 	},
 	{
@@ -297,7 +297,7 @@
 			"Microsoft.Maui.Graphics"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.0-preview.7.25406.3"
+			"net10.0": "10.0.100-rc.1.25451.107"
 		}
 	},
 	{

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -96,6 +96,11 @@ namespace Uno.UI.RemoteControl.Host
 
 				telemetry = globalServiceProvider.GetRequiredService<ITelemetry>();
 
+#pragma warning disable ASPDEPR004
+				// WebHostBuilder is deprecated in .NET 10 RC1.
+				// As we still build for .NET 9, ignore this warning until $(NetPrevious)=net10.
+				// https://github.com/aspnet/Announcements/issues/526
+
 				// STEP 2: Create the WebHost with reference to the global service provider
 				var builder = new WebHostBuilder()
 					.UseSetting("UseIISIntegration", false.ToString())
@@ -133,8 +138,12 @@ namespace Uno.UI.RemoteControl.Host
 					typeof(Program).Log().Log(LogLevel.Warning, "No solution file specified, add-ins will not be loaded which means that you won't be able to use any of the uno-studio features. Usually this indicates that your version of uno's IDE extension is too old.");
 					builder.ConfigureServices(services => services.AddSingleton(AddInsStatus.Empty));
 				}
+#pragma warning restore ASPDEPR004
 
+#pragma warning disable ASPDEPR008
+				// Ditto: https://github.com/aspnet/Announcements/issues/526
 				var host = builder.Build();
+#pragma warning restore ASPDEPR008
 
 				// Once the app has started, we use the logger from the host
 				Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory = host.Services.GetRequiredService<ILoggerFactory>();

--- a/src/Uno.UI.RuntimeTests/Extensions/DispatcherQueueExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Extensions/DispatcherQueueExtensions.cs
@@ -24,7 +24,7 @@ namespace Uno.UI.RuntimeTests.Extensions
 		/// <summary>
 		/// Indicates whether or not <see cref="DispatcherQueue.HasThreadAccess"/> is available.
 		/// </summary>
-		private static readonly bool IsHasThreadAccessPropertyAvailable = ApiInformation.IsMethodPresent("Windows.System.DispatcherQueue", "HasThreadAccess");
+		private static readonly bool IsHasThreadAccessPropertyAvailable = ApiInformation.IsMethodPresent("Windows.System.DispatcherQueue, Uno", "HasThreadAccess");
 
 		/// <summary>
 		/// Invokes a given function on the target <see cref="DispatcherQueue"/> and returns a

--- a/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.KeyboardHelper.cs
+++ b/src/Uno.UI.RuntimeTests/IntegrationTests/common/TestServices.KeyboardHelper.cs
@@ -129,7 +129,7 @@ namespace Private.Infrastructure
 				{"GamePadMenu",                 VirtualKey.GamepadMenu},
 			};
 
-			private static bool TargetSupportsPreviewKeyEvents() => ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.UIElement", "PreviewKeyDownEvent");
+			private static bool TargetSupportsPreviewKeyEvents() => ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.UIElement, Uno.UI", "PreviewKeyDownEvent");
 
 			public static async Task PressKeySequence(string keys, UIElement element = null)
 			{

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/IconSource/IconSourceApiTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/IconSource/IconSourceApiTests.cs
@@ -262,7 +262,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 				Verify.AreEqual(icon.UriSource, iconSource.UriSource);
 				Verify.AreEqual(bitmapIcon.UriSource, iconSource.UriSource);
 
-				if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.BitmapIcon", "ShowAsMonochrome"))
+				if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.BitmapIcon, Uno.UI", "ShowAsMonochrome"))
 				{
 					Verify.AreEqual(icon.ShowAsMonochrome, iconSource.ShowAsMonochrome);
 					Verify.AreEqual(bitmapIcon.ShowAsMonochrome, iconSource.ShowAsMonochrome);

--- a/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/NavigationView/NavigationViewTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Microsoft_UI_Xaml_Controls/NavigationView/NavigationViewTests.cs
@@ -864,7 +864,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 		[Ignore("This test is disabled in WinUI")]
 		public void VerifyCanNotAddWUXItems()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Controls.NavigationViewItem"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Controls.NavigationViewItem, Uno.UI"))
 			{
 				Log.Warning("WUX version of NavigationViewItem only available starting in RS3.");
 				return;

--- a/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/PersonPictureTests.cs
+++ b/src/Uno.UI.RuntimeTests/MUX/Windows_UI_Xaml_Controls/PersonPictureTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 				personPicture.Initials = "MS";
 				Verify.AreEqual(personPicture.Initials, "MS");
 
-				if (ApiInformation.IsTypePresent("Windows.ApplicationModel.Contacts.Contact"))
+				if (ApiInformation.IsTypePresent("Windows.ApplicationModel.Contacts.Contact, Uno"))
 				{
 					Contact contact = new Contact();
 					contact.FirstName = "FirstName";
@@ -79,7 +79,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 		[TestMethod]
 		public async Task VerifyAutomationName()
 		{
-			if (ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Automation.Peers.PersonPictureAutomationPeer"))
+			if (ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Automation.Peers.PersonPictureAutomationPeer, Uno.UI"))
 			{
 				await RunOnUIThread.ExecuteAsync(() =>
 				{
@@ -95,7 +95,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
 					automationName = AutomationProperties.GetName(personPicture);
 					Verify.AreEqual(automationName, "Jane Smith");
 
-					if (ApiInformation.IsTypePresent("Windows.ApplicationModel.Contacts.Contact"))
+					if (ApiInformation.IsTypePresent("Windows.ApplicationModel.Contacts.Contact, Uno"))
 					{
 						Contact contact = new Contact();
 						contact.FirstName = "John";

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_NavigationView.cs
@@ -181,7 +181,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 		[GitHubWorkItem("https://github.com/unoplatform/uno-private/issues/1091")]
 		public async Task When_Theme_Changes_NVItem_Foreground()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_RefreshContainer.cs
@@ -58,7 +58,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 		[RequiresFullWindow]
 		public async Task When_Child_Empty_List()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TreeView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Xaml_Controls/Given_TreeView.cs
@@ -453,7 +453,7 @@ namespace Uno.UI.RuntimeTests.Tests.Microsoft_UI_Xaml_Controls
 		[RequiresFullWindow]
 		public async Task When_ItemTemplateSelector_DataTemplate_Root_IsNot_TreeViewItem()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_AppDataUriEvaluator.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_Helpers/Given_AppDataUriEvaluator.cs
@@ -224,7 +224,7 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_Helpers
 		[TestMethod]
 		public void When_NonExistent_Method_Check()
 		{
-			Assert.IsFalse(ApiInformation.IsMethodPresent("Microsoft.UI.Composition.Compositor", "IDontExist"));
+			Assert.IsFalse(ApiInformation.IsMethodPresent("Microsoft.UI.Composition.Compositor, Uno.UI.Composition", "IDontExist"));
 		}
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_Foundation/Metadata/Given_ApiInformation.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_Foundation/Metadata/Given_ApiInformation.cs
@@ -15,9 +15,9 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_Foundation.Metadata
 			// but the second call resulted in false
 
 			// Application.Current is implemented on all targets
-			var isPresent = ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Application", "Current");
+			var isPresent = ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Application, Uno.UI", "Current");
 			Assert.IsTrue(isPresent);
-			var secondIsPresent = ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Application", "Current");
+			var secondIsPresent = ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Application, Uno.UI", "Current");
 			Assert.IsTrue(secondIsPresent);
 		}
 

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_MemoryManager.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_System/Given_MemoryManager.cs
@@ -25,7 +25,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_System
 
 		private void EnsureApiAvailable(string propertyName)
 		{
-			if (!Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Windows.System.MemoryManager", propertyName))
+			if (!Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Windows.System.MemoryManager, Uno", propertyName))
 			{
 				Assert.Inconclusive($"The Api {propertyName} is not implemented");
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FlowDirection.cs
@@ -82,7 +82,7 @@ public class Given_FlowDirection
 	[RequiresFullWindow]
 	public async Task When_RTL()
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}
@@ -300,7 +300,7 @@ public class Given_FlowDirection
 	[RequiresFullWindow]
 	public async Task When_RTL_RenderTransform_Translation()
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}
@@ -431,7 +431,7 @@ public class Given_FlowDirection
 	[RequiresFullWindow]
 	public async Task When_RTL_RenderTransform_Scaling()
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}
@@ -563,7 +563,7 @@ public class Given_FlowDirection
 	[RequiresFullWindow]
 	public async Task When_RTL_RenderTransform_Composite()
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_FrameworkElement.cs
@@ -435,7 +435,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_Alignment_Changes_During_Measure()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml/Given_UIElement.cs
@@ -90,7 +90,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[DataRow(10)]
 		public async Task When_Both_Layouting_Clip_And_Clip_DP(double newClipValue)
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -147,7 +147,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 #endif
 		public async Task When_TranslateTransform_And_Clip()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -1251,7 +1251,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml
 		[RunsOnUIThread]
 		public async Task When_Measure_Explicitly_Called()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Border.cs
@@ -178,7 +178,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		public async Task When_Clip_And_CornerRadius()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -213,7 +213,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		public async Task When_Clipped_With_TransformMatrix()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -332,7 +332,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			// Verify that border is drawn with the same thickness with/without CornerRadius
 			const string white = "#FFFFFFFF";
 
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -382,7 +382,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			const string lightPink = "#FF7F7F";
 			const string lightBlue = "#7F7FFF";
 
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -446,7 +446,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		{
 			const string red = "#FFFF0000";
 
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -485,7 +485,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		{
 			const string blue = "#FF0000FF";
 
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -591,7 +591,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if __APPLE_UIKIT__
 			Assert.Inconclusive(); // iOS not working currently. https://github.com/unoplatform/uno/issues/6749
 #endif
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -743,7 +743,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task Border_CornerRadius_GradientBrush()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Canvas_Measurement.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Canvas_Measurement.cs
@@ -43,7 +43,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RequiresFullWindow]
 		public async Task When_Verify_Canvas_With_Outer_Clip()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 			}
@@ -71,7 +71,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #if __APPLE_UIKIT__
 			Assert.Inconclusive(); // iOS doesn't support Canvas.ZIndex on any panel
 #endif
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -106,7 +106,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Verify_Canvas_In_Canvas()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 			}
@@ -125,7 +125,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		public async Task When_Canvas_Larger_Than_Parent_Should_Not_Clip()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ComboBox.cs
@@ -118,7 +118,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_IsEditable_False_Changes_To_True()
 		{
-			if (!ApiInformation.IsPropertyPresent("ComboBox", "IsEditable"))
+			if (!ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.ComboBox, Uno.UI", "IsEditable"))
 			{
 				Assert.Inconclusive();
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CommandBar.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CommandBar.cs
@@ -28,7 +28,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task TestNativeCommandBarIcon()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_FlipView.cs
@@ -61,7 +61,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RequiresFullWindow]
 		public async Task When_Given_Infinite_Width()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 			}
@@ -103,7 +103,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Background_Color()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Grid.cs
@@ -551,7 +551,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		public async Task When_Negative_Margin_Should_Not_Clip()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 			}
@@ -616,7 +616,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		public async Task When_RenderTransform_Ensure_Correct_Clipping()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Image.cs
@@ -331,7 +331,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_Image_Source_Nullify()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -388,7 +388,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 #endif
 		public async Task When_Image_Is_Monochromatic()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -508,7 +508,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[DataRow("ms-appx:///Uno.UI.RuntimeTests/Assets/help.svg")]
 		public async Task When_SVGImageSource(string imagePath)
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive("RenderTargetBitmap is not supported on this platform");
 			}
@@ -523,7 +523,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_SVGImageSource_Uri_Is_Null()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -538,7 +538,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_SVGImageSource_Uri_Is_Set_Null()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -622,7 +622,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_Exif_Rotated_MsAppx()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -634,7 +634,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_Exif_Rotated_MsAppx_Unequal_Dimensions()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -660,7 +660,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_Exif_Rotated_MsAppData()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -693,7 +693,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/20727")]
 		public async Task When_Alpha_Blending()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive("RenderTargetBitmap is not supported on this platform");
 			}
@@ -735,7 +735,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[RunsOnUIThread]
 		public async Task When_Exif_Rotated_From_Stream()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_ScrollViewer.cs
@@ -582,7 +582,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Scrolled_ViewportSizeLargerThanContent()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive();
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -56,7 +56,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[DataRow((ushort)600, FontStyle.Normal, FontStretch.SemiCondensed, "ms-appx:///Assets/Fonts/OpenSans/OpenSans_SemiCondensed-SemiBold.ttf#Open Sans")]
 		public async Task When_Font_Has_Manifest(ushort weight, FontStyle style, FontStretch stretch, string ttfFile)
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -228,7 +228,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			Assert.AreEqual("\r", segments[1].Text.ToString());
 #endif
 
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -618,7 +618,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Inlines_Transitively_Change()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -1007,7 +1007,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 		[TestMethod]
 		public async Task When_Padding()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive("RenderTargetBitmap is not supported on this platform");
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_GradientBrush.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_GradientBrush.cs
@@ -22,7 +22,7 @@ public class Given_GradientBrush
 	[RunsOnUIThread]
 	public async Task When_GradientStop_Color_Changes()
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 		}
@@ -62,7 +62,7 @@ public class Given_GradientBrush
 #endif
 	public async Task When_RadialGradientBrush_Ellipse_With_Non_Equal_Center_And_Origin()
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 		}
@@ -113,7 +113,7 @@ public class Given_GradientBrush
 #endif
 	public async Task When_RadialGradientBrush_Ellipse_With_Equal_Center_And_Origin()
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 		}
@@ -164,7 +164,7 @@ public class Given_GradientBrush
 #endif
 	public async Task When_RadialGradientBrush_Circle_With_Non_Equal_Center_And_Origin()
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 		}
@@ -215,7 +215,7 @@ public class Given_GradientBrush
 #endif
 	public async Task When_RadialGradientBrush_Circle_With_Equal_Center_And_Origin()
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // "System.NotImplementedException: RenderTargetBitmap is not supported on this platform.";
 		}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrush.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_ImageBrush.cs
@@ -43,7 +43,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 			const string Greenish = "#FF0ED145";
 			const string Transparent = "#00000000";
 
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_BitmapSource.cs
@@ -199,7 +199,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 		[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.NativeIOS)] // https://github.com/unoplatform/uno/issues/9080
 		public async Task When_Uri_Nullified()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive("Taking screenshots is not possible on this target platform.");
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_WriteableBitmap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_WriteableBitmap.cs
@@ -33,7 +33,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 #endif
 		public async Task When_Invalidated()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -84,7 +84,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 		[RunsOnUIThread]
 		public async Task When_WriteableBitmap_Assigned_With_Data_Present()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}
@@ -142,7 +142,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 #endif
 		public async Task When_WriteableBitmap_SetSource_Should_Update_PixelWidth_And_PixelHeight()
 		{
-			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+			if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 			{
 				Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 			}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Rectangle.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Shapes/Given_Rectangle.cs
@@ -81,7 +81,7 @@ public class Given_Rectangle
 #endif
 	public async Task When_StrokeThickness_Is_GreaterThan_Or_Equals_Width(double width, double height, double strokeThickness, double expectedWidth, double expectedHeight)
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}
@@ -119,7 +119,7 @@ public class Given_Rectangle
 #endif
 	public async Task When_StrokeThickness_Should_Arrange_Correctly(double strokeThickness, double expectedGreenWidth, double expectedGreenHeight)
 	{
-		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap"))
+		if (!ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.Imaging.RenderTargetBitmap, Uno.UI"))
 		{
 			Assert.Inconclusive(); // System.NotImplementedException: RenderTargetBitmap is not supported on this platform.;
 		}

--- a/src/Uno.UI/Helpers/WinUI/SharedHelpers.cs
+++ b/src/Uno.UI/Helpers/WinUI/SharedHelpers.cs
@@ -163,7 +163,7 @@ namespace Uno.UI.Helpers.WinUI
 		{
 			if (s_IsXamlCompositionBrushBaseAvailable_isAvailable == null)
 			{
-				s_IsXamlCompositionBrushBaseAvailable_isAvailable = IsRS3OrHigher() || ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.XamlCompositionBrushBase");
+				s_IsXamlCompositionBrushBaseAvailable_isAvailable = IsRS3OrHigher() || ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.XamlCompositionBrushBase, Uno.UI");
 			}
 
 			// On RS3 we know XamlCompositionBrushBase was always present, so short circuit the check there.
@@ -216,7 +216,7 @@ namespace Uno.UI.Helpers.WinUI
 				s_isFlyoutShowOptionsAvailable =
 					IsSystemDll() ||
 					Is19H1OrHigher() ||
-					ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Primitives.FlyoutShowOptions");
+					ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Primitives.FlyoutShowOptions, Uno.UI");
 			}
 			return s_isFlyoutShowOptionsAvailable.Value;
 		}
@@ -245,7 +245,7 @@ namespace Uno.UI.Helpers.WinUI
 				s_isScrollViewerReduceViewportForCoreInputViewOcclusionsAvailable =
 					IsSystemDll() ||
 					Is19H1OrHigher() ||
-					ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.ScrollViewer", "ReduceViewportForCoreInputViewOcclusions");
+					ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.ScrollViewer, Uno.UI", "ReduceViewportForCoreInputViewOcclusions");
 			}
 			return s_isScrollViewerReduceViewportForCoreInputViewOcclusionsAvailable.Value;
 		}
@@ -258,7 +258,7 @@ namespace Uno.UI.Helpers.WinUI
 				s_isScrollContentPresenterSizesContentToTemplatedParentAvailable =
 					IsSystemDll() ||
 					Is19H1OrHigher() ||
-					ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.ScrollContentPresenter", "SizesContentToTemplatedParent");
+					ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.ScrollContentPresenter, Uno.UI", "SizesContentToTemplatedParent");
 			}
 			return s_isScrollContentPresenterSizesContentToTemplatedParentAvailable.Value;
 		}
@@ -270,7 +270,7 @@ namespace Uno.UI.Helpers.WinUI
 			{
 				s_isBringIntoViewOptionsVerticalAlignmentRatioAvailable =
 					IsRS4OrHigher() ||
-					ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.BringIntoViewOptions", "VerticalAlignmentRatio");
+					ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.BringIntoViewOptions, Uno.UI", "VerticalAlignmentRatio");
 			}
 			return s_isBringIntoViewOptionsVerticalAlignmentRatioAvailable.Value;
 		}
@@ -293,7 +293,7 @@ namespace Uno.UI.Helpers.WinUI
 			{
 				s_isDisplayRegionGetForCurrentViewAvailable =
 					Is19H1OrHigher() ||
-					ApiInformation.IsMethodPresent("Windows.ApplicationModel.Core.DisplayRegion", "GetForCurrentView");
+					ApiInformation.IsMethodPresent("Windows.ApplicationModel.Core.DisplayRegion, Uno", "GetForCurrentView");
 			}
 			return s_isDisplayRegionGetForCurrentViewAvailable.Value;
 		}
@@ -314,7 +314,7 @@ namespace Uno.UI.Helpers.WinUI
 				s_IsIconSourceElementAvailable_isAvailable =
 					IsSystemDll() ||
 					Is19H1OrHigher() ||
-					ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Controls.IconSourceElement");
+					ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Controls.IconSourceElement, Uno.UI");
 			}
 			return s_IsIconSourceElementAvailable_isAvailable.Value;
 		}
@@ -327,8 +327,8 @@ namespace Uno.UI.Helpers.WinUI
 				s_IsStandardUICommandAvailable_isAvailable =
 					IsSystemDll() ||
 					Is19H1OrHigher() ||
-					(ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Input.XamlUICommand") &&
-						ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Input.StandardUICommand"));
+					(ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Input.XamlUICommand, Uno.UI") &&
+						ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Input.StandardUICommand, Uno.UI"));
 			}
 			return s_IsStandardUICommandAvailable_isAvailable.Value;
 		}
@@ -341,7 +341,7 @@ namespace Uno.UI.Helpers.WinUI
 				s_IsXamlRootAvailable =
 				   IsSystemDll() ||
 				   IsVanadiumOrHigher() ||
-				   ApiInformation.IsTypePresent("Microsoft.UI.Xaml.XamlRoot");
+				   ApiInformation.IsTypePresent("Microsoft.UI.Xaml.XamlRoot, Uno.UI");
 
 			}
 			return s_IsXamlRootAvailable.Value;
@@ -356,7 +356,7 @@ namespace Uno.UI.Helpers.WinUI
 				s_isThemeShadowAvailable =
 					(IsSystemDll() ||
 					IsVanadiumOrHigher()) &&
-					ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.ThemeShadow");
+					ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.ThemeShadow, Uno.UI");
 			}
 			return s_isThemeShadowAvailable.Value;
 		}
@@ -369,7 +369,7 @@ namespace Uno.UI.Helpers.WinUI
 				s_IsIsLoadedAvailable =
 					IsSystemDll() ||
 					IsRS5OrHigher() ||
-					ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.FrameworkElement", "IsLoaded");
+					ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.FrameworkElement, Uno.UI", "IsLoaded");
 			}
 			return s_IsIsLoadedAvailable.Value;
 		}
@@ -721,7 +721,7 @@ namespace Uno.UI.Helpers.WinUI
 					bitmapIcon.Foreground = bitmapIconSource.Foreground;
 				}
 
-				if (IsSystemDll() || ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.BitmapIcon", "ShowAsMonochrome"))
+				if (IsSystemDll() || ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Controls.BitmapIcon, Uno.UI", "ShowAsMonochrome"))
 				{
 					bitmapIcon.ShowAsMonochrome = bitmapIconSource.ShowAsMonochrome;
 				}

--- a/src/Uno.UI/UI/Xaml/Controls/ColorPicker/ColorPickerSliderAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ColorPicker/ColorPickerSliderAutomationPeer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.UI.Xaml.Automation.Peers
 
 		public void RaisePropertyChangedEvent(Color oldColor, Color newColor, int oldValue, int newValue)
 		{
-			if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Automation.ValuePatternIdentifiers", nameof(ValuePatternIdentifiers.ValueProperty)))
+			if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Automation.ValuePatternIdentifiers, Uno.UI", nameof(ValuePatternIdentifiers.ValueProperty)))
 			{
 				string oldValueString = GetValueString(oldColor, oldValue);
 				string newValueString = GetValueString(newColor, newValue);

--- a/src/Uno.UI/UI/Xaml/Controls/ColorPicker/ColorSpectrumAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ColorPicker/ColorSpectrumAutomationPeer.cs
@@ -112,7 +112,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 
 		public void RaisePropertyChangedEvent(Color oldColor, Color newColor, Vector4 oldHsvColor, Vector4 newHsvColor)
 		{
-			if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Automation.ValuePatternIdentifiers", nameof(ValuePatternIdentifiers.ValueProperty)))
+			if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Automation.ValuePatternIdentifiers, Uno.UI", nameof(ValuePatternIdentifiers.ValueProperty)))
 			{
 				string oldValueString = GetValueString(oldColor, oldHsvColor);
 				string newValueString = GetValueString(newColor, newHsvColor);

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/CommandBarFlyoutCommandBar.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBarFlyout/CommandBarFlyoutCommandBar.mux.cs
@@ -339,7 +339,7 @@ partial class CommandBarFlyoutCommandBar
 			secondaryItemsRoot.SizeChanged += sizeChangedHandler;
 			m_secondaryItemsRootSizeChangedRevoker.Disposable = Disposable.Create(() => secondaryItemsRoot.SizeChanged -= sizeChangedHandler);
 
-			if (ApiInformation.IsEventPresent("Microsoft.UI.Xaml.UIElement", "PreviewKeyDown"))
+			if (ApiInformation.IsEventPresent("Microsoft.UI.Xaml.UIElement, Uno.UI", "PreviewKeyDown"))
 			{
 				void previewKeyDownHandler(object sender, KeyRoutedEventArgs args)
 				{

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Uno.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Uno.cs
@@ -23,5 +23,5 @@ partial class NavigationView
 		}
 	}
 
-	private bool IsThemeShadowSupported() => ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.ThemeShadow");
+	private bool IsThemeShadowSupported() => ApiInformation.IsTypePresent("Microsoft.UI.Xaml.Media.ThemeShadow, Uno.UI");
 }

--- a/src/Uno.UI/UI/Xaml/Controls/NumberBox/NumberBoxAutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NumberBox/NumberBoxAutomationPeer.cs
@@ -65,7 +65,7 @@ public class NumberBoxAutomationPeer : AutomationPeer, IRangeValueProvider
 
 	internal void RaiseValueChangedEvent(double oldValue, double newValue)
 	{
-		if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Automation.RangeValuePatternIdentifiers", nameof(RangeValuePatternIdentifiers.ValueProperty)))
+		if (ApiInformation.IsPropertyPresent("Microsoft.UI.Xaml.Automation.RangeValuePatternIdentifiers, Uno.UI", nameof(RangeValuePatternIdentifiers.ValueProperty)))
 		{
 			RaisePropertyChangedEvent(RangeValuePatternIdentifiers.ValueProperty,
 						   oldValue,

--- a/src/Uno.UI/UI/Xaml/Controls/NumberBox/NumberBoxParser.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NumberBox/NumberBoxParser.cs
@@ -90,7 +90,7 @@ internal partial class NumberBoxParser
 		{
 			// Might be a number
 			var matchLength = match.Groups[0].Length;
-			var parsedNum = ApiInformation.IsTypePresent(numberParser?.GetType().FullName)
+			var parsedNum = ApiInformation.IsTypePresent(numberParser?.GetType().AssemblyQualifiedName)
 				? numberParser.ParseDouble(input.Substring(0, matchLength))
 				: double.TryParse(input.AsSpan().Slice(0, matchLength), out var d)
 					? (double?)d

--- a/src/Uno.UI/UI/Xaml/Controls/TeachingTip/TeachingTip.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TeachingTip/TeachingTip.mux.cs
@@ -974,7 +974,7 @@ public partial class TeachingTip : ContentControl
 					popup.IsOpen = true;
 					if (SharedHelpers.IsAnimationsEnabled()
 #if HAS_UNO // Uno specific: Make sure we skip animation when the required API is not supported
-						&& ApiInformation.IsTypePresent("Microsoft.UI.Composition.CompositionScopedBatch")
+						&& ApiInformation.IsTypePresent("Microsoft.UI.Composition.CompositionScopedBatch, Uno.UI.Composition")
 #endif
 						)
 					{
@@ -1493,7 +1493,7 @@ public partial class TeachingTip : ContentControl
 			// Contract animation
 			if (SharedHelpers.IsAnimationsEnabled()
 #if HAS_UNO // Uno specific: Make sure we skip animation when the required API is not supported
-				&& ApiInformation.IsTypePresent("Microsoft.UI.Composition.CompositionScopedBatch")
+				&& ApiInformation.IsTypePresent("Microsoft.UI.Composition.CompositionScopedBatch, Uno.UI.Composition")
 #endif
 				)
 			{
@@ -1693,7 +1693,7 @@ public partial class TeachingTip : ContentControl
 	private void CreateExpandAnimation()
 	{
 		// TODO: Uno specific - CompositionEasingFunction and related types not supported yet.
-		if (!ApiInformation.IsMethodPresent("Microsoft.UI.Composition.Compositor", "CreateCubicBezierEasingFunction"))
+		if (!ApiInformation.IsMethodPresent("Microsoft.UI.Composition.Compositor, Uno.UI.Composition", "CreateCubicBezierEasingFunction"))
 		{
 			return;
 		}
@@ -1756,7 +1756,7 @@ public partial class TeachingTip : ContentControl
 	private void CreateContractAnimation()
 	{
 		// TODO: Uno specific - CompositionEasingFunction and related types not supported yet.
-		if (!ApiInformation.IsMethodPresent("Microsoft.UI.Composition.Compositor", "CreateCubicBezierEasingFunction"))
+		if (!ApiInformation.IsMethodPresent("Microsoft.UI.Composition.Compositor, Uno.UI.Composition", "CreateCubicBezierEasingFunction"))
 		{
 			return;
 		}

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePoolDefaultPlatformProvider.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePoolDefaultPlatformProvider.cs
@@ -21,7 +21,7 @@ class FrameworkTemplatePoolDefaultPlatformProvider : IFrameworkTemplatePoolPlatf
 	static FrameworkTemplatePoolDefaultPlatformProvider()
 	{
 		_canUseMemoryManager =
-			ApiInformation.IsPropertyPresent("Windows.System.MemoryManager", "AppMemoryUsage")
+			ApiInformation.IsPropertyPresent("Windows.System.MemoryManager, Uno", "AppMemoryUsage")
 			&& MemoryManager.AppMemoryUsage > 0;
 	}
 

--- a/src/Uno.UWP/Buffers/DefaultArrayPoolPlatformProvider.cs
+++ b/src/Uno.UWP/Buffers/DefaultArrayPoolPlatformProvider.cs
@@ -21,7 +21,7 @@ namespace Uno.Buffers
 		static DefaultArrayPoolPlatformProvider()
 		{
 			_canUseMemoryManager =
-				Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Windows.System.MemoryManager", "AppMemoryUsage")
+				Windows.Foundation.Metadata.ApiInformation.IsPropertyPresent("Windows.System.MemoryManager, Uno", "AppMemoryUsage")
 				&& Windows.System.MemoryManager.IsAvailable;
 		}
 


### PR DESCRIPTION
Context: 69cc392740d79597b3f8e1a846d0562732c134ac
Context: https://github.com/aspnet/Announcements/issues/526

ASP.NET Core deprecated `WebHostBuilder` in .NET 10 RC1. Instead of following their migration logic, `#pragma warning disable` the relevant warnings.  This is because we still support .NET 9, and we don't yet know if their new code will work on .NET 9.

We can update this next year, when `$(NetPrevious)`=net10.0.

The bump to .NET 10 RC1 also "introduced" lots of IL2122 errors:

	src/Uno.UI/UI/Xaml/Controls/ColorPicker/ColorPickerSliderAutomationPeer.cs(80,8): error IL2122:
	Type 'Microsoft.UI.Xaml.Automation.ValuePatternIdentifiers' is not assembly qualified. Type name strings used for dynamically accessing a type should be assembly qualified.

@jonpryor *suspects* that this may be due to the introduction of `[DynamicallyAccessedMembers]` in various places within 69cc3927.

Update the various `ApiInformation.Is*Present()` invocations to assembly-qualify the type names based on Uno assembly names, e.g. `Microsoft.UI.Xaml.Automation.ValuePatternIdentifiers, Uno.UI`.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->