### PR TITLE
fix: Make sure to not show temp files in HRI when doing HR with agent

### DIFF
--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.MetadataUpdate.cs
@@ -246,6 +246,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				else
 				{
 					_reporter.Verbose($"Could not find document with path {file} in the workspace.");
+					hotReload.NotifyIgnored(file);
 				}
 			}
 
@@ -269,7 +270,6 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 			_reporter.Output($"Found {updates.Length} metadata updates after {sw.Elapsed}");
 			sw.Stop();
-
 
 			if (rudeEdits.IsEmpty && updates.IsEmpty)
 			{

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -288,7 +288,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			private readonly Timer _timeout;
 
 			private ImmutableHashSet<string> _consideredFilePaths; // All files that have been considered for this operation.
-			private ImmutableHashSet<string> _ignoredFilePaths = _empty; // The files that has been ignored by the compilator for this operation (basically because they are not part of the solution).
+			private ImmutableHashSet<string> _ignoredFilePaths = _empty; // The files that have been ignored by the compilator for this operation (basically because they are not part of the solution).
 			private int /* HotReloadResult */ _result = -1;
 			private CancellationTokenSource? _deferredCompletion;
 			private ImmutableArray<Diagnostic>? _diagnostics;
@@ -307,7 +307,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			public HotReloadServerOperation? Previous => _previous;
 
 			/// <summary>
-			/// List of all file paths that has been considered for this hot-reload operation.
+			/// List of all file paths that have been considered for this hot-reload operation.
 			/// </summary>
 			/// <remarks>This **includes** the <see cref="IgnoredFilePaths"/>.</remarks>
 			public ImmutableHashSet<string> ConsideredFilePaths => _consideredFilePaths;
@@ -316,7 +316,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			/// Gets the collection of file paths that are excluded from processing.
 			/// </summary>
 			/// <remarks>
-			/// Files are typically ignored when they are not existing yet in the current solution.
+			/// Files are typically ignored when they do not yet exist in the current solution.
 			/// </remarks>
 			public ImmutableHashSet<string> IgnoredFilePaths => _ignoredFilePaths;
 
@@ -392,11 +392,11 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			}
 
 			/// <summary>
-			/// Notifies a files has been ignored for this hot-reload operation.
+			/// Notifies a file has been ignored for this hot-reload operation.
 			/// </summary>
 			/// <param name="file"></param>
 			public void NotifyIgnored(string file)
-				=> ImmutableInterlocked.Update(ref _ignoredFilePaths, static (files, file) => files.Remove(file), file);
+				=> ImmutableInterlocked.Update(ref _ignoredFilePaths, static (files, file) => files.Add(file), file);
 
 			/// <summary>
 			/// As errors might get a bit after the complete from the IDE, we can defer the completion of the operation.

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -149,7 +149,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			{
 				measurements = new Dictionary<string, double>
 				{
-					["FileCount"] = _current.FilePaths.Count
+					["FileCount"] = _current.ConsideredFilePaths.Count
 				};
 				if (_current.CompletionTime != null)
 				{
@@ -256,9 +256,10 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 							?.Where(d => d.Severity >= DiagnosticSeverity.Warning)
 							.Select(d => CSharpDiagnosticFormatter.Instance.Format(d, CultureInfo.InvariantCulture))
 							.ToImmutableList() ?? ImmutableList<string>.Empty;
+						var files = operation.ConsideredFilePaths.Except(operation.IgnoredFilePaths);
 
 						foundCompleting |= operation == completing;
-						infos.Add(new(operation.Id, operation.StartTime, operation.FilePaths, operation.CompletionTime, operation.Result, diagnosticsResult));
+						infos.Add(new(operation.Id, operation.StartTime, files, operation.IgnoredFilePaths, operation.CompletionTime, operation.Result, diagnosticsResult));
 						operation = operation.Previous!;
 					}
 				}
@@ -286,7 +287,8 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			private readonly HotReloadServerOperation? _previous;
 			private readonly Timer _timeout;
 
-			private ImmutableHashSet<string> _filePaths;
+			private ImmutableHashSet<string> _consideredFilePaths; // All files that have been considered for this operation.
+			private ImmutableHashSet<string> _ignoredFilePaths = _empty; // The files that has been ignored by the compilator for this operation (basically because they are not part of the solution).
 			private int /* HotReloadResult */ _result = -1;
 			private CancellationTokenSource? _deferredCompletion;
 			private ImmutableArray<Diagnostic>? _diagnostics;
@@ -304,7 +306,19 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 
 			public HotReloadServerOperation? Previous => _previous;
 
-			public ImmutableHashSet<string> FilePaths => _filePaths;
+			/// <summary>
+			/// List of all file paths that has been considered for this hot-reload operation.
+			/// </summary>
+			/// <remarks>This **includes** the <see cref="IgnoredFilePaths"/>.</remarks>
+			public ImmutableHashSet<string> ConsideredFilePaths => _consideredFilePaths;
+
+			/// <summary>
+			/// Gets the collection of file paths that are excluded from processing.
+			/// </summary>
+			/// <remarks>
+			/// Files are typically ignored when they are not existing yet in teh current solution.
+			/// </remarks>
+			public ImmutableHashSet<string> IgnoredFilePaths => _ignoredFilePaths;
 
 			public ImmutableArray<Diagnostic>? Diagnostics => _diagnostics;
 
@@ -315,7 +329,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			{
 				_owner = owner;
 				_previous = previous;
-				_filePaths = filePaths ?? _empty;
+				_consideredFilePaths = filePaths ?? _empty;
 
 				_timeout = new Timer(
 					static that => _ = ((HotReloadServerOperation)that!).Complete(HotReloadServerResult.Aborted),
@@ -325,7 +339,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			}
 
 			/// <summary>
-			/// Attempts to update the <see cref="FilePaths"/> if we determine that the provided paths are corresponding to this operation.
+			/// Attempts to update the <see cref="ConsideredFilePaths"/> if we determine that the provided paths are corresponding to this operation.
 			/// </summary>
 			/// <returns>
 			/// True if this operation should be considered as valid for the given file paths (and has been merged with original paths),
@@ -338,7 +352,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 					return false;
 				}
 
-				var original = _filePaths;
+				var original = _consideredFilePaths;
 				while (true)
 				{
 					ImmutableHashSet<string> updated;
@@ -355,7 +369,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 						return false;
 					}
 
-					var current = Interlocked.CompareExchange(ref _filePaths, updated, original);
+					var current = Interlocked.CompareExchange(ref _consideredFilePaths, updated, original);
 					if (current == original)
 					{
 						_timeout.Change(_timeoutDelay, Timeout.InfiniteTimeSpan);
@@ -376,6 +390,13 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 				_noChangesRetry = attempts ?? DefaultAutoRetryIfNoChangesAttempts;
 				_noChangesRetryDelay = delay ?? DefaultAutoRetryIfNoChangesDelay;
 			}
+
+			/// <summary>
+			/// Notifies a files has been ignored for this hot-reload operation.
+			/// </summary>
+			/// <param name="file"></param>
+			public void NotifyIgnored(string file)
+				=> ImmutableInterlocked.Update(ref _ignoredFilePaths, static (files, file) => files.Remove(file), file);
 
 			/// <summary>
 			/// As errors might get a bit after the complete from the IDE, we can defer the completion of the operation.

--- a/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
+++ b/src/Uno.UI.RemoteControl.Server.Processors/HotReload/ServerHotReloadProcessor.cs
@@ -316,7 +316,7 @@ namespace Uno.UI.RemoteControl.Host.HotReload
 			/// Gets the collection of file paths that are excluded from processing.
 			/// </summary>
 			/// <remarks>
-			/// Files are typically ignored when they are not existing yet in teh current solution.
+			/// Files are typically ignored when they are not existing yet in the current solution.
 			/// </remarks>
 			public ImmutableHashSet<string> IgnoredFilePaths => _ignoredFilePaths;
 

--- a/src/Uno.UI.RemoteControl/HotReload/Messages/HotReloadStatusMessage.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/Messages/HotReloadStatusMessage.cs
@@ -35,6 +35,7 @@ namespace Uno.UI.RemoteControl.HotReload.Messages
 		long Id,
 		DateTimeOffset StartTime,
 		ImmutableHashSet<string> FilePaths,
+		ImmutableHashSet<string>? IgnoredFilePaths,
 		DateTimeOffset? EndTime,
 		HotReloadServerResult? Result,
 		IImmutableList<string>? Diagnostics);


### PR DESCRIPTION
## 🐞 Bugfix
Make sure to not show temp files in HRI when doing HR with agent

## What is the current behavior? 🤔
When agent uses temp files, we **might** see them in the HRI

## What is the new behavior? 🚀
Unknown files are explicitly ignored.

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
