### PR TITLE
chore: look for `icudata` et al in more locations

### DIFF
--- a/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UnicodeText.ICU.skia.cs
@@ -21,6 +21,12 @@ internal readonly partial struct UnicodeText
 		private static readonly IntPtr _libicuuc;
 		private static Dictionary<Type, object> _lookupCache = new();
 
+		private const DllImportSearchPath NativeLibrarySearchDirectories =
+			  DllImportSearchPath.ApplicationDirectory
+			| DllImportSearchPath.AssemblyDirectory
+			| DllImportSearchPath.UserDirectories
+			;
+
 		static unsafe ICU()
 		{
 			IntPtr libicuuc;
@@ -28,7 +34,7 @@ internal readonly partial struct UnicodeText
 			{
 				// On Windows, We get the ICU binaries from the Microsoft.ICU.ICU4C.Runtime package
 				_icuVersion = 72;
-				if (!NativeLibrary.TryLoad("icuuc72", typeof(ICU).Assembly, DllImportSearchPath.UserDirectories, out libicuuc))
+				if (!NativeLibrary.TryLoad("icuuc72", typeof(ICU).Assembly, NativeLibrarySearchDirectories, out libicuuc))
 				{
 					throw new Exception("Failed to load libicuuc.");
 				}
@@ -42,13 +48,13 @@ internal readonly partial struct UnicodeText
 			{
 				// On Linux and Android, we get the ICU binaries from the dynamic linker search path
 				// On MacOS, we get the ICU binaries from the uno.icu-macos package.
-				if (OperatingSystem.IsMacOS() && !NativeLibrary.TryLoad("icudata", typeof(ICU).Assembly, DllImportSearchPath.UserDirectories, out _))
+				if (OperatingSystem.IsMacOS() && !NativeLibrary.TryLoad("icudata", typeof(ICU).Assembly, NativeLibrarySearchDirectories, out _))
 				{
 					// MacOS doesn't automatically load icudata from icuuc for some reason even though the icuuc binary
 					// lists icudata in the `otool -L` output, so we have to load it by hand
 					throw new Exception("Failed to load libicudata.");
 				}
-				if (!NativeLibrary.TryLoad("icuuc", typeof(ICU).Assembly, DllImportSearchPath.UserDirectories, out libicuuc))
+				if (!NativeLibrary.TryLoad("icuuc", typeof(ICU).Assembly, NativeLibrarySearchDirectories, out libicuuc))
 				{
 					throw new Exception("Failed to load libicuuc.");
 				}


### PR DESCRIPTION
Context: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.dllimportsearchpath?view=net-10.0

While running the uno.chefs app on macOS under NativeAOT:

	dotnet publish -c Release -r osx-x64 -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop -bl \
	  Chefs/Chefs.csproj \
	  -p:SelfContained=true -p:PublishAot=true -p:UseSkiaRendering=true \
	  -p:TrimmerSingleWarn=false -p:IsTrimmable=true -p:IsAotCompatible=true -p:_ExtraTrimmerArgs=--verbose \
	  -p:IlcGenerateMapFile=true -p:IlcGenerateMstatFile=true -p:IlcGenerateDgmlFile=true -p:IlcGenerateMetadataLog=true \
	  -p:EmitCompilerGeneratedFiles=true -p:CompilerGeneratedFilesOutputPath=`pwd`/_gen
	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

when using recent versions of Uno, the app log (stdout) would contain:

	fail: Uno.UI.Dispatching.NativeDispatcher[0]
	      NativeDispatcher unhandled exception
	      System.TypeInitializationException: A type initializer threw an exception. To determine which type, inspect the InnerException's StackTrace property.
	       ---> System.Exception: Failed to load libicudata.
	         at Microsoft.UI.Xaml.Documents.UnicodeText.ICU..cctor() + 0x37c
		 …

`libicudata.dylib` *existed* in
`Chefs/bin/Release/net10.0-desktop/osx-x64/publish`, but wasn't found.

Update the `DllImportSearchPath` values used with
`NativeLibrary.TryLoad()` to include `.ApplicationDirectory` and `.AssemblyDirectory`:

> `.ApplicationDirectory`:
> Include the application directory in the DLL search path
>
> `.AssemblyDirectory`:
> When searching for assembly dependencies, include the directory that
> contains the assembly itself, and search that directory first.
> When used in Native AOT and single-file deployment models, the
> application's installation directory is considered the
> "assembly directory" and is searched.

This fixes the "fail" message.

TODO: figure out how to properly test this behavior on CI.

**GitHub Issue:** closes #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal), unless the change is documentation related. -->

## PR Type:

<!--
Copy the labels that apply to this PR and paste them above:

- 🐞 Bugfix
- ✨ Feature
- 🎨 Code style update (formatting)
- 🔄 Refactoring (no functional changes, no api changes)
- 🏗️ Build or CI related changes
- 📚 Documentation content changes
- 🤖 Project automation
- 💬 Other... (Please describe)

-->


## What is the current behavior? 🤔

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior? 🚀

<!-- Please describe the new behavior after your modifications. -->

## PR Checklist ✅

Please check if your PR fulfills the following requirements:

- [ ] 📝 Commits must be following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [ ] 🧪 Added [Runtime tests, UI tests, or a manual test sample](https://github.com/unoplatform/uno/blob/master/doc/articles/uno-development/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] 📚 Docs have been added/updated which fit [documentation template](https://github.com/unoplatform/uno/blob/master/doc/.feature-template.md) (for bug fixes / features)
- [ ] 🖼️ Validated PR `Screenshots Compare Test Run` results.
- [ ] ❗ Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information ℹ️

<!-- Please provide any additional information if necessary -->