### PR TITLE
docs: Add VS Code WebAssembly Hot Reload instructions (#21780)

### DIFF
--- a/doc/articles/create-an-app-vscode.md
+++ b/doc/articles/create-an-app-vscode.md
@@ -68,6 +68,15 @@ Next, open the project using Visual Studio Code.
   >
   > ![Uno Platform Sign in / Register notification](Assets/uno-settings-vsc-notification.png)
 
+  > [!NOTE]
+  > **For VS Code users:** To enable Hot Reload when running a WebAssembly app, use:
+  >
+  > ```bash
+  > dotnet watch run -f wasm --output wwwroot
+  > ```
+  >
+  > Then open http://localhost:5000 in your browser.
+
 # [**Copilot AI Prompt**](#tab/copilot-prompt)
 
 ## Using the `/mcp.uno.new` agent prompt


### PR DESCRIPTION
**GitHub Issue:** closes #21780

## PR Type:
📚 Documentation content changes

## What is the current behavior? 🤔
The VS Code WebAssembly Quick Start documentation does not include the Hot Reload command needed when running a WASM app from VS Code, which can cause confusion for new developers following the setup guide.

## What is the new behavior? 🚀
A new note has been added to the "Create the App" section that provides the correct VS Code command:

    dotnet watch run -f wasm --output wwwroot

The note also clarifies that the app will be available at http://localhost:5000.

This brings the documentation in line with the suggestion in issue #21780 and improves the onboarding experience for VS Code users.

## PR Checklist ✅

- [x] 📝 Commits follow the Conventional Commits specification.
- [x] 📚 Documentation updated to match the issue requirements.
- [x] ❗ Contains NO breaking changes

## Other information ℹ️
N/A
