### PR TITLE
fix(xamlreader): Accept valid toplevel properties and positional binding parameters

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Markup/Given_XamlReader.cs
@@ -16,6 +16,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Markup;
 using static Private.Infrastructure.TestServices;
 using System.Threading.Tasks;
+using Uno.Disposables;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 {
@@ -757,6 +758,188 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Markup
 			{
 				Load();
 			}
+		}
+
+		[TestMethod]
+		public void When_FailOnUnknownProperties_With_Valid_Binding()
+		{
+			using (EnsureFailOnUnknownProperty())
+			{
+				var tb = XamlHelper.LoadXaml<Page>(
+					"""
+					<Page
+					    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					    <TextBlock Text="{Binding Foo}" />
+					</Page>
+					""", autoInjectXmlns: false);
+
+				Assert.IsNotNull(tb);
+			}
+		}
+
+		[TestMethod]
+		public void When_FailOnUnknownProperties_With_Valid_Binding_Inside_DataTemplate()
+		{
+			using (EnsureFailOnUnknownProperty())
+			{
+				var tb = XamlHelper.LoadXaml<Page>(
+					"""
+					<Page
+					    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+						<ContentControl>
+							<ContentControl.ContentTemplate>
+								<DataTemplate>
+									<TextBlock Text="{Binding Foo}" />
+								</DataTemplate>
+							</ContentControl.ContentTemplate>
+						</ContentControl>
+					</Page>
+					""", autoInjectXmlns: false);
+
+				Assert.IsNotNull(tb);
+			}
+		}
+
+		[TestMethod]
+		public void When_FailOnUnknownProperties_With_Valid_Multi_Positional_Binding_Inside_DataTemplate()
+		{
+			using (EnsureFailOnUnknownProperty())
+			{
+				var tb = XamlHelper.LoadXaml<Page>(
+					"""
+					<Page
+					    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+						<ContentControl>
+							<ContentControl.ContentTemplate>
+								<DataTemplate>
+									<TextBlock Text="{Binding Foo, Mode=TwoWay}" />
+								</DataTemplate>
+							</ContentControl.ContentTemplate>
+						</ContentControl>
+					</Page>
+					""", autoInjectXmlns: false);
+
+				Assert.IsNotNull(tb);
+			}
+		}
+
+		[TestMethod]
+		public void When_FailOnUnknownProperties_With_Invalid_Multi_Positional_Binding_Inside_DataTemplate()
+		{
+			using (EnsureFailOnUnknownProperty())
+			{
+				var ex = Assert.ThrowsExactly<XamlParseException>(() =>
+				XamlHelper.LoadXaml<Page>(
+					"""
+					<Page
+					    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+						<ContentControl>
+							<ContentControl.ContentTemplate>
+								<DataTemplate>
+									<TextBlock Text="{Binding Foo, Test=Invalid}" />
+								</DataTemplate>
+							</ContentControl.ContentTemplate>
+						</ContentControl>
+					</Page>
+					""", autoInjectXmlns: false));
+
+				Assert.IsNotNull(ex);
+
+				// The type 'Microsoft.UI.Xaml.Data.Binding' does not contain a property or event named 'Test'. [Line: 7 Position: 6]"
+				Assert.AreEqual("The type 'Microsoft.UI.Xaml.Data.Binding' does not contain a property or event named 'Test'. [Line: 7 Position: 6]", ex.Message);
+				Assert.AreEqual(7, ex.LineNumber);
+				Assert.AreEqual(6, ex.LinePosition);
+			}
+		}
+
+		[TestMethod]
+		public void When_FailOnUnknownProperties_With_Valid_StaticResource()
+		{
+			using (EnsureFailOnUnknownProperty())
+			{
+				var tb = XamlHelper.LoadXaml<Page>(
+					"""
+					<Page
+					    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					    <TextBlock Text="{StaticResource Foo}" />
+					</Page>
+					""", autoInjectXmlns: false);
+
+				Assert.IsNotNull(tb);
+			}
+		}
+
+		[TestMethod]
+		public void When_FailOnUnknownProperties_With_Valid_Positional()
+		{
+			using (EnsureFailOnUnknownProperty())
+			{
+				var tb = XamlHelper.LoadXaml<Page>(
+					"""
+					<Page
+					    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+					    <TextBlock Text="{StaticResource ContextActions[0].Command}" />
+					</Page>
+					""", autoInjectXmlns: false);
+
+				Assert.IsNotNull(tb);
+			}
+		}
+
+		[TestMethod]
+		public void When_FailOnUnknownProperties_With_Valid_Nested()
+		{
+			using (EnsureFailOnUnknownProperty())
+			{
+				var tb = XamlHelper.LoadXaml<Page>(
+					"""
+					<Page
+					    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+						<StackPanel Orientation="Vertical" Spacing="2">
+							<TextBlock Text="{Binding Title}" Style="{StaticResource MaterialBodyMedium}" Foreground="{StaticResource OnSurfaceColor}" />
+							<TextBlock Text="{Binding Subtitle}" Style="{StaticResource MaterialBodySmall}" Foreground="{StaticResource OnSurfaceVariantColor}" />
+						</StackPanel>
+					</Page>
+					""", autoInjectXmlns: false);
+
+				Assert.IsNotNull(tb);
+			}
+		}
+
+		[TestMethod]
+		public void When_FailOnUnknownProperties_With_Top_Level_Binding()
+		{
+			using (EnsureFailOnUnknownProperty())
+			{
+				var tb = XamlHelper.LoadXaml<Page>(
+					"""
+					<Page
+					    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+						Background="{StaticResource BackgroundColor}">
+						<StackPanel Orientation="Vertical" Spacing="2">
+							<TextBlock Text="{Binding Title}" Style="{StaticResource MaterialBodyMedium}" Foreground="{StaticResource OnSurfaceColor}" />
+							<TextBlock Text="{Binding Subtitle}" Style="{StaticResource MaterialBodySmall}" Foreground="{StaticResource OnSurfaceVariantColor}" />
+						</StackPanel>
+					</Page>
+					""", autoInjectXmlns: false);
+
+				Assert.IsNotNull(tb);
+			}
+		}
+
+		private IDisposable EnsureFailOnUnknownProperty()
+		{
+			var original = FeatureConfiguration.XamlReader.FailOnUnknownProperties;
+			FeatureConfiguration.XamlReader.FailOnUnknownProperties = true;
+			return Disposable.Create(() => FeatureConfiguration.XamlReader.FailOnUnknownProperties = original);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -1601,7 +1601,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						}
 						else if (member.Member.Name == "_PositionalParameters")
 						{
-							// Skip, no validation needed, the string is used as-is
+							// Skip, no validation needed. This member represents positional parameters for XAML markup extensions (e.g., Binding).
 						}
 						else if (FeatureConfiguration.XamlReader.FailOnUnknownProperties && propertyInfo == null && eventInfo == null && !IsNestedChildNode(member) && !IsBlankBaseMember(member))
 						{

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -545,7 +545,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						}
 					}
 				}
-				else if (member.Member.Name == "base")
+				else if (IsBlankBaseMember(member))
 				{
 					// Skip, the information is not needed at runtime
 				}

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -545,6 +545,10 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 						}
 					}
 				}
+				else if (member.Member.Name == "base")
+				{
+					// Skip, the information is not needed at runtime
+				}
 				else if (FeatureConfiguration.XamlReader.FailOnUnknownProperties)
 				{
 					throw new InvalidOperationException($"The Property {member.Member.Name} does not exist on {member.Member.DeclaringType}");
@@ -1594,6 +1598,10 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 							&& (member.Member.Name is "Key" or "Name"))
 						{
 							// Skip, no validation needed
+						}
+						else if (member.Member.Name == "_PositionalParameters")
+						{
+							// Skip, no validation needed, the string is used as-is
 						}
 						else if (FeatureConfiguration.XamlReader.FailOnUnknownProperties && propertyInfo == null && eventInfo == null && !IsNestedChildNode(member) && !IsBlankBaseMember(member))
 						{


### PR DESCRIPTION
## PR Type:

- 🐞 Bugfix

## What is the current behavior? 🤔

Failures with:
- `The Property base does not exist on {http://schemas.microsoft.com/winfx/2006/xaml/presentation}Page...`
- `The type 'Microsoft.UI.Xaml.Data.Binding' does not contain a property or event named '_PositionalParameters'. [Line: 42 Position: 46];` when bindings are placed inside a data template

## What is the new behavior? 🚀

No failures.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->