### PR TITLE
feat: Excluding Hot Design Stories in Release

### DIFF
--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -158,6 +158,6 @@
 
 	<!-- Define the default folder for Hot Design Stories, so they can be excluded in Release -->
 	<PropertyGroup Condition="'$(UnoDisableHotDesign)' != 'true'">
-		<HotDesignStoryFolder Condition="'$(HotDesignStoryFolder)' == ''">HotDesignStories</HotDesignStoryFolder>
+		<HotDesignStoriesFolder Condition="'$(HotDesignStoriesFolder)' == ''">HotDesignStories</HotDesignStoriesFolder>
 	</PropertyGroup>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -155,4 +155,9 @@
 			   AND $(TargetFrameworks.Contains('desktop')) ">
 		<ProjectCapability Include="DotNetWslLaunch" />
 	</ItemGroup>
+
+	<!-- Define the default folder for Hot Design Stories, so they can be excluded in Release -->
+	<PropertyGroup Condition="'$(UnoDisableHotDesign)' != 'true'">
+		<HotDesignStoryFolder Condition="'$(HotDesignStoryFolder)' == ''">Stories</HotDesignStoryFolder>
+	</PropertyGroup>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.Common.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.targets
@@ -158,6 +158,6 @@
 
 	<!-- Define the default folder for Hot Design Stories, so they can be excluded in Release -->
 	<PropertyGroup Condition="'$(UnoDisableHotDesign)' != 'true'">
-		<HotDesignStoryFolder Condition="'$(HotDesignStoryFolder)' == ''">Stories</HotDesignStoryFolder>
+		<HotDesignStoryFolder Condition="'$(HotDesignStoryFolder)' == ''">HotDesignStories</HotDesignStoryFolder>
 	</PropertyGroup>
 </Project>

--- a/src/Uno.Sdk/targets/Uno.DefaultItems.targets
+++ b/src/Uno.Sdk/targets/Uno.DefaultItems.targets
@@ -43,7 +43,7 @@
 			Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Page);App.xaml"
 			IsDefaultItem="true" />
 		<UpToDateCheckInput Include="**\*.xaml"
-			Exclude="$(DefaultItemExcludes)"
+			Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)"
 			IsDefaultItem="true" />
 		<Compile Update="**\*.xaml.cs"
 			DependentUpon="%(Filename)"

--- a/src/Uno.Sdk/targets/Uno.DefaultItems.targets
+++ b/src/Uno.Sdk/targets/Uno.DefaultItems.targets
@@ -6,7 +6,7 @@
 		<DefaultItemExcludes Condition="!$(DefaultItemExcludes.Contains('obj/**'))">$(DefaultItemExcludes);obj/**</DefaultItemExcludes>
 
 		<!-- Exclude the Stories folder when in Optimize (aka Release) build configuration -->
-		<DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignStoryFolder)' != '' ">$(HotDesignStoryFolder)/**</DefaultItemExcludes>
+		<DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignStoriesFolder)' != '' ">$(HotDesignStoriesFolder)/**</DefaultItemExcludes>
 	</PropertyGroup>
 
 	<!-- Default Includes-->

--- a/src/Uno.Sdk/targets/Uno.DefaultItems.targets
+++ b/src/Uno.Sdk/targets/Uno.DefaultItems.targets
@@ -1,14 +1,15 @@
 <Project>
-	<ItemGroup>
-		<UpToDateCheckInput Include="**\*.xaml" Exclude="$(DefaultItemExcludes)" IsDefaultItem="true" />
-	</ItemGroup>
-	
+	<!-- Excludes -->
 	<PropertyGroup>
 		<!-- It's never useful to include bin/obj folders, even when UseArtifactsOutput is false  -->
 		<DefaultItemExcludes Condition="!$(DefaultItemExcludes.Contains('bin/**'))">$(DefaultItemExcludes);bin/**</DefaultItemExcludes>
 		<DefaultItemExcludes Condition="!$(DefaultItemExcludes.Contains('obj/**'))">$(DefaultItemExcludes);obj/**</DefaultItemExcludes>
+
+		<!-- Exclude the Stories folder when in Optimize (aka Release) build configuration -->
+		<DefaultItemExcludes Condition=" '$(Optimize)' == 'true' AND '$(HotDesignStoryFolder)' != '' ">$(HotDesignStoryFolder)/**</DefaultItemExcludes>
 	</PropertyGroup>
 
+	<!-- Default Includes-->
 	<ItemGroup Condition=" !$(IsWinAppSdk) ">
 		<!-- Include all images by default - matches the __WindowsAppSdkDefaultImageIncludes property in the WindowsAppSDK -->
 		<Content Include="$(AssetsFolder)**"
@@ -40,6 +41,9 @@
 			IsDefaultItem="true" />
 		<Page Include="**\*.xaml"
 			Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Page);App.xaml"
+			IsDefaultItem="true" />
+		<UpToDateCheckInput Include="**\*.xaml"
+			Exclude="$(DefaultItemExcludes)"
 			IsDefaultItem="true" />
 		<Compile Update="**\*.xaml.cs"
 			DependentUpon="%(Filename)"


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno.hotdesign/issues/4915


## PR Type:

- ✨ Feature
- 🏗️ Build or CI related changes


## What is the current behavior? 🤔

XAML/C# files in the Stories folder are always included

## What is the new behavior? 🚀

XAML/C# files in the Stories folder are excluded for Release build


## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

The name of the Hot Design stories folder can be overwritten by setting the HotDesignStoryFolder variable
If UnoDisableHotDesign is set to true, HotDesignStoryFolder won't be set and as such no files will be excluded in Release build



This pull request introduces improvements to how Hot Design Stories are managed in the build process, especially in Release (Optimize) configurations. The changes add a default folder for Hot Design Stories and ensure these files are excluded from builds when optimization is enabled. Additionally, there are adjustments to default item includes and excludes for XAML files and related artifacts.

**Hot Design Stories management:**

* Added a default property `HotDesignStoriesFolder` to specify the folder for Hot Design Stories, which can be conditionally disabled via `UnoDisableHotDesign`.
* Updated `DefaultItemExcludes` to automatically exclude the Hot Design Stories folder from builds when `Optimize` is enabled and the folder is set, ensuring these files are not included in Release builds.

**Default item includes/excludes:**

* Restored the `UpToDateCheckInput` for XAML files to ensure build up-to-date checks continue to work correctly, now with improved exclusion logic.
* Improved exclusion of `bin` and `obj` folders from default item includes, preventing unnecessary files from being processed in builds.