### PR TITLE
fix: Ensure pointer events are handled by the native element host

### DIFF
--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
@@ -59,6 +59,8 @@
 
 		private _source: any;
 		private _bootTime: Number;
+		// Cached reference to #uno-native-element-host. Refreshed if detached/replaced.
+		private _nativeElementHost: HTMLElement | null = null;
 
 		private constructor(manageSource: any) {
 			this._bootTime = Date.now() - performance.now();
@@ -81,11 +83,70 @@
 			element.addEventListener("wheel", this.onPointerEventReceived.bind(this), { capture: true, passive: false });
 		}
 
+
+		// Retrieve and cache the native element host reference.
+		// Refreshes if the node was detached or replaced (e.g., during hot reload).
+		private getNativeElementHostCached(): HTMLElement | null {
+			if (this._nativeElementHost === null || this._nativeElementHost.isConnected === false) {
+				this._nativeElementHost = document.getElementById("uno-native-element-host") as HTMLElement | null;
+			}
+			return this._nativeElementHost;
+		}
+
+
+		// Returns true if the event originated from within the native host subtree.
+		// Traverses regular DOM first, then crosses Shadow DOM boundaries when required.
+		// Uses identity comparisons only; avoids selector matching, allocations, and redundant lookups.
+		private isEventFromNativeElementHost(eventTarget: EventTarget | null) {
+			const hostElement = this.getNativeElementHostCached();
+			if (hostElement === null) {
+				return false; // No host exists; nothing to filter.
+			}
+
+			let currentNode = eventTarget as Node | null;
+
+			while (currentNode !== null) {
+				// Fast identity comparison.
+				if (currentNode === hostElement) {
+					return true;
+				}
+
+				// Normal DOM climb first (fastest path)
+				const parent = (currentNode as any).parentNode as Node | null;
+				if (parent) {
+					currentNode = parent;
+					continue;
+				}
+
+				// Only if parentNode is null, check for a shadow boundary.
+				const rootNode: any = typeof (currentNode as any).getRootNode === "function"
+					? (currentNode as any).getRootNode()
+					: null;
+
+				// If we're inside a shadow root, jump to its host to continue traversal
+				if (rootNode instanceof ShadowRoot && rootNode.host) {
+					currentNode = rootNode.host as Node; // cross shadow boundary
+					continue;
+				}
+
+				// Reached the top (Document or no further nodes)
+				break;
+			}
+
+			return false;
+		}
+
 		private onPointerEventReceived(evt: PointerEvent): void {
 			let id = (evt.target as HTMLElement)?.id;
 			if (id === "uno-enable-accessibility") {
 				// We have a div to enable accessibility (see enableA11y in WebAssemblyWindowWrapper).
 				// Pressing space on keyboard to click it will trigger pointer event which we want to ignore.
+				return;
+			}
+
+			if (this.isEventFromNativeElementHost(evt.target)) {
+				// Events from the native host are handled by the native control directly.
+				// We don't want to interfere with them.
 				return;
 			}
 

--- a/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
+++ b/src/Uno.UI.Runtime.Skia.WebAssembly.Browser/ts/Runtime/BrowserPointerInputSource.ts
@@ -119,9 +119,7 @@
 				}
 
 				// Only if parentNode is null, check for a shadow boundary.
-				const rootNode: any = typeof (currentNode as any).getRootNode === "function"
-					? (currentNode as any).getRootNode()
-					: null;
+				const rootNode = currentNode.getRootNode();
 
 				// If we're inside a shadow root, jump to its host to continue traversal
 				if (rootNode instanceof ShadowRoot && rootNode.host) {


### PR DESCRIPTION
Fixes various mouse issues related to mouse events not being processed by code running in the native element host on Skia WASM

**GitHub Issue:** closes # https://github.com/unoplatform/uno-private/issues/505

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Mouse events aren't seen by the native element host. Clicking does not do anything when it should.

## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->
Clicking works, scrolling with the wheel works.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->