### PR TITLE
feat: Register MSBuild defaults to ensure consistent Roslyn initialization

### DIFF
--- a/src/Uno.UI.RemoteControl.DevServer.Tests/BannerHelperTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/BannerHelperTests.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Uno.UI.RemoteControl.Host.Helpers;
+using Uno.UI.RemoteControl.Helpers;
 
 namespace Uno.UI.RemoteControl.DevServer.Tests.Helpers;
 

--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Uno.UI.RemoteControl.DevServer.Tests.csproj
@@ -19,7 +19,7 @@
 
 	<ItemGroup>
 		<!-- Include BannerHelper source file directly for testing -->
-		<Compile Include="..\Uno.UI.RemoteControl.Host\Helpers\BannerHelper.cs" Link="Helpers\BannerHelper.cs" />
+		<Compile Include="..\Uno.UI.RemoteControl.Server\Helpers\BannerHelper.cs" Link="Helpers\BannerHelper.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -19,7 +19,6 @@ using Uno.UI.RemoteControl.Server.Helpers;
 using Uno.UI.RemoteControl.Server.Telemetry;
 using Uno.UI.RemoteControl.Services;
 using Uno.UI.RemoteControl.Helpers;
-using Microsoft.Build.Locator;
 
 namespace Uno.UI.RemoteControl.Host
 {
@@ -27,13 +26,6 @@ namespace Uno.UI.RemoteControl.Host
 	{
 		static async Task Main(string[] args)
 		{
-			// Register MSBuild defaults before any MSBuild assemblies are loaded
-			// This prevents TypeLoadException for Microsoft.NET.StringTools.FowlerNollVo1aHash
-			if (!MSBuildLocator.IsRegistered)
-			{
-				MSBuildLocator.RegisterDefaults();
-			}
-
 			var startTime = Stopwatch.GetTimestamp();
 
 			ITelemetry? telemetry = null;
@@ -242,19 +234,21 @@ namespace Uno.UI.RemoteControl.Host
 					? $"dotnet v{Environment.Version} (Assembly target: {targetFrameworkAttr.FrameworkDisplayName})"
 					: $"dotnet v{Environment.Version}";
 
-				var entries = new List<Host.Helpers.BannerHelper.BannerEntry>()
+				var lastWriteTime = File.GetLastWriteTime(location);
+				var entries = new List<BannerHelper.BannerEntry>()
 				{
 #if DEBUG
 					("Build", "DEBUG"),
+					("Build Date/Time", $"{lastWriteTime:yyyy-MM-dd/HH:mm:ss} ({DateTime.Now - lastWriteTime:g} ago)"),
 #endif
 					("Version", version),
 					("Runtime", runtimeText),
 					("Assembly", assemblyName),
-					("Location", Path.GetDirectoryName(location) ?? location, Helpers.BannerHelper.ClipMode.Start),
+					("Location", Path.GetDirectoryName(location) ?? location, BannerHelper.ClipMode.Start),
 					("HTTP Port", httpPort.ToString(DateTimeFormatInfo.InvariantInfo)),
 				};
 
-				Helpers.BannerHelper.Write("Uno Platform DevServer", entries);
+				BannerHelper.Write("Uno Platform DevServer", entries);
 			}
 			catch (Exception ex)
 			{

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -19,6 +19,7 @@ using Uno.UI.RemoteControl.Server.Helpers;
 using Uno.UI.RemoteControl.Server.Telemetry;
 using Uno.UI.RemoteControl.Services;
 using Uno.UI.RemoteControl.Helpers;
+using Microsoft.Build.Locator;
 
 namespace Uno.UI.RemoteControl.Host
 {
@@ -26,6 +27,13 @@ namespace Uno.UI.RemoteControl.Host
 	{
 		static async Task Main(string[] args)
 		{
+			// Register MSBuild defaults before any MSBuild assemblies are loaded
+			// This prevents TypeLoadException for Microsoft.NET.StringTools.FowlerNollVo1aHash
+			if (!MSBuildLocator.IsRegistered)
+			{
+				MSBuildLocator.RegisterDefaults();
+			}
+
 			var startTime = Stopwatch.GetTimestamp();
 
 			ITelemetry? telemetry = null;

--- a/src/Uno.UI.RemoteControl.Host/RemoteControlExtensions.cs
+++ b/src/Uno.UI.RemoteControl.Host/RemoteControlExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Net.WebSockets;
 using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
@@ -80,6 +81,13 @@ namespace Uno.UI.RemoteControl.Host
 							{
 								app.Log().LogError($"Unable to find configuration service");
 							}
+						}
+					}
+					catch (WebSocketException)
+					{
+						if (app.Log().IsEnabled(LogLevel.Information))
+						{
+							app.Log().LogInformation("Connection from {Remote} has been closed", context.Connection.RemoteIpAddress);
 						}
 					}
 					finally

--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -22,6 +22,10 @@
 		<PackageReference Include="StreamJsonRpc" Version="2.14.24" />
 		<PackageReference Include="MessagePack" Version="2.5.187" />
 		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.1.1" />
+		
+		<!-- Ensure MSBuild assemblies are resolved from the correct SDK at runtime -->
+		<PackageReference Include="Microsoft.Build.Locator" Version="1.9.1" />
+		<PackageReference Include="Microsoft.NET.StringTools" Version="17.14.8" />
 
 		<!-- StreamJsonRpc 2.14.24 brings in Microsoft.VisualStudio.Threading (and in turn -->
 		<!-- Microsoft.VisualStudio.Threading.Analyzers) version 17.1.46 -->

--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -22,9 +22,8 @@
 		<PackageReference Include="StreamJsonRpc" Version="2.14.24" />
 		<PackageReference Include="MessagePack" Version="2.5.187" />
 		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.1.1" />
-		
-		<!-- Ensure MSBuild assemblies are resolved from the correct SDK at runtime -->
-		<PackageReference Include="Microsoft.Build.Locator" Version="1.9.1" />
+
+		<!-- Ensure MSBuild dependencies are resolved correctly -->
 		<PackageReference Include="Microsoft.NET.StringTools" Version="17.14.8" />
 
 		<!-- StreamJsonRpc 2.14.24 brings in Microsoft.VisualStudio.Threading (and in turn -->

--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -20,11 +20,8 @@
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" />
 		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
 		<PackageReference Include="StreamJsonRpc" Version="2.14.24" />
-		<PackageReference Include="MessagePack" Version="2.5.187" />
+		<PackageReference Include="MessagePack" Version="3.1.4" />
 		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.1.1" />
-
-		<!-- Ensure MSBuild dependencies are resolved correctly -->
-		<PackageReference Include="Microsoft.NET.StringTools" Version="17.14.8" />
 
 		<!-- StreamJsonRpc 2.14.24 brings in Microsoft.VisualStudio.Threading (and in turn -->
 		<!-- Microsoft.VisualStudio.Threading.Analyzers) version 17.1.46 -->

--- a/src/Uno.UI.RemoteControl.Server.Processors/Helpers/BannerHelper.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Helpers/BannerHelper.cs
@@ -2,8 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 
-namespace Uno.UI.RemoteControl.Host.Helpers
+namespace Uno.UI.RemoteControl.Helpers
 {
 	/// <summary>
 	/// Console banner rendering utilities.
@@ -26,6 +27,13 @@ namespace Uno.UI.RemoteControl.Host.Helpers
 		{
 			public static implicit operator BannerEntry((string Key, string Value, ClipMode Clip) t) => new(t.Key, t.Value, t.Clip);
 			public static implicit operator BannerEntry((string Key, string Value) t) => new(t.Key, t.Value);
+		}
+
+		public static void Write(string title, IReadOnlyDictionary<string, string> entries, int maxInnerWidth = 118, TextWriter? output = null)
+		{
+			ArgumentNullException.ThrowIfNull(title);
+			ArgumentNullException.ThrowIfNull(entries);
+			Write(title, [.. entries.Select(kvp => new BannerEntry(kvp.Key, kvp.Value))], maxInnerWidth, output);
 		}
 
 		/// <summary>

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -11,6 +11,7 @@ using Uno.UI.RemoteControl.Helpers;
 using System.Collections.Generic;
 using System.Runtime.Loader;
 using Microsoft.Extensions.Logging;
+using Microsoft.Build.Locator;
 using System.Composition.Hosting;
 
 namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
@@ -104,6 +105,14 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 
 		public static void InitializeRoslyn(string? workDir)
 		{
+			// Register MSBuild defaults to ensure a coherent set of MSBuild assemblies is loaded
+			// before any MSBuild/Roslyn types are referenced. This prevents mixed assembly
+			// load contexts that can cause TypeLoadException for Microsoft.NET.StringTools.
+			if (!MSBuildLocator.IsRegistered)
+			{
+				MSBuildLocator.RegisterDefaults();
+			}
+
 			RegisterAssemblyLoader();
 
 			MSBuildBasePath = BuildMSBuildPath(workDir);

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -11,8 +11,6 @@ using Uno.UI.RemoteControl.Helpers;
 using System.Collections.Generic;
 using System.Runtime.Loader;
 using Microsoft.Extensions.Logging;
-using Microsoft.Build.Locator;
-using System.Composition.Hosting;
 
 namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 {
@@ -140,7 +138,6 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 				throw new InvalidOperationException($"Invalid dotnet installation installation (Cannot find Microsoft.Build.dll in [{MSBuildBasePath}])");
 			}
 
-			// Add a banner with the version of the MSBuild used, project path (workdir), etc... using the banner helper
 			var entries = new List<BannerHelper.BannerEntry>()
 			{
 				("MSBuild", MSBuildBasePath),

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -28,6 +28,9 @@
 
 		<!-- Avoid transitive dependency from Microsoft.Build.Tasks.Core on 6.0.0 which has a vulnerability -->
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
+
+		<!-- Ensure MSBuild assemblies are resolved from the correct SDK at runtime -->
+		<PackageReference Include="Microsoft.Build.Locator" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net9.0'">

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -40,7 +40,7 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
-		<!-- TODO: Use version 8 when compiling against .NET 8? -->
+		<!-- TODO: Use version 9 when compiling against .NET 9? -->
 		<PackageReference Include="Microsoft.Build" Version="17.3.0" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="17.8.27" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.27" ExcludeAssets="runtime" />
@@ -50,11 +50,11 @@
 	<ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.13.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.13.0" />
-		<!-- TODO: Use version 9 when compiling against .NET 9? -->
+		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.14.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
+		<!-- TODO: Use version 10 when compiling against .NET 10? -->
 		<PackageReference Include="Microsoft.Build" Version="17.7.2" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="17.8.27" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.27" ExcludeAssets="runtime" />

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -28,9 +28,6 @@
 
 		<!-- Avoid transitive dependency from Microsoft.Build.Tasks.Core on 6.0.0 which has a vulnerability -->
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.2" />
-
-		<!-- Ensure MSBuild assemblies are resolved from the correct SDK at runtime -->
-		<PackageReference Include="Microsoft.Build.Locator" Version="1.9.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net9.0'">

--- a/src/Uno.UI.RemoteControl.Server/Helpers/BannerHelper.cs
+++ b/src/Uno.UI.RemoteControl.Server/Helpers/BannerHelper.cs
@@ -29,11 +29,11 @@ namespace Uno.UI.RemoteControl.Helpers
 			public static implicit operator BannerEntry((string Key, string Value) t) => new(t.Key, t.Value);
 		}
 
-		public static void Write(string title, IReadOnlyDictionary<string, string> entries, int maxInnerWidth = 118, TextWriter? output = null)
+		public static void Write(string title, IReadOnlyDictionary<string, string> dictionary, int maxInnerWidth = 118, TextWriter? output = null)
 		{
 			ArgumentNullException.ThrowIfNull(title);
-			ArgumentNullException.ThrowIfNull(entries);
-			Write(title, [.. entries.Select(kvp => new BannerEntry(kvp.Key, kvp.Value))], maxInnerWidth, output);
+			ArgumentNullException.ThrowIfNull(dictionary);
+			Write(title, [.. dictionary.Select(kvp => new BannerEntry(kvp.Key, kvp.Value))], maxInnerWidth, output);
 		}
 
 		/// <summary>

--- a/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
+++ b/src/Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj
@@ -46,7 +46,7 @@
 		<PackageReference Include="Newtonsoft.Json" />
 		<PackageReference Include="NuGet.VisualStudio" version="4.5.0" />
 		<PackageReference Include="Microsoft.VisualStudio.ProjectSystem" Version="17.0.1313-pre" />
-		<PackageReference Include="MessagePack" Version="2.5.187" />
+		<PackageReference Include="MessagePack" Version="3.1.4" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno.vscode/issues/1129

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

# 🐞 Bugfix
Fixed a regression caused by upgrade to `net10`.

## What is the new behavior? 🚀

This PR adds MSBuild defaults registration to ensure consistent Roslyn initialization in the Uno Platform's Remote Control Server. The main goal is to improve the reliability of compilation workspace creation by properly locating and initializing MSBuild assemblies.

Key changes include:
- Adjust dependencies to ensure proper resolution at runtime
- Enhanced debugging capabilities with banner displays showing MSBuild configuration
- Namespace consolidation and code organization improvements

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [X] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes
