### PR TITLE
[Docs]Fix typo in command for adding MCP with studio

### DIFF
--- a/doc/articles/get-started-ai-claude.md
+++ b/doc/articles/get-started-ai-claude.md
@@ -17,7 +17,7 @@ This guide will walk you through the setup process for getting started with Clau
 
     ```bash
     claude mcp add --transport http uno https://mcp.platform.uno/v1
-    claude mcp add --transport stdio "uno-app" -- dotnet dnx -y uno.devserver --mcp-app
+    claude mcp add --transport studio "uno-app" -- dotnet dnx -y uno.devserver --mcp-app
     ```
 
 1. Open Claude and run:


### PR DESCRIPTION
## PR Type:

- 📚 Documentation content changes


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

current command for setting up Claude Code is missing the "U" in studio 

`claude mcp add --transport stdio "uno-app" -- dotnet dnx -y uno.devserver --mcp-app`

## What is the new behavior? 🚀

`claude mcp add --transport studio "uno-app" -- dotnet dnx -y uno.devserver --mcp-app`

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->