### PR TITLE
chore: Fix many trimmer warnings in src/Uno.UI

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/DependencyObjectGeneratorTests/Given_DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators.Tests/DependencyObjectGeneratorTests/Given_DependencyObjectGenerator.cs
@@ -210,6 +210,7 @@ public class Given_DependencyObjectGenerator
 	 		}
 	 		
 	 		// Using a DependencyProperty as the backing store for DataContext.  This enables animation, styling, binding, etc...
+	 		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
 	 		public static DependencyProperty DataContextProperty { get ; } =
 	 			DependencyProperty.Register(
 	 				name: nameof(DataContext),
@@ -240,6 +241,7 @@ public class Given_DependencyObjectGenerator
 	 		
 	 		// Using a DependencyProperty as the backing store for TemplatedParent.  This enables animation, styling, binding, etc...
 	 		[EditorBrowsable(EditorBrowsableState.Never)]
+	 		[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2111")]
 	 		public static DependencyProperty TemplatedParentProperty { get ; } =
 	 			DependencyProperty.Register(
 	 				name: nameof(TemplatedParent),

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -627,6 +627,7 @@ public object DataContext
 }}
 
 // Using a DependencyProperty as the backing store for DataContext.  This enables animation, styling, binding, etc...
+[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(""Trimming"", ""IL2111"")]
 public static DependencyProperty DataContextProperty {{ get ; }} =
 	DependencyProperty.Register(
 		name: nameof(DataContext),
@@ -657,6 +658,7 @@ public static DependencyProperty DataContextProperty {{ get ; }} =
 
 // Using a DependencyProperty as the backing store for TemplatedParent.  This enables animation, styling, binding, etc...
 {legacyNonBrowsable}
+[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(""Trimming"", ""IL2111"")]
 public static DependencyProperty TemplatedParentProperty {{ get ; }} =
 	DependencyProperty.Register(
 		name: nameof(TemplatedParent),

--- a/src/Uno.Foundation/Uno.Foundation.Reference.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.Reference.csproj
@@ -18,6 +18,7 @@
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Foundation/Uno.Foundation.Skia.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.Skia.csproj
@@ -17,6 +17,7 @@
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Foundation/Uno.Foundation.Wasm.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.Wasm.csproj
@@ -17,6 +17,7 @@
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -14,6 +14,7 @@
 
 		<UnoRuntimeIdentifier>Skia</UnoRuntimeIdentifier>
 		<PlatformItemsBasePath>.\</PlatformItemsBasePath>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Foundation/Uno.Foundation.netcoremobile.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.netcoremobile.csproj
@@ -16,6 +16,7 @@
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
 		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
+++ b/src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -51,7 +52,7 @@ namespace Uno.UI.RemoteControl.HotReload
 
 			if (instance is FrameworkElement fe)
 			{
-				var instanceTypeName = (instance.GetType().GetOriginalType() ?? instance.GetType()).Name;
+				var instanceTypeName = GetInstanceTypeName(instance);
 				var instanceKey = parentKey is not null ? $"{parentKey}_{instanceTypeName}" : instanceTypeName;
 				var match = await predicate(fe, instanceKey);
 				if (match is not null)
@@ -82,7 +83,7 @@ namespace Uno.UI.RemoteControl.HotReload
 				var idx = 0;
 				foreach (var nativeChild in nativeView.EnumerateChildren())
 				{
-					var instanceTypeName = (instance.GetType().GetOriginalType() ?? instance.GetType()).Name;
+					var instanceTypeName = GetInstanceTypeName(instance);
 					var instanceKey = parentKey is not null ? $"{parentKey}_{instanceTypeName}" : instanceTypeName;
 					var inner = EnumerateHotReloadInstances(nativeChild, predicate, $"{instanceKey}_[{idx}]");
 
@@ -96,6 +97,10 @@ namespace Uno.UI.RemoteControl.HotReload
 			}
 #endif
 		}
+
+		[UnconditionalSuppressMessage("Trimming", "IL2072")]
+		private static string GetInstanceTypeName(object value)
+			=> (value.GetType().GetOriginalType() ?? value.GetType()).Name;
 
 		private static void SwapViews(FrameworkElement oldView, FrameworkElement newView)
 		{

--- a/src/Uno.UI/Controls/BindableImageView.Android.cs
+++ b/src/Uno.UI/Controls/BindableImageView.Android.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -37,8 +38,11 @@ namespace Uno.UI.Controls
 	[Microsoft.UI.Xaml.Data.Bindable]
 	public class BindableImageView : ImageView, View.IOnTouchListener
 	{
+		const DynamicallyAccessedMemberTypes DrawablesRequirements = DynamicallyAccessedMemberTypes.PublicFields;
+
 		private string _uriSource;
 
+		[DynamicallyAccessedMembers(DrawablesRequirements)]
 		private static Type _drawables;
 		private static Dictionary<string, int> _drawablesLookup;
 
@@ -182,6 +186,7 @@ namespace Uno.UI.Controls
 			base.SetImageBitmap(bm);
 		}
 
+		[DynamicallyAccessedMembers(DrawablesRequirements)]
 		public static Type Drawables
 		{
 			get

--- a/src/Uno.UI/Controls/CommandBar/CommandBarNavigationItemRenderer.UIKit.cs
+++ b/src/Uno.UI/Controls/CommandBar/CommandBarNavigationItemRenderer.UIKit.cs
@@ -18,8 +18,8 @@ namespace Uno.UI.Controls
 {
 	internal partial class CommandBarNavigationItemRenderer : Renderer<CommandBar, UINavigationItem?>
 	{
-		private static DependencyProperty NavigationCommandProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "NavigationCommand");
-		private static DependencyProperty BackButtonTitleProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "BackButtonTitle");
+		private static DependencyProperty NavigationCommandProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "NavigationCommand");
+		private static DependencyProperty BackButtonTitleProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "BackButtonTitle");
 
 		private TitleView? _titleView;
 

--- a/src/Uno.UI/Controls/CommandBar/CommandBarRenderer.Android.cs
+++ b/src/Uno.UI/Controls/CommandBar/CommandBarRenderer.Android.cs
@@ -27,11 +27,11 @@ namespace Uno.UI.Controls
 {
 	internal partial class CommandBarRenderer : Renderer<CommandBar, Toolbar>
 	{
-		private static DependencyProperty SubtitleProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "Subtitle");
-		private static DependencyProperty NavigationCommandProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "NavigationCommand");
-		private static DependencyProperty BackButtonVisibilityProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "BackButtonVisibility");
-		private static DependencyProperty BackButtonForegroundProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "BackButtonForeground");
-		private static DependencyProperty BackButtonIconProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "BackButtonIcon");
+		private static DependencyProperty SubtitleProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "Subtitle");
+		private static DependencyProperty NavigationCommandProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "NavigationCommand");
+		private static DependencyProperty BackButtonVisibilityProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "BackButtonVisibility");
+		private static DependencyProperty BackButtonForegroundProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "BackButtonForeground");
+		private static DependencyProperty BackButtonIconProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "BackButtonIcon");
 
 		private static string? _actionBarUpDescription;
 		private static string? ActionBarUpDescription

--- a/src/Uno.UI/Controls/CommandBar/CommandBarRenderer.UIKit.cs
+++ b/src/Uno.UI/Controls/CommandBar/CommandBarRenderer.UIKit.cs
@@ -17,8 +17,8 @@ namespace Uno.UI.Controls
 {
 	internal partial class CommandBarRenderer : Renderer<CommandBar, UINavigationBar>
 	{
-		private static DependencyProperty BackButtonForegroundProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "BackButtonForeground");
-		private static DependencyProperty BackButtonIconProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "BackButtonIcon");
+		private static DependencyProperty BackButtonForegroundProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "BackButtonForeground");
+		private static DependencyProperty BackButtonIconProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "BackButtonIcon");
 
 		public CommandBarRenderer(CommandBar element) : base(element) { }
 

--- a/src/Uno.UI/Controls/NativeFramePresenter.Android.cs
+++ b/src/Uno.UI/Controls/NativeFramePresenter.Android.cs
@@ -18,7 +18,7 @@ namespace Uno.UI.Controls
 {
 	public partial class NativeFramePresenter : Grid // Inheriting from Grid is a hack to remove 1 visual layer (Android 4.4 stack size limits)
 	{
-		private static DependencyProperty BackButtonVisibilityProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "BackButtonVisibility");
+		private static DependencyProperty BackButtonVisibilityProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "BackButtonVisibility");
 
 		private Frame _frame;
 		private bool _isUpdatingStack;

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.MemberBinder.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.MemberBinder.cs
@@ -1,5 +1,6 @@
 ﻿#if !NETFX_CORE
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 
 namespace Uno.UI.DataBinding
@@ -8,6 +9,7 @@ namespace Uno.UI.DataBinding
 	internal static partial class BindingPropertyHelper
 	{
 		[Preserve]
+		[RequiresDynamicCode("`System.Dynamic` use requires dynamic code.")]
 		private class UnoGetMemberBinder : GetMemberBinder
 		{
 			public UnoGetMemberBinder(string name, bool ignoreCase) : base(name, ignoreCase) { }
@@ -17,6 +19,7 @@ namespace Uno.UI.DataBinding
 		}
 
 		[Preserve]
+		[RequiresDynamicCode("`System.Dynamic` use requires dynamic code.")]
 		private class UnoSetMemberBinder : SetMemberBinder
 		{
 			public UnoSetMemberBinder(string name, bool ignoreCase) : base(name, ignoreCase) { }

--- a/src/Uno.UI/DirectUI/MetadataAPI.cs
+++ b/src/Uno.UI/DirectUI/MetadataAPI.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Data;
@@ -593,7 +594,21 @@ partial class MetadataAPI // quick impl
 		BindingFlags.Static |
 		BindingFlags.FlattenHierarchy;
 
-	public static DependencyProperty TryGetDependencyPropertyByName(Type type, string propertyName)
+	internal const DynamicallyAccessedMemberTypes TryGetDependencyPropertyByName_Type_Requirements =
+		  DynamicallyAccessedMemberTypes.PublicProperties
+		| DynamicallyAccessedMemberTypes.NonPublicProperties
+		| DynamicallyAccessedMemberTypes.PublicFields
+		| DynamicallyAccessedMemberTypes.NonPublicFields
+#if NET10_0_OR_GREATER
+		| DynamicallyAccessedMemberTypes.NonPublicFieldsWithInherited
+		| DynamicallyAccessedMemberTypes.NonPublicPropertiesWithInherited
+#endif  // NET10_0_OR_GREATER
+		;
+
+	public static DependencyProperty TryGetDependencyPropertyByName(
+		[DynamicallyAccessedMembers(TryGetDependencyPropertyByName_Type_Requirements)]
+		Type type,
+		string propertyName)
 	{
 		var key = (type, propertyName);
 

--- a/src/Uno.UI/DirectUI/PropertyAccess.cs
+++ b/src/Uno.UI/DirectUI/PropertyAccess.cs
@@ -697,6 +697,7 @@ partial class DependencyObjectPropertyAccess // src\dxaml\xcp\dxaml\lib\Dependen
 	public static PropertyAccess CreateInstance(
 		IPropertyAccessHost pOwner,
 		object pInspSource,
+		[DynamicallyAccessedMembers(MetadataAPI.TryGetDependencyPropertyByName_Type_Requirements)]
 		Type pSourceType,
 		bool fListenToChanges)
 	{
@@ -932,6 +933,7 @@ partial class DependencyObjectPropertyAccess // src\dxaml\xcp\dxaml\lib\Dependen
 
 	private static DependencyProperty ResolvePropertyName(
 	DependencyObject pSource,
+	[DynamicallyAccessedMembers(MetadataAPI.TryGetDependencyPropertyByName_Type_Requirements)]
 	Type pSourceType,
 	string szPropertyName)
 	{
@@ -1625,6 +1627,7 @@ internal class ReflectionPropertyAccess : PropertyAccess
 	public static PropertyAccess CreateInstance(
 		IPropertyAccessHost pOwner,
 		object pSource,
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
 		Type pSourceType,
 		bool fListenToChanges)
 	{

--- a/src/Uno.UI/DirectUI/PropertyPathStep.cs
+++ b/src/Uno.UI/DirectUI/PropertyPathStep.cs
@@ -454,7 +454,7 @@ partial class PropertyAccessPathStep // src\dxaml\xcp\dxaml\lib\PropertyAccessPa
 			}
 			else
 			{
-				spResult = DependencyObjectPropertyAccess.CreateInstance(this, spSourceForDP, pSourceType, fListenToChanges);
+				spResult = CreateFallbackPropertyAccess(this, spSourceForDP, pSourceType, fListenToChanges);
 			}
 		}
 
@@ -499,7 +499,7 @@ partial class PropertyAccessPathStep // src\dxaml\xcp\dxaml\lib\PropertyAccessPa
 			// uno: fallback to reflection
 			if (spResult is null)
 			{
-				spResult = ReflectionPropertyAccess.CreateInstance(this, spInsp, pSourceType, fListenToChanges);
+				spResult = CreateFallbackPropertyAccess(this, spInsp, pSourceType, fListenToChanges);
 			}
 #endif
 		}
@@ -518,6 +518,11 @@ partial class PropertyAccessPathStep // src\dxaml\xcp\dxaml\lib\PropertyAccessPa
 
 		return pbConnected;
 	}
+
+	[UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "`type` may come from `object.GetType()`, which is dynamic.")]
+	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "`type` may come from `object.GetType()`, which is dynamic.")]
+	private static PropertyAccess CreateFallbackPropertyAccess(IPropertyAccessHost owner, object source, Type type, bool fListenToChanges)
+		=> ReflectionPropertyAccess.CreateInstance(owner, source, type, fListenToChanges);
 
 	private void TraceConnectionError(object pSource)
 	{

--- a/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
+++ b/src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs
@@ -211,8 +211,7 @@ static partial class ViewExtensions
 	internal static bool TryGetDpValue<T>(object owner, string property, [NotNullWhen(true)] out T? value)
 	{
 		if (owner is DependencyObject @do &&
-			owner.GetType()
-				.GetProperty($"{property}Property", Public | Static | FlattenHierarchy)
+				GetProperty(owner.GetType(), $"{property}Property")
 				?.GetValue(null, null) is DependencyProperty dp)
 		{
 			value = (T)@do.GetValue(dp);
@@ -221,6 +220,11 @@ static partial class ViewExtensions
 
 		value = default;
 		return false;
+
+		[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` / `BindableMetadata.g.cs` ensures the property exists.")]
+		[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` / `BindableMetadata.g.cs` ensures the property exists.")]
+		static PropertyInfo? GetProperty(Type type, string propertyName)
+			=> type.GetProperty(propertyName, Public | Static | FlattenHierarchy);
 	}
 
 	/// <summary>

--- a/src/Uno.UI/FastInvokerBuilder.Android.cs
+++ b/src/Uno.UI/FastInvokerBuilder.Android.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 
@@ -18,6 +19,7 @@ namespace Uno.UI
 	{
 		public delegate object FastInvokerHandler(object instance, object[] parms);
 
+		[RequiresDynamicCode("From DynamicMethod: Creating a DynamicMethod requires dynamic code.")]
 		public static FastInvokerHandler DynamicInvokerBuilder(System.Reflection.MethodInfo methodInfo)
 		{
 			DynamicMethod dynamicMethod = new DynamicMethod(

--- a/src/Uno.UI/Helpers/TypeMappings.cs
+++ b/src/Uno.UI/Helpers/TypeMappings.cs
@@ -13,6 +13,11 @@ namespace Uno.UI.Helpers;
 /// </summary>
 public static class TypeMappings
 {
+	internal const DynamicallyAccessedMemberTypes TypeRequirements =
+		  DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+		| DynamicallyAccessedMemberTypes.PublicConstructors
+		;
+
 	/// <summary>
 	/// This maps a replacement type to the original type. This dictionary will grow with each iteration 
 	/// of the original type.
@@ -44,8 +49,9 @@ public static class TypeMappings
 	/// </summary>
 	/// <param name="instanceType">This is the type that may have been replaced</param>
 	/// <returns>If instanceType has been replaced, then the replacement type, otherwise the instanceType</returns>
+	[return: DynamicallyAccessedMembers(TypeRequirements)]
 	public static Type GetReplacementType(
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type instanceType)
+		[DynamicallyAccessedMembers(TypeRequirements)] this Type instanceType)
 	{
 		// Two scenarios:
 		// 1. The instance type is a mapped type, in which case we need to get the original type
@@ -60,7 +66,7 @@ public static class TypeMappings
 	/// <typeparam name="TOriginalType">The original type to be created</typeparam>
 	/// <returns>An new instance for the original type</returns>
 	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
-	public static object CreateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOriginalType>()
+	public static object CreateInstance<[DynamicallyAccessedMembers(TypeRequirements)] TOriginalType>()
 		=> Activator.CreateInstance(typeof(TOriginalType).GetReplacementType());
 
 	/// <summary>
@@ -69,16 +75,26 @@ public static class TypeMappings
 	/// <typeparam name="TOriginalType">The original type to be created</typeparam>
 	/// <param name="args">The arguments used to create the instance, passed to the ctor</param>
 	/// <returns>An new instance for the original type</returns>
-	public static object CreateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TOriginalType>(params object[] args)
+	public static object CreateInstance<[DynamicallyAccessedMembers(TypeRequirements)] TOriginalType>(params object[] args)
 		=> Activator.CreateInstance(typeof(TOriginalType).GetReplacementType(), args: args);
 
-	internal static Type GetMappedType(this Type originalType) =>
+	[return: DynamicallyAccessedMembers(TypeRequirements)]
+	internal static Type GetMappedType(
+		[DynamicallyAccessedMembers(TypeRequirements)]
+		this Type originalType) =>
 		OriginalTypeToMappedType.TryGetValue(originalType, out var mappedType) ? mappedType : default;
 
-	internal static Type GetOriginalType(this Type mappedType) =>
+	[return: DynamicallyAccessedMembers(TypeRequirements)]
+	internal static Type GetOriginalType(
+		[DynamicallyAccessedMembers(TypeRequirements)]
+		this Type mappedType) =>
 		MappedTypeToOriginalTypeMappings.TryGetValue(mappedType, out var originalType) ? originalType : default;
 
-	internal static bool IsReplacedBy(this Type sourceType, Type mappedType)
+	internal static bool IsReplacedBy(
+		[DynamicallyAccessedMembers(TypeRequirements)]
+		this Type sourceType,
+		[DynamicallyAccessedMembers(TypeRequirements)]
+		Type mappedType)
 	{
 		if (mappedType.GetOriginalType() is { } originalType)
 		{
@@ -92,7 +108,11 @@ public static class TypeMappings
 		return false;
 	}
 
-	internal static void RegisterMapping(Type mappedType, Type originalType)
+	internal static void RegisterMapping(
+		[DynamicallyAccessedMembers(TypeRequirements)]
+		Type mappedType,
+		[DynamicallyAccessedMembers(TypeRequirements)]
+		Type originalType)
 	{
 		AllMappedTypeToOriginalTypeMappings[mappedType] = originalType;
 		AllOriginalTypeToMappedType[originalType] = mappedType;

--- a/src/Uno.UI/ToolkitHelper.cs
+++ b/src/Uno.UI/ToolkitHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.UI.Xaml;
 
@@ -7,9 +8,17 @@ namespace Uno.UI
 {
 	internal static class ToolkitHelper
 	{
-		public static DependencyProperty GetProperty(string ownerTypeName, string propertyName)
+		[UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "[DynamicallyAccessedMembers] on ownerTypeName should ensure availability of target type.")]
+		public static DependencyProperty GetProperty(
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+			string ownerTypeName,
+			string propertyName)
 		{
-			var ownerType = Type.GetType(ownerTypeName + ",Uno.UI.Toolkit");
+			var ownerType = Type.GetType(ownerTypeName, throwOnError: false);
+			if (ownerType == null)
+			{
+				ownerType = Type.GetType(ownerTypeName + ",Uno.UI.Toolkit");
+			}
 			var dp = DependencyProperty.GetProperty(ownerType, propertyName);
 			return dp;
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/CommandBar/CommandBar.Partial.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/CommandBar/CommandBar.Partial.cs
@@ -368,7 +368,7 @@ namespace Microsoft.UI.Xaml.Controls
 		}
 
 #if __APPLE_UIKIT__ || __ANDROID__
-		private static DependencyProperty NavigationCommandProperty = Uno.UI.ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions", "NavigationCommand");
+		private static DependencyProperty NavigationCommandProperty = Uno.UI.ToolkitHelper.GetProperty("Uno.UI.Toolkit.CommandBarExtensions, Uno.UI.Toolkit", "NavigationCommand");
 
 		internal override void UpdateThemeBindings(ResourceUpdateReason updateReason)
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -165,7 +165,7 @@ public partial class Frame : ContentControl
 
 	[UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Types manipulated here have been marked earlier")]
 	internal static object CreatePageInstance(
-		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+		[DynamicallyAccessedMembers(TypeMappings.TypeRequirements)]
 		Type sourcePageType)
 	{
 		var replacementType = sourcePageType.GetReplacementType(); // Get latest replacement type to handle Hot Reload.

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.legacy.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.legacy.cs
@@ -65,7 +65,14 @@ public partial class Frame : ContentControl
 			// This is to support hot reload scenarios - the PageStackEntry 
 			// is used when navigating back to this page as it's maintained in the BackStack
 			CurrentEntry.Instance = newValue as Page;
-			CurrentEntry.SourcePageType = newValue.GetType();
+			SetSourcePageType(CurrentEntry, newValue.GetType());
+		}
+
+		[UnconditionalSuppressMessage("Trimming", "IL2067")]
+		// 'value' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'PageStackEntry.SourcePageType.set'.
+		static void SetSourcePageType(PageStackEntry entry, Type type)
+		{
+			entry.SourcePageType = type;
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/LayouterHelper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/LayouterHelper.Android.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Drawing;
@@ -23,8 +24,11 @@ namespace Microsoft.UI.Xaml.Controls
 	{
 		internal static readonly UnsafeWeakAttachedDictionary<View, string> LayoutProperties = new UnsafeWeakAttachedDictionary<View, string>();
 
+#pragma warning disable IL3050
 		internal static readonly FastInvokerBuilder.FastInvokerHandler SetMeasuredDimensions = GetSetMeasuredDimensionMethod();
+#pragma warning restore IL3050
 
+		[RequiresDynamicCode("From DynamicMethod: Creating a DynamicMethod requires dynamic code.")]
 		private static FastInvokerBuilder.FastInvokerHandler GetSetMeasuredDimensionMethod()
 		{
 			//

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.UIKit.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.UIKit.cs
@@ -16,7 +16,7 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class MenuFlyout
 	{
-		private static DependencyProperty CancelTextIosOverrideProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.MenuFlyoutExtensions", "CancelTextIosOverride");
+		private static DependencyProperty CancelTextIosOverrideProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.MenuFlyoutExtensions, Uno.UI.Toolkit", "CancelTextIosOverride");
 
 		private string LocalizedCancelString => NSBundle.FromIdentifier("com.apple.UIKit")
 			.GetLocalizedString("Cancel", null);

--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS8.UIKit.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.iOS8.UIKit.cs
@@ -12,7 +12,7 @@ namespace Microsoft.UI.Xaml.Controls
 {
 	public partial class MenuFlyout
 	{
-		private static DependencyProperty IsDestructiveProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.MenuFlyoutItemExtensions", "IsDestructive");
+		private static DependencyProperty IsDestructiveProperty = ToolkitHelper.GetProperty("Uno.UI.Toolkit.MenuFlyoutItemExtensions, Uno.UI.Toolkit", "IsDestructive");
 
 		private UIAlertController _alertController;
 

--- a/src/Uno.UI/UI/Xaml/Controls/NumberBox/NumberBoxParser.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NumberBox/NumberBoxParser.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.RegularExpressions;
 using Windows.Foundation.Metadata;
@@ -90,7 +91,7 @@ internal partial class NumberBoxParser
 		{
 			// Might be a number
 			var matchLength = match.Groups[0].Length;
-			var parsedNum = ApiInformation.IsTypePresent(numberParser?.GetType().AssemblyQualifiedName)
+			var parsedNum = IsTypePresent(numberParser?.GetType())
 				? numberParser.ParseDouble(input.Substring(0, matchLength))
 				: double.TryParse(input.AsSpan().Slice(0, matchLength), out var d)
 					? (double?)d
@@ -104,6 +105,10 @@ internal partial class NumberBoxParser
 		}
 
 		return (double.NaN, 0);
+
+		[UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` / `BindableMetadata.g.cs` ensures the type exists.")]
+		static bool IsTypePresent(Type type)
+			=> ApiInformation.IsTypePresent(type.AssemblyQualifiedName);
 	}
 
 	static int GetPrecedenceValue(char c)

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2WebMessageReceivedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2WebMessageReceivedEventArgs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Uno.Foundation.Logging;
 
@@ -36,7 +37,7 @@ public partial class CoreWebView2WebMessageReceivedEventArgs
 
 		try
 		{
-			return JsonSerializer.Deserialize<string>(WebMessageAsJson, s_stringJsonTypeInfo);
+			return JsonSerializer.Deserialize<string>(WebMessageAsJson, CoreWebView2WebMessageReceivedEventArgsJsonSerializerContext.Default.String);
 		}
 		catch (Exception)
 		{
@@ -48,16 +49,10 @@ public partial class CoreWebView2WebMessageReceivedEventArgs
 			throw new ArgumentException("The message posted is some other kind of JavaScript type.");
 		}
 	}
+}
 
-	private static readonly JsonSerializerOptions s_serializerOptions = new JsonSerializerOptions
-	{
-		TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
-		Converters =
-		{
-			JsonMetadataServices.StringConverter,
-		},
-	};
-
-	private static readonly JsonTypeInfo<string> s_stringJsonTypeInfo = JsonTypeInfo.CreateJsonTypeInfo<string>(s_serializerOptions);
-
+[JsonSourceGenerationOptions]
+[JsonSerializable(typeof(string))]
+internal sealed partial class CoreWebView2WebMessageReceivedEventArgsJsonSerializerContext : JsonSerializerContext
+{
 }

--- a/src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 using Uno.Extensions;
 using Microsoft.UI.Xaml.Controls;
 using Uno.UI;
+using System.Diagnostics.CodeAnalysis;
+
 
 #if NETFX_CORE
 using Microsoft.UI.Xaml;
@@ -79,7 +81,7 @@ namespace Microsoft.UI.Xaml
 			var currentType = element.GetType();
 			do
 			{
-				fieldInfo = currentType.GetTypeInfo().GetDeclaredField(property + "Property");
+				fieldInfo = GetField(currentType, property + "Property");
 
 				if (fieldInfo == null)
 				{
@@ -96,6 +98,11 @@ namespace Microsoft.UI.Xaml
 			}
 
 			return null;
+
+			[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` / `BindableMetadata.g.cs` ensures the field exists.")]
+			[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` / `BindableMetadata.g.cs` ensures the field exists.")]
+			static FieldInfo GetField(Type type, string fieldName)
+				=> type.GetTypeInfo().GetDeclaredField(fieldName);
 		}
 
 		private static DependencyProperty GetDependencyPropertyFromProperties(object element, string property)
@@ -105,7 +112,7 @@ namespace Microsoft.UI.Xaml
 
 			do
 			{
-				propertyInfo = currentType.GetTypeInfo().GetDeclaredProperty(property + "Property");
+				propertyInfo = GetProperty(currentType, property + "Property");
 
 				if (propertyInfo == null)
 				{
@@ -122,6 +129,11 @@ namespace Microsoft.UI.Xaml
 
 
 			return null;
+
+			[UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` / `BindableMetadata.g.cs` ensures the property exists.")]
+			[UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` / `BindableMetadata.g.cs` ensures the property exists.")]
+			static PropertyInfo GetProperty(Type type, string propertyName)
+				=> type.GetTypeInfo().GetDeclaredProperty(propertyName);
 		}
 
 		public static T Binding<T>(this T element, string property, string propertyPath) where T : DependencyObject

--- a/src/Uno.UI/UI/Xaml/Internal/CustomEventManager.cs
+++ b/src/Uno.UI/UI/Xaml/Internal/CustomEventManager.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -26,7 +27,10 @@ internal interface ICustomEventManager<T, TEventArgs>
 	void OnTick();
 }
 
-internal sealed class CustomKeepLastEventManager<T, TEventArgs> : ICustomEventManager<T, TEventArgs>
+internal sealed class CustomKeepLastEventManager<
+	T,
+	[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TEventArgs
+> : ICustomEventManager<T, TEventArgs>
 	where T : class
 	where TEventArgs : class
 {

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -772,6 +772,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 		{
 			if (TypeResolver.IsCollectionOrListType(property.Type))
 			{
+				[UnconditionalSuppressMessage("Trimming", "IL3050", Justification = "Hopefully Uno.UI.SourceGenerators.BindableTypeProviders.BindableTypeProvidersSourceGenerator will preserve what is needed.")]
 				object BuildInstance()
 				{
 					if (property.Type.GetGenericTypeDefinition() == typeof(IList<>))

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -50,6 +50,7 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				},
 			}.ToImmutableDictionary();
 
+		[UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "Need to ask @jeromelaban why e.g. `_isAttachedProperty` is a Func<…> instead of a method invocation.  See also 26c5cc5992cae3c8c25adf51eb77ca4b0dd34e93.")]
 		public XamlTypeResolver(XamlFileDefinition definition)
 		{
 			FileDefinition = definition;
@@ -447,7 +448,10 @@ namespace Microsoft.UI.Xaml.Markup.Reader
 				.Trim()
 				.FirstOrDefault();
 		}
-		private static bool SourceIsAttachedProperty(Type type, string name)
+		private static bool SourceIsAttachedProperty(
+			[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicMethods)]
+			Type type,
+			string name)
 		{
 			Type? currentType = type;
 

--- a/src/Uno.UI/UI/Xaml/Navigation/NavigationHistory.mux.cs
+++ b/src/Uno.UI/UI/Xaml/Navigation/NavigationHistory.mux.cs
@@ -326,12 +326,16 @@ internal partial class NavigationHistory
 		if (m_tpCurrentPageStackEntry is not null)
 		{
 			var strDescriptior = m_tpCurrentPageStackEntry.GetDescriptor();
-			var sourcePageType = Type.GetType(strDescriptior);
+			var sourcePageType = GetType(strDescriptior);
 			pFrame.SourcePageType = sourcePageType;
 			pFrame.CurrentSourcePageType = sourcePageType;
 		}
 
 		m_isSetNavigationStatePending = false;
+
+		[UnconditionalSuppressMessage("Trimming", "IL2057", Justification = "`Uno.UI.SourceGenerators/BindableTypeProviders` / `BindableMetadata.g.cs` ensures the type exists.")]
+		static Type GetType(string typeName)
+			=> Type.GetType(typeName);
 	}
 
 	private void ValidateCanChangePageStack()

--- a/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.Properties.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Animation;
+using Uno.UI.Helpers;
 
 namespace Microsoft.UI.Xaml.Navigation;
 
@@ -23,8 +26,10 @@ partial class PageStackEntry
 	/// <summary>
 	/// Gets the type of page associated with this navigation entry.
 	/// </summary>
+	[DynamicallyAccessedMembers(TypeMappings.TypeRequirements)]
 	public Type SourcePageType
 	{
+		[UnconditionalSuppressMessage("Trimming", "IL2073", Justification = "Relying on the declaring property to track this.")]
 		get => (Type)GetValue(SourcePageTypeProperty);
 		set => SetValue(SourcePageTypeProperty, value);
 	}
@@ -32,6 +37,7 @@ partial class PageStackEntry
 	/// <summary>
 	/// Identifies the SourcePageType dependency property.
 	/// </summary>
+	[UnconditionalSuppressMessage("Trimming", "IL2111", Justification = "@jonpryor has no idea what the trimmer is talking about.")]
 	public static DependencyProperty SourcePageTypeProperty { get; } =
 		DependencyProperty.Register(
 			nameof(SourcePageType),

--- a/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.cs
@@ -24,7 +24,11 @@ public sealed partial class PageStackEntry : DependencyObject
 	/// <param name="sourcePageType">The type of page associated with the navigation entry, as a type reference.</param>
 	/// <param name="parameter">The navigation parameter associated with the navigation entry.</param>
 	/// <param name="navigationTransitionInfo">Info about the animated transition associated with the navigation entry.</param>
-	public PageStackEntry(Type sourcePageType, object parameter, NavigationTransitionInfo navigationTransitionInfo)
+	public PageStackEntry(
+		[DynamicallyAccessedMembers(TypeMappings.TypeRequirements)]
+		Type sourcePageType,
+		object parameter,
+		NavigationTransitionInfo navigationTransitionInfo)
 	{
 		InitializeBinder();
 

--- a/src/Uno.UI/UI/Xaml/SpecializedResourceDictionary.cs
+++ b/src/Uno.UI/UI/Xaml/SpecializedResourceDictionary.cs
@@ -130,7 +130,7 @@ namespace Microsoft.UI.Xaml
 		private Entry[] _entries;
 #if TARGET_64BIT
 		private ulong _fastModMultiplier;
-		private static bool Is64Bits = Marshal.SizeOf(typeof(IntPtr)) >= 8
+		private static bool Is64Bits = IntPtr.Size >= 8
 #if __WASM__
 			|| WebAssemblyRuntime.IsWebAssembly;
 #else

--- a/src/Uno.UI/Uno.UI.Reference.csproj
+++ b/src/Uno.UI/Uno.UI.Reference.csproj
@@ -13,6 +13,7 @@
 		<DefineConstants>$(DefineConstants);IS_UNO;IS_UNO_UI_PROJECT</DefineConstants>
 		<BuildForLiveUnitTesting>false</BuildForLiveUnitTesting>
 		<NoWarn>$(NoWarn);NU1701;1572;1587;419;1574;1711;1734;CS0105</NoWarn>
+		<IsAotCompatible>true</IsAotCompatible>
 
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>

--- a/src/Uno.UI/Uno.UI.Skia.csproj
+++ b/src/Uno.UI/Uno.UI.Skia.csproj
@@ -14,6 +14,7 @@
 		<Deterministic>true</Deterministic>
 		<RootNamespace>Uno.UI</RootNamespace>
 		<AssemblyName>Uno.UI</AssemblyName>
+		<IsAotCompatible>true</IsAotCompatible>
 
 		<UnoRuntimeIdentifier>Skia</UnoRuntimeIdentifier>
 		<PlatformItemsBasePath>.\</PlatformItemsBasePath>

--- a/src/Uno.UI/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI/Uno.UI.Wasm.csproj
@@ -14,6 +14,7 @@
 		<Deterministic>true</Deterministic>
 		<RootNamespace>Uno.UI</RootNamespace>
 		<AssemblyName>Uno.UI</AssemblyName>
+		<IsAotCompatible>true</IsAotCompatible>
 
 		<TSBindingsPath>$(MSBuildThisFileDirectory)tsBindings</TSBindingsPath>
 		<TSBindingAssemblySource>Uno;Uno.UI</TSBindingAssemblySource>

--- a/src/Uno.UI/Uno.UI.netcoremobile.csproj
+++ b/src/Uno.UI/Uno.UI.netcoremobile.csproj
@@ -13,6 +13,7 @@
 		<DefineConstants>$(DefineConstants);IS_UNO;IS_UNO_UI_PROJECT</DefineConstants>
 		<BuildForLiveUnitTesting>false</BuildForLiveUnitTesting>
 		<NoWarn>$(NoWarn);NU1701;1572;1587;419;1574;1711;1734;CS0105</NoWarn>
+		<IsAotCompatible>true</IsAotCompatible>
 
 		<!-- Obsolete members CA1422 -->
 		<NoWarn>$(NoWarn);CA1422</NoWarn>


### PR DESCRIPTION
Context: https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming
Context: https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot#aot-compatibility-analyzers
Context: https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options
Context: 10480ec02ec24c8ba74aca0d25e94e461cfd4b0d
Context: 408e17789e8fd48f367a3012d6eb1bd6233d4538
Context: https://github.com/dotnet/android/issues/7473
Context: https://github.com/dotnet/android/commit/68368189d67c46ddbfed4e90e622f635c4aff11e

Enable `$(IsAotCompatible)`=true for the following projects:

  * `src/Uno.Foundation/Uno.Foundation.csproj`
  * `src/Uno.Foundation/Uno.Foundation.netcoremobile.csproj`
  * `src/Uno.Foundation/Uno.Foundation.Reference.csproj`
  * `src/Uno.Foundation/Uno.Foundation.Skia.csproj`
  * `src/Uno.Foundation/Uno.Foundation.Wasm.csproj`
  * `src/Uno.UI/Uno.UI.Skia.csproj`

Address the following warnings:

	src/Uno.UI/DataBinding/BindingPropertyHelper.MemberBinder.cs(13,60): error IL3050:
	  Using member 'System.Dynamic.GetMemberBinder.GetMemberBinder(String, Boolean)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.
	src/Uno.UI/DataBinding/BindingPropertyHelper.MemberBinder.cs(22,60): error IL3050:
	  Using member 'System.Dynamic.SetMemberBinder.SetMemberBinder(String, Boolean)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Creating a call site may require dynamic code generation.

Add `[RequiresDynamicCodeAttribute]` to the specified types.

Fix the following warnings:

	src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2WebMessageReceivedEventArgs.cs(61,70): error IL2026:
	  Using member 'System.Text.Json.Serialization.Metadata.JsonTypeInfo.CreateJsonTypeInfo<T>(JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2WebMessageReceivedEventArgs.cs(61,70): error IL3050:
	  Using member 'System.Text.Json.Serialization.Metadata.JsonTypeInfo.CreateJsonTypeInfo<T>(JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.
	src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2WebMessageReceivedEventArgs.cs(54,22): error IL2026:
	  Using member 'System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver.DefaultJsonTypeInfoResolver()' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code.
	  JSON serialization and deserialization might require types that cannot be statically analyzed.
	  Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
	src/Uno.UI/UI/Xaml/Controls/WebView/Core/CoreWebView2WebMessageReceivedEventArgs.cs(54,22): error IL3050:
	  Using member 'System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver.DefaultJsonTypeInfoResolver()' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.
	  Use System.Text.Json source generation for native AOT applications.

@jonpryor was under the mistaken belief that commit 10480ec0 would be
sufficient to fix these warnings, and was wrong.  Even though we
"only" need to turn JSON into a *`string`*, not a structure, do as
requested: use System.Text.Json source generation.  (Which, again,
feels rather weird as only `string` is needed!)

	[JsonSourceGenerationOptions]
	[JsonSerializable(typeof(string))]
	internal sealed partial class ExampleContext : JsonSerializerContext {}
	// then use ExampleContext.Default.String to deserialize to string!

Fix the following warning:

	src/Uno.UI/UI/Xaml/SpecializedResourceDictionary.cs(133,34): error IL3050:
	  Using member 'System.Runtime.InteropServices.Marshal.SizeOf(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  Marshalling code for the object might not be available.
	  Use the SizeOf<T> overload instead.

We *could* do as requested and use `Marshal.SizeOf<IntPtr>()`, but
the reason why `Marshal.SizeOf()` is used here is because of 408e1778,
which was to workaround dotnet/android#7473.  dotnet/android#7473 has
since been fixed in dotnet/android@68368189, meaning we don't actually
need to use `Marshal.SizeOf()` anymore.  Use `IntPtr.Size` instead.

Suppress the following warning:

	src/Uno.UI/UI/Xaml/Navigation/NavigationHistory.mux.cs(329,25): error IL2057:
	  Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'.
	  It's not possible to guarantee the availability of the target type.

TODO: investigate whether we can update `PageStackEntry.m_descriptor`
to have `[DynamicallyAccessedMembers]`.

Suppress the following warnings:

	src/Uno.UI/Extensions/ViewExtensions.visual-tree.cs(214,4): error IL2075:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperty(String, BindingFlags)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs(82,17): error IL2075:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.NonPublicFields' in call to 'System.Reflection.TypeInfo.GetDeclaredField(String)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs(82,17): error IL2075:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.NonPublicFields' in call to 'System.Reflection.TypeInfo.GetDeclaredField(String)'.
	  The return value of method 'System.Type.BaseType.get' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs(108,20): error IL2075:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Reflection.TypeInfo.GetDeclaredProperty(String)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs(108,20): error IL2075:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Reflection.TypeInfo.GetDeclaredProperty(String)'.
	  The return value of method 'System.Type.BaseType.get' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs(104,8): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.NonPublicFields' in call to 'System.Reflection.TypeInfo.GetDeclaredField(String)'.
	  The parameter 'type' of method 'GetField(Type, String)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/FrameworkElementExtensions.cs(134,8): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Reflection.TypeInfo.GetDeclaredProperty(String)'.
	  The parameter 'type' of method 'GetProperty(Type, String)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/DirectUI/PropertyPathStep.cs(502,16): error IL2072:
	  'pSourceType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'DirectUI.ReflectionPropertyAccess.CreateInstance(IPropertyAccessHost, Object, Type, Boolean)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/Controls/Frame/Frame.legacy.cs(68,4): error IL2072:
	  'value' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Microsoft.UI.Xaml.Navigation.PageStackEntry.SourcePageType.set'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/Controls/NumberBox/NumberBoxParser.cs(93,20): error IL2072:
	  'typeName' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods', 'DynamicallyAccessedMemberTypes.PublicFields', 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.PublicEvents' in call to 'Windows.Foundation.Metadata.ApiInformation.IsTypePresent(String)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

As these callsites are all rooted in `value.GetType().…`, I can't
think of a way to appease NativeAOT here.

Suppress the following warnings:

	C:\a\1\s\src\Uno.UI\obj\Uno.UI.netcoremobile\Release\net10.0-ios26.0\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.DependencyObject.DependencyObjectGenerator\Microsoft.UI.Xaml.Navigation.PageStackEntry.cs(120,4): error IL2111:
	  Method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.PageStackEntry(Type, Object, NavigationTransitionInfo)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.
	C:\a\1\s\src\Uno.UI\obj\Uno.UI.netcoremobile\Release\net10.0-ios26.0\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.DependencyObject.DependencyObjectGenerator\Microsoft.UI.Xaml.Navigation.PageStackEntry.cs(150,4): error IL2111:
	  Method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.PageStackEntry(Type, Object, NavigationTransitionInfo)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.

These warnings appear to be unactionable: what are we supposed to *do*?
Like, okay then?

Update `src/SourceGenerators` so that the callsite suppressses these.

Address the following warnings:

	src/Uno.UI/DirectUI/PropertyAccess.cs(1634,18): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperty(String, BindingFlags)'.
	  The parameter 'pSourceType' of method 'DirectUI.ReflectionPropertyAccess.CreateInstance(IPropertyAccessHost, Object, Type, Boolean)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/DirectUI/MetadataAPI.cs(603,5): error IL2070:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties', 'DynamicallyAccessedMemberTypes.NonPublicProperties' in call to 'System.Type.GetProperty(String, BindingFlags)'.
	  The parameter 'type' of method 'DirectUI.MetadataAPI.TryGetDependencyPropertyByName(Type, String)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.Properties.cs(32,10): error IL2073:
	  'Microsoft.UI.Xaml.Navigation.PageStackEntry.SourcePageType.get' method return value does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' requirements.
	  The return value of method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.GetValue(DependencyProperty)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Add the requested `[DynamicallyAccessedMembers]`.

Suppress the following warning:

	src/Uno.UI/UI/Xaml/Navigation/PageStackEntry.Properties.cs(41,3): error IL2111:
	  Method 'Microsoft.UI.Xaml.Navigation.PageStackEntry.PageStackEntry(Type, Object, NavigationTransitionInfo)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection.
	  Trimmer can't guarantee availability of the requirements of the method.

@jonpryor has no idea why this warning is appearing.

Address the following warning:

	src/Uno.UI/Helpers/TypeMappings.cs(76,6): error IL2072:
	  'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'System.Activator.CreateInstance(Type, params Object[])'.
	  The return value of method 'Uno.UI.Helpers.TypeMappings.GetReplacementType(Type)' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Update *the entire call hierarchy* within this file so that `Type`
parameters and `Type`-returning methods all declare *both*
`DynamicallyAccessedMemberTypes.PublicConstructors` and
`DynamicallyAccessedMemberTypes.PublicParameterlessConstructor`.
The latter is needed for `TypeMappings.CreateInstance<T>()`.

For the following warnings:

	src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs(463,23): error IL2075:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicProperties' in call to 'System.Type.GetProperties()'.
	  The return value of method 'System.Type.BaseType.get' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs(474,23): error IL2075:
	  'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods()'.
	  The return value of method 'System.Type.BaseType.get' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Annotate the `type` parameter with `[DynamicallyAccessedMembers]`.
(This doesn't touch `Type.BaseType`, but fixed the IL2075.)

Unfortunately, after addressing all of the above, *non*-trimmer
enabled builds start failing:

	src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs(54,29): error IL2072:
	  'mappedType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.UI.Helpers.TypeMappings.GetOriginalType(Type)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.Common.cs(85,30): error IL2072:
	  'mappedType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.UI.Helpers.TypeMappings.GetOriginalType(Type)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs(526,6): error IL2072:
	  'mappedType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.UI.Helpers.TypeMappings.RegisterMapping(Type, Type)'.
	  The return value of method 'System.Collections.IEnumerator.Current.get' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs(526,6): error IL2072:
	  'originalType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.UI.Helpers.TypeMappings.RegisterMapping(Type, Type)'.
	  The return value of method 'System.Reflection.CustomAttributeTypedArgument.Value.get' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs(164,25): error IL2072:
	  'mappedType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.UI.Helpers.TypeMappings.GetOriginalType(Type)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.
	src/Uno.UI.RemoteControl/HotReload/ClientHotReloadProcessor.MetadataUpdate.cs(180,23): error IL2072:
	  'originalType' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'Uno.UI.Helpers.TypeMappings.GetMappedType(Type)'.
	  The return value of method 'System.Object.GetType()' does not have matching annotations.
	  The source value must declare at least the same requirements as those declared on the target location it is assigned to.

Suppress these warnings.

Fix and suppress the following warning:

	src/Uno.UI/ToolkitHelper.cs(12,20): error IL2057: Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'.
	  It's not possible to guarantee the availability of the target type.

Fix this by updating all callsites to use an assembly-qualified name
instead of relying on `ToolkitHelper.GetProperty()` to do a string
concat before a `Type.GetType()` invocation.  This along with
`[DynamicallyAccessedMembers]` on the `typeName` parameter *should*
allow NativeAOT to preserve the referenced types.

That doesn't actually remove the IL2057, though, so suppress it.

For compatibility, if the initial `Type.GetType()` fails, fallback
to appending `",Uno.UI.Toolkit"` to the type name.