### PR TITLE
DevServer Processor Dependencies loading

### DIFF
--- a/src/Uno.UI.RemoteControl.DevServer.Tests/Telemetry/TelemetryProcessorTests.cs
+++ b/src/Uno.UI.RemoteControl.DevServer.Tests/Telemetry/TelemetryProcessorTests.cs
@@ -293,7 +293,7 @@ public class TelemetryProcessorTests : TelemetryTestBase
 				Assert.Fail($"Could not find test processor assembly. Make sure {testProcessorName} is built before running this test.");
 			}
 
-			// Also locate the dependency so we can temporarily hide it from the default load context
+			// Also locate the dependency; we'll copy it alongside the processor in the isolated folder
 			const string testDependencyName = "Uno.UI.RemoteControl.TestProcessor.Dependency.dll";
 			var testDependencyPath = ExternalDllDiscoveryHelper.DiscoverExternalDllPath(
 				Logger,
@@ -301,23 +301,8 @@ public class TelemetryProcessorTests : TelemetryTestBase
 				projectName: "Uno.UI.RemoteControl.TestProcessor.Dependency",
 				dllFileName: testDependencyName);
 
+			// We'll stash the original dependency later (after copying) to avoid default ALC resolution
 			string? stashedDependencyPath = null;
-			if (!string.IsNullOrWhiteSpace(testDependencyPath) && File.Exists(testDependencyPath))
-			{
-				// Move the dependency out of the way to avoid it being resolved from the default load context
-				// This ensures the only possible resolution location is alongside the processor in our isolated folder
-				stashedDependencyPath = Path.Combine(Path.GetTempPath(), $"{Path.GetFileNameWithoutExtension(testDependencyName)}-{Guid.NewGuid():N}.stash");
-				try
-				{
-					File.Move(testDependencyPath, stashedDependencyPath);
-					Logger.LogInformation("DEBUG_LOG: Stashed dependency from {Original} to {Stash}", testDependencyPath, stashedDependencyPath);
-				}
-				catch (Exception moveEx)
-				{
-					Logger.LogWarning(moveEx, "DEBUG_LOG: Failed to stash dependency at {Path}", testDependencyPath);
-					stashedDependencyPath = null; // don’t try to restore later if move failed
-				}
-			}
 
 			// Create an isolated directory structure to reproduce the issue
 			// The processor will be in tempDir/net10.0/ but the dependency won't be copied
@@ -328,9 +313,17 @@ public class TelemetryProcessorTests : TelemetryTestBase
 
 			try
 			{
-				// Copy only the processor DLL to the isolated directory (without dependencies)
+				// Copy the processor DLL to the isolated directory
 				var isolatedProcessorPath = Path.Combine(processorsDir, testProcessorName);
 				File.Copy(testProcessorPath, isolatedProcessorPath, overwrite: true);
+
+				// Also copy the dependency alongside the processor to validate the server resolves it from this folder
+				if (!string.IsNullOrWhiteSpace(testDependencyPath) && File.Exists(testDependencyPath))
+				{
+					var isolatedDependencyPath = Path.Combine(processorsDir, testDependencyName);
+					File.Copy(testDependencyPath, isolatedDependencyPath, overwrite: true);
+					Logger.LogInformation("DEBUG_LOG: Dependency copied to: {IsolatedDep}", isolatedDependencyPath);
+				}
 
 				Logger.LogInformation("DEBUG_LOG: Created isolated test directory at: {TempDir}", tempDir);
 				Logger.LogInformation("DEBUG_LOG: Processor copied to: {IsolatedPath}", isolatedProcessorPath);
@@ -351,6 +344,22 @@ public class TelemetryProcessorTests : TelemetryTestBase
 
 				try
 				{
+					// Before we trigger discovery, stash the dependency from the original bin folder so it cannot be resolved accidentally by default ALC
+					if (!string.IsNullOrWhiteSpace(testDependencyPath) && File.Exists(testDependencyPath))
+					{
+						stashedDependencyPath = Path.Combine(Path.GetTempPath(), $"{Path.GetFileNameWithoutExtension(testDependencyName)}-{Guid.NewGuid():N}.stash");
+						try
+						{
+							File.Move(testDependencyPath, stashedDependencyPath);
+							Logger.LogInformation("DEBUG_LOG: Stashed dependency from {Original} to {Stash}", testDependencyPath, stashedDependencyPath);
+						}
+						catch (Exception moveEx)
+						{
+							Logger.LogWarning(moveEx, "DEBUG_LOG: Failed to stash dependency at {Path}", testDependencyPath);
+							stashedDependencyPath = null;
+						}
+					}
+
 					// Send the parent directory as BasePath - server will discover processor in net10.0 subfolder
 					await client.SendMessage(new ProcessorsDiscovery(tempDir, appInstanceId));
 					using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(CT);
@@ -410,6 +419,165 @@ public class TelemetryProcessorTests : TelemetryTestBase
 		catch (Exception ex)
 		{
 			Logger.LogError(ex, "Dependency resolution test failed with exception");
+			await Console.Error.WriteLineAsync(helper.ConsoleOutput);
+			throw;
+		}
+		finally
+		{
+			await helper.StopAsync(CT);
+		}
+	}
+
+	[TestMethod]
+	public async Task Telemetry_ProcessorDiscovery_Should_Load_Dependencies_From_BasePath()
+	{
+		// Validate resolution when no TFM subfolder exists: processor and dependency are in BasePath
+		var solution = SolutionHelper;
+		var appInstanceId = Guid.NewGuid().ToString("N");
+
+		await solution.CreateSolutionFileAsync();
+
+		await using var helper = CreateTelemetryHelperWithExactPath(
+			GetTestTelemetryFileName("processor_dependency_resolution_basepath"),
+			solutionPath: solution.SolutionFile);
+
+		try
+		{
+			var started = await helper.StartAsync(CT);
+			helper.EnsureStarted();
+			started.Should().BeTrue();
+
+			var client = RemoteControlClient.Initialize(
+				typeof(object),
+				new[] { new ServerEndpointAttribute("localhost", helper.Port) }
+			);
+			await client.SendMessage(new KeepAliveMessage());
+
+			const string testProcessorName = "Uno.Test.Processor.dll";
+			const string testDependencyName = "Uno.UI.RemoteControl.TestProcessor.Dependency.dll";
+
+			var testProcessorPath = ExternalDllDiscoveryHelper.DiscoverExternalDllPath(
+				Logger,
+				typeof(DevServerTestHelper).Assembly,
+				projectName: "Uno.UI.RemoteControl.TestProcessor",
+				dllFileName: testProcessorName);
+
+			var testDependencyPath = ExternalDllDiscoveryHelper.DiscoverExternalDllPath(
+				Logger,
+				typeof(DevServerTestHelper).Assembly,
+				projectName: "Uno.UI.RemoteControl.TestProcessor.Dependency",
+				dllFileName: testDependencyName);
+
+			if (string.IsNullOrWhiteSpace(testProcessorPath) || !File.Exists(testProcessorPath))
+			{
+				Assert.Fail($"Could not find test processor assembly. Make sure {testProcessorName} is built before running this test.");
+			}
+			if (string.IsNullOrWhiteSpace(testDependencyPath) || !File.Exists(testDependencyPath))
+			{
+				Assert.Fail($"Could not find test dependency assembly. Make sure {testDependencyName} is built before running this test.");
+			}
+
+			// Create an isolated base directory WITHOUT a TFM subfolder
+			var tempDir = Path.Combine(Path.GetTempPath(), $"uno-processor-test-basepath-{Guid.NewGuid():N}");
+			Directory.CreateDirectory(tempDir);
+
+			string? stashedDependencyPath = null;
+
+			try
+			{
+				// Copy processor and dependency directly to BasePath (no net10.0 subfolder)
+				var isolatedProcessorPath = Path.Combine(tempDir, testProcessorName);
+				File.Copy(testProcessorPath, isolatedProcessorPath, overwrite: true);
+				var isolatedDependencyPath = Path.Combine(tempDir, testDependencyName);
+				File.Copy(testDependencyPath, isolatedDependencyPath, overwrite: true);
+
+				Logger.LogInformation("DEBUG_LOG: BasePath test dir: {TempDir}", tempDir);
+				Logger.LogInformation("DEBUG_LOG: Processor copied to: {IsolatedPath}", isolatedProcessorPath);
+				Logger.LogInformation("DEBUG_LOG: Dependency copied to: {IsolatedDep}", isolatedDependencyPath);
+
+				// Stash original dependency from default bin to prevent default ALC resolution
+				try
+				{
+					stashedDependencyPath = Path.Combine(Path.GetTempPath(), $"{Path.GetFileNameWithoutExtension(testDependencyName)}-{Guid.NewGuid():N}.stash");
+					File.Move(testDependencyPath, stashedDependencyPath);
+					Logger.LogInformation("DEBUG_LOG: Stashed dependency from {Original} to {Stash}", testDependencyPath, stashedDependencyPath);
+				}
+				catch (Exception moveEx)
+				{
+					Logger.LogWarning(moveEx, "DEBUG_LOG: Failed to stash dependency at {Path}", testDependencyPath);
+					stashedDependencyPath = null;
+				}
+
+				var discoveryTcs = new TaskCompletionSource<ProcessorsDiscoveryResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+				void Handler(object? sender, ReceivedFrameEventArgs args)
+				{
+					if (args.Frame.Scope == WellKnownScopes.DevServerChannel &&
+						args.Frame.Name == ProcessorsDiscoveryResponse.Name &&
+						args.Frame.TryGetContent(out ProcessorsDiscoveryResponse? response))
+					{
+						discoveryTcs.TrySetResult(response);
+					}
+				}
+
+				client.FrameReceived += Handler;
+
+				try
+				{
+					await client.SendMessage(new ProcessorsDiscovery(tempDir, appInstanceId));
+					using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(CT);
+					timeoutCts.CancelAfter(TimeSpan.FromSeconds(10));
+					var response = await discoveryTcs.Task.WaitAsync(timeoutCts.Token);
+
+					Logger.LogInformation("DEBUG_LOG: Received {ProcessorCount} processors in response", response.Processors.Count);
+					foreach (var proc in response.Processors)
+					{
+						Logger.LogInformation("DEBUG_LOG: Processor type={Type}, isLoaded={IsLoaded}, error={Error}",
+							proc.Type, proc.IsLoaded, proc.LoadError ?? "(none)");
+					}
+
+					const string telemetryProcessorTypeName = "TelemetryTestProcessor";
+					var telemetryProcessor = response.Processors.Single(p => p.Type.Contains(telemetryProcessorTypeName, StringComparison.Ordinal));
+
+					telemetryProcessor.IsLoaded.Should().BeTrue($"Processor discovery should load dependencies located alongside the processor assembly, but got IsLoaded=false with LoadError: {telemetryProcessor.LoadError}");
+					telemetryProcessor.LoadError.Should().BeNull($"Processor discovery should not report load errors, but got: {telemetryProcessor.LoadError}");
+				}
+				finally
+				{
+					client.FrameReceived -= Handler;
+				}
+			}
+			finally
+			{
+				// Cleanup isolated directory and restore dependency
+				try
+				{
+					if (Directory.Exists(tempDir))
+					{
+						Directory.Delete(tempDir, recursive: true);
+					}
+				}
+				catch (Exception ex)
+				{
+					Logger.LogWarning(ex, "Failed to cleanup temp directory: {TempDir}", tempDir);
+				}
+
+				try
+				{
+					if (!string.IsNullOrWhiteSpace(stashedDependencyPath) && File.Exists(stashedDependencyPath) && !string.IsNullOrWhiteSpace(testDependencyPath))
+					{
+						File.Move(stashedDependencyPath, testDependencyPath);
+						Logger.LogInformation("DEBUG_LOG: Restored dependency to {Original}", testDependencyPath);
+					}
+				}
+				catch (Exception restoreEx)
+				{
+					Logger.LogWarning(restoreEx, "DEBUG_LOG: Failed to restore dependency to {Original}", testDependencyPath);
+				}
+			}
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError(ex, "BasePath dependency resolution test failed with exception");
 			await Console.Error.WriteLineAsync(helper.ConsoleOutput);
 			throw;
 		}

--- a/src/Uno.UI.RemoteControl.TestProcessor.Dependency/DummyDependency.cs
+++ b/src/Uno.UI.RemoteControl.TestProcessor.Dependency/DummyDependency.cs
@@ -1,0 +1,6 @@
+namespace Uno.UI.RemoteControl.TestProcessor.Dependency;
+
+public static class DummyDependency
+{
+	public static string Touch() => "dependency-loaded";
+}

--- a/src/Uno.UI.RemoteControl.TestProcessor.Dependency/Uno.UI.RemoteControl.TestProcessor.Dependency.csproj
+++ b/src/Uno.UI.RemoteControl.TestProcessor.Dependency/Uno.UI.RemoteControl.TestProcessor.Dependency.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>$(NetCurrent)</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+</Project>

--- a/src/Uno.UI.RemoteControl.TestProcessor/TelemetryTestProcessor.cs
+++ b/src/Uno.UI.RemoteControl.TestProcessor/TelemetryTestProcessor.cs
@@ -2,6 +2,7 @@ using Uno.UI.RemoteControl.Host;
 using Uno.UI.RemoteControl.HotReload.Messages;
 using Uno.UI.RemoteControl.Messaging.IdeChannel;
 using Uno.UI.RemoteControl.Server.Telemetry;
+using Uno.UI.RemoteControl.TestProcessor.Dependency;
 
 // Mark this assembly with the ServerProcessor attribute to make it discoverable
 [assembly: ServerProcessor(typeof(Uno.UI.RemoteControl.TestProcessor.TelemetryTestProcessor))]
@@ -17,6 +18,7 @@ public class TelemetryTestProcessor : IServerProcessor, IDisposable
 {
 	private readonly IRemoteControlServer _server;
 	private readonly ITelemetry<TelemetryTestProcessor> _telemetry;
+	private readonly string _dependencyResult;
 
 	/// <summary>
 	/// Constructor called by the server's ActivatorUtilities.CreateInstance
@@ -26,13 +28,14 @@ public class TelemetryTestProcessor : IServerProcessor, IDisposable
 	{
 		_server = server;
 		_telemetry = telemetry;
+		_dependencyResult = DummyDependency.Touch();
 
 		Console.WriteLine("TelemetryTestProcessor initialized");
 
 		// Log a test event immediately to verify telemetry resolution works
 		_telemetry.TrackEvent(
 			"telemetry-test-initialized",
-			new Dictionary<string, string> { ["ProcessorType"] = GetType().Name, ["ServerScope"] = Scope },
+			new Dictionary<string, string> { ["ProcessorType"] = GetType().Name, ["ServerScope"] = Scope, ["DependencyResult"] = _dependencyResult },
 			new Dictionary<string, double> { ["Timestamp"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() });
 	}
 

--- a/src/Uno.UI.RemoteControl.TestProcessor/Uno.UI.RemoteControl.TestProcessor.csproj
+++ b/src/Uno.UI.RemoteControl.TestProcessor/Uno.UI.RemoteControl.TestProcessor.csproj
@@ -4,6 +4,8 @@
 		<TargetFramework>$(NetCurrent)</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<AssemblyName>Uno.Test.Processor</AssemblyName>
 	</PropertyGroup>
 
 	<Import Project="../targetframework-override-noplatform.props" />
@@ -11,6 +13,14 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.UI.RemoteControl.Server\Uno.UI.RemoteControl.Server.csproj" />
 		<ProjectReference Include="..\Uno.UI.RemoteControl.Messaging\Uno.UI.RemoteControl.Messaging.csproj" />
+		<ProjectReference Include="..\Uno.UI.RemoteControl.TestProcessor.Dependency\Uno.UI.RemoteControl.TestProcessor.Dependency.csproj" />
 	</ItemGroup>
+
+	<Target Name="CopyTestProcessorDependencies" AfterTargets="Build">
+		<ItemGroup>
+			<_TestProcessorDependency Include="..\Uno.UI.RemoteControl.TestProcessor.Dependency\bin\$(Configuration)\$(TargetFramework)\Uno.UI.RemoteControl.TestProcessor.Dependency.dll" />
+		</ItemGroup>
+		<Copy SourceFiles="@(_TestProcessorDependency)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+	</Target>
 
 </Project>

--- a/src/Uno.UI.slnx
+++ b/src/Uno.UI.slnx
@@ -107,6 +107,9 @@
     <Project Path="Uno.UI.RemoteControl.TestProcessor/Uno.UI.RemoteControl.TestProcessor.csproj">
       <BuildType Solution="Release_NoSamples|*" Project="Debug" />
     </Project>
+      <Project Path="Uno.UI.RemoteControl.TestProcessor.Dependency/Uno.UI.RemoteControl.TestProcessor.Dependency.csproj">
+          <BuildType Solution="Release_NoSamples|*" Project="Debug" />
+      </Project>
     <Project Path="Uno.UI.RemoteControl.VS/Uno.UI.RemoteControl.VS.csproj">
       <BuildType Solution="Release_NoSamples|*" Project="Release" />
     </Project>


### PR DESCRIPTION
Closes https://github.com/unoplatform/uno-private/issues/1552

# Bugfix
This PR fixes a critical dependency resolution bug in the Uno DevServer's processor discovery mechanism. When processors with dependencies were loaded, the AssemblyLoadContext's `Resolving` event handler couldn't locate dependencies because the resolve base path wasn't set before loading the processor assembly.

**Key changes:**
- Set the resolve base path (`_resolveAssemblyLocations[appId]`) **before** loading each processor assembly so the ALC can resolve dependencies from the processor's directory
- Rename the test processor assembly from `Uno.UI.RemoteControl.TestProcessor.dll` to `Uno.Test.Processor.dll` to match the discovery pattern `Uno.*.Processor*.dll` (requires `.Processor` segment)
- Add a `CopyTestProcessorDependencies` build target to ensure dependencies are copied alongside the processor
- Add comprehensive tests to verify dependency resolution works in both TFM subfolder and base path scenarios
- Add extensive documentation (`Processors.md`) explaining the discovery algorithm, dependency resolution contract, and troubleshooting

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [X] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [X] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [X] ❗ Contains **NO** breaking changes
