### PR TITLE
fix(ContentPresenter): native element not moving with scrolling

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.skia.cs
@@ -85,6 +85,9 @@ partial class ContentPresenter
 		_nativeElementAttached = true;
 		_nativeElementHostingExtension.Value!.AttachNativeElement(Content);
 		_nativeHosts.Add(this);
+
+		EffectiveViewportChanged += OnEffectiveViewportChanged;
+		LayoutUpdated += OnLayoutUpdated;
 	}
 
 	partial void DetachNativeElement(object content)
@@ -94,6 +97,10 @@ partial class ContentPresenter
 #endif
 		_lastNativeArrangeArgs = null;
 		_nativeHosts.Remove(this);
+
+		EffectiveViewportChanged -= OnEffectiveViewportChanged;
+		LayoutUpdated -= OnLayoutUpdated;
+
 		if (_nativeElementAttached)
 		{
 			_nativeElementAttached = false;
@@ -163,21 +170,51 @@ partial class ContentPresenter
 			{
 				host.DetachNativeElement(host.Content);
 				host.AttachNativeElement();
-				ArrangeNativeElement(host, index);
+				host.ArrangeNativeElement(index);
 			}
 		}
+	}
 
-		static void ArrangeNativeElement(ContentPresenter host, int zOrder)
+	private void ArrangeNativeElement()
+	{
+		if (!IsNativeHost)
 		{
-			var arrangeRect = host.GetAbsoluteBoundsRect();
-
-			var nativeArrangeArgs = (arrangeRect, zOrder);
-			if (host._lastNativeArrangeArgs != nativeArrangeArgs)
-			{
-				host._lastNativeArrangeArgs = nativeArrangeArgs;
-				host._nativeElementHostingExtension.Value!.ArrangeNativeElement(host.Content, arrangeRect);
-			}
+			// the ArrangeNativeElement call is queued on the dispatcher, so by the time we get here, the ContentPresenter
+			// might no longer be a NativeHost
+			return;
 		}
+
+		if (_nativeElementAttached && _lastNativeArrangeArgs?.zOrder is { } zOrder)
+		{
+			ArrangeNativeElement(zOrder);
+		}
+	}
+
+	private void ArrangeNativeElement(int zOrder)
+	{
+		var arrangeRect = this.GetAbsoluteBoundsRect();
+
+		var nativeArrangeArgs = (arrangeRect, zOrder);
+		if (_lastNativeArrangeArgs != nativeArrangeArgs)
+		{
+			_lastNativeArrangeArgs = nativeArrangeArgs;
+			_nativeElementHostingExtension.Value!.ArrangeNativeElement(Content, arrangeRect);
+		}
+	}
+
+	private void OnLayoutUpdated(object sender, object e)
+	{
+		// Not quite sure why we need to queue the arrange call, but the native element either explodes or doesn't
+		// respect alignments correctly otherwise. This is particularly relevant for the initial load.
+		DispatcherQueue.TryEnqueue(ArrangeNativeElement);
+	}
+
+	private void OnEffectiveViewportChanged(FrameworkElement sender, EffectiveViewportChangedEventArgs args)
+	{
+		global::System.Diagnostics.Debug.Assert(IsNativeHost);
+		// The arrange call here is queued because EVPChanged is fired before the layout of the ContentPresenter is updated,
+		// so calling ArrangeNativeElement synchronously would get outdated coordinates.
+		DispatcherQueue.TryEnqueue(ArrangeNativeElement);
 	}
 
 	internal object CreateSampleComponent(string text)


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#381
regression from #21638

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔
native-element would be stuck on the same position on the screen when scrolled, instead of moving with the scroll.

## What is the new behavior? 🚀
^ no more.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes