### PR TITLE
[WIP] [Win32] Use real window handle for `AppWindow`

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/UI/Xaml/Window/Win32WindowWrapper.cs
@@ -165,6 +165,8 @@ internal partial class Win32WindowWrapper : NativeWindowWrapperBase, IXamlRootHo
 		}
 	}
 
+	public override ulong NativeWindowId => (ulong)_hwnd.Value;
+
 	private unsafe void OnSystemThemeChanged(object? _, EventArgs __)
 	{
 		BOOL value = Win32SystemThemeHelperExtension.Instance.GetSystemTheme() is SystemTheme.Dark;

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
@@ -184,6 +184,28 @@ public class Given_AppWindow
 		}
 	}
 
+	[TestMethod]
+	public async Task When_WindowHandleAndIds_Should_BeConsistent()
+	{
+		var window = TestServices.WindowHelper.CurrentTestWindow;
+		var button = new Microsoft.UI.Xaml.Controls.Button { Content = "Test" };
+		window.Content = button;
+
+		await TestServices.WindowHelper.WaitForIdle();
+		await TestServices.WindowHelper.WaitForLoaded(button);
+
+		var hwnd = global::WinRT.Interop.WindowNative.GetWindowHandle(window);
+		var appWindowId = window.AppWindow.Id;
+		var xamlAppWindowId = button.XamlRoot.ContentIslandEnvironment.AppWindowId;
+
+		// HWND should be non-zero
+		Assert.AreNotEqual(IntPtr.Zero, hwnd, "Window handle should not be zero");
+
+		// All IDs should be the same (including HWND as WindowId)
+		Assert.AreEqual((long)appWindowId.Value, hwnd.ToInt64(), "AppWindow.Id should equal WindowId from HWND");
+		Assert.AreEqual(appWindowId, xamlAppWindowId, "AppWindow.Id should equal XamlRoot.ContentIslandEnvironment.AppWindowId");
+	}
+
 	private void AssertPositioningAndSizingSupport()
 	{
 		if (!OperatingSystem.IsLinux() &&

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
@@ -228,6 +228,28 @@ public class Given_AppWindow
 		}
 	}
 
+	[TestMethod]
+	public async Task When_WindowHandleAndIds_Should_BeConsistent()
+	{
+		var window = TestServices.WindowHelper.CurrentTestWindow;
+		var button = new Microsoft.UI.Xaml.Controls.Button { Content = "Test" };
+		window.Content = button;
+
+		await TestServices.WindowHelper.WaitForIdle();
+		await TestServices.WindowHelper.WaitForLoaded(button);
+
+		var hwnd = global::WinRT.Interop.WindowNative.GetWindowHandle(window);
+		var appWindowId = window.AppWindow.Id;
+		var xamlAppWindowId = button.XamlRoot.ContentIslandEnvironment.AppWindowId;
+
+		// HWND should be non-zero
+		Assert.AreNotEqual(IntPtr.Zero, hwnd, "Window handle should not be zero");
+
+		// All IDs should be the same (including HWND as WindowId)
+		Assert.AreEqual((long)appWindowId.Value, hwnd.ToInt64(), "AppWindow.Id should equal WindowId from HWND");
+		Assert.AreEqual(appWindowId, xamlAppWindowId, "AppWindow.Id should equal XamlRoot.ContentIslandEnvironment.AppWindowId");
+	}
+
 	private void AssertPositioningAndSizingSupport()
 	{
 		if (!OperatingSystem.IsLinux() &&

--- a/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_WindowId_Maps_Alc.cs
+++ b/src/Uno.UI.UnitTests/Windows_UI_Xaml/Given_WindowId_Maps_Alc.cs
@@ -70,7 +70,9 @@ public class Given_WindowId_Maps_Alc
 	[MethodImpl(MethodImplOptions.NoInlining)]
 	private static (MUXWindowId WindowId, WeakReference WeakAppWindow) CreateRegisteredAppWindow()
 	{
-		var appWindow = new AppWindow();
+		// An AppWindow id is the native window handle it was created for. This test host has no native
+		// windows, so a fixed synthetic handle stands in for one.
+		var appWindow = new AppWindow(0xF00DBEEF);
 		_ = CoreDragDropManager.GetOrCreateForWindowId(appWindow.Id);
 
 		Assert.IsNotNull(AppWindow.GetFromWindowId(appWindow.Id), "Pre-condition: AppWindow must be registered.");

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Content/ContentIslandEnvironment.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Content/ContentIslandEnvironment.cs
@@ -3,17 +3,17 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Content
 {
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class ContentIslandEnvironment
 	{
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if false
 		internal ContentIslandEnvironment()
 		{
 		}
 #endif
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public global::Microsoft.UI.WindowId AppWindowId
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Content/ContentIslandEnvironment.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Content/ContentIslandEnvironment.cs
@@ -3,12 +3,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Microsoft.UI.Content
 {
-#if __SKIA__
+#if false
 	[global::Uno.NotImplemented]
 #endif
 	public partial class ContentIslandEnvironment
 	{
-#if __SKIA__
+#if false
 		[global::Uno.NotImplemented("__SKIA__")]
 		public global::Microsoft.UI.WindowId AppWindowId
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/XamlRoot.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/XamlRoot.cs
@@ -12,7 +12,7 @@ namespace Microsoft.UI.Xaml
 		// Skipping already declared property IsHostVisible
 		// Skipping already declared property RasterizationScale
 		// Skipping already declared property Size
-#if __ANDROID__ || __IOS__ || __TVOS__ || IS_UNIT_TESTS || __WASM__ || __SKIA__ || __NETSTD_REFERENCE__
+#if false
 		[global::Uno.NotImplemented("__ANDROID__", "__IOS__", "__TVOS__", "IS_UNIT_TESTS", "__WASM__", "__SKIA__", "__NETSTD_REFERENCE__")]
 		public global::Microsoft.UI.Content.ContentIslandEnvironment ContentIslandEnvironment
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/XamlRoot.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Microsoft.UI.Xaml/XamlRoot.cs
@@ -19,7 +19,7 @@ namespace Microsoft.UI.Xaml
 			}
 		}
 #endif
-#if __SKIA__
+#if false
 		[global::Uno.NotImplemented("__SKIA__")]
 		public global::Microsoft.UI.Content.ContentIslandEnvironment ContentIslandEnvironment
 		{

--- a/src/Uno.UI/UI/Content/ContentIslandEnvironment.cs
+++ b/src/Uno.UI/UI/Content/ContentIslandEnvironment.cs
@@ -1,0 +1,17 @@
+namespace Microsoft.UI.Content;
+
+/// <summary>
+/// Provides general environment information to a ContentIsland.
+/// </summary>
+public partial class ContentIslandEnvironment
+{
+	internal ContentIslandEnvironment(WindowId appWindowId)
+	{
+		AppWindowId = appWindowId;
+	}
+
+	/// <summary>
+	/// Gets the ID of the top-level window.
+	/// </summary>
+	public WindowId AppWindowId { get; }
+}

--- a/src/Uno.UI/UI/Xaml/Internal/ContentRoot.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/ContentRoot.cs
@@ -282,4 +282,17 @@ internal partial class ContentRoot
 			_ => null
 		};
 	}
+
+	internal ContentIslandEnvironment? ContentIslandEnvironment
+	{
+		get
+		{
+			if (Type is ContentRootType.XamlIslandRoot && XamlIslandRoot is not null)
+			{
+				return XamlIslandRoot.ContentIslandEnvironment;
+			}
+
+			return null;
+		}
+	}
 }

--- a/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.Core.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.Core.cs
@@ -117,6 +117,8 @@ internal partial class XamlIslandRoot
 
 	internal ContentIsland? ContentIsland => ContentRoot?.CompositionContent;
 
+	internal ContentIslandEnvironment? ContentIslandEnvironment { get; set; }
+
 	internal void OnStateChanged()
 	{
 		// In the scope if this handler, we may find the the XamlRoot has changed in various ways.  This RAII

--- a/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/Islands/XamlIslandRoot.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WinUICoreServices = global::Uno.UI.Xaml.Core.CoreServices;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Content;
 
 namespace Uno.UI.Xaml.Islands;
 

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
@@ -50,6 +50,8 @@ internal class DesktopWindow : BaseWindowImplementation
 
 	public override XamlRoot? XamlRoot => _desktopWindowXamlSource?.XamlIsland.XamlRoot;
 
+	internal DesktopWindowXamlSource? DesktopWindowXamlSource => _desktopWindowXamlSource;
+
 	protected override void OnSizeChanged(Size newSize)
 	{
 		if (_desktopWindowXamlSource is null)

--- a/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Implementations/DesktopWindow.cs
@@ -63,6 +63,8 @@ internal class DesktopWindow : BaseWindowImplementation
 
 	public override XamlRoot? XamlRoot => _desktopWindowXamlSource?.XamlIsland.XamlRoot;
 
+	internal DesktopWindowXamlSource? DesktopWindowXamlSource => _desktopWindowXamlSource;
+
 	protected override void OnSizeChanged(Size newSize)
 	{
 		if (_desktopWindowXamlSource is null)

--- a/src/Uno.UI/UI/Xaml/Window/Native/INativeWindowWrapper.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/INativeWindowWrapper.cs
@@ -12,6 +12,8 @@ namespace Uno.UI.Xaml.Controls;
 
 internal interface INativeWindowWrapper : INativeAppWindow
 {
+	ulong NativeWindowId { get; }
+
 	ContentSiteView ContentSiteView { get; }
 
 	Rect Bounds { get; }

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
@@ -10,6 +10,8 @@ using Windows.Foundation;
 using Windows.Graphics;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
+using System.Threading;
+
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Dispatching;
@@ -36,6 +38,8 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	private protected Window? _window;
 	private float _rasterizationScale;
 	private readonly SerialDisposable _presenterSubscription = new SerialDisposable();
+	private static ulong _generatedWindowIdIterator;
+	private ulong _generatedWindowId;
 
 	protected NativeWindowWrapperBase(Window window, XamlRoot xamlRoot) : this()
 	{
@@ -44,6 +48,7 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 
 	protected NativeWindowWrapperBase()
 	{
+		_generatedWindowId = Interlocked.Increment(ref _generatedWindowIdIterator);
 	}
 
 	public ContentSiteView ContentSiteView => _contentSite.View;
@@ -63,6 +68,8 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	}
 
 	public abstract object? NativeWindow { get; }
+
+	public virtual ulong NativeWindowId => _generatedWindowId;
 
 	public Rect Bounds
 	{

--- a/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Native/NativeWindowWrapperBase.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System;
+using System.Threading;
 using Microsoft.UI.Content;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
@@ -30,6 +31,8 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	private protected Window? _window;
 	private float _rasterizationScale;
 	private readonly SerialDisposable _presenterSubscription = new SerialDisposable();
+	private static ulong _generatedWindowIdIterator;
+	private ulong _generatedWindowId;
 
 	protected NativeWindowWrapperBase(Window window, XamlRoot xamlRoot) : this()
 	{
@@ -38,6 +41,7 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 
 	protected NativeWindowWrapperBase()
 	{
+		_generatedWindowId = Interlocked.Increment(ref _generatedWindowIdIterator);
 	}
 
 	public ContentSiteView ContentSiteView => _contentSite.View;
@@ -57,6 +61,8 @@ internal abstract class NativeWindowWrapperBase : INativeWindowWrapper
 	}
 
 	public abstract object? NativeWindow { get; }
+
+	public virtual ulong NativeWindowId => _generatedWindowId;
 
 	public Rect Bounds
 	{

--- a/src/Uno.UI/UI/Xaml/Window/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window/Window.cs
@@ -27,6 +27,7 @@ using System.Runtime.CompilerServices;
 using Uno.UI;
 using Windows.ApplicationModel.Core;
 using Windows.Devices.PointOfService;
+using Microsoft.UI.Content;
 
 namespace Microsoft.UI.Xaml;
 
@@ -73,9 +74,6 @@ public partial class Window
 		InitialWindow ??= this;
 		_current ??= this; // TODO:MZ: Do we want this?
 
-		AppWindow = new AppWindow();
-		_appWindowMap[AppWindow] = this;
-
 		if (
 			!NativeWindowFactory.SupportsMultipleWindows
 
@@ -119,16 +117,6 @@ public partial class Window
 		if (Application.Current?.InitializationComplete == true)
 		{
 			Initialize();
-		}
-
-		// We set up the DisplayInformation instance after Initialize so that we have an actual window to bind to.
-		// A macOS hosted-ALC window has no native window (Initialize skips it), so skip this too: the macOS
-		// DisplayInformation extension subscribes to MacOSWindowNative.NativeWindowReady and only unsubscribes
-		// when a native window is created — which never happens here — leaking the extension (pinning the ALC)
-		// and letting it bind to the next unrelated native window.
-		if (!IsMacOSHostedAlcWindow)
-		{
-			global::Windows.Graphics.Display.DisplayInformation.GetOrCreateForWindowId(AppWindow.Id);
 		}
 	}
 
@@ -198,7 +186,7 @@ public partial class Window
 	}
 
 	public AppWindow AppWindow
-	{ get; }
+	{ get; private set; } = null!;
 
 	/// <summary>
 	/// Gets a Rect value containing the height and width of the application window in units of effective (view) pixels.
@@ -318,6 +306,25 @@ public partial class Window
 		}
 
 		_windowImplementation.Initialize();
+
+		// A macOS hosted-ALC window has no native window (Initialize skips it), so there is no native window
+		// id to derive the AppWindow from, and DisplayInformation must be skipped as well: the macOS
+		// DisplayInformation extension subscribes to MacOSWindowNative.NativeWindowReady and only unsubscribes
+		// when a native window is created — which never happens here — leaking the extension (pinning the ALC)
+		// and letting it bind to the next unrelated native window.
+		if (!IsMacOSHostedAlcWindow)
+		{
+			AppWindow = new AppWindow(_windowImplementation.NativeWindowWrapper!.NativeWindowId);
+			_appWindowMap[AppWindow] = this;
+
+			if (_windowImplementation is DesktopWindow { DesktopWindowXamlSource: { } desktopWindowXamlSource })
+			{
+				desktopWindowXamlSource.XamlIsland.ContentIslandEnvironment = new ContentIslandEnvironment(AppWindow.Id);
+			}
+
+			// We set up the DisplayInformation instance after Initialize so that we have an actual window to bind to.
+			global::Windows.Graphics.Display.DisplayInformation.GetOrCreateForWindowId(AppWindow.Id);
+		}
 	}
 
 	internal static void EnsureWindowCurrent()

--- a/src/Uno.UI/UI/Xaml/XamlRoot.cs
+++ b/src/Uno.UI/UI/Xaml/XamlRoot.cs
@@ -8,6 +8,7 @@ using Windows.Foundation;
 using Windows.Graphics.Display;
 using Uno.UI.Extensions;
 using Uno.UI.Xaml.Controls;
+using Microsoft.UI.Content;
 
 namespace Microsoft.UI.Xaml;
 

--- a/src/Uno.UI/UI/Xaml/XamlRoot.cs
+++ b/src/Uno.UI/UI/Xaml/XamlRoot.cs
@@ -12,6 +12,7 @@ using Uno.UI.Extensions;
 using Uno.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Content;
 
 namespace Microsoft.UI.Xaml;
 

--- a/src/Uno.UI/UI/Xaml/XamlRoot.mux.cs
+++ b/src/Uno.UI/UI/Xaml/XamlRoot.mux.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System.Runtime.CompilerServices;
+using Microsoft.UI.Content;
 using Uno.UI.Xaml.Core;
 using Windows.Foundation;
 
@@ -24,6 +25,8 @@ public sealed partial class XamlRoot
 	/// Gets a value that indicates whether the XamlRoot is visible.
 	/// </summary>
 	public bool IsHostVisible => VisualTree.IsVisible;
+
+	public ContentIslandEnvironment? ContentIslandEnvironment => VisualTree.ContentRoot?.ContentIslandEnvironment;
 
 	internal void RaiseChangedEvent() => Changed?.Invoke(this, new());
 

--- a/src/Uno.UWP/Microsoft/UI/Windowing/AppWindow.cs
+++ b/src/Uno.UWP/Microsoft/UI/Windowing/AppWindow.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
@@ -29,16 +30,14 @@ internal
 partial class AppWindow
 {
 	private static readonly ConcurrentDictionary<MUXWindowId, AppWindow> _windowIdMap = new();
-	private static ulong _windowIdIterator;
-
 	private INativeAppWindow _nativeAppWindow;
 
 	private AppWindowPresenter _presenter;
 	private string _titleCache; // only use this until the _nativeAppWindow is set
 
-	internal AppWindow()
+	internal AppWindow(ulong nativeId)
 	{
-		Id = new(Interlocked.Increment(ref _windowIdIterator));
+		Id = new(nativeId);
 
 		TitleBar = new(this);
 
@@ -132,17 +131,6 @@ partial class AppWindow
 
 	internal static bool TryGetFromWindowId(MUXWindowId windowId, [NotNullWhen(true)] out AppWindow appWindow)
 		=> _windowIdMap.TryGetValue(windowId, out appWindow);
-
-	internal static void SkipMainWindowId()
-	{
-		// In case of Uno Islands we currently have no "main window",
-		// so we must avoid assigning the first created secondary window
-		// Id = 1, otherwise it would be considered as the main window.
-		if (!CoreApplication.IsFullFledgedApp && _windowIdIterator == 0)
-		{
-			_windowIdIterator++;
-		}
-	}
 
 	/// <summary>
 	/// Shows the window and activates it.

--- a/src/Uno.WinRT/Microsoft/UI/Windowing/AppWindow.cs
+++ b/src/Uno.WinRT/Microsoft/UI/Windowing/AppWindow.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -25,16 +26,14 @@ internal
 partial class AppWindow
 {
 	private static readonly ConcurrentDictionary<MUXWindowId, AppWindow> _windowIdMap = new();
-	private static ulong _windowIdIterator;
-
 	private INativeAppWindow _nativeAppWindow;
 
 	private AppWindowPresenter _presenter;
 	private string _titleCache; // only use this until the _nativeAppWindow is set
 
-	internal AppWindow()
+	internal AppWindow(ulong nativeId)
 	{
-		Id = new(Interlocked.Increment(ref _windowIdIterator));
+		Id = new(nativeId);
 
 		TitleBar = new(this);
 
@@ -133,17 +132,6 @@ partial class AppWindow
 	/// the whole ALC. Called from ALC window close.
 	/// </summary>
 	internal static void DestroyForWindowId(MUXWindowId windowId) => _windowIdMap.TryRemove(windowId, out _);
-
-	internal static void SkipMainWindowId()
-	{
-		// In case of Uno Islands we currently have no "main window",
-		// so we must avoid assigning the first created secondary window
-		// Id = 1, otherwise it would be considered as the main window.
-		if (!CoreApplication.IsFullFledgedApp && _windowIdIterator == 0)
-		{
-			_windowIdIterator++;
-		}
-	}
 
 	/// <summary>
 	/// Sets the icon for the window.


### PR DESCRIPTION
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

Part of https://github.com/unoplatform/kahua-private/issues/365, closes https://github.com/unoplatform/uno/issues/21649

## PR Type: ✨ Feature

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- 
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->

## TODO

- [ ] Ensure the changes do not break any lifecycle interactions
- [ ] Properly handle `ApplicationView.GetForCurrentView()` - should apply to all windows for simplicity


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->