### PR TITLE
fix: `WebView2` local content mapping on Wasm

### DIFF
--- a/src/SamplesApp/SamplesApp.Skia.WebAssembly.Browser/SamplesApp.Skia.WebAssembly.Browser.csproj
+++ b/src/SamplesApp/SamplesApp.Skia.WebAssembly.Browser/SamplesApp.Skia.WebAssembly.Browser.csproj
@@ -51,6 +51,15 @@
 	
 	<ItemGroup>
 		<EmbeddedResource Include="WasmScripts\AppManifest.js" />
+	
+		<Content Include="..\LinkedFiles\WebContent\**\*.*">
+			<Link>WebContent\%(RecursiveDir)%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+
+		<WasmShellExtraFilesToDeploy Include="..\LinkedFiles\WebContent\**\*.*">
+			<TargetPath>WebContent/%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+		</WasmShellExtraFilesToDeploy>
 	</ItemGroup>
 
 	<!--

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Wasm/NativeWebView.Interop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Wasm/NativeWebView.Interop.wasm.cs
@@ -44,6 +44,9 @@ internal static partial class NativeWebView
 		[JSImport("globalThis.Microsoft.UI.Xaml.Controls.WebView.getAttribute")]
 		internal static partial string? GetAttribute(ElementId htmlId, string attribute);
 
+		[JSImport("globalThis.Microsoft.UI.Xaml.Controls.WebView.getPackageBase")]
+		internal static partial string GetPackageBase();
+
 		[JSImport("globalThis.Microsoft.UI.Xaml.Controls.WebView.setAttribute")]
 		internal static partial void SetAttribute(ElementId htmlId, string attribute, string value);
 

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Wasm/NativeWebView.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Native/Wasm/NativeWebView.wasm.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Web.WebView2.Core;
 using Uno.UI.Xaml.Controls;
+using Windows.Storage;
+using Windows.Storage.Helpers;
 using static __Microsoft.UI.Xaml.Controls.NativeWebView;
 
 #if WASM_SKIA
@@ -41,24 +43,24 @@ internal partial class NativeWebView : ICleanableNativeWebView
 	}
 
 	[JSExport]
-	internal static void DispatchLoadEvent(ElementId elementId)
+	internal static void DispatchLoadEvent(ElementId elementId, string? absoluteUrl)
 	{
 		if (_elementIdToNativeWebView.TryGetValue(elementId, out var nativeWebView))
 		{
-			nativeWebView.OnNavigationCompleted(nativeWebView._coreWebView, EventArgs.Empty);
+			nativeWebView.OnNavigationCompleted(nativeWebView._coreWebView, absoluteUrl);
 		}
 	}
 
 	public string DocumentTitle => NativeMethods.GetDocumentTitle(_elementId) ?? "";
 
-	private void OnNavigationCompleted(object sender, EventArgs e)
+	private void OnNavigationCompleted(object sender, string? absoluteUrl)
 	{
 		if (_coreWebView is null)
 		{
 			return;
 		}
 
-		var uriString = NativeMethods.GetAttribute(_elementId, "src");
+		var uriString = string.IsNullOrEmpty(absoluteUrl) ? NativeMethods.GetAttribute(_elementId, "src") : absoluteUrl;
 		Uri uri = CoreWebView2.BlankUri;
 		if (!string.IsNullOrEmpty(uriString))
 		{
@@ -98,48 +100,37 @@ internal partial class NativeWebView : ICleanableNativeWebView
 	{
 		var uriString = uri.OriginalString;
 
-		if (!string.IsNullOrEmpty(uri.Host) && _coreWebView.HostToFolderMap.TryGetValue(uri.Host.ToLowerInvariant(), out var folderName))
+		// Handle virtual host mapping for local assets
+		if (!string.IsNullOrEmpty(uri.Host) &&
+			_coreWebView.HostToFolderMap.TryGetValue(uri.Host.ToLowerInvariant(), out var folderName))
 		{
-			var packageBase = NativeMethods.GetPackageBase();
 			var relativePath = uri.AbsolutePath.TrimStart('/');
-			var mappedUrl = packageBase.TrimEnd('/') + "/" + folderName.TrimStart('/').TrimEnd('/');
+			var mappedPath = $"{folderName.TrimEnd('/')}/{relativePath}";
 
 			if (!string.IsNullOrEmpty(relativePath))
 			{
-				if (!relativePath.StartsWith(folderName.Trim('/'), StringComparison.OrdinalIgnoreCase))
-				{
-					mappedUrl += "/" + relativePath;
-				}
-				else
-				{
-					var afterFolder = relativePath[folderName.Trim('/').Length..].TrimStart('/');
-					if (!string.IsNullOrEmpty(afterFolder))
-					{
-						mappedUrl += "/" + afterFolder;
-					}
-				}
-			}
+				var packageBase = NativeMethods.GetPackageBase();
+				uriString = $"{packageBase.TrimEnd('/')}/{mappedPath.TrimStart('/')}";
 
-			if (!string.IsNullOrEmpty(uri.Query))
-			{
-				mappedUrl += uri.Query;
+				if (!string.IsNullOrEmpty(uri.Query))
+				{
+					uriString += uri.Query;
+				}
+				if (!string.IsNullOrEmpty(uri.Fragment))
+				{
+					uriString += uri.Fragment;
+				}
 			}
-			if (!string.IsNullOrEmpty(uri.Fragment))
-			{
-				mappedUrl += uri.Fragment;
-			}
-
-			uriString = mappedUrl;
 		}
 
 		ScheduleNavigationStarting(uriString, () => NativeMethods.SetAttribute(_elementId, "src", uriString));
-		OnNavigationCompleted(this, EventArgs.Empty);
+		OnNavigationCompleted(this, null);
 	}
 
 	public void ProcessNavigation(string html)
 	{
 		ScheduleNavigationStarting(null, () => NativeMethods.SetAttribute(_elementId, "srcdoc", html));
-		OnNavigationCompleted(this, EventArgs.Empty);
+		OnNavigationCompleted(this, null);
 	}
 
 	public void ProcessNavigation(HttpRequestMessage httpRequestMessage)
@@ -166,7 +157,7 @@ internal partial class NativeWebView : ICleanableNativeWebView
 	{
 		_elementIdToNativeWebView.TryAdd(_elementId, this);
 		NativeMethods.SetupEvents(_elementId);
-		DispatchLoadEvent(_elementId);
+		DispatchLoadEvent(_elementId, null);
 	}
 
 	public void OnUnloaded()

--- a/src/Uno.UI/ts/Windows/UI/Xaml/Controls/WebView.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/Controls/WebView.ts
@@ -1,68 +1,91 @@
 namespace Microsoft.UI.Xaml.Controls {
 
-	export class WebView {
-		private static unoExports: any;
+    export class WebView {
+        private static unoExports: any;
+        private static cachedPackageBase: string | null = null;
 
-		public static buildImports(assembly: string) {
-			if (!WebView.unoExports) {
-				(<any>window.Module).getAssemblyExports(assembly)
-					.then((e: any) => {
-						WebView.unoExports = e.Microsoft.UI.Xaml.Controls.NativeWebView;
-					});
-			}
-		}
+        public static buildImports(assembly: string) {
+            if (!WebView.unoExports) {
+                (<any>window.Module).getAssemblyExports(assembly)
+                    .then((e: any) => {
+                        WebView.unoExports = e.Microsoft.UI.Xaml.Controls.NativeWebView;
+                    });
+            }
+        }
 
-		static reload(htmlId: string): void {
-			(<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow.location.reload();
-		}
+        static reload(htmlId: string): void {
+            (<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow.location.reload();
+        }
 
-		static stop(htmlId: string): void {
-			(<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow.stop();
-		}
+        static stop(htmlId: string): void {
+            (<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow.stop();
+        }
 
-		static goBack(htmlId: string): void {
-			(<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow.history.back();
-		}
+        static goBack(htmlId: string): void {
+            (<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow.history.back();
+        }
 
-		static goForward(htmlId: string): void {
-			(<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow.history.forward();
-		}
+        static goForward(htmlId: string): void {
+            (<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow.history.forward();
+        }
 
-		static executeScript(htmlId: string, script: string): string {
-			return ((<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow as any).eval(script);
-		}
+        static executeScript(htmlId: string, script: string): string {
+            return ((<HTMLIFrameElement>document.getElementById(htmlId)).contentWindow as any).eval(script);
+        }
 
-		static getDocumentTitle(htmlId: string): string {
-			return (<HTMLIFrameElement>document.getElementById(htmlId)).contentDocument.title;
-		}
+        static getDocumentTitle(htmlId: string): string {
+            return (<HTMLIFrameElement>document.getElementById(htmlId)).contentDocument.title;
+        }
 
-		static setAttribute(htmlId: string, name: string, value: string) {
-			(<HTMLIFrameElement>document.getElementById(htmlId)).setAttribute(name, value);
-		}
+        static setAttribute(htmlId: string, name: string, value: string) {
+            (<HTMLIFrameElement>document.getElementById(htmlId)).setAttribute(name, value);
+        }
 
-		static getAttribute(htmlId: string, name: string): string {
-			return (<HTMLIFrameElement>document.getElementById(htmlId)).getAttribute(name);
-		}
+        static getAttribute(htmlId: string, name: string): string {
+            return (<HTMLIFrameElement>document.getElementById(htmlId)).getAttribute(name);
+        }
 
-		static initializeStyling(htmlId: string) {
-			const iframe = document.getElementById(htmlId) as HTMLIFrameElement;
-			iframe.style.backgroundColor = "transparent";
-			iframe.style.border = "0";
-		}
+        static initializeStyling(htmlId: string) {
+            const iframe = document.getElementById(htmlId) as HTMLIFrameElement;
+            iframe.style.backgroundColor = "transparent";
+            iframe.style.border = "0";
+        }
 
-		static setupEvents(htmlId: string) {
-			const iframe = <HTMLIFrameElement>document.getElementById(htmlId);
-			iframe.addEventListener('load', WebView.onLoad);
-		}
+        static getPackageBase(): string {
+            if (WebView.cachedPackageBase !== null) {
+                return WebView.cachedPackageBase;
+            }
 
-		static cleanupEvents(htmlId: string) {
-			const iframe = <HTMLIFrameElement>document.getElementById(htmlId);
-			iframe.removeEventListener('load', WebView.onLoad);
-		}
+            const pathsToCheck = [
+                ...Array.from(document.getElementsByTagName('script')).map(s => s.src),
+            ];
 
-		private static onLoad(event: Event) {
-			const iframe = event.currentTarget as HTMLIFrameElement;
-			WebView.unoExports.DispatchLoadEvent(iframe.id);
-		}
-	}
+            for (const path of pathsToCheck) {
+                const m = path?.match(/\/package_[^\/]+/);
+                if (m) {
+                    const packageBase = "./" + m[0].substring(1);
+                    WebView.cachedPackageBase = packageBase;
+                    return packageBase;
+                }
+            }
+
+			WebView.cachedPackageBase = ".";
+            return ".";
+        }
+
+        static setupEvents(htmlId: string) {
+            const iframe = <HTMLIFrameElement>document.getElementById(htmlId);
+            iframe.addEventListener('load', WebView.onLoad);
+        }
+
+        static cleanupEvents(htmlId: string) {
+            const iframe = <HTMLIFrameElement>document.getElementById(htmlId);
+            iframe.removeEventListener('load', WebView.onLoad);
+        }
+
+        private static onLoad(event: Event) {
+            const iframe = event.currentTarget as HTMLIFrameElement;
+            WebView.unoExports.DispatchLoadEvent(iframe.id);
+        }
+    }
 }

--- a/src/Uno.UI/ts/Windows/UI/Xaml/Controls/WebView.ts
+++ b/src/Uno.UI/ts/Windows/UI/Xaml/Controls/WebView.ts
@@ -69,7 +69,7 @@ namespace Microsoft.UI.Xaml.Controls {
                 }
             }
 
-			WebView.cachedPackageBase = ".";
+            WebView.cachedPackageBase = ".";
             return ".";
         }
 
@@ -85,7 +85,8 @@ namespace Microsoft.UI.Xaml.Controls {
 
         private static onLoad(event: Event) {
             const iframe = event.currentTarget as HTMLIFrameElement;
-            WebView.unoExports.DispatchLoadEvent(iframe.id);
+            const absoluteUrl = iframe.contentWindow.location.href;
+            WebView.unoExports.DispatchLoadEvent(iframe.id, absoluteUrl);
         }
     }
 }


### PR DESCRIPTION
**GitHub Issue:** part of #21601, closes https://github.com/unoplatform/uno/issues/21685

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix

## What is the new behavior? 🚀

The URI is correctly mapped to the location of the document. 


For commit [b3ac3eb](https://github.com/unoplatform/uno/pull/21651/commits/b3ac3eb1ef388ab83bf3187fe52b44693e79be0e):
Seeing some COEP issues when loading the document locally. Iframe refuses to display the content: 
<img width="390" height="160" alt="image" src="https://github.com/user-attachments/assets/923a4faa-8693-4725-aa09-d62a888a6cd6" />
From my testing, I was able to resolve this by adding CORS header manually in the DevTools. Should we do that automatically for the user?

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes