### PR TITLE
fix(calendarview): snapping back mid-scroll

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollViewer/ScrollViewer.cs
@@ -1235,6 +1235,12 @@ namespace Microsoft.UI.Xaml.Controls
 			{
 				Update(isIntermediate);
 
+				if (isIntermediate)
+				{
+					// when intermediate (aka manual) scrolling occurs,
+					// we want to cancel any pending snapping, to prevent snapping to occur mid-scroll.
+					_snapPointsTimer?.Stop();
+				}
 				if (!isIntermediate
 #if __APPLE_UIKIT__ || __ANDROID__
 					&& (_presenter as ListViewBaseScrollContentPresenter)?.NativePanel?.UseNativeSnapping != true
@@ -1258,6 +1264,7 @@ namespace Microsoft.UI.Xaml.Controls
 								DelayedMoveToSnapPoint();
 							};
 						}
+
 						_snapPointsTimer.Start();
 					}
 				}


### PR DESCRIPTION
**GitHub Issue:** closes unoplatform/kahua-private#383

## PR Type: 🐞 Bugfix

## What is the current behavior? 🤔
When scrolling with mouse wheel or via the `>` next button in rapid succession, the CalendarView would often snap back mid-scroll.

## What is the new behavior? 🚀
^ no more.

## PR Checklist ✅
Please check if your PR fulfills the following requirements:
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes