### PR TITLE
fix(win32): Explain more GL setup failures

### DIFF
--- a/src/Uno.UI.Runtime.Skia.Win32/Graphics/Win32NativeOpenGLWrapper.cs
+++ b/src/Uno.UI.Runtime.Skia.Win32/Graphics/Win32NativeOpenGLWrapper.cs
@@ -69,7 +69,7 @@ internal class Win32NativeOpenGLWrapper : INativeOpenGLWrapper
 			var choosePixelFormatError = Win32Helper.GetErrorMessage();
 			var success = PInvoke.ReleaseDC(_hwnd, _hdc) == 0;
 			if (!success) { this.LogError()?.Error($"{nameof(PInvoke.ReleaseDC)} failed: {Win32Helper.GetErrorMessage()}"); }
-			throw new InvalidOperationException($"{nameof(PInvoke.ChoosePixelFormat)} failed: {choosePixelFormatError}");
+			throw new InvalidOperationException($"{nameof(PInvoke.ChoosePixelFormat)} failed: {choosePixelFormatError}. Falling back to software rendering.");
 		}
 
 		// To inspect the chosen pixel format:
@@ -84,7 +84,7 @@ internal class Win32NativeOpenGLWrapper : INativeOpenGLWrapper
 			var setPixelFormatError = Win32Helper.GetErrorMessage();
 			var success = PInvoke.ReleaseDC(_hwnd, _hdc) == 0;
 			if (!success) { this.LogError()?.Error($"{nameof(PInvoke.ReleaseDC)} failed: {Win32Helper.GetErrorMessage()}"); }
-			throw new InvalidOperationException($"{nameof(PInvoke.SetPixelFormat)} failed: {setPixelFormatError}");
+			throw new InvalidOperationException($"{nameof(PInvoke.SetPixelFormat)} failed: {setPixelFormatError}. Falling back to software rendering.");
 		}
 
 		_glContext = PInvoke.wglCreateContext(_hdc);
@@ -93,7 +93,7 @@ internal class Win32NativeOpenGLWrapper : INativeOpenGLWrapper
 			var createContextError = Win32Helper.GetErrorMessage();
 			var success = PInvoke.ReleaseDC(_hwnd, _hdc) == 0;
 			if (!success) { this.LogError()?.Error($"{nameof(PInvoke.ReleaseDC)} failed: {Win32Helper.GetErrorMessage()}"); }
-			throw new InvalidOperationException($"{nameof(PInvoke.wglCreateContext)} failed: {createContextError}");
+			throw new InvalidOperationException($"{nameof(PInvoke.wglCreateContext)} failed: {createContextError}. Falling back to software rendering.");
 		}
 	}
 


### PR DESCRIPTION
## PR Type:

- 🐞 Bugfix

## What is the new behavior? 🚀

When running on a system without a useable graphics card, the error message will now tell that rendering is falling back to software rendering.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->