### PR TITLE
fix: Android allow reopening app after activity is backgrounded

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -344,8 +344,6 @@ namespace Microsoft.UI.Xaml
 			DismissKeyboard();
 		}
 
-		protected override void OnRestart() => base.OnRestart();
-
 		protected override void OnDestroy()
 		{
 			base.OnDestroy();

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -10,6 +10,8 @@ using Android.Runtime;
 using Android.Views;
 using Android.Views.InputMethods;
 using Android.Widget;
+using AndroidX.Activity;
+using AndroidX.Core.Graphics;
 using Microsoft.UI.Xaml.Media;
 using SkiaSharp;
 using Uno.Foundation.Logging;
@@ -20,15 +22,9 @@ using Uno.UI.Runtime.Skia.Android;
 using Uno.UI.Xaml.Controls;
 using Windows.Devices.Sensors;
 using Windows.Graphics.Display;
-using Windows.System;
-using Windows.UI.ViewManagement;
-using AndroidX.Core.Graphics;
-using Uno.UI.Helpers;
-using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
 using Windows.Storage.Pickers;
-using AndroidX.Activity;
-using Windows.Extensions;
-using Uno.WinUI.Runtime.Skia.Android;
+using Windows.UI.ViewManagement;
+using WinUICoreServices = Uno.UI.Xaml.Core.CoreServices;
 
 
 namespace Microsoft.UI.Xaml
@@ -49,7 +45,7 @@ namespace Microsoft.UI.Xaml
 		/// </summary>
 		internal static ApplicationActivity Instance { get; private set; } = null!;
 
-		internal RelativeLayout RelativeLayout { get; private set; } = null!;
+		internal static RelativeLayout RelativeLayout { get; private set; } = null!;
 
 		internal LayoutProvider LayoutProvider { get; private set; } = null!;
 
@@ -109,14 +105,6 @@ namespace Microsoft.UI.Xaml
 
 		protected override void InitializeComponent()
 		{
-			// Sometimes, within the same Application lifecycle, the main Activity is destroyed and a new one is created (i.e., when pressing the back button on the first page).
-			// This code transfers the content from the previous activity to the new one (if applicable).
-			//var initialWindow = Microsoft.UI.Xaml.Window.CurrentSafe ?? Microsoft.UI.Xaml.Window.InitialWindow;
-			//if (initialWindow?.RootElement is View content)
-			//{
-			//	(content.GetParent() as ViewGroup)?.RemoveView(content);
-			//	SetContentView(content);
-			//}
 		}
 
 		public override bool DispatchKeyEvent(KeyEvent? e)
@@ -272,6 +260,14 @@ namespace Microsoft.UI.Xaml
 					ViewGroup.LayoutParams.MatchParent);
 				RelativeLayout.AddView(NativeLayerHost);
 			}
+
+			var winUIWindow = Microsoft.UI.Xaml.Window.CurrentSafe ?? Microsoft.UI.Xaml.Window.InitialWindow;
+			if (winUIWindow?.RootElement is { } root)
+			{
+				// App was already running, but backed out of
+				winUIWindow.Activate();
+				InvalidateRender();
+			}
 		}
 
 		internal void InvalidateRender()
@@ -332,6 +328,8 @@ namespace Microsoft.UI.Xaml
 
 			DismissKeyboard();
 		}
+
+		protected override void OnRestart() => base.OnRestart();
 
 		protected override void OnDestroy()
 		{

--- a/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/ApplicationActivity.cs
@@ -271,7 +271,7 @@ namespace Microsoft.UI.Xaml
 					ViewGroup.LayoutParams.MatchParent,
 					ViewGroup.LayoutParams.MatchParent);
 
-				_skCanvasView ??= new UnoSKCanvasView(this);
+				_skCanvasView = new UnoSKCanvasView(this);
 				_skCanvasView.LayoutParameters = new ViewGroup.LayoutParams(
 					ViewGroup.LayoutParams.MatchParent,
 					ViewGroup.LayoutParams.MatchParent);

--- a/src/Uno.UI.Runtime.Skia.Android/Native/AndroidSkiaNativeElementHostingExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Native/AndroidSkiaNativeElementHostingExtension.cs
@@ -37,7 +37,7 @@ internal sealed class AndroidSkiaNativeElementHostingExtension : ContentPresente
 	{
 		if (content is View view)
 		{
-			if (ApplicationActivity.Instance.NativeLayerHost is { } host)
+			if (ApplicationActivity.NativeLayerHost is { } host)
 			{
 				host.AddView(view);
 			}
@@ -55,7 +55,7 @@ internal sealed class AndroidSkiaNativeElementHostingExtension : ContentPresente
 	{
 		if (content is View view)
 		{
-			if (ApplicationActivity.Instance.NativeLayerHost is { } host)
+			if (ApplicationActivity.NativeLayerHost is { } host)
 			{
 				host.RemoveView(view);
 			}
@@ -87,11 +87,11 @@ internal sealed class AndroidSkiaNativeElementHostingExtension : ContentPresente
 
 	public object? CreateSampleComponent(string text)
 	{
-		if (ApplicationActivity.Instance.NativeLayerHost is not { } host)
+		if (ApplicationActivity.NativeLayerHost is not { } host)
 		{
 			if (this.Log().IsEnabled(LogLevel.Error))
 			{
-				this.Log().Error($"Cannot create a sample native element because {nameof(ApplicationActivity.Instance.NativeLayerHost)} is null.");
+				this.Log().Error($"Cannot create a sample native element because {nameof(ApplicationActivity.NativeLayerHost)} is null.");
 			}
 
 			return null;

--- a/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
+++ b/src/Uno.UI.Runtime.Skia.Android/Rendering/UnoSKCanvasView.cs
@@ -32,12 +32,13 @@ internal sealed class UnoSKCanvasView : GLSurfaceView
 
 	internal static UnoSKCanvasView? Instance { get; private set; }
 
+	private readonly InternalRenderer _renderer;
+
 	public UnoSKCanvasView(Context context) : base(context)
 	{
 		SetEGLContextClientVersion(2);
 		SetEGLConfigChooser(8, 8, 8, 8, 0, 8);
-		SetRenderer(new InternalRenderer(this));
-
+		SetRenderer(_renderer = new InternalRenderer(this));
 		Instance = this;
 		ExploreByTouchHelper = new UnoExploreByTouchHelper(this);
 		TextInputPlugin = new TextInputPlugin(this);
@@ -70,6 +71,11 @@ internal sealed class UnoSKCanvasView : GLSurfaceView
 			: Rendermode.WhenDirty;
 	}
 
+	internal void ResetRendererContext()
+	{
+		_renderer.ResetContext();
+	}
+
 	internal void InvalidateRender()
 	{
 		if (Microsoft.UI.Xaml.Window.CurrentSafe is not { RootElement: { } root } window)
@@ -97,7 +103,7 @@ internal sealed class UnoSKCanvasView : GLSurfaceView
 
 		_fpsHelper.Scale = (float)scale;
 
-		if (ApplicationActivity.Instance.NativeLayerHost is { } nativeLayerHost)
+		if (ApplicationActivity.NativeLayerHost is { } nativeLayerHost)
 		{
 			nativeLayerHost.Path = path;
 			nativeLayerHost.Invalidate();
@@ -326,5 +332,7 @@ internal sealed class UnoSKCanvasView : GLSurfaceView
 			_context?.Dispose();
 			_context = null;
 		}
+
+		internal void ResetContext() => FreeContext();
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/BaseWindowImplementation.cs
@@ -270,13 +270,15 @@ internal abstract partial class BaseWindowImplementation : IWindowImplementation
 			bool cancelGuard = false;
 			using var guard = Disposable.Create(() =>
 			{
+				_isClosing = false;
+
 				if (cancelGuard)
 				{
 					return;
 				}
+
 				// in case of any failure, closing and closed states
 				// will reset so that closing operation can be attempted again
-				_isClosing = false;
 				_isClosed = false;
 			});
 
@@ -314,12 +316,13 @@ internal abstract partial class BaseWindowImplementation : IWindowImplementation
 				// because they check if window is closed already
 				Window.SetTitleBar(null);
 				Window.Content = null;
+
+				// _windowChrome.SetDesktopWindow(null);
+
+				// Mark Desktop Window instance as 'closed'
+				_isClosed = true;
 			}
 
-			// _windowChrome.SetDesktopWindow(null);
-
-			// Mark Desktop Window instance as 'closed'
-			_isClosed = true;
 			cancelGuard = true; // success, no need to reset closing and closed states
 
 			// if (!_minimizedOrHidden)
@@ -329,11 +332,9 @@ internal abstract partial class BaseWindowImplementation : IWindowImplementation
 				RaiseWindowVisibilityChangedEvent(false);
 			}
 
-			if (NativeWindowFactory.SupportsMultipleWindows)
-			{
-				// Close native window, cleanup, and unregister from hwnd mapping from DXamlCore
-				Shutdown();
-			}
+
+			// Close native window, cleanup, and unregister from hwnd mapping from DXamlCore
+			Shutdown();
 
 			return true;
 		}
@@ -343,14 +344,26 @@ internal abstract partial class BaseWindowImplementation : IWindowImplementation
 
 	private void Shutdown()
 	{
-		ApplicationHelper.RemoveWindow(Window);
+		if (NativeWindowFactory.SupportsMultipleWindows)
+		{
+			ApplicationHelper.RemoveWindow(Window);
+		}
 
 		if (NativeWindowWrapper is null)
 		{
 			throw new InvalidOperationException("Native window is not initialized.");
 		}
 
-		// If AppWindow closing is in progress, we don't need to do anything here.
+		NativeWindowWrapper.Hide();
+
+		// Allow the window to be re-shown on single-window targets.
+		if (!NativeWindowFactory.SupportsMultipleWindows)
+		{
+			NativeWindowWrapper.WasShown = false;
+		}
+
+		// If AppWindow closing is in progress, it means the native window
+		// itself triggered the closure and is already being closed.
 		if (_appWindowClosingEventArgs is null)
 		{
 			NativeWindowWrapper.Close();

--- a/src/Uno.UI/UI/Xaml/Window/Native/INativeWindowWrapper.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/INativeWindowWrapper.cs
@@ -24,7 +24,7 @@ internal interface INativeWindowWrapper : INativeAppWindow
 
 	float RasterizationScale { get; }
 
-	bool WasShown { get; }
+	bool WasShown { get; set; }
 
 	event EventHandler<Size>? SizeChanged;
 

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
@@ -220,6 +220,8 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	public void Close()
 	{
 		CloseCore();
+
+		IsVisible = false;
 	}
 
 	public virtual void ExtendContentIntoTitleBar(bool extend) { }
@@ -290,9 +292,7 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 
 	public void Destroy() { }
 
-	public void Hide()
-	{
-	}
+	public void Hide() => IsVisible = false;
 
 #if __APPLE_UIKIT__
 	public abstract Size GetWindowSize();

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
@@ -54,7 +54,7 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 
 	internal bool AssociatedWithManagedWindow => _window != null && _xamlRoot != null;
 
-	public bool WasShown { get; private set; }
+	public bool WasShown { get; set; }
 
 	internal void SetWindow(Window window, XamlRoot xamlRoot)
 	{
@@ -210,6 +210,9 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	{
 	}
 
+	/// <summary>
+	/// Request the close of the native window
+	/// </summary>
 	protected virtual void CloseCore()
 	{
 	}
@@ -217,14 +220,6 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	public void Close()
 	{
 		CloseCore();
-
-		IsVisible = false;
-
-		// Allow the window to be re-shown on single-window targets.
-		if (!NativeWindowFactory.SupportsMultipleWindows)
-		{
-			WasShown = false;
-		}
 	}
 
 	public virtual void ExtendContentIntoTitleBar(bool extend) { }
@@ -295,7 +290,9 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 
 	public void Destroy() { }
 
-	public void Hide() { }
+	public void Hide()
+	{
+	}
 
 #if __APPLE_UIKIT__
 	public abstract Size GetWindowSize();


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/343, closes https://github.com/unoplatform/uno/issues/21251

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

UI was not being reparented when activity changed


## What is the new behavior? 🚀

Reparenting happens correctly

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->