### PR TITLE
chore: add proper version overrides for net10 AndroidX packages

### DIFF
--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -193,7 +193,7 @@
 			"Xamarin.Google.Android.Material"
 		],
 		"versionOverride": {
-			"net10.0": "1.12.0.4"
+			"net10.0": "1.12.0.5"
 		}
 	},
 	{
@@ -243,7 +243,7 @@
 			"Xamarin.AndroidX.Activity"
 		],
 		"versionOverride": {
-			"net10.0": "1.10.1.2"
+			"net10.0": "1.10.1.3"
 		}
 	},
 	{
@@ -253,7 +253,7 @@
 			"Xamarin.AndroidX.Browser"
 		],
 		"versionOverride": {
-			"net10.0": "1.8.0.10"
+			"net10.0": "1.8.0.11"
 		}
 	},
 	{
@@ -263,7 +263,7 @@
 			"Xamarin.AndroidX.SwipeRefreshLayout"
 		],
 		"versionOverride": {
-			"net10.0": "1.1.0.28"
+			"net10.0": "1.1.0.29"
 		}
 	},
 	{
@@ -274,7 +274,10 @@
 			"Xamarin.AndroidX.Navigation.Fragment",
 			"Xamarin.AndroidX.Navigation.Runtime",
 			"Xamarin.AndroidX.Navigation.Common"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "2.9.2.1"
+		}
 	},
 	{
 		"group": "AndroidXCollection",
@@ -284,7 +287,7 @@
 			"Xamarin.AndroidX.Collection.Ktx"
 		],
 		"versionOverride": {
-			"net10.0": "1.5.0.2"
+			"net10.0": "1.5.0.3"
 		}
 	},
 	{


### PR DESCRIPTION
This pull request updates several AndroidX and related package versions in the `src/Uno.Sdk/packages.json` file to newer releases, ensuring compatibility and access to the latest features and fixes. The changes are focused on bumping version numbers for various dependencies and adding a missing `versionOverride` for the Navigation packages.

Dependency version updates:

* Bumped `Xamarin.Google.Android.Material` to version `1.12.0.5` for `.NET 10.0`.
* Bumped `Xamarin.AndroidX.Activity` to version `1.10.1.3` for `.NET 10.0`.
* Bumped `Xamarin.AndroidX.Browser` to version `1.8.0.11` for `.NET 10.0`.
* Bumped `Xamarin.AndroidX.SwipeRefreshLayout` to version `1.1.0.29` for `.NET 10.0`.
* Bumped `Xamarin.AndroidX.Collection.Ktx` to version `1.5.0.3` for `.NET 10.0`.

Navigation packages improvement:

* Added a missing `versionOverride` for the `Xamarin.AndroidX.Navigation` packages, setting `.NET 10.0` to `2.9.2.1`.