### PR TITLE
fix(xamlreader): Don't fail on ItemsPanelTemplate inside a frameworktemplate

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
@@ -14,6 +14,8 @@ using Microsoft.UI.Xaml.Shapes;
 using Windows.Foundation;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Markup;
+using static Private.Infrastructure.TestServices;
+using System.Threading.Tasks;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 {
@@ -864,6 +866,72 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 				Assert.AreEqual(4, (ae.InnerExceptions[1] as XamlParseException).LineNumber);
 				Assert.AreEqual(4, (ae.InnerExceptions[1] as XamlParseException).LinePosition);
 			}
+		}
+
+		[TestMethod]
+		public async Task When_ListView_ItemsPanelTemplate()
+		{
+			var sut = XamlHelper.LoadXaml<ListView>("""
+				<ListView>
+					<x:String>Hello</x:String>
+					<ListView.ItemsPanel>
+						<ItemsPanelTemplate>
+							<StackPanel Orientation="Horizontal" />
+						</ItemsPanelTemplate>
+					</ListView.ItemsPanel>
+				</ListView>
+			""");
+
+			WindowHelper.WindowContent = sut;
+			await WindowHelper.WaitForLoaded(sut);
+		}
+
+		[TestMethod]
+		public async Task When_ItemsControl_ItemsPanelTemplate_In_DataTemplate()
+		{
+			var sut = XamlHelper.LoadXaml<ContentControl>("""
+				<ContentControl Content="test" Width="100" Height="100">
+					<ContentControl.ContentTemplate>
+						<DataTemplate>
+							<ItemsControl ItemsSource="{Binding Assets}">
+								<ItemsControl.ItemsPanel>
+									<ItemsPanelTemplate>
+										<StackPanel Orientation="Horizontal"/>
+									</ItemsPanelTemplate>
+								</ItemsControl.ItemsPanel>
+							</ItemsControl>
+						</DataTemplate>
+					</ContentControl.ContentTemplate>
+				</ContentControl>
+			""");
+
+			WindowHelper.WindowContent = sut;
+			await WindowHelper.WaitForLoaded(sut);
+		}
+
+		[TestMethod]
+		public async Task When_ControlTemplate_In_DataTemplate()
+		{
+			var sut = XamlHelper.LoadXaml<ContentControl>("""
+				<ContentControl Content="test" Width="100" Height="100">
+					<ContentControl.ContentTemplate>
+						<DataTemplate>
+							<ContentControl Content="test2" Width="100" Height="100">
+								<ContentControl.Template>
+									<ControlTemplate TargetType="ContentControl">
+										<Border Background="LightGray">
+											<ContentPresenter />
+										</Border>
+									</ControlTemplate>
+								</ContentControl.Template>
+							</ContentControl>
+						</DataTemplate>
+					</ContentControl.ContentTemplate>
+				</ContentControl>
+			""");
+
+			WindowHelper.WindowContent = sut;
+			await WindowHelper.WaitForLoaded(sut);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -1535,7 +1535,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				var initializationMember = xamlObjectDefinition.Members.FirstOrDefault(m => m.Member.Name == "_Initialization");
 
 				if (contentProperty == null &&
-					xamlObjectDefinition.Type.Name is not ("ResourceDictionary" or "DataTemplate"))
+					xamlObjectDefinition.Type.Name is not ("ResourceDictionary" or "DataTemplate" or "ItemsPanelTemplate" or "ControlTemplate"))
 				{
 					if (xamlObjectDefinition.Members.Any(m => IsNestedChildNode(m)))
 					{


### PR DESCRIPTION
## PR Type:
- 🐞 Bugfix
## What is the current behavior? 🤔

Using an ItemsPaneltemplate inside a DataTemplate fails with:

```
The type 'Microsoft.UI.Xaml.Controls.ItemsPanelTemplate' does not support direct content.
```

## What is the new behavior? 🚀

This scenario is now properly supported.