### PR TITLE
fix: Improve mouse button state tracking and reset logic on macOS

### DIFF
--- a/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/MouseButtons.m
+++ b/src/Uno.UI.Runtime.Skia.MacOS/UnoNativeMac/UnoNativeMac/MouseButtons.m
@@ -52,10 +52,22 @@ static int sDepth[8] = {0};
             m |= (1 << i);
         }
     }
-    if (m != 0) return m;
-
+    
     // 2) Fall back to AppKit snapshot
     NSInteger appKitMask = [NSEvent pressedMouseButtons];
+    
+    if (m != 0) {
+        // If we think buttons are down, but AppKit says NONE are down, we likely missed a MouseUp.
+        // We trust AppKit and reset our counters.
+        if (appKitMask == 0) {
+            for (int i = 0; i < 8; i++) {
+                sDepth[i] = 0;
+            }
+            return 0;
+        }
+        return m;
+    }
+
     if (appKitMask != 0) return appKitMask;
 
     // 3) Quartz fallback (polls physical state; taps may already be up)


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/21839

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix


## What is the current behavior? 🤔

When having a native element inside an Uno Platform macOS Skia app, the native element starts to catch all the events and doesn't pass them to the Uno app, which results with the app uninteractive.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

Adds a trust AppKit mechanism: if internal counters disagree with AppKit (buttons down vs. none pressed), it resets counters and returns 0.

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->