### PR TITLE
fix: Ensure `TextBlock.Text` can be set via Style

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBlock.cs
@@ -1023,6 +1023,42 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			ImageAssert.DoesNotHaveColorInRectangle(screenshot, new Rectangle(0, 0, 50, 50), Colors.Red);
 		}
 
+#if HAS_RENDER_TARGET_BITMAP
+		[TestMethod]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/21322")]
+		public async Task When_Text_Set_By_Style_Setter()
+		{
+			var style = new Style(typeof(TextBlock));
+			const string text = "Hello from style";
+			style.Setters.Add(new Setter(TextBlock.TextProperty, text));
+			var container = new StackPanel() { Spacing = 8, Padding = new Thickness(4) };
+			var SUT = new TextBlock
+			{
+				Foreground = new SolidColorBrush(Colors.Red),
+				Style = style
+			};
+			var duplicate = new TextBlock
+			{
+				Foreground = new SolidColorBrush(Colors.Red),
+				Text = text
+			};
+			container.Children.Add(SUT);
+			container.Children.Add(duplicate);
+
+			await UITestHelper.Load(container);
+			Assert.AreEqual("Hello from style", SUT.Text);
+
+			// Verify the text is actually rendered
+			var screenshot = await UITestHelper.ScreenShot(SUT);
+			ImageAssert.HasColorInRectangle(screenshot, new Rectangle(0, 0, screenshot.Width, screenshot.Height), Colors.Red);
+
+			// Verify both TextBlocks render the same
+			var screenshot2 = await UITestHelper.ScreenShot(duplicate);
+			await ImageAssert.AreSimilarAsync(screenshot, screenshot2);
+		}
+#endif
+
+
 #if __SKIA__
 		[TestMethod]
 		public async Task When_RenderTransform_Rearrange()

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.cs
@@ -870,7 +870,7 @@ namespace Microsoft.UI.Xaml.Controls
 				return;
 			}
 
-			if (ReadLocalValue(TextProperty) == DependencyProperty.UnsetValue)
+			if (!this.IsDependencyPropertySet(TextProperty))
 			{
 				_skipInlinesChangedTextSetter = true;
 				Inlines.Clear();


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/21322

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

Text of a `TextBlock` is not settable via `Style`


## What is the new behavior? 🚀

Is settable

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes