### PR TITLE
Version bump after 6.4.0 release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.4.0-dev.{height}",
+  "version": "6.5.0-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.5.0-dev.{height}",
+  "version": "6.5-dev.{height}",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.4.0-dev.{height}",
+  "version": "6.4.0",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
This is an automated version bump of the  **master** branch after the creation of the release branch release/stable/6.4.0, based on #21742