### PR TITLE
fix: ensure GetCustomMarkupExtensionValue checks for nested extensions.

### DIFF
--- a/src/SourceGenerators/System.Xaml/System.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/ParsedMarkupExtensionInfo.cs
@@ -220,14 +220,7 @@ namespace Uno.Xaml
 				else if (c == '\'') isInQuot = !isInQuot;
 				else if (isInQuot) { }
 				else if (c == '{') bracketDepth++;
-				else if (c == '}')
-				{
-					bracketDepth--;
-					if (bracketDepth > 0)
-					{
-						throw Error("Unexpected '}}' in markup extension: '{0}'", raw);
-					}
-				}
+				else if (c == '}') bracketDepth--;
 				else if (c == ',' && bracketDepth == 0)
 				{
 					yield return vargs.Substring(lastSliceIndex + 1, i - lastSliceIndex - 1).Trim();

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.Reflection.cs
@@ -265,6 +265,17 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return _metadataHelper.FindPropertyByOwnerSymbol(type, xamlMember.Name);
 		}
 
+		private ISymbol? FindProperty(XamlMemberDefinition xamlMemberDefinition)
+		{
+			var declaringType = xamlMemberDefinition.Member.DeclaringType;
+
+			var type = IsCustomMarkupExtensionType(declaringType)
+				? GetMarkupExtensionType(declaringType)
+				: FindType(xamlMemberDefinition.Member.DeclaringType);
+
+			return _metadataHelper.FindPropertyByOwnerSymbol(type, xamlMemberDefinition.Member.Name);
+		}
+
 		private INamedTypeSymbol? FindPropertyType(XamlMember xamlMember) => FindProperty(xamlMember)?.FindDependencyPropertyType();
 
 		private bool IsAttachedProperty(XamlMemberDefinition member)

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -4657,7 +4657,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				throw new InvalidOperationException($"Unable to find markup extension type: '{member.Objects.FirstOrDefault()?.Type}' on '{member.Member}'");
 			}
 
-			var property = FindProperty(member.Member);
+			var property = FindProperty(member);
 			var declaringType = property?.ContainingType;
 			var propertyType = property?.FindDependencyPropertyType(unwrapNullable: false);
 
@@ -4684,7 +4684,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					var propertyType = markup.Symbol.GetPropertyWithName(m.Member.Name)?.Type as INamedTypeSymbol;
 					var resourceName = GetSimpleStaticResourceRetrieval(m, propertyType);
-					var value = resourceName ?? BuildLiteralValue(m, propertyType: propertyType, owner: member);
+					var value = resourceName ??
+						(HasCustomMarkupExtension(m)
+							? GetCustomMarkupExtensionValue(m, target, resourceOwner)
+							: BuildLiteralValue(m, propertyType: propertyType, owner: member));
 
 					return "{0} = {1}".InvariantCultureFormat(m.Member.Name, value);
 				})

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_MarkupExtension.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_MarkupExtension.cs
@@ -113,6 +113,14 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 			Assert.AreEqual(nameof(FullNameFirstMarkupExtension), (page.FullName as TextBlock).Tag);
 			Assert.AreEqual(nameof(ShortNameMarkup), (page.ShortName as TextBlock).Tag);
 		}
+
+		[TestMethod]
+		public void When_MarkupExtension_MultiLevelNesting()
+		{
+			var page = new MarkupExtension_MultiLevelNesting();
+
+			Assert.AreEqual(nameof(TargetValueExtension), (page.Nested as TextBlock).Tag);
+		}
 #endif
 	}
 }

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_MultiLevelNesting.xaml
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_MultiLevelNesting.xaml
@@ -1,0 +1,10 @@
+<Page x:Class="Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup.MarkupExtension_MultiLevelNesting"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup">
+	<StackPanel>
+		<TextBlock x:Name="Nested"
+				   x:FieldModifier="Public" 
+				   Tag="{local:Nested Value={local:Nested Value={local:Nested Value={local:TargetValue}}}}" />
+	</StackPanel>
+</Page>

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_MultiLevelNesting.xaml.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/MarkupExtension_MultiLevelNesting.xaml.cs
@@ -1,0 +1,24 @@
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Markup;
+
+namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup;
+
+public sealed partial class MarkupExtension_MultiLevelNesting : Page
+{
+	public MarkupExtension_MultiLevelNesting()
+	{
+		this.InitializeComponent();
+	}
+}
+
+public class NestedExtension : MarkupExtension
+{
+	public object Value { get; set; }
+
+	protected override object ProvideValue() => Value;
+}
+
+public class TargetValueExtension : MarkupExtension
+{
+	protected override object ProvideValue() => nameof(TargetValueExtension);
+}


### PR DESCRIPTION
Ensures GetCustomMarkupExtensionValue is recursive and evaluates for netsed custom Xaml extensions.

**GitHub Issue:** closes #21490

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->

- 🐞 Bugfix

## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using custom markup nested extensions, the XAML source generator is not designed to parse properties that are again a custom markup extension, so the next Xaml fails:

```xml
<lvc:CartesianChart>
	<lvc:CartesianChart.Series>
		<lvc:SeriesCollection>
			<lvc:XamlLineSeries
				SeriesName="Mary"
				Values="{lvc:Values FromString='5, 10, 8, 4'}"
				Stroke="{lvc:SolidColorPaint
					Color='#6495ED', 
					StrokeCap=Round, 
					StrokeWidth=10, 
					PathEffect={lvc:Dashed Array='30, 20'}}"/>
		</lvc:SeriesCollection>
	</lvc:CartesianChart.Series>
</lvc:CartesianChart>
```

It fails because the custom `SolidColorPaintExtension` sets the `PathEffect` property using the `Dashed` custom extension, this is currently not supported.

## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

This PR ensures that property members used in a custom markup extension evaluate whether the property is a custom markup extension, if it is then it recursively calls `GetCustomMarkupExtensionValue` to resolve the correct type and value for the property.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

No breaking changes.

## Other information ℹ️

<!-- Please provide any additional information if necessary -->