### PR TITLE
fix: Don't generate HR workaround on using with aliases

### DIFF
--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/uno56droidioswasmskia/UsingAliasValidation.cs
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/uno56droidioswasmskia/UsingAliasValidation.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MyCustom.Logging;
+
+internal interface ILogger
+{
+}

--- a/src/SolutionTemplate/5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj
+++ b/src/SolutionTemplate/5.6/uno56droidioswasmskia/uno56droidioswasmskia/uno56droidioswasmskia.csproj
@@ -53,6 +53,10 @@
     <Error Text="Missing asset $(OutputPath)\Assets\SharedAssets.md"
           Condition="!exists('$(OutputPath)\Assets\SharedAssets.md')" />
   </Target>
+  
+  <ItemGroup>
+    <Using Include="MyCustom.Logging.ILogger" Alias="ILogger" />
+  </ItemGroup>
 
   <!-- fail the build if a BundleResource.LogicalName contains a rooted path -->
   <Target Name="ValidateBundleResourceLogicalName" AfterTargets="AfterBuild">

--- a/src/Uno.Sdk/targets/Uno.Common.Wasm.targets
+++ b/src/Uno.Sdk/targets/Uno.Common.Wasm.targets
@@ -149,7 +149,7 @@
 		</PropertyGroup>
 
 		<ItemGroup>
-			<_UsingsDedup Include="%(Using.Identity)" KeepDuplicates="false" />
+			<_UsingsDedup Include="%(Using.Identity)" Condition="%(Using.Alias) == ''" KeepDuplicates="false" />
 			<_GlobalUsingMocksLines Include="@(_UsingsDedup->'namespace %(Identity) { class __HotReloadWorkaround__$(_FakeGlobalUsingsAssemblyName) { } }')" />
 		</ItemGroup>
 


### PR DESCRIPTION
Original fix from https://github.com/unoplatform/uno/pull/21539 by @dansiegel 

GitHub Issue (If applicable): 

- fixes #21525

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The HotReload Workaround is applied to all MSBuild `Using` items, including those with an Alias

## What is the new behavior?

`Using` items are only included where the `Alias == ''`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Validated PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal) and uses the [automatic close keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
- [ ] Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

Please backport to 6.2