### PR TITLE
fix(CalendarView): wrong string value when Spanish culture

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -1550,6 +1550,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarView_Cultures.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Native_With_AppBarButton_Binding.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -4346,7 +4350,6 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-        
     <Page Include="$(MSBuildThisFileDirectory)Microsoft_UI_Xaml_Controls\WebView2Tests\WebView2_TargetBlank.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -6496,6 +6499,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\BorderWithNullBrushAndNonZeroThickness.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\PanelWithNullBrushAndNonZeroThickness.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CalendarView\CalendarView_Cultures.xaml.cs">
+      <DependentUpon>CalendarView_Cultures.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Native_With_AppBarButton_Binding.xaml.cs">
       <DependentUpon>CommandBar_Native_With_AppBarButton_Binding.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Cultures.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Cultures.xaml
@@ -1,0 +1,33 @@
+﻿<Page
+    x:Class="UITests.Windows_UI_Xaml_Controls.CalendarView.CalendarView_Cultures"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CalendarView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid RowSpacing="12">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<TextBlock Grid.ColumnSpan="4" VerticalAlignment="Top">CalendarView with different Cultures</TextBlock>
+		<CalendarView Grid.Row="1" HorizontalAlignment="Center" />
+		<CalendarView Grid.Row="1" Grid.Column="1" Language="es-ES" HorizontalAlignment="Center" />
+		<CalendarView Grid.Row="1" Grid.Column="2" Language="zh" HorizontalAlignment="Center" />
+		<CalendarView Grid.Row="1" Grid.Column="3" Language="ca" HorizontalAlignment="Center" />
+		<TextBlock Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Center" Text="Default culture."/>
+		<TextBlock Grid.Row="2" Grid.Column="1" VerticalAlignment="Top" HorizontalAlignment="Center" Text="Spanish (es-ES) culture."/>
+		<TextBlock Grid.Row="2" Grid.Column="2" VerticalAlignment="Top" HorizontalAlignment="Center" Text="Chinesse (zh) culture."/>
+		<TextBlock Grid.Row="2" Grid.Column="3" VerticalAlignment="Top" HorizontalAlignment="Center" Text="Catalan (ca) culture."/>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Cultures.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Cultures.xaml
@@ -2,32 +2,67 @@
     x:Class="UITests.Windows_UI_Xaml_Controls.CalendarView.CalendarView_Cultures"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CalendarView"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:UITests.Windows_UI_Xaml_Controls.CalendarView"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
 
-	<Grid RowSpacing="12">
-		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="Auto" />
-		</Grid.RowDefinitions>
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition Width="*" />
-			<ColumnDefinition Width="*" />
-			<ColumnDefinition Width="*" />
-			<ColumnDefinition Width="*" />
-		</Grid.ColumnDefinitions>
-		<TextBlock Grid.ColumnSpan="4" VerticalAlignment="Top">CalendarView with different Cultures</TextBlock>
-		<CalendarView Grid.Row="1" HorizontalAlignment="Center" />
-		<CalendarView Grid.Row="1" Grid.Column="1" Language="es-ES" HorizontalAlignment="Center" />
-		<CalendarView Grid.Row="1" Grid.Column="2" Language="zh" HorizontalAlignment="Center" />
-		<CalendarView Grid.Row="1" Grid.Column="3" Language="ca" HorizontalAlignment="Center" />
-		<TextBlock Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Center" Text="Default culture."/>
-		<TextBlock Grid.Row="2" Grid.Column="1" VerticalAlignment="Top" HorizontalAlignment="Center" Text="Spanish (es-ES) culture."/>
-		<TextBlock Grid.Row="2" Grid.Column="2" VerticalAlignment="Top" HorizontalAlignment="Center" Text="Chinesse (zh) culture."/>
-		<TextBlock Grid.Row="2" Grid.Column="3" VerticalAlignment="Top" HorizontalAlignment="Center" Text="Catalan (ca) culture."/>
-	</Grid>
+    <Grid RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <TextBlock Grid.ColumnSpan="4" VerticalAlignment="Top">CalendarView with different Cultures</TextBlock>
+        <CalendarView Grid.Row="1" HorizontalAlignment="Center" />
+        <CalendarView
+            Grid.Row="1"
+            Grid.Column="1"
+            HorizontalAlignment="Center"
+            Language="es-ES" />
+        <CalendarView
+            Grid.Row="1"
+            Grid.Column="2"
+            HorizontalAlignment="Center"
+            Language="zh" />
+        <CalendarView
+            Grid.Row="1"
+            Grid.Column="3"
+            HorizontalAlignment="Center"
+            Language="ca" />
+        <TextBlock
+            Grid.Row="2"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Top"
+            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+            Text="Default culture." />
+        <TextBlock
+            Grid.Row="2"
+            Grid.Column="1"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Top"
+            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+            Text="Spanish (es-ES) culture." />
+        <TextBlock
+            Grid.Row="2"
+            Grid.Column="2"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Top"
+            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+            Text="Chinese (zh) culture." />
+        <TextBlock
+            Grid.Row="2"
+            Grid.Column="3"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Top"
+            Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+            Text="Catalan (ca) culture." />
+    </Grid>
 </Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Cultures.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Cultures.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
+﻿using Microsoft.UI.Xaml.Controls;
 using Uno.UI.Samples.Controls;
 
 namespace UITests.Windows_UI_Xaml_Controls.CalendarView;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Cultures.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/CalendarView/CalendarView_Cultures.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Windows_UI_Xaml_Controls.CalendarView;
+
+[Sample("Pickers", IgnoreInSnapshotTests = true, IsManualTest = true, Description = """
+		Showing CalendarView with different cultures.
+		""")]
+public sealed partial class CalendarView_Cultures : Page
+{
+	public CalendarView_Cultures()
+	{
+		this.InitializeComponent();
+	}
+}

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
@@ -201,6 +201,7 @@ public class Given_CalendarView
 			MinDate = DateTimeOffset.Now.AddDays(-10),
 			MaxDate = DateTimeOffset.Now.AddDays(10)
 		};
+
 		Assert.AreEqual(2, calendar.SelectedDates.Count);
 		Assert.AreEqual(day1, calendar.SelectedDates[0]);
 		Assert.AreEqual(day2, calendar.SelectedDates[1]);
@@ -302,6 +303,32 @@ public class Given_CalendarView
 			offsets.Zip(offsets.Skip(1)).All(x => x.Second >= x.First),
 			$"should never rewind back: (v-offsets: {string.Join(", ", offsets)})"
 		);
+	}
+
+	[TestMethod]
+	public async Task When_Spanish_Language()
+	{
+		var calendarView = new CalendarView();
+		TestServices.WindowHelper.WindowContent = calendarView;
+		await TestServices.WindowHelper.WaitForLoaded(calendarView);
+		calendarView.Language = "es-ES";
+		await TestServices.WindowHelper.WaitForIdle();
+		calendarView.SetDisplayDate(new DateTimeOffset(new DateTime(2024, 1, 1)));
+		await TestServices.WindowHelper.WaitForIdle();
+		Assert.AreEqual("enero de 2024", calendarView.TemplateSettings.HeaderText);
+	}
+
+	[TestMethod]
+	public async Task When_English_Language()
+	{
+		var calendarView = new CalendarView();
+		TestServices.WindowHelper.WindowContent = calendarView;
+		await TestServices.WindowHelper.WaitForLoaded(calendarView);
+		calendarView.Language = "en"; //default culture usually is en
+		await TestServices.WindowHelper.WaitForIdle();
+		calendarView.SetDisplayDate(new DateTimeOffset(new DateTime(2024, 1, 1)));
+		await TestServices.WindowHelper.WaitForIdle();
+		Assert.AreEqual("January 2024", calendarView.TemplateSettings.HeaderText);
 	}
 }
 #endif

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Controls/Given_CalendarView.cs
@@ -308,26 +308,26 @@ public class Given_CalendarView
 	[TestMethod]
 	public async Task When_Spanish_Language()
 	{
-		var calendarView = new CalendarView();
+		var calendarView = new CalendarView()
+		{
+			Language = "es-ES"
+		};
+		calendarView.SetDisplayDate(new DateTimeOffset(new DateTime(2024, 1, 1)));
 		TestServices.WindowHelper.WindowContent = calendarView;
 		await TestServices.WindowHelper.WaitForLoaded(calendarView);
-		calendarView.Language = "es-ES";
-		await TestServices.WindowHelper.WaitForIdle();
-		calendarView.SetDisplayDate(new DateTimeOffset(new DateTime(2024, 1, 1)));
-		await TestServices.WindowHelper.WaitForIdle();
 		Assert.AreEqual("enero de 2024", calendarView.TemplateSettings.HeaderText);
 	}
 
 	[TestMethod]
 	public async Task When_English_Language()
 	{
-		var calendarView = new CalendarView();
+		var calendarView = new CalendarView()
+		{
+			Language = "en-US"
+		};
+		calendarView.SetDisplayDate(new DateTimeOffset(new DateTime(2024, 1, 1)));
 		TestServices.WindowHelper.WindowContent = calendarView;
 		await TestServices.WindowHelper.WaitForLoaded(calendarView);
-		calendarView.Language = "en"; //default culture usually is en
-		await TestServices.WindowHelper.WaitForIdle();
-		calendarView.SetDisplayDate(new DateTimeOffset(new DateTime(2024, 1, 1)));
-		await TestServices.WindowHelper.WaitForIdle();
 		Assert.AreEqual("January 2024", calendarView.TemplateSettings.HeaderText);
 	}
 }

--- a/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
+++ b/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
@@ -802,7 +802,7 @@ public sealed partial class DateTimeFormatter
 				return string.Empty;
 			}
 
-			char singleQuoteChar = '\'';
+			const char singleQuoteChar = '\'';
 			var builder = new StringBuilder();
 			int i = 0;
 			int len = str.Length;
@@ -844,17 +844,16 @@ public sealed partial class DateTimeFormatter
 				}
 				else
 				{
-					char lastChar = currentChar;
 					int count = 1;
 					i++;
 
-					while (i < len && str[i] == lastChar && str[i] != '\'')
+					while (i < len && str[i] == currentChar)
 					{
 						count++;
 						i++;
 					}
 
-					AddToBuilder(builder, lastChar, count);
+					AddToBuilder(builder, currentChar, count);
 				}
 			}
 

--- a/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
+++ b/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
@@ -806,12 +806,20 @@ public sealed partial class DateTimeFormatter
 
 			foreach (var part in IsWithinSingleQuotesRegex().Split(str))
 			{
-				// add quoted literal as is, without the quotes
-				if (part.StartsWith('\''))
+				// skip empty block
+				if (part.Length == 0)
 				{
-					builder.Append(part[1..^1]);
+					continue;
 				}
-				// for non-quoted parts, further segment them by continous character
+				// add quoted literal as is, without the quotes
+				else if (part.StartsWith('\''))
+				{
+					if (part.Length > 2)
+					{
+						builder.Append(part[1..^1]);
+					}
+				}
+				// for non-quoted parts, further segment them by grouping repeated character(s)
 				else
 				{
 					foreach (var segment in DateTimeFormatPartsRegex().EnumerateMatches(part))
@@ -820,6 +828,7 @@ public sealed partial class DateTimeFormatter
 					}
 				}
 			}
+
 			return builder.ToString();
 		}
 	}

--- a/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
+++ b/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
@@ -804,7 +804,7 @@ public sealed partial class DateTimeFormatter
 
 			var builder = new StringBuilder();
 
-			foreach (var part in IsWithinSingleQuotesRegex().Split(str))
+			foreach (var part in StringLiteralRegex().Split(str))
 			{
 				// skip empty block
 				if (part.Length == 0)
@@ -822,7 +822,7 @@ public sealed partial class DateTimeFormatter
 				// for non-quoted parts, further segment them by grouping repeated character(s)
 				else
 				{
-					foreach (var segment in DateTimeFormatPartsRegex().EnumerateMatches(part))
+					foreach (var segment in RepeatedCharactersRegex().EnumerateMatches(part))
 					{
 						AddToBuilder(builder, part[segment.Index], segment.Length);
 					}
@@ -834,8 +834,8 @@ public sealed partial class DateTimeFormatter
 	}
 
 	[GeneratedRegex(@"('[^']+')")]
-	private static partial Regex IsWithinSingleQuotesRegex();
+	private static partial Regex StringLiteralRegex();
 
 	[GeneratedRegex(@"(.)(\1+)?")]
-	private static partial Regex DateTimeFormatPartsRegex();
+	private static partial Regex RepeatedCharactersRegex();
 }

--- a/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
+++ b/src/Uno.UWP/Globalization/DateTimeFormatting/DateTimeFormatter.cs
@@ -797,27 +797,68 @@ public sealed partial class DateTimeFormatter
 
 		string ConstructPattern(string str)
 		{
-			var builder = new StringBuilder();
-			char lastChar = str[0];
-			int count = 1;
-			for (int i = 1; i < str.Length; i++)
+			if (string.IsNullOrEmpty(str))
 			{
-				if (lastChar != str[i])
-				{
-					AddToBuilder(builder, lastChar, count);
+				return string.Empty;
+			}
 
-					lastChar = str[i];
-					count = 1;
+			char singleQuoteChar = '\'';
+			var builder = new StringBuilder();
+			int i = 0;
+			int len = str.Length;
+
+			while (i < len)
+			{
+				char currentChar = str[i];
+
+				// Handle quoted section (literals) "MMMM 'de' yyyy"
+				if (currentChar == singleQuoteChar)
+				{
+					i++;
+					var literal = new StringBuilder();
+
+					while (i < len)
+					{
+						if (str[i] == singleQuoteChar)
+						{
+							if (i + 1 < len && str[i + 1] == singleQuoteChar)
+							{
+								literal.Append(singleQuoteChar);
+								i += 2;
+							}
+							else
+							{
+								// End of quoted section
+								i++;
+								break;
+							}
+						}
+						else
+						{
+							literal.Append(str[i]);
+							i++;
+						}
+					}
+
+					builder.Append(literal);
 				}
 				else
 				{
-					count++;
+					char lastChar = currentChar;
+					int count = 1;
+					i++;
+
+					while (i < len && str[i] == lastChar && str[i] != '\'')
+					{
+						count++;
+						i++;
+					}
+
+					AddToBuilder(builder, lastChar, count);
 				}
 			}
 
-			AddToBuilder(builder, lastChar, count);
 			return builder.ToString();
 		}
 	}
-
 }


### PR DESCRIPTION
**GitHub Issue:** closes https://github.com/unoplatform/add-private/discussions/51

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

- 🐞 Bugfix


## What is the current behavior? 🤔

Wrong string format when CalendarView uses es-Es (Spanish Language)

<img width="465" height="154" alt="image" src="https://github.com/user-attachments/assets/d35c22da-2553-4b7a-82cb-37c9eedd4c71" />


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<img width="1518" height="1143" alt="Screenshot 2025-12-02 231819" src="https://github.com/user-attachments/assets/81b5be91-d391-46e7-bd6e-f55c01edb194" />


<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [x] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [x] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->