### PR TITLE
chore: extend the lifetime of SKPicture

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Media/CompositionTarget.Rendering.skia.cs
@@ -140,6 +140,8 @@ public partial class CompositionTarget
 
 			InvokeRendering();
 
+			GC.KeepAlive(lastRenderedFrame.frame);
+
 			return lastRenderedFrame.nativeElementClipPath;
 		}
 	}


### PR DESCRIPTION
Context: 41a5796ea0a3a2d270999696ea7e0ce529755e41
Context: 92676ea716a37dfec6786b3fbfd4a8d230f1981f
Context: https://github.com/unoplatform/uno/issues/21656#issuecomment-3428656561
Context: https://github.com/unoplatform/uno/pull/21643
Context: https://learn.microsoft.com/en-us/archive/blogs/cbrumme/lifetime-gc-keepalive-handle-recycling

Ever since the integration of running `SamplesApp.Skia.netcoremobile` on CoreCLR (41a5796e) and NativeAOT (92676ea7), we've seen "flakiness" in unit test execution, with the test harness occasionally crashing:

	F DEBUG   : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0000000000000610
	F DEBUG   : Cause: null pointer dereference
	F DEBUG   :     rax 0000000000000108  rbx 000073a6f12f0210  rcx 0000000000000000  rdx 000000000000007a
	F DEBUG   :     r8  d92d00000010200b  r9  00007364a8b8ea00  r10 0000000000000000  r11 0000000000000000
	F DEBUG   :     r12 0000000000000610  r13 0000000000000061  r14 000073a6612f43f0  r15 00007364a76012d8
	F DEBUG   :     rdi 0000000000000610  rsi 00007364a76012d8
	F DEBUG   :     rbp 0000000000000000  rsp 00007364a7601230  rip 00007364a8db47c7
	F DEBUG   : 25 total frames
	F DEBUG   : backtrace:
	F DEBUG   :       #00 pc 00000000003057c7  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #01 pc 00000000003053ce  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #02 pc 00000000002e4c74  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #03 pc 00000000002749a4  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #04 pc 00000000002747bd  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSkiaSharp.so
	F DEBUG   :       #05 pc 000000000024f36f  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSkiaSharp.so (sk_canvas_draw_picture+95)
	F DEBUG   :       #06 pc 0000000009acb685  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSamplesApp.so (SkiaSharp_SkiaSharp_SkiaApi__sk_canvas_draw_picture+101) (BuildId: 5f9d8dc654dfed4438273840dd8a19b67d66bc03)
	F DEBUG   :       #07 pc 000000000aa5a09d  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSamplesApp.so (Uno_UI_Uno_UI_Helpers_SkiaRenderHelper__RenderPicture+141) (BuildId: 5f9d8dc654dfed4438273840dd8a19b67d66bc03)
	F DEBUG   :       #08 pc 000000000a2d49a9  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSamplesApp.so (Uno_UI_Microsoft_UI_Xaml_Media_CompositionTarget__Draw+777) (BuildId: 5f9d8dc654dfed4438273840dd8a19b67d66bc03)
	F DEBUG   :       #09 pc 000000000a2d5c09  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSamplesApp.so (Uno_UI_Microsoft_UI_Xaml_Media_CompositionTarget__OnNativePlatformFrameRequested+553) (BuildId: 5f9d8dc654dfed4438273840dd8a19b67d66bc03)
	F DEBUG   :       #10 pc 000000000b05777e  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSamplesApp.so (Uno_UI_Runtime_Skia_Android_Uno_UI_Runtime_Skia_Android_UnoSKCanvasView_InternalRenderer__Android_Opengl_GLSurfaceView_IRenderer_OnDrawFrame+270) (BuildId: 5f9d8dc654dfed4438273840dd8a19b67d66bc03)
	F DEBUG   :       #11 pc 00000000086a4401  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSamplesApp.so (Mono_Android_Android_Opengl_GLSurfaceView_IRendererInvoker__n_OnDrawFrame_Ljavax_microedition_khronos_opengles_GL10_+193) (BuildId: 5f9d8dc654dfed4438273840dd8a19b67d66bc03)
	F DEBUG   :       #12 pc 000000000ca286ba  /data/app/~~ZYVR5YT-bvI6JuPKmxmqTg==/uno.platform.samplesapp.skia.nativeaot-xixpSuclgZh9X9KMhU1l5A==/lib/x86_64/libSamplesApp.so (Internal_CompilerGenerated__Module___<ReverseOpenStaticDelegateStub>Mono_Android__JniMarshal_PPL_V+90) (BuildId: 5f9d8dc654dfed4438273840dd8a19b67d66bc03)
	F DEBUG   :       #13 pc 0000000000391a4b  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+219) (BuildId: b6dc79e02101ea00827a35a55ab6597a)

With #21643, we're now able to symbolicate the native side of the crash and gain a better understanding of what's happening.

What *appears* to be happening is that the CoreCLR & NativeAOT GC is collecting a managed instance while it's "native side" is still being used by native code:

 1. Main thread: calls `CompositionHelper.Render()`, which sets `CompositionHelper._lastRenderedFrame`.
 2. Render thread: reads `CompositionHelper._lastRenderedFrame` into `lastRenderedFrame`, eventually calls `canvas.DrawPicture(lastRenderedFrame.frame)`;
 3. Render thread is suspended within native code, "within" `canvas.DrawPicture(lastRenderedFrame.frame)`.
 4. GC thread comes along, sees that (`picture` parameter in `SkiaRenderHelper.RenderPicture()` / `lastRenderedFrame.frame` value within `CompositionTarget.Draw()`) is no longer referenced from managed code.
 5. GC thread invokes `lastRenderedFrame.frame.Finalize()`
 6. `SKPicture` (SkiaSharp) / `SkBigPicture` (Skia) is finalized.
 7. Render thread resumes within native code, accesses the `SkBigPicture` *destroyed* in (6).
 8. SIGSEGV

A plausible solution to the above scenario is to extend the lifetime of `lastRenderedFrame.frame` until *after* `canvas.DrawPicture()` completes.  This can be done via `GC.KeepAlive()`.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->