### PR TITLE
fix(RenderTargetBitmap): Don't clip the rendered element using its current parent layout slot

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media_Imaging/Given_RenderTargetBitmap.cs
@@ -195,5 +195,34 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media_Imaging
 			CollectionAssert.AreNotEqual(svBitmap1.GetPixels()[..bytesToCompare], svBitmap2.GetPixels()[..bytesToCompare]);
 		}
 #endif
+
+#if HAS_UNO
+		[TestMethod]
+#if !__SKIA__
+		[Ignore("The behaviour is only correct on skia due to the changes in https://github.com/unoplatform/uno/pull/15875")]
+#endif
+		public async Task When_Large_Image()
+		{
+			var outerBorder = new Border
+			{
+				Width = 100,
+				Height = 100,
+				Child = new Border
+				{
+					Width = 1000,
+					Height = 1000,
+					Background = new SolidColorBrush(Colors.Red),
+					BorderBrush = new SolidColorBrush(Colors.Green),
+					BorderThickness = new Thickness(10)
+				}
+			};
+
+			await UITestHelper.Load(outerBorder);
+
+			var irBitmap1 = await UITestHelper.ScreenShot(outerBorder.Child as FrameworkElement);
+
+			ImageAssert.HasColorAt(irBitmap1, irBitmap1.Width - 5, irBitmap1.Height - 5, Colors.Green);
+		}
+#endif
 	}
 }


### PR DESCRIPTION
## PR Type:

- 🐞 Bugfix

## What is the new behavior? 🚀

This allows the rendering of UIElement instances using any arbitrary size, regardless of their actual parent size.

Skia Renderer only.
