### PR TITLE
fix(win32): white flicker on the first frame on dark-mode systems

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.RenderScheduling.skia.cs
@@ -156,6 +156,13 @@ public partial class CompositionTarget
 		}
 	}
 
+	/// <summary>
+	/// This method is called from each platform's rendering logic in response to the native windowing/composition
+	/// engine's signal requesting the Uno app to draw something _right now_, usually synced to the refresh rate
+	/// of the screen (e.g. Android's IRenderer.OnDrawFrame). This class does not assume that this method will only
+	/// be called once per <see cref="IXamlRootHost.InvalidateRender"/> call, but the contract allows any number
+	/// of repeated calls, even if no new invalidations are requested.
+	/// </summary>
 	internal SKPath OnNativePlatformFrameRequested(SKCanvas? canvas, Func<Size, SKCanvas> resizeFunc)
 	{
 		this.LogTrace()?.Trace($"CompositionTarget#{GetHashCode()}: {nameof(OnNativePlatformFrameRequested)}");


### PR DESCRIPTION
**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->