### PR TITLE
fix(devserver): Align nuspec TFMs, add missing net9 BuildHost, host select (net9/net10) and Roslyn TFM check

### DIFF
--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -335,7 +335,7 @@
 	<Target Name="BuildNuGetPackage" AfterTargets="Build" DependsOnTargets="PrepareBuildAssets" Condition="'$(BuildingInsideVisualStudio)'=='' and '$(Configuration)'=='Release'">
 		<PropertyGroup>
 			<!-- NU5123: Long paths — disabled because buildTransitive targets in Uno.UI.Runtime.Skia.WebAssembly.Browser exceed path length limits -->
-			<NuSpecProperties>NoWarn=NU5100,NU5105,NU5131,NU5123;branch=$(NBGV_BuildingRef);commitid=$(NBGV_GitCommitId)</NuSpecProperties>
+			<NuSpecProperties>NoWarn=NU5100;NU5105;NU5131;NU5123;branch=$(NBGV_BuildingRef);commitid=$(NBGV_GitCommitId)</NuSpecProperties>
 			<NuSpecProperties Condition="'$(UNO_UWP_BUILD)'=='true'">$(NuSpecProperties);winuisourcepath=uap10.0.19041;winuitargetpath=UAP</NuSpecProperties>
 			<NuSpecProperties Condition="'$(UNO_UWP_BUILD)'!='true'">$(NuSpecProperties);winuisourcepath=net9.0-windows10.0.19041.0;winuitargetpath=net9.0-windows10.0.19041.0</NuSpecProperties>
 		</PropertyGroup>

--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -334,8 +334,8 @@
 
 	<Target Name="BuildNuGetPackage" AfterTargets="Build" DependsOnTargets="PrepareBuildAssets" Condition="'$(BuildingInsideVisualStudio)'=='' and '$(Configuration)'=='Release'">
 		<PropertyGroup>
-			<!-- NU5123: Long paths - disabled as tragets in Uno.UI.Runtime.Skia.WebAssembly.Browser\buildTransitive have too long paths -->
-			<NuSpecProperties>NoWarn=NU5100,NU5105,NU5131;NU5123;branch=$(NBGV_BuildingRef);commitid=$(NBGV_GitCommitId)</NuSpecProperties>
+			<!-- NU5123: Long paths — disabled because buildTransitive targets in Uno.UI.Runtime.Skia.WebAssembly.Browser exceed path length limits -->
+			<NuSpecProperties>NoWarn=NU5100,NU5105,NU5131,NU5123;branch=$(NBGV_BuildingRef);commitid=$(NBGV_GitCommitId)</NuSpecProperties>
 			<NuSpecProperties Condition="'$(UNO_UWP_BUILD)'=='true'">$(NuSpecProperties);winuisourcepath=uap10.0.19041;winuitargetpath=UAP</NuSpecProperties>
 			<NuSpecProperties Condition="'$(UNO_UWP_BUILD)'!='true'">$(NuSpecProperties);winuisourcepath=net9.0-windows10.0.19041.0;winuitargetpath=net9.0-windows10.0.19041.0</NuSpecProperties>
 		</PropertyGroup>

--- a/build/nuget/Uno.WinUI.DevServer.nuspec
+++ b/build/nuget/Uno.WinUI.DevServer.nuspec
@@ -176,7 +176,10 @@
 		<!-- Remote Control host and integration -->
 		<file src="..\..\src\Uno.UI.RemoteControl.Host\bin\Release\net9.0\*.*" target="tools\rc\host\net9.0" />
 		<file src="..\..\src\Uno.UI.RemoteControl.Host\bin\Release\net10.0\*.*" target="tools\rc\host\net10.0" />
-		
+		<!-- BuildHost payloads required at runtime -->
+		<file src="..\..\src\Uno.UI.RemoteControl.Server\bin\Release\net9.0\BuildHost-netcore\**"  target="tools\rc\host\net9.0\BuildHost-netcore" />
+		<file src="..\..\src\Uno.UI.RemoteControl.Server\bin\Release\net10.0\BuildHost-netcore\**" target="tools\rc\host\net10.0\BuildHost-netcore" />
+
 		<file src="..\..\src\Uno.UI.RemoteControl.VS\bin\Release\net48\*.dll" target="tools\rc\17.0" />
 		<file src="..\..\src\Uno.UI.RemoteControl.VS\bin\Release\net48\*.pdb" target="tools\rc\17.0" />
 		<file src="..\..\src\Uno.UI.RemoteControl.VS\bin\Release\net48\Newtonsoft.Json.dll" target="tools\rc\17.0" />

--- a/build/nuget/Uno.WinUI.DevServer.nuspec
+++ b/build/nuget/Uno.WinUI.DevServer.nuspec
@@ -80,7 +80,7 @@
 				<dependency id="Newtonsoft.Json" version="13.0.3" />
 			</group>
 
-			<!-- .NET 9.0 (Reference API) -->
+			<!-- .NET 10.0 (Reference API) -->
 			<group targetFramework="net10.0">
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
@@ -89,7 +89,7 @@
 				<dependency id="Uno.Wasm.WebSockets" version="1.1.0" />
 			</group>
 
-			<!-- .NET 8.0 (Reference API) -->
+			<!-- .NET 9.0 (Reference API) -->
 			<group targetFramework="net9.0">
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 				<dependency id="Uno.WinUI.DevServer.Messaging" version="1.29.0-dev.93" />
@@ -98,12 +98,12 @@
 				<dependency id="Uno.Wasm.WebSockets" version="1.1.0" />
 			</group>
 
-			<!-- .NET 9.0 (WinUI) -->
+			<!-- .NET 10.0 (WinUI) -->
 			<group targetFramework="net10.0-windows10.0.19041.0">
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 			</group>
 
-			<!-- .NET 8.0 (WinUI) -->
+			<!-- .NET 9.0 (WinUI) -->
 			<group targetFramework="net9.0-windows10.0.19041.0">
 				<dependency id="Uno.WinUI" version="1.29.0-dev.93" />
 			</group>
@@ -149,6 +149,7 @@
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net9.0\*.pdb" target="tools\rc\processors\net9.0" />
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net10.0\*.dll" target="tools\rc\processors\net10.0" />
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net10.0\*.pdb" target="tools\rc\processors\net10.0" />
+		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net9.0\BuildHost-netcore\**" target="tools\rc\processors\net9.0\BuildHost-netcore" />
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net10.0\BuildHost-netcore\**" target="tools\rc\processors\net10.0\BuildHost-netcore" />
 
 		<!-- Build targets -->

--- a/build/nuget/Uno.WinUI.DevServer.nuspec
+++ b/build/nuget/Uno.WinUI.DevServer.nuspec
@@ -151,6 +151,8 @@
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net10.0\*.pdb" target="tools\rc\processors\net10.0" />
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net9.0\BuildHost-netcore\**" target="tools\rc\processors\net9.0\BuildHost-netcore" />
 		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net10.0\BuildHost-netcore\**" target="tools\rc\processors\net10.0\BuildHost-netcore" />
+		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net9.0\BuildHost-net472\**" target="tools\rc\processors\net9.0\BuildHost-net472" />
+		<file src="..\..\src\Uno.UI.RemoteControl.Server.Processors\bin\Release\net10.0\BuildHost-net472\**" target="tools\rc\processors\net10.0\BuildHost-net472" />
 
 		<!-- Build targets -->
 		<file src="..\..\src\Uno.UI.RemoteControl\buildTransitive\*" target="buildTransitive" />

--- a/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
+++ b/src/Uno.UI.RemoteControl.Host/Uno.UI.RemoteControl.Host.csproj
@@ -32,6 +32,17 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Build" Version="17.8.27" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="17.8.27" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.27" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.27" ExcludeAssets="runtime" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Drawing.Common" Version="9.0.0" ExcludeAssets="runtime" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<Compile Include="..\Uno.UI.RemoteControl\Helpers\**\*.cs" Exclude="..\Uno.UI.RemoteControl\Helpers\ServiceCollectionExtensions.cs" Link="Helpers/%(Filename)" />
 		<Compile Include="..\Uno.UI.RemoteControl.Server.Processors\Helpers\**\*.cs" Link="Helpers/%(Filename)" />
 	</ItemGroup>

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/MetadataUpdates/CompilationWorkspaceProvider.cs
@@ -140,9 +140,16 @@ namespace Uno.UI.RemoteControl.Host.HotReload.MetadataUpdates
 			}
 		}
 
-		// Prefer UNO_RC_HOST_TFM (set by targets) to decide the expected major.
+		// Prefer UNO_RC_HOST_SDK_MAJOR (set by targets) to decide the expected major; fall back to legacy UNO_RC_HOST_TFM.
 		private static int GetExpectedMajorFromHostOrSdk(string? workDir)
 		{
+			var sdkMajorEnv = Environment.GetEnvironmentVariable("UNO_RC_HOST_SDK_MAJOR");
+			if (!string.IsNullOrWhiteSpace(sdkMajorEnv) && int.TryParse(sdkMajorEnv.Trim(), out var envMajor) && envMajor > 0)
+			{
+				return envMajor;
+			}
+
+			// Legacy env var: UNO_RC_HOST_TFM with values like net10.0 / net9.0
 			var tfm = Environment.GetEnvironmentVariable("UNO_RC_HOST_TFM");
 			if (!string.IsNullOrEmpty(tfm))
 			{

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>$(NetPrevious);$(NetCurrent)</TargetFrameworks>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<Nullable>enable</Nullable>
-		
+
 		<!-- We need all the intermediate assemblies to be located in the processors -->
 		<DisablePrivateProjectReference>true</DisablePrivateProjectReference>
 	</PropertyGroup>
@@ -31,14 +31,15 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net9.0'">
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+		<!-- Logging aligned with .NET 9 runtime -->
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.8.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
-		<!-- TODO: Use version 8 when compiling against .NET 8? -->
-		<PackageReference Include="Microsoft.Build" Version="17.3.0" ExcludeAssets="runtime" />
+		<!-- MSBuild toolset aligned across TFMs -->
+		<PackageReference Include="Microsoft.Build" Version="17.8.27" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="17.8.27" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.27" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.27" ExcludeAssets="runtime" />
@@ -51,8 +52,8 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.14.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
-		<!-- TODO: Use version 9 when compiling against .NET 9? -->
-		<PackageReference Include="Microsoft.Build" Version="17.7.2" ExcludeAssets="runtime" />
+		<!-- MSBuild toolset used by Roslyn on .NET 10 -->
+		<PackageReference Include="Microsoft.Build" Version="17.8.27" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Framework" Version="17.8.27" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.27" ExcludeAssets="runtime" />
 		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.27" ExcludeAssets="runtime" />
@@ -66,7 +67,6 @@
 		<PropertyGroup>
 			<_OverridePackageId>uno.ui</_OverridePackageId>
 			<_OverridePackageId Condition="'$(UNO_UWP_BUILD)'=='false'">uno.winui</_OverridePackageId>
-
 			<_TargetNugetFolder>$(NuGetPackageRoot)\$(_OverridePackageId).devserver\$(UnoNugetOverrideVersion)\tools\rc\processors\$(TargetFramework)</_TargetNugetFolder>
 		</PropertyGroup>
 		<ItemGroup>
@@ -79,5 +79,35 @@
 	</Target>
 
 	<Target Name="GetTargetPath" />
+
+	<!--
+		Ensure BuildHost-netcore exists and is populated for the current TFM.
+		The nuspec packs src/Uno.UI.RemoteControl.Server.Processors/bin/Release/net9.0/BuildHost-netcore/** and net10.0/BuildHost-netcore/**
+		We mirror the host payload from the Server project output into the Processors output so packing succeeds for both TFMs.
+	-->
+	<Target Name="EnsureBuildHostNetcore"
+			AfterTargets="Build">
+		<PropertyGroup>
+			<_ServerHostDir>$(MSBuildThisFileDirectory)..\Uno.UI.RemoteControl.Server\bin\$(Configuration)\$(TargetFramework)\BuildHost-netcore</_ServerHostDir>
+			<_ProcessorsHostDir>$(TargetDir)BuildHost-netcore</_ProcessorsHostDir>
+		</PropertyGroup>
+
+		<!-- If the Server project produced a host folder, mirror it -->
+		<ItemGroup Condition="Exists('$(_ServerHostDir)')">
+			<_HostFiles Include="$(_ServerHostDir)\**\*.*" />
+		</ItemGroup>
+
+		<!-- Only create the folder if it doesn’t exist -->
+		<MakeDir Directories="$(_ProcessorsHostDir)" Condition="!Exists('$(_ProcessorsHostDir)')" />
+
+		<Copy Condition="@( _HostFiles ) != ''"
+			  SourceFiles="@(_HostFiles)"
+			  DestinationFiles="@(_HostFiles->'$(_ProcessorsHostDir)\%(RecursiveDir)%(Filename)%(Extension)')"
+			  SkipUnchangedFiles="true" />
+
+		<Message Importance="High" Text="EnsureBuildHostNetcore: From='$(_ServerHostDir)' To='$(_ProcessorsHostDir)'. Files copied: @( _HostFiles->Count() )" />
+		<Warning Condition="!Exists('$(_ServerHostDir)')"
+				 Text="BuildHost-netcore was not found at '$(_ServerHostDir)'. The nuspec may fail to pack this TFM." />
+	</Target>
 
 </Project>

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -86,7 +86,8 @@
 		We mirror the host payload from the Server project output into the Processors output so packing succeeds for both TFMs.
 	-->
 	<Target Name="EnsureBuildHostNetcore"
-			AfterTargets="Build">
+			AfterTargets="Build"
+			Condition="'$(IsCrossTargetingBuild)' != 'true' and '$(TargetFramework)' != ''">
 		<PropertyGroup>
 			<_ServerHostDir>$(MSBuildThisFileDirectory)..\Uno.UI.RemoteControl.Server\bin\$(Configuration)\$(TargetFramework)\BuildHost-netcore</_ServerHostDir>
 			<_ProcessorsHostDir>$(TargetDir)BuildHost-netcore</_ProcessorsHostDir>

--- a/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
+++ b/src/Uno.UI.RemoteControl.Server.Processors/Uno.UI.RemoteControl.Server.Processors.csproj
@@ -111,4 +111,17 @@
 				 Text="BuildHost-netcore was not found at '$(_ServerHostDir)'. The nuspec may fail to pack this TFM." />
 	</Target>
 
+	<!-- Ensure BuildHost-net472 folder exists so nuspec <file> entries resolve -->
+	<Target Name="EnsureBuildHostNet472"
+			AfterTargets="Build"
+			Condition="'$(IsCrossTargetingBuild)' != 'true' and '$(TargetFramework)' != ''">
+		<PropertyGroup>
+			<_ProcessorsHostDirNet472>$(TargetDir)BuildHost-net472</_ProcessorsHostDirNet472>
+		</PropertyGroup>
+
+		<!-- Ensure folder exists before nuspec packing. Folder will normally contain mirrored BuildHost-netcore files, but NuGet.exe requires the directory to exist even if empty. -->
+		<MakeDir Directories="$(_ProcessorsHostDirNet472)" Condition="!Exists('$(_ProcessorsHostDirNet472)')" />
+		<Message Importance="High" Text="EnsureBuildHostNet472: Ensured '$(_ProcessorsHostDirNet472)'" />
+	</Target>
+
 </Project>

--- a/src/Uno.UI.RemoteControl.Server/Uno.UI.RemoteControl.Server.csproj
+++ b/src/Uno.UI.RemoteControl.Server/Uno.UI.RemoteControl.Server.csproj
@@ -21,13 +21,68 @@
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" />
 		<PackageReference Include="Uno.DevTools.Telemetry" Version="1.1.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Build" Version="17.8.27" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Framework" Version="17.8.27" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.27" ExcludeAssets="runtime" />
+		<PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.27" ExcludeAssets="runtime" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Drawing.Common" Version="9.0.0" ExcludeAssets="runtime" />
+	</ItemGroup>
+
+	<!-- Roslyn MSBuild Workspaces; GeneratePathProperty gives $(PkgMicrosoft_CodeAnalysis_Workspaces_MSBuild) -->
+	<ItemGroup Condition="'$(TargetFramework)'=='$(NetPrevious)'">
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" GeneratePathProperty="true" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='$(NetCurrent)'">
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" GeneratePathProperty="true" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.UI.RemoteControl.Messaging\Uno.UI.RemoteControl.Messaging.csproj" />
 	</ItemGroup>
+
+	<!-- Create BuildHost-netcore next to Server output using the Roslyn MSBuild tools -->
+	<Target Name="PrepareBuildHostNetcore" AfterTargets="Build">
+		<PropertyGroup>
+			<!-- Path provided by GeneratePathProperty -->
+			<_RoslynToolsRoot>$(PkgMicrosoft_CodeAnalysis_Workspaces_MSBuild)\tools</_RoslynToolsRoot>
+
+			<!-- Choose the tools TFM based on current target -->
+			<_RoslynToolsTfm Condition="'$(TargetFramework)'=='net9.0'">net9.0</_RoslynToolsTfm>
+			<_RoslynToolsTfm Condition="'$(TargetFramework)'=='net10.0'">net10.0</_RoslynToolsTfm>
+
+			<_RoslynToolsDir>$(_RoslynToolsRoot)\$(_RoslynToolsTfm)</_RoslynToolsDir>
+			<_OutDir>$(TargetDir)BuildHost-netcore</_OutDir>
+		</PropertyGroup>
+
+		<!-- Prefer /tools/<tfm>, fall back to /tools if layout differs -->
+		<ItemGroup Condition="Exists('$(_RoslynToolsDir)')">
+			<_RoslynFiles Include="$(_RoslynToolsDir)\**\*.*" />
+		</ItemGroup>
+		<ItemGroup Condition="!Exists('$(_RoslynToolsDir)') and Exists('$(_RoslynToolsRoot)')">
+			<_RoslynFiles Include="$(_RoslynToolsRoot)\**\*.*" />
+		</ItemGroup>
+
+		<MakeDir Directories="$(_OutDir)" />
+
+		<Copy Condition="@( _RoslynFiles ) != ''"
+			  SourceFiles="@(_RoslynFiles)"
+			  DestinationFiles="@(_RoslynFiles->'$(_OutDir)\%(RecursiveDir)%(Filename)%(Extension)')"
+			  SkipUnchangedFiles="true" />
+
+		<Message Importance="High"
+				 Text="PrepareBuildHostNetcore: From='$(_RoslynToolsDir)' To='$(_OutDir)'. Files: @(_RoslynFiles->Count())" />
+		<Warning Condition="@( _RoslynFiles ) == ''"
+				 Text="Roslyn BuildHost tools not found in '$(PkgMicrosoft_CodeAnalysis_Workspaces_MSBuild)'. BuildHost-netcore will be empty for $(TargetFramework)." />
+	</Target>
 
 	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
 		<PropertyGroup>

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -3,10 +3,10 @@
 
 	<ItemGroup>
 		<UnoRuntimeEnabledPackage Include="Uno.UI.DevServer" PackageBasePath="$(MSBuildThisFileDirectory)" Condition="'$(MSBuildThisFile)'=='uno.ui.devserver.targets'" />
-		<UnoRuntimeEnabledPackage Include="Uno.WinUI.DevServer"  PackageBasePath="$(MSBuildThisFileDirectory)" Condition="'$(MSBuildThisFile)'=='uno.winui.devserver.targets'"  />
+		<UnoRuntimeEnabledPackage Include="Uno.WinUI.DevServer" PackageBasePath="$(MSBuildThisFileDirectory)" Condition="'$(MSBuildThisFile)'=='uno.winui.devserver.targets'" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$(UnoRemoteControlConfigCookie) != ''">
+	<ItemGroup Condition="'$(UnoRemoteControlConfigCookie)' != ''">
 		<UpToDateCheckInput Include="$(UnoRemoteControlConfigCookie)" />
 	</ItemGroup>
 
@@ -15,33 +15,48 @@
 		<UnoRemoteControlProcessorsPath Condition="'$(SolutionFileName)'!='Uno.UI.sln'">$(MSBuildThisFileDirectory)../tools/rc/processors</UnoRemoteControlProcessorsPath>
 	</PropertyGroup>
 
+	<!-- Select the DevServer host TFM by SDK major, with fallbacks to net9.0/net10.0.
+		 Expose selected TFM as UNO_RC_HOST_TFM for the running app. -->
 	<Target Name="GetRemoteControlHostPath">
 		<PropertyGroup>
 			<_IsRCClientRemote>false</_IsRCClientRemote>
 			<_IsRCClientRemote Condition="'$(PkgUno_Wasm_Bootstrap_DevServer)'!=''">true</_IsRCClientRemote>
 
-			<_UnoRCHostVersionPath>net9.0</_UnoRCHostVersionPath>
+			<!-- Derive SDK major from BundledNETCoreAppTargetFrameworkVersion (e.g., 9.0.2 -> 9). Default to 9. -->
+			<_UnoRCHostMajor>$([System.Text.RegularExpressions.Regex]::Match('$(BundledNETCoreAppTargetFrameworkVersion)', '^\d+').Value)</_UnoRCHostMajor>
+			<_UnoRCHostMajor Condition="'$(_UnoRCHostMajor)'==''">9</_UnoRCHostMajor>
 
-			<!-- Use the SDK version used to build the app, not the target framework (e.g. a net9.0 app may be built with a net9 SDK)-->
-			<_UnoRCHostVersionPath Condition="'$(BundledNETCoreAppTargetFrameworkVersion)' &gt; 9">net10.0</_UnoRCHostVersionPath>
+			<_UnoRCHostVersionPath>net$(_UnoRCHostMajor).0</_UnoRCHostVersionPath>
+			<_UnoRCHostDll>$(MSBuildThisFileDirectory)../tools/rc/host/$(_UnoRCHostVersionPath)/Uno.UI.RemoteControl.Host.dll</_UnoRCHostDll>
+
+			<!-- Fallbacks if computed host path doesn't exist -->
+			<_UnoRCHostDll Condition="!Exists('$(_UnoRCHostDll)')">$(MSBuildThisFileDirectory)../tools/rc/host/net9.0/Uno.UI.RemoteControl.Host.dll</_UnoRCHostDll>
+			<_UnoRCHostDll Condition="!Exists('$(_UnoRCHostDll)')">$(MSBuildThisFileDirectory)../tools/rc/host/net10.0/Uno.UI.RemoteControl.Host.dll</_UnoRCHostDll>
+
+			<!-- Extract the selected TFM folder name (e.g., net9.0 / net10.0) from the final path -->
+			<_UnoRCHostTfm>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('$(_UnoRCHostDll)'))))</_UnoRCHostTfm>
 		</PropertyGroup>
 
-		<Message Text="&lt;RemoteControlHostPath&gt;$(MSBuildThisFileDirectory)../tools/rc/host/$(_UnoRCHostVersionPath)/Uno.UI.RemoteControl.Host.dll&lt;/RemoteControlHostPath&gt;" Importance="High" />
+		<Error Condition="!Exists('$(_UnoRCHostDll)')"
+			   Text="Uno DevServer host not found (tried $(_UnoRCHostVersionPath), net9.0, net10.0). Ensure the package includes tools/rc/host for your .NET SDK." />
+
+		<Message Text="&lt;RemoteControlHostPath&gt;$(_UnoRCHostDll)&lt;/RemoteControlHostPath&gt;" Importance="High" />
 		<Message Text="&lt;IntermediateOutputPath&gt;$(MSBuildProjectDirectory)/$(IntermediateOutputPath)&lt;/IntermediateOutputPath&gt;" Importance="High" />
 		<Message Text="&lt;IsRCClientRemote&gt;$(_IsRCClientRemote)&lt;/IsRCClientRemote&gt;" Importance="High" />
+		<Message Text="&lt;UnoRCHostTfm&gt;$(_UnoRCHostTfm)&lt;/UnoRCHostTfm&gt;" Importance="High" />
 	</Target>
 
 	<Target Name="UnoDumpRemoteControlAddIns">
 		<Message Text="&lt;RemoteControlAddIns&gt;@(UnoRemoteControlAddIns)&lt;/RemoteControlAddIns&gt;" Importance="High" />
 		<WriteLinesToFile
-			Condition="$(UnoDumpRemoteControlAddInsTargetFile) != ''"
+			Condition="'$(UnoDumpRemoteControlAddInsTargetFile)' != ''"
 			File="$(UnoDumpRemoteControlAddInsTargetFile)"
 			Lines="@(UnoRemoteControlAddIns)"
 			Overwrite="false"
-			Encoding="Unicode"/>
+			Encoding="Unicode" />
 	</Target>
 
-	<!-- .NET 7 and earlier compatibility for .NET8 msbuild CLI `getProperty` equivalent -->
+	<!-- .NET 7 and earlier compatibility for .NET 8 msbuild CLI `getProperty` equivalent -->
 	<Target Name="UnoVSCodeGetProjectProperties">
 		<Message Text='{%0a  "Properties": {%0a    "TargetFramework": "$(TargetFramework)",' Importance="High" />
 		<Message Text='    "TargetFrameworks": "$(TargetFrameworks)",' Importance="High" />
@@ -53,16 +68,15 @@
 	<Target Name="InjectRemoteControlHost"
 			BeforeTargets="BeforeBuild"
 			Condition="exists('$(IntermediateOutputPath)\RemoteControlHost.config') and '$(BuildingInsideVisualStudio)'!='true' and '$(Configuration)'=='Debug'">
-
 		<Warning
-			Text="The version of uno's extension installed on your IDE is obsolete, please update to the latest version.
-				  If error persists, try to delete obj folder and rebuild your solution." />
+			Text="The version of Uno Platform's extension installed on your IDE is obsolete, please update to the latest version. If error persists, try to delete the obj folder and rebuild your solution." />
 	</Target>
 
+	<!-- Android: Add DOTNET_MODIFIABLE_ASSEMBLIES=debug and UNO_RC_HOST_TFM -->
 	<Target
 		Name="_UnoHotReloadConfigAndroidEnv"
 		BeforeTargets="BeforeBuild"
-		Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'android' and '$(Optimize)'!='true'">
+		Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' and '$(Optimize)'!='true'">
 
 		<PropertyGroup>
 			<_UnoHotReloadEnvironmentConfig>$(IntermediateOutputPath)environment.hotreload.conf</_UnoHotReloadEnvironmentConfig>
@@ -71,7 +85,7 @@
 		<WriteLinesToFile
 			Overwrite="True"
 			File="$(_UnoHotReloadEnvironmentConfig)"
-			Lines="DOTNET_MODIFIABLE_ASSEMBLIES=debug" />
+			Lines="DOTNET_MODIFIABLE_ASSEMBLIES=debug%0aUNO_RC_HOST_TFM=$(_UnoRCHostTfm)" />
 
 		<ItemGroup>
 			<AndroidEnvironment Include="$(_UnoHotReloadEnvironmentConfig)" />
@@ -79,11 +93,15 @@
 		</ItemGroup>
 	</Target>
 
-	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'ios' and '$(Optimize)'!='true'">
-		<MlaunchEnvironmentVariables  Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
+	<!-- iOS: Add UNO_RC_HOST_TFM and DOTNET_MODIFIABLE_ASSEMBLIES -->
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' and '$(Optimize)'!='true'">
+		<MlaunchEnvironmentVariables Include="UNO_RC_HOST_TFM" Value="$(_UnoRCHostTfm)" />
+		<MlaunchEnvironmentVariables Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
 	</ItemGroup>
 
-	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'browserwasm' and '$(Optimize)'!='true'">
+	<!-- BrowserWasm: Add UNO_RC_HOST_TFM and DOTNET_MODIFIABLE_ASSEMBLIES -->
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm' and '$(Optimize)'!='true'">
+		<WasmShellMonoEnvironment Include="UNO_RC_HOST_TFM" Value="$(_UnoRCHostTfm)" />
 		<WasmShellMonoEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
 	</ItemGroup>
 

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<!-- Select the DevServer host TFM by SDK major, with fallbacks to net9.0/net10.0.
-		 Expose selected TFM as UNO_RC_HOST_TFM for the running app. -->
+       Expose selected TFM as UNO_RC_HOST_TFM for the running app. -->
 	<Target Name="GetRemoteControlHostPath">
 		<PropertyGroup>
 			<_IsRCClientRemote>false</_IsRCClientRemote>
@@ -49,11 +49,11 @@
 	<Target Name="UnoDumpRemoteControlAddIns">
 		<Message Text="&lt;RemoteControlAddIns&gt;@(UnoRemoteControlAddIns)&lt;/RemoteControlAddIns&gt;" Importance="High" />
 		<WriteLinesToFile
-			Condition="'$(UnoDumpRemoteControlAddInsTargetFile)' != ''"
-			File="$(UnoDumpRemoteControlAddInsTargetFile)"
-			Lines="@(UnoRemoteControlAddIns)"
-			Overwrite="false"
-			Encoding="Unicode" />
+		  Condition="'$(UnoDumpRemoteControlAddInsTargetFile)' != ''"
+		  File="$(UnoDumpRemoteControlAddInsTargetFile)"
+		  Lines="@(UnoRemoteControlAddIns)"
+		  Overwrite="false"
+		  Encoding="Unicode" />
 	</Target>
 
 	<!-- .NET 7 and earlier compatibility for .NET 8 msbuild CLI `getProperty` equivalent -->
@@ -69,23 +69,23 @@
 			BeforeTargets="BeforeBuild"
 			Condition="exists('$(IntermediateOutputPath)\RemoteControlHost.config') and '$(BuildingInsideVisualStudio)'!='true' and '$(Configuration)'=='Debug'">
 		<Warning
-			Text="The version of Uno Platform's extension installed on your IDE is obsolete, please update to the latest version. If error persists, try to delete the obj folder and rebuild your solution." />
+		  Text="The version of Uno Platform's extension installed on your IDE is obsolete, please update to the latest version. If error persists, try to delete the obj folder and rebuild your solution." />
 	</Target>
 
 	<!-- Android: Add DOTNET_MODIFIABLE_ASSEMBLIES=debug and UNO_RC_HOST_TFM -->
 	<Target
-		Name="_UnoHotReloadConfigAndroidEnv"
-		BeforeTargets="BeforeBuild"
-		Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android' and '$(Optimize)'!='true'">
+	  Name="_UnoHotReloadConfigAndroidEnv"
+	  BeforeTargets="BeforeBuild"
+	  Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'android' and '$(Optimize)'!='true'">
 
 		<PropertyGroup>
 			<_UnoHotReloadEnvironmentConfig>$(IntermediateOutputPath)environment.hotreload.conf</_UnoHotReloadEnvironmentConfig>
 		</PropertyGroup>
 
 		<WriteLinesToFile
-			Overwrite="True"
-			File="$(_UnoHotReloadEnvironmentConfig)"
-			Lines="DOTNET_MODIFIABLE_ASSEMBLIES=debug%0aUNO_RC_HOST_TFM=$(_UnoRCHostTfm)" />
+		  Overwrite="True"
+		  File="$(_UnoHotReloadEnvironmentConfig)"
+		  Lines="DOTNET_MODIFIABLE_ASSEMBLIES=debug%0aUNO_RC_HOST_TFM=$(_UnoRCHostTfm)" />
 
 		<ItemGroup>
 			<AndroidEnvironment Include="$(_UnoHotReloadEnvironmentConfig)" />
@@ -94,13 +94,13 @@
 	</Target>
 
 	<!-- iOS: Add UNO_RC_HOST_TFM and DOTNET_MODIFIABLE_ASSEMBLIES -->
-	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' and '$(Optimize)'!='true'">
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'ios' and '$(Optimize)'!='true'">
 		<MlaunchEnvironmentVariables Include="UNO_RC_HOST_TFM" Value="$(_UnoRCHostTfm)" />
 		<MlaunchEnvironmentVariables Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
 	</ItemGroup>
 
 	<!-- BrowserWasm: Add UNO_RC_HOST_TFM and DOTNET_MODIFIABLE_ASSEMBLIES -->
-	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'browserwasm' and '$(Optimize)'!='true'">
+	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'browserwasm' and '$(Optimize)'!='true'">
 		<WasmShellMonoEnvironment Include="UNO_RC_HOST_TFM" Value="$(_UnoRCHostTfm)" />
 		<WasmShellMonoEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
 	</ItemGroup>

--- a/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
+++ b/src/Uno.UI.RemoteControl/buildTransitive/Uno.WinUI.DevServer.targets
@@ -15,15 +15,43 @@
 		<UnoRemoteControlProcessorsPath Condition="'$(SolutionFileName)'!='Uno.UI.sln'">$(MSBuildThisFileDirectory)../tools/rc/processors</UnoRemoteControlProcessorsPath>
 	</PropertyGroup>
 
-	<!-- Select the DevServer host TFM by SDK major, with fallbacks to net9.0/net10.0.
-       Expose selected TFM as UNO_RC_HOST_TFM for the running app. -->
 	<Target Name="GetRemoteControlHostPath">
+		<!-- Determine the .NET SDK/runtime version by running the dotnet CLI version command from the project directory
+		     so that global.json in the repo is honored. Fallbacks keep previous behavior.
+		      
+		     This is needed to pick the right Uno.UI.RemoteControl.Host.dll version, as it is built against multiple .NET versions.
+		     
+		     Important: the goal here is to detect the .NET SDK version used to build the project, **NOT THE TARGET FRAMEWORK**.
+		     As you can perfectly build and run a net9.0 project with .NET 10.x SDK. -->
+
 		<PropertyGroup>
+			<!-- Default values -->
 			<_IsRCClientRemote>false</_IsRCClientRemote>
 			<_IsRCClientRemote Condition="'$(PkgUno_Wasm_Bootstrap_DevServer)'!=''">true</_IsRCClientRemote>
+			<_UnoSdkVersion></_UnoSdkVersion>
+			<_UnoSdkVersionFile>$(IntermediateOutputPath)dotnet.sdk.version.txt</_UnoSdkVersionFile>
+		</PropertyGroup>
 
-			<!-- Derive SDK major from BundledNETCoreAppTargetFrameworkVersion (e.g., 9.0.2 -> 9). Default to 9. -->
-			<_UnoRCHostMajor>$([System.Text.RegularExpressions.Regex]::Match('$(BundledNETCoreAppTargetFrameworkVersion)', '^\d+').Value)</_UnoRCHostMajor>
+		<!-- Ensure intermediate directory exists -->
+		<MakeDir Directories="$(IntermediateOutputPath)" Condition="!Exists('$(IntermediateOutputPath)')" />
+
+		<!-- Capture the dotnet version output into a file executed from the project directory -->
+		<Exec Command="dotnet --version &gt; &quot;$(_UnoSdkVersionFile)&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" ContinueOnError="WarnAndContinue" />
+
+		<!-- Read captured version -->
+		<ReadLinesFromFile File="$(_UnoSdkVersionFile)" Condition="Exists('$(_UnoSdkVersionFile)')">
+			<Output TaskParameter="Lines" ItemName="_UnoSdkVersionLines" />
+		</ReadLinesFromFile>
+		<PropertyGroup>
+			<_UnoSdkVersion>@(_UnoSdkVersionLines)</_UnoSdkVersion>
+		</PropertyGroup>
+
+		<PropertyGroup>
+			<!-- Derive SDK major from the detected SDK version (e.g., 9.0.3 -> 9). -->
+			<_UnoRCHostMajor>$([System.Text.RegularExpressions.Regex]::Match('$(_UnoSdkVersion)', '^\d+').Value)</_UnoRCHostMajor>
+			<!-- Fallback to BundledNETCoreAppTargetFrameworkVersion if detection failed -->
+			<_UnoRCHostMajor Condition="'$(_UnoRCHostMajor)'==''">$([System.Text.RegularExpressions.Regex]::Match('$(BundledNETCoreAppTargetFrameworkVersion)', '^\d+').Value)</_UnoRCHostMajor>
+			<!-- Final fallback to 9 if everything else failed -->
 			<_UnoRCHostMajor Condition="'$(_UnoRCHostMajor)'==''">9</_UnoRCHostMajor>
 
 			<_UnoRCHostVersionPath>net$(_UnoRCHostMajor).0</_UnoRCHostVersionPath>
@@ -33,8 +61,10 @@
 			<_UnoRCHostDll Condition="!Exists('$(_UnoRCHostDll)')">$(MSBuildThisFileDirectory)../tools/rc/host/net9.0/Uno.UI.RemoteControl.Host.dll</_UnoRCHostDll>
 			<_UnoRCHostDll Condition="!Exists('$(_UnoRCHostDll)')">$(MSBuildThisFileDirectory)../tools/rc/host/net10.0/Uno.UI.RemoteControl.Host.dll</_UnoRCHostDll>
 
-			<!-- Extract the selected TFM folder name (e.g., net9.0 / net10.0) from the final path -->
-			<_UnoRCHostTfm>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('$(_UnoRCHostDll)'))))</_UnoRCHostTfm>
+			<!-- Selected host folder (e.g., net9.0 / net10.0) from the final path -->
+			<_UnoRCHostSelectedFolder>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('$(_UnoRCHostDll)'))))</_UnoRCHostSelectedFolder>
+			<!-- SDK major used to choose the host (not a TFM) -->
+			<_UnoRCHostSdkMajor>$(_UnoRCHostMajor)</_UnoRCHostSdkMajor>
 		</PropertyGroup>
 
 		<Error Condition="!Exists('$(_UnoRCHostDll)')"
@@ -43,7 +73,9 @@
 		<Message Text="&lt;RemoteControlHostPath&gt;$(_UnoRCHostDll)&lt;/RemoteControlHostPath&gt;" Importance="High" />
 		<Message Text="&lt;IntermediateOutputPath&gt;$(MSBuildProjectDirectory)/$(IntermediateOutputPath)&lt;/IntermediateOutputPath&gt;" Importance="High" />
 		<Message Text="&lt;IsRCClientRemote&gt;$(_IsRCClientRemote)&lt;/IsRCClientRemote&gt;" Importance="High" />
-		<Message Text="&lt;UnoRCHostTfm&gt;$(_UnoRCHostTfm)&lt;/UnoRCHostTfm&gt;" Importance="High" />
+		<Message Text="&lt;UnoRCHostSelectedFolder&gt;$(_UnoRCHostSelectedFolder)&lt;/UnoRCHostSelectedFolder&gt;" Importance="High" />
+		<Message Text="&lt;UnoRCHostSdkMajor&gt;$(_UnoRCHostSdkMajor)&lt;/UnoRCHostSdkMajor&gt;" Importance="High" />
+		<Message Text="&lt;DetectedDotNetSdkVersion&gt;$(_UnoSdkVersion)&lt;/DetectedDotNetSdkVersion&gt;" Importance="High" />
 	</Target>
 
 	<Target Name="UnoDumpRemoteControlAddIns">
@@ -72,7 +104,7 @@
 		  Text="The version of Uno Platform's extension installed on your IDE is obsolete, please update to the latest version. If error persists, try to delete the obj folder and rebuild your solution." />
 	</Target>
 
-	<!-- Android: Add DOTNET_MODIFIABLE_ASSEMBLIES=debug and UNO_RC_HOST_TFM -->
+	<!-- Android: Add DOTNET_MODIFIABLE_ASSEMBLIES=debug and UNO_RC_HOST_SDK_MAJOR (legacy UNO_RC_HOST_TFM kept for compatibility) -->
 	<Target
 	  Name="_UnoHotReloadConfigAndroidEnv"
 	  BeforeTargets="BeforeBuild"
@@ -85,7 +117,7 @@
 		<WriteLinesToFile
 		  Overwrite="True"
 		  File="$(_UnoHotReloadEnvironmentConfig)"
-		  Lines="DOTNET_MODIFIABLE_ASSEMBLIES=debug%0aUNO_RC_HOST_TFM=$(_UnoRCHostTfm)" />
+		  Lines="DOTNET_MODIFIABLE_ASSEMBLIES=debug%0aUNO_RC_HOST_SDK_MAJOR=$(_UnoRCHostSdkMajor)%0aUNO_RC_HOST_TFM=$(_UnoRCHostSelectedFolder)" />
 
 		<ItemGroup>
 			<AndroidEnvironment Include="$(_UnoHotReloadEnvironmentConfig)" />
@@ -93,15 +125,17 @@
 		</ItemGroup>
 	</Target>
 
-	<!-- iOS: Add UNO_RC_HOST_TFM and DOTNET_MODIFIABLE_ASSEMBLIES -->
+	<!-- iOS: Add UNO_RC_HOST_SDK_MAJOR (and legacy UNO_RC_HOST_TFM) and DOTNET_MODIFIABLE_ASSEMBLIES -->
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'ios' and '$(Optimize)'!='true'">
-		<MlaunchEnvironmentVariables Include="UNO_RC_HOST_TFM" Value="$(_UnoRCHostTfm)" />
+		<MlaunchEnvironmentVariables Include="UNO_RC_HOST_SDK_MAJOR" Value="$(_UnoRCHostSdkMajor)" />
+		<MlaunchEnvironmentVariables Include="UNO_RC_HOST_TFM" Value="$(_UnoRCHostSelectedFolder)" />
 		<MlaunchEnvironmentVariables Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
 	</ItemGroup>
 
-	<!-- BrowserWasm: Add UNO_RC_HOST_TFM and DOTNET_MODIFIABLE_ASSEMBLIES -->
+	<!-- BrowserWasm: Add UNO_RC_HOST_SDK_MAJOR (and legacy UNO_RC_HOST_TFM) and DOTNET_MODIFIABLE_ASSEMBLIES -->
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework))) == 'browserwasm' and '$(Optimize)'!='true'">
-		<WasmShellMonoEnvironment Include="UNO_RC_HOST_TFM" Value="$(_UnoRCHostTfm)" />
+		<WasmShellMonoEnvironment Include="UNO_RC_HOST_SDK_MAJOR" Value="$(_UnoRCHostSdkMajor)" />
+		<WasmShellMonoEnvironment Include="UNO_RC_HOST_TFM" Value="$(_UnoRCHostSelectedFolder)" />
 		<WasmShellMonoEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES" Value="debug" />
 	</ItemGroup>
 


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno.rider/issues/360

## PR Type:
- 🏗️ Build or CI related changes
- 🐞 Bugfix

## Current behavior 🤔
Packaging and targets in **Uno.UI.DevServer** were incomplete or inconsistent with .NET 9 and .NET 10:
- `tools/rc/processors/net9.0/BuildHost-netcore` missing → Hot Reload init failed for net9 apps.  
- nuspec groups/comments mislabeled for net9 vs net10.  
- Targets defaulted to net10 host even when app SDK = net9.  
- Roslyn validation only checked SDK, not host TFM → mismatched errors (`Expected: net9, Current: net10`).  
- Incorrect `NoWarn` separator in nuspec → unreliable warnings suppression.  

## New behavior 🚀
- Restores `BuildHost-netcore` packaging for both net9.0 + net10.0.  
  - Adds target to copy host payloads from **Server** to **Processors** so nuspec packs both.  
- Fixes nuspec groups/comments for net9/net10/WinUI TFMs.  
- Updates MSBuild targets to:  
  - Resolve host TFM via `BundledNETCoreAppTargetFrameworkVersion`.  
  - Fallback between net9.0 and net10.0.  
  - Expose `UNO_RC_HOST_TFM` for runtime.  
- Roslyn init now respects `UNO_RC_HOST_TFM` → no net9/net10 mismatch.  
- Corrects `NoWarn` separator in `NuSpecProperties`.  
- Verified processors + hosts are shipped for both net9.0 and net10.0.  

DevServer and Hot Reload will now initialize properly with both .NET 9 and .NET 10.

## PR Checklist ✅ 
- [x] 📝 Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes (if applicable). 
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (if applicable). 
- [ ] 🖼️ Validated PR Screenshots Compare Test Run results. 
- [x] ❗ Contains **NO** breaking changes.