### PR TITLE
fix(macOS): only display windows when Activate is called

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -25,6 +25,12 @@ window_move_or_resize_fn_ptr uno_get_window_resize_callback(void);
 - (void) applicationDidChangeScreenParametersNotification:(NSNotification*) note;
 @end
 
+typedef NS_ENUM(sint32, OverlappedPresenterState) {
+    OverlappedPresenterStateMaximized,
+    OverlappedPresenterStateMinimized,
+    OverlappedPresenterStateRestored,
+};
+
 @interface UNOWindow : NSWindow <NSWindowDelegate>
 
 + (void)initialize;
@@ -33,7 +39,13 @@ window_move_or_resize_fn_ptr uno_get_window_resize_callback(void);
 
 @property (strong) UNOMetalViewDelegate* metalViewDelegate;
 
+@property OverlappedPresenterState overlappedPresenterState;
+
 - (void)sendEvent:(NSEvent *)event;
+
+- (void)windowWillMiniaturize:(NSNotification *)notification;
+- (void)windowDidMiniaturize:(NSNotification *)notification;
+- (void)windowDidDeminiaturize:(NSNotification *)notification;
 
 - (BOOL)windowShouldZoom:(NSWindow *)window toFrame:(NSRect)newFrame;
 - (void)windowDidMove:(NSNotification *)notification;
@@ -59,16 +71,12 @@ bool uno_window_is_full_screen(NSWindow *window);
 bool uno_window_enter_full_screen(NSWindow *window);
 void uno_window_exit_full_screen(NSWindow *window);
 
+void uno_window_maximize(NSWindow *window);
 void uno_window_minimize(NSWindow *window, bool activateWindow);
 void uno_window_restore(NSWindow *window, bool activateWindow);
 
 bool uno_window_clip_svg(UNOWindow* window, const char* svg);
 
-typedef NS_ENUM(sint32, OverlappedPresenterState) {
-    OverlappedPresenterStateMaximized,
-    OverlappedPresenterStateMinimized,
-    OverlappedPresenterStateRestored,
-};
 OverlappedPresenterState uno_window_get_overlapped_presenter_state(NSWindow *window);
 
 void uno_window_set_always_on_top(NSWindow* window, bool isAlwaysOnTop);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -71,13 +71,13 @@ bool uno_window_is_full_screen(NSWindow *window);
 bool uno_window_enter_full_screen(NSWindow *window);
 void uno_window_exit_full_screen(NSWindow *window);
 
-void uno_window_maximize(NSWindow *window);
+void uno_window_maximize(UNOWindow *window);
 void uno_window_minimize(NSWindow *window, bool activateWindow);
 void uno_window_restore(NSWindow *window, bool activateWindow);
 
 bool uno_window_clip_svg(UNOWindow* window, const char* svg);
 
-OverlappedPresenterState uno_window_get_overlapped_presenter_state(NSWindow *window);
+OverlappedPresenterState uno_window_get_overlapped_presenter_state(UNOWindow *window);
 
 void uno_window_set_always_on_top(NSWindow* window, bool isAlwaysOnTop);
 void uno_window_set_border_and_title_bar(NSWindow *window, bool hasBorder, bool hasTitleBar);

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.h
@@ -71,9 +71,9 @@ bool uno_window_is_full_screen(NSWindow *window);
 bool uno_window_enter_full_screen(NSWindow *window);
 void uno_window_exit_full_screen(NSWindow *window);
 
-void uno_window_maximize(UNOWindow *window);
+void uno_window_maximize(NSWindow *window);
 void uno_window_minimize(NSWindow *window, bool activateWindow);
-void uno_window_restore(NSWindow *window, bool activateWindow);
+void uno_window_restore(UNOWindow *window, bool activateWindow);
 
 bool uno_window_clip_svg(UNOWindow* window, const char* svg);
 

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -151,10 +151,14 @@ void uno_window_activate(UNOWindow *window)
     NSLog(@"uno_window_activate %@ state %d", window, window.overlappedPresenterState);
 #endif
     switch (window.overlappedPresenterState) {
-        case OverlappedPresenterStateRestored:
+        case OverlappedPresenterStateRestored: {
+            // ordering to front can move the window (but not resize it) from what was set before activating it, so we move it back
+            CGPoint current = window.frame.origin;
             // don't call `uno_window_restore` since we want the pre-activation state (not the current one) to be used
             [window orderFrontRegardless];
+            [window setFrameOrigin:current];
             break;
+        }
         case OverlappedPresenterStateMinimized:
             uno_window_minimize(window, false);
             break;

--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/UNOWindow.m
@@ -281,7 +281,7 @@ void uno_window_exit_full_screen(NSWindow *window)
 }
 
 // on macOS double-clicking on the titlebar maximize the window (not the green icon)
-void uno_window_maximize(UNOWindow *window)
+void uno_window_maximize(NSWindow *window)
 {
 #if DEBUG
     NSLog(@"uno_window_maximize %@", window);
@@ -300,7 +300,7 @@ void uno_window_minimize(NSWindow *window, bool activateWindow)
     }
 }
 
-void uno_window_restore(NSWindow *window, bool activateWindow)
+void uno_window_restore(UNOWindow *window, bool activateWindow)
 {
 #if DEBUG
     NSLog(@"uno_window_restore %@ %s", window, activateWindow ? "true" : "false");
@@ -1046,6 +1046,7 @@ NSOperatingSystemVersion _osVersion;
 
 - (void) performMiniaturize:(id) sender {
     self.overlappedPresenterState = OverlappedPresenterStateMinimized;
+    [super performMiniaturize:sender];
 }
 
 - (void)windowWillMiniaturize:(NSNotification *)notification {

--- a/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Microsoft_UI_Windowing/Given_AppWindow.cs
@@ -155,7 +155,7 @@ public class Given_AppWindow
 	[TestMethod]
 	[CombinatorialData]
 	[GitHubWorkItem("https://github.com/unoplatform/uno/issues/21435")]
-	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaX11 | RuntimeTestPlatforms.SkiaMacOS)] // Skia/X11 & macOS: Fail in CI (#21194)
+	[PlatformCondition(ConditionMode.Exclude, RuntimeTestPlatforms.SkiaX11)] // Skia/X11: Fail in CI (#21194)
 	public async Task When_Change_Window_State_Before_Activate(OverlappedPresenterState state)
 	{
 		AssertPositioningAndSizingSupport();


### PR DESCRIPTION
**GitHub Issue:** closes #21503 and #21509

## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

On macOS the window is shown when created instead of when `Activate` is called.


## What is the new behavior? 🚀

Window is shown only when `Activate` is called.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

This currently breaks the `When_Move_Before_Activate` test case. It worked earlier because the window was shown earlier than intended. Making this a draft until this is also solved (and look why resize is still working).
