### PR TITLE
feat(udei): Add ability to forward commands from VSIX

### DIFF
--- a/src/Uno.UI.RemoteControl.Messaging/IDEChannel/DevelopmentEnvironmentStatusIdeMessage.cs
+++ b/src/Uno.UI.RemoteControl.Messaging/IDEChannel/DevelopmentEnvironmentStatusIdeMessage.cs
@@ -25,16 +25,20 @@ public record DevelopmentEnvironmentStatusIdeMessage(
 /// The unique identifier of the development environment component
 /// (e.g. uno.dev_server)
 /// </param>
+/// <param name="Name">
+/// A user-friendly name of the development environment component
+/// (e.g. "Dev-server.").
+/// </param>
 /// <param name="Description">
 /// A user-friendly description of the development environment component
 /// (e.g. "The local server that allows the application to interact with the IDE and the file-system.").
 /// </param>
-public record DevelopmentEnvironmentComponent(string Id, string Description)
+public record DevelopmentEnvironmentComponent(string Id, string Name, string Description)
 {
 	// Well-known components of the development environment, this is **NOT** an exhaustive list!
-	public static DevelopmentEnvironmentComponent Solution { get; } = new("uno.solution", "Load of the solution, resolution of nuget packages and validation of uno's SDK version.");
-	public static DevelopmentEnvironmentComponent UnoCheck { get; } = new("uno.check", "Validates all external dependencies has been installed on the computer.");
-	public static DevelopmentEnvironmentComponent DevServer { get; } = new("uno.dev_server", "The local server that allows the application to interact with the IDE and the file-system.");
+	public static DevelopmentEnvironmentComponent Solution { get; } = new("uno.solution", "Solution", "Load of the solution, resolution of nuget packages and validation of uno's SDK version.");
+	public static DevelopmentEnvironmentComponent UnoCheck { get; } = new("uno.check", "Uno-check", "Validates all external dependencies has been installed on the computer.");
+	public static DevelopmentEnvironmentComponent DevServer { get; } = new("uno.dev_server", "Dev-server", "The local server that allows the application to interact with the IDE and the file-system.");
 }
 
 /// <summary>

--- a/src/Uno.UI.RemoteControl.VS/VSIXChannel/DevServerCommandHandler.cs
+++ b/src/Uno.UI.RemoteControl.VS/VSIXChannel/DevServerCommandHandler.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading;
+using Uno.UI.RemoteControl.Messaging.IdeChannel;
+using Uno.UI.RemoteControl.VS.IdeChannel;
+
+namespace Uno.IDE;
+
+internal class DevServerCommandHandler(IdeChannelClient ideChannel) : ICommandHandler, IDisposable
+{
+	private CancellationTokenSource _ct = new();
+	
+	/// <inheritdoc />
+	public void Execute(Command command)
+	{
+		if (_ct.IsCancellationRequested)
+		{
+			return;
+		}
+
+		_ = ideChannel.SendToDevServerAsync(new CommandRequestIdeMessage(System.Diagnostics.Process.GetCurrentProcess().Id, command.Name, command.Parameter), _ct.Token);
+	}
+
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		_ct.Cancel();
+		_ct.Dispose();
+	}
+}

--- a/src/Uno.UI.RemoteControl.VS/VSIXChannel/DevServerCommandHandler.cs
+++ b/src/Uno.UI.RemoteControl.VS/VSIXChannel/DevServerCommandHandler.cs
@@ -7,8 +7,8 @@ namespace Uno.IDE;
 
 internal class DevServerCommandHandler(IdeChannelClient ideChannel) : ICommandHandler, IDisposable
 {
-	private CancellationTokenSource _ct = new();
-	
+	private readonly CancellationTokenSource _ct = new();
+
 	/// <inheritdoc />
 	public void Execute(Command command)
 	{

--- a/src/Uno.UI.RemoteControl.VS/VSIXChannel/ICommandHandler.cs
+++ b/src/Uno.UI.RemoteControl.VS/VSIXChannel/ICommandHandler.cs
@@ -1,0 +1,16 @@
+﻿using Uno.UI.RemoteControl.Messaging.IdeChannel;
+
+namespace Uno.IDE;
+
+internal interface ICommandHandler
+{
+	/*
+	* WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+	*
+	* This interface is shared between Uno's VS extension and the Uno.RC package, make sure to keep in sync.
+	* In order to avoid versioning issues, avoid modifications and **DO NOT** remove any member from this interface.
+	*
+	*/
+
+	void Execute(Command command);
+}

--- a/src/Uno.UI.RemoteControl.VS/VSIXChannel/IdeCommandHandler.cs
+++ b/src/Uno.UI.RemoteControl.VS/VSIXChannel/IdeCommandHandler.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics;
+using Uno.UI.RemoteControl.Messaging.IdeChannel;
+using Uno.UI.RemoteControl.VS.Helpers;
+
+namespace Uno.IDE;
+
+/// <summary>
+/// Basic command handler that natively only supports opening links in the browser (ide.open_browser).
+/// Other commands are forwarded to a remote handler that can be registered via <see cref="SetRemoteHandler(ICommandHandler)"/>.
+/// The "remote handler" is resolved from the VS.RC package and will typically send commands to the dev-server.
+/// </summary>
+internal sealed class IdeCommandHandler(ILogger log) : ICommandHandler
+{
+	private ICommandHandler? _handler;
+
+	public void SetRemoteHandler(ICommandHandler execute)
+		=> _handler = execute ?? throw new ArgumentNullException(nameof(execute));
+
+	public void Execute(Command command)
+	{
+		switch (command.Name)
+		{
+			case "ide.open_browser" when command.Parameter is not null && Uri.TryCreate(command.Parameter, UriKind.Absolute, out var target):
+				// Note: We validate the URI is valid to avoid potential security issues with Process.Start
+				_ = Process.Start(new ProcessStartInfo(target.OriginalString) { UseShellExecute = true });
+				break;
+
+			case "ide.open_browser":
+				log.Error($"'{command.Parameter}' is not a valid absolute URI.");
+				break;
+
+			default:
+				if (_handler is null)
+				{
+					log.Error($"No handler registered for command '{command.Text}' ({command.Name}).");
+				}
+				else
+				{
+					try
+					{
+						_handler.Execute(command);
+					}
+					catch (Exception error)
+					{
+						log.Error($"Failed to execute command '{command.Text}' ({command.Name}).\r\n{error.Message}");
+					}
+				}
+				break;
+		}
+	}
+}


### PR DESCRIPTION
linked https://github.com/unoplatform/uno-private/issues/1484

## ✨ Feature
Add ability to forward commands from VSIX

## What is the current behavior? 🤔
Commands request are only emitted by the RC.VS package

## What is the new behavior? 🚀
Commands can be received from the VSIX and forwarded to the dev-server

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
