### PR TITLE
fix: Adjust nuget override location

### DIFF
--- a/src/Uno.Foundation.Logging/Uno.Foundation.Logging.csproj
+++ b/src/Uno.Foundation.Logging/Uno.Foundation.Logging.csproj
@@ -20,7 +20,7 @@
     	<Description>This package provides internal logging utilities for Uno.UI and Uno.WinUI packages</Description>
 		
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
+		<CommonOverridePackageId>Uno.Foundation.Logging</CommonOverridePackageId>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Uno.Foundation/Uno.Foundation.Reference.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.Reference.csproj
@@ -17,7 +17,7 @@
 		<UnoRuntimeIdentifier>Reference</UnoRuntimeIdentifier>
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
+		<CommonOverridePackageId>Uno.Foundation</CommonOverridePackageId>
 		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 

--- a/src/Uno.Foundation/Uno.Foundation.Skia.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.Skia.csproj
@@ -16,7 +16,7 @@
 		<PlatformItemsBasePath>.\</PlatformItemsBasePath>
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
+		<CommonOverridePackageId>Uno.Foundation</CommonOverridePackageId>
 		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 

--- a/src/Uno.Foundation/Uno.Foundation.Wasm.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.Wasm.csproj
@@ -16,7 +16,7 @@
 		<PlatformItemsBasePath>.\</PlatformItemsBasePath>
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
+		<CommonOverridePackageId>Uno.Foundation</CommonOverridePackageId>
 		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 

--- a/src/Uno.Foundation/Uno.Foundation.netcoremobile.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.netcoremobile.csproj
@@ -15,7 +15,7 @@
 		<Deterministic>true</Deterministic>
 
 		<UseCommonOverridePackage>true</UseCommonOverridePackage>
-		<CommonOverridePackageId>Uno.UI</CommonOverridePackageId>
+		<CommonOverridePackageId>Uno.Foundation</CommonOverridePackageId>
 		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 


### PR DESCRIPTION
This change avoids invalid override locations when changing `UnoNugetOverrideVersion`.