### PR TITLE
ci: Allow for package duplicates

### DIFF
--- a/build/ci/templates/nuget-publish-public.yml
+++ b/build/ci/templates/nuget-publish-public.yml
@@ -8,4 +8,5 @@ steps:
       nuGetFeedType: 'external'
       publishFeedCredentials: 'nuget.org uno packages'
       verbosityPush: 'Normal'
+      allowPackageConflicts: true
 


### PR DESCRIPTION
Don't fail the build on nuget.org publish conflicts