### PR TITLE
[Win32] Drag & drop indicator position

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_Files.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_Files.xaml.cs
@@ -20,7 +20,7 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 		Description =
 		"""
 		- This test showcases the common scenario of dragging files and/or folders from another window (usually a file explorer) into a specific rectangle that accepts the drop. The files that were dragged and dropped should be seen as a list.
-		- If you have non-100% scaling of your screen, the drag indicator should always render above your mouse cursor, irrespective on where in the app's window you move it.
+		- If you have non-100% scaling of your screen, the drag indicator should always render above your mouse cursor, irrespective of where in the app's window you move it.
 		""",
 		IsManualTest = true,
 		IgnoreInSnapshotTests = true)]

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_Files.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/DragAndDrop/DragDrop_Files.xaml.cs
@@ -18,7 +18,10 @@ namespace UITests.Windows_UI_Xaml.DragAndDrop
 {
 	[Sample(
 		Description =
-			"This test showcases the common scenario of dragging files and/or folders from another window (usually a file explorer) into a specific rectangle that accepts the drop. The files that were dragged and dropped should be seen as a list.",
+		"""
+		- This test showcases the common scenario of dragging files and/or folders from another window (usually a file explorer) into a specific rectangle that accepts the drop. The files that were dragged and dropped should be seen as a list.
+		- If you have non-100% scaling of your screen, the drag indicator should always render above your mouse cursor, irrespective on where in the app's window you move it.
+		""",
 		IsManualTest = true,
 		IgnoreInSnapshotTests = true)]
 	public sealed partial class DragDrop_Files : UserControl

--- a/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/DragDrop/Win32DragDropExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/ApplicationMode/DataTransfer/DragDrop/Win32DragDropExtension.cs
@@ -65,7 +65,6 @@ internal class Win32DragDropExtension : IDragDropExtension, IDropTarget.Interfac
 	{
 		var xamlRoot = _manager.ContentRoot.GetOrCreateXamlRoot();
 		return new Point(x / xamlRoot.RasterizationScale, y / xamlRoot.RasterizationScale);
-
 	}
 
 	unsafe HRESULT IDropTarget.Interface.DragEnter(IDataObject* dataObject, MODIFIERKEYS_FLAGS grfKeyState, POINTL pt, DROPEFFECT* pdwEffect)

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DragDrop/Core/CoreDragDropManager.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DragDrop/Core/CoreDragDropManager.cs
@@ -57,6 +57,8 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 
 		private IDragDropManager? _manager;
 
+		public AppWindow AppWindow => AppWindow.GetFromWindowId(_windowId)!;
+
 		public bool AreConcurrentOperationsEnabled
 		{
 			get => _manager?.AreConcurrentOperationsEnabled ?? false;

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DragDrop/Core/CoreDragDropManager.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DragDrop/Core/CoreDragDropManager.cs
@@ -57,8 +57,6 @@ namespace Windows.ApplicationModel.DataTransfer.DragDrop.Core
 
 		private IDragDropManager? _manager;
 
-		public AppWindow AppWindow => AppWindow.GetFromWindowId(_windowId)!;
-
 		public bool AreConcurrentOperationsEnabled
 		{
 			get => _manager?.AreConcurrentOperationsEnabled ?? false;


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/kahua-private/issues/353

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

On HDPI screens the d&d indicator position might have become misaligned against the position of the pointer.


## What is the new behavior? 🚀

Scaling the position properly

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->