### PR TITLE
feat: Log HR diagnostics to the console when devserver HR is enabled

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -281,7 +281,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				}
 				else
 				{
-					await hotReload.Complete(HotReloadServerResult.Failed);
+					await hotReload.Complete(HotReloadServerResult.Failed, diagnostics: hotReloadDiagnostics);
 				}
 
 				return;
@@ -296,7 +296,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					_reporter.Verbose(CSharpDiagnosticFormatter.Instance.Format(diagnostic, CultureInfo.InvariantCulture));
 				}
 
-				await hotReload.Complete(HotReloadServerResult.RudeEdit);
+				await hotReload.Complete(HotReloadServerResult.RudeEdit, diagnostics: hotReloadDiagnostics);
 				return;
 			}
 

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -3,11 +3,14 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Logging;
 using Uno.Disposables;
 using Uno.Extensions;
@@ -249,8 +252,13 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 							state = HotReloadState.Processing;
 						}
 
+						var diagnosticsResult = operation.Diagnostics
+							?.Where(d => d.Severity >= DiagnosticSeverity.Warning)
+							.Select(d => CSharpDiagnosticFormatter.Instance.Format(d, CultureInfo.InvariantCulture))
+							.ToImmutableList() ?? ImmutableList<string>.Empty;
+
 						foundCompleting |= operation == completing;
-						infos.Add(new(operation.Id, operation.StartTime, operation.FilePaths, operation.CompletionTime, operation.Result));
+						infos.Add(new(operation.Id, operation.StartTime, operation.FilePaths, operation.CompletionTime, operation.Result, diagnosticsResult));
 						operation = operation.Previous!;
 					}
 				}
@@ -281,6 +289,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			private ImmutableHashSet<string> _filePaths;
 			private int /* HotReloadResult */ _result = -1;
 			private CancellationTokenSource? _deferredCompletion;
+			private ImmutableArray<Diagnostic>? _diagnostics;
 
 			// In VS we forcefully request to VS to hot-reload application, but in some cases the changes are not detected by VS and it returns a NoChanges result.
 			// In such cases we can retry the hot-reload request to VS to let it process the file updates.
@@ -296,6 +305,8 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			public HotReloadServerOperation? Previous => _previous;
 
 			public ImmutableHashSet<string> FilePaths => _filePaths;
+
+			public ImmutableArray<Diagnostic>? Diagnostics => _diagnostics;
 
 			public HotReloadServerResult? Result => _result is -1 ? null : (HotReloadServerResult)_result;
 
@@ -384,10 +395,10 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				}
 			}
 
-			public ValueTask Complete(HotReloadServerResult result, Exception? exception = null)
-				=> Complete(result, exception, isFromNext: false);
+			public ValueTask Complete(HotReloadServerResult result, Exception? exception = null, ImmutableArray<Diagnostic>? diagnostics = null)
+				=> Complete(result, exception, isFromNext: false, diagnostics: diagnostics);
 
-			private async ValueTask Complete(HotReloadServerResult result, Exception? exception, bool isFromNext)
+			private async ValueTask Complete(HotReloadServerResult result, Exception? exception, bool isFromNext, ImmutableArray<Diagnostic>? diagnostics)
 			{
 				if (_result is -1
 					&& result is HotReloadServerResult.NoChanges
@@ -416,6 +427,8 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					return; // Already completed
 				}
 
+				_diagnostics = diagnostics;
+
 				CompletionTime = DateTimeOffset.Now;
 				await _timeout.DisposeAsync();
 
@@ -425,7 +438,8 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					await _previous.Complete(
 						HotReloadServerResult.Aborted,
 						new TimeoutException("An more recent hot-reload operation has completed."),
-						isFromNext: true);
+						isFromNext: true,
+						diagnostics: diagnostics);
 				}
 
 				if (!isFromNext) // Only the head of the list should request update

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -439,7 +439,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						HotReloadServerResult.Aborted,
 						new TimeoutException("An more recent hot-reload operation has completed."),
 						isFromNext: true,
-						diagnostics: diagnostics);
+						diagnostics: null);
 				}
 
 				if (!isFromNext) // Only the head of the list should request update

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -108,7 +108,7 @@ public partial class ClientHotReloadProcessor
 			// For tooling purposes, we dump the diagnostics in the log of the application.
 			foreach (var serverOp in status.Operations)
 			{
-				owner.ReportDiagnostics(serverOp.Value.Diagnostics);
+				owner.ReportDiagnostics(serverOp.Diagnostics);
 			}
 
 			NotifyStatusChanged();

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -147,6 +147,11 @@ public partial class ClientHotReloadProcessor
 			{
 				this.Log().Error("Failed to notify the status changed.", error);
 			}
+
+			foreach (var serverOp in _serverOperations)
+			{
+				owner.ReportDiagnostics(serverOp.Value.Diagnostics);
+			}
 		}
 
 		private Status BuildStatus()
@@ -161,6 +166,24 @@ public partial class ClientHotReloadProcessor
 			};
 
 			return new(globalState, (serverState, _serverOperations.Values.ToImmutableArray()), (localState, _localOperations));
+		}
+	}
+
+	private void ReportDiagnostics(IImmutableList<string>? diagnostics)
+	{
+		if (
+			diagnostics is { Count: > 0 }
+
+			// We should only report this when server metadata
+			// updates are enabled, other targets don't set diagnostics.
+			&& _serverMetadataUpdatesEnabled)
+		{
+			_log.Error("The Hot Reload compilation failed with the following errors:");
+
+			foreach (var operation in diagnostics)
+			{
+				_log.Error(operation);
+			}
 		}
 	}
 

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -171,6 +171,7 @@ public partial class ClientHotReloadProcessor
 		}
 	}
 
+#if HAS_UNO_WINUI
 	private void ReportDiagnostics(IImmutableList<string>? diagnostics)
 	{
 		if (diagnostics is { Count: > 0 })
@@ -183,6 +184,7 @@ public partial class ClientHotReloadProcessor
 			}
 		}
 	}
+#endif
 
 	public class HotReloadClientOperation
 	{

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.Status.cs
@@ -105,8 +105,8 @@ public partial class ClientHotReloadProcessor
 			}
 			ImmutableInterlocked.Update(ref _serverOperations, UpdateOperations, status.Operations);
 
-			// For tooling purposes, we dump the diagnosticss in the log of the application.
-			foreach (var serverOp in _serverOperations)
+			// For tooling purposes, we dump the diagnostics in the log of the application.
+			foreach (var serverOp in status.Operations)
 			{
 				owner.ReportDiagnostics(serverOp.Value.Diagnostics);
 			}

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/HotReloadStatusMessage.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/HotReloadStatusMessage.cs
@@ -36,5 +36,6 @@ namespace Uno.UI.RemoteControl.HotReload.Messages
 		DateTimeOffset StartTime,
 		ImmutableHashSet<string> FilePaths,
 		DateTimeOffset? EndTime,
-		HotReloadServerResult? Result);
+		HotReloadServerResult? Result,
+		IImmutableList<string>? Diagnostics);
 }


### PR DESCRIPTION
## PR Type:

- ✨ Feature

## What is the new behavior? 🚀

When running an app with HR devserver enabled, show diagnostics in the console.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->