### PR TITLE
fix(ScrollViewer): ViewChanged.IsIntermediate

### DIFF
--- a/src/Uno.UI.RuntimeTests/Extensions/EnumerableExtensions.cs
+++ b/src/Uno.UI.RuntimeTests/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Uno.UI.RuntimeTests.Extensions;
+
+internal static class EnumerableExtensions
+{
+	public static IEnumerable<T> DistinctUntilChanged<T>(this IEnumerable<T> source)
+	{
+		using var enumerator = source.GetEnumerator();
+
+		T previous;
+
+		if (!enumerator.MoveNext()) yield break;
+		yield return (previous = enumerator.Current);
+		while (enumerator.MoveNext())
+		{
+			var current = enumerator.Current;
+			if (!EqualityComparer<T>.Default.Equals(previous, current))
+			{
+				yield return current;
+				previous = current;
+			}
+		}
+	}
+}


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#317

## PR Type:
- 🐞 Bugfix

## What is the current behavior? 🤔
Currently, on mobile, when observing the sequence of ScrollViewer.ViewChanged events raised from manipulation(scrolling gesture), it does not terminate with an event with `e.IsIntermadiate=false` to mark the final event of said sequence.

## What is the new behavior? 🚀
A `e.IsIntermadiate=false` ScrollViewer.ViewChanged event is now raised when the manipulation completes.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️
<!-- Please provide any additional information if necessary -->