### PR TITLE
fix: allow picking executables and files without extensions in Linux file picker

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileOpenPickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileOpenPickerTests.xaml.cs
@@ -20,6 +20,7 @@ namespace UITests.Shared.Windows_Storage.Pickers
 - Selecting a file should show information below the file picker buttons.
 - It should be possible to pick multiple files, even if PicturesLibrary is selected and .jpg is used as file type.
 - Important (iOS): iOS 17 changed the way the file picker works. When testing this sample make sure to test it on iOS 17 or higher and iOS 16 or lower.
+- Important (Linux): Make sure that extension-less files can be picked
 """
 	)]
 	public sealed partial class FileOpenPickerTests : Page

--- a/src/Uno.UI.Runtime.Skia.X11/Storage/Pickers/LinuxFilePickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/Storage/Pickers/LinuxFilePickerExtension.cs
@@ -227,7 +227,7 @@ internal class LinuxFilePickerExtension(IFilePicker picker) : IFileOpenPickerExt
 
 			if (pattern == "*")
 			{
-				list.Add(Struct.Create("All Files", new Array<Struct<uint, string>>(new[] { Struct.Create((uint)0, "*.*") })));
+				list.Add(Struct.Create("All Files", new Array<Struct<uint, string>>(new[] { Struct.Create((uint)0, "*") })));
 			}
 			else if (pattern.StartsWith('.') && pattern[1..] is var ext && ext.All(char.IsLetterOrDigit))
 			{


### PR DESCRIPTION
**GitHub Issue:** closes #21606

## PR Type:  
🐞 Bugfix

## What is the current behavior? 🤔

The Linux file picker extension uses a filter pattern of "*.*" for the "All Files" option, which only matches files that have an extension (contain a dot). This prevents users from selecting executable files and files without extensions, which is common on Linux systems.

## What is the new behavior? 🚀

Changed the "All Files" filter pattern from "*.*" to "*" to properly match all files, including executables and files without extensions. This aligns with expected behavior on Linux platforms, where many files (especially executables) don't have file extensions.

## Testing

This PR must be tested using `FileOpenPickerTests` on linux.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->