### PR TITLE
chore: docs staging auto-pr

### DIFF
--- a/.github/actions/docs-update/action.yml
+++ b/.github/actions/docs-update/action.yml
@@ -1,0 +1,119 @@
+name: "Docs Update"
+description: "Update external docs commit hashes to latest from default branches"
+
+inputs:
+  branch:
+    description: 'base branch'
+    required: true
+    default: 'master'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup PowerShell
+      shell: pwsh
+      run: |
+        Write-Host "Setting up environment for docs update..." -ForegroundColor Green
+
+    - name: Update external docs commit hashes
+      shell: pwsh
+      run: |
+        Write-Host "Updating external docs commit hashes..." -ForegroundColor Green
+        
+        # List of repositories to track (will fetch default branch dynamically)
+        $repos = @(
+            "uno.wasm.bootstrap",
+            "uno.themes",
+            "uno.toolkit.ui",
+            "uno.check",
+            "uno.xamlmerge.task",
+            "figma-docs",
+            "uno.resizetizer",
+            "uno.uitest",
+            "uno.extensions",
+            "workshops",
+            "uno.samples",
+            "uno.chefs",
+            "hd-docs"
+        )
+        
+        $scriptPath = "doc/import_external_docs.ps1"
+        
+        if (-Not (Test-Path $scriptPath)) {
+            Write-Error "Script not found: $scriptPath"
+            exit 1
+        }
+        
+        # Read the current script content
+        $content = Get-Content $scriptPath -Raw
+        $updatedCount = 0
+        
+        foreach ($repo in $repos) {
+            Write-Host "Processing $repo..." -ForegroundColor Cyan
+            
+            try {
+                # First, get the repository info to find the default branch
+                $repoInfoUrl = "https://api.github.com/repos/unoplatform/$repo"
+                $repoInfo = Invoke-RestMethod -Uri $repoInfoUrl -Headers @{
+                    "Accept" = "application/vnd.github.v3+json"
+                    "User-Agent" = "Uno-Docs-Updater"
+                }
+                
+                $defaultBranch = $repoInfo.default_branch
+                Write-Host "  Default branch: $defaultBranch" -ForegroundColor Gray
+                
+                # Get the latest commit hash from the default branch
+                $commitUrl = "https://api.github.com/repos/unoplatform/$repo/commits/$defaultBranch"
+                $commitInfo = Invoke-RestMethod -Uri $commitUrl -Headers @{
+                    "Accept" = "application/vnd.github.v3+json"
+                    "User-Agent" = "Uno-Docs-Updater"
+                }
+                
+                $latestHash = $commitInfo.sha
+                Write-Host "  Latest commit: $latestHash" -ForegroundColor Gray
+                
+                # Update the hash in the script using regex
+                # Match pattern: "repo-name" = @{ ref="<hash>" } #comment
+                $pattern = "(`"$repo`"\s*=\s*@\{\s*ref\s*=\s*`")[a-f0-9]{40}(`"\s*}[^#]*)(#.*)?$"
+                $comment = "latest $defaultBranch commit"
+                $replacement = "`${1}$latestHash`${2}#$comment"
+                
+                $newContent = $content -replace $pattern, $replacement
+                
+                if ($newContent -ne $content) {
+                    $content = $newContent
+                    $updatedCount++
+                    Write-Host "  ✓ Updated $repo to $latestHash" -ForegroundColor Green
+                } else {
+                    Write-Host "  ⚠ No change for $repo (already up to date or pattern not matched)" -ForegroundColor Yellow
+                }
+            }
+            catch {
+                Write-Warning "Failed to process $repo : $_"
+            }
+        }
+        
+        # Write the updated content back to the file
+        if ($updatedCount -gt 0) {
+            Set-Content -Path $scriptPath -Value $content -NoNewline
+            Write-Host "`n✓ Updated $updatedCount commit hash(es) in $scriptPath" -ForegroundColor Green
+        } else {
+            Write-Host "`n⚠ No updates were made" -ForegroundColor Yellow
+        }
+        
+        # Show git diff for verification
+        Write-Host "`nChanges made:" -ForegroundColor Cyan
+        git diff $scriptPath
+
+    - name: Check for changes
+      id: check_changes
+      shell: pwsh
+      run: |
+        $changes = git status --porcelain doc/import_external_docs.ps1
+        if ($changes) {
+            echo "has_changes=true" >> $env:GITHUB_OUTPUT
+            Write-Host "Changes detected in import_external_docs.ps1" -ForegroundColor Green
+        } else {
+            echo "has_changes=false" >> $env:GITHUB_OUTPUT
+            Write-Host "No changes detected in import_external_docs.ps1" -ForegroundColor Yellow
+        }

--- a/.github/actions/docs-update/action.yml
+++ b/.github/actions/docs-update/action.yml
@@ -20,29 +20,24 @@ runs:
       run: |
         Write-Host "Updating external docs commit hashes..." -ForegroundColor Green
         
-        # List of repositories to track (will fetch default branch dynamically)
-        $repos = @(
-            "uno.wasm.bootstrap",
-            "uno.themes",
-            "uno.toolkit.ui",
-            "uno.check",
-            "uno.xamlmerge.task",
-            "figma-docs",
-            "uno.resizetizer",
-            "uno.uitest",
-            "uno.extensions",
-            "workshops",
-            "uno.samples",
-            "uno.chefs",
-            "hd-docs"
-        )
-        
         $scriptPath = "doc/import_external_docs.ps1"
         
         if (-Not (Test-Path $scriptPath)) {
             Write-Error "Script not found: $scriptPath"
             exit 1
         }
+        
+        # Get the list of repositories from the script
+        Write-Host "Getting repository list from $scriptPath..." -ForegroundColor Cyan
+        $repos = & $scriptPath -ListRepos
+        
+        if (-not $repos -or $repos.Count -eq 0) {
+            Write-Warning "No repositories found in $scriptPath"
+            exit 0
+        }
+        
+        Write-Host "Found $($repos.Count) repositories to update:" -ForegroundColor Green
+        $repos | ForEach-Object { Write-Host "  - $_" -ForegroundColor Gray }
         
         # Read the current script content
         $content = Get-Content $scriptPath -Raw

--- a/.github/actions/docs-update/action.yml
+++ b/.github/actions/docs-update/action.yml
@@ -69,7 +69,8 @@ runs:
                 
                 # Update the hash in the script using regex
                 # Match pattern: "repo-name" = @{ ref="<hash>" } #comment
-                $pattern = "`"$repo`"\s*=\s*@\{\s*ref\s*=\s*`"([a-f0-9]{40})`"\s*\}(\s*;\s*[^#]*)?\s*(#.*)?"
+                $escapedRepo = [regex]::Escape($repo)
+                $pattern = "`"$escapedRepo`"\s*=\s*@\{\s*ref\s*=\s*`"([a-f0-9]{40})`"\s*\}(\s*;\s*[^#]*)?\s*(#.*)?"
                 $comment = "latest $defaultBranch commit"
                 $replacement = "`"$repo`" = @{ ref=`"$latestHash`" }${2} #$comment"
                 

--- a/.github/actions/docs-update/action.yml
+++ b/.github/actions/docs-update/action.yml
@@ -69,9 +69,9 @@ runs:
                 
                 # Update the hash in the script using regex
                 # Match pattern: "repo-name" = @{ ref="<hash>" } #comment
-                $pattern = "(`"$repo`"\s*=\s*@\{\s*ref\s*=\s*`")[a-f0-9]{40}(`"\s*}[^#]*)(#.*)?$"
+                $pattern = "`"$repo`"\s*=\s*@\{\s*ref\s*=\s*`"([a-f0-9]{40})`"\s*\}(\s*;\s*[^#]*)?\s*(#.*)?"
                 $comment = "latest $defaultBranch commit"
-                $replacement = "`${1}$latestHash`${2}#$comment"
+                $replacement = "`"$repo`" = @{ ref=`"$latestHash`" }${2} #$comment"
                 
                 $newContent = $content -replace $pattern, $replacement
                 

--- a/.github/actions/docs-update/action.yml
+++ b/.github/actions/docs-update/action.yml
@@ -7,6 +7,11 @@ inputs:
     required: true
     default: 'master'
 
+outputs:
+  has_changes:
+    description: 'Whether changes were detected'
+    value: ${{ steps.check_changes.outputs.has_changes }}
+
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -1,0 +1,87 @@
+name: Update External Docs Commit Hashes
+
+on:
+  schedule:
+    # Run every 6 hours at minutes 0 (00:00, 06:00, 12:00, 18:00 UTC)
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to update'
+        required: true
+        default: 'master'
+
+concurrency:
+  group: ${{ github.workflow }} - ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-update:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch:
+          - master
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+
+      - name: "Docs Update"
+        uses: ./.github/actions/docs-update
+        with:
+          branch: ${{ matrix.branch }}
+
+      - name: Set target branch
+        id: targetbranch
+        run: |
+          if [[ "${{ matrix.branch }}" == "master" ]]; then
+            echo "targetbranch=docs/update/dev" >> $GITHUB_OUTPUT
+          else
+            versionNumber=$(echo "${{ matrix.branch }}" | cut -d'/' -f 3)
+            echo "targetbranch=docs/update/release/$versionNumber" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ matrix.branch }}
+          branch: ${{ steps.targetbranch.outputs.targetbranch }}
+          commit-message: 'chore: Update external docs commit hashes'
+          title: External Docs Update - ${{ matrix.branch }}
+          body: |
+            This updates the external documentation commit hashes in `doc/import_external_docs.ps1` to the latest commits from each repository's default branch.
+            
+            The following repositories are automatically tracked and updated to their default branch:
+            - uno.wasm.bootstrap
+            - uno.themes
+            - uno.toolkit.ui
+            - uno.check
+            - uno.xamlmerge.task
+            - figma-docs
+            - uno.resizetizer
+            - uno.uitest
+            - uno.extensions
+            - workshops
+            - uno.samples
+            - uno.chefs
+            - hd-docs
+            
+            Each repository's default branch (main, master, or configured default) is automatically detected and used.
+            
+            This is an automated update created by the external docs updater workflow.
+          labels: docs-update
+          draft: false
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -18,30 +18,26 @@ concurrency:
 jobs:
   docs-update:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch:
-          - master
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.branch }}
+          ref: ${{ inputs.branch || 'master' }}
           fetch-depth: 0
 
       - name: "Docs Update"
         uses: ./.github/actions/docs-update
         with:
-          branch: ${{ matrix.branch }}
+          branch: ${{ inputs.branch || 'master' }}
 
       - name: Set target branch
         id: targetbranch
         run: |
-          if [[ "${{ matrix.branch }}" == "master" ]]; then
+          BRANCH="${{ inputs.branch || 'master' }}"
+          if [[ "$BRANCH" == "master" ]]; then
             echo "targetbranch=docs/update/dev" >> $GITHUB_OUTPUT
           else
-            versionNumber=$(echo "${{ matrix.branch }}" | cut -d'/' -f 3)
+            versionNumber=$(echo "$BRANCH" | cut -d'/' -f 3)
             echo "targetbranch=docs/update/release/$versionNumber" >> $GITHUB_OUTPUT
           fi
         shell: bash
@@ -51,13 +47,13 @@ jobs:
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          base: ${{ matrix.branch }}
+          base: ${{ inputs.branch || 'master' }}
           branch: ${{ steps.targetbranch.outputs.targetbranch }}
           commit-message: 'chore: Update external docs commit hashes'
-          title: 'chore(docs): External Docs Update - ${{ matrix.branch }}'
+          title: 'chore(docs): External Docs Update - ${{ inputs.branch || ''master'' }}'
           body: |
             This updates the external documentation commit hashes in `doc/import_external_docs.ps1` to the latest commits from each repository's default branch.
-            
+
             The following repositories are automatically tracked and updated to their default branch:
             - uno.wasm.bootstrap
             - uno.themes
@@ -72,9 +68,9 @@ jobs:
             - uno.samples
             - uno.chefs
             - hd-docs
-            
+
             Each repository's default branch (main, master, or configured default) is automatically detected and used.
-            
+
             This is an automated update created by the external docs updater workflow.
           labels: docs-update
           draft: false

--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -54,7 +54,7 @@ jobs:
           base: ${{ matrix.branch }}
           branch: ${{ steps.targetbranch.outputs.targetbranch }}
           commit-message: 'chore: Update external docs commit hashes'
-          title: External Docs Update - ${{ matrix.branch }}
+          title: 'chore(docs): External Docs Update - ${{ matrix.branch }}'
           body: |
             This updates the external documentation commit hashes in `doc/import_external_docs.ps1` to the latest commits from each repository's default branch.
             

--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -12,7 +12,7 @@ on:
         default: 'master'
 
 concurrency:
-  group: ${{ github.workflow }} - ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -10,7 +10,9 @@ on:
         description: 'Branch to update'
         required: true
         default: 'master'
-
+permissions:
+  contents: write
+  pull-requests: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -37,9 +37,12 @@ jobs:
           BRANCH="${{ inputs.branch || 'master' }}"
           if [[ "$BRANCH" == "master" ]]; then
             echo "targetbranch=docs/update/dev" >> $GITHUB_OUTPUT
-          else
-            versionNumber=$(echo "$BRANCH" | cut -d'/' -f 3)
+          elif [[ "$BRANCH" =~ ^release/stable/([0-9]+\.[0-9]+)$ ]]; then
+            versionNumber="${BASH_REMATCH[1]}"
             echo "targetbranch=docs/update/release/$versionNumber" >> $GITHUB_OUTPUT
+          else
+            echo "Unexpected branch format: $BRANCH"
+            exit 1
           fi
         shell: bash
 

--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -52,24 +52,9 @@ jobs:
           base: ${{ inputs.branch || 'master' }}
           branch: ${{ steps.targetbranch.outputs.targetbranch }}
           commit-message: 'chore: Update external docs commit hashes'
-          title: 'chore(docs): External Docs Update - ${{ inputs.branch || ''master'' }}'
+          title: "chore(docs): External Docs Update - ${{ inputs.branch || 'master' }}"
           body: |
             This updates the external documentation commit hashes in `doc/import_external_docs.ps1` to the latest commits from each repository's default branch.
-
-            The following repositories are automatically tracked and updated to their default branch:
-            - uno.wasm.bootstrap
-            - uno.themes
-            - uno.toolkit.ui
-            - uno.check
-            - uno.xamlmerge.task
-            - figma-docs
-            - uno.resizetizer
-            - uno.uitest
-            - uno.extensions
-            - workshops
-            - uno.samples
-            - uno.chefs
-            - hd-docs
 
             Each repository's default branch (main, master, or configured default) is automatically detected and used.
 

--- a/.github/workflows/docs-updater.yml
+++ b/.github/workflows/docs-updater.yml
@@ -31,6 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Docs Update"
+        id: docs_update
         uses: ./.github/actions/docs-update
         with:
           branch: ${{ matrix.branch }}
@@ -48,6 +49,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
+        if: steps.docs_update.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/import_external_docs.ps1
+++ b/doc/import_external_docs.ps1
@@ -1,6 +1,7 @@
 param(
   [Parameter(ValueFromPipelineByPropertyName = $true)]
-  $branches = $null
+  $branches = $null,
+  [switch]$ListRepos
 )
 
 Set-PSDebug -Trace 1
@@ -27,6 +28,13 @@ $external_docs = @{
 $uno_git_url = "https://github.com/unoplatform/"
 
 # --- END OF CONFIGURATION --------------------------------------------------
+
+# If -ListRepos flag is set, output the repository names and exit
+if ($ListRepos) {
+    Set-PSDebug -Off
+    $external_docs.Keys | ForEach-Object { Write-Output $_ }
+    exit 0
+}
 
 # If branches are passed, use them to override the default ones (ref, but not dest)
 if ($branches) {


### PR DESCRIPTION
This pull request introduces a new automated workflow for keeping external documentation commit hashes up to date. It adds a reusable GitHub Action and a scheduled workflow that regularly checks for the latest commits in a list of external repositories, updates the tracked commit hashes in `doc/import_external_docs.ps1`, and creates a pull request with the changes. This ensures that the documentation always references the most current versions of external docs.

**Automation of external docs tracking:**

* Added a new composite GitHub Action (`.github/actions/docs-update/action.yml`) that fetches the latest commit hashes from the default branches of a predefined list of external repositories, updates the corresponding entries in `doc/import_external_docs.ps1`, and displays a diff for verification.

**Scheduled workflow integration:**

* Introduced a new workflow (`.github/workflows/docs-updater.yml`) that runs the docs update action every 6 hours and on manual dispatch, checks out the relevant branch, updates hashes, and automatically creates a pull request with the changes. Automerge is enabled for these pull requests.
* The workflow dynamically detects each repository's default branch (e.g., main or master) to ensure hashes are always up to date with the latest commits. [[1]](diffhunk://#diff-101b50ad773a292d834f0ce2351f91bc07e8c5dc6ad8cb418a71d0ee1c00c107R1-R119) [[2]](diffhunk://#diff-611ad9b6bf62b5a0ceb5e5275ebd0d92d723b440dedc0d2c63f2650e1a850ef3R1-R87)