### PR TITLE
chore: Update selected package versions in packages.json to match latest uno.templates 6.4

### DIFF
--- a/build/ci/templates/dotnet-install-previous-wasmtools.yml
+++ b/build/ci/templates/dotnet-install-previous-wasmtools.yml
@@ -1,0 +1,8 @@
+parameters:
+  UnoCheckParameters: ''
+
+steps:
+  - powershell: |
+      & dotnet workload install wasm-tools-net9
+    displayName: Install Previous .NET Wasm Workloads
+    retryCountOnTaskFailure: 3

--- a/build/ci/tests/.azure-devops-tests-templates.yml
+++ b/build/ci/tests/.azure-devops-tests-templates.yml
@@ -35,6 +35,7 @@ jobs:
 
   - template: ../templates/gitversion.yml
   - template: ../templates/dotnet-mobile-install-windows.yml
+  - template: ../templates/dotnet-install-previous-wasmtools.yml
   - template: ../templates/uno-dev-feed.yml
 
   - task: CopyFiles@2
@@ -104,6 +105,7 @@ jobs:
       xCodeRoot: ${{ parameters.xCodeRoot }}
 
   - template: ../templates/dotnet-mobile-install-mac.yml
+  - template: ../templates/dotnet-install-previous-wasmtools.yml
   - template: ../templates/uno-dev-feed.yml
 
   - task: CopyFiles@2
@@ -158,6 +160,7 @@ jobs:
 
   - template: ../templates/gitversion.yml
   - template: ../templates/dotnet-mobile-install-linux.yml
+  - template: ../templates/dotnet-install-previous-wasmtools.yml
   - template: ../templates/gitversion.yml
   - template: ../templates/uno-dev-feed.yml
   - template: ../templates/host-cleanup-linux.yml

--- a/build/ci/tests/.azure-devops-tests-templates.yml
+++ b/build/ci/tests/.azure-devops-tests-templates.yml
@@ -36,6 +36,7 @@ jobs:
   - template: ../templates/gitversion.yml
   - template: ../templates/dotnet-mobile-install-windows.yml
   - template: ../templates/dotnet-install-previous-wasmtools.yml
+  
   - template: ../templates/uno-dev-feed.yml
 
   - task: CopyFiles@2
@@ -124,6 +125,7 @@ jobs:
     env:
       BUILD_SOURCESDIRECTORY: $(BUILD.SOURCESDIRECTORY)
       NBGV_SemVer2: $(NBGV_SemVer2)
+      WasmCachePath: $(WasmCachePath)
 
   - task: PublishBuildArtifacts@1
     retryCountOnTaskFailure: 3
@@ -212,6 +214,7 @@ jobs:
     env:
       BUILD_SOURCESDIRECTORY: $(BUILD.SOURCESDIRECTORY)
       NBGV_SemVer2: $(NBGV_SemVer2)
+      WasmCachePath: $(WasmCachePath)
 
   - task: PublishBuildArtifacts@1
     retryCountOnTaskFailure: 3
@@ -285,3 +288,4 @@ jobs:
     env:
       BUILD_SOURCESDIRECTORY: $(BUILD.SOURCESDIRECTORY)
       NBGV_SemVer2: $(NBGV_SemVer2)
+      WasmCachePath: $(WasmCachePath)

--- a/src/Uno.Sdk/packages.json
+++ b/src/Uno.Sdk/packages.json
@@ -32,14 +32,14 @@
 	},
 	{
 		"group": "WasmBootstrap",
-		"version": "9.0.20",
+		"version": "9.0.23",
 		"packages": [
 			"Uno.Wasm.Bootstrap",
 			"Uno.Wasm.Bootstrap.DevServer",
 			"Uno.Wasm.Bootstrap.Server"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.0-dev.36"
+			"net10.0": "10.0.13"
 		}
 	},
 	{
@@ -73,7 +73,7 @@
 	},
 	{
 		"group": "Resizetizer",
-		"version": "1.11.1",
+		"version": "1.12.1",
 		"packages": [
 			"Uno.Resizetizer"
 		]
@@ -87,14 +87,14 @@
 	},
 	{
 		"group": "settings",
-		"version": "1.6.3",
+		"version": "1.7.1",
 		"packages": [
 			"Uno.Settings.DevServer"
 		]
 	},
 	{
 		"group": "hotdesign",
-		"version": "1.16.109",
+		"version": "1.17.224",
 		"packages": [
 			"Uno.UI.HotDesign"
 		]
@@ -128,34 +128,34 @@
 	},
 	{
 		"group": "WinAppSdkBuildTools",
-		"version": "10.0.26100.6584",
+		"version": "10.0.26100.6901",
 		"packages": [
 			"Microsoft.Windows.SDK.BuildTools"
 		]
 	},
 	{
 		"group": "MicrosoftLoggingConsole",
-		"version": "9.0.9",
+		"version": "9.0.11",
 		"packages": [
 			"Microsoft.Extensions.Logging.Console"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.0-rc.2.25502.107"
+			"net10.0": "10.0.0"
 		}
 	},
 	{
 		"group": "WindowsCompatibility",
-		"version": "9.0.9",
+		"version": "9.0.11",
 		"packages": [
 			"Microsoft.Windows.Compatibility"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.0-rc.2.25502.107"
+			"net10.0": "10.0.0"
 		}
 	},
 	{
 		"group": "MsalClient",
-		"version": "4.76.0",
+		"version": "4.78.0",
 		"packages": [
 			"Microsoft.Identity.Client",
 			"Microsoft.Identity.Client.Extensions.Msal"
@@ -179,7 +179,7 @@
 	},
 	{
 		"group": "UnoFonts",
-		"version": "2.7.1",
+		"version": "2.8.1",
 		"packages": [
 			"Uno.Fonts.OpenSans",
 			"Uno.Fonts.Fluent",
@@ -193,7 +193,7 @@
 			"Xamarin.Google.Android.Material"
 		],
 		"versionOverride": {
-			"net10.0": "1.12.0.4"
+			"net10.0": "1.12.0.5"
 		}
 	},
 	{
@@ -223,7 +223,7 @@
 			"Xamarin.AndroidX.AppCompat"
 		],
 		"versionOverride": {
-			"net10.0": "1.7.0.7"
+			"net10.0": "1.7.1.1"
 		}
 	},
 	{
@@ -233,7 +233,7 @@
 			"Xamarin.AndroidX.RecyclerView"
 		],
 		"versionOverride": {
-			"net10.0": "1.4.0.2"
+			"net10.0": "1.4.0.3"
 		}
 	},
 	{
@@ -243,7 +243,7 @@
 			"Xamarin.AndroidX.Activity"
 		],
 		"versionOverride": {
-			"net10.0": "1.10.1.2"
+			"net10.0": "1.10.1.3"
 		}
 	},
 	{
@@ -253,7 +253,7 @@
 			"Xamarin.AndroidX.Browser"
 		],
 		"versionOverride": {
-			"net10.0": "1.8.0.10"
+			"net10.0": "1.8.0.11"
 		}
 	},
 	{
@@ -263,7 +263,7 @@
 			"Xamarin.AndroidX.SwipeRefreshLayout"
 		],
 		"versionOverride": {
-			"net10.0": "1.1.0.28"
+			"net10.0": "1.1.0.29"
 		}
 	},
 	{
@@ -274,7 +274,10 @@
 			"Xamarin.AndroidX.Navigation.Fragment",
 			"Xamarin.AndroidX.Navigation.Runtime",
 			"Xamarin.AndroidX.Navigation.Common"
-		]
+		],
+		"versionOverride": {
+			"net10.0": "2.9.2.1"
+		}
 	},
 	{
 		"group": "AndroidXCollection",
@@ -284,24 +287,24 @@
 			"Xamarin.AndroidX.Collection.Ktx"
 		],
 		"versionOverride": {
-			"net10.0": "1.5.0.2"
+			"net10.0": "1.5.0.3"
 		}
 	},
 	{
 		"group": "Maui",
-		"version": "9.0.100",
+		"version": "9.0.120",
 		"packages": [
 			"Microsoft.Maui.Controls",
 			"Microsoft.Maui.Controls.Compatibility",
 			"Microsoft.Maui.Graphics"
 		],
 		"versionOverride": {
-			"net10.0": "10.0.0-rc.2.25504.7"
+			"net10.0": "10.0.0"
 		}
 	},
 	{
 		"group": "CSharpMarkup",
-		"version": "6.3.19",
+		"version": "6.4.17",
 		"packages": [
 			"Uno.WinUI.Markup",
 			"Uno.Extensions.Markup.Generators"
@@ -309,7 +312,7 @@
 	},
 	{
 		"group": "Extensions",
-		"version": "6.2.3",
+		"version": "7.0.4",
 		"packages": [
 			"Uno.Extensions.Authentication.WinUI",
 			"Uno.Extensions.Authentication.MSAL.WinUI",
@@ -339,7 +342,7 @@
 	},
 	{
 		"group": "Toolkit",
-		"version": "8.2.4",
+		"version": "8.3.2",
 		"packages": [
 			"Uno.Toolkit.WinUI",
 			"Uno.Toolkit.WinUI.Cupertino",
@@ -351,7 +354,7 @@
 	},
 	{
 		"group": "Themes",
-		"version": "5.7.3",
+		"version": "6.0.2",
 		"packages": [
 			"Uno.Material.WinUI",
 			"Uno.Material.WinUI.Markup",
@@ -368,14 +371,14 @@
 	},
 	{
 		"group": "MicrosoftWebView2",
-		"version": "1.0.3485.44",
+		"version": "1.0.3595.46",
 		"packages": [
 			"Microsoft.Web.WebView2"
 		]
 	},
 	{
 		"group": "AppMcp",
-		"version": "1.0-dev.15",
+		"version": "1.0.8",
 		"packages": [
 			"Uno.UI.App.Mcp"
 		]


### PR DESCRIPTION
Related item: https://github.com/unoplatform/private/issues/930
Version bump for packages.json to match the latest 6.4 Release Stable Versions