### PR TITLE
fix(AppleUIKit): Add NativeHandle ctor to SinglelineInvisibleTextBoxView

### DIFF
--- a/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
+++ b/src/Uno.UI.Runtime.Skia.AppleUIKit/UI/Xaml/Controls/TextBox/SinglelineInvisibleTextBoxView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using CoreGraphics;
 using Foundation;
@@ -26,6 +26,22 @@ internal partial class SinglelineInvisibleTextBoxView : UITextField, IInvisibleT
 	private bool _settingSelectionFromManaged;
 
 	public TextBoxView? Owner => TextBoxViewExtension?.Owner;
+
+	// Required for ObjC -> .NET rebind when UIKit gives an existing native instance
+	protected SinglelineInvisibleTextBoxView(NativeHandle handle) : base(handle)
+	{
+		_textBoxViewExtension = new WeakReference<InvisibleTextBoxViewExtension>(null!);
+		Alpha = 0;
+		Initialize();
+	}
+
+	// Common UIKit activation path
+	protected SinglelineInvisibleTextBoxView(NSObjectFlag t) : base(t)
+	{
+		_textBoxViewExtension = new WeakReference<InvisibleTextBoxViewExtension>(null!);
+		Alpha = 0;
+		Initialize();
+	}
 
 	public SinglelineInvisibleTextBoxView(InvisibleTextBoxViewExtension textBoxView)
 	{


### PR DESCRIPTION
**GitHub Issue:** ~possible fix for https://github.com/unoplatform/kahua-private/issues/345~

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

When resuming an iOS app from the background, the runtime may attempt to rebind a managed peer to an existing native `UITextField` instance corresponding to `SinglelineInvisibleTextBoxView`. Because the class does not currently define a `(NativeHandle handle)` constructor, the ObjC ↔ .NET runtime cannot create a managed peer for the existing native object. This results in a runtime exception and crash:
```
Failed to marshal the Objective-C object 0x1417f0000 (type: Uno_WinUI_Runtime_Skia_AppleUIKit_Controls_SinglelineInvisibleTextBoxView). Could not find an existing managed instance for this object, nor was it possible to create a new managed instance (because the type 'Uno.WinUI.Runtime.Skia.AppleUIKit.Controls.SinglelineInvisibleTextBoxView' does not have a constructor that takes one NativeHandle argument).
```

## What is the new behavior? 🚀

This PR adds the missing constructors to `SinglelineInvisibleTextBoxView`:

- `(NativeHandle handle) : base(handle)`  
- `(NSObjectFlag t) : base(t)` (for completeness with other UIKit subclasses)

Both constructors call `Initialize()` to ensure consistent setup. This aligns with the pattern used in other Uno UIKit subclasses and allows the runtime to safely materialize managed peers when UIKit provides existing native instances.
As a result, iOS apps using Skia should no longer crash when returning from background.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes
