### PR TITLE
fix: Fix possible invalid encoding when HR with VS

### DIFF
--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -763,6 +763,8 @@ public partial class EntryPoint : IDisposable
 
 	private async Task OnUpdateFileRequestedAsync(UpdateFileIdeMessage request)
 	{
+		System.Diagnostics.Debugger.Launch();
+
 		try
 		{
 			if (request.FileContent is { Length: > 0 } fileContent)
@@ -795,12 +797,13 @@ public partial class EntryPoint : IDisposable
 					}
 
 					document.Close(vsSaveChanges.vsSaveChangesNo);
+					document = null;
 					await Task.Delay(250); // Small delay to ensure file system is ready
 				}
 
 				// If the file is open and encoding compatible, we update its content in-memory
 				// TODO: We should NOT assume the `fileContent` to contains the full document content!
-				if (document?.Object("TextDocument") as TextDocument is { } textDocument && currentEncoding != targetEncoding)
+				if (document?.Object("TextDocument") as TextDocument is { } textDocument && currentEncoding == targetEncoding)
 				{
 					_debugAction?.Invoke($"Updating {Path.GetFileName(filePath)} (in memory).");
 

--- a/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
+++ b/src/Uno.UI.RemoteControl.VS/EntryPoint.cs
@@ -761,102 +761,6 @@ public partial class EntryPoint : IDisposable
 		}
 	}
 
-	private System.Text.Encoding DetectFileEncoding(string filePath)
-	{
-		if (!File.Exists(filePath))
-		{
-			return new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
-		}
-
-		Encoding encoding;
-		using (var reader = new StreamReader(filePath, detectEncodingFromByteOrderMarks: true))
-		{
-			reader.Peek(); // Need to read at least one char to detect encoding
-			encoding = reader.CurrentEncoding;
-		}
-
-		// Confirm BOM presence for UTF encodings
-		switch (encoding)
-		{
-			case UTF8Encoding:
-			{
-				using var file = File.OpenRead(filePath);
-				encoding = (file.Length < 3 ? (0x00, 0x00, 0x00) : (file.ReadByte(), file.ReadByte(), file.ReadByte())) switch
-				{
-					(0xEF, 0xBB, 0xBF) => new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
-					_ => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-				};
-				break;
-			}
-			case UnicodeEncoding: // UTF16
-			{
-				using var file = File.OpenRead(filePath);
-				encoding = (file.Length < 2 ? (0x00, 0x00) : (file.ReadByte(), file.ReadByte())) switch
-				{
-					(0xFE, 0xFF) => new UnicodeEncoding(bigEndian: true, byteOrderMark: true),
-					(0xFF, 0xFE) => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
-					_ => new UnicodeEncoding(bigEndian: encoding.CodePage is 1201, byteOrderMark: false),
-				};
-				break;
-			}
-			case UTF32Encoding:
-			{
-				using var file = File.OpenRead(filePath);
-				encoding = (file.Length < 2 ? (0x00, 0x00) : (file.ReadByte(), file.ReadByte())) switch
-				{
-					(0xFE, 0xFF) => new UTF32Encoding(bigEndian: true, byteOrderMark: true),
-					(0xFF, 0xFE) => new UTF32Encoding(bigEndian: false, byteOrderMark: true),
-					_ => new UTF32Encoding(bigEndian: encoding.CodePage is 12001, byteOrderMark: false),
-				};
-				break;
-			}
-		}
-
-		return encoding;
-	}
-
-	private bool SupportsUnicode(System.Text.Encoding encoding)
-	{
-		// Check if the encoding supports Unicode characters (including emojis)
-		// UTF-8, UTF-16, and UTF-32 all support the full Unicode range
-		var isSupported = encoding is UTF8Encoding
-			|| encoding is UnicodeEncoding
-			|| encoding is UTF32Encoding
-			|| encoding.CodePage == 65001  // UTF-8
-			|| encoding.CodePage == 1200   // UTF-16 LE
-			|| encoding.CodePage == 1201   // UTF-16 BE
-			|| encoding.CodePage == 12000  // UTF-32 LE
-			|| encoding.CodePage == 12001; // UTF-32 BE
-
-		// Even if supported, we validate if the BOM has been enabled
-		if (!isSupported || encoding.GetPreamble() == Array.Empty<byte>())
-		{
-			return false;
-		}
-
-		return true;
-	}
-
-	private bool ContainsSpecialCharacters(string content)
-	{
-		// Check if content contains characters outside the Basic Multilingual Plane (BMP)
-		// This includes emojis and other special Unicode characters
-		foreach (var c in content)
-		{
-			if (char.IsSurrogate(c))
-			{
-				return true;
-			}
-		}
-		return false;
-	}
-
-	private Encoding GetCompatibleEncoding(Encoding currentEncoding, string newContent)
-		// If content has special characters and encoding doesn't support Unicode, upgrade to UTF-8 with BOM
-		=> ContainsSpecialCharacters(newContent) && !SupportsUnicode(currentEncoding)
-			? new UTF8Encoding(encoderShouldEmitUTF8Identifier: true)
-			: currentEncoding;
-
 	private async Task OnUpdateFileRequestedAsync(UpdateFileIdeMessage request)
 	{
 		try
@@ -866,8 +770,8 @@ public partial class EntryPoint : IDisposable
 				var filePath = Path.GetFullPath(request.FileFullName);
 
 				// Determine the appropriate encoding for the file
-				var currentEncoding = DetectFileEncoding(filePath);
-				var targetEncoding = GetCompatibleEncoding(currentEncoding, fileContent);
+				var currentEncoding = EncodingHelpers.DetectFileEncoding(filePath);
+				var targetEncoding = EncodingHelpers.GetCompatibleEncoding(currentEncoding, fileContent);
 
 				// Check if document is already open in IDE
 				var document = _dte2

--- a/src/Uno.UI.RemoteControl.VS/Helpers/EncodingHelpers.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/EncodingHelpers.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Uno.UI.RemoteControl.VS.Helpers;
+
+internal class EncodingHelpers
+{
+	public static System.Text.Encoding DetectFileEncoding(string filePath)
+	{
+		if (!File.Exists(filePath))
+		{
+			return new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+		}
+
+		Encoding encoding;
+		using (var reader = new StreamReader(filePath, detectEncodingFromByteOrderMarks: true))
+		{
+			reader.Peek(); // Need to read at least one char to detect encoding
+			encoding = reader.CurrentEncoding;
+		}
+
+		// Confirm BOM presence for UTF encodings
+		switch (encoding)
+		{
+			case UTF8Encoding:
+				{
+					using var file = File.OpenRead(filePath);
+					encoding = (file.Length < 3 ? (0x00, 0x00, 0x00) : (file.ReadByte(), file.ReadByte(), file.ReadByte())) switch
+					{
+						(0xEF, 0xBB, 0xBF) => new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
+						_ => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+					};
+					break;
+				}
+			case UnicodeEncoding: // UTF16
+				{
+					using var file = File.OpenRead(filePath);
+					encoding = (file.Length < 2 ? (0x00, 0x00) : (file.ReadByte(), file.ReadByte())) switch
+					{
+						(0xFE, 0xFF) => new UnicodeEncoding(bigEndian: true, byteOrderMark: true),
+						(0xFF, 0xFE) => new UnicodeEncoding(bigEndian: false, byteOrderMark: true),
+						_ => new UnicodeEncoding(bigEndian: encoding.CodePage is 1201, byteOrderMark: false),
+					};
+					break;
+				}
+			case UTF32Encoding:
+				{
+					using var file = File.OpenRead(filePath);
+					encoding = (file.Length < 2 ? (0x00, 0x00) : (file.ReadByte(), file.ReadByte())) switch
+					{
+						(0xFE, 0xFF) => new UTF32Encoding(bigEndian: true, byteOrderMark: true),
+						(0xFF, 0xFE) => new UTF32Encoding(bigEndian: false, byteOrderMark: true),
+						_ => new UTF32Encoding(bigEndian: encoding.CodePage is 12001, byteOrderMark: false),
+					};
+					break;
+				}
+		}
+
+		return encoding;
+	}
+
+	private static bool SupportsUnicode(System.Text.Encoding encoding)
+	{
+		// Check if the encoding supports Unicode characters (including emojis)
+		// UTF-8, UTF-16, and UTF-32 all support the full Unicode range
+		var isSupported = encoding is UTF8Encoding
+			|| encoding is UnicodeEncoding
+			|| encoding is UTF32Encoding
+			|| encoding.CodePage == 65001  // UTF-8
+			|| encoding.CodePage == 1200   // UTF-16 LE
+			|| encoding.CodePage == 1201   // UTF-16 BE
+			|| encoding.CodePage == 12000  // UTF-32 LE
+			|| encoding.CodePage == 12001; // UTF-32 BE
+
+		// Even if supported, we validate if the BOM has been enabled
+		if (!isSupported || encoding.GetPreamble() == Array.Empty<byte>())
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	private static bool ContainsSpecialCharacters(string content)
+	{
+		// Check if content contains characters outside the Basic Multilingual Plane (BMP)
+		// This includes emojis and other special Unicode characters
+		foreach (var c in content)
+		{
+			if (char.IsSurrogate(c))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public static Encoding GetCompatibleEncoding(Encoding currentEncoding, string newContent)
+		// If content has special characters and encoding doesn't support Unicode, upgrade to UTF-8 with BOM
+		=> ContainsSpecialCharacters(newContent) && !SupportsUnicode(currentEncoding)
+			? new UTF8Encoding(encoderShouldEmitUTF8Identifier: true)
+			: currentEncoding;
+
+}

--- a/src/Uno.UI.RemoteControl.VS/Helpers/EncodingHelpers.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/EncodingHelpers.cs
@@ -77,7 +77,7 @@ internal class EncodingHelpers
 			|| encoding.CodePage == 12001; // UTF-32 BE
 
 		// Even if supported, we validate if the BOM has been enabled
-		if (!isSupported || encoding.GetPreamble() == Array.Empty<byte>())
+		if (!isSupported || encoding.GetPreamble().Length == 0)
 		{
 			return false;
 		}

--- a/src/Uno.UI.RemoteControl.VS/Helpers/EncodingHelpers.cs
+++ b/src/Uno.UI.RemoteControl.VS/Helpers/EncodingHelpers.cs
@@ -50,10 +50,10 @@ internal class EncodingHelpers
 			case UTF32Encoding:
 				{
 					using var file = File.OpenRead(filePath);
-					encoding = (file.Length < 2 ? (0x00, 0x00) : (file.ReadByte(), file.ReadByte())) switch
+					encoding = (file.Length < 4 ? (0x00, 0x00, 0x00, 0x00) : (file.ReadByte(), file.ReadByte(), file.ReadByte(), file.ReadByte())) switch
 					{
-						(0xFE, 0xFF) => new UTF32Encoding(bigEndian: true, byteOrderMark: true),
-						(0xFF, 0xFE) => new UTF32Encoding(bigEndian: false, byteOrderMark: true),
+						(0x00, 0x00, 0xFE, 0xFF) => new UTF32Encoding(bigEndian: true, byteOrderMark: true),
+						(0xFF, 0xFE, 0x00, 0x00) => new UTF32Encoding(bigEndian: false, byteOrderMark: true),
 						_ => new UTF32Encoding(bigEndian: encoding.CodePage is 12001, byteOrderMark: false),
 					};
 					break;


### PR DESCRIPTION
closes https://github.com/unoplatform/uno-private/issues/1609

## ✨ Feature
Fix possible invalid encoding when HR with VS

## What is the current behavior? 🤔
Keep current file encoding

## What is the new behavior? 🚀
Make sure to enable BOM for UTF encodings

## PR Checklist ✅
- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes
