### PR TITLE
chore: Remove use of [Java.Interop.Export]

### DIFF
--- a/src/SamplesApp/SamplesApp.netcoremobile/Android/MainActivity.Android.cs
+++ b/src/SamplesApp/SamplesApp.netcoremobile/Android/MainActivity.Android.cs
@@ -33,7 +33,7 @@ namespace SamplesApp.Droid
 			Android.Content.Intent.CategoryBrowsable,
 		},
 		DataScheme = "uno-samples-test")]
-	public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
+	public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity, Uno.UI.ISamplesAppMainActivity
 	{
 		private HandlerThread _pixelCopyHandlerThread;
 
@@ -44,19 +44,15 @@ namespace SamplesApp.Droid
 			base.OnCreate(bundle);
 		}
 
-		[Export("RunTest")]
 		public string RunTest(string metadataName) => App.RunTest(metadataName);
 
-		[Export("IsTestDone")]
 		public bool IsTestDone(string testId) => App.IsTestDone(testId);
 
-		[Export("GetDisplayScreenScaling")]
 		public string GetDisplayScreenScaling(string displayId) => App.GetDisplayScreenScaling(displayId);
 
 		/// <summary>
 		/// Returns a base64 encoded PNG file
 		/// </summary>
-		[Export("GetScreenshot")]
 		public string GetScreenshot(string displayId)
 		{
 			var rootView = ((ICompositionRoot)this).Content;
@@ -96,7 +92,6 @@ namespace SamplesApp.Droid
 		}
 
 
-		[Export("SetFullScreenMode")]
 		public void SetFullScreenMode(bool fullscreen)
 		{
 			// workaround for #2747: force the app into fullscreen

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/ISamplesAppMainActivity.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/ISamplesAppMainActivity.java
@@ -1,0 +1,9 @@
+package Uno.UI;
+
+public interface ISamplesAppMainActivity {
+	String RunTest(String metadataName);
+	boolean IsTestDone(String testId);
+	String GetDisplayScreenScaling(String displayId);
+	String GetScreenshot(String displayId);
+	void SetFullScreenMode(boolean fullscreen);
+}

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/IUIElement.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/IUIElement.java
@@ -1,0 +1,6 @@
+package Uno.UI;
+
+public interface IUIElement {
+	String SetDependencyPropertyValue(String dependencyPropertyNameAndValue);
+	Object GetDependencyPropertyValue(String dependencyPropertyName);
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.Android.cs
@@ -21,7 +21,7 @@ using Microsoft.UI.Xaml.Markup;
 
 namespace Microsoft.UI.Xaml
 {
-	public partial class UIElement : BindableView
+	public partial class UIElement : BindableView, Uno.UI.IUIElement
 	{
 		/// <summary>
 		/// Keeps the count of native children (non-UIElements), for clipping purposes.
@@ -425,9 +425,11 @@ namespace Microsoft.UI.Xaml
 		/// </summary>
 		/// <param name="dependencyPropertyNameAndvalue">The name and value of the property</param>
 		/// <returns>The currenty set value at the Local precedence</returns>
-		[Java.Interop.Export(nameof(SetDependencyPropertyValue))]
 		public string SetDependencyPropertyValue(string dependencyPropertyNameAndValue)
 			=> SetDependencyPropertyValueInternal(this, dependencyPropertyNameAndValue);
+
+		string IUIElement.SetDependencyPropertyValue(string dependencyPropertyNameAndValue)
+			=> SetDependencyPropertyValue(dependencyPropertyNameAndValue);
 
 		/// <summary>
 		/// Provides a native value for the dependency property with the given name on the current instance. If the value is a primitive type,
@@ -435,7 +437,6 @@ namespace Microsoft.UI.Xaml
 		/// </summary>
 		/// <param name="dependencyPropertyName">The name of the target dependency property</param>
 		/// <returns>The content of the target dependency property (its actual value if it is a primitive type ot its <see cref="object.ToString"/> representation otherwise</returns>
-		[Java.Interop.Export(nameof(GetDependencyPropertyValue))]
 		public Java.Lang.Object GetDependencyPropertyValue(string dependencyPropertyName)
 		{
 			var dpValue = GetDependencyPropertyValueInternal(this, dependencyPropertyName);
@@ -496,6 +497,9 @@ namespace Microsoft.UI.Xaml
 #pragma warning restore CA1422 // Validate platform compatibility
 #pragma warning restore CS0618 // deprecated members
 		}
+
+		Java.Lang.Object IUIElement.GetDependencyPropertyValue(string dependencyPropertyName)
+			=> GetDependencyPropertyValue(dependencyPropertyName);
 
 #if DEBUG
 		public static Predicate<View> ViewOfInterestSelector { get; set; } = v => (v as FrameworkElement)?.Name == "TargetView";


### PR DESCRIPTION
Context: 4d84ee31adb3e7ecd3fcbdc248b79fee78211d3e

NativeAOT doesn't support the use of `[Java.Interop.ExportAttribute]`.

Update `Uno.UI.BindingHelper.Android` to add some new interfaces so that `src/SamplesApp/SamplesApp.netcoremobile` and `src/Uno.UI` can implement those interfaces, which allows us to use (build-time) `generator`-emitted marshaling code which works in a NativeAOT environment.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->