### PR TITLE
Win32 `FileSavePicker` improvements (file extension, computer folder)

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pickers="using:UITests.Shared.Windows_Storage.Pickers"
-	xmlns:wasm="http://uno.ui/wasm"
+    xmlns:wasm="http://uno.ui/wasm"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     mc:Ignorable="d wasm">
 
@@ -14,16 +14,20 @@
         Padding="12,12,24,12"
         HorizontalContentAlignment="Left">
         <StackPanel Spacing="8">
-			<wasm:ToggleSwitch IsOn="{x:Bind ViewModel.UseNativePicker, Mode=TwoWay}" OffContent="Use native picker" OnContent="Use native picker" />
-			<ComboBox
+            <wasm:ToggleSwitch
+                IsOn="{x:Bind ViewModel.UseNativePicker, Mode=TwoWay}"
+                OffContent="Use native picker"
+                OnContent="Use native picker" />
+            <ComboBox
                 Header="Suggested start location"
                 ItemsSource="{x:Bind ViewModel.SuggestedStartLocations, Mode=OneWay}"
                 SelectedItem="{x:Bind ViewModel.SuggestedStartLocation, Mode=TwoWay}" />
 
-			<TextBox Header="Settings identifier" Text="{x:Bind ViewModel.SettingsIdentifier, Mode=TwoWay}" />
+            <TextBox Header="Settings identifier" Text="{x:Bind ViewModel.SettingsIdentifier, Mode=TwoWay}" />
             <TextBox Header="Commit button text" Text="{x:Bind ViewModel.CommitButtonText, Mode=TwoWay}" />
 
             <TextBox Header="Suggested file name" Text="{x:Bind ViewModel.SuggestedFileName, Mode=TwoWay}" />
+
             <StackPanel Orientation="Horizontal" Spacing="4">
                 <Button Click="{x:Bind ViewModel.PickSuggestedSaveFile}" Content="Pick suggested save file" />
                 <Button Click="{x:Bind ViewModel.PickSuggestedSaveFile}" Content="Clear" />
@@ -35,10 +39,9 @@
                 BorderBrush="Black"
                 BorderThickness="1"
                 CornerRadius="4">
-                <StackPanel Orientation="Horizontal" Spacing="4">
-					<TextBlock 
-						Text="To add a file type selection group, first enter extension names one at a time, then press 'Add extension'. Once done, select a file choice name, then click Add file type choice." />
-					<TextBox
+                <StackPanel Orientation="Vertical" Spacing="4">
+                    <TextBlock Text="To add a file type selection group, first enter extension names one at a time, then press 'Add extension'. Once done, select a file choice name, then click Add file type choice." TextWrapping="Wrap" />
+                    <TextBox
                         Width="140"
                         Header="File choice name"
                         Text="{x:Bind ViewModel.NewFileTypeChoice.Name, Mode=TwoWay}" />
@@ -62,6 +65,7 @@
                 </StackPanel>
                 <Button Click="{x:Bind ViewModel.AddFileTypeChoice}" Content="Add file type choice" />
             </StackPanel>
+            <TextBox Header="Default extension" Text="{x:Bind ViewModel.DefaultExtension, Mode=TwoWay}" />
 
             <ListView
                 Height="100"

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml.cs
@@ -44,6 +44,7 @@ namespace UITests.Shared.Windows_Storage.Pickers
 		private string _statusMessage = string.Empty;
 		private string _suggestedFileName = string.Empty;
 		private string _fileChoiceExtension = string.Empty;
+		private string _defaultExtension = string.Empty;
 
 		private StorageFile _suggestedSaveFile = null;
 		private StorageFile _pickedFile = null;
@@ -202,6 +203,16 @@ namespace UITests.Shared.Windows_Storage.Pickers
 			}
 		}
 
+		public string DefaultExtension
+		{
+			get => _defaultExtension;
+			set
+			{
+				_defaultExtension = value;
+				RaisePropertyChanged();
+			}
+		}
+
 		public async void PickSuggestedSaveFile()
 		{
 			ErrorMessage = string.Empty;
@@ -252,6 +263,12 @@ namespace UITests.Shared.Windows_Storage.Pickers
 				{
 					fileSavePicker.FileTypeChoices.Add(fileTypeChoice.Name, fileTypeChoice.Extensions);
 				}
+
+				if (!string.IsNullOrEmpty(DefaultExtension))
+				{
+					fileSavePicker.DefaultFileExtension = DefaultExtension;
+				}
+
 				var pickedFile = await fileSavePicker.PickSaveFileAsync();
 				if (pickedFile != null)
 				{

--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileSavePickerTests.xaml.cs
@@ -21,7 +21,10 @@ using Microsoft.UI.Xaml.Media.Imaging;
 namespace UITests.Shared.Windows_Storage.Pickers
 {
 	[Sample("Windows.Storage", ViewModelType = typeof(FileSavePickerTestsViewModel), IsManualTest = true,
-		Description = "Allows testing all features of FileSavePicker. Not selecting a file should not cause an exception.")]
+		Description =
+			"Allows testing all features of FileSavePicker. Not selecting a file should not cause an exception. " +
+			"Default extension should work on Windows. " +
+			"When the requested file does not exist yet, it should be created before the picker returns.")]
 	public sealed partial class FileSavePickerTests : Page
 	{
 		public FileSavePickerTests()

--- a/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
+++ b/src/Uno.UI.Runtime.Skia.Win32.Support/NativeMethods.txt
@@ -203,6 +203,7 @@ SetWindowPos
 SetWindowRgn
 SetWindowText
 SHCreateItemFromParsingName
+SHCreateItemInKnownFolder
 ShowWindow
 SwapBuffers
 TranslateMessage

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/SuggestedStartLocationHandler.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/SuggestedStartLocationHandler.cs
@@ -19,11 +19,11 @@ namespace Uno.UI.Runtime.Skia.Win32.Storage.Pickers;
 
 internal static class SuggestedStartLocationHandler
 {
-	internal static unsafe IDisposable SetDefaultFolder(PickerLocationId startLocation, Func<ComScope<IShellItem>, HRESULT> defaultFolderSetter)
+	internal static unsafe ComScope<IShellItem> GetStartLocationShellItem(PickerLocationId startLocation)
 	{
 		if (startLocation == PickerLocationId.Unspecified)
 		{
-			return Disposable.Empty;
+			return default;
 		}
 
 		Guid? folderGuid = startLocation is PickerLocationId.ComputerFolder ?
@@ -49,20 +49,9 @@ internal static class SuggestedStartLocationHandler
 				typeof(SuggestedStartLocationHandler).LogError()?.Error($"{methodName} failed: {Win32Helper.GetErrorMessage(hResult)}");
 			}
 
-			ComScope<IShellItem> defaultFolderItem = new((IShellItem*)defaultFolderItemRaw);
-
-			hResult = defaultFolderSetter.Invoke(defaultFolderItem);
-			if (hResult.Failed)
-			{
-				typeof(SuggestedStartLocationHandler).LogError()?.Error($"{nameof(IFileDialog.SetDefaultFolder)} failed: {Win32Helper.GetErrorMessage(hResult)}");
-			}
-
-			return Disposable.Create(() =>
-			{
-				defaultFolderItem.Dispose();
-			});
+			return new((IShellItem*)defaultFolderItemRaw);
 		}
 
-		return Disposable.Empty;
+		return default;
 	}
 }

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/SuggestedStartLocationHandler.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/SuggestedStartLocationHandler.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.Disposables;
+using Uno.Foundation.Logging;
+using Uno.UI.Helpers;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Com;
+using Windows.Win32.UI.Shell;
+using Windows.Win32.UI.Shell.Common;
+using static Uno.WinRTFeatureConfiguration.Storage;
+
+namespace Uno.UI.Runtime.Skia.Win32.Storage.Pickers;
+
+internal static class SuggestedStartLocationHandler
+{
+	internal static unsafe IDisposable SetDefaultFolder(PickerLocationId startLocation, Func<ComScope<IShellItem>, HRESULT> defaultFolderSetter)
+	{
+		if (startLocation == PickerLocationId.Unspecified)
+		{
+			return Disposable.Empty;
+		}
+
+		Guid? folderGuid = startLocation is PickerLocationId.ComputerFolder ?
+			PickerHelpers.WindowsComputerFolderGUID :
+			null;
+
+		var folderPath = folderGuid is null ?
+			PickerHelpers.GetInitialDirectory(startLocation) :
+			null;
+
+		if (folderGuid is not null || !string.IsNullOrEmpty(folderPath))
+		{
+			void* defaultFolderItemRaw;
+			var hResult = folderGuid is not null
+				? PInvoke.SHCreateItemInKnownFolder(folderGuid.Value, KNOWN_FOLDER_FLAG.KF_FLAG_DEFAULT, null, IShellItem.IID_Guid, out defaultFolderItemRaw)
+				: PInvoke.SHCreateItemFromParsingName(folderPath, null, IShellItem.IID_Guid, out defaultFolderItemRaw);
+
+			if (hResult.Failed)
+			{
+				var methodName = folderGuid is not null ?
+					nameof(PInvoke.SHCreateItemInKnownFolder) :
+					nameof(PInvoke.SHCreateItemFromParsingName);
+				typeof(SuggestedStartLocationHandler).LogError()?.Error($"{methodName} failed: {Win32Helper.GetErrorMessage(hResult)}");
+			}
+
+			ComScope<IShellItem> defaultFolderItem = new((IShellItem*)defaultFolderItemRaw);
+
+			hResult = defaultFolderSetter.Invoke(defaultFolderItem);
+			if (hResult.Failed)
+			{
+				typeof(SuggestedStartLocationHandler).LogError()?.Error($"{nameof(IFileDialog.SetDefaultFolder)} failed: {Win32Helper.GetErrorMessage(hResult)}");
+			}
+
+			return Disposable.Create(() =>
+			{
+				defaultFolderItem.Dispose();
+			});
+		}
+
+		return Disposable.Empty;
+	}
+}

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileFolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileFolderPickerExtension.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Uno.Disposables;
+using Uno.Extensions.Storage.Pickers;
+using Uno.Foundation.Logging;
+using Uno.UI.Helpers;
+using Uno.UI.Helpers.WinUI;
+using Uno.UI.Runtime.Skia.Win32.Storage.Pickers;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.Win32;
@@ -10,10 +16,6 @@ using Windows.Win32.Foundation;
 using Windows.Win32.System.Com;
 using Windows.Win32.UI.Shell;
 using Windows.Win32.UI.Shell.Common;
-using Uno.Disposables;
-using Uno.Extensions.Storage.Pickers;
-using Uno.Foundation.Logging;
-using Uno.UI.Helpers.WinUI;
 
 namespace Uno.UI.Runtime.Skia.Win32;
 
@@ -95,6 +97,10 @@ internal class Win32FileFolderPickerExtension(IFilePicker picker) : IFileOpenPic
 				return Task.FromResult<IReadOnlyList<StorageFile>>([]);
 			}
 		}
+
+		using var defaultFolder = SuggestedStartLocationHandler.SetDefaultFolder(
+			picker.SuggestedStartLocationInternal,
+			i => iFileOpenDialog.Value->SetDefaultFolder(i));
 
 		hResult = iFileOpenDialog.Value->SetOkButtonLabel(string.IsNullOrEmpty(picker.CommitButtonTextInternal) ? ResourceAccessor.GetLocalizedStringResource("FILE_PICKER_ACCEPT_LABEL") : picker.CommitButtonTextInternal);
 		if (hResult.Failed)

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileFolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileFolderPickerExtension.cs
@@ -98,9 +98,11 @@ internal class Win32FileFolderPickerExtension(IFilePicker picker) : IFileOpenPic
 			}
 		}
 
-		using var defaultFolder = SuggestedStartLocationHandler.SetDefaultFolder(
-			picker.SuggestedStartLocationInternal,
-			i => iFileOpenDialog.Value->SetDefaultFolder(i));
+		using var defaultFolder = SuggestedStartLocationHandler.GetStartLocationShellItem(picker.SuggestedStartLocationInternal);
+		if (defaultFolder != default)
+		{
+			iFileOpenDialog.Value->SetDefaultFolder(defaultFolder);
+		}
 
 		hResult = iFileOpenDialog.Value->SetOkButtonLabel(string.IsNullOrEmpty(picker.CommitButtonTextInternal) ? ResourceAccessor.GetLocalizedStringResource("FILE_PICKER_ACCEPT_LABEL") : picker.CommitButtonTextInternal);
 		if (hResult.Failed)

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
@@ -188,7 +188,7 @@ internal class Win32FileSaverExtension(FileSavePicker picker) : IFileSavePickerE
 			// FileSavePicker creates the file if it does not exist yet.
 			if (!File.Exists(path))
 			{
-				File.Create(path).Dispose();
+				File.WriteAllBytes(path, Array.Empty<byte>());
 			}
 		}
 		catch (Exception ex)

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
@@ -140,6 +140,18 @@ internal class Win32FileSaverExtension(FileSavePicker picker) : IFileSavePickerE
 				this.LogError()?.Error($"{nameof(IFileDialog.SetFileTypes)} failed: {Win32Helper.GetErrorMessage(hResult)}");
 				return Task.FromResult<StorageFile?>(null);
 			}
+
+			// Set default extension (e.g., "txt" from "*.txt")
+			var firstPattern = !string.IsNullOrEmpty(picker.DefaultFileExtension) ? picker.DefaultFileExtension : picker.FileTypeChoices.First().Value.FirstOrDefault();
+			if (!string.IsNullOrEmpty(firstPattern) && firstPattern.StartsWith('.'))
+			{
+				hResult = iFileSaveDialog.Value->SetDefaultExtension(firstPattern.TrimStart('.'));
+				if (hResult.Failed)
+				{
+					this.LogError()?.Error($"{nameof(IFileDialog.SetDefaultExtension)} failed: {Win32Helper.GetErrorMessage(hResult)}");
+					return Task.FromResult<StorageFile?>(null);
+				}
+			}
 		}
 
 		hResult = iFileSaveDialog.Value->SetOkButtonLabel(string.IsNullOrEmpty(picker.CommitButtonText) ? ResourceAccessor.GetLocalizedStringResource("FILE_SAVER_ACCEPT_LABEL") : picker.CommitButtonText);

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileSaverExtension.cs
@@ -80,9 +80,11 @@ internal class Win32FileSaverExtension(FileSavePicker picker) : IFileSavePickerE
 			iFileSaveDialog.Value->SetFileName(picker.SuggestedFileName);
 		}
 
-		using var defaultFolder = SuggestedStartLocationHandler.SetDefaultFolder(
-			picker.SuggestedStartLocation,
-			i => iFileSaveDialog.Value->SetDefaultFolder(i));
+		using var defaultFolder = SuggestedStartLocationHandler.GetStartLocationShellItem(picker.SuggestedStartLocation);
+		if (defaultFolder != default)
+		{
+			iFileSaveDialog.Value->SetDefaultFolder(defaultFolder);
+		}
 
 		if (fileTypeList.Count > 0)
 		{

--- a/src/Uno.UI/Helpers/PickerHelpers.cs
+++ b/src/Uno.UI/Helpers/PickerHelpers.cs
@@ -8,6 +8,8 @@ namespace Uno.UI.Helpers
 {
 	internal static class PickerHelpers
 	{
+		// These GUIDs are documented at https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
+		internal static readonly Guid WindowsComputerFolderGUID = new("0AC0837C-BBF8-452A-850D-79D08E667CA7");
 		private static readonly Guid WindowsDownloadsGUID = new("374DE290-123F-4565-9164-39C4925E467B");
 
 		public static string GetInitialDirectory(PickerLocationId location)

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FileSavePicker.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Storage.Pickers/FileSavePicker.cs
@@ -12,7 +12,7 @@ namespace Windows.Storage.Pickers
 		// Skipping already declared property SuggestedSaveFile
 		// Skipping already declared property SuggestedFileName
 		// Skipping already declared property SettingsIdentifier
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || false || false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public string DefaultFileExtension
 		{

--- a/src/Uno.UWP/Storage/Pickers/FileSavePicker.cs
+++ b/src/Uno.UWP/Storage/Pickers/FileSavePicker.cs
@@ -14,6 +14,7 @@ namespace Windows.Storage.Pickers
 		private string _suggestedFileName = string.Empty;
 		private string _settingsIdentifier = string.Empty;
 		private string _commitButtonText = string.Empty;
+		private string _defaultFileExtension = string.Empty;
 
 		/// <summary>
 		/// Gets the collection of valid file types that the user can choose to assign to a file.
@@ -42,6 +43,18 @@ namespace Windows.Storage.Pickers
 			get => _settingsIdentifier;
 			set => _settingsIdentifier = value ?? throw new ArgumentNullException(nameof(value));
 		}
+
+#if __SKIA__ || __NETSTD_REFERENCE__
+		/// <summary>
+		/// Gets or sets the default file name extension that the fileSavePicker gives to files to be saved.
+		/// </summary>
+		/// <remarks>Use format starting with a dot, e.g. ".xyz"</remarks>
+		public string DefaultFileExtension
+		{
+			get => _defaultFileExtension;
+			set => _defaultFileExtension = value ?? throw new ArgumentNullException(nameof(value));
+		}
+#endif
 
 		/// <summary>
 		/// Gets or sets the storageFile that the file picker suggests to the user for saving a file.


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/351

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix, ✨ Feature

<!--
Copy the labels that apply to this PR and paste them above:

- 
- 
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

- `ComputerFolder` does not work as default location
- `DefaultFileExtension` is not supported
- When the selected save file does not exist, it is created automatically

## What is the new behavior? 🚀

Fixed

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes