### PR TITLE
fix(trimmer): Fix IL2026 warnings around DynamicallyAccessedMemberTypes.All

### DIFF
--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -1231,7 +1231,7 @@ namespace Uno.UI.DataBinding
 
 		[UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Types may be removed or not present as part of the normal operations of that method")]
 		[UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "Types may be removed or not present as part of the normal operations of that method")]
-		private static object? ConvertUsingTypeDescriptor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type, object value)
+		private static object? ConvertUsingTypeDescriptor(Type type, object value)
 		{
 			var valueTypeConverter = TypeDescriptor.GetConverter(value.GetType());
 			if (valueTypeConverter.CanConvertTo(type))
@@ -1295,7 +1295,7 @@ namespace Uno.UI.DataBinding
 		}
 
 		internal static object? Convert(
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? propertyType,
+			Type? propertyType,
 			object? value)
 		{
 			if (value != null)

--- a/src/Uno.UI/UI/Xaml/Markup/XamlBindingHelper.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/XamlBindingHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.UI.Xaml.Markup
 		/// Converts a value from a source type to a target type.
 		/// </summary>
 		public static object ConvertValue(
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type,
+			Type type,
 			object value)
 			=> Uno.UI.DataBinding.BindingPropertyHelper.Convert(type, value);
 

--- a/src/Uno.UI/UI/Xaml/ResourceResolver.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolver.cs
@@ -85,7 +85,7 @@ namespace Uno.UI
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static object ResolveResourceStatic(
 			object key,
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type,
+			Type type,
 			object context = null)
 		{
 			if (TryStaticRetrieval(new SpecializedResourceDictionary.ResourceKey(key), context, out var value))

--- a/src/Uno.UI/UI/Xaml/ResourceResolverSingleton.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceResolverSingleton.cs
@@ -32,7 +32,7 @@ namespace Uno.UI
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public object ResolveResourceStatic(
 			object key,
-			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type,
+			Type type,
 			object context)
 			=> ResourceResolver.ResolveResourceStatic(key, type, context);
 


### PR DESCRIPTION
…es.All

Context: https://github.com/dotnet/runtime/issues/121074
Context: 4595bcba9d963b8b240ee097c25e10adf6fbb6d6

When building [uno.chefs][0] with trimmer warnings enabled (and turned up to 11):

	dotnet publish -c Release -f net10.0-android -r android-x64 \
	  -p:TargetFrameworkOverride=net10.0-android -p:PublishAot=true \
	  -p:UseSkiaRendering=true Chefs/Chefs.csproj -bl \
	  -p:TrimmerSingleWarn=false -p:_ExtraTrimmerArgs=--verbose -p:IsTrimmable=true -p:IsAotCompatible=true

2541 warnings (!) are generated.  The "fun" thing is, many of them are seemingly nonsensical:

	ILC : Trim analysis warning IL2026: Uno.Material.WinUI.GlobalStaticResources.ResourceDictionarySingleton__mergedpages_v1_c15678b9f7eb6ae0d4e176be633434fa.Get_9(Object): Using member 'System.Delegate.Delegate(Object,String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The target method might be removed.
	ILC : Trim analysis warning IL2111: Uno.Material.WinUI.GlobalStaticResources.ResourceDictionarySingleton__mergedpages_v1_c15678b9f7eb6ae0d4e176be633434fa.Get_9(Object): Method 'System.Delegate.Delegate(Type,String)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2026: Uno.Material.WinUI.GlobalStaticResources.ResourceDictionarySingleton__mergedpages_v1_c15678b9f7eb6ae0d4e176be633434fa.Get_9(Object): Using member 'System.Delegate.CreateDelegate(Type,Object,String,Boolean,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The target method might be removed.
	ILC : Trim analysis warning IL2111: Uno.Material.WinUI.GlobalStaticResources.ResourceDictionarySingleton__mergedpages_v1_c15678b9f7eb6ae0d4e176be633434fa.Get_9(Object): Method 'System.Delegate.CreateDelegate(Type,Type,String,Boolean,Boolean)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2026: Uno.Material.WinUI.GlobalStaticResources.ResourceDictionarySingleton__mergedpages_v1_c15678b9f7eb6ae0d4e176be633434fa.Get_9(Object): Using member 'System.Delegate.CreateDelegate(Type,Object,String)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The target method might be removed.
	ILC : Trim analysis warning IL2026: Uno.Material.WinUI.GlobalStaticResources.ResourceDictionarySingleton__mergedpages_v1_c15678b9f7eb6ae0d4e176be633434fa.Get_9(Object): Using member 'System.Delegate.CreateDelegate(Type,Object,String,Boolean)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. The target method might be removed.
	ILC : Trim analysis warning IL2111: Uno.Material.WinUI.GlobalStaticResources.ResourceDictionarySingleton__mergedpages_v1_c15678b9f7eb6ae0d4e176be633434fa.Get_9(Object): Method 'System.Delegate.CreateDelegate(Type,Type,String)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111: Uno.Material.WinUI.GlobalStaticResources.ResourceDictionarySingleton__mergedpages_v1_c15678b9f7eb6ae0d4e176be633434fa.Get_9(Object): Method 'System.Delegate.CreateDelegate(Type,Type,String,Boolean)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
	ILC : Trim analysis warning IL2111: Uno.Material.WinUI.GlobalStaticResources.ResourceDictionarySingleton__mergedpages_v1_c15678b9f7eb6ae0d4e176be633434fa.Get_9(Object): Method 'System.MulticastDelegate.MulticastDelegate(Type,String)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.

How are we reaching `System.Delegate`?!

What's happening is:

 1. `ResourceResolver.ResolveResourceStatic()` used `DynamicallyAccessedMemberTypes.All`:

        partial class ResourceResolver {
            public static object ResolveResourceStatic(
                object key,
                [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type,
                object context = null
            );
        }

 2. `src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs` emits calls to `ResourceResolver.ResolveResourceStatic()`, a'la:

        __p1.BasedOn = (global::Microsoft.UI.Xaml.Style)global::Uno.UI.ResourceResolverSingleton.Instance.ResolveResourceStatic(
            "NativeDefaultTextBox",
            typeof(global::Microsoft.UI.Xaml.Style),
            context: this.__ParseContext_);

 3. The `Style` class has a nested delegate type:

        partial class Style {
            public delegate Style StyleProviderHandler()
        }

 4. `DynamicallyAccessedMemberTypes.All` includes (a) nested types such as `Style.StyleProviderHandler`, and (b) *all inherited members* of those nested types.

Which is how `Delegate.CreateDelegate()` gets pulled in: it's an inherited member of `Style.StyleProviderHandler`, and because we specified `DynamicallyAccessedMemberTypes.All` for `Style`, we eventually hit `Delegate.CreateDelegate()`!

Which now makes a *bit* of sense…

…but how did we get here?

How we got here was commit 4595bcba, which added
`DynamicallyAccessedMemberTypes.All` to
`ResourceResolver.ResolveResourceStatic()`.

What we don't know is what set of warnings that was attempting to fix, as that was not recorded and has been lost to time.

Regardless, what we can say *now* is that
`DynamicallyAccessedMemberTypes.All` is almost certainly a "code smell" and should be avoided: it attempts to pull in *too much*, resulting in "noise" from the various trimmer analyzers.

Remove use of `DynamicallyAccessedMemberTypes.All` from `BindingPropertyHelper.cs`, `XamlBindingHelper.cs`, and `ResourceResolver.cs`.  Just removing
`DynamicallyAccessedMemberTypes.All` use from these locations reduces the number of warnings in uno.chefs from 2541 down to 903, which is still a lot, but a bit more reasonable.

[0]: https://github.com/unoplatform/uno.chefs

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->