### PR TITLE
feat: Improve file type filter handling in Win32 file open picker

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileOpenPickerTests.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_Storage/Pickers/FileOpenPickerTests.xaml.cs
@@ -20,7 +20,8 @@ namespace UITests.Shared.Windows_Storage.Pickers
 - Selecting a file should show information below the file picker buttons.
 - It should be possible to pick multiple files, even if PicturesLibrary is selected and .jpg is used as file type.
 - Important (iOS): iOS 17 changed the way the file picker works. When testing this sample make sure to test it on iOS 17 or higher and iOS 16 or lower.
-- Important (Linux): Make sure that extension-less files can be picked
+- Important (Linux): Make sure that extension-less files can be picked.
+- Win32: When multiple filters are specified (e.g. .jpg and .png) and there is no wildcard (*), the picker should include and preselect a merged filter (e.g. "All files (*.jpg, *.png)").
 """
 	)]
 	public sealed partial class FileOpenPickerTests : Page

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileFolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileFolderPickerExtension.cs
@@ -186,6 +186,8 @@ internal class Win32FileFolderPickerExtension(IFilePicker picker) : IFileOpenPic
 	private List<(Win32Helper.NativeNulTerminatedUtf16String friendlyName, Win32Helper.NativeNulTerminatedUtf16String pattern)> GetFilterString()
 	{
 		var list = new List<(Win32Helper.NativeNulTerminatedUtf16String, Win32Helper.NativeNulTerminatedUtf16String)>();
+
+		var wildcardPatterns = new List<string>(picker.FileTypeFilterInternal.Count);
 		foreach (var pattern in picker.FileTypeFilterInternal.Distinct())
 		{
 			if (pattern is null)
@@ -195,11 +197,13 @@ internal class Win32FileFolderPickerExtension(IFilePicker picker) : IFileOpenPic
 
 			if (pattern == "*")
 			{
-				list.Add((new Win32Helper.NativeNulTerminatedUtf16String("All Files"), new Win32Helper.NativeNulTerminatedUtf16String("*.*")));
+				list.Add((new Win32Helper.NativeNulTerminatedUtf16String("All files"), new Win32Helper.NativeNulTerminatedUtf16String("*.*")));
+				wildcardPatterns.Add("*.*");
 			}
 			else if (pattern.StartsWith('.') && pattern[1..] is var ext && ext.All(char.IsLetterOrDigit))
 			{
-				list.Add((new Win32Helper.NativeNulTerminatedUtf16String($"{ext.ToUpperInvariant()} Files"), new Win32Helper.NativeNulTerminatedUtf16String($"*.{ext}")));
+				list.Add((new Win32Helper.NativeNulTerminatedUtf16String($"{ext.ToUpperInvariant()} files"), new Win32Helper.NativeNulTerminatedUtf16String($"*.{ext}")));
+				wildcardPatterns.Add($"*.{ext}");
 			}
 			else
 			{
@@ -207,9 +211,16 @@ internal class Win32FileFolderPickerExtension(IFilePicker picker) : IFileOpenPic
 			}
 		}
 
-		if (list.Count == 0)
+		if (wildcardPatterns.Count > 1)
 		{
-			list.Add((new Win32Helper.NativeNulTerminatedUtf16String("All Files"), new Win32Helper.NativeNulTerminatedUtf16String("*.*")));
+			// If there are multiple patterns, add an "All Files" entry with all patterns merged.
+			var allPatterns = string.Join(';', wildcardPatterns);
+			list.Insert(0, (new Win32Helper.NativeNulTerminatedUtf16String("All files"), new Win32Helper.NativeNulTerminatedUtf16String(allPatterns)));
+		}
+		else if (list.Count == 0)
+		{
+			// If no filter was provided, add a wildcard filter.
+			list.Add((new Win32Helper.NativeNulTerminatedUtf16String("All files"), new Win32Helper.NativeNulTerminatedUtf16String("*.*")));
 		}
 		return list;
 	}

--- a/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileFolderPickerExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Storage/Pickers/Win32FileFolderPickerExtension.cs
@@ -187,6 +187,7 @@ internal class Win32FileFolderPickerExtension(IFilePicker picker) : IFileOpenPic
 	{
 		var list = new List<(Win32Helper.NativeNulTerminatedUtf16String, Win32Helper.NativeNulTerminatedUtf16String)>();
 
+		var hasAnyFilePattern = false;
 		var wildcardPatterns = new List<string>(picker.FileTypeFilterInternal.Count);
 		foreach (var pattern in picker.FileTypeFilterInternal.Distinct())
 		{
@@ -197,8 +198,7 @@ internal class Win32FileFolderPickerExtension(IFilePicker picker) : IFileOpenPic
 
 			if (pattern == "*")
 			{
-				list.Add((new Win32Helper.NativeNulTerminatedUtf16String("All files"), new Win32Helper.NativeNulTerminatedUtf16String("*.*")));
-				wildcardPatterns.Add("*.*");
+				hasAnyFilePattern = true;
 			}
 			else if (pattern.StartsWith('.') && pattern[1..] is var ext && ext.All(char.IsLetterOrDigit))
 			{
@@ -211,17 +211,17 @@ internal class Win32FileFolderPickerExtension(IFilePicker picker) : IFileOpenPic
 			}
 		}
 
-		if (wildcardPatterns.Count > 1)
+		if (hasAnyFilePattern || list.Count == 0)
+		{
+			list.Insert(0, (new Win32Helper.NativeNulTerminatedUtf16String("All files"), new Win32Helper.NativeNulTerminatedUtf16String("*")));
+		}
+		else if (wildcardPatterns.Count > 1)
 		{
 			// If there are multiple patterns, add an "All Files" entry with all patterns merged.
 			var allPatterns = string.Join(';', wildcardPatterns);
 			list.Insert(0, (new Win32Helper.NativeNulTerminatedUtf16String("All files"), new Win32Helper.NativeNulTerminatedUtf16String(allPatterns)));
 		}
-		else if (list.Count == 0)
-		{
-			// If no filter was provided, add a wildcard filter.
-			list.Add((new Win32Helper.NativeNulTerminatedUtf16String("All files"), new Win32Helper.NativeNulTerminatedUtf16String("*.*")));
-		}
+
 		return list;
 	}
 }


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/362, closes https://github.com/unoplatform/uno/issues/21363

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: ✨ Feature

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- 
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

When user provides multiple file filters, they appear as separate entries in the resulting picker.


## What is the new behavior? 🚀

There is a merged filter that includes all other file filters.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->