### PR TITLE
chore(deps): use SkiaSharp 3.119.2-preview.1

### DIFF
--- a/build/ci/tests/.azure-devops-tests-android-coreclr-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-android-coreclr-skia-build.yml
@@ -27,7 +27,7 @@ jobs:
     parameters:
       UnoCheckParameters: '--tfm net10.0-android'
 
-  - powershell: dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -c Release -r android-x64 -f net10.0-android -p:UnoTargetFrameworkOverride=net10.0-android -p:ApplicationId=uno.platform.samplesapp.skia.coreclr -p:UseMonoRuntime=false /bl:$(build.artifactstagingdirectory)/logs/build-skia-android-coreclr.binlog
+  - powershell: dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -c Release -r android-x64 -f net10.0-android -p:UnoTargetFrameworkOverride=net10.0-android -p:ApplicationId=uno.platform.samplesapp.skia.coreclr -p:UseMonoRuntime=false -p:SkiaSharpVersion=3.119.2-preview.1 /bl:$(build.artifactstagingdirectory)/logs/build-skia-android-coreclr.binlog
     displayName: Build Android+CoreCLR Skia Head
 
   - script: >

--- a/build/ci/tests/.azure-devops-tests-android-nativeaot-skia-build.yml
+++ b/build/ci/tests/.azure-devops-tests-android-nativeaot-skia-build.yml
@@ -27,7 +27,7 @@ jobs:
     parameters:
       UnoCheckParameters: '--tfm net10.0-android'
 
-  - powershell: dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -c Release -r android-x64 -f net10.0-android -p:UnoTargetFrameworkOverride=net10.0-android -p:ApplicationId=uno.platform.samplesapp.skia.nativeaot -p:SkiaPublishAot=true /bl:$(build.artifactstagingdirectory)/logs/build-skia-android-nativeaot.binlog
+  - powershell: dotnet publish src/SamplesApp/SamplesApp.Skia.netcoremobile/SamplesApp.Skia.netcoremobile.csproj -c Release -r android-x64 -f net10.0-android -p:UnoTargetFrameworkOverride=net10.0-android -p:ApplicationId=uno.platform.samplesapp.skia.nativeaot -p:SkiaPublishAot=true -p:SkiaSharpVersion=3.119.2-preview.1 /bl:$(build.artifactstagingdirectory)/logs/build-skia-android-nativeaot.binlog
     displayName: Build Android+NativeAOT Skia Head
 
   - script: >


### PR DESCRIPTION
Context: 41a5796ea0a3a2d270999696ea7e0ce529755e41
Context: https://github.com/unoplatform/uno/pull/21477#issuecomment-3293703279
Context: https://dev.azure.com/xamarin/public/_artifacts/feed/SkiaSharp/NuGet/_SymbolsPreview/overview/0.0.0-branch.release.3.119.2-preview.1.2266

After CoreCLR tests were merged (41a5796e), we started seeing occasional flakiness on CI, in which `SamplesApp.Skia.netcoremobile` would *crash* within SkiaSharp:

	F DEBUG   : Cause: null pointer dereference
	F DEBUG   :     rax 00000000000001a9  rbx 00007259ee698820  rcx 0000000000000000  rdx 0000000000000275
	F DEBUG   :     r8  4d1f000000050005  r9  0000000000000000  r10 000072592e679b24  r11 0000000000000001
	F DEBUG   :     r12 0000000000000330  r13 0000000000000033  r14 0000725a3e6f7670  r15 000072170df19fd8
	F DEBUG   :     rdi 0000000000000330  rsi 000072170df19fd8
	F DEBUG   :     rbp 0000000000000000  rsp 000072170df19f30  rip 00007217123b06b7
	F DEBUG   : 7 total frames
	F DEBUG   : backtrace:
	F DEBUG   :       #00 pc 00000000003056b7  /data/app/~~MTMdmfvAFJoDhk7yNyJTzA==/uno.platform.samplesapp.skia.coreclr-qeZLZ4L2cypBk9-ouYLb1Q==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #01 pc 00000000003052be  /data/app/~~MTMdmfvAFJoDhk7yNyJTzA==/uno.platform.samplesapp.skia.coreclr-qeZLZ4L2cypBk9-ouYLb1Q==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #02 pc 00000000002e4b64  /data/app/~~MTMdmfvAFJoDhk7yNyJTzA==/uno.platform.samplesapp.skia.coreclr-qeZLZ4L2cypBk9-ouYLb1Q==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #03 pc 0000000000274884  /data/app/~~MTMdmfvAFJoDhk7yNyJTzA==/uno.platform.samplesapp.skia.coreclr-qeZLZ4L2cypBk9-ouYLb1Q==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #04 pc 000000000027469d  /data/app/~~MTMdmfvAFJoDhk7yNyJTzA==/uno.platform.samplesapp.skia.coreclr-qeZLZ4L2cypBk9-ouYLb1Q==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #05 pc 000000000024f28f  /data/app/~~MTMdmfvAFJoDhk7yNyJTzA==/uno.platform.samplesapp.skia.coreclr-qeZLZ4L2cypBk9-ouYLb1Q==/lib/x86_64/libSkiaSharp.so (sk_canvas_draw_picture+95)
	F DEBUG   :       #06 pc 000000000010897e  /memfd:doublemapper (deleted) (offset 0x3181000)

@jonpryor suspects that this is because the GC is collecting *something*, which causes whatever SkiaSharp is attempting to use to be `null`.  The question is, *what* is SkiaSharp attempting to use that triggers the SIGSEGV?

Answering this requires debug symbols for SkiaSharp, which did not exist.

Enter [SkiaSharp 3.119.2-preview.1][0], which *has* symbols, though it takes a bit of work to obtain them:

 1. Go to <https://dev.azure.com/xamarin/public/_artifacts/feed/SkiaSharp/NuGet/_SymbolsPreview/overview/0.0.0-branch.release.3.119.2-preview.1.2266>
 2. Click **↓ Download**
 3. `unzip _SymbolsPreview.0.0.0-branch.release.3.119.2-preview.1.2266.nupkg`
 4. `unzip -d _t tools/SkiaSharp.NativeAssets.Android.3.119.2-preview.1.symbols.nupkg`

Then e.g. `_t/runtimes/android-x64/native/libSkiaSharp.so.dbg` contains debug symbols for `libSkiaSharp.so`.

Bump `$(SkiaSharpVersion)` to 3.119.2-preview.1, so that when `SamplesApp.Skia.netcoremobile` crashes in the future, we can better investigate the native side of the crash.

[0]: https://www.nuget.org/packages/SkiaSharp/3.119.2-preview.1

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->