### PR TITLE
fix: Add missing persistence method for UIKit/Android

### DIFF
--- a/src/Uno.UWP/Storage/ApplicationData.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.Android.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Windows.Storage
 {
@@ -9,7 +10,7 @@ namespace Windows.Storage
 		/// On Android, persistence is always enabled and requires no additional setup.
 		/// This method is provided for cross-platform compatibility and returns a completed task.
 		/// </summary>
-		internal System.Threading.Tasks.Task EnablePersistenceAsync() => Task.CompletedTask;
+		internal Task EnablePersistenceAsync() => Task.CompletedTask;
 
 		private static string GetLocalCacheFolder()
 			=> GetAndroidAppContext().CacheDir.AbsolutePath;

--- a/src/Uno.UWP/Storage/ApplicationData.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.Android.cs
@@ -9,7 +9,7 @@ namespace Windows.Storage
 		/// On Android, persistence is always enabled and requires no additional setup.
 		/// This method is provided for cross-platform compatibility and returns a completed task.
 		/// </summary>
-		internal Task EnablePersistenceAsync() => Task.CompletedTask;
+		internal System.Threading.Tasks.Task EnablePersistenceAsync() => Task.CompletedTask;
 
 		private static string GetLocalCacheFolder()
 			=> GetAndroidAppContext().CacheDir.AbsolutePath;

--- a/src/Uno.UWP/Storage/ApplicationData.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.Android.cs
@@ -5,6 +5,10 @@ namespace Windows.Storage
 {
 	partial class ApplicationData
 	{
+		/// <summary>
+		/// On Android, persistence is always enabled and requires no additional setup.
+		/// This method is provided for cross-platform compatibility and returns a completed task.
+		/// </summary>
 		internal Task EnablePersistenceAsync() => Task.CompletedTask;
 
 		private static string GetLocalCacheFolder()

--- a/src/Uno.UWP/Storage/ApplicationData.Android.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.Android.cs
@@ -5,6 +5,8 @@ namespace Windows.Storage
 {
 	partial class ApplicationData
 	{
+		internal Task EnablePersistenceAsync() => Task.CompletedTask;
+
 		private static string GetLocalCacheFolder()
 			=> GetAndroidAppContext().CacheDir.AbsolutePath;
 

--- a/src/Uno.UWP/Storage/ApplicationData.UIKit.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.UIKit.cs
@@ -22,6 +22,8 @@ namespace Windows.Storage
 			}
 		}
 
+		internal Task EnablePersistenceAsync() => Task.CompletedTask;
+
 		private static string GetTemporaryFolder()
 			=> Path.GetTempPath();
 

--- a/src/Uno.UWP/Storage/ApplicationData.UIKit.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.UIKit.cs
@@ -22,6 +22,10 @@ namespace Windows.Storage
 			}
 		}
 
+		/// <summary>
+		/// On this platform, persistence is always enabled or not applicable, so this method is a no-op.
+		/// Returns a completed task to satisfy the cross-platform interface.
+		/// </summary>
 		internal Task EnablePersistenceAsync() => Task.CompletedTask;
 
 		private static string GetTemporaryFolder()

--- a/src/Uno.UWP/Storage/ApplicationData.UIKit.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.UIKit.cs
@@ -26,7 +26,7 @@ namespace Windows.Storage
 		/// On this platform, persistence is always enabled or not applicable, so this method is a no-op.
 		/// Returns a completed task to satisfy the cross-platform interface.
 		/// </summary>
-		internal Task EnablePersistenceAsync() => Task.CompletedTask;
+		internal System.Threading.Tasks.Task EnablePersistenceAsync() => Task.CompletedTask;
 
 		private static string GetTemporaryFolder()
 			=> Path.GetTempPath();

--- a/src/Uno.UWP/Storage/ApplicationData.UIKit.cs
+++ b/src/Uno.UWP/Storage/ApplicationData.UIKit.cs
@@ -1,6 +1,7 @@
 using System;
 using Foundation;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Windows.Storage
 {
@@ -26,7 +27,7 @@ namespace Windows.Storage
 		/// On this platform, persistence is always enabled or not applicable, so this method is a no-op.
 		/// Returns a completed task to satisfy the cross-platform interface.
 		/// </summary>
-		internal System.Threading.Tasks.Task EnablePersistenceAsync() => Task.CompletedTask;
+		internal Task EnablePersistenceAsync() => Task.CompletedTask;
 
 		private static string GetTemporaryFolder()
 			=> Path.GetTempPath();


### PR DESCRIPTION
## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

```
10-18 09:32:56.515 I/DOTNET  (23055): App failed to initialize: System.MissingMethodException: Method not found: System.Threading.Tasks.Task Windows.Storage.ApplicationData.EnablePersistenceAsync()
10-18 09:32:56.515 I/DOTNET  (23055):    at Microsoft.UI.Xaml.Application.Start(ApplicationInitializationCallback callback) in C:\a\1\s\src\Uno.UI\UI\Xaml\Application.cs:line 295
10-18 09:32:56.515 I/DOTNET  (23055):    at Uno.UI.Runtime.Skia.Android.AndroidHost.Run() in C:\a\1\s\src\Uno.UI.Runtime.Skia.Android\Hosting\AndroidHost.cs:line 52
```

## What is the new behavior? 🚀

App starts properly.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->