### PR TITLE
chore: build & run SamplesApp.Skia.netcoremobile with CoreCLR on Android

### DIFF
--- a/build/ci/tests/.azure-devops-tests-android-coreclr-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-android-coreclr-skia-build.yml
@@ -1,0 +1,61 @@
+parameters:
+  vmLinuxPool: ''
+  UNO_UWP_BUILD: ''
+  XAML_FLAVOR_BUILD: ''
+
+jobs:
+- job: Skia_Android_CoreCLR_Tests_Build
+  displayName: 'Build Skia Android+CoreCLR Samples App'
+  timeoutInMinutes: 60
+  cancelTimeoutInMinutes: 1
+
+  pool: ${{ parameters.vmLinuxPool }}
+
+  variables:
+    CombinedConfiguration: Release|Any CPU
+    CI_Build: true
+
+    UNO_UWP_BUILD: ${{ parameters.UNO_UWP_BUILD }}
+    XAML_FLAVOR_BUILD: ${{ parameters.XAML_FLAVOR_BUILD }}
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - template: ../templates/gitversion.yml
+  - template: ../templates/dotnet-mobile-install-linux.yml
+    parameters:
+      UnoCheckParameters: '--tfm net10.0-android'
+
+  - powershell: dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -c Release -r android-x64 -f net10.0-android -p:UnoTargetFrameworkOverride=net10.0-android -p:ApplicationId=uno.platform.samplesapp.skia.coreclr -p:UseMonoRuntime=false /bl:$(build.artifactstagingdirectory)/logs/build-skia-android-coreclr.binlog
+    displayName: Build Android+CoreCLR Skia Head
+
+  - script: >
+      rm -Rf src/SamplesApp/SamplesApp.Skia.netcoremobile/obj
+    workingDirectory: $(Build.SourcesDirectory)
+    displayName: Build Android+CoreCLR Skia Head
+
+  - task: CopyFiles@2
+    displayName: 'Copy Generated Android APK'
+    inputs:
+      SourceFolder: $(build.sourcesdirectory)/src/SamplesApp/SamplesApp.Skia.netcoremobile/bin/Release/net10.0-android/android-x64/publish/
+      Contents: 'uno.platform.samplesapp.skia.coreclr-Signed.apk'
+      TargetFolder: $(build.artifactstagingdirectory)/android-coreclr
+      CleanTargetFolder: false
+      OverWrite: false
+      flattenFolders: false
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Android+CoreCLR Binaries'
+    retryCountOnTaskFailure: 3
+    inputs:
+      targetPath: $(build.artifactstagingdirectory)/android-coreclr
+      ArtifactName: uitests-android-coreclr-skia-build
+
+  - task: PublishBuildArtifacts@1
+    retryCountOnTaskFailure: 3
+    condition: always()
+    inputs:
+      PathtoPublish: $(build.artifactstagingdirectory)/logs
+      ArtifactName: skia-samples-app-binlog
+      ArtifactType: Container

--- a/build/ci/tests/.azure-devops-tests-android-coreclr-skia.yml
+++ b/build/ci/tests/.azure-devops-tests-android-coreclr-skia.yml
@@ -1,0 +1,131 @@
+parameters:
+  vmLinuxPool: ''
+  UNO_UWP_BUILD: ''
+  XAML_FLAVOR_BUILD: ''
+
+jobs:
+##
+## Android+CoreCLR Skia
+##
+
+- job: Android_CorCLR_Tests
+  displayName: ' ' ## Name is concatenated with the matrix group name
+  timeoutInMinutes: 45
+  dependsOn: Skia_Android_CoreCLR_Tests_Build
+  pool: ${{ parameters.vmLinuxPool }}
+
+  variables:
+    CI_Build: true
+    SourceLinkEnabled: false
+    NUGET_PACKAGES: $(Agent.WorkFolder)/.nuget
+
+  strategy:
+    matrix:
+
+      'Runtime Tests 0':
+        ANDROID_SIMULATOR_APILEVEL: 34
+        UITEST_TEST_MODE_NAME: RuntimeTests
+        UNO_UITEST_BUCKET_ID: RuntimeTests
+        UITEST_RUNTIME_TEST_GROUP: 0
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 4
+        SAMPLEAPP_ARTIFACT_NAME: uitests-android-coreclr-skia-build
+        TARGETPLATFORM_NAME: net10
+        UITEST_TEST_TIMEOUT: '2600s'
+
+      'Runtime Tests 1':
+        ANDROID_SIMULATOR_APILEVEL: 34
+        UITEST_TEST_MODE_NAME: RuntimeTests
+        UNO_UITEST_BUCKET_ID: RuntimeTests
+        UITEST_RUNTIME_TEST_GROUP: 1
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 5
+        SAMPLEAPP_ARTIFACT_NAME: uitests-android-coreclr-skia-build
+        TARGETPLATFORM_NAME: net10
+        UITEST_TEST_TIMEOUT: '2600s'
+
+      'Runtime Tests 2':
+        ANDROID_SIMULATOR_APILEVEL: 34
+        UITEST_TEST_MODE_NAME: RuntimeTests
+        UNO_UITEST_BUCKET_ID: RuntimeTests
+        UITEST_RUNTIME_TEST_GROUP: 2
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 5
+        SAMPLEAPP_ARTIFACT_NAME: uitests-android-coreclr-skia-build
+        TARGETPLATFORM_NAME: net10
+        UITEST_TEST_TIMEOUT: '2600s'
+
+      'Runtime Tests 3':
+        ANDROID_SIMULATOR_APILEVEL: 34
+        UITEST_TEST_MODE_NAME: RuntimeTests
+        UNO_UITEST_BUCKET_ID: RuntimeTests
+        UITEST_RUNTIME_TEST_GROUP: 3
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 5
+        SAMPLEAPP_ARTIFACT_NAME: uitests-android-coreclr-skia-build
+        TARGETPLATFORM_NAME: net10
+        UITEST_TEST_TIMEOUT: '2600s'
+
+      'Runtime Tests 4':
+        ANDROID_SIMULATOR_APILEVEL: 34
+        UITEST_TEST_MODE_NAME: RuntimeTests
+        UNO_UITEST_BUCKET_ID: RuntimeTests
+        UITEST_RUNTIME_TEST_GROUP: 4
+        UITEST_RUNTIME_TEST_GROUP_COUNT: 5
+        SAMPLEAPP_ARTIFACT_NAME: uitests-android-coreclr-skia-build
+        TARGETPLATFORM_NAME: net10
+        UITEST_TEST_TIMEOUT: '2600s'
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - bash: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+    displayName: 'Enable KVM'
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Downloading $(SAMPLEAPP_ARTIFACT_NAME)
+    inputs:
+      artifact: $(SAMPLEAPP_ARTIFACT_NAME)
+      path: '$(build.sourcesdirectory)/build/$(SAMPLEAPP_ARTIFACT_NAME)/android'
+
+  - task: DownloadBuildArtifacts@0
+    condition: gt(variables['System.JobAttempt'], 1)
+    continueOnError: true
+    displayName: Download previous test runs failed tests
+    inputs:
+        artifactName: uitests-android-coreclr-failure-results
+        downloadPath: '$(build.sourcesdirectory)/build'
+
+  - template: ../templates/dotnet-install.yml
+
+  - bash: |
+      chmod +x $(build.sourcesdirectory)/build/test-scripts/android-run-skia-runtime-tests.sh
+      UNO_UITEST_APP_ID=uno.platform.samplesapp.skia.coreclr \
+        $(build.sourcesdirectory)/build/test-scripts/android-run-skia-runtime-tests.sh
+
+    displayName: Run Android+CoreCLR Skia Tests
+
+  - task: PublishTestResults@2
+    condition: always()
+    inputs:
+      testRunTitle: 'Android+CoreCLR Skia Runtime Tests $(UITEST_RUNTIME_TEST_GROUP)'
+      testResultsFormat: 'NUnit'
+      testResultsFiles: '$(build.sourcesdirectory)/build/*TestResult*.xml'
+      failTaskOnFailedTests: true
+
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(build.artifactstagingdirectory)
+      ArtifactName: android-coreclr-skia-results
+      ArtifactType: Container
+
+  - task: PublishBuildArtifacts@1
+    condition: always()
+    displayName: Publish Failed Tests Results
+    retryCountOnTaskFailure: 3
+    inputs:
+      PathtoPublish: $(build.sourcesdirectory)/build/uitests-failure-results
+      ArtifactName: uitests-android-coreclr-failure-results
+      ArtifactType: Container

--- a/build/ci/tests/.azure-devops-tests-skia-stages.yml
+++ b/build/ci/tests/.azure-devops-tests-skia-stages.yml
@@ -58,6 +58,23 @@ stages:
       UNO_UWP_BUILD: '${{ parameters.UNO_UWP_BUILD }}'
       XAML_FLAVOR_BUILD: '${{ parameters.XAML_FLAVOR_BUILD }}'
 
+- stage: runtime_tests_skia_android_coreclr
+  displayName: Tests - Android+CoreCLR Skia
+  dependsOn:
+    - Setup
+
+  jobs:
+  - template: .azure-devops-tests-android-coreclr-skia-build.yml
+    parameters:
+      vmLinuxPool: '${{ parameters.vmLinuxPool }}'
+      UNO_UWP_BUILD: '${{ parameters.UNO_UWP_BUILD }}'
+      XAML_FLAVOR_BUILD: '${{ parameters.XAML_FLAVOR_BUILD }}'
+  - template: .azure-devops-tests-android-coreclr-skia.yml
+    parameters:
+      vmLinuxPool: '${{ parameters.vmLinuxPool }}'
+      UNO_UWP_BUILD: '${{ parameters.UNO_UWP_BUILD }}'
+      XAML_FLAVOR_BUILD: '${{ parameters.XAML_FLAVOR_BUILD }}'
+
 - stage: runtime_tests_skia_ios
   displayName: Tests - iOS Skia
   dependsOn:

--- a/build/test-scripts/android-run-skia-runtime-tests.sh
+++ b/build/test-scripts/android-run-skia-runtime-tests.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 set -x
 
 export UITEST_IS_LOCAL=${UITEST_IS_LOCAL=false}
-export UNO_UITEST_APP_ID="uno.platform.samplesapp.skia"
+export UNO_UITEST_APP_ID="${UNO_UITEST_APP_ID=uno.platform.samplesapp.skia}"
 export UNO_UITEST_ANDROIDAPK_PATH=$BUILD_SOURCESDIRECTORY/build/$SAMPLEAPP_ARTIFACT_NAME/android/$UNO_UITEST_APP_ID-Signed.apk
 export UITEST_RUNTIME_TEST_GROUP=${UITEST_RUNTIME_TEST_GROUP=automated}
 export UNO_ORIGINAL_TEST_RESULTS=$BUILD_SOURCESDIRECTORY/build/TestResult-original.xml
@@ -131,7 +131,7 @@ $ANDROID_HOME/platform-tools/adb shell pm grant $UNO_UITEST_APP_ID android.permi
 
 # start the android app using environment variables using adb
 $ANDROID_HOME/platform-tools/adb shell am start \
-  -n uno.platform.samplesapp.skia/crc6448f3b0362cbf4bc9.MainActivity \
+  -n $UNO_UITEST_APP_ID/crc6448f3b0362cbf4bc9.MainActivity \
   -e UITEST_RUNTIME_TEST_GROUP "$UITEST_RUNTIME_TEST_GROUP" \
   -e UITEST_RUNTIME_TEST_GROUP_COUNT "$UITEST_RUNTIME_TEST_GROUP_COUNT" \
   -e UITEST_RUNTIME_AUTOSTART_RESULT_FILE "$UITEST_RUNTIME_AUTOSTART_RESULT_DEVICE_PATH" \

--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/Android/AndroidManifest.xml
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="uno.platform.samplesapp.skia" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="35" />
 	<!-- NOTE: Add permissions in AssemblyInfo.cs -->
 	<application android:label="Uno Samples (Skia)" android:usesCleartextTraffic="true">

--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/Android/Main.Android.cs
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/Android/Main.Android.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 using Android.App;
@@ -110,6 +111,11 @@ namespace SamplesApp.Droid
 		public override void OnCreate()
 		{
 			base.OnCreate();
+
+#if RUNTIME_CORECLR
+			// TODO: remove once the Android+CoreCLR runtime properly inits crypto, possibly .NET 10 RC2?
+			Java.Lang.JavaSystem.LoadLibrary("System.Security.Cryptography.Native.Android");
+#endif  // RUNTIME_CORECLR
 
 			// Initialize Android-specific extensions.
 			// These would be generally registered automatically by App.xaml generator,

--- a/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj
@@ -11,9 +11,11 @@
 
 		<AssemblyName>SamplesApp</AssemblyName>
 		<DefineConstants>$(DefineConstants);XAMARIN;HAS_UNO</DefineConstants>
+		<DefineConstants Condition=" '$(UseMonoRuntime)' == 'false' ">$(DefineConstants);RUNTIME_CORECLR</DefineConstants>
 		<IsUnoHead>true</IsUnoHead>
 
-		<ApplicationId>uno.platform.samplesapp.skia</ApplicationId>
+		<ApplicationId Condition=" '$(ApplicationId)' != '' ">$(ApplicationId)</ApplicationId>
+		<ApplicationId Condition=" '$(ApplicationId)' == '' ">uno.platform.samplesapp.skia</ApplicationId>
 
 		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">iossimulator-x64</RuntimeIdentifier>
 		<RuntimeIdentifier Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">maccatalyst-x64</RuntimeIdentifier>

--- a/src/Uno.UI.Runtime.Skia.Android/Native/AndroidSkiaNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Native/AndroidSkiaNativeElementHostingExtension.cs
@@ -119,7 +119,15 @@ internal sealed class AndroidSkiaNativeElementHostingExtension : ContentPresente
 		if (content is View view)
 		{
 			var availablePhysical = availableSize.LogicalToPhysicalPixels();
-			view.Measure((int)availablePhysical.Width, (int)availablePhysical.Height);
+
+			// Note: View.Measure(widthMeasureSpec, heightMeasureSpec) doesn't take "raw" sizes,
+			// it instead takes a "MeasureSpec" which is 2 bits of "mode" and 30 bits of "size".
+			// As e.g. availablePhysical.Width could be int.MaxValue -- when availableSize.Width is Infinite --
+			// then availablePhysical.Width could *exceed* 30 bits.
+			// Using MakeMeasureSpec() ensures that the size we specify doesn't overflow into "mode".
+			int widthMeasureSpec = View.MeasureSpec.MakeMeasureSpec((int)availablePhysical.Width, MeasureSpecMode.Unspecified);
+			int heightMeasureSpec = View.MeasureSpec.MakeMeasureSpec((int)availablePhysical.Height, MeasureSpecMode.Unspecified);
+			view.Measure(widthMeasureSpec, heightMeasureSpec);
 			return new Size(view.MeasuredWidth, view.MeasuredHeight).PhysicalToLogicalPixels();
 		}
 


### PR DESCRIPTION
chore: build & run SamplesApp.Skia.netcoremobile with CoreCLR on Android

Context: https://github.com/dotnet/core/blob/4c489a6ae54f71c30c1d21f2fe0ebb3489482e92/release-notes/10.0/preview/rc1/dotnetmaui.md#experimental-coreclr
Context: https://github.com/dotnet/android/issues/10463
Context: https://github.com/dotnet/runtime/issues/119821

.NET 10 RC1 adds:

> **(Experimental) CoreCLR**
>
> Enables Android apps to run on the CoreCLR runtime (instead of Mono).
> To use it [set the `$(UseMonoRuntime)` MSBuild property to `false`].

As building `SamplesApp.Skia.netcoremobile.csproj` with CoreCLR can
take a significant amount of time and disk space, we've decided to
introduce a new `Tests - Android+CoreCLR Skia` stage to build and
run these unit tests within an Android+CoreCLR environment.

To help reduce disk usage, after building the `.apk` we delete the
`obj` directory.

Update `src/SamplesApp/SamplesApp.Skia.netcoremobile` so that
`$(ApplicationId)` can be overridden via the new `$(SkiaApplicationId)`
MSBuild property.  This allows CoreCLR builds to have distinct package
names vs. default (MonoVM) builds, and allows them to be installed
side-by-side (disk space pemitting).

Additionally, crypto is not initialized when using CoreCLR under
.NET 10 RC1, which resembles dotnet/android#10463.  Add a call to
`System.loadLibrary("System.Security.Cryptography.Native.Android")`
to load and initialize Crypto support.

Update `android-run-skia-runtime-tests.sh` so that `UNO_UITEST_APP_ID`
can be overridden.  This allows `uno.platform.samplesapp.skia.coreclr`
to be launched.

Finally, the behavior around storing `int.MaxValue` within a `float`
differs between MonoVM and CoreCLR; see dotnet/runtime#119821.
Update `AndroidSkiaNativeElementHostingExtension.MeasureNativeElement()`
to use [`Android.Views.View.MeasureSpec.MakeMeasureSpec()`][0] instead
of `(int)availablePhysical.Height`, as `.Height` will hold a
`float` containing `int.MaxValue` if/when `availableSize.Height` is
Infinite, which triggers differing behavior between MonoVM & CoreCLR.
Using `MakeMeasureSpec()` fixes this inconsistency.

[0]:https://developer.android.com/reference/android/view/View.MeasureSpec#makeMeasureSpec(int,%20int)

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->