### PR TITLE
fix: Transform `TextBox` touch-based carets correctly

### DIFF
--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4610,6 +4610,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 		[TestMethod]
 		[RequiresFullWindow]
+		[GitHubWorkItem("https://github.com/unoplatform/uno/issues/21961")]
 		public async Task When_Caret_Positioning_With_Complex_Transformations()
 		{
 			var textBox = new TextBox

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -4618,7 +4618,6 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				Text = "Test"
 			};
 			textBox.RenderTransform = new RotateTransform { Angle = 30 };
-			var grid = new Grid();
 			var viewbox = new Viewbox
 			{
 				HorizontalAlignment = HorizontalAlignment.Center,
@@ -4674,7 +4673,7 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 				var boundary = ellipseTransform.TransformPoint(localBoundary);
 
 				// actual radius after rotation/scale/etc.
-				double radius = Math.Sqrt(Math.Pow(boundary.X - center.X, 2) + Math.Pow(boundary.Y - center.Y, 2));
+				double radius = Math.Sqrt(Math.Pow(boundary.X - ellipseCenter.X, 2) + Math.Pow(boundary.Y - ellipseCenter.Y, 2));
 				// Check that the line from bottomLeft to bottomRight intersects the ellipse using DistancePointToSegment
 				var distance = DistancePointToSegment(ellipseCenter, bottomLeft, bottomRight);
 				Assert.IsTrue(distance < radius, "Caret ellipse should intersect the bottom border of the TextBox");

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_TextBox.skia.cs
@@ -9,11 +9,13 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Media3D;
 using MUXControlsTestApp.Utilities;
 using SamplesApp.UITests;
 using Uno.Disposables;
 using Uno.Extensions;
 using Uno.UI.RuntimeTests.Helpers;
+using Uno.UI.Toolkit.DevTools.Input;
 using Uno.UI.Xaml.Core;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
@@ -23,7 +25,6 @@ using Windows.UI.Input.Preview.Injection;
 using static Private.Infrastructure.TestServices;
 using Color = Windows.UI.Color;
 using Point = Windows.Foundation.Point;
-using Uno.UI.Toolkit.DevTools.Input;
 
 namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 {
@@ -4605,6 +4606,104 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Controls
 
 			var screenshot2 = await UITestHelper.ScreenShot(SUT2);
 			await ImageAssert.AreEqualAsync(screenshot1, screenshot2);
+		}
+
+		[TestMethod]
+		[RequiresFullWindow]
+		public async Task When_Caret_Positioning_With_Complex_Transformations()
+		{
+			var textBox = new TextBox
+			{
+				Text = "Test"
+			};
+			textBox.RenderTransform = new RotateTransform { Angle = 30 };
+			var grid = new Grid();
+			var viewbox = new Viewbox
+			{
+				HorizontalAlignment = HorizontalAlignment.Center,
+				VerticalAlignment = VerticalAlignment.Center,
+				Width = 200,
+				Height = 200,
+				Child = textBox
+			};
+			await UITestHelper.Load(viewbox);
+			await WindowHelper.WaitForIdle();
+
+			var injector = InputInjector.TryCreate() ?? throw new InvalidOperationException("Failed to init the InputInjector");
+			// Double tap the TextBox with finger to ensure we have "touch" based carets
+			using var finger = injector.GetFinger();
+			var textBoxBounds = textBox.GetAbsoluteBoundsRect();
+			var center = textBoxBounds.GetCenter();
+			finger.Press(center);
+			finger.Release();
+			await WindowHelper.WaitFor(() => textBox.FocusState == FocusState.Pointer);
+			textBox.SelectAll();
+
+			// Everything should be selected
+			Assert.AreEqual(0, textBox.SelectionStart);
+			Assert.AreEqual(textBox.Text.Length, textBox.SelectionLength);
+
+			// Wait for the caret popups to appear
+			await WindowHelper.WaitFor(() => VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot).Where(p => p.Child.FindFirstChild<Microsoft.UI.Xaml.Shapes.Ellipse>() is not null).Any());
+
+			// Get the caret popups
+			var caretPopups = VisualTreeHelper.GetOpenPopupsForXamlRoot(WindowHelper.XamlRoot).Where(p => p.Child.FindFirstChild<Microsoft.UI.Xaml.Shapes.Ellipse>() is not null).ToList();
+			// We should have two caret popups (start and end)
+			Assert.AreEqual(2, caretPopups.Count);
+
+			// Validate the Ellipses of the carets are intersecting the bottom border of the TextBox
+			var textBoxTransform = textBox.TransformToVisual(null);
+			var bottomLeft = textBoxTransform.TransformPoint(new Point(0, textBox.ActualHeight));
+			var bottomRight = textBoxTransform.TransformPoint(new Point(textBox.ActualWidth, textBox.ActualHeight));
+
+			foreach (var popup in caretPopups)
+			{
+				var ellipse = popup.Child.FindFirstChild<Microsoft.UI.Xaml.Shapes.Ellipse>()!;
+				Assert.IsNotNull(ellipse);
+
+				// center in local space
+				var localCenter = new Point(ellipse.Width / 2, ellipse.Height / 2);
+
+				// pick a boundary point on the right side in local space
+				var localBoundary = new Point(ellipse.Width, ellipse.Height / 2);
+
+				// transform both to visual space
+				var ellipseTransform = ellipse.TransformToVisual(null);
+				var ellipseCenter = ellipseTransform.TransformPoint(localCenter);
+				var boundary = ellipseTransform.TransformPoint(localBoundary);
+
+				// actual radius after rotation/scale/etc.
+				double radius = Math.Sqrt(Math.Pow(boundary.X - center.X, 2) + Math.Pow(boundary.Y - center.Y, 2));
+				// Check that the line from bottomLeft to bottomRight intersects the ellipse using DistancePointToSegment
+				var distance = DistancePointToSegment(ellipseCenter, bottomLeft, bottomRight);
+				Assert.IsTrue(distance < radius, "Caret ellipse should intersect the bottom border of the TextBox");
+			}
+		}
+
+		private double DistancePointToSegment(Point p, Point a, Point b)
+		{
+			var ax = a.X; var ay = a.Y;
+			var bx = b.X; var by = b.Y;
+			var px = p.X; var py = p.Y;
+
+			var abx = bx - ax;
+			var aby = by - ay;
+			var apx = px - ax;
+			var apy = py - ay;
+
+			// Project AP onto AB, clamp to [0,1]
+			double abLenSq = abx * abx + aby * aby;
+			double t = (apx * abx + apy * aby) / abLenSq;
+			t = Math.Clamp(t, 0, 1);
+
+			// Closest point
+			var cx = ax + t * abx;
+			var cy = ay + t * aby;
+
+			// Distance to closest point
+			var dx = px - cx;
+			var dy = py - cy;
+			return Math.Sqrt(dx * dx + dy * dy);
 		}
 
 		private static bool HasColorInRectangle(RawBitmap screenshot, Rectangle rect, Color expectedColor)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -308,6 +308,7 @@ public partial class TextBox
 	{
 		if (CaretMode is CaretDisplayMode.CaretWithThumbsOnlyEndShowing or CaretDisplayMode.CaretWithThumbsBothEndsShowing)
 		{
+			var transform = TextBoxView.DisplayBlock.TransformToVisual(null);
 			foreach (var (rectNullable, caret) in (ReadOnlySpan<(Rect?, CaretWithStemAndThumb)>)[(_lastStartCaretRect, _selectionStartThumbfulCaret), (_lastEndCaretRect, _selectionEndThumbfulCaret)])
 			{
 				if (rectNullable is not { } rect)
@@ -316,7 +317,6 @@ public partial class TextBox
 					continue;
 				}
 				caret.Height = rect.Height + 16;
-				var transform = TextBoxView.DisplayBlock.TransformToVisual(null);
 				if (transform.TransformBounds(rect).IntersectWith(this.GetAbsoluteBoundsRect()) is not null)
 				{
 					var matrixTransform = (MatrixTransform)transform;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -30,10 +30,6 @@ using Microsoft.UI.Xaml.Media.Media3D;
 using System.Numerics;
 using System.Text.RegularExpressions;
 
-
-
-
-
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;
 #else

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.skia.cs
@@ -28,7 +28,6 @@ using Uno.Foundation;
 using DispatcherQueuePriority = Microsoft.UI.Dispatching.DispatcherQueuePriority;
 using Microsoft.UI.Xaml.Media.Media3D;
 using System.Numerics;
-using System.Text.RegularExpressions;
 
 #if HAS_UNO_WINUI
 using Microsoft.UI.Input;


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/uno/issues/21961

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type: 🐞 Bugfix

<!--
Copy the labels that apply to this PR and paste them above:

- 
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

When `TextBox` is transformed, the transforms of its touch carets do not match the expected location


## What is the new behavior? 🚀

Carets are transformed to match up with `TextBox`

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes