### PR TITLE
docs: uno.extensions reference to latest commit

### DIFF
--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -17,7 +17,7 @@ $external_docs = @{
     "figma-docs"         = @{ ref="842a2792282b88586a337381b2b3786e779973b4" } #latest main commit
     "uno.resizetizer"    = @{ ref="6466544fb9a3b8c4c7fd92518442cc11166d532a" } #latest main commit
     "uno.uitest"         = @{ ref="94d027295b779e28064aebf99aeaee2b393ad558" } #latest master commit
-    "uno.extensions"     = @{ ref="fef5267cde4dc70aa2e61235557e29ee4b78f44c" } #latest main commit
+    "uno.extensions"     = @{ ref="7053aa37b8ca323957ef10a59b08529e2ae0381e" } #latest main commit
     "workshops"          = @{ ref="3515c29e03dea36cf2206d797d1bf9f8620370e3" } #latest master commit
     "uno.samples"        = @{ ref="11137484a1c8929b0bcb1a805eedc798590d835a" } #latest master commit
     "uno.chefs"          = @{ ref="754767e050dc725721e7c7aa134adf1ed93ea9a4" } #latest main commit


### PR DESCRIPTION
This pull request updates the reference commit for the `uno.extensions` external documentation source to a newer commit in the `doc/import_external_docs.ps1` script.

* Updated the `ref` value for `uno.extensions` to commit `7053aa37b8ca323957ef10a59b08529e2ae0381e` to ensure the latest documentation is imported.