### PR TITLE
fix: Use information log level for devserver CLI commands

### DIFF
--- a/src/Uno.UI.DevServer.Cli/Program.cs
+++ b/src/Uno.UI.DevServer.Cli/Program.cs
@@ -93,11 +93,7 @@ internal class Program
 			}
 		}
 
-#if DEBUG
 		return LogLevel.Information;
-#else
-		return LogLevel.Warning;
-#endif
 	}
 
 	private static string? GetFileLogPathFromArgs(string[] args, out string? error)


### PR DESCRIPTION
## PR Type:

- 🐞 Bugfix

## What is the new behavior? 🚀

`uno-devserver start|stop` logs more information by default.

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

closes https://github.com/unoplatform/uno/pull/21883