### PR TITLE
fix: Fix possible invalid error message

### DIFF
--- a/src/Uno.UI.RemoteControl.Host/IDEChannel/IdeChannelServer.cs
+++ b/src/Uno.UI.RemoteControl.Host/IDEChannel/IdeChannelServer.cs
@@ -83,7 +83,7 @@ internal class IdeChannelServer : IIdeChannel, IDisposable
 		{
 			_logger.LogWarning(error, "An error occurred while disposing the existing IDE channel server. Continuing initialization.");
 		}
-		
+
 		try
 		{
 			if (channelId == Guid.Empty)

--- a/src/Uno.UI.RemoteControl.Host/IDEChannel/IdeChannelServer.cs
+++ b/src/Uno.UI.RemoteControl.Host/IDEChannel/IdeChannelServer.cs
@@ -96,6 +96,7 @@ internal class IdeChannelServer : IIdeChannel, IDisposable
 
 	private async Task StartKeepAliveAsync()
 	{
+		// Note: The dev-server is expected to send message regularly ... and AS SOON AS POSSIBLE (the Task.Delay is after the first SendToIde()!).
 		while (_pipeServer?.IsConnected ?? false)
 		{
 			_proxy?.SendToIde(new KeepAliveIdeMessage("dev-server"));

--- a/src/Uno.UI.RemoteControl.Host/IDEChannel/IdeChannelServerOptions.cs
+++ b/src/Uno.UI.RemoteControl.Host/IDEChannel/IdeChannelServerOptions.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Uno.UI.RemoteControl.Host.IdeChannel;
+
+public class IdeChannelServerOptions
+{
+	public Guid ChannelId { get; set; }
+}

--- a/src/Uno.UI.RemoteControl.Host/Program.cs
+++ b/src/Uno.UI.RemoteControl.Host/Program.cs
@@ -42,6 +42,7 @@ namespace Uno.UI.RemoteControl.Host
 				var httpPort = 0;
 				var parentPID = 0;
 				var solution = default(string);
+				var ideChannel = Guid.Empty;
 				var command = default(string);
 				var workingDir = default(string);
 				var timeoutMs = 30000;
@@ -73,6 +74,14 @@ namespace Uno.UI.RemoteControl.Host
 							}
 
 							solution = s;
+						}
+					},
+					{
+						"ideChannel=", s => {
+							if(!Guid.TryParse(s, out ideChannel))
+							{
+								throw new ArgumentException($"The ide channel parameter is invalid {s}");
+							}
 						}
 					},
 					{
@@ -134,6 +143,7 @@ namespace Uno.UI.RemoteControl.Host
 					.SetMinimumLevel(LogLevel.Debug));
 
 				globalServices.AddGlobalTelemetry(); // Global telemetry services (Singleton)
+				globalServices.AddOptions<IdeChannelServerOptions>().Configure(opts => opts.ChannelId = ideChannel);
 				globalServices.AddSingleton<IIdeChannel, IdeChannelServer>();
 
 #pragma warning disable ASP0000 // Do not call ConfigureServices after calling UseKestrel.

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -527,7 +527,8 @@ public partial class EntryPoint : IDisposable
 
 		async Task TrackConnectionTimeoutAsync(IdeChannelClient ideChannel)
 		{
-			await Task.Delay(5000, devServerCt.Token);
+			// The dev-server is expected to connect back to the IDE as soon as possible, 10sec should be more than enough.
+			await Task.Delay(10_000, devServerCt.Token);
 			if (ideChannel.MessagesReceivedCount is 0 && _udei is not null && !devServerCt.IsCancellationRequested)
 			{
 				await _udei.NotifyDevServerTimeoutAsync(devServerCt.Token);


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/21622

## 🐞 Bugfix
Possible invalid error message in logs / output

## What is the current behavior? 🤔
The dev-server connects back to the IDE only once it's fully setup, including after the add-ins has been resolved, which might take a while. This drives the VS extension to assume something went wrong as it didn't get any news from the dev-server in the given delay.

## What is the new behavior? 🚀
IDE channel is enable much earlier.

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
