### PR TITLE
fix(slider): thumb not being positioned correctly on reload

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Slider.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_Slider.cs
@@ -1,25 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
-using Windows.UI.Input.Preview.Injection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
-using static Private.Infrastructure.TestServices;
+using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Shapes;
 using MUXControlsTestApp.Utilities;
 using Uno.Extensions;
-using Uno.UI.RuntimeTests.Helpers;
-
-#if WINAPPSDK
 using Uno.UI.Extensions;
-#elif __APPLE_UIKIT__
-using UIKit;
-#else
-using Uno.UI;
-#endif
+using Uno.UI.RuntimeTests.Helpers;
+using Windows.UI.Input.Preview.Injection;
+using static Private.Infrastructure.TestServices;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -138,6 +129,45 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 			mouse.Release();
 		}
 #endif
+
+		[TestMethod]
+		public async Task When_Reloaded_With_Value_Binding()
+		{
+			var slider = new Slider
+			{
+				Minimum = 0,
+				Maximum = 20,
+				Orientation = Orientation.Horizontal,
+			};
+			var container = new Border
+			{
+				Width = 100,
+				Height = 50,
+				Child = slider
+			};
+
+			// cant repro with explicit value. we need to use binding,
+			// with the dc flowing from the container, so it can "attach/detach" on load/unload
+			slider.SetBinding(Slider.ValueProperty, new Binding());
+			container.DataContext = 10;
+
+			await UITestHelper.Load(container);
+			var thumb = slider.FindFirstDescendantOrThrow<Thumb>("HorizontalThumb");
+
+			// record thumb position
+			await UITestHelper.WaitForIdle();
+			var dx0 = thumb.TransformToVisual(slider).TransformPoint(default).X;
+
+			// reload the slider
+			container.Child = null;
+			await UITestHelper.WaitForIdle();
+			container.Child = slider;
+			await UITestHelper.WaitForIdle();
+
+			// check that thumb position is still the same
+			var dx1 = thumb.TransformToVisual(slider).TransformPoint(default).X;
+			Assert.AreEqual(dx0, dx1, delta: 1, message: "Thumb#HorizontalThumb position is no longer the same after reloading the slider");
+		}
 	}
 
 	public partial class MySlider : Slider

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.Uno.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.Uno.cs
@@ -29,6 +29,9 @@ public partial class Slider
 		{
 			AttachHorizontalThumbSubscriptions();
 		}
+
+		// workaround for #21543 slider thumb not being positioned correctly on reload
+		UpdateTrackLayout();
 	}
 
 	private void Slider_Unloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
**GitHub Issue:** closes #21543

## PR Type:
- 🐞 Bugfix

## What is the current behavior? 🤔
Slider with a data-bound Value will have an incorrect thumb position when reloaded.

## What is the new behavior? 🚀
^ no more

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
The problem happens when the binding disconnects, a value of 0 is pushed onto the dependency-property, causing the position to reset to 0. However, when it reconnects with a value of 9, we dont reach to the assignment in UpdateTrackLayout due the actual-size being 0x0 (not measured yet).