### PR TITLE
feat: Implement clipboard monitoring via XFixes on Linux

### DIFF
--- a/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
@@ -1,4 +1,4 @@
-// This implementation has a lot of the structure of Avalonia's implementation
+﻿// This implementation has a lot of the structure of Avalonia's implementation
 // with the actual logic ported from xsel
 
 // The MIT License (MIT)
@@ -91,10 +91,10 @@ internal class X11ClipboardExtension : IClipboardExtension
 	// these are only valid if CurrentlyOwningClipboard. However, reading outdated values is benign, so no lock needed for now
 	private IntPtr _ownershipTimestamp;
 	private DataPackageView _clipboardData;
+	private volatile bool _isMonitoringEnabled;
+	private int _xfixesEventBase = -1;
 
-#pragma warning disable CS0067 // Event is never used
 	public event EventHandler<object> ContentChanged;
-#pragma warning restore CS0067 // Event is never used
 
 	public static X11ClipboardExtension Instance { get; } = new X11ClipboardExtension();
 
@@ -111,20 +111,16 @@ internal class X11ClipboardExtension : IClipboardExtension
 				this.Log().Error("XLIB ERROR: Cannot connect to X server");
 			}
 		}
-
 		int screen = XLib.XDefaultScreen(display);
 
-		IntPtr window = XLib.XCreateSimpleWindow(
-			display,
-			XLib.XRootWindow(display, screen),
-			0,
-			0,
-			1,
-			1,
-			0,
-			XLib.XBlackPixel(display, screen),
-			XLib.XWhitePixel(display, screen));
+		IntPtr window = XLib.XCreateSimpleWindow(display, XLib.XRootWindow(display, screen), 0, 0, 1, 1, 0, 0, 0);
 
+		// Query XFixes extension to get the event base for clipboard monitoring
+		if (XLib.XQueryExtension(display, "XFIXES", out _, out _xfixesEventBase, out _))
+		{
+			IntPtr clipboard = X11Helper.GetAtom(display, X11Helper.CLIPBOARD);
+			XLib.XFixesSelectSelectionInput(display, window, clipboard, 1);
+		}
 		_ = XLib.XFlush(display); // unnecessary on most Xlib implementations
 
 		if (this.Log().IsEnabled(LogLevel.Trace))
@@ -150,8 +146,23 @@ internal class X11ClipboardExtension : IClipboardExtension
 		selThread.Start();
 	}
 
-	public void StartContentChanged() => throw new NotImplementedException();
-	public void StopContentChanged() => throw new NotImplementedException();
+	public void StartContentChanged()
+	{
+		_isMonitoringEnabled = true;
+		if (this.Log().IsEnabled(LogLevel.Trace))
+		{
+			this.Log().Trace("XCLIP: Clipboard monitoring enabled");
+		}
+	}
+
+	public void StopContentChanged()
+	{
+		_isMonitoringEnabled = false;
+		if (this.Log().IsEnabled(LogLevel.Trace))
+		{
+			this.Log().Trace("XCLIP: Clipboard monitoring disabled");
+		}
+	}
 
 	public void Clear() => SetContent(new DataPackage());
 
@@ -445,6 +456,20 @@ internal class X11ClipboardExtension : IClipboardExtension
 					if (this.Log().IsEnabled(LogLevel.Trace))
 					{
 						this.Log().Trace($"XSEL EVENT: {event_.type}");
+					}
+
+					// Check if this is an XFixes SetSelectionOwner event
+					if ((int)event_.type == _xfixesEventBase + (int)SelectionEvent.SetSelectionOwner)
+					{
+						var selectionNotify = event_.SelectionNotifyEvent;
+						if (selectionNotify.selection == X11Helper.GetAtom(_x11Window.Display, X11Helper.CLIPBOARD))
+						{
+							if (_isMonitoringEnabled)
+							{
+								ContentChanged?.Invoke(null, EventArgs.Empty);
+							}
+						}
+						continue;
 					}
 
 					if (!_currentlyOwningClipboard)

--- a/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
@@ -1,4 +1,4 @@
-﻿// This implementation has a lot of the structure of Avalonia's implementation
+// This implementation has a lot of the structure of Avalonia's implementation
 // with the actual logic ported from xsel
 
 // The MIT License (MIT)
@@ -92,7 +92,6 @@ internal class X11ClipboardExtension : IClipboardExtension
 	private IntPtr _ownershipTimestamp;
 	private DataPackageView _clipboardData;
 
-	private readonly IntPtr _privateDisplay;
 	private volatile bool _isMonitoringEnabled;
 	private int _xfixesEventBase = -1;
 
@@ -103,11 +102,10 @@ internal class X11ClipboardExtension : IClipboardExtension
 	private X11ClipboardExtension()
 	{
 		IntPtr display = XLib.XOpenDisplay(IntPtr.Zero);
-		_privateDisplay = XLib.XOpenDisplay(IntPtr.Zero);
-		
+
 		using var lockDiposable = X11Helper.XLock(display);
 
-		if (display == IntPtr.Zero || _privateDisplay == IntPtr.Zero)
+		if (display == IntPtr.Zero)
 		{
 			if (this.Log().IsEnabled(LogLevel.Error))
 			{
@@ -486,7 +484,7 @@ internal class X11ClipboardExtension : IClipboardExtension
 					if ((int)event_.type == _xfixesEventBase + (int)SelectionEvent.SetSelectionOwner)
 					{
 						var selectionNotify = event_.SelectionNotifyEvent;
-						if (selectionNotify.selection == X11Helper.GetAtom(_privateDisplay, X11Helper.CLIPBOARD))
+						if (selectionNotify.selection == X11Helper.GetAtom(_x11Window.Display, X11Helper.CLIPBOARD))
 						{
 							if (_isMonitoringEnabled)
 							{

--- a/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
@@ -490,7 +490,7 @@ internal class X11ClipboardExtension : IClipboardExtension
 						{
 							if (_isMonitoringEnabled)
 							{
-								ContentChanged?.Invoke(null, EventArgs.Empty);
+								ContentChanged?.Invoke(this, EventArgs.Empty);
 							}
 						}
 						continue;

--- a/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/ApplicationModel/DataTransfer/X11ClipboardExtension.cs
@@ -121,8 +121,29 @@ internal class X11ClipboardExtension : IClipboardExtension
 		// Query XFixes extension to get the event base for clipboard monitoring
 		if (XLib.XQueryExtension(display, "XFIXES", out _, out _xfixesEventBase, out _))
 		{
-			IntPtr clipboard = X11Helper.GetAtom(display, X11Helper.CLIPBOARD);
-			XLib.XFixesSelectSelectionInput(display, window, clipboard, 1);
+			if (NativeLibrary.TryLoad(XLib.libXfixes, out var xfixesHandle))
+			{
+				// We only need to ensure the library is present; let the runtime manage its own load.
+				NativeLibrary.Free(xfixesHandle);
+				IntPtr clipboard = X11Helper.GetAtom(display, X11Helper.CLIPBOARD);
+				const int XFixesSetSelectionOwnerNotifyMask = 1;
+				XLib.XFixesSelectSelectionInput(display, window, clipboard, XFixesSetSelectionOwnerNotifyMask);
+			}
+			else
+			{
+				if (this.Log().IsEnabled(LogLevel.Warning))
+				{
+					this.Log().Warn("XFIXES extension is available, but libXfixes.so.3 could not be loaded. Clipboard change monitoring will be disabled.");
+				}
+				_xfixesEventBase = -1;
+			}
+		}
+		else
+		{
+			if (this.Log().IsEnabled(LogLevel.Information))
+			{
+				this.Log().LogInfo("X11 XFixes extension is not available; clipboard content change monitoring is disabled.");
+			}
 		}
 		_ = XLib.XFlush(display); // unnecessary on most Xlib implementations
 

--- a/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/x11bindings_X11Structs.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/x11bindings_X11Structs.cs
@@ -494,6 +494,21 @@ namespace Uno.WinUI.Runtime.Skia.X11
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
+	public struct XFixesSelectionNotifyEvent
+	{
+		public XEventName type;
+		public IntPtr serial;
+		public int send_event;
+		public IntPtr display;
+		public IntPtr window;
+		public int subtype;
+		public IntPtr owner;
+		public IntPtr selection;
+		public IntPtr timestamp;
+		public IntPtr selection_timestamp;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
 	public struct XColormapEvent
 	{
 		public XEventName type;
@@ -636,6 +651,7 @@ namespace Uno.WinUI.Runtime.Skia.X11
 		[FieldOffset(0)] public XSelectionClearEvent SelectionClearEvent;
 		[FieldOffset(0)] public XSelectionRequestEvent SelectionRequestEvent;
 		[FieldOffset(0)] public XSelectionEvent SelectionEvent;
+		[FieldOffset(0)] public XFixesSelectionNotifyEvent SelectionNotifyEvent;
 		[FieldOffset(0)] public XColormapEvent ColormapEvent;
 		[FieldOffset(0)] public XClientMessageEvent ClientMessageEvent;
 		[FieldOffset(0)] public XMappingEvent MappingEvent;
@@ -836,6 +852,13 @@ namespace Uno.WinUI.Runtime.Skia.X11
 		MappingNotify = 34,
 		GenericEvent = 35,
 		LASTEvent
+	}
+
+	public enum SelectionEvent
+	{
+		SetSelectionOwner = 0,
+		SelectionWindowDestroy = 1,
+		SelectionClientClose = 2,
 	}
 
 	[Flags]

--- a/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/x11bindings_XLib.cs
+++ b/src/Uno.UI.Runtime.Skia.X11/X11_Bindings/x11bindings_XLib.cs
@@ -46,6 +46,7 @@ namespace Uno.WinUI.Runtime.Skia.X11
 		private const string libX11 = "libX11.so.6";
 		private const string libX11Randr = "libXrandr.so.2";
 		internal const string libXInput = "libXi.so.6";
+		internal const string libXfixes = "libXfixes.so.3";
 
 		[LibraryImport(libX11)]
 		public static partial IntPtr XOpenDisplay(IntPtr display);
@@ -159,6 +160,9 @@ namespace Uno.WinUI.Runtime.Skia.X11
 
 		[LibraryImport(libX11, StringMarshallingCustomType = typeof(AnsiStringMarshaller))]
 		public static partial IntPtr XInternAtom(IntPtr display, string atom_name, [MarshalAs(UnmanagedType.Bool)] bool only_if_exists);
+
+		[LibraryImport(libXfixes)]
+		public static partial void XFixesSelectSelectionInput(IntPtr display, IntPtr window, IntPtr selection, IntPtr event_mask);
 
 		[LibraryImport(libX11)]
 		public static partial IntPtr XGetAtomName(IntPtr display, IntPtr atom);


### PR DESCRIPTION
**GitHub Issue:** closes #21561

## PR Type: 🐞 Bugfix, ✨ Feature

## What is the current behavior? 🤔

The Clipboard.ContentChanged event was not implemented for the Skia.X11 backend. Applications running on Linux had no way to detect when clipboard content was updated.

## What is the new behavior? 🚀

This PR implements clipboard content monitoring for the Skia.X11 backend.
It utilizes the XFixes extension to listen for the SetSelectionOwner event. With this change, the Clipboard.ContentChanged event now fires correctly whenever the clipboard ownership changes.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [x] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

## Other information ℹ️


https://github.com/user-attachments/assets/3b86153a-5e1a-4be5-be62-25cf6102948c

