### PR TITLE
ci: Disable man to improve build perf

### DIFF
--- a/build/ci/templates/linux-install-deps.yml
+++ b/build/ci/templates/linux-install-deps.yml
@@ -9,7 +9,7 @@ steps:
       echo '#!/bin/sh' | sudo tee /usr/bin/mandb >/dev/null
       echo 'exit 0' | sudo tee -a /usr/bin/mandb >/dev/null
       sudo chmod 755 /usr/bin/mandb
-    name: Disable man-db
+    displayName: Disable man-db
 
   - bash: |
       sudo apt-get update

--- a/build/ci/templates/linux-install-deps.yml
+++ b/build/ci/templates/linux-install-deps.yml
@@ -1,4 +1,15 @@
 steps:
+          
+  - bash: |
+      # Used to improve the install performance, since we don't need man
+      set -e
+      # Divert /usr/bin/mandb to avoid package ownership conflicts
+      sudo dpkg-divert --local --rename --add /usr/bin/mandb
+      # Replace with a no-op
+      echo '#!/bin/sh' | sudo tee /usr/bin/mandb >/dev/null
+      echo 'exit 0' | sudo tee -a /usr/bin/mandb >/dev/null
+      sudo chmod 755 /usr/bin/mandb
+    name: Disable man-db
 
   - bash: |
       sudo apt-get update


### PR DESCRIPTION
## PR Type:

- 🏗️ Build or CI related changes

## What is the new behavior? 🚀

Disable man-db for CI builds, we don't need man in this context.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->