### PR TITLE
fix(trimer): Fix IL2026 JSON warnings in src/Uno.UI

### DIFF
--- a/src/Uno.UI/UI/Xaml/FontManifest.cs
+++ b/src/Uno.UI/UI/Xaml/FontManifest.cs
@@ -1,7 +1,14 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Uno.UI.Xaml.Media;
 
+[JsonSourceGenerationOptions(
+	AllowTrailingCommas = true,
+	GenerationMode = JsonSourceGenerationMode.Metadata | JsonSourceGenerationMode.Serialization,
+	PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+	ReadCommentHandling = JsonCommentHandling.Skip,
+	UseStringEnumConverter = true)]
 [JsonSerializable(typeof(FontManifest))]
 internal sealed partial class FontManifestSerializerContext : JsonSerializerContext
 {

--- a/src/Uno.UI/UI/Xaml/FontManifestHelpers.cs
+++ b/src/Uno.UI/UI/Xaml/FontManifestHelpers.cs
@@ -18,20 +18,8 @@ internal static class FontManifestHelpers
 		Equivalent,
 	}
 
-	private static readonly JsonSerializerOptions _options = new JsonSerializerOptions()
-	{
-		AllowTrailingCommas = true,
-		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-		ReadCommentHandling = JsonCommentHandling.Skip,
-		Converters =
-		{
-			new JsonStringEnumConverter(),
-		},
-		TypeInfoResolver = FontManifestSerializerContext.Default,
-	};
-
 	internal static FontManifest? DeserializeManifest(Stream manifestStream)
-		=> JsonSerializer.Deserialize<FontManifest>(manifestStream, _options);
+		=> JsonSerializer.Deserialize<FontManifest>(manifestStream, FontManifestSerializerContext.Default.FontManifest);
 
 	internal static string GetFamilyNameFromManifest(Stream jsonStream, FontWeight weight, FontStyle style, FontStretch stretch)
 	{


### PR DESCRIPTION
Context: https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
Context: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation#specify-options

When building `src/Uno.UI` with trimmer warnings enabled (and turned up to 11):

	dotnet build  src/Uno.UI/Uno.UI.Skia.csproj -bl \
	  -p:TrimmerSingleWarn=false -p:_ExtraTrimmerArgs=--verbose -p:IsTrimmable=true -p:IsAotCompatible=true

Many of the warnings are around System.Text.Json usage:

	…/src/Uno.UI/UI/Xaml/FontManifestHelpers.cs(34,6): error IL2026:
	  Using member 'System.Text.Json.JsonSerializer.Deserialize<TValue>(Stream, JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  JSON serialization and deserialization might require types that cannot be statically analyzed.
	  Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.

Update `JsonSerializer.Deserialize<TValue>()` usage to remove the IL2026 warnings.

Specifically, update `CoreWebView2WebMessageReceivedEventArgs.cs` to use `JsonSerializer.Deserialize<string>(string, JsonTypeInfo<string>)`, providing a `JsonTypeInfo<string>` derived from a
`JsonSerializerOptions` instance that only supports strings.

Update `FontManifest*.cs` to use
[`JsonSourceGenerationOptionsAttribute`][0] so that System.Text.Json source generation can generate an appropriate `JsonSerializerOptions`. This allows us to use
`JsonSerializer.Deserialize<FontManifest>(Stream, JsonSerializerContext)`.

[0]: https://learn.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonsourcegenerationoptionsattribute?view=net-9.0

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->